### PR TITLE
SILGen: Fix an assert when emitting SIL for `if #available`

### DIFF
--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -265,11 +265,17 @@ SILGenFunction::emitIfAvailableQuery(SILLocation loc,
   SILType i1 = SILType::getBuiltinIntegerType(1, ctx);
   auto query = availability->getAvailabilityQuery();
 
-  // The query might not have been computed by Sema if availability checking
-  // was disabled. Otherwise, there's a bug in Sema.
-  DEBUG_ASSERT(query || ctx.LangOpts.DisableAvailabilityChecking);
+  // The query may not have been computed by Sema under the following
+  // conditions:
+  // - Availability checking was disabled (-disable-availabilty-checking).
+  // - The query was marked invalid in the AST for a non-fatal reason.
+  //
+  // Otherwise, there's a bug in Sema.
+  DEBUG_ASSERT(query || availability->isInvalid() ||
+               ctx.LangOpts.DisableAvailabilityChecking);
 
-  // Treat the condition as if it always evaluates true if Sema skipped it.
+  // If Sema skipped the query then treat the condition as if it always
+  // evaluates true.
   if (!query)
     return B.createIntegerLiteral(loc, i1, !availability->isUnavailability());
 

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -45,6 +45,9 @@ if #available(OSX 0.0) { // expected-warning {{expected version number; this is 
 if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
+if #available(iDishwasherOS 0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
+}
+
 if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 // expected-error@-1 {{condition required for target platform}}
 }

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -109,6 +109,11 @@ if #available(OSX 10, *) {
 if #unavailable(OSX 10) {
 }
 
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_br [[TRUE]]
+if #available(macOS 0) { // expected-warning {{expected version number}}
+}
+
 // CHECK: }
 
 func doThing() {}


### PR DESCRIPTION
Empty version numbers in availability specs are accepted by Sema prior to Swift 6, and when they occur in `if #available` queries they can make the query AST node invalid without aborting compilation. Adjust an assertion in SILGen to compensate.
