### PR TITLE
Sema: Diagnose invalid platform versions in more places

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2939,6 +2939,9 @@ public:
 /// available for back deployment to older OSes via emission into the client
 /// binary.
 class BackDeployedAttr : public DeclAttribute {
+  const PlatformKind Platform;
+  const llvm::VersionTuple Version;
+
 public:
   BackDeployedAttr(SourceLoc AtLoc, SourceRange Range, PlatformKind Platform,
                    const llvm::VersionTuple &Version, bool Implicit)
@@ -2946,10 +2949,15 @@ public:
         Platform(Platform), Version(Version) {}
 
   /// The platform the decl is available for back deployment in.
-  const PlatformKind Platform;
+  PlatformKind getPlatform() const { return Platform; }
 
-  /// The earliest platform version that may use the back deployed implementation.
-  const llvm::VersionTuple Version;
+  /// The `before:` version tuple that was written in source.
+  llvm::VersionTuple getParsedVersion() const { return Version; }
+
+  /// The `before:` version, which is the earliest platform version that may use
+  /// the back deployed implementation. This may be different from the version
+  /// that was written in source due to canonicalization.
+  llvm::VersionTuple getVersion() const;
 
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx, bool forTargetVariant) const;

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2399,6 +2399,11 @@ public:
 /// The variable \p foo was originally defined in another module called
 /// \p Original prior to OSX 10.15
 class OriginallyDefinedInAttr: public DeclAttribute {
+  const StringRef ManglingModuleName;
+  const StringRef LinkerModuleName;
+  const PlatformKind Platform;
+  const llvm::VersionTuple MovedVersion;
+
 public:
   OriginallyDefinedInAttr(SourceLoc AtLoc, SourceRange Range,
                           StringRef OriginalModuleName,
@@ -2420,16 +2425,22 @@ public:
   OriginallyDefinedInAttr *clone(ASTContext &C, bool implicit) const;
 
   // The original module name for mangling.
-  const StringRef ManglingModuleName;
+  StringRef getManglingModuleName() const { return ManglingModuleName; }
 
   // The original module name for linker directives.
-  const StringRef LinkerModuleName;
+  StringRef getLinkerModuleName() const { return LinkerModuleName; }
 
   /// The platform of the symbol.
-  const PlatformKind Platform;
+  PlatformKind getPlatform() const { return Platform; }
 
-  /// Indicates when the symbol was moved here.
-  const llvm::VersionTuple MovedVersion;
+  /// The version of the platform that the symbol was moved in, as it was
+  /// written in source.
+  llvm::VersionTuple getParsedMovedVersion() const { return MovedVersion; }
+
+  /// The version of the platform that the symbol was moved in. This may be
+  /// different than the version that was written in source due to
+  /// canonicalization.
+  llvm::VersionTuple getMovedVersion() const;
 
   struct ActiveVersion {
     StringRef ManglingModuleName;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5121,9 +5121,10 @@ public:
   }
   void visitBackDeployedAttr(BackDeployedAttr *Attr, Label label) {
     printCommon(Attr, "back_deployed_attr", label);
-    printField(Attr->Platform, Label::always("platform"));
-    printFieldRaw([&](auto &out) { out << Attr->Version.getAsString(); },
-                  Label::always("version"));
+    printField(Attr->getPlatform(), Label::always("platform"));
+    printFieldRaw(
+        [&](auto &out) { out << Attr->getParsedVersion().getAsString(); },
+        Label::always("version"));
     printFoot();
   }
   void visitCDeclAttr(CDeclAttr *Attr, Label label) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5347,11 +5347,12 @@ public:
   void visitOriginallyDefinedInAttr(OriginallyDefinedInAttr *Attr,
                                     Label label) {
     printCommon(Attr, "originally_defined_in_attr", label);
-    printField(Attr->ManglingModuleName, Label::always("mangling_module"));
-    printField(Attr->LinkerModuleName, Label::always("linker_module"));
-    printField(Attr->Platform, Label::always("platform"));
-    printFieldRaw([&](auto &out) { out << Attr->MovedVersion.getAsString(); },
-                  Label::always("moved_version"));
+    printField(Attr->getManglingModuleName(), Label::always("mangling_module"));
+    printField(Attr->getLinkerModuleName(), Label::always("linker_module"));
+    printField(Attr->getPlatform(), Label::always("platform"));
+    printFieldRaw(
+        [&](auto &out) { out << Attr->getParsedMovedVersion().getAsString(); },
+        Label::always("moved_version"));
     printFoot();
   }
   void visitPrivateImportAttr(PrivateImportAttr *Attr, Label label) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6058,9 +6058,9 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     if (Options.UseOriginallyDefinedInModuleNames) {
       Decl *D = Ty->getDecl();
       for (auto attr: D->getAttrs().getAttributes<OriginallyDefinedInAttr>()) {
-        Name = Mod->getASTContext()
-          .getIdentifier(const_cast<OriginallyDefinedInAttr*>(attr)
-                         ->ManglingModuleName);
+        Name = Mod->getASTContext().getIdentifier(
+            const_cast<OriginallyDefinedInAttr *>(attr)
+                ->getManglingModuleName());
         break;
       }
     }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -370,7 +370,7 @@ bool AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
   if (!hasRemap)
     return false;
 
-  auto beforeVersion = attr->Version;
+  auto beforeVersion = attr->getVersion();
   auto potentiallyRemappedIntroducedVersion =
       getRemappedIntroducedVersionForFallbackPlatform(ctx, beforeVersion);
   if (potentiallyRemappedIntroducedVersion.has_value()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -611,7 +611,7 @@ std::optional<std::pair<const BackDeployedAttr *, AvailabilityRange>>
 Decl::getBackDeployedAttrAndRange(ASTContext &Ctx,
                                   bool forTargetVariant) const {
   if (auto *attr = getAttrs().getBackDeployed(Ctx, forTargetVariant)) {
-    auto version = attr->Version;
+    auto version = attr->getVersion();
     AvailabilityDomain ignoredDomain;
     AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
         attr, getASTContext(), ignoredDomain, version);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1142,7 +1142,7 @@ StringRef Decl::getAlternateModuleName() const {
   for (auto *Att: Attrs) {
     if (auto *OD = dyn_cast<OriginallyDefinedInAttr>(Att)) {
       if (!OD->isInvalid() && OD->isActivePlatform(getASTContext())) {
-        return OD->ManglingModuleName;
+        return OD->getManglingModuleName();
       }
     }
   }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2540,10 +2540,10 @@ private:
       if (auto Attribute =
               ND->getAttrs().getAttribute<OriginallyDefinedInAttr>()) {
         auto Identifier = IGM.getSILModule().getASTContext().getIdentifier(
-            Attribute->ManglingModuleName);
+            Attribute->getManglingModuleName());
         void *Key = (void *)Identifier.get();
-        Scope = getOrCreateModule(Key, TheCU, Attribute->ManglingModuleName, {},
-                                  {});
+        Scope = getOrCreateModule(Key, TheCU,
+                                  Attribute->getManglingModuleName(), {}, {});
       } else {
         Context = ND->getParent();
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5195,8 +5195,8 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
       return true;
     }
 
+    auto rawVersion = parsedSpec->getRawVersion();
     if (hasVersion) {
-      auto rawVersion = parsedSpec->getRawVersion();
       if (!VersionRange::isValidVersion(rawVersion)) {
         diags
             .diagnose(loc, diag::availability_unsupported_version_number,
@@ -5210,6 +5210,12 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
       if (!hasVersion) {
         diags.diagnose(loc, diag::avail_query_expected_version_number);
         return true;
+      }
+
+      if (!domain.isVersionValid(rawVersion)) {
+        diags.diagnose(loc,
+                       diag::availability_invalid_version_number_for_domain,
+                       rawVersion, domain);
       }
     } else if (hasVersion) {
       diags.diagnose(loc, diag::availability_unexpected_version, domain)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4923,7 +4923,7 @@ void AttributeChecker::checkOriginalDefinedInAttrs(
       continue;
 
     auto AtLoc = Attr->AtLoc;
-    auto Platform = Attr->Platform;
+    auto Platform = Attr->getPlatform();
     if (!seenPlatforms.insert({Platform, AtLoc}).second) {
       // We've seen the platform before, emit error to the previous one which
       // comes later in the source order.
@@ -4941,7 +4941,7 @@ void AttributeChecker::checkOriginalDefinedInAttrs(
       return;
 
     auto IntroVer = D->getIntroducedOSVersion(Platform);
-    if (IntroVer.value() > Attr->MovedVersion) {
+    if (IntroVer.value() > Attr->getMovedVersion()) {
       diagnose(AtLoc,
                diag::originally_definedin_must_not_before_available_version);
       return;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3086,19 +3086,19 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     case DeclAttrKind::OriginallyDefinedIn: {
       auto *theAttr = cast<OriginallyDefinedInAttr>(DA);
-      ENCODE_VER_TUPLE(
-          Moved, std::optional<llvm::VersionTuple>(theAttr->MovedVersion));
+      ENCODE_VER_TUPLE(Moved, std::optional<llvm::VersionTuple>(
+                                  theAttr->getParsedMovedVersion()));
       auto abbrCode = S.DeclTypeAbbrCodes[OriginallyDefinedInDeclAttrLayout::Code];
       llvm::SmallString<32> blob;
-      blob.append(theAttr->ManglingModuleName.str());
+      blob.append(theAttr->getManglingModuleName().str());
       blob.push_back('\0');
-      blob.append(theAttr->LinkerModuleName.str());
+      blob.append(theAttr->getLinkerModuleName().str());
       blob.push_back('\0');
       OriginallyDefinedInDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode,
           theAttr->isImplicit(),
           LIST_VER_TUPLE_PIECES(Moved),
-          static_cast<unsigned>(theAttr->Platform),
+          static_cast<unsigned>(theAttr->getPlatform()),
           blob);
       return;
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3164,14 +3164,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     case DeclAttrKind::BackDeployed: {
       auto *theAttr = cast<BackDeployedAttr>(DA);
-      ENCODE_VER_TUPLE(Version,
-                       std::optional<llvm::VersionTuple>(theAttr->Version));
+      ENCODE_VER_TUPLE(
+          Version, std::optional<llvm::VersionTuple>(theAttr->getVersion()));
       auto abbrCode = S.DeclTypeAbbrCodes[BackDeployedDeclAttrLayout::Code];
       BackDeployedDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode,
           theAttr->isImplicit(),
           LIST_VER_TUPLE_PIECES(Version),
-          static_cast<unsigned>(theAttr->Platform));
+          static_cast<unsigned>(theAttr->getPlatform()));
       return;
     }
 

--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -49,7 +49,7 @@ func testSpecialize<T>(arg: T) -> T {}
 public func testBackDeployed() {}
 
 @available(macOS 10, iOS 12, *)
-@_originallyDefinedIn(module: "OriginalModule", macOS 12.0, iOS 23.2)
+@_originallyDefinedIn(module: "OriginalModule", macOS 12.0, iOS 13.2)
 public func testOriginallyDefinedIn() {}
 
 

--- a/test/Availability/availability_versions_canonical.swift
+++ b/test/Availability/availability_versions_canonical.swift
@@ -94,6 +94,11 @@ func useUnderPoundAvailable() {
   }
 
   if #available(macOS 17.0, iOS 20.0, watchOS 13.0, tvOS 20.0, visionOS 4.0, *) {
+    // expected-warning@-1 {{'17.0' is not a valid version number for macOS}}
+    // expected-warning@-2 {{'20.0' is not a valid version number for iOS}}
+    // expected-warning@-3 {{'13.0' is not a valid version number for watchOS}}
+    // expected-warning@-4 {{'20.0' is not a valid version number for tvOS}}
+    // expected-warning@-5 {{'4.0' is not a valid version number for visionOS}}
     introducedInVersionsMappingTo27_0()
     introducedIn27_0()
   }

--- a/test/ModuleInterface/back-deployed-attr.swift
+++ b/test/ModuleInterface/back-deployed-attr.swift
@@ -72,6 +72,21 @@ public func backDeployTopLevelFunc_macOS() -> Int {
 #endif
 }
 
+// CHECK: @backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
+// CHECK: public func backDeployedBeforeVersionsMappingTo26() -> Swift.Int { return 26 }
+@backDeployed(before: macOS 16.0, iOS 19.0, tvOS 19.0, watchOS 12.0, visionOS 3.0)
+public func backDeployedBeforeVersionsMappingTo26() -> Int { return 26 }
+
+// CHECK: @backDeployed(before: macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0)
+// CHECK: public func backDeployedBeforeVersionsMappingTo27() -> Swift.Int { return 27 }
+@backDeployed(before: macOS 17.0, iOS 20.0, tvOS 20.0, watchOS 13.0, visionOS 4.0)
+public func backDeployedBeforeVersionsMappingTo27() -> Int { return 27 }
+
+// CHECK: @backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
+// CHECK: public func backDeployedBefore26() -> Swift.Int { return 26 }
+@backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
+public func backDeployedBefore26() -> Int { return 26 }
+
 // MARK: - Availability macros
 
 // CHECK: @backDeployed(before: macOS 12.1)

--- a/test/ModuleInterface/originally-defined-attr.swift
+++ b/test/ModuleInterface/originally-defined-attr.swift
@@ -14,6 +14,7 @@
 // RUN: %FileCheck %s < %t/printed-module.txt
 
 // CHECK: @_originallyDefinedIn(module: "another", macOS 13.13)
+// CHECK-LABEL: protocol SimpleProto
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "another", OSX 13.13)
 public protocol SimpleProto { }
@@ -22,6 +23,7 @@ public protocol SimpleProto { }
 // CHECK: @_originallyDefinedIn(module: "another_original", macOS 2.0)
 // CHECK: @_originallyDefinedIn(module: "another_original", iOS 3.0)
 // CHECK: @_originallyDefinedIn(module: "another_original", watchOS 4.0)
+// CHECK-LABEL: struct SimpleStruct
 @available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
 @_originallyDefinedIn(module: "original", tvOS 1.0)
 @_originallyDefinedIn(module: "another_original", OSX 2.0, iOS 3.0, watchOS 4.0)
@@ -29,23 +31,57 @@ public struct SimpleStruct {}
 
 // CHECK: @_originallyDefinedIn(module: "other0", macOS 10.10)
 // CHECK: @_originallyDefinedIn(module: "other0", iOS 8.0)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros0
 @available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
 @_originallyDefinedIn(module: "other0", _iOS8Aligned)
 public struct SimpleThingInAlphabeticalOrderForMacros0 {}
 
 // CHECK: @_originallyDefinedIn(module: "other1", iOS 9.0)
 // CHECK: @_originallyDefinedIn(module: "other1", macOS 10.11)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros1
 @available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
 @_originallyDefinedIn(module: "other1", _iOS9, _macOS10_11)
 public struct SimpleThingInAlphabeticalOrderForMacros1 {}
 
 // CHECK: @_originallyDefinedIn(module: "other2", macOS 10.11)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros2
 @available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
 @_originallyDefinedIn(module: "other2", _myProject 1.0)
 public struct SimpleThingInAlphabeticalOrderForMacros2 {}
 
 // CHECK: @_originallyDefinedIn(module: "another", macOS 13.13)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros3_UsableFromInline
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "another", OSX 13.13)
 @usableFromInline
 internal struct SimpleThingInAlphabeticalOrderForMacros3_UsableFromInline {}
+
+// CHECK: @_originallyDefinedIn(module: "pre26", macOS 26.0)
+// CHECK: @_originallyDefinedIn(module: "pre26", iOS 26.0)
+// CHECK: @_originallyDefinedIn(module: "pre26", watchOS 26.0)
+// CHECK: @_originallyDefinedIn(module: "pre26", tvOS 26.0)
+// CHECK: @_originallyDefinedIn(module: "pre26", visionOS 26.0)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros4_VersionsMappingTo26
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "pre26", macOS 16, iOS 19, watchOS 12, tvOS 19, visionOS 3)
+public struct SimpleThingInAlphabeticalOrderForMacros4_VersionsMappingTo26 {}
+
+// CHECK: @_originallyDefinedIn(module: "pre27", macOS 27)
+// CHECK: @_originallyDefinedIn(module: "pre27", iOS 27)
+// CHECK: @_originallyDefinedIn(module: "pre27", watchOS 27)
+// CHECK: @_originallyDefinedIn(module: "pre27", tvOS 27)
+// CHECK: @_originallyDefinedIn(module: "pre27", visionOS 27)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros5_VersionsMappingTo27
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "pre27", macOS 17, iOS 20, watchOS 13, tvOS 20, visionOS 4)
+public struct SimpleThingInAlphabeticalOrderForMacros5_VersionsMappingTo27 {}
+
+// CHECK: @_originallyDefinedIn(module: "pre26", macOS 26)
+// CHECK: @_originallyDefinedIn(module: "pre26", iOS 26)
+// CHECK: @_originallyDefinedIn(module: "pre26", watchOS 26)
+// CHECK: @_originallyDefinedIn(module: "pre26", tvOS 26)
+// CHECK: @_originallyDefinedIn(module: "pre26", visionOS 26)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros6_Version26
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "pre26", macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26)
+public struct SimpleThingInAlphabeticalOrderForMacros6_Version26 {}

--- a/test/Parse/original_defined_in_attr.swift
+++ b/test/Parse/original_defined_in_attr.swift
@@ -56,7 +56,12 @@ internal class ToplevelClass8 {}
 public class ToplevelClass9 {}
 
 @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
-@_originallyDefinedIn(module: "foo", macOS 17, iOS 20, watchOS 13, tvOS 20, visionOS 4) // FIXME: Should be diagnosed
+@_originallyDefinedIn(module: "foo", macOS 17, iOS 20, watchOS 13, tvOS 20, visionOS 4)
+// expected-warning@-1 {{'17' is not a valid version number for macOS}}
+// expected-warning@-2 {{'20' is not a valid version number for iOS}}
+// expected-warning@-3 {{'13' is not a valid version number for watchOS}}
+// expected-warning@-4 {{'20' is not a valid version number for tvOS}}
+// expected-warning@-5 {{'4' is not a valid version number for visionOS}}
 public class ToplevelClass10 {}
 
 @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)

--- a/test/Parse/original_defined_in_attr.swift
+++ b/test/Parse/original_defined_in_attr.swift
@@ -50,3 +50,15 @@ fileprivate class ToplevelClass7 {}
 @available(OSX 13.10, *)
 @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0) // expected-warning {{'@_originallyDefinedIn' does not have any effect on internal declarations}}
 internal class ToplevelClass8 {}
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "foo", macOS 16, iOS 19, watchOS 12, tvOS 19, visionOS 3)
+public class ToplevelClass9 {}
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "foo", macOS 17, iOS 20, watchOS 13, tvOS 20, visionOS 4) // FIXME: Should be diagnosed
+public class ToplevelClass10 {}
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+@_originallyDefinedIn(module: "foo", macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26)
+public class ToplevelClass11 {}

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -100,3 +100,15 @@ public func backDeployedNonisolatedNonsending() async -> Int {
   // CHECK:   apply [[SHIPPING_FN]](%0)
   return 0
 }
+
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy0A32DeployedBeforeVersionMappingTo26SiyFTwb :
+@backDeployed(before: macOS 16)
+public func backDeployedBeforeVersionMappingTo26() -> Int {
+  // CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 26
+  // CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK: [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK: [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK: cond_br [[AVAIL]]
+  return 0
+}

--- a/test/TBD/Inputs/linker-directive.swift
+++ b/test/TBD/Inputs/linker-directive.swift
@@ -9,3 +9,19 @@ public struct Vehicle {
   @available(macOS 10.15, iOS 13, *)
   public func originallyDefinedInCurrentModule() {}
 }
+
+@available(macOS 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 15, iOS 18)
+public func movedPriorTo26() {}
+
+@available(macOS 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 16, iOS 19)
+public func movedInVersionsMappingTo26() {}
+
+@available(macOS 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 17, iOS 20)
+public func movedInVersionsMappingTo27() {}
+
+@available(macOS 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 26, iOS 26)
+public func movedInVersion26() {}

--- a/test/TBD/linker-directives-ld-previous-ios.swift
+++ b/test/TBD/linker-directives-ld-previous-ios.swift
@@ -12,9 +12,17 @@
 // CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMa$
 // CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMn$
 // CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVN$
+// CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$18.0$_$s10ToasterKit14movedPriorTo26yyF
+// CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$26.0$_$s10ToasterKit16movedInVersion26yyF$
+// CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$26.0$_$s10ToasterKit26movedInVersionsMappingTo26yyF$
+// CHECK-objc-simulator-false: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$27.0$_$s10ToasterKit26movedInVersionsMappingTo27yyF$
 
 // CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit5toastyyF$
 // CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleV4moveyyF$
 // CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVMa$
 // CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVMn$
 // CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVN$
+// CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$18.0$_$s10ToasterKit14movedPriorTo26yyF
+// CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$26.0$_$s10ToasterKit16movedInVersion26yyF$
+// CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$26.0$_$s10ToasterKit26movedInVersionsMappingTo26yyF$
+// CHECK-objc-simulator-true: D $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$27.0$_$s10ToasterKit26movedInVersionsMappingTo27yyF$

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -18,11 +18,19 @@
 // CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$13.0$_$s10ToasterKit7VehicleVMa$
 // CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$13.0$_$s10ToasterKit7VehicleVMn$
 // CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$13.0$_$s10ToasterKit7VehicleVN$
+// CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$18.0$_$s10ToasterKit14movedPriorTo26yyF
+// CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$26.0$_$s10ToasterKit16movedInVersion26yyF$
+// CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$26.0$_$s10ToasterKit26movedInVersionsMappingTo26yyF$
+// CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$27.0$_$s10ToasterKit26movedInVersionsMappingTo27yyF$
 
 // CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
 // CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
 // CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMa$
 // CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMn$
 // CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVN$
+// CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$15.0$_$s10ToasterKit14movedPriorTo26yyF$
+// CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$26.0$_$s10ToasterKit16movedInVersion26yyF$
+// CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$26.0$_$s10ToasterKit26movedInVersionsMappingTo26yyF$
+// CHECK-MAC: D $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$27.0$_$s10ToasterKit26movedInVersionsMappingTo27yyF$
 
 // CHECK-NOT: $_$s10ToasterKit7VehicleV32originallyDefinedInCurrentModuleyyF

--- a/test/TBD/linker-directives.swift
+++ b/test/TBD/linker-directives.swift
@@ -4,10 +4,12 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck %s -tbd-install_name directive_use -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS-NOT
 
-// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT 
 // RUN: %target-swift-frontend -typecheck %s -tbd-install_name directive_use -emit-tbd -emit-tbd-path %t/linker_directives.tbd
-// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT 
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS-NOT
 
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "ToasterKit", macOS 10.15)
@@ -18,3 +20,25 @@ public func toast() {}
 
 // CHECK-HAS-NOT-NOT: $ld$hide$os10.15$_$s10ToasterKit5toastyyF
 // CHECK-HAS-NOT-NOT: $ld$hide$os10.7$_$s10ToasterKit5toastyyF
+
+@available(macOS 15, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 16)
+public func toastMovedInVersionMappingTo26() {}
+
+// CHECK-HAS: D $ld$hide$os15.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os15.1$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os15.10$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// FIXME: Symbols shouldn't be generated for non-existent intermediate OS versions.
+// CHECK-HAS: D $ld$hide$os16.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os17.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os18.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os19.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os20.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os21.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os22.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os23.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os24.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS: D $ld$hide$os25.0$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+
+// CHECK-HAS-NOT-NOT: $ld$hide$os14.{{.*}}$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF
+// CHECK-HAS-NOT-NOT: $ld$hide$os26.{{.*}}$_$s10ToasterKit30toastMovedInVersionMappingTo26yyF

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -205,6 +205,19 @@ extension TopLevelProtocol {
   public func backDeployedExtensionMethod() {}
 }
 
+@backDeployed(before: macOS 16.0, iOS 19.0, tvOS 19.0, watchOS 12.0, visionOS 3.0)
+public func backDeployedBeforeVersionsMappingTo26() -> Int { 26 }
+
+@backDeployed(before: macOS 17.0, iOS 20.0, tvOS 20.0, watchOS 13.0, visionOS 4.0)
+// expected-warning@-1 {{'17.0' is not a valid version number for macOS}}
+// expected-warning@-2 {{'20.0' is not a valid version number for iOS}}
+// expected-warning@-3 {{'20.0' is not a valid version number for tvOS}}
+// expected-warning@-4 {{'13.0' is not a valid version number for watchOS}}
+// expected-warning@-5 {{'4.0' is not a valid version number for visionOS}}
+public func backDeployedBeforeVersionsMappingTo27() -> Int { 27 }
+
+@backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
+public func backDeployedBefore26() -> Int { 26 }
 
 // MARK: - Unsupported declaration kinds
 


### PR DESCRIPTION
Invalid OS versions like `macOS 17` are already diagnosed in `@available` attributes but they also need to be diagnosed in `if #available`, `@_originallyDefinedIn`, and `@backDeployed`.

Resolves rdar://155558161.