### PR TITLE
[NFC][RemoteInspection] Add an opaque AddressSpace field to RemoteAddress

### DIFF
--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -132,7 +132,10 @@
 #ifndef SWIFT_BASIC_RELATIVEPOINTER_H
 #define SWIFT_BASIC_RELATIVEPOINTER_H
 
+#include <cassert>
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 
 namespace swift {
 

--- a/include/swift/Remote/CMemoryReader.h
+++ b/include/swift/Remote/CMemoryReader.h
@@ -69,7 +69,7 @@ class CMemoryReader final : public MemoryReader {
   // that we're likely failing to strip a signed pointer when reading from it.
   bool hasSignatureBits(RemoteAddress address) {
     return false;
-    uint64_t addressData = address.getAddressData();
+    uint64_t addressData = address.getRawAddress();
     return addressData != (addressData & getPtrauthMask());
   }
 
@@ -89,13 +89,12 @@ public:
   RemoteAddress getSymbolAddress(const std::string &name) override {
     auto addressData = Impl.getSymbolAddress(Impl.reader_context,
                                              name.c_str(), name.size());
-    return RemoteAddress(addressData);
+    return RemoteAddress(addressData, RemoteAddress::DefaultAddressSpace);
   }
 
   uint64_t getStringLength(RemoteAddress address) {
     assert(!hasSignatureBits(address));
-    return Impl.getStringLength(Impl.reader_context,
-                                address.getAddressData());
+    return Impl.getStringLength(Impl.reader_context, address.getRawAddress());
   }
 
   bool readString(RemoteAddress address, std::string &dest) override {
@@ -120,7 +119,7 @@ public:
   ReadBytesResult readBytes(RemoteAddress address, uint64_t size) override {
     assert(!hasSignatureBits(address));
     void *FreeContext;
-    auto Ptr = Impl.readBytes(Impl.reader_context, address.getAddressData(),
+    auto Ptr = Impl.readBytes(Impl.reader_context, address.getRawAddress(),
                               size, &FreeContext);
 
     auto Free = Impl.free;
@@ -134,8 +133,7 @@ public:
     return ReadBytesResult(Ptr, freeLambda);
   }
 };
-
-}
-}
+} // namespace remote
+} // namespace swift
 
 #endif

--- a/include/swift/Remote/Failure.h
+++ b/include/swift/Remote/Failure.h
@@ -288,7 +288,7 @@ public:
       case ArgStorageKind::Address: {
         result += '0';
         result += 'x';
-        uint64_t address = Args[argIndex].Address.getAddressData();
+        uint64_t address = Args[argIndex].Address.getRawAddress();
         unsigned max = ((address >> 32) != 0 ? 16 : 8);
         for (unsigned i = 0; i != max; ++i) {
           result += "0123456789abcdef"[(address >> (max - 1 - i) * 4) & 0xF];

--- a/include/swift/Remote/InProcessMemoryReader.h
+++ b/include/swift/Remote/InProcessMemoryReader.h
@@ -105,8 +105,8 @@ class InProcessMemoryReader final : public MemoryReader {
     return ReadBytesResult(address.getLocalPointer<void>(), [](const void *) {});
   }
 };
- 
-}
-}
+
+} // namespace remote
+} // namespace swift
 
 #endif

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -147,7 +147,7 @@ public:
   virtual RemoteAbsolutePointer resolvePointer(RemoteAddress address,
                                                uint64_t readValue) {
     // Default implementation returns the read value as is.
-    return RemoteAbsolutePointer("", readValue);
+    return RemoteAbsolutePointer(RemoteAddress(readValue));
   }
 
   /// Performs the inverse operation of \ref resolvePointer.
@@ -166,7 +166,7 @@ public:
   virtual RemoteAbsolutePointer getSymbol(RemoteAddress address) {
     if (auto symbol = resolvePointerAsSymbol(address))
       return *symbol;
-    return RemoteAbsolutePointer("", address.getAddressData());
+    return RemoteAbsolutePointer(address);
   }
 
   /// Lookup a dynamic symbol name (ie dynamic loader binding) for the given

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -57,13 +57,31 @@ public:
   ///
   /// Returns false if the operation failed.
   virtual bool readString(RemoteAddress address, std::string &dest) = 0;
-  
+
+  /// Attempts to read a remote address from the given address in the remote
+  /// process.
+  ///
+  /// Returns false if the operator failed.
+  template <typename IntegerType>
+  bool readRemoteAddress(RemoteAddress address, RemoteAddress &out) {
+    IntegerType buf;
+    if (!readInteger(address, &buf))
+      return false;
+
+    out = RemoteAddress((uint64_t)buf, address.getAddressSpace());
+    return true;
+  }
+
   /// Attempts to read an integer from the given address in the remote
   /// process.
   ///
   /// Returns false if the operation failed.
   template <typename IntegerType>
   bool readInteger(RemoteAddress address, IntegerType *dest) {
+    static_assert(!std::is_same<RemoteAddress, IntegerType>(),
+                  "RemoteAddress cannot be read in directly, use "
+                  "readRemoteAddress instead.");
+
     return readBytes(address, reinterpret_cast<uint8_t*>(dest),
                      sizeof(IntegerType));
   }
@@ -147,7 +165,8 @@ public:
   virtual RemoteAbsolutePointer resolvePointer(RemoteAddress address,
                                                uint64_t readValue) {
     // Default implementation returns the read value as is.
-    return RemoteAbsolutePointer(RemoteAddress(readValue));
+    return RemoteAbsolutePointer(
+        RemoteAddress(readValue, address.getAddressSpace()));
   }
 
   /// Performs the inverse operation of \ref resolvePointer.
@@ -263,7 +282,7 @@ public:
   virtual ~MemoryReader() = default;
 };
 
-} // end namespace reflection
+} // end namespace remote
 } // end namespace swift
 
 #endif // SWIFT_REFLECTION_READER_H

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -58,19 +58,17 @@ enum class MangledNameKind {
 template <typename T>
 class RemoteRef {
 private:
-  uint64_t Address;
+  RemoteAddress Address;
   const T *LocalBuffer;
 
 public:
-  RemoteRef()
-    : Address(0), LocalBuffer(nullptr) {}
+  RemoteRef() : Address(), LocalBuffer(nullptr) {}
 
   /*implicit*/
   RemoteRef(std::nullptr_t _) : RemoteRef() {}
 
-  template<typename StoredPointer>
-  explicit RemoteRef(StoredPointer address, const T *localBuffer)
-    : Address((uint64_t)address), LocalBuffer(localBuffer) {}
+  explicit RemoteRef(RemoteAddress address, const T *localBuffer)
+      : Address(address), LocalBuffer(localBuffer) {}
 
   // <rdar://99715218> Some versions of clang++ sometimes fail to generate the
   // copy constructor for this type correctly - add a workaround
@@ -83,9 +81,7 @@ public:
     return *this;
   }
 
-  uint64_t getAddressData() const {
-    return Address;
-  }
+  RemoteAddress getRemoteAddress() const { return Address; }
 
   const T *getLocalBuffer() const {
     return LocalBuffer;
@@ -113,23 +109,23 @@ public:
   template<typename U>
   RemoteRef<U> getField(U &field) const {
     auto offset = (intptr_t)&field - (intptr_t)LocalBuffer;
-    return RemoteRef<U>((uint64_t)(Address + (int64_t)offset), &field);
+    return RemoteRef<U>((Address + (int64_t)offset), &field);
   }
   
   /// Resolve the remote address of a relative offset stored at the remote address.
-  uint64_t resolveRelativeAddressData() const {
+  RemoteAddress resolveRelativeAddressData() const {
     int32_t offset;
     memcpy(&offset, LocalBuffer, sizeof(int32_t));
     if (offset == 0)
-      return 0;
+      return RemoteAddress();
     return Address + (int64_t)offset;
   }
-  
-  template<typename U>
-  uint64_t resolveRelativeFieldData(U &field) const {
+
+  template <typename U>
+  RemoteAddress resolveRelativeFieldData(U &field) const {
     return getField(field).resolveRelativeAddressData();
   }
-  
+
   RemoteRef atByteOffset(int64_t Offset) const {
     return RemoteRef(Address + Offset,
                      (const T *)((intptr_t)LocalBuffer + Offset));
@@ -195,10 +191,10 @@ private:
   /// amounts of data when we encounter corrupt values for sizes/counts.
   static const uint64_t MaxMetadataSize = 1048576; // 1MB
 
-  /// The dense map info for a std::pair<StoredPointer, bool>.
+  /// The dense map info for a std::pair<RemoteAddress, bool>.
   struct DenseMapInfoTypeCacheKey {
-    using Pair = std::pair<StoredPointer, bool>;
-    using StoredPointerInfo = llvm::DenseMapInfo<StoredPointer>;
+    using Pair = std::pair<RemoteAddress, bool>;
+    using StoredPointerInfo = llvm::DenseMapInfo<RemoteAddress>;
 
     static inline Pair getEmptyKey() {
       // Since bool doesn't have an empty key implementation, we only use the
@@ -223,7 +219,7 @@ private:
 
   /// A cache of built types, keyed by the address of the type and whether the
   /// request ignored articial superclasses or not.
-  llvm::DenseMap<std::pair<StoredPointer, bool>, BuiltType,
+  llvm::DenseMap<std::pair<RemoteAddress, bool>, BuiltType,
                  DenseMapInfoTypeCacheKey>
       TypeCache;
 
@@ -231,7 +227,7 @@ private:
   using OwnedMetadataRef = MemoryReader::ReadBytesResult;
 
   /// A cache of read type metadata, keyed by the address of the metadata.
-  llvm::DenseMap<StoredPointer, OwnedMetadataRef> MetadataCache;
+  llvm::DenseMap<RemoteAddress, OwnedMetadataRef> MetadataCache;
 
   using ContextDescriptorRef =
       RemoteRef<const TargetContextDescriptor<Runtime>>;
@@ -313,14 +309,14 @@ private:
 
   /// A cache of read nominal type descriptors, keyed by the address of the
   /// nominal type descriptor.
-  llvm::DenseMap<StoredPointer, OwnedContextDescriptorRef>
+  llvm::DenseMap<RemoteAddress, OwnedContextDescriptorRef>
       ContextDescriptorCache;
 
   using OwnedProtocolDescriptorRef =
     std::unique_ptr<const TargetProtocolDescriptor<Runtime>, delete_with_free>;
   /// A cache of read extended existential shape metadata, keyed by the
   /// address of the shape metadata.
-  llvm::DenseMap<StoredPointer, OwnedShapeRef> ShapeCache;
+  llvm::DenseMap<RemoteAddress, OwnedShapeRef> ShapeCache;
 
   enum class IsaEncodingKind {
     /// We haven't checked yet.
@@ -359,8 +355,8 @@ private:
   StoredPointer IsaIndexShift;
   StoredPointer IsaMagicMask;
   StoredPointer IsaMagicValue;
-  StoredPointer IndexedClassesPointer;
-  StoredPointer IndexedClassesCountPointer;
+  RemoteAddress IndexedClassesPointer;
+  RemoteAddress IndexedClassesCountPointer;
   StoredPointer LastIndexedClassesCount = 0;
 
   enum class TaggedPointerEncodingKind {
@@ -389,11 +385,11 @@ private:
   StoredPointer TaggedPointerMask;
   StoredPointer TaggedPointerSlotShift;
   StoredPointer TaggedPointerSlotMask;
-  StoredPointer TaggedPointerClasses;
+  RemoteAddress TaggedPointerClasses;
   StoredPointer TaggedPointerExtendedMask;
   StoredPointer TaggedPointerExtendedSlotShift;
   StoredPointer TaggedPointerExtendedSlotMask;
-  StoredPointer TaggedPointerExtendedClasses;
+  RemoteAddress TaggedPointerExtendedClasses;
   StoredPointer TaggedPointerObfuscator;
 
   Demangle::NodeFactory Factory;
@@ -411,14 +407,21 @@ public:
 
   StoredPointer PtrAuthMask;
 
-  StoredPointer stripSignedPointer(StoredSignedPointer P) {
-    return P.SignedValue & PtrAuthMask;
+  RemoteAddress stripSignedPointer(RemoteAddress P) {
+    // Only pointers in the default address space are signed.
+    if (P.getAddressSpace() == RemoteAddress::DefaultAddressSpace)
+      return P & PtrAuthMask;
+    return P;
+  }
+
+  RemoteAddress stripSignedPointer(StoredSignedPointer P) {
+    return RemoteAddress(P.SignedValue & PtrAuthMask,
+                         RemoteAddress::DefaultAddressSpace);
   }
 
   RemoteAbsolutePointer stripSignedPointer(const RemoteAbsolutePointer &P) {
-    return RemoteAbsolutePointer(
-        P.getSymbol(), P.getOffset(),
-        RemoteAddress(P.getResolvedAddress().getAddressData() & PtrAuthMask));
+    auto Stripped = stripSignedPointer(P.getResolvedAddress());
+    return RemoteAbsolutePointer(P.getSymbol(), P.getOffset(), Stripped);
   }
 
   StoredPointer queryPtrAuthMask() {
@@ -431,11 +434,9 @@ public:
   }
 
   template <class... T>
-  MetadataReader(std::shared_ptr<MemoryReader> reader, T &&... args)
-    : Builder(std::forward<T>(args)...),
-      Reader(std::move(reader)),
-      PtrAuthMask(queryPtrAuthMask()) {
-  }
+  MetadataReader(std::shared_ptr<MemoryReader> reader, T &&...args)
+      : Builder(std::forward<T>(args)...), Reader(std::move(reader)),
+        PtrAuthMask(queryPtrAuthMask()) {}
 
   MetadataReader(const MetadataReader &other) = delete;
   MetadataReader &operator=(const MetadataReader &other) = delete;
@@ -462,7 +463,7 @@ public:
       auto offsetInMangledName =
             (const char *)base - mangledName.getLocalBuffer();
       auto remoteAddress =
-        mangledName.getAddressData() + offsetInMangledName + offset;
+          mangledName.getRemoteAddress() + offsetInMangledName + offset;
 
       RemoteAbsolutePointer resolved;
       if (directness == Directness::Indirect) {
@@ -472,7 +473,7 @@ public:
           return nullptr;
         }
       } else {
-        resolved = Reader->getSymbol(RemoteAddress(remoteAddress));
+        resolved = Reader->getSymbol(remoteAddress);
       }
 
       switch (kind) {
@@ -486,9 +487,13 @@ public:
         if (useOpaqueTypeSymbolicReferences
            && context.isResolved()
            && context.getResolved()->getKind() == ContextDescriptorKind::OpaqueType){
+          // FIXME: this loses the address space. This can be fixed by adding an
+          // opaque field in Node that can store the address space. This
+          // wouldn't degrade performance as Node's address is part of an union
+          // which is 16 bytes longs
           return dem.createNode(
-                            Node::Kind::OpaqueTypeDescriptorSymbolicReference,
-                            context.getResolved().getAddressData());
+              Node::Kind::OpaqueTypeDescriptorSymbolicReference,
+              context.getResolved().getRemoteAddress().getRawAddress());
         }
 
         return buildContextMangling(context, dem);
@@ -502,27 +507,27 @@ public:
         // The symbolic reference points at a unique extended
         // existential type shape.
         return dem.createNode(
-                          Node::Kind::UniqueExtendedExistentialTypeShapeSymbolicReference,
-                          resolved.getResolvedAddress().getAddressData());
+            Node::Kind::UniqueExtendedExistentialTypeShapeSymbolicReference,
+            resolved.getResolvedAddress().getRawAddress());
       }
       case Demangle::SymbolicReferenceKind::NonUniqueExtendedExistentialTypeShape: {
         // The symbolic reference points at a non-unique extended
         // existential type shape.
+        // FIXME: this loses the address space.
         return dem.createNode(
-                          Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference,
-                          resolved.getResolvedAddress().getAddressData());
+            Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference,
+            resolved.getResolvedAddress().getRawAddress());
       }
       case Demangle::SymbolicReferenceKind::ObjectiveCProtocol: {
         // 'resolved' points to a struct of two relative addresses.
         // The second entry is a relative address to the mangled protocol
         // without symbolic references.
 
-        auto addr =
-            resolved.getResolvedAddress().getAddressData() + sizeof(int32_t);
+        auto addr = resolved.getResolvedAddress() + sizeof(int32_t);
         int32_t offset;
-        Reader->readInteger(RemoteAddress(addr), &offset);
+        Reader->readInteger(addr, &offset);
         auto addrOfTypeRef = addr + offset;
-        resolved = Reader->getSymbol(RemoteAddress(addrOfTypeRef));
+        resolved = Reader->getSymbol(addrOfTypeRef);
 
         // Dig out the protocol from the protocol list.
         auto protocolList = readMangledName(resolved.getResolvedAddress(),
@@ -576,10 +581,9 @@ public:
   /// Demangle a mangled name from a potentially temporary std::string. The
   /// demangler may produce pointers into the string data, so this copies the
   /// string into the demangler's allocation first.
-  Demangle::NodePointer demangle(uint64_t remoteAddress,
+  Demangle::NodePointer demangle(RemoteAddress remoteAddress,
                                  const std::string &mangledName,
-                                 MangledNameKind kind,
-                                 Demangler &dem) {
+                                 MangledNameKind kind, Demangler &dem) {
     StringRef mangledNameCopy = dem.copyString(mangledName);
     return demangle(RemoteRef<char>(remoteAddress, mangledNameCopy.data()),
                     kind, dem);
@@ -607,7 +611,7 @@ public:
 
   /// Given a remote pointer to metadata, attempt to discover its MetadataKind.
   std::optional<MetadataKind>
-  readKindFromMetadata(StoredPointer MetadataAddress) {
+  readKindFromMetadata(RemoteAddress MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta)
       return std::nullopt;
@@ -616,11 +620,10 @@ public:
   }
 
   /// Given a remote pointer to class metadata, attempt to read its superclass.
-  StoredPointer
-  readSuperClassFromClassMetadata(StoredPointer MetadataAddress) {
+  RemoteAddress readSuperClassFromClassMetadata(RemoteAddress MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::Class)
-      return StoredPointer();
+      return RemoteAddress();
 
     auto classMeta = cast<TargetClassMetadata>(meta);
     return stripSignedPointer(classMeta->Superclass);
@@ -629,7 +632,7 @@ public:
   /// Given a remote pointer to class metadata, attempt to discover its class
   /// instance size and whether fields should use the resilient layout strategy.
   std::optional<unsigned>
-  readInstanceStartFromClassMetadata(StoredPointer MetadataAddress) {
+  readInstanceStartFromClassMetadata(RemoteAddress MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::Class)
       return std::nullopt;
@@ -638,7 +641,7 @@ public:
       // The following algorithm only works on the non-fragile Apple runtime.
 
       // Grab the RO-data pointer.  This part is not ABI.
-      StoredPointer roDataPtr = readObjCRODataPtr(MetadataAddress);
+      RemoteAddress roDataPtr = readObjCRODataPtr(MetadataAddress);
       if (!roDataPtr)
         return std::nullopt;
 
@@ -646,7 +649,7 @@ public:
       auto address = roDataPtr + sizeof(uint32_t) * 1;
 
       unsigned start;
-      if (!Reader->readInteger(RemoteAddress(address), &start))
+      if (!Reader->readInteger(address, &start))
         return std::nullopt;
 
       return start;
@@ -676,19 +679,19 @@ public:
   /// witness table. Note that it's not safe to access any non-mandatory
   /// members of the value witness table, like extra inhabitants or enum members.
   std::optional<TargetValueWitnessTable<Runtime>>
-  readValueWitnessTable(StoredPointer MetadataAddress) {
+  readValueWitnessTable(RemoteAddress MetadataAddress) {
     // The value witness table pointer is at offset -1 from the metadata
     // pointer, that is, the pointer-sized word immediately before the
     // pointer's referenced address.
     TargetValueWitnessTable<Runtime> VWT;
     auto ValueWitnessTableAddrAddr = MetadataAddress - sizeof(StoredPointer);
     StoredSignedPointer SignedValueWitnessTableAddr;
-    if (!Reader->readInteger(RemoteAddress(ValueWitnessTableAddrAddr),
+    if (!Reader->readInteger(ValueWitnessTableAddrAddr,
                              &SignedValueWitnessTableAddr))
       return std::nullopt;
-    auto ValueWitnessTableAddr = stripSignedPointer(SignedValueWitnessTableAddr);
-    if (!Reader->readBytes(RemoteAddress(ValueWitnessTableAddr),
-                           (uint8_t *)&VWT, sizeof(VWT)))
+    auto ValueWitnessTableAddr =
+        stripSignedPointer(SignedValueWitnessTableAddr);
+    if (!Reader->readBytes(ValueWitnessTableAddr, (uint8_t *)&VWT, sizeof(VWT)))
       return std::nullopt;
     return VWT;
   }
@@ -700,8 +703,7 @@ public:
   std::optional<RemoteExistential>
   readMetadataAndValueErrorExistential(RemoteAddress ExistentialAddress) {
     // An pointer to an error existential is always an heap object.
-    auto MetadataAddress =
-        readMetadataFromInstance(ExistentialAddress.getAddressData());
+    auto MetadataAddress = readMetadataFromInstance(ExistentialAddress);
     if (!MetadataAddress)
       return std::nullopt;
 
@@ -730,18 +732,15 @@ public:
 
     if (isBridged) {
       // NSError instances don't need to be unwrapped.
-      return RemoteExistential(RemoteAddress(*MetadataAddress),
-                               ExistentialAddress,
-                               isBridged);
+      return RemoteExistential(*MetadataAddress, ExistentialAddress, isBridged);
     }
 
     // In addition to the isa pointer and two 32-bit reference counts, if the
     // error existential is layout-compatible with NSError, we also need to
     // skip over its three word-sized fields: the error code, the domain,
     // and userInfo.
-    StoredPointer InstanceMetadataAddressAddress =
-        ExistentialAddress.getAddressData() +
-        (isObjC ? 5 : 2) * sizeof(StoredPointer);
+    RemoteAddress InstanceMetadataAddressAddress =
+        ExistentialAddress + (isObjC ? 5 : 2) * sizeof(StoredPointer);
 
     // We need to get the instance's alignment info so we can get the exact
     // offset of the start of its data in the class.
@@ -757,7 +756,7 @@ public:
 
     // Now we need to skip over the instance metadata pointer and instance's
     // conformance pointer for Swift.Error.
-    StoredPointer InstanceAddress =
+    RemoteAddress InstanceAddress =
         InstanceMetadataAddressAddress + 2 * sizeof(StoredPointer);
 
     // When built with Objective-C interop, the runtime also stores a conformance
@@ -770,10 +769,8 @@ public:
     auto AlignmentMask = VWT->getAlignmentMask();
     InstanceAddress = (InstanceAddress + AlignmentMask) & ~AlignmentMask;
 
-    return RemoteExistential(
-        RemoteAddress(*InstanceMetadataAddress),
-        RemoteAddress(InstanceAddress),
-        isBridged);
+    return RemoteExistential(*InstanceMetadataAddress, InstanceAddress,
+                             isBridged);
   }
 
   /// Given a known-opaque existential, attempt to discover the pointer to its
@@ -783,10 +780,11 @@ public:
     // OpaqueExistentialContainer is the layout of an opaque existential.
     // `Type` is the pointer to the metadata.
     TargetOpaqueExistentialContainer<Runtime> Container;
-    if (!Reader->readBytes(RemoteAddress(ExistentialAddress),
-                           (uint8_t *)&Container, sizeof(Container)))
+    if (!Reader->readBytes(ExistentialAddress, (uint8_t *)&Container,
+                           sizeof(Container)))
       return std::nullopt;
-    auto MetadataAddress = static_cast<StoredPointer>(Container.Type);
+    auto MetadataAddress =
+        RemoteAddress(Container.Type, ExistentialAddress.getAddressSpace());
     auto Metadata = readMetadata(MetadataAddress);
     if (!Metadata)
       return std::nullopt;
@@ -798,20 +796,19 @@ public:
     // Inline representation (the value fits in the existential container).
     // So, the value starts at the first word of the container.
     if (VWT->isValueInline())
-      return RemoteExistential(RemoteAddress(MetadataAddress),
-                               ExistentialAddress);
+      return RemoteExistential(MetadataAddress, ExistentialAddress);
 
     // Non-inline (box'ed) representation.
     // The first word of the container stores the address to the box.
-    StoredPointer BoxAddress;
-    if (!Reader->readInteger(ExistentialAddress, &BoxAddress))
+    RemoteAddress BoxAddress;
+    if (!Reader->readRemoteAddress<StoredPointer>(ExistentialAddress,
+                                                  BoxAddress))
       return std::nullopt;
 
     auto AlignmentMask = VWT->getAlignmentMask();
     auto Offset = (sizeof(HeapObject) + AlignmentMask) & ~AlignmentMask;
     auto StartOfValue = BoxAddress + Offset;
-    return RemoteExistential(RemoteAddress(MetadataAddress),
-                             RemoteAddress(StartOfValue));
+    return RemoteExistential(MetadataAddress, StartOfValue);
   }
 
   /// Given a known-opaque existential, discover if its value is inlined in
@@ -821,10 +818,12 @@ public:
     // OpaqueExistentialContainer is the layout of an opaque existential.
     // `Type` is the pointer to the metadata.
     TargetOpaqueExistentialContainer<Runtime> Container;
-    if (!Reader->readBytes(RemoteAddress(ExistentialAddress),
-                           (uint8_t *)&Container, sizeof(Container)))
+    if (!Reader->readBytes(ExistentialAddress, (uint8_t *)&Container,
+                           sizeof(Container)))
       return std::nullopt;
-    auto MetadataAddress = static_cast<StoredPointer>(Container.Type);
+    auto MetadataAddress =
+        RemoteAddress(Container.Type, ExistentialAddress.getAddressSpace());
+
     auto Metadata = readMetadata(MetadataAddress);
     if (!Metadata)
       return std::nullopt;
@@ -837,11 +836,10 @@ public:
   }
 
   /// Read a protocol from a reference to said protocol.
-  template<typename Resolver>
+  template <typename Resolver>
   typename Resolver::Result readProtocol(
-      const TargetProtocolDescriptorRef<Runtime> &ProtocolAddress,
-      Demangler &dem,
-      Resolver resolver) {
+      const RemoteTargetProtocolDescriptorRef<Runtime> &ProtocolAddress,
+      Demangler &dem, Resolver resolver) {
 #if SWIFT_OBJC_INTEROP
     if (Runtime::ObjCInterop) {
       // Check whether we have an Objective-C protocol.
@@ -877,8 +875,7 @@ public:
 #endif
 
     // Swift-native protocol.
-    auto Demangled =
-      readDemanglingForContextDescriptor(
+    auto Demangled = readDemanglingForContextDescriptor(
         stripSignedPointer({ProtocolAddress.getSwiftProtocol()}), dem);
     if (!Demangled)
       return resolver.failure();
@@ -888,10 +885,10 @@ public:
 
   /// Given a remote pointer to metadata, attempt to turn it into a type.
   BuiltType
-  readTypeFromMetadata(StoredPointer MetadataAddress,
+  readTypeFromMetadata(RemoteAddress MetadataAddress,
                        bool skipArtificialSubclasses = false,
                        int recursion_limit = defaultTypeRecursionLimit) {
-    std::pair<StoredPointer, bool> TypeCacheKey(MetadataAddress,
+    std::pair<RemoteAddress, bool> TypeCacheKey(MetadataAddress,
                                                 skipArtificialSubclasses);
     auto Cached = TypeCache.find(TypeCacheKey);
     if (Cached != TypeCache.end())
@@ -934,17 +931,20 @@ public:
 
       for (unsigned i = 0, n = tupleMeta->NumElements; i != n; ++i) {
         auto &element = tupleMeta->getElement(i);
-        if (auto elementType =
-                readTypeFromMetadata(element.Type, false, recursion_limit))
+        auto elementTypeAddress =
+            RemoteAddress(element.Type, MetadataAddress.getAddressSpace());
+        if (auto elementType = readTypeFromMetadata(elementTypeAddress, false,
+                                                    recursion_limit))
           elementTypes.push_back(elementType);
         else
           return BuiltType();
       }
 
       // Read the labels string.
+      auto labelAddress =
+          RemoteAddress(tupleMeta->Labels, MetadataAddress.getAddressSpace());
       std::string labelStr;
-      if (tupleMeta->Labels &&
-          !Reader->readString(RemoteAddress(tupleMeta->Labels), labelStr))
+      if (labelAddress && !Reader->readString(labelAddress, labelStr))
         return BuiltType();
 
       std::vector<llvm::StringRef> labels;
@@ -970,8 +970,10 @@ public:
 
       std::vector<FunctionParam<BuiltType>> Parameters;
       for (unsigned i = 0, n = Function->getNumParameters(); i != n; ++i) {
-        auto ParamTypeRef = readTypeFromMetadata(Function->getParameter(i),
-                                                 false, recursion_limit);
+        auto paramAddress = RemoteAddress(Function->getParameter(i),
+                                          MetadataAddress.getAddressSpace());
+        auto ParamTypeRef =
+            readTypeFromMetadata(paramAddress, false, recursion_limit);
         if (!ParamTypeRef)
           return BuiltType();
 
@@ -981,8 +983,10 @@ public:
         Parameters.push_back(std::move(Param));
       }
 
+      auto resultTypeAddress = RemoteAddress(Function->ResultType,
+                                             MetadataAddress.getAddressSpace());
       auto Result =
-          readTypeFromMetadata(Function->ResultType, false, recursion_limit);
+          readTypeFromMetadata(resultTypeAddress, false, recursion_limit);
       if (!Result)
         return BuiltType();
 
@@ -994,8 +998,10 @@ public:
 
       BuiltType globalActor = BuiltType();
       if (Function->hasGlobalActor()) {
-        globalActor = readTypeFromMetadata(Function->getGlobalActor(), false,
-                                           recursion_limit);
+        auto globalActorAddress = RemoteAddress(
+            Function->getGlobalActor(), MetadataAddress.getAddressSpace());
+        globalActor =
+            readTypeFromMetadata(globalActorAddress, false, recursion_limit);
         if (!globalActor)
           return BuiltType();
       }
@@ -1017,8 +1023,10 @@ public:
 
       BuiltType thrownError = BuiltType();
       if (Function->hasThrownError()) {
-        thrownError = readTypeFromMetadata(Function->getThrownError(), false,
-                                           recursion_limit);
+        auto thrownErrorAddress = RemoteAddress(
+            Function->getThrownError(), MetadataAddress.getAddressSpace());
+        thrownError =
+            readTypeFromMetadata(thrownErrorAddress, false, recursion_limit);
         if (!thrownError)
           return BuiltType();
       }
@@ -1037,9 +1045,12 @@ public:
 
       BuiltType SuperclassType = BuiltType();
       if (Exist->Flags.hasSuperclassConstraint()) {
+        auto superclassContraintAddress =
+            RemoteAddress(Exist->getSuperclassConstraint(),
+                          MetadataAddress.getAddressSpace());
         // The superclass is stored after the list of protocols.
-        SuperclassType = readTypeFromMetadata(Exist->getSuperclassConstraint(),
-                                              false, recursion_limit);
+        SuperclassType = readTypeFromMetadata(superclassContraintAddress, false,
+                                              recursion_limit);
         if (!SuperclassType) return BuiltType();
 
         HasExplicitAnyObject = true;
@@ -1069,7 +1080,10 @@ public:
       Demangler dem;
       std::vector<BuiltProtocolDecl> Protocols;
       for (auto ProtocolAddress : Exist->getProtocols()) {
-        if (auto Protocol = readProtocol(ProtocolAddress, dem, resolver))
+        auto ProtocolRef = RemoteTargetProtocolDescriptorRef<Runtime>(
+            RemoteAddress(ProtocolAddress.getRawData(),
+                          MetadataAddress.getAddressSpace()));
+        if (auto Protocol = readProtocol(ProtocolRef, dem, resolver))
           Protocols.push_back(Protocol);
         else
           return BuiltType();
@@ -1083,7 +1097,7 @@ public:
       auto Exist = cast<TargetExtendedExistentialTypeMetadata<Runtime>>(Meta);
 
       // Read the shape for this existential.
-      StoredPointer shapeAddress = stripSignedPointer(Exist->Shape);
+      RemoteAddress shapeAddress = stripSignedPointer(Exist->Shape);
       ShapeRef Shape = readShape(shapeAddress);
       if (!Shape)
         return BuiltType();
@@ -1095,7 +1109,10 @@ public:
       std::vector<BuiltType> builtArgs;
       for (unsigned i = 0; i < shapeArgumentCount; ++i) {
         auto remoteArg = Exist->getGeneralizationArguments()[i];
-        auto builtArg = readTypeFromMetadata(remoteArg, false, recursion_limit);
+        auto remoteArgAddress =
+            RemoteAddress(remoteArg, MetadataAddress.getAddressSpace());
+        auto builtArg =
+            readTypeFromMetadata(remoteArgAddress, false, recursion_limit);
         if (!builtArg)
           return BuiltType();
         builtArgs.push_back(builtArg);
@@ -1105,8 +1122,8 @@ public:
       Demangler dem;
       auto mangledExistentialAddr =
           resolveRelativeField(Shape, Shape->ExistentialType);
-      auto node = readMangledName(RemoteAddress(mangledExistentialAddr),
-                                  MangledNameKind::Type, dem);
+      auto node =
+          readMangledName(mangledExistentialAddr, MangledNameKind::Type, dem);
       if (!node)
         return BuiltType();
 
@@ -1140,8 +1157,8 @@ public:
         auto mangledContextName = Shape->getTypeExpression();
         auto mangledNameAddress =
             resolveRelativeField(Shape, mangledContextName->name);
-        auto node = readMangledName(RemoteAddress(mangledNameAddress),
-                                    MangledNameKind::Type, dem);
+        auto node =
+            readMangledName(mangledNameAddress, MangledNameKind::Type, dem);
         if (!node)
           return BuiltType();
 
@@ -1160,8 +1177,10 @@ public:
 
     case MetadataKind::Metatype: {
       auto Metatype = cast<TargetMetatypeMetadata<Runtime>>(Meta);
+      auto InstanceTypeAddress = RemoteAddress(
+          Metatype->InstanceType, MetadataAddress.getAddressSpace());
       auto Instance =
-          readTypeFromMetadata(Metatype->InstanceType, false, recursion_limit);
+          readTypeFromMetadata(InstanceTypeAddress, false, recursion_limit);
       if (!Instance) return BuiltType();
       auto BuiltMetatype = Builder.createMetatypeType(Instance);
       TypeCache[TypeCacheKey] = BuiltMetatype;
@@ -1169,7 +1188,8 @@ public:
     }
     case MetadataKind::ObjCClassWrapper: {
       auto objcWrapper = cast<TargetObjCClassWrapperMetadata<Runtime>>(Meta);
-      auto classAddress = objcWrapper->Class;
+      auto classAddress =
+          RemoteAddress(objcWrapper->Class, MetadataAddress.getAddressSpace());
 
       std::string className;
       if (!readObjCClassName(classAddress, className))
@@ -1181,8 +1201,10 @@ public:
     }
     case MetadataKind::ExistentialMetatype: {
       auto Exist = cast<TargetExistentialMetatypeMetadata<Runtime>>(Meta);
+      auto classAddress =
+          RemoteAddress(Exist->InstanceType, MetadataAddress.getAddressSpace());
       auto Instance =
-          readTypeFromMetadata(Exist->InstanceType, false, recursion_limit);
+          readTypeFromMetadata(classAddress, false, recursion_limit);
       if (!Instance) return BuiltType();
       auto BuiltExist = Builder.createExistentialMetatypeType(Instance);
       TypeCache[TypeCacheKey] = BuiltExist;
@@ -1263,8 +1285,13 @@ public:
       switch (req.Flags.getKind()) {
       case GenericRequirementKind::SameType: {
         Demangler rdem;
+        // FIXME: This should not work since the mangled name pointer is on the
+        // local process.
+        auto mangledNameAddress =
+            RemoteAddress((uint64_t)req.getMangledTypeName().data(),
+                          RemoteAddress::DefaultAddressSpace);
         auto demangledConstraint =
-            demangle(RemoteRef<char>(req.getMangledTypeName().data(),
+            demangle(RemoteRef<char>(mangledNameAddress,
                                      req.getMangledTypeName().data()),
                      MangledNameKind::Type, rdem);
         auto constraintType = decodeMangledType(demangledConstraint);
@@ -1305,7 +1332,9 @@ public:
         Demangler dem;
         auto protocolAddress =
             resolveRelativeIndirectProtocol(contextRef, req.Protocol);
-        auto protocol = readProtocol(protocolAddress, dem, resolver);
+        auto protocolRef =
+            RemoteTargetProtocolDescriptorRef<Runtime>(protocolAddress);
+        auto protocol = readProtocol(protocolRef, dem, resolver);
         if (!protocol) {
           return TypeLookupError("Failed to read protocol type in conformance "
                                  "requirement of runtime generic signature.");
@@ -1317,8 +1346,13 @@ public:
       }
       case GenericRequirementKind::BaseClass: {
         Demangler rdem;
+        // FIXME: This should not work since the mangled name pointer is on the
+        // local process.
+        auto mangledNameAddress =
+            RemoteAddress((uint64_t)req.getMangledTypeName().data(),
+                          RemoteAddress::DefaultAddressSpace);
         auto demangledConstraint =
-            demangle(RemoteRef<char>(req.getMangledTypeName().data(),
+            demangle(RemoteRef<char>(mangledNameAddress,
                                      req.getMangledTypeName().data()),
                      MangledNameKind::Type, rdem);
         auto constraintType = decodeMangledType(demangledConstraint);
@@ -1366,14 +1400,13 @@ public:
       if (address.getOffset() == 0)
         return ParentContextDescriptorRef(address.getSymbol());
     }
-    
+
     return ParentContextDescriptorRef(
-          readContextDescriptor(address.getResolvedAddress().getAddressData()));
+        readContextDescriptor(address.getResolvedAddress()));
   }
 
-  ShapeRef
-  readShape(StoredPointer address) {
-    if (address == 0)
+  ShapeRef readShape(RemoteAddress address) {
+    if (!address)
       return nullptr;
 
     auto cached = ShapeCache.find(address);
@@ -1383,8 +1416,7 @@ public:
             cached->second.get()));
 
     ExtendedExistentialTypeShapeFlags flags;
-    if (!Reader->readBytes(RemoteAddress(address), (uint8_t*)&flags,
-                           sizeof(flags)))
+    if (!Reader->readBytes(address, (uint8_t *)&flags, sizeof(flags)))
       return nullptr;
 
     // Read the size of the requirement signature.
@@ -1394,8 +1426,7 @@ public:
       GenericContextDescriptorHeader header;
       auto headerAddr = address + sizeof(flags);
 
-      if (!Reader->readBytes(RemoteAddress(headerAddr),
-                             (uint8_t*)&header, sizeof(header)))
+      if (!Reader->readBytes(headerAddr, (uint8_t *)&header, sizeof(header)))
         return nullptr;
 
       reqSigGenericSize = reqSigGenericSize
@@ -1413,7 +1444,7 @@ public:
                     reqSigGenericSize;
     if (size > MaxMetadataSize)
       return nullptr;
-    auto readResult = Reader->readBytes(RemoteAddress(address), size);
+    auto readResult = Reader->readBytes(address, size);
     if (!readResult)
       return nullptr;
 
@@ -1427,22 +1458,21 @@ public:
   }
 
   /// Given the address of a context descriptor, attempt to read it.
-  ContextDescriptorRef
-  readContextDescriptor(StoredPointer address) {
-    if (address == 0)
+  ContextDescriptorRef readContextDescriptor(RemoteAddress remoteAddress) {
+    if (!remoteAddress)
       return nullptr;
 
-    auto remoteAddress = RemoteAddress(address);
     auto ptr = Reader->readBytes(remoteAddress,
                                  sizeof(TargetContextDescriptor<Runtime>));
     if (!ptr)
       return nullptr;
 
-    auto cached = ContextDescriptorCache.find(address);
+    auto cached = ContextDescriptorCache.find(remoteAddress);
     if (cached != ContextDescriptorCache.end())
       return ContextDescriptorRef(
-          address, reinterpret_cast<const TargetContextDescriptor<Runtime> *>(
-                       cached->second.get()));
+          remoteAddress,
+          reinterpret_cast<const TargetContextDescriptor<Runtime> *>(
+              cached->second.get()));
 
     bool success = false;
     switch (
@@ -1492,8 +1522,9 @@ public:
 
     auto *descriptor =
         reinterpret_cast<const TargetContextDescriptor<Runtime> *>(ptr.get());
-    ContextDescriptorCache.insert(std::make_pair(address, std::move(ptr)));
-    return ContextDescriptorRef(address, descriptor);
+    ContextDescriptorCache.insert(
+        std::make_pair(remoteAddress, std::move(ptr)));
+    return ContextDescriptorRef(remoteAddress, descriptor);
   }
 
   template <typename DescriptorTy>
@@ -1606,19 +1637,17 @@ public:
   /// Read a context descriptor from the given address and build a mangling
   /// tree representing it.
   Demangle::NodePointer
-  readDemanglingForContextDescriptor(StoredPointer contextAddress,
+  readDemanglingForContextDescriptor(RemoteAddress contextAddress,
                                      Demangler &Dem) {
     auto context = readContextDescriptor(contextAddress);
     if (!context)
       return nullptr;
     return buildContextMangling(context, Dem);
   }
-  
+
   /// Read the mangled underlying type from an opaque type descriptor.
-  Demangle::NodePointer
-  readUnderlyingTypeManglingForOpaqueTypeDescriptor(StoredPointer contextAddr,
-                                                    unsigned ordinal,
-                                                    Demangler &Dem) {
+  Demangle::NodePointer readUnderlyingTypeManglingForOpaqueTypeDescriptor(
+      RemoteAddress contextAddr, unsigned ordinal, Demangler &Dem) {
     auto context = readContextDescriptor(contextAddr);
     if (!context)
       return nullptr;
@@ -1634,13 +1663,12 @@ public:
     
     auto nameAddr = resolveRelativeField(context,
                      opaqueType->getUnderlyingTypeArgumentMangledName(ordinal));
-    
-    return readMangledName(RemoteAddress(nameAddr),
-                                MangledNameKind::Type, Dem);
+
+    return readMangledName(nameAddr, MangledNameKind::Type, Dem);
   }
 
   TypeLookupErrorOr<typename BuilderType::BuiltType>
-  readUnderlyingTypeForOpaqueTypeDescriptor(StoredPointer contextAddr,
+  readUnderlyingTypeForOpaqueTypeDescriptor(RemoteAddress contextAddr,
                                             unsigned ordinal) {
     Demangle::Demangler Dem;
     auto node = readUnderlyingTypeManglingForOpaqueTypeDescriptor(contextAddr,
@@ -1650,31 +1678,33 @@ public:
     return decodeMangledType(node);
   }
 
-  bool isTaggedPointer(StoredPointer objectAddress) {
+  bool isTaggedPointer(RemoteAddress objectAddress) {
     if (getTaggedPointerEncoding() != TaggedPointerEncodingKind::Extended)
       return false;
-  
-    return (objectAddress ^ TaggedPointerObfuscator) & TaggedPointerMask;
+
+    return (bool)((objectAddress ^ TaggedPointerObfuscator) &
+                  TaggedPointerMask);
   }
 
   /// Read the isa pointer of an Object-C tagged pointer value.
-  std::optional<StoredPointer>
-  readMetadataFromTaggedPointer(StoredPointer objectAddress) {
+  std::optional<RemoteAddress>
+  readMetadataFromTaggedPointer(RemoteAddress objectAddress) {
     auto readArrayElement =
-        [&](StoredPointer base,
-            StoredPointer tag) -> std::optional<StoredPointer> {
-      StoredPointer addr = base + tag * sizeof(StoredPointer);
-      StoredPointer isa;
-      if (!Reader->readInteger(RemoteAddress(addr), &isa))
+        [&](RemoteAddress base,
+            StoredPointer tag) -> std::optional<RemoteAddress> {
+      RemoteAddress addr = base + tag * sizeof(StoredPointer);
+      RemoteAddress isa;
+      if (!Reader->readRemoteAddress<StoredPointer>(addr, isa))
         return std::nullopt;
       return isa;
     };
 
     // Extended pointers have a tag of 0b111, using 8 additional bits
     // to specify the class.
-    if (TaggedPointerExtendedMask != 0 &&
-        (((objectAddress ^ TaggedPointerObfuscator) & TaggedPointerExtendedMask)
-           == TaggedPointerExtendedMask)) {
+    if (TaggedPointerExtendedMask &&
+        ((((StoredPointer)objectAddress.getRawAddress() ^
+           TaggedPointerObfuscator) &
+          TaggedPointerExtendedMask) == TaggedPointerExtendedMask)) {
       auto tag = ((objectAddress >> TaggedPointerExtendedSlotShift) &
                   TaggedPointerExtendedSlotMask);
       return readArrayElement(TaggedPointerExtendedClasses, tag);
@@ -1688,13 +1718,13 @@ public:
 
   /// Read the isa pointer of a class or closure context instance and apply
   /// the isa mask.
-  std::optional<StoredPointer>
-  readMetadataFromInstance(StoredPointer objectAddress) {
+  std::optional<RemoteAddress>
+  readMetadataFromInstance(RemoteAddress objectAddress) {
     if (isTaggedPointer(objectAddress))
       return readMetadataFromTaggedPointer(objectAddress);
 
-    StoredPointer isa;
-    if (!Reader->readInteger(RemoteAddress(objectAddress), &isa))
+    RemoteAddress isa;
+    if (!Reader->readRemoteAddress<StoredPointer>(objectAddress, isa))
       return std::nullopt;
 
     switch (getIsaEncoding()) {
@@ -1711,11 +1741,12 @@ public:
     case IsaEncodingKind::Indexed: {
       // If applying the magic mask doesn't give us the magic value,
       // it's not an indexed isa.
-      if ((isa & IsaMagicMask) != IsaMagicValue)
+      if (((StoredPointer)(isa & IsaMagicMask).getRawAddress()) !=
+          IsaMagicValue)
         return isa;
 
       // Extract the index.
-      auto classIndex = (isa & IsaIndexMask) >> IsaIndexShift;
+      StoredPointer classIndex = (isa & IsaIndexMask) >> IsaIndexShift;
 
       // 0 is never a valid index.
       if (classIndex == 0) {
@@ -1741,10 +1772,10 @@ public:
       RemoteAddress eltPointer =
         RemoteAddress(IndexedClassesPointer
                         + classIndex * sizeof(StoredPointer));
-      StoredPointer metadataPointer;
-      if (!Reader->readInteger(eltPointer, &metadataPointer)) {
+      RemoteAddress metadataPointer;
+      if (!Reader->readRemoteAddress<StoredPointer>(eltPointer,
+                                                    metadataPointer))
         return std::nullopt;
-      }
 
       return metadataPointer;
     }
@@ -1845,7 +1876,7 @@ public:
 
             return cls->getClassBoundsAsSwiftSuperclass();
           },
-          [](StoredPointer objcClassName)
+          [](RemoteAddress objcClassName)
               -> std::optional<ClassMetadataBounds> {
             // We have no ability to look up an ObjC class by name.
             // FIXME: add a query for this; clients may have a way to do it.
@@ -1863,14 +1894,14 @@ public:
   template <class Result, class DescriptorFn, class MetadataFn,
             class ClassNameFn>
   std::optional<Result> forTypeReference(TypeReferenceKind refKind,
-                                         StoredPointer ref,
+                                         RemoteAddress ref,
                                          const DescriptorFn &descriptorFn,
                                          const MetadataFn &metadataFn,
                                          const ClassNameFn &classNameFn) {
     switch (refKind) {
     case TypeReferenceKind::IndirectTypeDescriptor: {
       StoredSignedPointer descriptorAddress;
-      if (!Reader->readInteger(RemoteAddress(ref), &descriptorAddress)) {
+      if (!Reader->readInteger(ref, &descriptorAddress)) {
         return std::nullopt;
       }
 
@@ -1890,8 +1921,8 @@ public:
       return classNameFn(ref);
 
     case TypeReferenceKind::IndirectObjCClass: {
-      StoredPointer classRef = 0;
-      if (!Reader->readInteger(RemoteAddress(ref), &classRef))
+      RemoteAddress classRef;
+      if (!Reader->readRemoteAddress<StoredPointer>(ref, classRef))
         return std::nullopt;
 
       auto metadata = readMetadata(classRef);
@@ -1907,8 +1938,8 @@ public:
 
   /// Read a single generic type argument from a bound generic type
   /// metadata.
-  std::optional<StoredPointer>
-  readGenericArgFromMetadata(StoredPointer metadata, unsigned index) {
+  std::optional<RemoteAddress>
+  readGenericArgFromMetadata(RemoteAddress metadata, unsigned index) {
     auto Meta = readMetadata(metadata);
     if (!Meta)
       return std::nullopt;
@@ -1938,9 +1969,9 @@ public:
     if (index >= generics->getGenericContextHeader().getNumArguments())
       return std::nullopt;
 
-    StoredPointer genericArgAddress;
-    if (!Reader->readInteger(RemoteAddress(addressOfGenericArgAddress),
-                             &genericArgAddress))
+    RemoteAddress genericArgAddress;
+    if (!Reader->readRemoteAddress<StoredPointer>(addressOfGenericArgAddress,
+                                                  genericArgAddress))
       return std::nullopt;
 
     return genericArgAddress;
@@ -1948,7 +1979,7 @@ public:
 
   /// Given the address of a nominal type descriptor, attempt to resolve
   /// its nominal type declaration.
-  BuiltTypeDecl readNominalTypeFromDescriptor(StoredPointer address) {
+  BuiltTypeDecl readNominalTypeFromDescriptor(RemoteAddress address) {
     auto descriptor = readContextDescriptor(address);
     if (!descriptor)
       return BuiltTypeDecl();
@@ -1957,7 +1988,7 @@ public:
   }
 
   /// Try to read the offset of a tuple element from a tuple metadata.
-  bool readTupleElementOffset(StoredPointer metadataAddress, unsigned eltIndex,
+  bool readTupleElementOffset(RemoteAddress metadataAddress, unsigned eltIndex,
                               StoredSize *offset) {
     // Read the metadata.
     auto metadata = readMetadata(metadataAddress);
@@ -1981,7 +2012,7 @@ public:
 
   /// Given a remote pointer to class metadata, attempt to read its superclass.
   std::optional<StoredPointer>
-  readOffsetToFirstCaptureFromMetadata(StoredPointer MetadataAddress) {
+  readOffsetToFirstCaptureFromMetadata(RemoteAddress MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::HeapLocalVariable)
       return std::nullopt;
@@ -1990,15 +2021,15 @@ public:
     return heapMeta->OffsetToFirstCapture;
   }
 
-  std::optional<RemoteAbsolutePointer> readPointer(StoredPointer address) {
-    return Reader->readPointer(RemoteAddress(address), sizeof(StoredPointer));
+  std::optional<RemoteAbsolutePointer> readPointer(RemoteAddress address) {
+    return Reader->readPointer(address, sizeof(StoredPointer));
   }
 
-  std::optional<StoredPointer> readResolvedPointerValue(StoredPointer address) {
+  std::optional<RemoteAddress> readResolvedPointerValue(RemoteAddress address) {
     if (auto pointer = readPointer(address)) {
       if (!pointer->getResolvedAddress())
         return std::nullopt;
-      return (StoredPointer)pointer->getResolvedAddress().getAddressData();
+      return pointer->getResolvedAddress();
     }
     return std::nullopt;
   }
@@ -2007,13 +2038,13 @@ public:
   RemoteAbsolutePointer resolvePointerField(RemoteRef<T> base,
                                             const U &field) {
     auto pointerRef = base.getField(field);
-    return Reader->resolvePointer(RemoteAddress(getAddress(pointerRef)),
+    return Reader->resolvePointer(getAddress(pointerRef),
                                   *pointerRef.getLocalBuffer());
   }
 
   /// Given a remote pointer to class metadata, attempt to read its superclass.
   std::optional<RemoteAbsolutePointer>
-  readCaptureDescriptorFromMetadata(StoredPointer MetadataAddress) {
+  readCaptureDescriptorFromMetadata(RemoteAddress MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::HeapLocalVariable)
       return std::nullopt;
@@ -2023,15 +2054,14 @@ public:
   }
 
 protected:
-  template<typename Base>
-  StoredPointer getAddress(RemoteRef<Base> base) {
-    return (StoredPointer)base.getAddressData();
+  template <typename Base>
+  RemoteAddress getAddress(RemoteRef<Base> base) {
+    return base.getRemoteAddress();
   }
-  
-  template<typename Base, typename Field>
-  StoredPointer resolveRelativeField(
-                            RemoteRef<Base> base, const Field &field) {
-    return (StoredPointer)base.resolveRelativeFieldData(field);
+
+  template <typename Base, typename Field>
+  RemoteAddress resolveRelativeField(RemoteRef<Base> base, const Field &field) {
+    return base.resolveRelativeFieldData(field);
   }
 
   template <typename Base, typename Field>
@@ -2047,9 +2077,9 @@ protected:
     offset &= ~1u;
     
     using SignedPointer = typename std::make_signed<StoredPointer>::type;
-    
-    StoredPointer resultAddress = getAddress(fieldRef) + (SignedPointer)offset;
-    
+
+    RemoteAddress resultAddress = getAddress(fieldRef) + (SignedPointer)offset;
+
     // Low bit set in the offset indicates that the offset leads to the absolute
     // address in memory.
     if (indirect) {
@@ -2058,16 +2088,16 @@ protected:
       }
       return std::nullopt;
     }
-    
-    return RemoteAbsolutePointer(RemoteAddress(resultAddress));
+
+    return RemoteAbsolutePointer(resultAddress);
   }
 
   /// Given a pointer to an Objective-C class, try to read its class name.
-  bool readObjCClassName(StoredPointer classAddress, std::string &className) {
+  bool readObjCClassName(RemoteAddress classAddress, std::string &className) {
     // The following algorithm only works on the non-fragile Apple runtime.
 
     // Grab the RO-data pointer.  This part is not ABI.
-    StoredPointer roDataPtr = readObjCRODataPtr(classAddress);
+    RemoteAddress roDataPtr = readObjCRODataPtr(classAddress);
     if (!roDataPtr) return false;
 
     // This is ABI.
@@ -2076,18 +2106,19 @@ protected:
       + sizeof(StoredPointer);
 
     // Read the name pointer.
-    StoredPointer namePtr;
-    if (!Reader->readInteger(RemoteAddress(roDataPtr + OffsetToName), &namePtr))
+    RemoteAddress namePtr;
+    if (!Reader->readRemoteAddress<StoredPointer>(roDataPtr + OffsetToName,
+                                                  namePtr))
       return false;
 
     // If the name pointer is null, treat that as an error.
     if (!namePtr)
       return false;
 
-    return Reader->readString(RemoteAddress(namePtr), className);
+    return Reader->readString(namePtr, className);
   }
 
-  MetadataRef readMetadata(StoredPointer address) {
+  MetadataRef readMetadata(RemoteAddress address) {
     auto cached = MetadataCache.find(address);
     if (cached != MetadataCache.end())
       return MetadataRef(address,
@@ -2095,7 +2126,7 @@ protected:
                              cached->second.get()));
 
     StoredPointer KindValue = 0;
-    if (!Reader->readInteger(RemoteAddress(address), &KindValue))
+    if (!Reader->readInteger(address, &KindValue))
       return nullptr;
 
     switch (getEnumeratedMetadataKind(KindValue)) {
@@ -2108,20 +2139,17 @@ protected:
       case MetadataKind::ErrorObject:
         return _readMetadata<TargetEnumMetadata>(address);
       case MetadataKind::Existential: {
-        StoredPointer flagsAddress = address +
-          sizeof(StoredPointer);
+        RemoteAddress flagsAddress = address + sizeof(StoredPointer);
 
         ExistentialTypeFlags::int_type flagsData;
-        if (!Reader->readInteger(RemoteAddress(flagsAddress),
-                                 &flagsData))
+        if (!Reader->readInteger(flagsAddress, &flagsData))
           return nullptr;
 
         ExistentialTypeFlags flags(flagsData);
 
-        StoredPointer numProtocolsAddress = flagsAddress + sizeof(flagsData);
+        RemoteAddress numProtocolsAddress = flagsAddress + sizeof(flagsData);
         uint32_t numProtocols;
-        if (!Reader->readInteger(RemoteAddress(numProtocolsAddress),
-                                 &numProtocols))
+        if (!Reader->readInteger(numProtocolsAddress, &numProtocols))
           return nullptr;
 
         // Make sure the number of protocols is reasonable
@@ -2142,9 +2170,10 @@ protected:
       case MetadataKind::ExtendedExistential: {
         // We need to read the shape in order to figure out how large
         // the generalization arguments are.
-        StoredPointer shapeAddress = address + sizeof(StoredPointer);
-        StoredSignedPointer signedShapePtr;
-        if (!Reader->readInteger(RemoteAddress(shapeAddress), &signedShapePtr))
+        RemoteAddress shapeAddress = address + sizeof(StoredPointer);
+        RemoteAddress signedShapePtr;
+        if (!Reader->readRemoteAddress<StoredPointer>(shapeAddress,
+                                                      signedShapePtr))
           return nullptr;
         auto shapePtr = stripSignedPointer(signedShapePtr);
 
@@ -2166,7 +2195,7 @@ protected:
         StoredSize flagsValue;
         auto flagsAddr =
             address + TargetFunctionTypeMetadata<Runtime>::OffsetToFlags;
-        if (!Reader->readInteger(RemoteAddress(flagsAddr), &flagsValue))
+        if (!Reader->readInteger(flagsAddr, &flagsValue))
           return nullptr;
 
         auto flags =
@@ -2203,8 +2232,7 @@ protected:
         auto numElementsAddress = address +
           TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements();
         StoredSize numElements;
-        if (!Reader->readInteger(RemoteAddress(numElementsAddress),
-                                 &numElements))
+        if (!Reader->readInteger(numElementsAddress, &numElements))
           return nullptr;
         auto totalSize = sizeof(TargetTupleTypeMetadata<Runtime>) +
                          numElements * sizeof(TupleTypeMetadata::Element);
@@ -2225,7 +2253,7 @@ protected:
     return nullptr;
   }
 
-  StoredPointer
+  RemoteAddress
   readAddressOfNominalTypeDescriptor(MetadataRef &metadata,
                                      bool skipArtificialSubclasses = false) {
     switch (metadata->getKind()) {
@@ -2233,28 +2261,29 @@ protected:
       auto classMeta = cast<TargetClassMetadata>(metadata);
       while (true) {
         if (!classMeta->isTypeMetadata())
-          return 0;
+          return RemoteAddress();
 
         StoredSignedPointer descriptorAddressSigned = classMeta->getDescriptionAsSignedPointer();
-        StoredPointer descriptorAddress = stripSignedPointer(descriptorAddressSigned);
+        RemoteAddress descriptorAddress =
+            stripSignedPointer(descriptorAddressSigned);
 
         // If this class has a null descriptor, it's artificial,
         // and we need to skip it upon request.  Otherwise, we're done.
         if (descriptorAddress || !skipArtificialSubclasses)
-          return static_cast<StoredPointer>(descriptorAddress);
+          return descriptorAddress;
 
         auto superclassMetadataAddress =
             stripSignedPointer(classMeta->Superclass);
         if (!superclassMetadataAddress)
-          return 0;
+          return RemoteAddress();
 
         auto superMeta = readMetadata(superclassMetadataAddress);
         if (!superMeta)
-          return 0;
+          return RemoteAddress();
 
         auto superclassMeta = dyn_cast<TargetClassMetadata>(superMeta);
         if (!superclassMeta)
-          return 0;
+          return RemoteAddress();
 
         classMeta = superclassMeta;
         metadata = superMeta;
@@ -2266,39 +2295,42 @@ protected:
     case MetadataKind::Enum: {
       auto valueMeta = cast<TargetValueMetadata<Runtime>>(metadata);
       StoredSignedPointer descriptorAddressSigned = valueMeta->getDescriptionAsSignedPointer();
-      StoredPointer descriptorAddress = stripSignedPointer(descriptorAddressSigned);
+      RemoteAddress descriptorAddress =
+          stripSignedPointer(descriptorAddressSigned);
       return descriptorAddress;
     }
         
     case MetadataKind::ForeignClass: {
       auto foreignMeta = cast<TargetForeignClassMetadata<Runtime>>(metadata);
       StoredSignedPointer descriptorAddressSigned = foreignMeta->getDescriptionAsSignedPointer();
-      StoredPointer descriptorAddress = stripSignedPointer(descriptorAddressSigned);
+      RemoteAddress descriptorAddress =
+          stripSignedPointer(descriptorAddressSigned);
       return descriptorAddress;
     }
 
     case MetadataKind::ForeignReferenceType: {
       auto foreignMeta = cast<TargetForeignReferenceTypeMetadata<Runtime>>(metadata);
       StoredSignedPointer descriptorAddressSigned = foreignMeta->getDescriptionAsSignedPointer();
-      StoredPointer descriptorAddress = stripSignedPointer(descriptorAddressSigned);
+      RemoteAddress descriptorAddress =
+          stripSignedPointer(descriptorAddressSigned);
       return descriptorAddress;
     }
 
     default:
-      return 0;
+      return RemoteAddress();
     }
   }
 
 private:
   template <template <class R> class M>
-  MetadataRef _readMetadata(StoredPointer address) {
+  MetadataRef _readMetadata(RemoteAddress address) {
     return _readMetadata(address, sizeof(M<Runtime>));
   }
 
-  MetadataRef _readMetadata(StoredPointer address, size_t sizeAfter) {
+  MetadataRef _readMetadata(RemoteAddress address, size_t sizeAfter) {
     if (sizeAfter > MaxMetadataSize)
       return nullptr;
-    auto readResult = Reader->readBytes(RemoteAddress(address), sizeAfter);
+    auto readResult = Reader->readBytes(address, sizeAfter);
     if (!readResult)
       return nullptr;
 
@@ -2324,7 +2356,7 @@ private:
     auto addr = parentAddress->getResolvedAddress();
     if (!addr)
       return ParentContextDescriptorRef();
-    if (auto parentDescriptor = readContextDescriptor(addr.getAddressData()))
+    if (auto parentDescriptor = readContextDescriptor(addr))
       return ParentContextDescriptorRef(parentDescriptor);
     return std::nullopt;
   }
@@ -2352,7 +2384,7 @@ private:
     if (auto protoBuffer =
             dyn_cast<TargetProtocolDescriptor<Runtime>>(context)) {
       auto nameAddress = resolveRelativeField(descriptor, protoBuffer->Name);
-      if (Reader->readString(RemoteAddress(nameAddress), name))
+      if (Reader->readString(nameAddress, name))
         return name;
 
       return std::nullopt;
@@ -2362,7 +2394,7 @@ private:
     if (auto moduleBuffer =
             dyn_cast<TargetModuleContextDescriptor<Runtime>>(context)) {
       auto nameAddress = resolveRelativeField(descriptor, moduleBuffer->Name);
-      if (Reader->readString(RemoteAddress(nameAddress), name))
+      if (Reader->readString(nameAddress, name))
         return name;
 
       return std::nullopt;
@@ -2374,7 +2406,7 @@ private:
       return std::nullopt;
 
     auto nameAddress = resolveRelativeField(descriptor, typeBuffer->Name);
-    if (!Reader->readString(RemoteAddress(nameAddress), name))
+    if (!Reader->readString(nameAddress, name))
       return std::nullopt;
 
     // Read the TypeImportInfo if present.
@@ -2385,7 +2417,7 @@ private:
       while (true) {
         // Read the next string.
         std::string temp;
-        if (!Reader->readString(RemoteAddress(nameAddress), temp))
+        if (!Reader->readString(nameAddress, temp))
           return std::nullopt;
 
         // If we read an empty string, we're done.
@@ -2445,8 +2477,7 @@ private:
         return nullptr;
 
       // Move the address forward and add the next chunk.
-      currentAddress =
-        RemoteAddress(currentAddress.getAddressData() + chunk.size() + 1);
+      currentAddress = currentAddress + chunk.size() + 1;
       mangledName += std::move(chunk);
 
       // Scan through the mangled name to skip over symbolic references.
@@ -2480,7 +2511,7 @@ private:
       // We're done.
       break;
     }
-    return demangle(address.getAddressData(), mangledName, kind, dem);
+    return demangle(address, mangledName, kind, dem);
   }
 
   /// Read and demangle the name of an anonymous context.
@@ -2497,9 +2528,7 @@ private:
     auto mangledContextName = anonymousBuffer->getMangledContextName();
     auto mangledNameAddress = resolveRelativeField(contextRef,
                                                    mangledContextName->name);
-    return readMangledName(RemoteAddress(mangledNameAddress),
-                           MangledNameKind::Symbol,
-                           dem);
+    return readMangledName(mangledNameAddress, MangledNameKind::Symbol, dem);
   }
 
   /// If we have a context whose parent context is an anonymous context
@@ -2581,18 +2610,18 @@ private:
   /// Resolve a relative target protocol descriptor pointer, which uses
   /// the lowest bit to indicate an indirect vs. direct relative reference and
   /// the second lowest bit to indicate whether it is an Objective-C protocol.
-  template<typename Base>
-  StoredPointer resolveRelativeIndirectProtocol(
+  template <typename Base>
+  RemoteAddress resolveRelativeIndirectProtocol(
       RemoteRef<Base> descriptor,
       const RelativeTargetProtocolDescriptorPointer<Runtime> &protocol) {
     // Map the offset from within our local buffer to the remote address.
     auto distance = (intptr_t)&protocol - (intptr_t)descriptor.getLocalBuffer();
-    StoredPointer targetAddress(getAddress(descriptor) + distance);
+    RemoteAddress targetAddress(getAddress(descriptor) + distance);
 
     // Read the relative offset.
     int32_t relative;
-    if (!Reader->readInteger(RemoteAddress(targetAddress), &relative))
-      return StoredPointer();
+    if (!Reader->readInteger(targetAddress, &relative))
+      return RemoteAddress();
 
     // Collect and mask off the 'indirect' and 'isObjC' bits.
     bool indirect = relative & 1;
@@ -2603,15 +2632,14 @@ private:
     using SignedPointer = typename std::make_signed<StoredPointer>::type;
     auto signext = (SignedPointer)(int32_t)relative;
 
-    StoredPointer resultAddress = targetAddress + signext;
+    RemoteAddress resultAddress = targetAddress + signext;
 
     // Low bit set in the offset indicates that the offset leads to the absolute
     // address in memory.
     if (indirect) {
-      if (!Reader->readBytes(RemoteAddress(resultAddress),
-                             (uint8_t *)&resultAddress,
-                             sizeof(StoredPointer)))
-        return StoredPointer();
+      if (!Reader->readRemoteAddress<StoredPointer>(resultAddress,
+                                                    resultAddress))
+        return RemoteAddress();
     }
 
     // Add back the Objective-C bit.
@@ -2734,9 +2762,7 @@ private:
         resolveRelativeField(descriptor, extensionBuffer->ExtendedContext);
 
       auto demangledExtendedContext =
-        readMangledName(RemoteAddress(extendedContextAddress),
-                        MangledNameKind::Type,
-                        dem);
+          readMangledName(extendedContextAddress, MangledNameKind::Type, dem);
       if (!demangledExtendedContext)
         return nullptr;
 
@@ -2785,8 +2811,7 @@ private:
           // Demangle the subject.
           auto subjectAddress = resolveRelativeField(descriptor, req.Param);
           swift::Demangle::NodePointer subject =
-              readMangledName(RemoteAddress(subjectAddress),
-                              MangledNameKind::Type, dem);
+              readMangledName(subjectAddress, MangledNameKind::Type, dem);
           if (!subject) {
             failed = true;
             break;
@@ -2796,8 +2821,9 @@ private:
           case GenericRequirementKind::Protocol: {
             auto protocolAddress =
               resolveRelativeIndirectProtocol(descriptor, req.Protocol);
-            auto protocol = readProtocol(protocolAddress, dem,
-                                         protocolResolver);
+            auto protocolRef =
+                RemoteTargetProtocolDescriptorRef<Runtime>(protocolAddress);
+            auto protocol = readProtocol(protocolRef, dem, protocolResolver);
             if (!protocol) {
               failed = true;
               break;
@@ -2817,8 +2843,7 @@ private:
             // Demangle the right-hand type.
             auto typeAddress = resolveRelativeField(descriptor, req.Type);
             swift::Demangle::NodePointer type =
-                readMangledName(RemoteAddress(typeAddress),
-                                MangledNameKind::Type, dem);
+                readMangledName(typeAddress, MangledNameKind::Type, dem);
             if (!type) {
               failed = true;
               break;
@@ -2846,11 +2871,11 @@ private:
             // address.
             auto distance =
               (intptr_t)&req.Layout - (intptr_t)descriptor.getLocalBuffer();
-            StoredPointer targetAddress(getAddress(descriptor) + distance);
+            RemoteAddress targetAddress(getAddress(descriptor) + distance);
 
             GenericRequirementLayoutKind kind;
-            if (!Reader->readBytes(RemoteAddress(targetAddress),
-                                   (uint8_t *)&kind, sizeof(kind))) {
+            if (!Reader->readBytes(targetAddress, (uint8_t *)&kind,
+                                   sizeof(kind))) {
               failed = true;
               break;
             }
@@ -2885,10 +2910,10 @@ private:
     case ContextDescriptorKind::Anonymous: {
       // Use the remote address to identify the anonymous context.
       char addressBuf[18];
-      RemoteAddress address(descriptor.getAddressData());
+      RemoteAddress address(descriptor.getRemoteAddress());
       address = Reader->resolveRemoteAddress(address).value_or(address);
       snprintf(addressBuf, sizeof(addressBuf), "$%" PRIx64,
-               (uint64_t)address.getAddressData());
+               (uint64_t)descriptor.getRemoteAddress().getRawAddress());
       auto anonNode = dem.createNode(Node::Kind::AnonymousContext);
       CharVector addressStr;
       addressStr.append(addressBuf, dem);
@@ -2913,7 +2938,7 @@ private:
       auto nameAddress
         = resolveRelativeField(descriptor, moduleBuffer->Name);
       std::string moduleName;
-      if (!Reader->readString(RemoteAddress(nameAddress), moduleName))
+      if (!Reader->readString(nameAddress, moduleName))
         return nullptr;
 
       // The form of module contexts is a little different from other
@@ -3071,7 +3096,7 @@ private:
   }
 
 #if SWIFT_OBJC_INTEROP
-  std::string readObjCProtocolName(StoredPointer Address) {
+  std::string readObjCProtocolName(RemoteAddress Address) {
     auto Size = sizeof(TargetObjCProtocolPrefix<Runtime>);
     auto Buffer = (uint8_t *)malloc(Size);
     if (!Buffer)
@@ -3080,13 +3105,15 @@ private:
       free(Buffer);
     };
 
-    if (!Reader->readBytes(RemoteAddress(Address), Buffer, Size))
+    if (!Reader->readBytes(Address, Buffer, Size))
       return std::string();
 
     auto ProtocolDescriptor
       = reinterpret_cast<TargetObjCProtocolPrefix<Runtime> *>(Buffer);
+    auto NameAddress =
+        RemoteAddress(ProtocolDescriptor->Name, Address.getAddressSpace());
     std::string Name;
-    if (!Reader->readString(RemoteAddress(ProtocolDescriptor->Name), Name))
+    if (!Reader->readString(NameAddress, Name))
       return std::string();
 
     return Name;
@@ -3123,10 +3150,9 @@ private:
           if (numGenericArgs == 0)
             return {};
           --numGenericArgs;
-          
-          StoredPointer arg;
-          if (!Reader->readBytes(RemoteAddress(genericArgsAddr),
-                                 (uint8_t*)&arg, sizeof(arg))) {
+
+          RemoteAddress arg;
+          if (!Reader->readRemoteAddress<StoredPointer>(genericArgsAddr, arg)) {
             return {};
           }
           genericArgsAddr += sizeof(StoredPointer);
@@ -3249,17 +3275,16 @@ private:
 
   /// Given that the remote process is running the non-fragile Apple runtime,
   /// grab the ro-data from a class pointer.
-  StoredPointer readObjCRODataPtr(StoredPointer classAddress) {
+  RemoteAddress readObjCRODataPtr(RemoteAddress classAddress) {
     // WARNING: the following algorithm works on current modern Apple
     // runtimes but is not actually ABI.  But it is pretty reliable.
 
 #if SWIFT_OBJC_INTEROP
-    StoredPointer dataPtr;
-    if (!Reader->readInteger(
-            RemoteAddress(classAddress +
-                          TargetClassMetadataObjCInterop::offsetToData()),
-            &dataPtr))
-      return StoredPointer();
+    RemoteAddress dataPtr;
+    if (!Reader->readRemoteAddress<StoredPointer>(
+            classAddress + TargetClassMetadataObjCInterop::offsetToData(),
+            dataPtr))
+      return RemoteAddress();
 
     // Apply the data-pointer mask.
     // These values have been stolen from the runtime source.
@@ -3267,12 +3292,12 @@ private:
       (Runtime::PointerSize == 8 ? 0x00007ffffffffff8ULL : 0xfffffffcULL);
     dataPtr &= StoredPointer(DataPtrMask);
     if (!dataPtr)
-      return StoredPointer();
+      return RemoteAddress();
 
     // Read the flags, which is a 32-bit header on both formats.
     uint32_t flags;
-    if (!Reader->readInteger(RemoteAddress(dataPtr), &flags))
-      return StoredPointer();
+    if (!Reader->readInteger(dataPtr, &flags))
+      return RemoteAddress();
 
     // If the type is not realized, this is the RO-data.
     static constexpr uint32_t RO_REALIZED = 0x80000000U;
@@ -3283,22 +3308,22 @@ private:
     // well-known position within the RW-data.
     StoredSignedPointer signedDataPtr;
     static constexpr uint32_t OffsetToROPtr = 8;
-    if (!Reader->readInteger(RemoteAddress(dataPtr + OffsetToROPtr), &signedDataPtr))
-      return StoredPointer();
+    if (!Reader->readInteger(dataPtr + OffsetToROPtr, &signedDataPtr))
+      return RemoteAddress();
     dataPtr = stripSignedPointer(signedDataPtr);
 
     // Newer Objective-C runtimes implement a size optimization where the RO
     // field is a tagged union. If the low-bit is set, then the pointer needs
     // to be dereferenced once more to yield the real class_ro_t pointer.
     if (dataPtr & 1) {
-      if (!Reader->readInteger(RemoteAddress(dataPtr^1), &signedDataPtr))
-        return StoredPointer();
+      if (!Reader->readInteger(dataPtr ^ 1, &signedDataPtr))
+        return RemoteAddress();
       dataPtr = stripSignedPointer(signedDataPtr);
     }
 
     return dataPtr;
 #else
-    return StoredPointer();
+    return RemoteAddress();
 #endif
   }
 
@@ -3341,9 +3366,9 @@ private:
         tryFindAndReadSymbol(IsaIndexShift,
                              "objc_debug_indexed_isa_index_shift");
         tryFindSymbol(indexedClasses, "objc_indexed_classes");
-        IndexedClassesPointer = indexedClasses.getAddressData();
+        IndexedClassesPointer = indexedClasses;
         tryFindSymbol(indexedClassesCount, "objc_indexed_classes_count");
-        IndexedClassesCountPointer = indexedClassesCount.getAddressData();
+        IndexedClassesCountPointer = indexedClassesCount;
 
         return finish(IsaEncodingKind::Indexed);
       }
@@ -3409,8 +3434,8 @@ private:
                   "objc_debug_taggedpointer_classes");
     if (!TaggedPointerClassesAddr)
       finish(TaggedPointerEncodingKind::Error);
-    TaggedPointerClasses = TaggedPointerClassesAddr.getAddressData();
-    
+    TaggedPointerClasses = TaggedPointerClassesAddr;
+
     // Extended tagged pointers don't exist on older OSes. Handle those
     // by setting the variables to zero.
     tryFindAndReadSymbolWithDefault(TaggedPointerExtendedMask,
@@ -3425,15 +3450,12 @@ private:
     auto TaggedPointerExtendedClassesAddr =
       Reader->getSymbolAddress("objc_debug_taggedpointer_ext_classes");
     if (TaggedPointerExtendedClassesAddr)
-      TaggedPointerExtendedClasses =
-          TaggedPointerExtendedClassesAddr.getAddressData();
+      TaggedPointerExtendedClasses = TaggedPointerExtendedClassesAddr;
 
     // The tagged pointer obfuscator is not present on older OSes, in
     // which case we can treat it as zero.
     tryFindAndReadSymbolWithDefault(TaggedPointerObfuscator,
-                                    "objc_debug_taggedpointer_obfuscator",
-                                    0);
-    
+                                    "objc_debug_taggedpointer_obfuscator", 0);
 #   undef tryFindSymbol
 #   undef tryReadSymbol
 #   undef tryFindAndReadSymbol

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -416,11 +416,9 @@ public:
   }
 
   RemoteAbsolutePointer stripSignedPointer(const RemoteAbsolutePointer &P) {
-    if (P.isResolved()) {
-      return RemoteAbsolutePointer("", 
-        P.getResolvedAddress().getAddressData() & PtrAuthMask);
-    }
-    return P;
+    return RemoteAbsolutePointer(
+        P.getSymbol(), P.getOffset(),
+        RemoteAddress(P.getResolvedAddress().getAddressData() & PtrAuthMask));
   }
 
   StoredPointer queryPtrAuthMask() {
@@ -519,28 +517,12 @@ public:
         // The second entry is a relative address to the mangled protocol
         // without symbolic references.
 
-        // lldb might return an unresolved remote absolute pointer from its
-        // resolvePointerAsSymbol implementation -- workaround this.
-        if (!resolved.isResolved()) {
-          auto remoteAddr = RemoteAddress(remoteAddress);
-          resolved =
-            RemoteAbsolutePointer("", remoteAddr.getAddressData());
-        }
-
         auto addr =
             resolved.getResolvedAddress().getAddressData() + sizeof(int32_t);
         int32_t offset;
         Reader->readInteger(RemoteAddress(addr), &offset);
         auto addrOfTypeRef = addr + offset;
         resolved = Reader->getSymbol(RemoteAddress(addrOfTypeRef));
-
-        // lldb might return an unresolved remote absolute pointer from its
-        // resolvePointerAsSymbol implementation -- workaround this.
-        if (!resolved.isResolved()) {
-          auto remoteAddr = RemoteAddress(addrOfTypeRef);
-          resolved =
-            RemoteAbsolutePointer("", remoteAddr.getAddressData());
-        }
 
         // Dig out the protocol from the protocol list.
         auto protocolList = readMangledName(resolved.getResolvedAddress(),
@@ -1379,12 +1361,10 @@ public:
   ParentContextDescriptorRef
   readContextDescriptor(const RemoteAbsolutePointer &address) {
     // Map an unresolved pointer to an unresolved context ref.
-    if (!address.isResolved()) {
+    if (!address.getSymbol().empty()) {
       // We can only handle references to a symbol without an offset currently.
-      if (address.getOffset() != 0) {
-        return ParentContextDescriptorRef();
-      }
-      return ParentContextDescriptorRef(address.getSymbol());
+      if (address.getOffset() == 0)
+        return ParentContextDescriptorRef(address.getSymbol());
     }
     
     return ParentContextDescriptorRef(
@@ -2016,7 +1996,7 @@ public:
 
   std::optional<StoredPointer> readResolvedPointerValue(StoredPointer address) {
     if (auto pointer = readPointer(address)) {
-      if (!pointer->isResolved())
+      if (!pointer->getResolvedAddress())
         return std::nullopt;
       return (StoredPointer)pointer->getResolvedAddress().getAddressData();
     }
@@ -2079,7 +2059,7 @@ protected:
       return std::nullopt;
     }
     
-    return RemoteAbsolutePointer("", resultAddress);
+    return RemoteAbsolutePointer(RemoteAddress(resultAddress));
   }
 
   /// Given a pointer to an Objective-C class, try to read its class name.
@@ -2335,13 +2315,11 @@ private:
     auto parentAddress = resolveRelativeIndirectableField(base, base->Parent);
     if (!parentAddress)
       return std::nullopt;
-    if (!parentAddress->isResolved()) {
+    if (!parentAddress->getSymbol().empty()) {
       // Currently we can only handle references directly to a symbol without
       // an offset.
-      if (parentAddress->getOffset() != 0) {
-        return std::nullopt;
-      }
-      return ParentContextDescriptorRef(parentAddress->getSymbol());
+      if (parentAddress->getOffset() == 0)
+        return ParentContextDescriptorRef(parentAddress->getSymbol());
     }
     auto addr = parentAddress->getResolvedAddress();
     if (!addr)

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -55,16 +55,42 @@ public:
     return !operator==(other);
   }
 
+  bool inRange(const RemoteAddress &begin, const RemoteAddress &end) const {
+    assert(begin.AddressSpace != end.AddressSpace &&
+           "Unexpected address spaces");
+    if (AddressSpace != begin.AddressSpace)
+      return false;
+    return begin <= *this && *this < end;
+  }
+
   bool operator<(const RemoteAddress rhs) const {
     assert(AddressSpace == rhs.AddressSpace &&
            "Comparing remote addresses of different address spaces");
     return Data < rhs.Data;
   }
 
+  /// Less than operator to be used for ordering purposes. The default less than
+  /// operator asserts if the address spaces are different, this one takes it
+  /// into account to determine the order of the addresses.
+  bool orderedLessThan(const RemoteAddress rhs) const {
+    if (AddressSpace == rhs.AddressSpace)
+      return Data < rhs.Data;
+    return AddressSpace < rhs.AddressSpace;
+  }
+
   bool operator<=(const RemoteAddress rhs) const {
     assert(AddressSpace == rhs.AddressSpace &&
            "Comparing remote addresses of different address spaces");
     return Data <= rhs.Data;
+  }
+
+  /// Less than or equal operator to be used for ordering purposes. The default
+  /// less than or equal operator asserts if the address spaces are different,
+  /// this one takes it into account to determine the order of the addresses.
+  bool orderedLessThanOrEqual(const RemoteAddress rhs) const {
+    if (AddressSpace == rhs.AddressSpace)
+      return Data <= rhs.Data;
+    return AddressSpace <= rhs.AddressSpace;
   }
 
   bool operator>(const RemoteAddress &rhs) const {

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -18,47 +18,154 @@
 #ifndef SWIFT_REMOTE_REMOTEADDRESS_H
 #define SWIFT_REMOTE_REMOTEADDRESS_H
 
-#include <cstdint>
-#include <string>
-#include <llvm/ADT/StringRef.h>
+#include "swift/ABI/MetadataRef.h"
+#include "swift/Basic/RelativePointer.h"
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
 #include <cassert>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <llvm/ADT/StringRef.h>
+#include <ostream>
+#include <sstream>
+#include <string>
 
 namespace swift {
 namespace remote {
 
 /// An abstract address in the remote process's address space.
 class RemoteAddress {
-  uint64_t Data;
 public:
-  explicit RemoteAddress(const void *localPtr)
-    : Data(reinterpret_cast<uintptr_t>(localPtr)) {}
+  // The default address space, meaning the remote process address space.
+  static constexpr uint8_t DefaultAddressSpace = 0;
 
-  explicit RemoteAddress(uint64_t addressData) : Data(addressData) {}
+  explicit RemoteAddress(uint64_t addressData, uint8_t addressSpace)
+      : Data(addressData), AddressSpace(addressSpace) {}
 
-  explicit operator bool() const {
-    return Data != 0;
+  explicit RemoteAddress() {}
+
+  explicit operator bool() const { return Data != 0; }
+
+  bool operator==(const RemoteAddress rhs) const {
+    return Data == rhs.Data && AddressSpace == rhs.AddressSpace;
   }
 
-  template <class T>
-  const T *getLocalPointer() const {
-    return reinterpret_cast<const T*>(static_cast<uintptr_t>(Data));
+  bool operator!=(const RemoteAddress other) const {
+    return !operator==(other);
   }
 
-  uint64_t getAddressData() const {
-    return Data;
+  bool operator<(const RemoteAddress rhs) const {
+    assert(AddressSpace == rhs.AddressSpace &&
+           "Comparing remote addresses of different address spaces");
+    return Data < rhs.Data;
   }
 
-  template<typename IntegerType>
-  RemoteAddress& operator+=(const IntegerType& rhs) {
+  bool operator<=(const RemoteAddress rhs) const {
+    assert(AddressSpace == rhs.AddressSpace &&
+           "Comparing remote addresses of different address spaces");
+    return Data <= rhs.Data;
+  }
+
+  bool operator>(const RemoteAddress &rhs) const {
+    assert(AddressSpace == rhs.AddressSpace &&
+           "Comparing remote addresses of different address spaces");
+    return Data > rhs.Data;
+  }
+
+  bool operator>=(const RemoteAddress &rhs) const { return Data >= rhs.Data; }
+
+  template <typename IntegerType>
+  RemoteAddress &operator+=(const IntegerType rhs) {
     Data += rhs;
     return *this;
   }
 
-  template<typename IntegerType>
-  friend RemoteAddress operator+(RemoteAddress lhs,
-                                 const IntegerType& rhs) {
-    return lhs += rhs;
+  template <typename IntegerType>
+  RemoteAddress operator+(const IntegerType &rhs) const {
+    return RemoteAddress(Data + rhs, getAddressSpace());
   }
+
+  template <typename IntegerType>
+  RemoteAddress operator-(const IntegerType &rhs) const {
+    return RemoteAddress(Data - rhs, getAddressSpace());
+  }
+
+  RemoteAddress operator-(const RemoteAddress &rhs) const {
+    if (AddressSpace != rhs.AddressSpace)
+      return RemoteAddress();
+    return RemoteAddress(Data - rhs.Data, getAddressSpace());
+  }
+
+  template <typename IntegerType>
+  RemoteAddress operator^(const IntegerType &rhs) const {
+    return RemoteAddress(Data ^ rhs, getAddressSpace());
+  }
+
+  template <class IntegerType>
+  RemoteAddress operator&(IntegerType other) const {
+    return RemoteAddress(Data & other, getAddressSpace());
+  }
+
+  template <typename IntegerType>
+  RemoteAddress &operator&=(const IntegerType rhs) {
+    Data &= rhs;
+    return *this;
+  }
+
+  template <typename IntegerType>
+  RemoteAddress &operator|=(const IntegerType rhs) {
+    Data |= rhs;
+    return *this;
+  }
+
+  template <typename IntegerType>
+  IntegerType operator>>(const IntegerType rhs) const {
+    return (IntegerType)Data >> rhs;
+  }
+
+  uint64_t getRawAddress() const { return Data; }
+
+  uint8_t getAddressSpace() const { return AddressSpace; }
+
+  template <class IntegerType>
+  RemoteAddress applyRelativeOffset(IntegerType offset) const {
+    auto atOffset = detail::applyRelativeOffset((const char *)Data, offset);
+    return RemoteAddress(atOffset, getAddressSpace());
+  }
+
+  template <typename T, bool Nullable, typename Offset>
+  RemoteAddress getRelative(
+      const RelativeDirectPointer<T, Nullable, Offset> *relative) const {
+    auto ptr = relative->getRelative((void *)Data);
+    return RemoteAddress((uint64_t)ptr, getAddressSpace());
+  }
+
+  template <class T>
+  const T *getLocalPointer() const {
+    return reinterpret_cast<const T *>(static_cast<uintptr_t>(Data));
+  }
+
+  std::string getDescription() const {
+    std::stringstream sstream;
+    // FIXME: this should print the address space too, but because Node can't
+    // carry the address space yet, comparing the strings produced by this type
+    // and a Node that carries an address would produce incorrect results.
+    // Revisit this once Node carries the address space.
+    sstream << std::hex << Data;
+    return sstream.str();
+  }
+
+  friend llvm::hash_code hash_value(const RemoteAddress &address) {
+    using llvm::hash_value;
+    return hash_value(address.Data);
+  }
+
+  friend struct std::hash<swift::remote::RemoteAddress>;
+
+private:
+  uint64_t Data = 0;
+  uint8_t AddressSpace = 0;
 };
 
 /// A symbolic relocated absolute pointer value.
@@ -69,7 +176,7 @@ class RemoteAbsolutePointer {
   /// The offset from the symbol.
   int64_t Offset = 0;
   /// The resolved remote address.
-  RemoteAddress Address = RemoteAddress{(uint64_t)0};
+  RemoteAddress Address = RemoteAddress();
 
 public:
   RemoteAbsolutePointer() = default;
@@ -90,8 +197,60 @@ public:
   }
 };
 
+template <typename Runtime>
+class RemoteTargetProtocolDescriptorRef {
+  TargetProtocolDescriptorRef<Runtime> ProtocolRef;
+  RemoteAddress address;
+
+public:
+  RemoteTargetProtocolDescriptorRef(RemoteAddress address)
+      : ProtocolRef(address.getRawAddress()), address(address) {}
+
+  bool isObjC() const { return ProtocolRef.isObjC(); }
+
+  RemoteAddress getObjCProtocol() const {
+    auto pointer = ProtocolRef.getObjCProtocol();
+    return RemoteAddress(pointer, address.getAddressSpace());
+  }
+
+  RemoteAddress getSwiftProtocol() const {
+    auto pointer = ProtocolRef.getSwiftProtocol();
+    return RemoteAddress(pointer, address.getAddressSpace());
+  }
+};
 } // end namespace remote
 } // end namespace swift
 
-#endif // SWIFT_REMOTE_REMOTEADDRESS_H
+namespace std {
+template <>
+struct hash<swift::remote::RemoteAddress> {
+  size_t operator()(const swift::remote::RemoteAddress &address) const {
+    return llvm::hash_combine(address.Data, address.AddressSpace);
+  }
+};
+} // namespace std
 
+namespace llvm {
+template <>
+struct DenseMapInfo<swift::remote::RemoteAddress> {
+  static swift::remote::RemoteAddress getEmptyKey() {
+    return swift::remote::RemoteAddress(DenseMapInfo<uint64_t>::getEmptyKey(),
+                                        0);
+  }
+
+  static swift::remote::RemoteAddress getTombstoneKey() {
+    return swift::remote::RemoteAddress(
+        DenseMapInfo<uint64_t>::getTombstoneKey(), 0);
+  }
+
+  static unsigned getHashValue(swift::remote::RemoteAddress address) {
+    return std::hash<swift::remote::RemoteAddress>()(address);
+  }
+  static bool isEqual(swift::remote::RemoteAddress lhs,
+                      swift::remote::RemoteAddress rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
+
+#endif // SWIFT_REMOTE_REMOTEADDRESS_H

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -63,35 +63,30 @@ public:
 
 /// A symbolic relocated absolute pointer value.
 class RemoteAbsolutePointer {
-  /// The symbol name that the pointer refers to. Empty if the value is absolute.
+  /// The symbol name that the pointer refers to. Empty if only an absolute
+  /// address is available.
   std::string Symbol;
-  /// The offset from the symbol, or the resolved remote address if \c Symbol is empty.
-  int64_t Offset;
+  /// The offset from the symbol.
+  int64_t Offset = 0;
+  /// The resolved remote address.
+  RemoteAddress Address = RemoteAddress{(uint64_t)0};
 
 public:
-  RemoteAbsolutePointer()
-    : Symbol(), Offset(0)
-  {}
-  
-  RemoteAbsolutePointer(std::nullptr_t)
-    : RemoteAbsolutePointer()
-  {}
-  
-  RemoteAbsolutePointer(llvm::StringRef Symbol, int64_t Offset)
-    : Symbol(Symbol), Offset(Offset)
-  {}
-  
-  bool isResolved() const { return Symbol.empty(); }
+  RemoteAbsolutePointer() = default;
+  RemoteAbsolutePointer(std::nullptr_t) : RemoteAbsolutePointer() {}
+
+  RemoteAbsolutePointer(llvm::StringRef Symbol, int64_t Offset,
+                        RemoteAddress Address)
+      : Symbol(Symbol), Offset(Offset), Address(Address) {}
+  RemoteAbsolutePointer(RemoteAddress Address) : Address(Address) {}
+
   llvm::StringRef getSymbol() const { return Symbol; }
   int64_t getOffset() const { return Offset; }
-  
-  RemoteAddress getResolvedAddress() const {
-    assert(isResolved());
-    return RemoteAddress(Offset);
-  }
-  
+
+  RemoteAddress getResolvedAddress() const { return Address; }
+
   explicit operator bool() const {
-    return Offset != 0 || !Symbol.empty();
+    return Address || !Symbol.empty();
   }
 };
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1020,7 +1020,7 @@ public:
       auto CDAddr = this->readCaptureDescriptorFromMetadata(*MetadataAddress);
       if (!CDAddr)
         return nullptr;
-      if (!CDAddr->isResolved())
+      if (!CDAddr->getResolvedAddress())
         return nullptr;
 
       // FIXME: Non-generic SIL boxes also use the HeapLocalVariable metadata

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -123,8 +123,7 @@ class ReflectionContext
   using super::readMetadata;
   using super::readObjCClassName;
   using super::readResolvedPointerValue;
-  llvm::DenseMap<std::pair<typename super::StoredPointer,
-                           remote::TypeInfoProvider::IdType>,
+  llvm::DenseMap<std::pair<RemoteAddress, remote::TypeInfoProvider::IdType>,
                  const RecordTypeInfo *>
       Cache;
 
@@ -256,17 +255,15 @@ public:
 
     // The layout of the executable is such that the commands immediately follow
     // the header.
-    auto CmdStartAddress =
-        RemoteAddress(ImageStart.getAddressData() + sizeof(typename T::Header));
+    auto CmdStartAddress = ImageStart + sizeof(typename T::Header);
     uint32_t SegmentCmdHdrSize = sizeof(typename T::SegmentCmd);
     uint64_t Offset = 0;
 
     // Find the __TEXT segment.
     typename T::SegmentCmd *TextCommand = nullptr;
     for (unsigned I = 0; I < NumCommands; ++I) {
-      auto CmdBuf = this->getReader().readBytes(
-          RemoteAddress(CmdStartAddress.getAddressData() + Offset),
-          SegmentCmdHdrSize);
+      auto CmdBuf = this->getReader().readBytes(CmdStartAddress + Offset,
+                                                SegmentCmdHdrSize);
       if (!CmdBuf)
         return {};
       auto CmdHdr = reinterpret_cast<typename T::SegmentCmd *>(CmdBuf.get());
@@ -283,26 +280,24 @@ public:
       return {};
 
    // Find the load command offset.
-    auto loadCmdOffset = ImageStart.getAddressData() + Offset + sizeof(typename T::Header);
+    auto loadCmdOffset = ImageStart + Offset + sizeof(typename T::Header);
 
     // Read the load command.
-    auto LoadCmdAddress = reinterpret_cast<const char *>(loadCmdOffset);
     auto LoadCmdBuf = this->getReader().readBytes(
-        RemoteAddress(LoadCmdAddress), sizeof(typename T::SegmentCmd));
+        loadCmdOffset, sizeof(typename T::SegmentCmd));
     if (!LoadCmdBuf)
       return {};
     auto LoadCmd = reinterpret_cast<typename T::SegmentCmd *>(LoadCmdBuf.get());
 
     // The sections start immediately after the load command.
     unsigned NumSect = LoadCmd->nsects;
-    auto SectAddress = reinterpret_cast<const char *>(loadCmdOffset) +
-                       sizeof(typename T::SegmentCmd);
+    auto SectAddress = loadCmdOffset + sizeof(typename T::SegmentCmd);
     auto Sections = this->getReader().readBytes(
-        RemoteAddress(SectAddress), NumSect * sizeof(typename T::Section));
+        SectAddress, NumSect * sizeof(typename T::Section));
     if (!Sections)
       return {};
 
-    auto Slide = ImageStart.getAddressData() - TextCommand->vmaddr;
+    auto Slide = ImageStart - TextCommand->vmaddr;
     auto SectionsBuf = reinterpret_cast<const char *>(Sections.get());
 
     auto findMachOSectionByName = [&](llvm::StringRef Name)
@@ -313,9 +308,9 @@ public:
         if (strncmp(S->sectname, Name.data(), sizeof(S->sectname)) != 0)
           continue;
 
-        auto RemoteSecStart = S->addr + Slide;
+        auto RemoteSecStart = Slide + S->addr;
         auto LocalSectBuf =
-            this->getReader().readBytes(RemoteAddress(RemoteSecStart), S->size);
+            this->getReader().readBytes(RemoteSecStart, S->size);
         if (!LocalSectBuf)
           return {nullptr, 0};
 
@@ -368,14 +363,12 @@ public:
 
     auto TextSegmentStart = Slide + TextCommand->vmaddr;
     auto TextSegmentEnd = TextSegmentStart + TextCommand->vmsize;
-    textRanges.push_back(std::make_tuple(RemoteAddress(TextSegmentStart),
-                                         RemoteAddress(TextSegmentEnd)));
+    textRanges.push_back(std::make_tuple(TextSegmentStart, TextSegmentEnd));
 
     // Find the __DATA segments.
     for (unsigned I = 0; I < NumCommands; ++I) {
-      auto CmdBuf = this->getReader().readBytes(
-          RemoteAddress(CmdStartAddress.getAddressData() + Offset),
-          SegmentCmdHdrSize);
+      auto CmdBuf = this->getReader().readBytes(CmdStartAddress + Offset,
+                                                SegmentCmdHdrSize);
       if (!CmdBuf)
         return {};
       auto CmdHdr = reinterpret_cast<typename T::SegmentCmd *>(CmdBuf.get());
@@ -384,10 +377,9 @@ public:
           strncmp(CmdHdr->segname, "__AUTH", 6) == 0) {
         auto DataSegmentStart = Slide + CmdHdr->vmaddr;
         auto DataSegmentEnd = DataSegmentStart + CmdHdr->vmsize;
-        assert(DataSegmentStart > ImageStart.getAddressData() &&
+        assert(DataSegmentStart > ImageStart &&
                "invalid range for __DATA/__AUTH");
-        dataRanges.push_back(std::make_tuple(RemoteAddress(DataSegmentStart),
-                                             RemoteAddress(DataSegmentEnd)));
+        dataRanges.push_back(std::make_tuple(DataSegmentStart, DataSegmentEnd));
       }
       Offset += CmdHdr->cmdsize;
     }
@@ -407,12 +399,11 @@ public:
       return {};
     auto DOSHdr =
         reinterpret_cast<const llvm::object::dos_header *>(DOSHdrBuf.get());
-    auto COFFFileHdrAddr = ImageStart.getAddressData() +
-                           DOSHdr->AddressOfNewExeHeader +
+    auto COFFFileHdrAddr = ImageStart + DOSHdr->AddressOfNewExeHeader +
                            sizeof(llvm::COFF::PEMagic);
 
     auto COFFFileHdrBuf = this->getReader().readBytes(
-        RemoteAddress(COFFFileHdrAddr), sizeof(llvm::object::coff_file_header));
+        COFFFileHdrAddr, sizeof(llvm::object::coff_file_header));
     if (!COFFFileHdrBuf)
       return {};
     auto COFFFileHdr = reinterpret_cast<const llvm::object::coff_file_header *>(
@@ -422,7 +413,7 @@ public:
                             sizeof(llvm::object::coff_file_header) +
                             COFFFileHdr->SizeOfOptionalHeader;
     auto SectionTableBuf = this->getReader().readBytes(
-        RemoteAddress(SectionTableAddr),
+        SectionTableAddr,
         sizeof(llvm::object::coff_section) * COFFFileHdr->NumberOfSections);
     if (!SectionTableBuf)
       return {};
@@ -440,9 +431,8 @@ public:
                 : llvm::StringRef(COFFSec->Name, llvm::COFF::NameSize);
         if (SectionName != Name)
           continue;
-        auto Addr = ImageStart.getAddressData() + COFFSec->VirtualAddress;
-        auto Buf = this->getReader().readBytes(RemoteAddress(Addr),
-                                               COFFSec->VirtualSize);
+        auto Addr = ImageStart + COFFSec->VirtualAddress;
+        auto Buf = this->getReader().readBytes(Addr, COFFSec->VirtualSize);
         if (!Buf)
           return {nullptr, 0};
         auto BufStart = Buf.get();
@@ -512,10 +502,9 @@ public:
 
     auto DOSHdr = reinterpret_cast<const llvm::object::dos_header *>(Buf.get());
 
-    auto PEHeaderAddress =
-        ImageStart.getAddressData() + DOSHdr->AddressOfNewExeHeader;
+    auto PEHeaderAddress = ImageStart + DOSHdr->AddressOfNewExeHeader;
 
-    Buf = this->getReader().readBytes(RemoteAddress(PEHeaderAddress),
+    Buf = this->getReader().readBytes(PEHeaderAddress,
                                       sizeof(llvm::COFF::PEMagic));
     if (!Buf)
       return {};
@@ -647,8 +636,7 @@ public:
               continue;
             if (Retained != bool(Hdr->sh_flags & llvm::ELF::SHF_GNU_RETAIN))
               continue;
-            RemoteAddress SecStart =
-                RemoteAddress(ImageStart.getAddressData() + Hdr->sh_addr);
+            RemoteAddress SecStart = ImageStart + Hdr->sh_addr;
             auto SecSize = Hdr->sh_size;
             MemoryReader::ReadBytesResult SecBuf;
             if (FileBuffer.has_value()) {
@@ -670,8 +658,7 @@ public:
             }
             if (!SecBuf)
               return {nullptr, 0};
-            auto SecContents =
-                RemoteRef<void>(SecStart.getAddressData(), SecBuf.get());
+            auto SecContents = RemoteRef<void>(SecStart, SecBuf.get());
             savedBuffers.push_back(std::move(SecBuf));
             return {SecContents, SecSize};
           }
@@ -904,10 +891,10 @@ public:
   }
 
   bool ownsObject(RemoteAddress ObjectAddress) {
-    auto MetadataAddress = readMetadataFromInstance(ObjectAddress.getAddressData());
+    auto MetadataAddress = readMetadataFromInstance(ObjectAddress);
     if (!MetadataAddress)
       return true;
-    return ownsAddress(RemoteAddress(*MetadataAddress));
+    return ownsAddress(*MetadataAddress);
   }
 
   /// Returns true if the address falls within the given address ranges.
@@ -917,8 +904,7 @@ public:
     for (auto Range : ranges) {
       auto Start = std::get<0>(Range);
       auto End = std::get<1>(Range);
-      if (Start.getAddressData() <= Address.getAddressData()
-          && Address.getAddressData() < End.getAddressData())
+      if (Start <= Address && Address < End)
         return true;
     }
 
@@ -940,10 +926,10 @@ public:
       // This is usually called on a Metadata address which might have been
       // on the heap. Try reading it and looking up its type context descriptor
       // instead.
-      if (auto Metadata = readMetadata(Address.getAddressData()))
+      if (auto Metadata = readMetadata(Address))
         if (auto DescriptorAddress =
             super::readAddressOfNominalTypeDescriptor(Metadata, true))
-          if (ownsAddress(RemoteAddress(DescriptorAddress), textRanges))
+          if (ownsAddress(DescriptorAddress, textRanges))
             return true;
     }
     return false;
@@ -951,17 +937,18 @@ public:
 
   /// Returns the address of the nominal type descriptor given a metadata
   /// address.
-  StoredPointer nominalTypeDescriptorFromMetadata(StoredPointer MetadataAddress) {
+  RemoteAddress
+  nominalTypeDescriptorFromMetadata(RemoteAddress MetadataAddress) {
     auto Metadata = readMetadata(MetadataAddress);
     if (!Metadata)
-      return 0;
+      return RemoteAddress();
     return super::readAddressOfNominalTypeDescriptor(Metadata, true);
   }
 
   /// Return a description of the layout of a class instance with the given
   /// metadata as its isa pointer.
   const RecordTypeInfo *
-  getMetadataTypeInfo(StoredPointer MetadataAddress,
+  getMetadataTypeInfo(RemoteAddress MetadataAddress,
                       remote::TypeInfoProvider *ExternalTypeInfo) {
     // See if we cached the layout already
     auto ExternalTypeInfoId = ExternalTypeInfo ? ExternalTypeInfo->getId() : 0;
@@ -1002,7 +989,7 @@ public:
   /// Return a description of the layout of a class instance with the given
   /// metadata as its isa pointer.
   const TypeInfo *
-  getInstanceTypeInfo(StoredPointer ObjectAddress,
+  getInstanceTypeInfo(RemoteAddress ObjectAddress,
                       remote::TypeInfoProvider *ExternalTypeInfo) {
     auto MetadataAddress = readMetadataFromInstance(ObjectAddress);
     if (!MetadataAddress)
@@ -1029,8 +1016,7 @@ public:
       //
       // Non-generic SIL boxes share metadata among types with compatible
       // layout, but we need some way to get an outgoing pointer map for them.
-      auto CD = getBuilder().getCaptureDescriptor(
-                                CDAddr->getResolvedAddress().getAddressData());
+      auto CD = getBuilder().getCaptureDescriptor(CDAddr->getResolvedAddress());
       if (CD == nullptr)
         return nullptr;
 
@@ -1045,8 +1031,9 @@ public:
       if (auto Meta = readMetadata(*MetadataAddress)) {
         if (auto *GenericHeapMeta = cast<TargetGenericBoxHeapMetadata<Runtime>>(
                 Meta.getLocalBuffer())) {
-          auto MetadataAddress = GenericHeapMeta->BoxedType;
-          auto TR = readTypeFromMetadata(MetadataAddress);
+          auto BoxedTypeAddress = RemoteAddress(
+              GenericHeapMeta->BoxedType, ObjectAddress.getAddressSpace());
+          auto TR = readTypeFromMetadata(BoxedTypeAddress);
           return getTypeInfo(TR, ExternalTypeInfo);
         }
       }
@@ -1064,8 +1051,7 @@ public:
 
   std::optional<std::pair<const TypeRef *, RemoteAddress>>
   getDynamicTypeAndAddressClassExistential(RemoteAddress ExistentialAddress) {
-    auto PointerValue =
-        readResolvedPointerValue(ExistentialAddress.getAddressData());
+    auto PointerValue = readResolvedPointerValue(ExistentialAddress);
     if (!PointerValue)
       return {};
     auto Result = readMetadataFromInstance(*PointerValue);
@@ -1074,7 +1060,7 @@ public:
     auto TypeResult = readTypeFromMetadata(Result.value());
     if (!TypeResult)
       return {};
-    return {{std::move(TypeResult), RemoteAddress(*PointerValue)}};
+    return {{std::move(TypeResult), *PointerValue}};
   }
 
   std::optional<std::pair<const TypeRef *, RemoteAddress>>
@@ -1084,8 +1070,7 @@ public:
     if (!Result)
       return {};
 
-    auto TypeResult =
-        readTypeFromMetadata(Result->MetadataAddress.getAddressData());
+    auto TypeResult = readTypeFromMetadata(Result->MetadataAddress);
     if (!TypeResult)
       return {};
 
@@ -1101,8 +1086,7 @@ public:
     if (!Result)
       return {};
 
-    auto TypeResult =
-        readTypeFromMetadata(Result->MetadataAddress.getAddressData());
+    auto TypeResult = readTypeFromMetadata(Result->MetadataAddress);
     if (!TypeResult)
       return {};
     return {{std::move(TypeResult), Result->PayloadAddress}};
@@ -1139,8 +1123,7 @@ public:
       if (!OptMetaAndValue)
         return false;
 
-      auto InstanceTR = readTypeFromMetadata(
-          OptMetaAndValue->MetadataAddress.getAddressData());
+      auto InstanceTR = readTypeFromMetadata(OptMetaAndValue->MetadataAddress);
       if (!InstanceTR)
         return false;
 
@@ -1156,8 +1139,7 @@ public:
 
       // FIXME: Check third value, 'IsBridgedError'
 
-      auto InstanceTR = readTypeFromMetadata(
-          OptMetaAndValue->MetadataAddress.getAddressData());
+      auto InstanceTR = readTypeFromMetadata(OptMetaAndValue->MetadataAddress);
       if (!InstanceTR)
         return false;
 
@@ -1192,10 +1174,10 @@ public:
     };
 
     auto DereferenceAndSet = [&](RemoteAddress &Address) {
-      auto PointerValue = readResolvedPointerValue(Address.getAddressData());
+      auto PointerValue = readResolvedPointerValue(Address);
       if (!PointerValue)
         return false;
-      Address = RemoteAddress(*PointerValue);
+      Address = *PointerValue;
       return true;
     };
 
@@ -1332,7 +1314,7 @@ public:
     return dyn_cast_or_null<const RecordTypeInfo>(TypeInfo);
   }
 
-  bool metadataIsActor(StoredPointer MetadataAddress) {
+  bool metadataIsActor(RemoteAddress MetadataAddress) {
     auto Metadata = readMetadata(MetadataAddress);
     if (!Metadata)
       return false;
@@ -1345,12 +1327,11 @@ public:
         super::readAddressOfNominalTypeDescriptor(Metadata);
     if (!DescriptorAddress)
       return false;
-    if (!ownsAddress(RemoteAddress(DescriptorAddress), textRanges))
+    if (!ownsAddress(DescriptorAddress, textRanges))
       return false;
 
-    auto DescriptorBytes =
-        getReader().readBytes(RemoteAddress(DescriptorAddress),
-                              sizeof(TargetTypeContextDescriptor<Runtime>));
+    auto DescriptorBytes = getReader().readBytes(
+        DescriptorAddress, sizeof(TargetTypeContextDescriptor<Runtime>));
     if (!DescriptorBytes)
       return false;
     auto Descriptor =
@@ -1361,12 +1342,13 @@ public:
 
   /// Iterate the protocol conformance cache tree rooted at NodePtr, calling
   /// Call with the type and protocol in each node.
-  void iterateConformanceTree(StoredPointer NodePtr,
-    std::function<void(StoredPointer Type, StoredPointer Proto)> Call) {
+  void iterateConformanceTree(
+      RemoteAddress NodePtr,
+      std::function<void(RemoteAddress Type, RemoteAddress Proto)> Call) {
     if (!NodePtr)
       return;
-    auto NodeBytes = getReader().readBytes(RemoteAddress(NodePtr),
-                                           sizeof(ConformanceNode<Runtime>));
+    auto NodeBytes =
+        getReader().readBytes(NodePtr, sizeof(ConformanceNode<Runtime>));
     if (!NodeBytes)
       return;
     auto NodeData =
@@ -1378,8 +1360,8 @@ public:
 
   void IterateConformanceTable(
       RemoteAddress ConformancesPtr,
-      std::function<void(StoredPointer Type, StoredPointer Proto)> Call) {
-    auto MapBytes = getReader().readBytes(RemoteAddress(ConformancesPtr),
+      std::function<void(RemoteAddress Type, RemoteAddress Proto)> Call) {
+    auto MapBytes = getReader().readBytes(ConformancesPtr,
                                           sizeof(ConcurrentHashMap<Runtime>));
     if (!MapBytes)
       return;
@@ -1389,8 +1371,9 @@ public:
     auto Count = MapData->ElementCount;
     auto Size = Count * sizeof(ConformanceCacheEntry<Runtime>) + sizeof(StoredPointer);
 
-    auto ElementsBytes =
-        getReader().readBytes(RemoteAddress(MapData->Elements), Size);
+    auto ElementsBytes = getReader().readBytes(
+        RemoteAddress(MapData->Elements, ConformancesPtr.getAddressSpace()),
+        Size);
     if (!ElementsBytes)
       return;
     auto ElementsData =
@@ -1399,7 +1382,8 @@ public:
 
     for (StoredSize i = 0; i < Count; i++) {
       auto &Element = ElementsData[i];
-      Call(Element.Type, Element.Proto);
+      Call(RemoteAddress(Element.Type, ConformancesPtr.getAddressSpace()),
+           RemoteAddress(Element.Proto, ConformancesPtr.getAddressSpace()));
     }
   }
 
@@ -1407,7 +1391,7 @@ public:
   /// with the type and protocol of each conformance. Returns None on success,
   /// and a string describing the error on failure.
   std::optional<std::string> iterateConformances(
-      std::function<void(StoredPointer Type, StoredPointer Proto)> Call) {
+      std::function<void(RemoteAddress Type, RemoteAddress Proto)> Call) {
     std::string ConformancesPointerName =
         "_swift_debug_protocolConformanceStatePointer";
     auto ConformancesAddrAddr =
@@ -1429,15 +1413,15 @@ public:
   StoredPointer allocationMetadataPointer(
     MetadataAllocation<Runtime> Allocation) {
     if (Allocation.Tag == GenericMetadataCacheTag) {
-        auto AllocationBytes =
-          getReader().readBytes(RemoteAddress(Allocation.Ptr),
-                                              Allocation.Size);
-        if (!AllocationBytes)
-          return 0;
-        auto Entry =
+      auto AllocationBytes = getReader().readBytes(
+          RemoteAddress(Allocation.Ptr, RemoteAddress::DefaultAddressSpace),
+          Allocation.Size);
+      if (!AllocationBytes)
+        return 0;
+      auto Entry =
           reinterpret_cast<const GenericMetadataCacheEntry<StoredPointer> *>(
-            AllocationBytes.get());
-        return Entry->Value;
+              AllocationBytes.get());
+      return Entry->Value;
     }
     return 0;
   }
@@ -1474,7 +1458,8 @@ public:
     case ForeignMetadataCacheTag:
     case GenericWitnessTableCacheTag: {
       auto NodeBytes = getReader().readBytes(
-          RemoteAddress(Allocation.Ptr), sizeof(MetadataCacheNode<Runtime>));
+          RemoteAddress(Allocation.Ptr, RemoteAddress::DefaultAddressSpace),
+          sizeof(MetadataCacheNode<Runtime>));
       if (!NodeBytes)
         return std::nullopt;
       auto Node =
@@ -1517,14 +1502,14 @@ public:
       return "failed to read value of " + AllocationPoolPointerName;
 
     struct PoolRange {
-      StoredPointer Begin;
+      RemoteAddress Begin;
       StoredSize Remaining;
     };
     struct PoolTrailer {
-      StoredPointer PrevTrailer;
+      RemoteAddress PrevTrailer;
       StoredSize PoolSize;
     };
-    struct alignas(StoredPointer) AllocationHeader {
+    struct alignas(RemoteAddress) AllocationHeader {
       uint16_t Size;
       uint16_t Tag;
     };
@@ -1544,14 +1529,13 @@ public:
 
     auto TrailerPtr = Pool->Begin + Pool->Remaining;
     while (TrailerPtr && LoopCount++ < LoopLimit) {
-      auto TrailerBytes = getReader()
-        .readBytes(RemoteAddress(TrailerPtr), sizeof(PoolTrailer));
+      auto TrailerBytes =
+          getReader().readBytes(TrailerPtr, sizeof(PoolTrailer));
       if (!TrailerBytes)
         break;
       auto Trailer = reinterpret_cast<const PoolTrailer *>(TrailerBytes.get());
       auto PoolStart = TrailerPtr - Trailer->PoolSize;
-      auto PoolBytes = getReader()
-        .readBytes(RemoteAddress(PoolStart), Trailer->PoolSize);
+      auto PoolBytes = getReader().readBytes(PoolStart, Trailer->PoolSize);
       if (!PoolBytes)
         break;
       auto PoolPtr = (const char *)PoolBytes.get();
@@ -1565,7 +1549,10 @@ public:
         auto RemoteAddr = PoolStart + Offset + sizeof(AllocationHeader);
         MetadataAllocation<Runtime> Allocation;
         Allocation.Tag = Header->Tag;
-        Allocation.Ptr = RemoteAddr;
+
+        if (RemoteAddr.getAddressSpace() != RemoteAddress::DefaultAddressSpace)
+          return "storing remote address from non-default address space.";
+        Allocation.Ptr = RemoteAddr.getRawAddress();
         Allocation.Size = Header->Size;
         Call(Allocation);
 
@@ -1601,15 +1588,15 @@ public:
     auto BacktraceListNext = BacktraceListNextPtr->getResolvedAddress();
     while (BacktraceListNext && LoopCount++ < LoopLimit) {
       auto HeaderBytes = getReader().readBytes(
-          RemoteAddress(BacktraceListNext),
+          BacktraceListNext,
           sizeof(MetadataAllocationBacktraceHeader<Runtime>));
       if (!HeaderBytes) {
         // FIXME: std::stringstream would be better, but LLVM's standard library
         // introduces a vtable and we don't want that.
         char result[128];
         std::snprintf(result, sizeof(result),
-            "unable to read Next pointer %#" PRIx64,
-            BacktraceListNext.getAddressData());
+                      "unable to read Next pointer %#" PRIx64,
+                      BacktraceListNext.getRawAddress());
         return std::string(result);
       }
       auto HeaderPtr =
@@ -1618,15 +1605,15 @@ public:
       auto BacktraceAddrPtr =
           BacktraceListNext +
           sizeof(MetadataAllocationBacktraceHeader<Runtime>);
-      auto BacktraceBytes =
-          getReader().readBytes(RemoteAddress(BacktraceAddrPtr),
-                                HeaderPtr->Count * sizeof(StoredPointer));
+      auto BacktraceBytes = getReader().readBytes(
+          BacktraceAddrPtr, HeaderPtr->Count * sizeof(StoredPointer));
       auto BacktracePtr =
           reinterpret_cast<const StoredPointer *>(BacktraceBytes.get());
 
       Call(HeaderPtr->Allocation, HeaderPtr->Count, BacktracePtr);
 
-      BacktraceListNext = RemoteAddress(HeaderPtr->Next);
+      BacktraceListNext =
+          RemoteAddress(HeaderPtr->Next, RemoteAddress::DefaultAddressSpace);
     }
     return std::nullopt;
   }
@@ -1635,7 +1622,8 @@ public:
   asyncTaskSlabAllocations(StoredPointer SlabPtr) {
     using StackAllocator = StackAllocator<Runtime>;
     auto SlabBytes = getReader().readBytes(
-        RemoteAddress(SlabPtr), sizeof(typename StackAllocator::Slab));
+        RemoteAddress(SlabPtr, RemoteAddress::DefaultAddressSpace),
+        sizeof(typename StackAllocator::Slab));
     auto Slab = reinterpret_cast<const typename StackAllocator::Slab *>(
         SlabBytes.get());
     if (!Slab)
@@ -1660,14 +1648,14 @@ public:
     NextPtrChunk.Kind = AsyncTaskAllocationChunk::ChunkKind::RawPointer;
 
     // Total slab size is the slab's capacity plus the header.
-    StoredPointer SlabSize = Slab->Capacity + HeaderSize;
+    auto SlabSize = Slab->Capacity + HeaderSize;
 
     return {std::nullopt,
             {Slab->Next, SlabSize, {NextPtrChunk, AllocatedSpaceChunk}}};
   }
 
   std::pair<std::optional<std::string>, AsyncTaskInfo>
-  asyncTaskInfo(StoredPointer AsyncTaskPtr, unsigned ChildTaskLimit,
+  asyncTaskInfo(RemoteAddress AsyncTaskPtr, unsigned ChildTaskLimit,
                 unsigned AsyncBacktraceLimit) {
     loadTargetPointers();
 
@@ -1682,7 +1670,7 @@ public:
   }
 
   std::pair<std::optional<std::string>, ActorInfo>
-  actorInfo(StoredPointer ActorPtr) {
+  actorInfo(RemoteAddress ActorPtr) {
     if (supportsPriorityEscalation)
       return actorInfo<
           DefaultActorImpl<Runtime, ActiveActorStatusWithEscalation<Runtime>>>(
@@ -1692,10 +1680,10 @@ public:
           Runtime, ActiveActorStatusWithoutEscalation<Runtime>>>(ActorPtr);
   }
 
-  StoredPointer nextJob(StoredPointer JobPtr) {
+  StoredPointer nextJob(RemoteAddress JobPtr) {
     using Job = Job<Runtime>;
 
-    auto JobBytes = getReader().readBytes(RemoteAddress(JobPtr), sizeof(Job));
+    auto JobBytes = getReader().readBytes(JobPtr, sizeof(Job));
     auto *JobObj = reinterpret_cast<const Job *>(JobBytes.get());
     if (!JobObj)
       return 0;
@@ -1770,7 +1758,7 @@ private:
 
   template <typename AsyncTaskType>
   std::pair<std::optional<std::string>, AsyncTaskInfo>
-  asyncTaskInfo(StoredPointer AsyncTaskPtr, unsigned ChildTaskLimit,
+  asyncTaskInfo(RemoteAddress AsyncTaskPtr, unsigned ChildTaskLimit,
                 unsigned AsyncBacktraceLimit) {
     auto AsyncTaskObj = readObj<AsyncTaskType>(AsyncTaskPtr);
     if (!AsyncTaskObj)
@@ -1805,7 +1793,8 @@ private:
 
     // Find all child tasks.
     unsigned ChildTaskLoopCount = 0;
-    auto RecordPtr = AsyncTaskObj->PrivateStorage.Status.Record;
+    auto RecordPtr = RemoteAddress(AsyncTaskObj->PrivateStorage.Status.Record,
+                                   RemoteAddress::DefaultAddressSpace);
     while (RecordPtr && ChildTaskLoopCount++ < ChildTaskLimit) {
       auto RecordObj = readObj<TaskStatusRecord<Runtime>>(RecordPtr);
       if (!RecordObj)
@@ -1829,8 +1818,10 @@ private:
       }
 
       while (ChildTask && ChildTaskLoopCount++ < ChildTaskLimit) {
+        RemoteAddress ChildTaskAddress =
+            RemoteAddress(ChildTask, RemoteAddress::DefaultAddressSpace);
         // Read the child task.
-        auto ChildTaskObj = readObj<AsyncTaskType>(ChildTask);
+        auto ChildTaskObj = readObj<AsyncTaskType>(ChildTaskAddress);
         if (!ChildTaskObj)
           return {std::string("found unreadable child task pointer"), Info};
 
@@ -1843,7 +1834,7 @@ private:
                                 "iterate child tasks"),
                     Info};
 
-          StoredPointer ChildFragmentAddr = ChildTask + asyncTaskSize;
+          RemoteAddress ChildFragmentAddr = ChildTaskAddress + asyncTaskSize;
           auto ChildFragmentObj =
               readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
           if (ChildFragmentObj)
@@ -1856,7 +1847,8 @@ private:
         }
       }
 
-      RecordPtr = RecordObj->Parent;
+      RecordPtr =
+          RemoteAddress(RecordObj->Parent, RemoteAddress::DefaultAddressSpace);
     }
 
     const auto TaskResumeContext = AsyncTaskObj->ResumeContextAndReserved[0];
@@ -1867,12 +1859,14 @@ private:
       auto ResumeContext = TaskResumeContext;
       unsigned AsyncBacktraceLoopCount = 0;
       while (ResumeContext && AsyncBacktraceLoopCount++ < AsyncBacktraceLimit) {
-        auto ResumeContextObj = readObj<AsyncContext<Runtime>>(ResumeContext);
+        auto ResumeContextObj = readObj<AsyncContext<Runtime>>(
+            RemoteAddress(ResumeContext, RemoteAddress::DefaultAddressSpace));
         if (!ResumeContextObj)
           break;
         Info.AsyncBacktraceFrames.push_back(
-            stripSignedPointer(ResumeContextObj->ResumeParent));
-        ResumeContext = stripSignedPointer(ResumeContextObj->Parent);
+            stripSignedPointer(ResumeContextObj->ResumeParent).getRawAddress());
+        ResumeContext =
+            stripSignedPointer(ResumeContextObj->Parent).getRawAddress();
       }
     }
 
@@ -1881,7 +1875,7 @@ private:
 
   template <typename ActorType>
   std::pair<std::optional<std::string>, ActorInfo>
-  actorInfo(StoredPointer ActorPtr) {
+  actorInfo(RemoteAddress ActorPtr) {
     auto ActorObj = readObj<ActorType>(ActorPtr);
     if (!ActorObj)
       return {std::string("failure reading actor"), {}};
@@ -1900,7 +1894,7 @@ private:
     // Don't read FirstJob when idle.
     if (Info.State != concurrency::ActorFlagConstants::Idle) {
       // This is a JobRef which stores flags in the low bits.
-      Info.FirstJob = ActorObj->Status.FirstJob & ~StoredPointer(0x3);
+      Info.FirstJob = ActorObj->Status.FirstJob & ~0x3;
     }
 
     std::tie(Info.HasThreadPort, Info.ThreadPort) =
@@ -1913,27 +1907,29 @@ private:
   // like AsyncTask::getResumeFunctionForLogging does.
   template <typename AsyncTaskType>
   StoredPointer getRunJob(const AsyncTaskType *AsyncTaskObj) {
-    auto Fptr = stripSignedPointer(AsyncTaskObj->RunJob);
+    auto Fptr = stripSignedPointer(AsyncTaskObj->RunJob).getRawAddress();
 
     loadTargetPointers();
     auto ResumeContextPtr = AsyncTaskObj->ResumeContextAndReserved[0];
     if (target_non_future_adapter && Fptr == target_non_future_adapter) {
       using Prefix = AsyncContextPrefix<Runtime>;
       auto PrefixAddr = ResumeContextPtr - sizeof(Prefix);
-      auto PrefixBytes =
-          getReader().readBytes(RemoteAddress(PrefixAddr), sizeof(Prefix));
+      auto PrefixBytes = getReader().readBytes(
+          RemoteAddress(PrefixAddr, RemoteAddress::DefaultAddressSpace),
+          sizeof(Prefix));
       if (PrefixBytes) {
         auto PrefixPtr = reinterpret_cast<const Prefix *>(PrefixBytes.get());
-        return stripSignedPointer(PrefixPtr->AsyncEntryPoint);
+        return stripSignedPointer(PrefixPtr->AsyncEntryPoint).getRawAddress();
       }
     } else if (target_future_adapter && Fptr == target_future_adapter) {
       using Prefix = FutureAsyncContextPrefix<Runtime>;
       auto PrefixAddr = ResumeContextPtr - sizeof(Prefix);
-      auto PrefixBytes =
-          getReader().readBytes(RemoteAddress(PrefixAddr), sizeof(Prefix));
+      auto PrefixBytes = getReader().readBytes(
+          RemoteAddress(PrefixAddr, RemoteAddress::DefaultAddressSpace),
+          sizeof(Prefix));
       if (PrefixBytes) {
         auto PrefixPtr = reinterpret_cast<const Prefix *>(PrefixBytes.get());
-        return stripSignedPointer(PrefixPtr->AsyncEntryPoint);
+        return stripSignedPointer(PrefixPtr->AsyncEntryPoint).getRawAddress();
       }
     } else if ((target_task_wait_throwing_resume_adapter &&
                 Fptr == target_task_wait_throwing_resume_adapter) ||
@@ -1944,11 +1940,12 @@ private:
       // and the pointers are potentially stale.
       if (AsyncTaskObj->PrivateStorage.DependencyRecord) {
         auto ContextBytes = getReader().readBytes(
-            RemoteAddress(ResumeContextPtr), sizeof(AsyncContext<Runtime>));
+            RemoteAddress(ResumeContextPtr, RemoteAddress::DefaultAddressSpace),
+            sizeof(AsyncContext<Runtime>));
         if (ContextBytes) {
           auto ContextPtr = reinterpret_cast<const AsyncContext<Runtime> *>(
               ContextBytes.get());
-          return stripSignedPointer(ContextPtr->ResumeParent);
+          return stripSignedPointer(ContextPtr->ResumeParent).getRawAddress();
         }
       }
     }
@@ -1967,7 +1964,7 @@ private:
       auto Pointer = getReader().readPointer(Symbol, sizeof(StoredPointer));
       if (!Pointer)
         return 0;
-      return Pointer->getResolvedAddress().getAddressData();
+      return Pointer->getResolvedAddress().getRawAddress();
     };
     target_asyncTaskMetadata =
         getPointer("_swift_concurrency_debug_asyncTaskMetadata");
@@ -1995,7 +1992,7 @@ private:
   }
 
   const TypeInfo *
-  getClosureContextInfo(StoredPointer Context, const ClosureContextInfo &Info,
+  getClosureContextInfo(RemoteAddress Context, const ClosureContextInfo &Info,
                         remote::TypeInfoProvider *ExternalTypeInfo) {
     RecordTypeInfoBuilder Builder(getBuilder().getTypeConverter(),
                                   RecordKind::ClosureContext);
@@ -2144,8 +2141,8 @@ private:
   /// above.
   ///
   /// \param Builder Used to obtain offsets of elements known so far.
-  std::optional<StoredPointer>
-  readMetadataSource(StoredPointer Context, const MetadataSource *MS,
+  std::optional<RemoteAddress>
+  readMetadataSource(RemoteAddress Context, const MetadataSource *MS,
                      const RecordTypeInfoBuilder &Builder) {
     switch (MS->getKind()) {
     case MetadataSourceKind::ClosureBinding: {
@@ -2161,9 +2158,9 @@ private:
       unsigned Offset = getSizeOfHeapObject() +
                         sizeof(StoredPointer) * Index;
 
-      StoredPointer MetadataAddress;
-      if (!getReader().readInteger(RemoteAddress(Context + Offset),
-                                   &MetadataAddress))
+      RemoteAddress MetadataAddress;
+      if (!getReader().template readRemoteAddress<StoredPointer>(
+              Context + Offset, MetadataAddress))
         break;
 
       return MetadataAddress;
@@ -2175,9 +2172,9 @@ private:
       // of this capture in the context.
       unsigned CaptureOffset = Builder.getFieldOffset(Index);
 
-      StoredPointer CaptureAddress;
-      if (!getReader().readInteger(RemoteAddress(Context + CaptureOffset),
-                                   &CaptureAddress))
+      RemoteAddress CaptureAddress;
+      if (!getReader().template readRemoteAddress<StoredPointer>(
+              Context + CaptureOffset, CaptureAddress))
         break;
 
       // Read the requested capture's isa pointer.
@@ -2190,9 +2187,9 @@ private:
       // of this capture in the context.
       unsigned CaptureOffset = Builder.getFieldOffset(Index);
 
-      StoredPointer CaptureAddress;
-      if (!getReader().readInteger(RemoteAddress(Context + CaptureOffset),
-                                   &CaptureAddress))
+      RemoteAddress CaptureAddress;
+      if (!getReader().template readRemoteAddress<StoredPointer>(
+              Context + CaptureOffset, CaptureAddress))
         break;
 
       return CaptureAddress;
@@ -2219,8 +2216,8 @@ private:
   }
 
   template <typename T>
-  MemoryReader::ReadObjResult<T> readObj(StoredPointer Ptr) {
-    return getReader().template readObj<T>(RemoteAddress(Ptr));
+  MemoryReader::ReadObjResult<T> readObj(RemoteAddress Ptr) {
+    return getReader().template readObj<T>(Ptr);
   }
 };
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -904,7 +904,7 @@ public:
     for (auto Range : ranges) {
       auto Start = std::get<0>(Range);
       auto End = std::get<1>(Range);
-      if (Start <= Address && Address < End)
+      if (Address.inRange(Start, End))
         return true;
     }
 

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -63,16 +63,17 @@ public:
 
   size_t size() const { return Size; }
 
-  bool containsRemoteAddress(uint64_t remoteAddr, uint64_t size) const {
-    return Start.getAddressData() <= remoteAddr &&
-           remoteAddr + size <= Start.getAddressData() + Size;
+  bool containsRemoteAddress(remote::RemoteAddress remoteAddr,
+                             uint64_t size) const {
+    return Start.getRemoteAddress() <= remoteAddr &&
+           remoteAddr + size <= Start.getRemoteAddress() + Size;
   }
 
   template <typename U>
-  RemoteRef<U> getRemoteRef(uint64_t remoteAddr) const {
+  RemoteRef<U> getRemoteRef(remote::RemoteAddress remoteAddr) const {
     assert(containsRemoteAddress(remoteAddr, sizeof(U)));
     auto localAddr = (uint64_t)(uintptr_t)Start.getLocalBuffer() +
-                     (remoteAddr - Start.getAddressData());
+                     (remoteAddr - Start.getRemoteAddress()).getRawAddress();
 
     return RemoteRef<U>(remoteAddr, (const U *)localAddr);
   }
@@ -124,7 +125,7 @@ public:
 
   RemoteRef<Descriptor> operator*() const {
     assert(Size > 0);
-    return RemoteRef<Descriptor>(Cur.getAddressData(),
+    return RemoteRef<Descriptor>(Cur.getRemoteAddress(),
                                  (const Descriptor *)Cur.getLocalBuffer());
   }
 
@@ -499,7 +500,8 @@ public:
 
     /// Get the raw capture descriptor for a remote capture descriptor
     /// address.
-    RemoteRef<CaptureDescriptor> getCaptureDescriptor(uint64_t RemoteAddress);
+    RemoteRef<CaptureDescriptor>
+    getCaptureDescriptor(remote::RemoteAddress RemoteAddress);
 
     /// Get the unsubstituted capture types for a closure context.
     ClosureContextInfo getClosureContextInfo(RemoteRef<CaptureDescriptor> CD);
@@ -512,11 +514,11 @@ public:
                                      const std::string &Member,
                                      StringRef Protocol);
 
-    RemoteRef<char> readTypeRef(uint64_t remoteAddr);
+    RemoteRef<char> readTypeRef(remote::RemoteAddress remoteAddr);
 
     template <typename Record, typename Field>
     RemoteRef<char> readTypeRef(RemoteRef<Record> record, const Field &field) {
-      uint64_t remoteAddr = record.resolveRelativeFieldData(field);
+      remote::RemoteAddress remoteAddr = record.resolveRelativeFieldData(field);
 
       return readTypeRef(remoteAddr);
     }
@@ -544,7 +546,8 @@ public:
                                StringRef searchName);
 
     std::optional<std::reference_wrapper<const ReflectionInfo>>
-    findReflectionInfoWithTypeRefContainingAddress(uint64_t remoteAddr);
+    findReflectionInfoWithTypeRefContainingAddress(
+        remote::RemoteAddress remoteAddr);
 
     std::vector<ReflectionInfo> ReflectionInfos;
 
@@ -555,8 +558,7 @@ public:
     llvm::DenseSet<size_t> ProcessedReflectionInfoIndexes;
 
     /// Cache for capture descriptor lookups.
-    std::unordered_map<uint64_t /* remote address*/,
-                       RemoteRef<CaptureDescriptor>>
+    std::unordered_map<remote::RemoteAddress, RemoteRef<CaptureDescriptor>>
         CaptureDescriptorsByAddress;
     uint32_t CaptureDescriptorsByAddressLastReflectionInfoCache = 0;
 
@@ -565,7 +567,7 @@ public:
         FieldTypeInfoCache;
 
     /// Cache for normalized reflection name lookups.
-    std::unordered_map<uint64_t /* remote address */,
+    std::unordered_map<remote::RemoteAddress /* remote address */,
                        std::optional<std::string>>
         NormalizedReflectionNameCache;
 
@@ -1107,8 +1109,12 @@ public:
     // Try to resolve to the underlying type, if we can.
     if (opaqueDescriptor->getKind() ==
         Node::Kind::OpaqueTypeDescriptorSymbolicReference) {
-      auto underlyingTy =
-          OpaqueUnderlyingTypeReader(opaqueDescriptor->getIndex(), ordinal);
+      // FIXME: Node should carry a data structure that can fit a remote
+      // address. For now assume that this is a virtual address.
+      auto underlyingTy = OpaqueUnderlyingTypeReader(
+          remote::RemoteAddress(opaqueDescriptor->getIndex(),
+                                remote::RemoteAddress::DefaultAddressSpace),
+          ordinal);
 
       if (!underlyingTy)
         return nullptr;
@@ -1457,7 +1463,7 @@ private:
   llvm::DenseSet<size_t> ProcessedReflectionInfoIndexes;
 
 public:
-  RemoteRef<char> readTypeRef(uint64_t remoteAddr) {
+  RemoteRef<char> readTypeRef(remote::RemoteAddress remoteAddr) {
     return RDF.readTypeRef(remoteAddr);
   }
   template <typename Record, typename Field>
@@ -1471,7 +1477,7 @@ public:
 private:
   using RefDemangler = std::function<Demangle::Node *(RemoteRef<char>, bool)>;
   using UnderlyingTypeReader =
-      std::function<const TypeRef *(uint64_t, unsigned)>;
+      std::function<const TypeRef *(remote::RemoteAddress, unsigned)>;
   using ByteReader = std::function<remote::MemoryReader::ReadBytesResult(
       remote::RemoteAddress, unsigned)>;
   using StringReader =
@@ -1528,7 +1534,7 @@ public:
                                  useOpaqueTypeSymbolicReferences);
         }),
         OpaqueUnderlyingTypeReader(
-            [&reader](uint64_t descriptorAddr,
+            [&reader](remote::RemoteAddress descriptorAddr,
                       unsigned ordinal) -> const TypeRef * {
               return reader
                   .readUnderlyingTypeForOpaqueTypeDescriptor(descriptorAddr,
@@ -1616,7 +1622,8 @@ public:
 
   /// Get the raw capture descriptor for a remote capture descriptor
   /// address.
-  RemoteRef<CaptureDescriptor> getCaptureDescriptor(uint64_t RemoteAddress) {
+  RemoteRef<CaptureDescriptor>
+  getCaptureDescriptor(remote::RemoteAddress RemoteAddress) {
     return RDF.getCaptureDescriptor(RemoteAddress);
   }
 
@@ -1697,8 +1704,11 @@ public:
         auto opaqueTypeChildDemangleTree = childDemangleTree->getFirstChild();
         if (opaqueTypeChildDemangleTree->getKind() ==
             Node::Kind::OpaqueTypeDescriptorSymbolicReference) {
+          // FIXME: Node should carry a data structure that can fit a remote
+          // address. For now assume that this is a process address.
           extractOpaqueTypeProtocolRequirements<ObjCInteropKind, PointerSize>(
-              opaqueTypeChildDemangleTree->getIndex(),
+              remote::RemoteAddress(opaqueTypeChildDemangleTree->getIndex(),
+                                    remote::RemoteAddress::DefaultAddressSpace),
               opaqueTypeConformanceRequirements, sameTypeRequirements);
         }
       }
@@ -1708,7 +1718,7 @@ public:
 private:
   struct ContextNameInfo {
     std::string name;
-    uintptr_t descriptorAddress;
+    remote::RemoteAddress descriptorAddress;
     bool isAnonymous;
 
     ~ContextNameInfo() {}
@@ -1731,10 +1741,10 @@ private:
           OpaqueDynamicSymbolResolver(dynamicSymbolResolver) {}
 
     std::optional<std::string> readProtocolNameFromProtocolDescriptor(
-        uintptr_t protocolDescriptorAddress) {
+        remote::RemoteAddress protocolDescriptorAddress) {
       std::string protocolName;
       auto protocolDescriptorBytes = OpaqueByteReader(
-          remote::RemoteAddress(protocolDescriptorAddress),
+          protocolDescriptorAddress,
           sizeof(ExternalProtocolDescriptor<ObjCInteropKind, PointerSize>));
       if (!protocolDescriptorBytes.get()) {
         Error = "Error reading protocol descriptor.";
@@ -1747,11 +1757,11 @@ private:
 
       // Compute the address of the protocol descriptor's name field and read
       // the offset
-      auto protocolNameOffsetAddress = detail::applyRelativeOffset(
-          (const char *)protocolDescriptorAddress,
-          (int32_t)protocolDescriptor->getNameOffset());
-      auto protocolNameOffsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(protocolNameOffsetAddress), sizeof(uint32_t));
+      auto protocolNameOffsetAddress =
+          protocolDescriptorAddress.applyRelativeOffset(
+              (int32_t)protocolDescriptor->getNameOffset());
+      auto protocolNameOffsetBytes =
+          OpaqueByteReader(protocolNameOffsetAddress, sizeof(uint32_t));
       if (!protocolNameOffsetBytes.get()) {
         Error = "Failed to read type name offset in a protocol descriptor.";
         return std::nullopt;
@@ -1760,74 +1770,71 @@ private:
 
       // Using the offset above, compute the address of the name field itsel
       // and read it.
-      auto protocolNameAddress =
-          detail::applyRelativeOffset((const char *)protocolNameOffsetAddress,
-                                      (int32_t)*protocolNameOffset);
-      OpaqueStringReader(remote::RemoteAddress(protocolNameAddress),
-                         protocolName);
+      auto protocolNameAddress = protocolNameOffsetAddress.applyRelativeOffset(
+          (int32_t)*protocolNameOffset);
+      OpaqueStringReader(protocolNameAddress, protocolName);
       return protocolName;
     }
 
     std::optional<std::string> readTypeNameFromTypeDescriptor(
         const ExternalTypeContextDescriptor<ObjCInteropKind, PointerSize>
             *typeDescriptor,
-        uintptr_t typeDescriptorAddress) {
-      auto typeNameOffsetAddress =
-          detail::applyRelativeOffset((const char *)typeDescriptorAddress,
-                                      (int32_t)typeDescriptor->getNameOffset());
-      auto typeNameOffsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(typeNameOffsetAddress), sizeof(uint32_t));
+        remote::RemoteAddress typeDescriptorAddress) {
+      auto typeNameOffsetAddress = typeDescriptorAddress.applyRelativeOffset(
+          (int32_t)typeDescriptor->getNameOffset());
+      auto typeNameOffsetBytes =
+          OpaqueByteReader(typeNameOffsetAddress, sizeof(uint32_t));
       if (!typeNameOffsetBytes.get()) {
         Error = "Failed to read type name offset in a type descriptor.";
         return std::nullopt;
       }
       auto typeNameOffset = (const uint32_t *)typeNameOffsetBytes.get();
-      auto typeNameAddress = detail::applyRelativeOffset(
-          (const char *)typeNameOffsetAddress, (int32_t)*typeNameOffset);
+      auto typeNameAddress =
+          typeNameOffsetAddress.applyRelativeOffset((int32_t)*typeNameOffset);
       std::string typeName;
-      OpaqueStringReader(remote::RemoteAddress(typeNameAddress), typeName);
+      OpaqueStringReader(typeNameAddress, typeName);
       return typeName;
     }
 
     std::optional<std::string> readModuleNameFromModuleDescriptor(
         const ExternalModuleContextDescriptor<ObjCInteropKind, PointerSize>
             *moduleDescriptor,
-        uintptr_t moduleDescriptorAddress) {
-      auto parentNameOffsetAddress = detail::applyRelativeOffset(
-          (const char *)moduleDescriptorAddress,
-          (int32_t)moduleDescriptor->getNameOffset());
-      auto parentNameOffsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(parentNameOffsetAddress), sizeof(uint32_t));
+        remote::RemoteAddress moduleDescriptorAddress) {
+      auto parentNameOffsetAddress =
+          moduleDescriptorAddress.applyRelativeOffset(
+              (int32_t)moduleDescriptor->getNameOffset());
+      auto parentNameOffsetBytes =
+          OpaqueByteReader(parentNameOffsetAddress, sizeof(uint32_t));
       if (!parentNameOffsetBytes.get()) {
         Error = "Failed to read parent name offset in a module descriptor.";
         return std::nullopt;
       }
       auto parentNameOffset = (const uint32_t *)parentNameOffsetBytes.get();
-      auto parentNameAddress = detail::applyRelativeOffset(
-          (const char *)parentNameOffsetAddress, (int32_t)*parentNameOffset);
+      auto parentNameAddress = parentNameOffsetAddress.applyRelativeOffset(
+          (int32_t)*parentNameOffset);
       std::string parentName;
-      OpaqueStringReader(remote::RemoteAddress(parentNameAddress), parentName);
+      OpaqueStringReader(parentNameAddress, parentName);
       return parentName;
     }
 
     std::optional<std::string> readAnonymousNameFromAnonymousDescriptor(
         const ExternalAnonymousContextDescriptor<ObjCInteropKind, PointerSize>
             *anonymousDescriptor,
-        uintptr_t anonymousDescriptorAddress) {
+        remote::RemoteAddress anonymousDescriptorAddress) {
       if (!anonymousDescriptor->hasMangledName()) {
         std::stringstream stream;
-        stream << "(unknown context at $" << std::hex
-               << anonymousDescriptorAddress << ")";
+        stream << "(unknown context at $"
+               << anonymousDescriptorAddress.getDescription() << ")";
         return stream.str();
       }
       return std::nullopt;
     }
 
     std::optional<std::string>
-    readFullyQualifiedTypeName(uintptr_t typeDescriptorTarget) {
+    readFullyQualifiedTypeName(remote::RemoteAddress typeDescriptorTarget) {
       std::string typeName;
       auto contextTypeDescriptorBytes = OpaqueByteReader(
-          remote::RemoteAddress(typeDescriptorTarget),
+          typeDescriptorTarget,
           sizeof(ExternalContextDescriptor<ObjCInteropKind, PointerSize>));
       if (!contextTypeDescriptorBytes.get()) {
         Error = "Failed to read context descriptor.";
@@ -1861,16 +1868,15 @@ private:
       return constructFullyQualifiedNameFromContextChain(contextNameChain);
     }
 
-    std::optional<std::string>
-    readFullyQualifiedProtocolName(uintptr_t protocolDescriptorTarget) {
+    std::optional<std::string> readFullyQualifiedProtocolName(
+        remote::RemoteAddress protocolDescriptorTarget) {
       std::optional<std::string> protocolName;
       // Set low bit indicates that this is an indirect
       // reference
       if (protocolDescriptorTarget & 0x1) {
         auto adjustedProtocolDescriptorTarget = protocolDescriptorTarget & ~0x1;
-        if (auto symbol = OpaquePointerReader(
-                remote::RemoteAddress(adjustedProtocolDescriptorTarget),
-                PointerSize)) {
+        if (auto symbol = OpaquePointerReader(adjustedProtocolDescriptorTarget,
+                                              PointerSize)) {
           if (!symbol->getSymbol().empty() && symbol->getOffset() == 0) {
             Demangle::Context Ctx;
             auto demangledRoot =
@@ -1882,8 +1888,7 @@ private:
                 nodeToString(demangledRoot->getChild(0)->getChild(0));
           } else {
             // This is an absolute address of a protocol descriptor
-            auto protocolDescriptorAddress =
-                (uintptr_t)symbol->getResolvedAddress().getAddressData();
+            auto protocolDescriptorAddress = symbol->getResolvedAddress();
             protocolName = readFullyQualifiedProtocolNameFromProtocolDescriptor(
                 protocolDescriptorAddress);
           }
@@ -1903,13 +1908,13 @@ private:
   private:
     std::optional<std::string>
     readFullyQualifiedProtocolNameFromProtocolDescriptor(
-        uintptr_t protocolDescriptorAddress) {
+        remote::RemoteAddress protocolDescriptorAddress) {
       std::optional<std::string> protocolName =
           readProtocolNameFromProtocolDescriptor(protocolDescriptorAddress);
 
       // Read the protocol conformance descriptor itself
       auto protocolContextDescriptorBytes = OpaqueByteReader(
-          remote::RemoteAddress(protocolDescriptorAddress),
+          protocolDescriptorAddress,
           sizeof(ExternalContextDescriptor<ObjCInteropKind, PointerSize>));
       if (!protocolContextDescriptorBytes.get()) {
         return std::nullopt;
@@ -1927,23 +1932,22 @@ private:
       return constructFullyQualifiedNameFromContextChain(contextNameChain);
     }
 
-    uintptr_t getParentDescriptorAddress(
-        uintptr_t contextDescriptorAddress,
+    remote::RemoteAddress getParentDescriptorAddress(
+        remote::RemoteAddress contextDescriptorAddress,
         const ExternalContextDescriptor<ObjCInteropKind, PointerSize>
             *contextDescriptor) {
-      auto parentOffsetAddress = detail::applyRelativeOffset(
-          (const char *)contextDescriptorAddress,
+      auto parentOffsetAddress = contextDescriptorAddress.applyRelativeOffset(
           (int32_t)contextDescriptor->getParentOffset());
-      auto parentOfsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(parentOffsetAddress), sizeof(uint32_t));
+      auto parentOfsetBytes =
+          OpaqueByteReader(parentOffsetAddress, sizeof(uint32_t));
       auto parentFieldOffset = (const int32_t *)parentOfsetBytes.get();
-      auto parentTargetAddress = detail::applyRelativeOffset(
-          (const char *)parentOffsetAddress, *parentFieldOffset);
+      auto parentTargetAddress =
+          parentOffsetAddress.applyRelativeOffset(*parentFieldOffset);
       return parentTargetAddress;
     }
 
     std::optional<ContextNameInfo>
-    getContextName(uintptr_t contextDescriptorAddress,
+    getContextName(remote::RemoteAddress contextDescriptorAddress,
                    const ExternalContextDescriptor<ObjCInteropKind, PointerSize>
                        *contextDescriptor) {
       if (auto moduleDescriptor = dyn_cast<
@@ -1989,7 +1993,7 @@ private:
     }
 
     void getParentContextChain(
-        uintptr_t contextDescriptorAddress,
+        remote::RemoteAddress contextDescriptorAddress,
         const ExternalContextDescriptor<ObjCInteropKind, PointerSize>
             *contextDescriptor,
         std::vector<ContextNameInfo> &chain) {
@@ -1997,10 +2001,10 @@ private:
           contextDescriptorAddress, contextDescriptor);
 
       auto addParentNameAndRecurse =
-          [&](uintptr_t parentContextDescriptorAddress,
+          [&](remote::RemoteAddress parentContextDescriptorAddress,
               std::vector<ContextNameInfo> &chain) -> void {
         auto parentContextDescriptorBytes = OpaqueByteReader(
-            remote::RemoteAddress(parentContextDescriptorAddress),
+            parentContextDescriptorAddress,
             sizeof(ExternalContextDescriptor<ObjCInteropKind, PointerSize>));
         if (!parentContextDescriptorBytes.get()) {
           Error = "Failed to read context descriptor.";
@@ -2024,9 +2028,8 @@ private:
       // Set low bit indicates that this is an indirect reference
       if (parentDescriptorAddress & 0x1) {
         auto adjustedParentTargetAddress = parentDescriptorAddress & ~0x1;
-        if (auto symbol = OpaquePointerReader(
-                remote::RemoteAddress(adjustedParentTargetAddress),
-                PointerSize)) {
+        if (auto symbol =
+                OpaquePointerReader(adjustedParentTargetAddress, PointerSize)) {
           if (!symbol->getSymbol().empty() && symbol->getOffset() == 0) {
             Demangle::Context Ctx;
             auto demangledRoot =
@@ -2072,8 +2075,9 @@ private:
             lastContext ? false : contextNameChain[i + 1].isAnonymous;
         if (nextContextIsAnonymous && !currentContextIsAnonymous) {
           std::stringstream stream;
-          stream << "(" << contextNameInfo.name << " in $" << std::hex
-                 << contextNameChain[i + 1].descriptorAddress << ")";
+          stream << "(" << contextNameInfo.name << " in $"
+                 << contextNameChain[i + 1].descriptorAddress.getDescription()
+                 << ")";
           reversedQualifiedTypeNameMembers.push_back(stream.str());
           skipNext = true;
         } else if (nextContextIsAnonymous && currentContextIsAnonymous) {
@@ -2104,11 +2108,11 @@ private:
   template <template <typename Runtime> class ObjCInteropKind,
             unsigned PointerSize>
   void extractOpaqueTypeProtocolRequirements(
-      uintptr_t opaqueTypeDescriptorAddress,
+      remote::RemoteAddress opaqueTypeDescriptorAddress,
       std::vector<std::string> &protocolRequirements,
       std::vector<TypeAliasInfo> &sameTypeRequirements) {
     auto opaqueTypeDescriptorBytes = OpaqueByteReader(
-        remote::RemoteAddress(opaqueTypeDescriptorAddress),
+        opaqueTypeDescriptorAddress,
         sizeof(ExternalOpaqueTypeDescriptor<ObjCInteropKind, PointerSize>));
     if (!opaqueTypeDescriptorBytes.get()) {
       return;
@@ -2126,16 +2130,15 @@ private:
     // is an offset to a TypeRef string, read it.
     auto readRequirementTypeRefAddress =
         [&](uintptr_t offsetFromOpaqueDescBase,
-            uintptr_t requirementAddress) -> uintptr_t {
+            uintptr_t requirementAddress) -> remote::RemoteAddress {
       std::string typeRefString = "";
       auto fieldOffsetOffset = requirementAddress + offsetFromOpaqueDescBase -
                                (uintptr_t)opaqueTypeDescriptor;
       auto fieldOffsetAddress = opaqueTypeDescriptorAddress + fieldOffsetOffset;
-      auto fieldOffsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(fieldOffsetAddress), sizeof(uint32_t));
+      auto fieldOffsetBytes =
+          OpaqueByteReader(fieldOffsetAddress, sizeof(uint32_t));
       auto fieldOffset = (const int32_t *)fieldOffsetBytes.get();
-      auto fieldAddress = detail::applyRelativeOffset(
-          (const char *)fieldOffsetAddress, *fieldOffset);
+      auto fieldAddress = fieldOffsetAddress.applyRelativeOffset(*fieldOffset);
       return fieldAddress;
     };
 
@@ -2153,9 +2156,9 @@ private:
 
         // Compute the address of the protocol descriptor by following the
         // offset
-        auto protocolDescriptorAddress = detail::applyRelativeOffset(
-            (const char *)protocolDescriptorOffsetAddress,
-            protocolDescriptorOffsetValue);
+        auto protocolDescriptorAddress =
+            protocolDescriptorOffsetAddress.applyRelativeOffset(
+                protocolDescriptorOffsetValue);
 
         auto nameReader =
             QualifiedContextNameReader<ObjCInteropKind, PointerSize>(
@@ -2220,7 +2223,7 @@ private:
     /// Extract conforming type's name from a Conformance Descriptor
     /// Returns a pair of (mangledTypeName, fullyQualifiedTypeName)
     std::optional<std::pair<std::string, std::string>> getConformingTypeName(
-        const uintptr_t conformanceDescriptorAddress,
+        const remote::RemoteAddress conformanceDescriptorAddress,
         const ExternalProtocolConformanceDescriptor<
             ObjCInteropKind, PointerSize> &conformanceDescriptor) {
       std::string typeName;
@@ -2242,12 +2245,11 @@ private:
       //    descriptor
       //    - Address of the type descriptor is found at the (2) offset from the
       //      conformance descriptor address
-      auto contextDescriptorFieldAddress = detail::applyRelativeOffset(
-          (const char *)conformanceDescriptorAddress,
-          (int32_t)conformanceDescriptor.getTypeRefDescriptorOffset());
+      auto contextDescriptorFieldAddress =
+          conformanceDescriptorAddress.applyRelativeOffset(
+              (int32_t)conformanceDescriptor.getTypeRefDescriptorOffset());
       auto contextDescriptorOffsetBytes =
-          OpaqueByteReader(remote::RemoteAddress(contextDescriptorFieldAddress),
-                           sizeof(uint32_t));
+          OpaqueByteReader(contextDescriptorFieldAddress, sizeof(uint32_t));
       if (!contextDescriptorOffsetBytes.get()) {
         Error =
             "Failed to read type descriptor field in conformance descriptor.";
@@ -2257,14 +2259,14 @@ private:
           (const int32_t *)contextDescriptorOffsetBytes.get();
 
       // Read the type descriptor itself using the address computed above
-      auto contextTypeDescriptorAddress = detail::applyRelativeOffset(
-          (const char *)contextDescriptorFieldAddress,
-          *contextDescriptorOffset);
+      auto contextTypeDescriptorAddress =
+          contextDescriptorFieldAddress.applyRelativeOffset(
+              *contextDescriptorOffset);
 
       // Instead of a type descriptor this may just be a reference to an
       // external, check that first
-      if (auto symbol = OpaqueDynamicSymbolResolver(
-              remote::RemoteAddress(contextTypeDescriptorAddress))) {
+      if (auto symbol =
+              OpaqueDynamicSymbolResolver(contextTypeDescriptorAddress)) {
         if (!symbol->getSymbol().empty() && symbol->getOffset() == 0) {
           Demangle::Context Ctx;
           auto demangledRoot =
@@ -2287,8 +2289,7 @@ private:
         } else if (symbol->getResolvedAddress()) {
           // If symbol is empty and has an offset, this is the resolved remote
           // address
-          contextTypeDescriptorAddress =
-              symbol->getResolvedAddress().getAddressData();
+          contextTypeDescriptorAddress = symbol->getResolvedAddress();
         }
       }
 
@@ -2302,17 +2303,17 @@ private:
 
     /// Extract protocol name from a Conformance Descriptor
     std::optional<std::string> getConformanceProtocolName(
-        const uintptr_t conformanceDescriptorAddress,
+        const remote::RemoteAddress conformanceDescriptorAddress,
         const ExternalProtocolConformanceDescriptor<
             ObjCInteropKind, PointerSize> &conformanceDescriptor) {
       std::optional<std::string> protocolName;
-      auto protocolDescriptorFieldAddress = detail::applyRelativeOffset(
-          (const char *)conformanceDescriptorAddress,
-          (int32_t)conformanceDescriptor.getProtocolDescriptorOffset());
+      auto protocolDescriptorFieldAddress =
+          conformanceDescriptorAddress.applyRelativeOffset(
 
-      auto protocolDescriptorOffsetBytes = OpaqueByteReader(
-          remote::RemoteAddress(protocolDescriptorFieldAddress),
-          sizeof(uint32_t));
+              (int32_t)conformanceDescriptor.getProtocolDescriptorOffset());
+
+      auto protocolDescriptorOffsetBytes =
+          OpaqueByteReader(protocolDescriptorFieldAddress, sizeof(uint32_t));
       if (!protocolDescriptorOffsetBytes.get()) {
         Error = "Error reading protocol descriptor field in conformance "
                 "descriptor.";
@@ -2321,9 +2322,9 @@ private:
       auto protocolDescriptorOffset =
           (const uint32_t *)protocolDescriptorOffsetBytes.get();
 
-      auto protocolDescriptorTarget = detail::applyRelativeOffset(
-          (const char *)protocolDescriptorFieldAddress,
-          (int32_t)*protocolDescriptorOffset);
+      auto protocolDescriptorTarget =
+          protocolDescriptorFieldAddress.applyRelativeOffset(
+              (int32_t)*protocolDescriptorOffset);
 
       return NameReader.readFullyQualifiedProtocolName(
           protocolDescriptorTarget);
@@ -2340,11 +2341,11 @@ private:
                *)conformanceRecordRef.getLocalBuffer();
       // Read the Protocol Conformance Descriptor by getting its address from
       // the conformance record.
-      auto conformanceDescriptorAddress = (uintptr_t)CD->getRelative(
-          (void *)conformanceRecordRef.getAddressData());
+      auto conformanceDescriptorAddress =
+          conformanceRecordRef.getRemoteAddress().getRelative(CD);
 
       auto descriptorBytes = OpaqueByteReader(
-          remote::RemoteAddress(conformanceDescriptorAddress),
+          conformanceDescriptorAddress,
           sizeof(ExternalProtocolConformanceDescriptor<ObjCInteropKind,
                                                        PointerSize>));
       if (!descriptorBytes.get()) {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -65,6 +65,10 @@ public:
 
   bool containsRemoteAddress(remote::RemoteAddress remoteAddr,
                              uint64_t size) const {
+    if (Start.getRemoteAddress().getAddressSpace() !=
+        remoteAddr.getAddressSpace())
+      return false;
+
     return Start.getRemoteAddress() <= remoteAddr &&
            remoteAddr + size <= Start.getRemoteAddress() + Size;
   }

--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -39,8 +39,12 @@ private:
   uint64_t HeaderAddress;
   std::vector<Segment> Segments;
   struct DynamicRelocation {
+    /// The symbol name that the pointer refers to. Empty if only an absolute
+    /// address is available.
     StringRef Symbol;
-    uint64_t Offset;
+    // The offset (if the symbol is available), or the resolved remote address
+    // if the symbol is empty.
+    uint64_t OffsetOrAddress;
   };
   llvm::DenseMap<uint64_t, DynamicRelocation> DynamicRelocations;
 

--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -92,13 +92,18 @@ class ObjectMemoryReader : public reflection::MemoryReader {
   };
   std::vector<ImageEntry> Images;
 
+  uint64_t PtrauthMask = 0;
+
   std::pair<const Image *, uint64_t>
   decodeImageIndexAndAddress(uint64_t Addr) const;
 
-  uint64_t encodeImageIndexAndAddress(const Image *image,
-                                      uint64_t imageAddr) const;
+  remote::RemoteAddress
+  encodeImageIndexAndAddress(const Image *image,
+                             remote::RemoteAddress imageAddr) const;
 
   StringRef getContentsAtAddress(uint64_t Addr, uint64_t Size);
+
+  uint64_t getPtrauthMask();
 
 public:
   explicit ObjectMemoryReader(
@@ -114,7 +119,7 @@ public:
   // TODO: We could consult the dynamic symbol tables of the images to
   // implement this.
   reflection::RemoteAddress getSymbolAddress(const std::string &name) override {
-    return reflection::RemoteAddress(nullptr);
+    return reflection::RemoteAddress();
   }
 
   ReadBytesResult readBytes(reflection::RemoteAddress Addr,

--- a/lib/RemoteAST/InProcessMemoryReader.cpp
+++ b/lib/RemoteAST/InProcessMemoryReader.cpp
@@ -35,5 +35,5 @@ RemoteAddress InProcessMemoryReader::getSymbolAddress(const std::string &name) {
 #else
     auto pointer = dlsym(RTLD_DEFAULT, name.c_str());
 #endif
-    return RemoteAddress(pointer);
+    return RemoteAddress((uint64_t)pointer, RemoteAddress::DefaultAddressSpace);
 }

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -322,9 +322,9 @@ Image::resolvePointer(uint64_t Addr, uint64_t pointerValue) const {
   // 32 bits.
   if (isMachOWithPtrAuth()) {
     return remote::RemoteAbsolutePointer(
-        "", HeaderAddress + (pointerValue & 0xffffffffull));
+        remote::RemoteAddress(HeaderAddress + (pointerValue & 0xffffffffull)));
   } else {
-    return remote::RemoteAbsolutePointer("", pointerValue);
+    return remote::RemoteAbsolutePointer(remote::RemoteAddress(pointerValue));
   }
 }
 
@@ -333,7 +333,8 @@ remote::RemoteAbsolutePointer Image::getDynamicSymbol(uint64_t Addr) const {
   if (found == DynamicRelocations.end())
     return nullptr;
   return remote::RemoteAbsolutePointer(found->second.Symbol,
-                                       found->second.Offset);
+                                       found->second.Offset,
+                                       remote::RemoteAddress((uint64_t)0));
 }
 
 std::pair<const Image *, uint64_t>
@@ -526,8 +527,8 @@ ObjectMemoryReader::resolvePointer(reflection::RemoteAddress Addr,
   // Mix in the image index again to produce a remote address pointing into the
   // same image.
   return remote::RemoteAbsolutePointer(
-      "", encodeImageIndexAndAddress(
-              image, resolved.getResolvedAddress().getAddressData()));
+      remote::RemoteAddress(encodeImageIndexAndAddress(
+          image, resolved.getResolvedAddress().getAddressData())));
 }
 
 remote::RemoteAbsolutePointer

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -321,10 +321,11 @@ Image::resolvePointer(uint64_t Addr, uint64_t pointerValue) const {
   // base address in the low 32 bits, and ptrauth discriminator info in the top
   // 32 bits.
   if (isMachOWithPtrAuth()) {
-    return remote::RemoteAbsolutePointer(
-        remote::RemoteAddress(HeaderAddress + (pointerValue & 0xffffffffull)));
+    return remote::RemoteAbsolutePointer(remote::RemoteAddress(
+        HeaderAddress + (pointerValue & 0xffffffffull), 0));
   } else {
-    return remote::RemoteAbsolutePointer(remote::RemoteAddress(pointerValue));
+    return remote::RemoteAbsolutePointer(remote::RemoteAddress(
+        pointerValue, reflection::RemoteAddress::DefaultAddressSpace));
   }
 }
 
@@ -352,9 +353,8 @@ ObjectMemoryReader::decodeImageIndexAndAddress(uint64_t Addr) const {
   return {nullptr, 0};
 }
 
-uint64_t
-ObjectMemoryReader::encodeImageIndexAndAddress(const Image *image,
-                                               uint64_t imageAddr) const {
+remote::RemoteAddress ObjectMemoryReader::encodeImageIndexAndAddress(
+    const Image *image, remote::RemoteAddress imageAddr) const {
   auto entry = (const ImageEntry *)image;
   return imageAddr + entry->Slide;
 }
@@ -486,19 +486,21 @@ ObjectMemoryReader::getImageStartAddress(unsigned i) const {
   assert(i < Images.size());
 
   return reflection::RemoteAddress(encodeImageIndexAndAddress(
-      &Images[i].TheImage, Images[i].TheImage.getStartAddress()));
+      &Images[i].TheImage,
+      remote::RemoteAddress(Images[i].TheImage.getStartAddress(),
+                            reflection::RemoteAddress::DefaultAddressSpace)));
 }
 
 ReadBytesResult ObjectMemoryReader::readBytes(reflection::RemoteAddress Addr,
                                               uint64_t Size) {
-  auto addrValue = Addr.getAddressData();
+  auto addrValue = Addr.getRawAddress();
   auto resultBuffer = getContentsAtAddress(addrValue, Size);
   return ReadBytesResult(resultBuffer.data(), no_op_destructor);
 }
 
 bool ObjectMemoryReader::readString(reflection::RemoteAddress Addr,
                                     std::string &Dest) {
-  auto addrValue = Addr.getAddressData();
+  auto addrValue = Addr.getRawAddress();
   auto resultBuffer = getContentsAtAddress(addrValue, 1);
   if (resultBuffer.empty())
     return false;
@@ -519,7 +521,7 @@ found_terminator:
 remote::RemoteAbsolutePointer
 ObjectMemoryReader::resolvePointer(reflection::RemoteAddress Addr,
                                    uint64_t pointerValue) {
-  auto addrValue = Addr.getAddressData();
+  auto addrValue = Addr.getRawAddress();
   const Image *image;
   uint64_t imageAddr;
   std::tie(image, imageAddr) = decodeImageIndexAndAddress(addrValue);
@@ -530,14 +532,13 @@ ObjectMemoryReader::resolvePointer(reflection::RemoteAddress Addr,
   auto resolved = image->resolvePointer(imageAddr, pointerValue);
   // Mix in the image index again to produce a remote address pointing into the
   // same image.
-  return remote::RemoteAbsolutePointer(
-      remote::RemoteAddress(encodeImageIndexAndAddress(
-          image, resolved.getResolvedAddress().getAddressData())));
+  return remote::RemoteAbsolutePointer(remote::RemoteAddress(
+      encodeImageIndexAndAddress(image, resolved.getResolvedAddress())));
 }
 
 remote::RemoteAbsolutePointer
 ObjectMemoryReader::getDynamicSymbol(reflection::RemoteAddress Addr) {
-  auto addrValue = Addr.getAddressData();
+  auto addrValue = Addr.getRawAddress();
   const Image *image;
   uint64_t imageAddr;
   std::tie(image, imageAddr) = decodeImageIndexAndAddress(addrValue);
@@ -546,6 +547,31 @@ ObjectMemoryReader::getDynamicSymbol(reflection::RemoteAddress Addr) {
     return nullptr;
 
   return image->getDynamicSymbol(imageAddr);
+}
+
+uint64_t ObjectMemoryReader::getPtrauthMask() {
+  auto initializePtrauthMask = [&]() -> uint64_t {
+    uint8_t pointerSize = 0;
+    if (!queryDataLayout(DataLayoutQueryType::DLQ_GetPointerSize, nullptr,
+                         &pointerSize))
+      return ~0ull;
+
+    if (pointerSize == 4) {
+      uint32_t ptrauthMask32 = 0;
+      if (queryDataLayout(DataLayoutQueryType::DLQ_GetPtrAuthMask, nullptr,
+                          &ptrauthMask32))
+        return (uint64_t)ptrauthMask32;
+    } else if (pointerSize == 8) {
+      uint64_t ptrauthMask64 = 0;
+      if (queryDataLayout(DataLayoutQueryType::DLQ_GetPtrAuthMask, nullptr,
+                          &ptrauthMask64))
+        return ptrauthMask64;
+    }
+    return ~0ull;
+  };
+  if (!PtrauthMask)
+    PtrauthMask = initializePtrauthMask();
+  return PtrauthMask;
 }
 
 template <typename Runtime>

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -332,9 +332,13 @@ remote::RemoteAbsolutePointer Image::getDynamicSymbol(uint64_t Addr) const {
   auto found = DynamicRelocations.find(Addr);
   if (found == DynamicRelocations.end())
     return nullptr;
-  return remote::RemoteAbsolutePointer(found->second.Symbol,
-                                       found->second.Offset,
-                                       remote::RemoteAddress((uint64_t)0));
+  if (!found->second.Symbol.empty())
+    return remote::RemoteAbsolutePointer(found->second.Symbol,
+                                         found->second.OffsetOrAddress,
+                                         remote::RemoteAddress());
+  return remote::RemoteAbsolutePointer(
+      remote::RemoteAddress(found->second.OffsetOrAddress,
+                            remote::RemoteAddress::DefaultAddressSpace));
 }
 
 std::pair<const Image *, uint64_t>

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -408,8 +408,7 @@ bool RecordTypeInfo::readExtraInhabitantIndex(remote::MemoryReader &reader,
       [](const FieldInfo &lhs, const FieldInfo &rhs) {
         return lhs.TI.getNumExtraInhabitants() < rhs.TI.getNumExtraInhabitants();
       });
-    auto fieldAddress = remote::RemoteAddress(address.getAddressData()
-                                              + mostCapaciousField->Offset);
+    auto fieldAddress = address + mostCapaciousField->Offset;
     return mostCapaciousField->TI.readExtraInhabitantIndex(
       reader, fieldAddress, extraInhabitantIndex);
   }

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -64,7 +64,7 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::
                   .TypeReference.startAddress()
                   .getRemoteAddress();
 
-          return typeReferenceAStart < typeReferenceBStart;
+          return typeReferenceAStart.orderedLessThan(typeReferenceBStart);
         });
   }
 
@@ -75,9 +75,11 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::
       ReflectionInfoIndexesSortedByTypeReferenceRange.begin(),
       ReflectionInfoIndexesSortedByTypeReferenceRange.end(), remoteAddr,
       [&](uint32_t ReflectionInfoIndex, remote::RemoteAddress remoteAddr) {
-        return ReflectionInfos[ReflectionInfoIndex]
-                   .TypeReference.endAddress()
-                   .getRemoteAddress() <= remoteAddr;
+        auto reflectionInfoAddress = ReflectionInfos[ReflectionInfoIndex]
+                                         .TypeReference.endAddress()
+                                         .getRemoteAddress();
+
+        return reflectionInfoAddress.orderedLessThanOrEqual(remoteAddr);
       });
 
   if (possiblyMatchingReflectionInfoIndex ==

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -233,7 +233,9 @@ ReflectionSection<Iterator> sectionFromInfo(const swift_reflection_info_t &Info,
     - Info.LocalStartAddress
     + Info.RemoteStartAddress;
 
-  auto Start = RemoteRef<void>(RemoteSectionStart, Section.section.Begin);
+  auto Start = RemoteRef<void>(
+      RemoteAddress(RemoteSectionStart, RemoteAddress::DefaultAddressSpace),
+      Section.section.Begin);
 
   return ReflectionSection<Iterator>(Start,
              (uintptr_t)Section.section.End - (uintptr_t)Section.section.Begin);
@@ -244,7 +246,9 @@ ReflectionSection<Iterator> reflectionSectionFromLocalAndRemote(
     const swift_reflection_section_mapping_t &Section) {
   auto RemoteSectionStart = (uint64_t)Section.remote_section.StartAddress;
 
-  auto Start = RemoteRef<void>(RemoteSectionStart, Section.local_section.Begin);
+  auto Start = RemoteRef<void>(
+      RemoteAddress(RemoteSectionStart, RemoteAddress::DefaultAddressSpace),
+      Section.local_section.Begin);
 
   return ReflectionSection<Iterator>(Start,
                                      (uintptr_t)Section.remote_section.Size);
@@ -309,7 +313,10 @@ int
 swift_reflection_addImage(SwiftReflectionContextRef ContextRef,
                           swift_addr_t imageStart) {
   return ContextRef->withContext<int>([&](auto *Context) {
-    return Context->addImage(RemoteAddress(imageStart)).has_value();
+    return Context
+        ->addImage(
+            RemoteAddress(imageStart, RemoteAddress::DefaultAddressSpace))
+        .has_value();
   });
 }
 
@@ -331,7 +338,8 @@ swift_typeref_t
 swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Metadata) {
   return ContextRef->withContext<swift_typeref_t>([&](auto *Context) {
-    auto TR = Context->readTypeFromMetadata(Metadata);
+    auto TR = Context->readTypeFromMetadata(RemoteAddress(Metadata,
+                                            RemoteAddress::DefaultAddressSpace));
     return reinterpret_cast<swift_typeref_t>(TR);
   });
 }
@@ -339,21 +347,24 @@ swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
 int
 swift_reflection_ownsObject(SwiftReflectionContextRef ContextRef, uintptr_t Object) {
   return ContextRef->withContext<int>([&](auto *Context) {
-    return Context->ownsObject(RemoteAddress(Object));
+    return Context->ownsObject(
+        RemoteAddress(Object, RemoteAddress::DefaultAddressSpace));
   });
 }
 
 int
 swift_reflection_ownsAddress(SwiftReflectionContextRef ContextRef, uintptr_t Address) {
   return ContextRef->withContext<int>([&](auto *Context) {
-    return Context->ownsAddress(RemoteAddress(Address));
+    return Context->ownsAddress(
+        RemoteAddress(Address, RemoteAddress::DefaultAddressSpace));
   });
 }
 
 int
 swift_reflection_ownsAddressStrict(SwiftReflectionContextRef ContextRef, uintptr_t Address) {
   return ContextRef->withContext<int>([&](auto *Context) {
-    return Context->ownsAddress(RemoteAddress(Address), false);
+    return Context->ownsAddress(
+        RemoteAddress(Address, RemoteAddress::DefaultAddressSpace), false);
   });
 }
 
@@ -361,10 +372,11 @@ uintptr_t
 swift_reflection_metadataForObject(SwiftReflectionContextRef ContextRef,
                                    uintptr_t Object) {
   return ContextRef->withContext<uintptr_t>([&](auto *Context) -> uintptr_t {
-    auto MetadataAddress = Context->readMetadataFromInstance(Object);
+    auto MetadataAddress = Context->readMetadataFromInstance(
+        RemoteAddress(Object, RemoteAddress::DefaultAddressSpace));
     if (!MetadataAddress)
       return 0;
-    return *MetadataAddress;
+    return MetadataAddress->getRawAddress();
   });
 }
 
@@ -372,14 +384,19 @@ swift_reflection_ptr_t
 swift_reflection_metadataNominalTypeDescriptor(SwiftReflectionContextRef ContextRef,
                                                swift_reflection_ptr_t MetadataAddress) {
   return ContextRef->withContext<swift_reflection_ptr_t>([&](auto *Context) {
-    return Context->nominalTypeDescriptorFromMetadata(MetadataAddress);
+    return Context
+        ->nominalTypeDescriptorFromMetadata(
+            RemoteAddress(MetadataAddress, RemoteAddress::DefaultAddressSpace))
+        .getRawAddress();
   });
 }
 
 int swift_reflection_metadataIsActor(SwiftReflectionContextRef ContextRef,
                                      swift_reflection_ptr_t Metadata) {
-  return ContextRef->withContext<int>(
-      [&](auto *Context) { return Context->metadataIsActor(Metadata); });
+  return ContextRef->withContext<int>([&](auto *Context) {
+    return Context->metadataIsActor(
+        RemoteAddress(Metadata, RemoteAddress::DefaultAddressSpace));
+  });
 }
 
 swift_typeref_t
@@ -387,7 +404,8 @@ swift_reflection_typeRefForInstance(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Object) {
   return ContextRef->withContext<swift_typeref_t>(
       [&](auto *Context) -> swift_typeref_t {
-        auto MetadataAddress = Context->readMetadataFromInstance(Object);
+        auto MetadataAddress = Context->readMetadataFromInstance(
+            RemoteAddress(Object, RemoteAddress::DefaultAddressSpace));
         if (!MetadataAddress)
           return 0;
         auto TR = Context->readTypeFromMetadata(*MetadataAddress);
@@ -443,7 +461,8 @@ swift_reflection_copyDemangledNameForProtocolDescriptor(
   return ContextRef->withContext<char *>([&](auto *Context) {
 
     Demangle::Demangler Dem;
-    auto Demangling = Context->readDemanglingForContextDescriptor(Proto, Dem);
+    auto Demangling = Context->readDemanglingForContextDescriptor(
+        RemoteAddress(Proto, RemoteAddress::DefaultAddressSpace), Dem);
     auto Name = nodeToString(Demangling);
     return strdup(Name.c_str());
   });
@@ -649,7 +668,8 @@ swift_typeinfo_t
 swift_reflection_infoForMetadata(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Metadata) {
   return ContextRef->withContext<swift_typeinfo_t>([&](auto *Context) {
-    auto *TI = Context->getMetadataTypeInfo(Metadata, nullptr);
+    auto *TI = Context->getMetadataTypeInfo(
+        RemoteAddress(Metadata, RemoteAddress::DefaultAddressSpace), nullptr);
     return convertTypeInfo(TI);
   });
 }
@@ -659,7 +679,8 @@ swift_reflection_childOfMetadata(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Metadata,
                                  unsigned Index) {
   return ContextRef->withContext<swift_childinfo_t>([&](auto *Context) {
-    auto *TI = Context->getMetadataTypeInfo(Metadata, nullptr);
+    auto *TI = Context->getMetadataTypeInfo(
+        RemoteAddress(Metadata, RemoteAddress::DefaultAddressSpace), nullptr);
     return convertChild(TI, Index);
   });
 }
@@ -668,7 +689,8 @@ swift_typeinfo_t
 swift_reflection_infoForInstance(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Object) {
   return ContextRef->withContext<swift_typeinfo_t>([&](auto *Context) {
-    auto *TI = Context->getInstanceTypeInfo(Object, nullptr);
+    auto *TI = Context->getInstanceTypeInfo(
+        RemoteAddress(Object, RemoteAddress::DefaultAddressSpace), nullptr);
     return convertTypeInfo(TI);
   });
 }
@@ -678,7 +700,8 @@ swift_reflection_childOfInstance(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Object,
                                  unsigned Index) {
   return ContextRef->withContext<swift_childinfo_t>([&](auto *Context) {
-    auto *TI = Context->getInstanceTypeInfo(Object, nullptr);
+    auto *TI = Context->getInstanceTypeInfo(
+        RemoteAddress(Object, RemoteAddress::DefaultAddressSpace), nullptr);
     return convertChild(TI, Index);
   });
 }
@@ -690,16 +713,17 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
                                         swift_addr_t *StartOfInstanceData) {
   return ContextRef->withContext<int>([&](auto *Context) {
     auto ExistentialTR = reinterpret_cast<const TypeRef *>(ExistentialTypeRef);
-    auto RemoteExistentialAddress = RemoteAddress(ExistentialAddress);
+    auto RemoteExistentialAddress =
+        RemoteAddress(ExistentialAddress, RemoteAddress::DefaultAddressSpace);
     const TypeRef *InstanceTR = nullptr;
-    RemoteAddress RemoteStartOfInstanceData(nullptr);
+    RemoteAddress RemoteStartOfInstanceData;
     auto Success = Context->projectExistential(
         RemoteExistentialAddress, ExistentialTR, &InstanceTR,
         &RemoteStartOfInstanceData, nullptr);
 
     if (Success) {
       *InstanceTypeRef = reinterpret_cast<swift_typeref_t>(InstanceTR);
-      *StartOfInstanceData = RemoteStartOfInstanceData.getAddressData();
+      *StartOfInstanceData = RemoteStartOfInstanceData.getRawAddress();
     }
 
     return Success;
@@ -713,14 +737,15 @@ int swift_reflection_projectExistentialAndUnwrapClass(SwiftReflectionContextRef 
                                         swift_addr_t *StartOfInstanceData) {
   return ContextRef->withContext<int>([&](auto *Context) {
     auto ExistentialTR = reinterpret_cast<const TypeRef *>(ExistentialTypeRef);
-    auto RemoteExistentialAddress = RemoteAddress(ExistentialAddress);
+    auto RemoteExistentialAddress =
+        RemoteAddress(ExistentialAddress, RemoteAddress::DefaultAddressSpace);
     auto Pair = Context->projectExistentialAndUnwrapClass(
         RemoteExistentialAddress, *ExistentialTR);
     if (!Pair.has_value())
       return false;
     *InstanceTypeRef =
         reinterpret_cast<swift_typeref_t>(std::get<const TypeRef *>(*Pair));
-    *StartOfInstanceData = std::get<RemoteAddress>(*Pair).getAddressData();
+    *StartOfInstanceData = std::get<RemoteAddress>(*Pair).getRawAddress();
 
     return true;
   });
@@ -732,7 +757,8 @@ int swift_reflection_projectEnumValue(SwiftReflectionContextRef ContextRef,
                                       int *CaseIndex) {
   return ContextRef->withContext<int>([&](auto *Context) {
     auto EnumTR = reinterpret_cast<const TypeRef *>(EnumTypeRef);
-    auto RemoteEnumAddress = RemoteAddress(EnumAddress);
+    auto RemoteEnumAddress =
+        RemoteAddress(EnumAddress, RemoteAddress::DefaultAddressSpace);
     if (!Context->projectEnumValue(RemoteEnumAddress, EnumTR, CaseIndex,
                                    nullptr)) {
       return false;
@@ -791,7 +817,8 @@ void swift_reflection_dumpInfoForTypeRef(SwiftReflectionContextRef ContextRef,
 void swift_reflection_dumpInfoForMetadata(SwiftReflectionContextRef ContextRef,
                                           uintptr_t Metadata) {
   ContextRef->withContext<void>([&](auto *Context) {
-    auto TI = Context->getMetadataTypeInfo(Metadata, nullptr);
+    auto TI = Context->getMetadataTypeInfo(
+        RemoteAddress(Metadata, RemoteAddress::DefaultAddressSpace), nullptr);
     if (TI == nullptr) {
       std::cout << "<null type info>\n";
     } else {
@@ -803,7 +830,8 @@ void swift_reflection_dumpInfoForMetadata(SwiftReflectionContextRef ContextRef,
 void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
                                           uintptr_t Object) {
   ContextRef->withContext<void>([&](auto *Context) {
-    auto TI = Context->getInstanceTypeInfo(Object, nullptr);
+    auto TI = Context->getInstanceTypeInfo(
+        RemoteAddress(Object, RemoteAddress::DefaultAddressSpace), nullptr);
     if (TI == nullptr) {
       std::cout << "<null type info>\n";
     } else {
@@ -831,7 +859,7 @@ const char *swift_reflection_iterateConformanceCache(
   void *ContextPtr) {
   return ContextRef->withContext<const char *>([&](auto *Context) {
     auto Error = Context->iterateConformances([&](auto Type, auto Proto) {
-      Call(Type, Proto, ContextPtr);
+      Call(Type.getRawAddress(), Proto.getRawAddress(), ContextPtr);
     });
     return returnableCString(ContextRef, Error);
   });
@@ -939,7 +967,8 @@ swift_reflection_asyncTaskSlabPointer(SwiftReflectionContextRef ContextRef,
         unsigned AsyncBacktraceLimit = 0;
 
         auto [Error, TaskInfo] = Context->asyncTaskInfo(
-            AsyncTaskPtr, ChildTaskLimit, AsyncBacktraceLimit);
+            RemoteAddress(AsyncTaskPtr, RemoteAddress::DefaultAddressSpace),
+            ChildTaskLimit, AsyncBacktraceLimit);
 
         swift_async_task_slab_return_t Result = {};
         if (Error) {
@@ -999,7 +1028,8 @@ swift_reflection_asyncTaskInfo(SwiftReflectionContextRef ContextRef,
     unsigned AsyncBacktraceLimit = 1000;
 
     auto [Error, TaskInfo] = Context->asyncTaskInfo(
-        AsyncTaskPtr, ChildTaskLimit, AsyncBacktraceLimit);
+        RemoteAddress(AsyncTaskPtr, RemoteAddress::DefaultAddressSpace),
+        ChildTaskLimit, AsyncBacktraceLimit);
 
     swift_async_task_info_t Result = {};
     if (Error) {
@@ -1054,7 +1084,8 @@ swift_actor_info_t
 swift_reflection_actorInfo(SwiftReflectionContextRef ContextRef,
                            swift_reflection_ptr_t ActorPtr) {
   return ContextRef->withContext<swift_actor_info_t>([&](auto *Context) {
-    auto [Error, ActorInfo] = Context->actorInfo(ActorPtr);
+    auto [Error, ActorInfo] = Context->actorInfo(
+        RemoteAddress(ActorPtr, RemoteAddress::DefaultAddressSpace));
 
     swift_actor_info_t Result = {};
     Result.Error = returnableCString(ContextRef, Error);
@@ -1075,6 +1106,7 @@ swift_reflection_ptr_t
 swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
                          swift_reflection_ptr_t JobPtr) {
   return ContextRef->withContext<swift_reflection_ptr_t>([&](auto *Context) {
-    return Context->nextJob(JobPtr);
+    return Context->nextJob(
+        RemoteAddress(JobPtr, RemoteAddress::DefaultAddressSpace));
   });
 }

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -77,8 +77,8 @@ printMetadataType(const Metadata *typeMetadata) {
   auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
-  auto result =
-    remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(typeMetadata));
+  auto result = remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(
+      (uint64_t)typeMetadata, RemoteAddress::DefaultAddressSpace));
   if (result) {
     out << "found type: ";
     result.getValue().print(out);
@@ -95,8 +95,8 @@ printHeapMetadataType(void *object) {
   auto &remoteAST = getRemoteASTContext();
   auto &out = llvm::outs();
 
-  auto metadataResult =
-    remoteAST.getHeapMetadataForObject(RemoteAddress(object));
+  auto metadataResult = remoteAST.getHeapMetadataForObject(
+      RemoteAddress((uint64_t)object, RemoteAddress::DefaultAddressSpace));
   if (!metadataResult) {
     out << metadataResult.getFailure().render() << '\n';
     return;
@@ -120,8 +120,8 @@ static void printMemberOffset(const Metadata *typeMetadata,
   auto &out = llvm::outs();
 
   // The first thing we have to do is get the type.
-  auto typeResult =
-    remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(typeMetadata));
+  auto typeResult = remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(
+      (uint64_t)typeMetadata, RemoteAddress::DefaultAddressSpace));
   if (!typeResult) {
     out << "failed to find type: " << typeResult.getFailure().render() << '\n';
     return;
@@ -130,7 +130,9 @@ static void printMemberOffset(const Metadata *typeMetadata,
   Type type = typeResult.getValue();
 
   RemoteAddress address =
-    (passMetadata ? RemoteAddress(typeMetadata) : RemoteAddress(nullptr));
+      (passMetadata ? RemoteAddress((uint64_t)typeMetadata,
+                                    RemoteAddress::DefaultAddressSpace)
+                    : RemoteAddress());
 
   auto offsetResult =
     remoteAST.getOffsetOfMember(type, address, memberName);
@@ -170,8 +172,8 @@ printDynamicTypeAndAddressForExistential(void *object,
 
   // First, retrieve the static type of the existential, so we can understand
   // which kind of existential this is.
-  auto staticTypeResult =
-      remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(typeMetadata));
+  auto staticTypeResult = remoteAST.getTypeForRemoteTypeMetadata(RemoteAddress(
+      (uint64_t)typeMetadata, RemoteAddress::DefaultAddressSpace));
   if (!staticTypeResult) {
     out << "failed to resolve static type: "
         << staticTypeResult.getFailure().render() << '\n';
@@ -180,7 +182,8 @@ printDynamicTypeAndAddressForExistential(void *object,
 
   // OK, we can reconstruct the dynamic type and the address now.
   auto result = remoteAST.getDynamicTypeAndAddressForExistential(
-      RemoteAddress(object), staticTypeResult.getValue());
+      RemoteAddress((uint64_t)object, RemoteAddress::DefaultAddressSpace),
+      staticTypeResult.getValue());
   if (result) {
     out << "found type: ";
     result.getValue().InstanceType.print(out);


### PR DESCRIPTION
- **Explanation**: 
LLDB employs an optimization where it reads memory from files instead of the running process whenever it can to speed up memory reads (these can be slow when debugging something over a network). To do this, it needs to keep track whether an address originated from a process or a file. It currently distinguishes addresses by setting an unused high bit on the address, but because of pointer authentication this is not a reliable solution. 
In order to keep this optimization working, the main commit adds an extra opaque AddressSpace field to RemoteAddress, which LLDB can use on its own implementation of MemoryReader to distinguish between addresses, the others are commits supporting that change.
.
- **Scope**: This patch is limited to Remote Mirrors, and has no changes on the actual compiler or runtime. Furthermore, unless taking advantage of the new address space (which LLDB will use) all the changes are non functional changes.
- **Issues**: [https://github.com/swiftlang/swift/issues/82905 / rdar://155399531](rdar://148361743)
- **Original PRs**: 
  - The main PR: https://github.com/swiftlang/swift/pull/82638. 
  - Supporting PRS: 
    - https://github.com/swiftlang/swift/pull/82325
    - https://github.com/swiftlang/swift/pull/82981
    - https://github.com/swiftlang/swift/pull/82995
- **Risk**: Medium. There are a large amount of line changes, however, the changes are largely mechanical (replacing threading of `StoredPointer` with `RemoteAddress`, using the new `RemoteAddress` constructor, etc) and are NFC for other remote mirrors clients.
- **Testing**: All of the reflection tests in this repo and LLDB.
- **Reviewers**: @adrian-prantl, @mikeash 
