### PR TITLE
Runtimes: correct the Android overlay install more precisely

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -30,8 +30,11 @@ target_compile_options(SwiftAndroid INTERFACE
 
 install(FILES
   android.modulemap
-  posix_filesystem.apinotes
-  spawn.apinotes
   SwiftAndroidNDK.h
   SwiftBionic.h
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
+
+install(FILES
+  posix_filesystem.apinotes
+  spawn.apinotes
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/apinotes)


### PR DESCRIPTION
The install location of the APINotes is separate from the rest of the overlay content. These are installed unlabelled by the OS (which is a potential issue if there are conflicts with other OSes!). The swift swift-driver properly locates the APINotes it appears, but the C++ swift-driver does not. Install the APINotes to a location that both will function with.