### PR TITLE
[cxx-interop] Fix assert failure due to invalid location

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2885,9 +2885,10 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
   // Estimate locations for the begin and end of parameter list.
   auto begin = clangDecl->getLocation();
   auto end = begin;
-  if (!params.empty()) {
-    begin = params.front()->getBeginLoc();
-    end = params.back()->getEndLoc();
+  auto paramsRange = clangDecl->getParametersSourceRange();
+  if (paramsRange.isValid()) {
+    begin = paramsRange.getBegin();
+    end = paramsRange.getEnd();
   }
   return ParameterList::create(SwiftContext, importSourceLoc(begin), parameters,
                                importSourceLoc(end));


### PR DESCRIPTION
We hit an assert failure do to creating a range where the begin was a valid source location while the end range was an invalid one. Unfortunately, I was not able to create a minimal reproducer but I was able to verify that this fix works because I was able to reproduce this issue while compiling Swift with a patched version of Clang.

rdar://155379027
