### PR TITLE
GettingStarted.md: avoid preinstalling CMake

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -142,10 +142,10 @@ toolchain as a one-off, there are a couple of differences:
 1. Install Xcode. The minimum required version is specified in the node
    information on <https://ci.swift.org>, may change frequently, and is often
    a beta release.
-1. Install [CMake][], [Ninja][] and [Sccache][]:
+1. Install [Ninja][] and [Sccache][]:
    - Via [Homebrew][] (recommended):
      ```sh
-     brew install cmake ninja sccache
+     brew install ninja sccache
      ```
    - Via [Homebrew Bundle][]:
      ```sh
@@ -153,7 +153,6 @@ toolchain as a one-off, there are a couple of differences:
      ```
 
 [Xcode]: https://developer.apple.com/xcode/resources/
-[CMake]: https://cmake.org
 [Ninja]: https://ninja-build.org
 [Homebrew]: https://brew.sh/
 [Homebrew Bundle]: https://github.com/Homebrew/homebrew-bundle
@@ -200,7 +199,6 @@ toolchain as a one-off, there are a couple of differences:
 
 ### Spot check dependencies
 
-* Run `cmake --version`; this should be at least 3.19.6 (3.24.2 if you want to use Xcode for editing on macOS).
 * Run `python3 --version`; this should be at least 3.6.
 * Run `ninja --version`; check that this succeeds.
 * If you installed and want to use Sccache: Run `sccache --version`; check


### PR DESCRIPTION
We're seeing multiple build failures with CMake 4.0: e.g. SwiftPM bootstrapping issues  on macOS. `build-script` will always build a fixed version of CMake that's known to work if preinstalled one is not found. Let's reduce the chances for confusion by not recommending preinstalled CMake in `GettingStarted.md`.
