### PR TITLE
utils: correct flag handling for static runtime libdispatch handling

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2357,7 +2357,8 @@ function Build-ExperimentalRuntime {
         CMAKE_Swift_COMPILER_TARGET = (Get-ModuleTriple $Platform);
         CMAKE_Swift_COMPILER_WORKS = "YES";
         # TODO(compnerd) enforce dynamic linking of BlocksRuntime and dispatch.
-        CMAKE_Swift_FLAGS = $(if ($Static) { @("-Xcc", "-static-libclosure", "-Xcc", "-Ddispatch_STATIC") } else { @() });
+        CMAKE_CXX_FLAGS = $(if ($Static) { @("-Ddispatch_STATIC") } else { @() });
+        CMAKE_Swift_FLAGS = $(if ($Static) { @("-Xcc", "-static-libclosure") } else { @() });
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
         CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
@@ -2762,8 +2763,7 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
         CMAKE_Swift_COMPILER_TARGET = (Get-ModuleTriple $Platform);
         CMAKE_Swift_COMPILER_WORKS = "YES";
-        # TODO(compnerd) enforce dynamic linking of BlocksRuntime and dispatch.
-        CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir", "-Xcc", "-Ddispatch_STATIC");
+        CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
 


### PR DESCRIPTION
We were not passing along the proper flags to the runtime build resulting in the library expecting libdispatch to be linked dynamically.