### PR TITLE
[CS] Handle `TVO_CanBindToPack` in `mergeEquivalenceClasses`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -582,6 +582,12 @@ public:
         recordBinding(*trail);
       getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToNoEscape;
     }
+
+    if (canBindToPack() && !otherRep->getImpl().canBindToPack()) {
+      if (trail)
+        recordBinding(*trail);
+      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToPack;
+    }
   }
 
   /// Retrieve the fixed type that corresponds to this type variable,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -803,3 +803,15 @@ func testInvalidDecomposition() {
   func id<T>(_ x: T) -> T {}
   let (a, b) = id((repeat each undefined)) // expected-error {{cannot find 'undefined' in scope}}
 }
+
+func testPackToScalarShortFormConstructor() {
+  struct S {
+    init(_ x: Int) {}
+    init<T>(_ x: T) {}
+  }
+
+  // Make sure we diagnose.
+  func foo<each T>(_ xs: repeat each T) {
+    S(repeat each xs) // expected-error {{cannot pass value pack expansion to non-pack parameter of type 'Int'}}
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/437e5d84c586a6e9.swift
+++ b/validation-test/compiler_crashers_2_fixed/437e5d84c586a6e9.swift
@@ -1,3 +1,3 @@
 // {"signature":"std::__1::optional<swift::Type> llvm::function_ref<std::__1::optional<swift::Type> (swift::TypeBase*)>::callback_fn<swift::constraints::FailureDiagnostic::resolveType(swift::Type, bool, bool) const::$_0>(long, swift::TypeBase*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 Array(repeat a

--- a/validation-test/compiler_crashers_2_fixed/859bb4ca7e7e2bd.swift
+++ b/validation-test/compiler_crashers_2_fixed/859bb4ca7e7e2bd.swift
@@ -1,0 +1,5 @@
+// {"kind":"emit-silgen","original":"6943e75f","signature":"swift::SILFunctionType::SILFunctionType(swift::GenericSignature, swift::SILExtInfo, swift::SILCoroutineKind, swift::ParameterConvention, llvm::ArrayRef<swift::SILParameterInfo>, llvm::ArrayRef<swift::SILYieldInfo>, llvm::ArrayRef<swift::SILResultInfo>, std::__1::optional<swift::SILResultInfo>, swift::SubstitutionMap, swift::SubstitutionMap, swift::ASTContext const&, swift::RecursiveTypeProperties, swift::ProtocolConformanceRef)"}
+// RUN: not %target-swift-frontend -emit-silgen %s
+func a<each b : BinaryInteger>(c : repeat each b) {
+  UInt32(repeat each c)
+}


### PR DESCRIPTION
Previously we could incorrectly propagate `TVO_CanBindToPack` to a type variable that cannot bound to a pack type.