### PR TITLE
[Serialization] Move `nonisolated(nonsending)` isolation kind above g…

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 955; // Lifetime dependencies on enum element
+const uint16_t SWIFTMODULE_VERSION_MINOR = 956; // nonisolated(nonsending) isolation was moved
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -707,8 +707,9 @@ enum class FunctionTypeIsolation : uint8_t {
   NonIsolated,
   Parameter,
   Erased,
-  GlobalActorOffset, // Add this to the global actor type ID
   NonIsolatedCaller,
+  // NOTE: All of the new kinds should be added above.
+  GlobalActorOffset, // Add this to the global actor type ID
 };
 using FunctionTypeIsolationField = TypeIDField;
 

--- a/test/Concurrency/attr_execution/cross_module.swift
+++ b/test/Concurrency/attr_execution/cross_module.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 6 -enable-library-evolution \
+// RUN:   -emit-module-path %t/A.swiftmodule \
+// RUN:   -emit-module-interface-path %t/A.swiftinterface
+
+// Build the client using module
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift
+
+// RUN: rm %t/A.swiftmodule
+
+// Re-build the client using interface
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift
+
+//--- A.swift
+@MainActor
+public final class Test {
+  public func test(_: @escaping @Sendable @MainActor () -> Void) {}
+}
+
+//--- Client.swift
+import A
+
+@MainActor
+func test(t: Test, fn: @escaping @Sendable @MainActor () -> Void) {
+  t.test(fn) // Ok
+}


### PR DESCRIPTION
…lobal actor one

Global actor kind also appends type offset that indicates what global actor to use with the type. All of the isolation kinds should be placed above it to make sure that there is never a clash when i.e. `MainActor` is serialized as id `1`.

Resolves: rdar://153487603

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
