### PR TITLE
Remove `cmake` from `Brewfile`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,2 @@
-brew "cmake"
 brew "ninja"
 brew "sccache"


### PR DESCRIPTION
`Brewfile` is not used on CI and is purely a contributor experience helper for at-desk builds. We're seeing multiple build failures with CMake 4.0 on macOS: e.g. SwiftPM bootstrapping issues. `build-script` will always build a fixed version of CMake that's known to work, if preinstalled one is not found. Let's reduce the chances for confusion by not preinstalling CMake for those who use `Brewfile`.
