### PR TITLE
[6.2][Test] Fix test failure caused by invalid iOS version for availability

### DIFF
--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
@@ -4,7 +4,7 @@
 // RUN: %swift -emit-module -target %target-cpu-apple-ios13.1-macabi -o %t.mod/availability.swiftmodule %s -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc
 // RUN: %sourcekitd-test -req=doc-info -module availability -- -target %target-cpu-apple-ios13.1-macabi -I %t.mod | %FileCheck %s
 
-@available(macCatalyst, deprecated: 20.0)
+@available(macCatalyst, deprecated: 50.0)
 public func deprecatedInFutureVersion_catalyst() {}
 // CHECK-LABEL: key.name: "deprecatedInFutureVersion_catalyst()"
 // CHECK-NOT: {
@@ -12,12 +12,12 @@ public func deprecatedInFutureVersion_catalyst() {}
 // CHECK-NEXT:     {
 // CHECK-NEXT:       key.kind: source.lang.swift.attribute.availability,
 // CHECK-NEXT:       key.platform: source.availability.platform.maccatalyst,
-// CHECK-NEXT:       key.deprecated: "20.0"
+// CHECK-NEXT:       key.deprecated: "50.0"
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ]
 // CHECK-NEXT: }
 
-@available(iOS, deprecated: 20.0)
+@available(iOS, deprecated: 50.0)
 public func deprecatedInFutureVersion_iOS() {}
 // CHECK-LABEL: key.name: "deprecatedInFutureVersion_iOS()"
 // CHECK-NOT: {
@@ -25,7 +25,7 @@ public func deprecatedInFutureVersion_iOS() {}
 // CHECK-NEXT:     {
 // CHECK-NEXT:       key.kind: source.lang.swift.attribute.availability,
 // CHECK-NEXT:       key.platform: source.availability.platform.ios,
-// CHECK-NEXT:       key.deprecated: "20.0"
+// CHECK-NEXT:       key.deprecated: "50.0"
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ]
 // CHECK-NEXT: }


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/83039 into `release/6.2`

* **Explanation**: This test has been failing  because `20.0` iOS version is translated to `27.0` since https://github.com/swiftlang/swift/pull/82151. Fix it by changing the testing version to `50.0` which is reasonably distant future.
* **Scope**: SourceKit test
* **Risk**: Low. Just changing the _future_ version number in testing
* **Testing**: Updated test
* **Issues**: rdar://155463166
* **Reviewers**: Ben Barham