### PR TITLE
[SE-0466] Nested types of nonisolated types don't infer main-actor isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6084,13 +6084,28 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
         -> std::optional<std::tuple<InferredActorIsolation, ValueDecl *,
                                     std::optional<ActorIsolation>>> {
       // Default global actor isolation does not apply to any declarations
-      // within actors and distributed actors.
-      bool inActorContext = false;
+      // within actors and distributed actors, nor does it apply in a
+      // nonisolated type.
       auto *dc = value->getInnermostDeclContext();
-      while (dc && !inActorContext) {
+      while (dc) {
         if (auto *nominal = dc->getSelfNominalTypeDecl()) {
           if (nominal->isAnyActor())
             return {};
+
+          if (dc != dyn_cast<DeclContext>(value)) {
+            switch (getActorIsolation(nominal)) {
+            case ActorIsolation::Unspecified:
+            case ActorIsolation::ActorInstance:
+            case ActorIsolation::Nonisolated:
+            case ActorIsolation::NonisolatedUnsafe:
+            case ActorIsolation::Erased:
+            case ActorIsolation::CallerIsolationInheriting:
+              return {};
+
+            case ActorIsolation::GlobalActor:
+              break;
+            }
+          }
         }
         dc = dc->getParent();
       }

--- a/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
@@ -9,8 +9,13 @@ enum CK: CodingKey {
   case one
 
   func f() { }
+
+  struct Nested {
+    func g() { }
+  }
 }
 
-nonisolated func testCK(x: CK) {
+nonisolated func testCK(x: CK, y: CK.Nested) {
   x.f() // okay, because CK and CK.f are not @MainActor.
+  y.g()
 }


### PR DESCRIPTION
Under discussion as part of an amendment to SE-0466, limit default main actor inference so it doesn't apply to a nested type within a nonisolated type.