### PR TITLE
[windows][lldb] fix incorrect LLVM_HOST_TRIPLE when cross-compiling

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1834,7 +1834,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
     LLVM_CONFIG_PATH = (Join-Path -Path $BuildTools -ChildPath "llvm-config.exe");
     LLVM_ENABLE_ASSERTIONS = $(if ($Variant -eq "Asserts") { "YES" } else { "NO" })
     LLVM_EXTERNAL_SWIFT_SOURCE_DIR = "$SourceCache\swift";
-    LLVM_HOST_TRIPLE = $BuildPlatform.Triple;
+    LLVM_HOST_TRIPLE = $Platform.Triple;
     LLVM_NATIVE_TOOL_DIR = $BuildTools;
     LLVM_TABLEGEN = (Join-Path $BuildTools -ChildPath "llvm-tblgen.exe");
     LLVM_USE_HOST_TOOLS = "NO";


### PR DESCRIPTION
When building the toolchain on an `X86_64` machine targeting `ARM64`, which the bots do, `LLVM_HOST_TRIPLE` will be set to `x86_64-unknown-windows-msvc` instead of `aarch64-pc-windows-msvc`.

This causes the following crashes related to LLDB not inferring the debugging platform correctly (when cross-compiling, i.e with the bots't builds)
- The swift REPL does not work on ARM64.
- LLDB crashes when immediately when hitting a breakpoint.
- LLDB crashes when interrupting a program.
- lldb-dap crashes when stepping.

This patch fixes the issue by passing the correct `LLVM_HOST_TRIPLE` when building.

rdar://155876394