### PR TITLE
[Dependency Scanning] Restrict Swift overlay lookup to "visible" Clang modules only

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -212,6 +212,11 @@ public:
   /// The macro dependencies.
   std::map<std::string, MacroPluginDependency> macroDependencies;
 
+  /// A list of Clang modules that are visible to this Swift module. This
+  /// includes both direct Clang modules as well as transitive Clang
+  /// module dependencies when they are exported
+  llvm::StringSet<> visibleClangModules;
+
   /// ModuleDependencyInfo is finalized (with all transitive dependencies
   /// and inputs).
   bool finalized;
@@ -816,7 +821,17 @@ public:
       cast<ClangModuleDependencyStorage>(storage.get())->CASFileSystemRootID =
           rootID;
     else
-      llvm_unreachable("Unexpected type");
+      llvm_unreachable("Unexpected module dependency kind");
+  }
+
+  llvm::StringSet<> &getVisibleClangModules() const {
+    return storage->visibleClangModules;
+  }
+
+  void
+  addVisibleClangModules(const std::vector<std::string> &moduleNames) const {
+    storage->visibleClangModules.insert(moduleNames.begin(),
+                                        moduleNames.end());
   }
 
   /// Whether explicit input paths of all the module dependencies
@@ -1057,6 +1072,9 @@ public:
   /// Query all cross-import overlay dependencies
   llvm::ArrayRef<ModuleDependencyID>
   getCrossImportOverlayDependencies(const ModuleDependencyID &moduleID) const;
+  /// Query all visible Clang modules for a given Swift dependency
+  llvm::StringSet<>&
+  getVisibleClangModules(ModuleDependencyID moduleID) const;
 
   /// Look for module dependencies for a module with the given ID
   ///
@@ -1122,6 +1140,11 @@ public:
   void
   setCrossImportOverlayDependencies(ModuleDependencyID moduleID,
                                     const ArrayRef<ModuleDependencyID> dependencyIDs);
+
+  /// Add to this module's set of visible Clang modules
+  void
+  addVisibleClangModules(ModuleDependencyID moduleID,
+                         const std::vector<std::string> &moduleNames);
 
   StringRef getMainModuleName() const { return mainScanModuleName; }
 

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/Import.h"
 #include "swift/AST/LinkLibrary.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Serialization/Validation.h"
@@ -1105,9 +1106,9 @@ public:
   void recordDependency(StringRef moduleName,
                         ModuleDependencyInfo dependencies);
 
-  /// Record dependencies for the given module collection.
-  void recordDependencies(ModuleDependencyVector moduleDependencies,
-                          DiagnosticEngine &diags);
+  /// Record dependencies for the given collection of Clang modules.
+  void recordClangDependencies(ModuleDependencyVector moduleDependencies,
+                               DiagnosticEngine &diags);
 
   /// Update stored dependencies for the given module.
   void updateDependency(ModuleDependencyID moduleID,
@@ -1140,7 +1141,6 @@ public:
   void
   setCrossImportOverlayDependencies(ModuleDependencyID moduleID,
                                     const ArrayRef<ModuleDependencyID> dependencyIDs);
-
   /// Add to this module's set of visible Clang modules
   void
   addVisibleClangModules(ModuleDependencyID moduleID,

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -40,7 +40,7 @@ public:
 
 private:
   /// Retrieve the module dependencies for the Clang module with the given name.
-  ModuleDependencyVector scanFilesystemForClangModuleDependency(
+  ClangModuleScannerQueryResult scanFilesystemForClangModuleDependency(
       Identifier moduleName,
       const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
           &alreadySeenModules);
@@ -72,6 +72,7 @@ private:
       ModuleDependencyIDSetVector &headerClangModuleDependencies,
       std::vector<std::string> &headerFileInputs,
       std::vector<std::string> &bridgingHeaderCommandLine,
+      std::vector<std::string> &visibleClangModules,
       std::optional<std::string> &includeTreeID);
 
 

--- a/include/swift/Serialization/ScanningLoaders.h
+++ b/include/swift/Serialization/ScanningLoaders.h
@@ -40,6 +40,18 @@ struct SwiftModuleScannerQueryResult {
   std::vector<IncompatibleCandidate> incompatibleCandidates;
 };
 
+/// Result of looking up a Clang module on the current filesystem
+/// search paths.
+struct ClangModuleScannerQueryResult {
+  ClangModuleScannerQueryResult(const ModuleDependencyVector &dependencyModuleGraph,
+                                const std::vector<std::string> &visibleModuleIdentifiers)
+      : foundDependencyModuleGraph(dependencyModuleGraph),
+        visibleModuleIdentifiers(visibleModuleIdentifiers) {}
+
+  ModuleDependencyVector foundDependencyModuleGraph;
+  std::vector<std::string> visibleModuleIdentifiers;
+};
+
 /// A module "loader" that looks for .swiftinterface and .swiftmodule files
 /// for the purpose of determining dependencies, but does not attempt to
 /// load the module files.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -918,6 +918,24 @@ ModuleDependenciesCache::setCrossImportOverlayDependencies(ModuleDependencyID mo
   updateDependency(moduleID, updatedDependencyInfo);
 }
 
+void
+ModuleDependenciesCache::addVisibleClangModules(ModuleDependencyID moduleID,
+                                                const std::vector<std::string> &moduleNames) {
+  if (moduleNames.empty())
+    return;
+  auto dependencyInfo = findKnownDependency(moduleID);
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.addVisibleClangModules(moduleNames);
+  updateDependency(moduleID, updatedDependencyInfo);
+}
+
+llvm::StringSet<> &ModuleDependenciesCache::getVisibleClangModules(ModuleDependencyID moduleID) const {
+  ASSERT(moduleID.Kind == ModuleDependencyKind::SwiftSource ||
+         moduleID.Kind == ModuleDependencyKind::SwiftInterface ||
+         moduleID.Kind == ModuleDependencyKind::SwiftBinary);
+  return findKnownDependency(moduleID).getVisibleClangModules();
+}
+
 ModuleDependencyIDSetVector
 ModuleDependenciesCache::getAllDependencies(const ModuleDependencyID &moduleID) const {
   const auto &moduleInfo = findKnownDependency(moduleID);

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -336,7 +336,7 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
   }
 
   return ClangImporter::bridgeClangModuleDependencies(
-      *workerASTContext, clangScanningTool, *clangModuleDependencies,
+      *workerASTContext, clangScanningTool, clangModuleDependencies->ModuleGraph,
       lookupModuleOutput,
       [&](StringRef path) { return remapPath(PrefixMapper, path); });
 }

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1226,8 +1226,16 @@ static bool diagnoseCycle(const CompilerInstance &instance,
   while (!openSet.empty()) {
     auto lastOpen = openSet.back();
     auto beforeSize = openSet.size();
+
+#ifndef NDEBUG
+    if (!cache.findDependency(lastOpen)) {
+      llvm::dbgs() << "Missing Dependency Info during cycle diagnosis\n";
+      llvm::dbgs() << "mainID: " << mainId.ModuleName << "\n";
+      llvm::dbgs() << "lastOpen: " << lastOpen.ModuleName << "\n";
+    }
+#endif
     assert(cache.findDependency(lastOpen).has_value() &&
-           "Missing dependency info during cycle diagnosis.");
+           "Missing dependency info during cycle diagnosis");
     for (const auto &depId : cache.getAllDependencies(lastOpen)) {
       if (closeSet.count(depId))
         continue;

--- a/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
+++ b/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
@@ -1,0 +1,72 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %empty-directory(%t/swiftDeps)
+// RUN: %empty-directory(%t/clangDeps)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t/swiftDeps -I %t/clangDeps
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// Ensure Swift module 'E' has a Swift overlay dependency on
+// 'G', because Clang module 'G' is a visible dependency of Clang module 'E'
+//
+// CHECK-LABEL:        "modulePath": "{{.*}}E-{{.*}}.swiftmodule"
+// CHECK:              "swiftOverlayDependencies": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "swift": "G"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+
+// Ensure Swift module 'A' does not have a Swift overlay dependency on
+// 'G', because although 'A' depends on Clang module 'G', it does not export it
+// and therefore it is not visible
+//
+// CHECK:        "modulePath": "{{.*}}A-{{.*}}.swiftmodule"
+// CHECK-NOT:              "swiftOverlayDependencies": [
+
+//--- swiftDeps/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -enable-library-evolution
+@_exported import A
+public func overlayFuncA() {}
+
+//--- swiftDeps/E.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E -enable-library-evolution
+@_exported import E
+public func overlayFuncE() {}
+
+//--- swiftDeps/G.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G -enable-library-evolution
+@_exported import G
+public func overlayFuncG() {}
+
+//--- clangDeps/module.modulemap
+module A {
+  header "A.h"
+  // No export *
+}
+module E {
+  header "E.h"
+  export *
+}
+module G {
+  header "G.h"
+  export *
+}
+
+//--- clangDeps/A.h
+#include "G.h"
+void funcA(void);
+
+//--- clangDeps/E.h
+#include "G.h"
+void funcE(void);
+
+//--- clangDeps/G.h
+void funcG(void);
+
+//--- client.swift
+import A
+import E


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/147969 added support to the Clang dependency scanner to query the set of "visible" modules for a given TU or named query. Swift must utilize this data to driver lookup of Swift module overlays. Previously, the scanner implementation queried Swift module overlay dependencies for a Swift module by checking *all* of its imported Clang modules, direct and transitive - even when not re-exported. With this change, the scanner's overlay lookup is only done for a Swift module's "visible" set of Clang module dependencies as reported by the scanner, matching the behavior expected to occur in the subsequent compilation task.