### PR TITLE
Runtimes: add an initial build of Observation

### DIFF
--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -156,8 +156,8 @@ copy_files(public/Platform Overlay/Windows/CRT
 # libraries, and test support libraries.
 
 # Supplemental Libraries
-copy_library_sources("Synchronization" "public" "Supplemental")
-
+copy_library_sources(Synchronization "public" "Supplemental")
+copy_library_sources(Observation "public" "Supplemental")
 
 # Copy StringProcessing, RegexParser, RegexBuilder
 if(NOT DEFINED StringProcessing_ROOT_DIR)

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -1,0 +1,112 @@
+cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
+
+if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+  cmake_policy(SET CMP0157 OLD)
+endif()
+
+if($ENV{BUILD_NUMBER})
+  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
+  set(BUILD_NUMBER ".${BUILD_NUMBER}")
+endif()
+project(SwiftObservation
+  LANGUAGES Swift CXX
+  VERSION 6.1.0${BUILD_NUMBER})
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift Observation must build as a standalone project")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
+
+set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
+  "${PROJECT_SOURCE_DIR}/../../../"
+  CACHE FILEPATH "Path to the root source directory of the Swift compiler")
+
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
+  CACHE FILEPATH "Location for private build system extension")
+
+find_package(SwiftCore REQUIRED)
+
+include(GNUInstallDirs)
+
+include(AvailabilityMacros)
+include(EmitSwiftInterface)
+include(InstallSwiftInterface)
+include(PlatformInfo)
+include(gyb)
+include(ResourceEmbedding)
+include(CatalystSupport)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
+
+option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
+
+option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
+  ${SwiftCore_ENABLE_PRESPECIALIZATION})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  $<$<COMPILE_LANGUAGE:Swift>:-enable-builtin-module>
+  $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature RawLayout>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StaticExclusiveOnly>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
+
+add_library(swiftObservation
+  Sources/Observation/Locking.swift
+  Sources/Observation/Observable.swift
+  Sources/Observation/ObservationRegistrar.swift
+  Sources/Observation/ObservationTracking.swift
+  Sources/Observation/Observations.swift
+  Sources/Observation/ThreadLocal.swift
+  Sources/Observation/ThreadLocal.cpp)
+set_target_properties(swiftObservation PROPERTIES
+  Swift_MODULE_NAME Observation)
+# FIXME: We should split out the parts that are needed by the runtime to avoid
+# pulling in headers from the compiler.
+target_include_directories(swiftObservation PRIVATE
+  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include")
+target_link_libraries(swiftObservation PRIVATE
+  swiftCore
+  swift_Concurrency
+  $<$<PLATFORM_ID:Android>:swiftAndroid>
+  $<$<PLATFORM_ID:Darwin>:swiftDarwin>
+  $<$<PLATFORM_ID:Linux>:swiftGlibc>
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
+
+install(TARGETS swiftObservation
+  EXPORT SwiftObservationTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swiftObservation)
+install_swift_interface(swiftObservation)
+
+# Configure plist creation for Darwin platforms.
+generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftObservation)
+embed_manifest(swiftObservation)
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swiftObservation.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Observation/Info.plist.in
+++ b/Runtimes/Supplemental/Observation/Info.plist.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>@PLIST_INFO_UTI@</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>@PLIST_INFO_NAME@</string>
+        <key>CFBundleShortVersionString</key>
+        <string>@PLIST_INFO_VERSION@</string>
+        <key>CFBundleVersion</key>
+        <string>@PLIST_INFO_BUILD_VERSION@</string>
+</dict>
+</plist>


### PR DESCRIPTION
This migrates Observation to the new runtimes build. It requires some additional help during the build to locate the internal `CMakeConfig.h` header from the runtime build. However, this is a good skeleton for us to start addressing some of those issues.