### PR TITLE
[6.2][Concurrency] Replace `nonisolated` with `nonisolated(nonsending)` when isolation is inferred

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6275,10 +6275,12 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
   if (isolationFromAttr && isolationFromAttr->getKind() ==
           ActorIsolation::CallerIsolationInheriting) {
     auto nonisolated = value->getAttrs().getAttribute<NonisolatedAttr>();
-    if (!nonisolated || !nonisolated->isNonSending())
-      value->getAttrs().add(new (ctx) NonisolatedAttr(
-          /*atLoc*/ {}, /*range=*/{}, NonIsolatedModifier::NonSending,
-          /*implicit=*/true));
+    // Replace `nonisolated` with `nonisolated(nonsending)`
+    if (!nonisolated || !nonisolated->isNonSending()) {
+      value->getAttrs().removeAttribute(nonisolated);
+      value->getAttrs().add(NonisolatedAttr::createImplicit(
+          ctx, NonIsolatedModifier::NonSending));
+    }
   }
 
   if (auto *fd = dyn_cast<FuncDecl>(value)) {

--- a/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
+++ b/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 6 -enable-library-evolution \
+// RUN:   -enable-upcoming-feature NonisolatedNonsendingByDefault \
+// RUN:   -emit-module-path %t/A.swiftmodule \
+// RUN:   -emit-module-interface-path %t/A.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/A.swiftinterface) -module-name A
+
+// Build the client using module
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+// RUN: rm %t/A.swiftmodule
+
+// Re-build the client using interface
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+//--- A.swift
+@MainActor
+
+public final class Test {
+  public nonisolated func test() async {}
+}
+
+//--- Client.swift
+import A
+
+// CHECK-LABEL: sil hidden @$s6Client4test1ty1A4TestC_tYaF : $@convention(thin) @async (@guaranteed Test) -> ()
+// CHECK: bb0([[SELF:%.*]] : $Test):
+// CHECK:  [[MAIN_ACTOR_EXISTENTIAL:%.*]] = init_existential_ref %4 : $MainActor : $MainActor, $any Actor
+// CHECK:  [[ANY_ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, [[MAIN_ACTOR_EXISTENTIAL]]
+// CHECK:  [[TEST_METHOD:%.*]] = function_ref @$s1A4TestC4testyyYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed Test) -> ()
+// CHECK:  apply [[TEST_METHOD]]([[ANY_ACTOR]], [[SELF]])
+// CHECK: } // end sil function '$s6Client4test1ty1A4TestC_tYaF'
+@MainActor
+func test(t: Test) async {
+  await t.test() // Ok
+}


### PR DESCRIPTION
- Explanation:

  With `NonisolatedNonsendingByDefault` an explicit `nonisolated` attribute in declaration context is inferred to mean `nonisolated(nonsending)` and it should be printed as such in interface files and other places.

  The inference logic that did didn't remove the original attribute which meant that it would be printed twice i.e.
`nonisolated nonisolated(nonsending) func test() async` which is incorrect and would fail swift interface validation.

- Resolves: rdar://155847011

- Main Branch PR: https://github.com/swiftlang/swift/pull/83056

- Risk: Very Low. This is a very narrow fix when the feature is enabled.
 
- Reviewed By: @DougGregor 

- Testing: Added new test-cases to the Concurrency suite.

(cherry picked from commit b519c07428f00a8a52ab622776b6d86fa7ceaaf3)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
