### PR TITLE
[cxx-interop] Types exposed from ObjC modules should be behind a macro

### DIFF
--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -112,6 +112,9 @@ inline bool isExposableToCxx(
   return !getDeclRepresentation(VD, isZeroSized).isUnsupported();
 }
 
+bool isObjCxxOnly(const ValueDecl *VD);
+bool isObjCxxOnly(const clang::Decl *D);
+
 /// Returns true if the given value decl D is visible to C++ of its
 /// own accord (i.e. without considering its context)
 bool isVisibleToCxx(const ValueDecl *VD, AccessLevel minRequiredAccess,

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -29,6 +29,7 @@
 #include "swift/Basic/StringExtras.h"
 
 #include "clang/AST/DeclObjC.h"
+#include "clang/Basic/Module.h"
 #include "llvm/ADT/SmallString.h"
 #include <optional>
 
@@ -237,6 +238,39 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
   return VD->getBaseIdentifier().str();
 }
 
+namespace {
+struct ObjCTypeWalker : TypeWalker {
+  bool hadObjCType = false;
+  Action walkToTypePre(Type ty) override {
+    if (auto *nominal = ty->getNominalOrBoundGenericNominal()) {
+      if (auto clangDecl = nominal->getClangDecl()) {
+        if (cxx_translation::isObjCxxOnly(clangDecl)) {
+          hadObjCType = true;
+          return Action::Stop;
+        }
+      }
+    }
+    return Action::Continue;
+  }
+};
+} // namespace
+
+bool swift::cxx_translation::isObjCxxOnly(const ValueDecl *VD) {
+  ObjCTypeWalker walker;
+  VD->getInterfaceType().walk(walker);
+  return walker.hadObjCType;
+}
+
+bool swift::cxx_translation::isObjCxxOnly(const clang::Decl *D) {
+  // By default, we import all modules in Obj-C++ mode, so there is no robust
+  // way to tell if something is coming from an Obj-C module. The best
+  // approximation is to check if something is a framework module as most of
+  // those are written in Obj-C. Ideally, we want to add `requires ObjC` to all
+  // ObjC modules and respect that here to make this completely precise.
+  return D->getASTContext().getLangOpts().ObjC &&
+         D->getOwningModule()->isPartOfFramework();
+}
+
 swift::cxx_translation::DeclRepresentation
 swift::cxx_translation::getDeclRepresentation(
     const ValueDecl *VD,
@@ -322,6 +356,9 @@ swift::cxx_translation::getDeclRepresentation(
   if (!isExposableToCxx(genericSignature)) {
     return {Unsupported, UnrepresentableGenericRequirements};
   }
+
+  if (isObjCxxOnly(VD))
+    return {ObjCxxOnly, std::nullopt};
 
   return {Representable, std::nullopt};
 }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -812,7 +812,8 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     ClangSyntaxPrinter(FD->getASTContext(), functionSignatureOS).printInlineForThunk();
 
   ClangRepresentation resultingRepresentation =
-      ClangRepresentation::representable;
+      cxx_translation::isObjCxxOnly(FD) ? ClangRepresentation::objcxxonly
+                                        : ClangRepresentation::representable;
 
   // Print out the return type.
   if (FD->hasThrows() && outputLang == OutputLanguageMode::Cxx)

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend %s -module-name UseFoundation -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseFoundation.h
 // RUN: %FileCheck %s < %t/UseFoundation.h
 
+// RUN: %check-interop-cxx-header-in-clang(%t/UseFoundation.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
 // REQUIRES: objc_interop
 
 import Foundation
@@ -10,6 +12,10 @@ import Foundation
 public enum UseFoundationEnum {
     case A(Data)
     case B
+}
+
+public func f() -> NSEdgeInsets {
+    NSEdgeInsets()
 }
 
 // CHECK: class UseFoundationEnum { } SWIFT_UNAVAILABLE_MSG("Swift enum 'UseFoundationEnum' cannot be represented in C++");


### PR DESCRIPTION
Functions or template instantiations with Obj-C types should always be behind a macro to make sure the interop header compiles cleanly in C++.

rdar://152836730