### PR TITLE
[Runtimes] Enable overlay builds in macOS smoketest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
 /Runtimes/**/*.cmake                                    @etcwilde @compnerd @edymtt @justice-adams-apple
 /Runtimes/**/CMakeLists.txt                             @etcwilde @compnerd @edymtt @justice-adams-apple
 /Runtimes/Core/cmake/caches/Vendors/Apple/              @etcwilde @shahmishal @edymtt @justice-adams-apple
-/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake @tshortli @etcwilde @compnerd @edymtt @justice-adams-apple
+/Runtimes/*/cmake/modules/ExperimentalFeatures.cmake @tshortli @etcwilde @compnerd @edymtt @justice-adams-apple
 
 # SwiftCompilerSources
 /SwiftCompilerSources                     @eeckstein

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1653,9 +1653,31 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
 
       ExternalProject_Get_Property("${stdlib_target}-core" INSTALL_DIR)
 
+      ExternalProject_Add("${stdlib_target}-Overlay"
+        SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Overlay"
+        DEPENDS "${stdlib_target}-core"
+        INSTALL_DIR "${INSTALL_DIR}"
+        LIST_SEPARATOR "|"
+        # To ensure incremental builds work as expected
+        BUILD_ALWAYS 1
+        CMAKE_ARGS
+          -DBUILD_SHARED_LIBS=YES
+          -DCMAKE_Swift_COMPILER_WORKS:BOOLEAN=YES
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+          -DCMAKE_INSTALL_PREFIX:FILEPATH=${INSTALL_DIR}
+          -DCMAKE_Swift_COMPILER:FILEPATH=$<IF:$<BOOL:${CMAKE_CROSSCOMPILING}>,${CMAKE_Swift_COMPILER},$<PATH:REPLACE_FILENAME,$<TARGET_FILE:swift-frontend>,swiftc>>
+          -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+          -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+          -DCMAKE_Swift_COMPILER_TARGET:STRING=${stdlib_target_triple}
+          -DCMAKE_C_COMPILER_TARGET:STRING=${stdlib_target_triple}
+          -DCMAKE_CXX_COMPILER_TARGET:STRING=${stdlib_target_triple}
+          -DCMAKE_COLOR_DIAGNOSTICS:BOOLEAN=${CMAKE_COLOR_DIAGNOSTICS}
+          -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+          -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=TRUE)
+
       ExternalProject_Add("${stdlib_target}-Supplemental"
         SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Supplemental"
-        DEPENDS "${stdlib_target}-core"
+        DEPENDS "${stdlib_target}-core" "${stdlib_target}-Overlay"
         INSTALL_DIR "${INSTALL_DIR}"
         INSTALL_COMMAND ""
         LIST_SEPARATOR "|"

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -31,6 +31,8 @@ project(SwiftOverlay
   LANGUAGES C CXX Swift
   VERSION 6.1.0${BUILD_NUMBER})
 
+set(CMAKE_Swift_LANGUAGE_VERSION 5)
+
 find_package(SwiftCore)
 
 # FIXME: We should not need to refer back into the compiler sources. This is
@@ -55,9 +57,21 @@ option(SwiftOverlay_INSTALL_NESTED_SUBDIR "Install libraries under a platform an
 set(SwiftOverlay_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${SwiftOverlay_INSTALL_NESTED_SUBDIR}>:/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR}>")
 set(SwiftOverlay_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${SwiftOverlay_INSTALL_NESTED_SUBDIR}>:/${SwiftOverlay_PLATFORM_SUBDIR}>")
 
+option(SwiftOverlay_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
+
 add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-ossa-modules>"
+  "$<$<AND:$<BOOL:${SwiftOverlay_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
+
+include(ExperimentalFeatures)
 
 add_subdirectory(clang)
 if(ANDROID)

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(swift_Builtin_float
 set_target_properties(swift_Builtin_float PROPERTIES
   Swift_MODULE_NAME _Builtin_float)
 target_compile_options(swift_Builtin_float PRIVATE
-  "$<$<PLATFORM_ID:Darwin>:SHELL:-Xfrontend -module-abi-name -Xfrontend Darwin>")
+  "$<$<AND:$<PLATFORM_ID:Darwin>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -module-abi-name -Xfrontend Darwin>"
+  $<$<COMPILE_LANGUAGE:Swift>:-autolink-force-load>)
 target_link_libraries(swift_Builtin_float PRIVATE
   $<$<PLATFORM_ID:Windows>:ClangModules>
   swiftCore)

--- a/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
@@ -1,0 +1,9 @@
+add_compile_options(
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>")


### PR DESCRIPTION
Take the chance to match the flags used in the existing build system, and adjust code ownership to cover the file I added to track the experimental flags for the overlays.

Addresses rdar://155882420