### PR TITLE
[6.2] Bailout SwiftCompilerSource's function signature opts for functions with lifetime dependencies

### DIFF
--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -mandatory-performance-optimizations | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -mandatory-performance-optimizations -enable-experimental-feature Lifetimes | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage canonical
 
@@ -220,6 +221,78 @@ sil [ossa] @metatype_arg : $@convention(thin) (Int, @thick Int.Type, @owned Buil
 bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : @owned $Builtin.NativeObject):
   fix_lifetime %1 : $@thick Int.Type
   return %2 : $Builtin.NativeObject
+}
+
+sil [no_locks] [perf_constraint] [ossa] @dont_remove_metatype_arg_lifetime : $@convention(thin) (Int, UnsafeRawPointer) -> @lifetime(borrow 1) Span<Int> {
+bb0(%0 : $Int, %1 : $UnsafeRawPointer):
+  %3 = metatype $@thick Int.Type
+  %7 = function_ref @metatype_arg_lifetime : $@convention(thin) (Int, @thick Int.Type, UnsafeRawPointer) -> @lifetime(borrow 2) Span<Int>
+  %8 = apply %7(%0, %3, %1) : $@convention(thin) (Int, @thick Int.Type, UnsafeRawPointer) -> @lifetime(borrow 2) Span<Int>
+  return %8
+}
+
+sil [ossa] @get_span : $@convention(thin) (UnsafeRawPointer) -> @lifetime(borrow 0) Span<Int>
+
+// CHECK-NOT: sil [signature_optimized_thunk] [ossa] @metatype_arg_lifetime :
+sil [ossa] @metatype_arg_lifetime : $@convention(thin) (Int, @thick Int.Type, UnsafeRawPointer) -> @lifetime(borrow 2) Span<Int> {
+bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : $UnsafeRawPointer):
+  fix_lifetime %1 : $@thick Int.Type
+  %3 = function_ref @get_span : $@convention(thin) (UnsafeRawPointer) -> @lifetime(borrow 0) Span<Int>
+  %4 = apply %3(%2) : $@convention(thin) (UnsafeRawPointer) -> @lifetime(borrow 0) Span<Int>
+  return %4
+}
+
+sil [no_locks] [perf_constraint] [ossa] @can_remove_metatype_arg_lifetime : $@convention(thin) (Int, UnsafeRawPointer) -> @lifetime(borrow 1) Span<Int> {
+bb0(%0 : $Int, %1 : $UnsafeRawPointer):
+  %3 = metatype $@thick Int.Type
+  %7 = function_ref @metatype_arg_lifetime_opt : $@convention(thin) (UnsafeRawPointer, Int, @thick Int.Type) -> @lifetime(borrow 0) Span<Int>
+  %8 = apply %7(%1, %0, %3) : $@convention(thin) (UnsafeRawPointer, Int, @thick Int.Type) -> @lifetime(borrow 0) Span<Int>
+  return %8
+}
+
+// CHECK: sil [signature_optimized_thunk] [ossa] @metatype_arg_lifetime_opt :
+sil [ossa] @metatype_arg_lifetime_opt : $@convention(thin) (UnsafeRawPointer, Int, @thick Int.Type) -> @lifetime(borrow 0) Span<Int> {
+bb0(%2 : $UnsafeRawPointer, %0 : $Int, %1 : $@thick Int.Type):
+  fix_lifetime %1 : $@thick Int.Type
+  %3 = function_ref @get_span : $@convention(thin) (UnsafeRawPointer) -> @lifetime(borrow 0) Span<Int>
+  %4 = apply %3(%2) : $@convention(thin) (UnsafeRawPointer) -> @lifetime(borrow 0) Span<Int>
+  return %4
+}
+
+sil [no_locks] [perf_constraint] [ossa] @dont_remove_metatype_arg_lifetime_inout : $@convention(thin) (Int, @lifetime(copy 2) @inout MutableSpan<Int>, @owned MutableSpan<Int>) -> () {
+bb0(%0 : $Int, %1 : $*MutableSpan<Int>, %2 : @owned $MutableSpan<Int>):
+  %3 = metatype $@thick Int.Type
+  %7 = function_ref @metatype_arg_lifetime_inout : $@convention(thin) (Int, @thick Int.Type, @lifetime(copy 3) @inout MutableSpan<Int>, @owned MutableSpan<Int>) -> ()
+  %8 = apply %7(%0, %3, %1, %2) : $@convention(thin) (Int, @thick Int.Type, @lifetime(copy 3) @inout MutableSpan<Int>, @owned MutableSpan<Int>) -> ()
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-NOT: sil [signature_optimized_thunk] [ossa] @metatype_arg_lifetime_inout :
+sil [ossa] @metatype_arg_lifetime_inout : $@convention(thin) (Int, @thick Int.Type, @lifetime(copy 3) @inout MutableSpan<Int>, @owned MutableSpan<Int>) -> () {
+bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : $*MutableSpan<Int>, %3 : @owned $MutableSpan<Int>):
+  fix_lifetime %1 : $@thick Int.Type
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}
+
+sil [no_locks] [perf_constraint] [ossa] @dont_remove_metatype_arg_lifetime_inout_source : $@convention(thin) (Int, @lifetime(copy 2) @inout MutableSpan<Int>, @owned MutableSpan<Int>) -> () {
+bb0(%0 : $Int, %1 : $*MutableSpan<Int>, %2 : @owned $MutableSpan<Int>):
+  %3 = metatype $@thick Int.Type
+  %7 = function_ref @metatype_arg_lifetime_inout_source : $@convention(thin) (@lifetime(copy 3) @inout MutableSpan<Int>, Int, @thick Int.Type, @owned MutableSpan<Int>) -> ()
+  %8 = apply %7(%1, %0, %3, %2) : $@convention(thin) (@lifetime(copy 3) @inout MutableSpan<Int>, Int, @thick Int.Type, @owned MutableSpan<Int>) -> ()
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-NOT: sil [signature_optimized_thunk] [ossa] @metatype_arg_lifetime_inout_source :
+sil [ossa] @metatype_arg_lifetime_inout_source : $@convention(thin) (@lifetime(copy 3) @inout MutableSpan<Int>, Int, @thick Int.Type, @owned MutableSpan<Int>) -> () {
+bb0(%2 : $*MutableSpan<Int>, %0 : $Int, %1 : $@thick Int.Type, %3 : @owned $MutableSpan<Int>):
+  fix_lifetime %1 : $@thick Int.Type
+  destroy_value %3
+  %r = tuple ()
+  return %r
 }
 
 // CHECK-LABEL: sil [no_locks] [perf_constraint] [ossa] @remove_metatype_arg_throws :


### PR DESCRIPTION
Explanation: If a function has lifetime dependencies, disable deleting dead params. It is problematic to dead code params that are not dependency sources, since lifetime dependent sources are stored as indices and deleting dead parameters will require recomputation of these indices. Similar to https://github.com/swiftlang/swift/pull/82963 

Scope: Affects mandatory optimization of functions with lifetime dependencies

Risk: Low

Reviewer: @eeckstein 

Main PR: https://github.com/swiftlang/swift/pull/83037

Testing: Swift CI testing

Radar: TBD
