### PR TITLE
[6.2] IRGen fixes to avoid using mangled names for metadata on older platforms

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -204,9 +204,10 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
     Swift_5_5,
     Swift_6_0,
     Swift_6_1,
+    Swift_6_2,
 
     // Short-circuit if we find this requirement.
-    Latest = Swift_6_1
+    Latest = Swift_6_2
   };
 
   VersionRequirement latestRequirement = None;
@@ -222,6 +223,11 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
     if (auto fn = dyn_cast<AnyFunctionType>(t)) {
       auto isolation = fn->getIsolation();
       auto sendingResult = fn->hasSendingResult();
+
+      // The mangling for nonisolated(nonsending) function types was introduced
+      // in Swift 6.2.
+      if (isolation.isNonIsolatedCaller())
+        return addRequirement(Swift_6_2);
 
       // The Swift 6.1 runtime fixes a bug preventing successful demangling
       // when @isolated(any) or global actor isolation is combined with a
@@ -290,6 +296,7 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
   });
 
   switch (latestRequirement) {
+  case Swift_6_2: return llvm::VersionTuple(6, 2);
   case Swift_6_1: return llvm::VersionTuple(6, 1);
   case Swift_6_0: return llvm::VersionTuple(6, 0);
   case Swift_5_5: return llvm::VersionTuple(5, 5);

--- a/test/IRGen/backward_deploy_nonisolated_nonsending_function_type.swift
+++ b/test/IRGen/backward_deploy_nonisolated_nonsending_function_type.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+func useGenericMetatype(_ type: Any.Type) { }
+
+// CHECK-LABEL: define hidden swiftcc void @"$s52backward_deploy_nonisolated_nonsending_function_type29testNonisolatedNonsendingTypeyyF"()
+func testNonisolatedNonsendingType() {
+  typealias Fn = nonisolated(nonsending) () async throws -> Int
+
+  // CHECK: call swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"
+  // CHECK: call swiftcc void @"$s52backward_deploy_nonisolated_nonsending_function_type18useGenericMetatypeyyypXpF"
+  useGenericMetatype(Fn.self)
+}
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"
+// CHECK: call ptr @swift_getExtendedFunctionTypeMetadata(i{{32|64}} 2768240640, {{i32|i64}} 0, ptr null, ptr null, ptr @"$sSiN"

--- a/test/IRGen/backward_deploy_span.swift
+++ b/test/IRGen/backward_deploy_span.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+func useGenericMetatype(_ type: any ~Escapable.Type) { }
+
+// CHECK-LABEL: define hidden swiftcc void @"$s20backward_deploy_span11testSpanIntyyF"()
+func testSpanInt() {
+  // CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
+  // CHECK: call swiftcc void @"$s20backward_deploy_span18useGenericMetatypeyyypRi0_s_XPXpF"
+  useGenericMetatype(Span<Int>.self)
+}
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"(i64 %0)
+// CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVMa"(i64 %0, ptr @"$sSiN")
+
+

--- a/test/IRGen/backward_deploy_span.swift
+++ b/test/IRGen/backward_deploy_span.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s
-// REQUIRES: concurrency
 // REQUIRES: OS=macosx
 
 func useGenericMetatype(_ type: any ~Escapable.Type) { }
@@ -11,7 +10,5 @@ func testSpanInt() {
   useGenericMetatype(Span<Int>.self)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"(i64 %0)
-// CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVMa"(i64 %0, ptr @"$sSiN")
-
-
+// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$ss4SpanVySiGMa"
+// CHECK: call swiftcc %swift.metadata_response @"$ss4SpanVMa"({{i32|i64}} %0, ptr @"$sSiN")


### PR DESCRIPTION
- **Explanation**: When we have type system changes that affect name mangling and are usable on older platforms, we cannot use the demangle-to-metadata path for creating metadata for those types, because those older platforms will fail to demangle the type. Fix two instances of this: (1) `Span` et al are in a back-deployed dylib, so make sure we don't use mangling for them when deploying back to a pre-Swift 6.0 runtime due to inverse generics, and (2) `nonisolated(nonsending)` function types were introduced in Swift 6.2. 
- **Scope**: Only affect back-deployment when used with these new features.
- **Issues**: rdar://155639204
- **Original PRs**: https://github.com/swiftlang/swift/pull/83012
- **Risk**: Low. These are new features, and the changes only take affect when back-deploying and using them together. This is also a well-trod path of falling back to metadata accessors rather than using demangling to get metadata.
- **Testing**: CI + separate app back-deploying to iOS 17.
- **Reviewers**: @slavapestov 
