### PR TITLE
[6.2][IRGen] Set generic context before getting call emission in visitFull…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3850,6 +3850,10 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     }
   }
 
+  // Lower the arguments and return value in the callee's generic context.
+  GenericContextScope scope(IGM,
+                            origCalleeType->getInvocationGenericSignature());
+
   Explosion llArgs;
   WitnessMetadata witnessMetadata;
   auto emission = getCallEmissionForLoweredValue(
@@ -3861,9 +3865,6 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   }
 
   emission->begin();
-
-  // Lower the arguments and return value in the callee's generic context.
-  GenericContextScope scope(IGM, origCalleeType->getInvocationGenericSignature());
 
   auto &calleeFP = emission->getCallee().getFunctionPointer();
 

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -359,3 +359,15 @@ struct SomeStruct {
 func someFunc() async throws(SmallError) -> SomeStruct {
     SomeStruct(x: 42, y: 23, z: 25)
 }
+
+// Used to crash the compiler -- https://github.com/swiftlang/swift/issues/80732
+protocol PAssoc<T>: AnyObject {
+    associatedtype T
+    func foo() async throws(SmallError) -> (any PAssoc<T>)
+}
+
+class MyProtocolImpl<T>: PAssoc {
+    func foo() async throws(SmallError) -> (any PAssoc<T>) {
+        fatalError()
+    }
+}


### PR DESCRIPTION
…ApplySite

- **Explanation**: Without the generic context, the result type can't be mapped into the current context, causing the compiler to crash.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Code gen for typed throws in generic context
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://149007227
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/80746
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: The only change is that the generic context gets set earlier, so it's available in the call emission. This should not affect anything but the bug this fixes.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added regression tests.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @aschwaighofer 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->