### PR TITLE
SILGen: Fix crash when default witness table entry comes from a concrete conformance

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -778,13 +778,14 @@ SILFunction *SILGenModule::emitProtocolWitness(
   // in a protocol extension, the generic signature will have an additional
   // generic parameter representing Self, so the generic parameters of the
   // class will all be shifted down by one.
-  auto conformance = reqtSubMap.lookupConformance(M.getASTContext().TheSelfType,
-                                                  origConformance.getProtocol())
-      .mapConformanceOutOfContext();
-  ASSERT(conformance.isAbstract() == origConformance.isAbstract());
-
+  auto conformance = origConformance;
   ProtocolConformance *manglingConformance = nullptr;
   if (conformance.isConcrete()) {
+    conformance = reqtSubMap.lookupConformance(M.getASTContext().TheSelfType,
+                                               origConformance.getProtocol())
+        .mapConformanceOutOfContext();
+    ASSERT(!conformance.isAbstract());
+
     manglingConformance = conformance.getConcrete();
     if (auto *inherited = dyn_cast<InheritedProtocolConformance>(manglingConformance)) {
       manglingConformance = inherited->getInheritedConformance();

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -259,6 +259,15 @@ public protocol ResilientAssocTypes {
   associatedtype AssocType: P = ConformsToP
 }
 
+// rdar://155798849 - This is a pointless protocol and conformance but it shouldn't crash
+public protocol SillyP: SillyC {
+  func f()
+}
+
+public class SillyC: SillyP {
+  public func f() {}
+}
+
 // CHECK-LABEL: sil_default_witness_table P {
 // CHECK-NEXT: }
 


### PR DESCRIPTION
This of course means the entire protocol is pointless, but as they say, the customer is always right.

Fixes rdar://155798849.