### PR TITLE
build-presets.ini: add `wasm_stdlib,macos` for at-desk development

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3278,8 +3278,8 @@ swiftpm
 swift-driver
 swiftsyntax
 skip-test-swiftpm
-; swift-testing
-; swift-testing-macros
+swift-testing
+swift-testing-macros
 
 release
 build-ninja
@@ -3295,6 +3295,8 @@ install-llbuild
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 install-wasmkit
 install-destdir=%(install_destdir)s
 #

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3280,6 +3280,7 @@ swiftsyntax
 skip-test-swiftpm
 swift-testing
 swift-testing-macros
+build-wasm-stdlib
 
 release
 build-ninja

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3270,6 +3270,60 @@ install-swift-testing
 install-swift-testing-macros
 install-xctest
 
+[preset: wasm_stdlib,macos]
+
+mixin-preset=mixin_buildbot_install_components_with_clang
+llbuild
+swiftpm
+swift-driver
+swiftsyntax
+skip-test-swiftpm
+; swift-testing
+; swift-testing-macros
+
+release
+build-ninja
+
+build-embedded-stdlib-cross-compiling
+
+# Don't build the benchmarks
+skip-build-benchmarks
+
+install-llvm
+install-swift
+install-llbuild
+install-swiftpm
+install-swift-driver
+install-swiftsyntax
+install-wasmkit
+install-destdir=%(install_destdir)s
+#
+# Path where the compiler, the runtime and the standard libraries will be
+# installed.
+install-prefix=%(install_toolchain_dir)s/usr
+
+# Executes the lit tests for the installable package that is created
+# Assumes the swift-integration-tests repo is checked out
+
+; test-installable-package
+
+# If someone uses this for incremental builds, force reconfiguration.
+reconfigure
+
+# Path to the .tar.gz package we would create.
+installable-package=%(installable_package)s
+
+# Info.plist
+darwin-toolchain-bundle-identifier=%(darwin_toolchain_bundle_identifier)s
+darwin-toolchain-display-name=%(darwin_toolchain_display_name)s
+darwin-toolchain-display-name-short=%(darwin_toolchain_display_name_short)s
+darwin-toolchain-name=%(darwin_toolchain_xctoolchain_name)s
+darwin-toolchain-version=%(darwin_toolchain_version)s
+darwin-toolchain-alias=%(darwin_toolchain_alias)s
+darwin-toolchain-require-use-os-runtime=0
+
+build-subdir=wasm_stdlib
+
 # For local use only. This allows quickly rebuilding and testing Wasm stdlib
 # end-to-end without rebuilding the whole toolchain.
 [preset: wasm_stdlib_incremental]
@@ -3301,6 +3355,7 @@ skip-build-swift
 skip-early-swift-driver
 skip-build-cmark
 install-destdir=%(install_destdir)s
+build-subdir=wasm_stdlib_incremental
 
 [preset: wasm_stdlib_incremental,macos]
 


### PR DESCRIPTION
There are no non-incremental presets currently available for macOS in `build-presets.ini`, and existing non-incremental presets only cross-compile to Wasm on Linux. Let's add one for macOS to make development on that platform easier.
