### PR TITLE
Runtimes: detect the existence of `dispatch_async_swift_job`

### DIFF
--- a/Runtimes/Core/Concurrency/dispatch.cmake
+++ b/Runtimes/Core/Concurrency/dispatch.cmake
@@ -1,12 +1,16 @@
 
 find_package(dispatch QUIET REQUIRED)
 
+check_symbol_exists("dispatch_async_swift_job" "dispatch/private.h"
+  SwiftConcurrency_HAS_DISPATCH_ASYNC_SWIFT_JOB)
+
 target_sources(swift_Concurrency PRIVATE
   DispatchGlobalExecutor.cpp
   DispatchExecutor.swift
   CFExecutor.swift
   ExecutorImpl.swift)
 target_compile_definitions(swift_Concurrency PRIVATE
+  $<$<BOOL:${SwiftConcurrency_HAS_DISPATCH_ASYNC_SWIFT_JOB}>:-DSwiftConcurrency_HAS_DISPATCH_ASYNC_SWIFT_JOB=1>
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_CONCURRENCY_USES_DISPATCH=1>)
 target_compile_options(swift_Concurrency PRIVATE
   $<$<COMPILE_LANGUAGE:Swift>:-DSWIFT_CONCURRENCY_USES_DISPATCH>

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -103,12 +103,14 @@ static void initializeDispatchEnqueueFunc(dispatch_queue_t queue, void *obj,
   if (SWIFT_RUNTIME_WEAK_CHECK(dispatch_async_swift_job))
     func = SWIFT_RUNTIME_WEAK_USE(dispatch_async_swift_job);
 #elif defined(_WIN32)
+#if SwiftConcurrency_HAS_DISPATCH_ASYNC_SWIFT_JOB
 #if defined(dispatch_STATIC)
   func = dispatch_async_swift_job;
 #else
   func = function_cast<dispatchEnqueueFuncType>(
       GetProcAddress(LoadLibraryW(L"dispatch.dll"),
       "dispatch_async_swift_job"));
+#endif
 #endif
 #else
   func = function_cast<dispatchEnqueueFuncType>(


### PR DESCRIPTION
This function is used by the executor to help schedule the async job. While not currently available on Windows on main, this allows correctly handling the presence of the symbol for static linking.