### PR TITLE
[6.2] Bailout from an illegal transformation in semantic arc opts

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -503,6 +503,13 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
     if (visitedInsts.count(use->getUser()))
       return false;
 
+    // If the cvi's operand value has a non-consuming use in the same
+    // instruction which consumes the copy, bailout. NOTE:
+    // isUseBetweenInstAndBlockEnd does not check this.
+    if (user == singleCVIConsumingUse->getUser()) {
+      return false;
+    }
+
     // Ok, we have a use that isn't in our visitedInsts region. That being said,
     // we may still have a use that introduces a new BorrowScope onto our
     // copy_value's operand that overlaps with our forwarding value region. In
@@ -513,7 +520,7 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
     // we need to only find scopes that end within the region in between the
     // singleConsumingUse (the original forwarded use) and the destroy_value. In
     // such a case, we must bail!
-    if (auto operand = BorrowingOperand(use))
+    if (auto operand = BorrowingOperand(use)) {
       if (!operand.visitScopeEndingUses([&](Operand *endScopeUse) {
             // Return false if we did see the relevant end scope instruction
             // in the block. That means that we are going to exit early and
@@ -521,6 +528,7 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
             return !visitedInsts.count(endScopeUse->getUser());
           }))
         return false;
+    }
   }
 
   // Ok, we now know that we can eliminate this value.

--- a/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
+++ b/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
@@ -978,3 +978,42 @@ bb0:
   return %r : $()
 }
 
+sil @consume_and_borrow : $@convention(thin) (@owned Klass, @guaranteed Klass) -> ()
+sil @borrow : $@convention(thin) (@guaranteed Klass) -> ()
+sil @consume : $@convention(thin) (@owned Klass) -> ()
+sil @get_klass : $@convention(thin) () -> @owned Klass
+
+// CHECK-LABEL: sil hidden [ossa] @borrow_and_consume_copyable_test1 :
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'borrow_and_consume_copyable_test1'
+sil hidden [ossa] @borrow_and_consume_copyable_test1 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @get_klass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = move_value [var_decl] %1
+  %3 = copy_value %2
+  %4 = function_ref @borrow : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+  %6 = function_ref @consume : $@convention(thin) (@owned Klass) -> ()
+  %7 = apply %6(%3) : $@convention(thin) (@owned Klass) -> ()
+  destroy_value %2
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil hidden [ossa] @borrow_and_consume_copyable_test2 : 
+// CHECK: copy_value
+// CHECK-LABEL: } // end sil function 'borrow_and_consume_copyable_test2'
+sil hidden [ossa] @borrow_and_consume_copyable_test2 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @get_klass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = move_value [var_decl] %1
+  %3 = copy_value %2
+  %4 = function_ref @consume_and_borrow : $@convention(thin) (@owned Klass, @guaranteed Klass) -> ()
+  %5 = apply %4(%3, %2) : $@convention(thin) (@owned Klass, @guaranteed Klass) -> ()
+  destroy_value %2
+  %7 = tuple ()
+  return %7
+}
+


### PR DESCRIPTION
Explanation: `tryJoinIfDestroyConsumingUseInSameBlock` replaces a copy with its operand when there is no use of the copy's operand between the copy's forwarded consuming use and the copy operand's destroy in the same block. It is illegal to do this transformation when there is a non-consuming use of the copy operand after the forwarded consuming use of the copy.

The code checking this illegal case was not considering the case where the consuming use of the copy was in the same instruction as the non-consuming use of the copy operand. 

Scope: Affects Copyable types in optimized code. It can come up in code where the same instruction can borrow and consume. Like a call to:
`func borrowAndCnsm(_ x: borrowing Span<Int>, _ y: consuming Span<Int>) { }` 

Risk: Low

Issue: rdar://154712867

Main PR: https://github.com/swiftlang/swift/pull/83052

Testing: Swift CI testing



