### PR TITLE
AST: Remove MakeAbstractConformanceForGenericType

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -105,16 +105,6 @@ public:
                                     Type dependentType,
                                     ProtocolDecl *proto) const;
 };
-
-/// Functor class suitable for use as a \c LookupConformanceFn that provides
-/// only abstract conformances for generic types. Asserts that the replacement
-/// type is an opaque generic type.
-class MakeAbstractConformanceForGenericType {
-public:
-  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
-                                    Type dependentType,
-                                    ProtocolDecl *proto) const;
-};
   
 /// Flags that can be passed when substituting into a type.
 enum class SubstFlags {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6889,15 +6889,8 @@ CanSILBoxType SILBoxType::get(CanType boxedType) {
                                         /*mutable*/ true),
                                /*captures generic env*/ false);
 
-  auto subMap =
-    SubstitutionMap::get(
-      singleGenericParamSignature,
-      [&](SubstitutableType *type) -> Type {
-        if (type->isEqual(genericParam)) return boxedType;
-
-        return nullptr;
-      },
-      MakeAbstractConformanceForGenericType());
+  auto subMap = SubstitutionMap::get(singleGenericParamSignature, boxedType,
+                                     LookUpConformanceInModule());
   return get(boxedType->getASTContext(), layout, subMap);
 }
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -353,9 +353,9 @@ Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
 Type TypeBase::mapTypeOutOfContext() {
   assert(!hasTypeParameter() && "already have an interface type");
   return Type(this).subst(MapTypeOutOfContext(),
-    MakeAbstractConformanceForGenericType(),
-    SubstFlags::PreservePackExpansionLevel |
-    SubstFlags::SubstitutePrimaryArchetypes);
+                          LookUpConformanceInModule(),
+                          SubstFlags::PreservePackExpansionLevel |
+                          SubstFlags::SubstitutePrimaryArchetypes);
 }
 
 auto GenericEnvironment::getOrCreateNestedTypeStorage() -> NestedTypeStorage & {
@@ -684,7 +684,7 @@ GenericEnvironment::mapElementTypeIntoPackContext(Type type) const {
 
       return archetype->getInterfaceType();
     },
-    MakeAbstractConformanceForGenericType(),
+    LookUpConformanceInModule(),
     SubstFlags::PreservePackExpansionLevel |
     SubstFlags::SubstitutePrimaryArchetypes |
     SubstFlags::SubstituteLocalArchetypes);
@@ -754,7 +754,7 @@ GenericEnvironment::getForwardingSubstitutionMap() const {
   auto genericSig = getGenericSignature();
   return SubstitutionMap::get(genericSig,
                               BuildForwardingSubstitutions(this),
-                              MakeAbstractConformanceForGenericType());
+                              LookUpConformanceInModule());
 }
 
 OpenedElementContext

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -641,7 +641,7 @@ SubstitutionMap GenericSignatureImpl::getIdentitySubstitutionMap() const {
         return param;
       return PackType::getSingletonPackExpansion(param);
     },
-    MakeAbstractConformanceForGenericType());
+    LookUpConformanceInModule());
 }
 
 GenericTypeParamType *GenericSignatureImpl::getSugaredType(

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -214,7 +214,7 @@ Type swift::mapLocalArchetypesOutOfContext(
     GenericSignature baseGenericSig,
     ArrayRef<GenericEnvironment *> capturedEnvs) {
   return type.subst(MapLocalArchetypesOutOfContext(baseGenericSig, capturedEnvs),
-                    MakeAbstractConformanceForGenericType(),
+                    LookUpConformanceInModule(),
                     SubstFlags::PreservePackExpansionLevel |
                     SubstFlags::SubstitutePrimaryArchetypes |
                     SubstFlags::SubstituteLocalArchetypes);

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -118,13 +118,13 @@ ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() cons
   if (isConcrete()) {
     return getConcrete()->subst(
         MapTypeOutOfContext(),
-        MakeAbstractConformanceForGenericType(),
+        LookUpConformanceInModule(),
         SubstFlags::PreservePackExpansionLevel |
         SubstFlags::SubstitutePrimaryArchetypes);
   } else if (isPack()) {
     return getPack()->subst(
         MapTypeOutOfContext(),
-        MakeAbstractConformanceForGenericType(),
+        LookUpConformanceInModule(),
         SubstFlags::PreservePackExpansionLevel |
         SubstFlags::SubstitutePrimaryArchetypes);
   } else if (isAbstract()) {

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/AST/RequirementEnvironment.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -70,7 +71,7 @@ RequirementEnvironment::RequirementEnvironment(
     return t;
   };
   auto conformanceToWitnessThunkConformanceFn =
-      MakeAbstractConformanceForGenericType();
+      LookUpConformanceInModule();
 
   auto substConcreteType = concreteType.subst(
       conformanceToWitnessThunkTypeFn,
@@ -140,7 +141,7 @@ RequirementEnvironment::RequirementEnvironment(
 
       // All other generic parameters come from the requirement itself
       // and conform abstractly.
-      return MakeAbstractConformanceForGenericType()(IFS, type, proto);
+      return lookupConformance(type.subst(IFS), proto);
     });
 
   // If the requirement itself is non-generic, the witness thunk signature

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -629,7 +629,7 @@ AbstractGenericSignatureRequest::evaluate(
             }
             return Type(type);
           },
-          MakeAbstractConformanceForGenericType(),
+          LookUpConformanceInModule(),
           SubstFlags::PreservePackExpansionLevel);
       resugaredRequirements.push_back(resugaredReq);
     }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -304,7 +304,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
 SubstitutionMap SubstitutionMap::mapReplacementTypesOutOfContext() const {
   return subst(MapTypeOutOfContext(),
-               MakeAbstractConformanceForGenericType(),
+               LookUpConformanceInModule(),
                SubstFlags::PreservePackExpansionLevel |
                SubstFlags::SubstitutePrimaryArchetypes);
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2010,7 +2010,7 @@ CanType TypeConverter::getExemplarType(CanType contextTy) {
           return getExemplarArchetype(arch);
         return type;
       },
-      MakeAbstractConformanceForGenericType(),
+      LookUpConformanceInModule(),
       SubstFlags::PreservePackExpansionLevel |
       SubstFlags::SubstitutePrimaryArchetypes);
     return CanType(exemplified);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -5123,7 +5123,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
 
       return paramTy;
     },
-    MakeAbstractConformanceForGenericType(),
+    LookUpConformanceInModule(),
     SubstFlags::PreservePackExpansionLevel)->getCanonicalType());
 }
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -535,7 +535,7 @@ void ExistentialTransform::populateThunkBody() {
           return type;
         }
       },
-      MakeAbstractConformanceForGenericType());
+      LookUpConformanceInModule());
 
   /// Perform the substitutions.
   auto SubstCalleeType = GenCalleeType->substGenericArgs(

--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -495,12 +495,10 @@ emitTypeCheck(SILBasicBlock *FailedTypeCheckBB, SubstitutableType *ParamTy,
   Builder.emitBlock(SuccessBB);
 }
 
-static SubstitutionMap getSingleSubstitutionMap(SILFunction *F,
-                                                  Type Ty) {
+static SubstitutionMap getSingleSubstitutionMap(SILFunction *F, Type Ty) {
   return SubstitutionMap::get(
-    F->getGenericEnvironment()->getGenericSignature(),
-    [&](SubstitutableType *type) { return Ty; },
-    MakeAbstractConformanceForGenericType());
+    F->getGenericEnvironment()->getGenericSignature(), Ty,
+    LookUpConformanceInModule());
 }
 
 void EagerDispatch::emitIsTrivialCheck(SILBasicBlock *FailedTypeCheckBB,

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -317,7 +317,7 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
         ASSERT(type->isEqual(origParam));
         return openedParam;
       },
-      MakeAbstractConformanceForGenericType());
+      LookUpConformanceInModule());
   }
 
   if (genericSig) {
@@ -464,7 +464,7 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
         [&](SubstitutableType *type) -> Type {
           return existentialSig.SelfType;
         },
-        MakeAbstractConformanceForGenericType());
+        LookUpConformanceInModule());
 
       // Make sure this is valid first.
       if (!existentialSig.OpenedSig->isValidTypeParameter(ty)) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3044,7 +3044,7 @@ TypeResolver::resolveOpenedExistentialArchetype(
         [&](SubstitutableType *type) -> Type {
           return env->getGenericSignature().getGenericParams().back();
         },
-        MakeAbstractConformanceForGenericType());
+        LookUpConformanceInModule());
 
     archetypeType = env->mapTypeIntoContext(interfaceType);
     ASSERT(archetypeType->is<ExistentialArchetypeType>());

--- a/validation-test/compiler_crashers_2_fixed/1cafc0c1955e56b5.swift
+++ b/validation-test/compiler_crashers_2_fixed/1cafc0c1955e56b5.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::MakeAbstractConformanceForGenericType::operator()(swift::InFlightSubstitution&, swift::Type, swift::ProtocolDecl*) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol A {}
 struct C<T: A> {}
 protocol E {

--- a/validation-test/compiler_crashers_2_fixed/d885506018b583.swift
+++ b/validation-test/compiler_crashers_2_fixed/d885506018b583.swift
@@ -1,3 +1,3 @@
 // {"signature":"swift::AvailabilityContext::Storage::get(swift::AvailabilityRange const&, bool, llvm::ArrayRef<swift::AvailabilityContext::DomainInfo>, swift::ASTContext const&)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a extension a where b == Self{c : } typealias b : Sequence


### PR DESCRIPTION
While the intent behind this functor was noble, it has grown in complexity considerably over the years, and it seems to be nothing but a source of crashes in practice. I don't want to deal with it anymore, so I've decided to just subsume all usages with LookUpConformanceInModule instead.