### PR TITLE
[concurrency] Make optimize hop to executor more conservative for 6.2 around caller isolation inheriting functions.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -894,6 +894,21 @@ public:
            getNumIndirectSILErrorResults();
   }
 
+  std::optional<ActorIsolation> getActorIsolation() const {
+    if (auto isolation = getIsolationCrossing();
+        isolation && isolation->getCalleeIsolation())
+      return isolation->getCalleeIsolation();
+    auto *calleeFunction = getCalleeFunction();
+    if (!calleeFunction)
+      return {};
+    return calleeFunction->getActorIsolation();
+  }
+
+  bool isCallerIsolationInheriting() const {
+    auto isolation = getActorIsolation();
+    return isolation && isolation->isCallerIsolationInheriting();
+  }
+
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }
 
   static bool classof(const SILInstruction *inst) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -95,6 +95,11 @@ llvm::cl::opt<bool> SILPrintGenericSpecializationInfo(
     llvm::cl::desc("Include generic specialization"
                    "information info in SIL output"));
 
+llvm::cl::opt<bool> SILPrintFunctionIsolationInfo(
+    "sil-print-function-isolation-info", llvm::cl::init(false),
+    llvm::cl::desc("Print out isolation info on functions in a manner that SIL "
+                   "understands [e.x.: not in comments]"));
+
 static std::string demangleSymbol(StringRef Name) {
   if (SILFullDemangle)
     return Demangle::demangleSymbolAsString(Name);
@@ -3628,6 +3633,15 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   auto availability = getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
     OS << "[available " << availability.getVersionString() << "] ";
+  }
+
+  // This is here only for testing purposes.
+  if (SILPrintFunctionIsolationInfo) {
+    if (auto isolation = getActorIsolation()) {
+      OS << "[isolation \"";
+      isolation->printForSIL(OS);
+      OS << "\"] ";
+    }
   }
 
   switch (getInlineStrategy()) {

--- a/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
+++ b/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
@@ -193,12 +193,16 @@ void OptimizeHopToExecutor::solveDataflowBackward() {
 /// Returns true if \p inst is a suspension point or an async call.
 static bool isSuspensionPoint(SILInstruction *inst) {
   if (auto applySite = FullApplySite::isa(inst)) {
+    // NOTE: For 6.2, we consider nonisolated(nonsending) to be a suspension
+    // point, when it really isn't. We do this so that we have a truly
+    // conservative change that does not change output.
     if (applySite.isAsync())
       return true;
     return false;
   }
   if (isa<AwaitAsyncContinuationInst>(inst))
     return true;
+
   return false;
 }
 
@@ -311,6 +315,40 @@ void OptimizeHopToExecutor::updateNeedExecutor(int &needExecutor,
     needExecutor = BlockState::NoExecutorNeeded;
     return;
   }
+
+  // For 6.2 to be conservative, if we are calling a function with
+  // caller_isolation_inheriting isolation, treat the callsite as if the
+  // callsite is an instruction that needs an executor.
+  //
+  // DISCUSSION: The reason why we are doing this is that in 6.2, we are going
+  // to continue treating caller isolation inheriting functions as a suspension
+  // point for the purpose of eliminating redundant hop to executor to not make
+  // this optimization more aggressive. Post 6.2, we will stop treating caller
+  // isolation inheriting functions as suspension points, meaning this code can
+  // be deleted.
+  if (auto fas = FullApplySite::isa(inst);
+      fas && fas.isAsync() && fas.isCallerIsolationInheriting()) {
+    needExecutor = BlockState::ExecutorNeeded;
+    return;
+  }
+
+  // For 6.2, if we are in a caller isolation inheriting function, we need to
+  // treat its return as an executor needing function before
+  // isSuspensionPoint.
+  //
+  // DISCUSSION: We need to do this here since for 6.2, a caller isolation
+  // inheriting function is going to be considered a suspension point to be
+  // conservative and make this optimization strictly more conservative. Post
+  // 6.2, since caller isolation inheriting functions will no longer be
+  // considered suspension points, we will be able to sink this code into needs
+  // executor.
+  if (auto isolation = inst->getFunction()->getActorIsolation();
+      isolation && isolation->isCallerIsolationInheriting() &&
+      isa<ReturnInst>(inst)) {
+    needExecutor = BlockState::ExecutorNeeded;
+    return;
+  }
+
   if (isSuspensionPoint(inst)) {
     needExecutor = BlockState::NoExecutorNeeded;
     return;

--- a/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
+++ b/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -module-name test -swift-version 6 -emit-sil %s | %FileCheck --implicit-check-not=hop_to_executor  %s
+
+// REQUIRES: concurrency
+
+// CHECK-LABEL: sil hidden [noinline] @$s4testAAyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
+// CHECK: hop_to_executor
+// CHECK: } // end sil function '$s4testAAyyYaF'
+@inline(never)
+nonisolated(nonsending) func test() async {}
+
+// CHECK-LABEL: sil hidden [noinline] @$s4test5test2yyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
+// CHECK: hop_to_executor
+// CHECK: hop_to_executor
+// CHECK: } // end sil function '$s4test5test2yyYaF'
+@inline(never)
+nonisolated(nonsending) func test2() async {
+  await test()
+}
+
+@inline(never)
+func test3() async {
+}
+
+// CHECK-LABEL: sil @$s4test6calleryyYaF : $@convention(thin) @async () -> () {
+// CHECK: hop_to_executor
+// CHECK: function_ref @$s4testAAyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+// CHECK: hop_to_executor
+// CHECK: function_ref @$s4test5test2yyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+// CHECK: } // end sil function '$s4test6calleryyYaF'
+public func caller() async {
+  await test()
+  await test2()
+  await test3()
+}

--- a/test/SIL/Parser/actor_isolation.sil
+++ b/test/SIL/Parser/actor_isolation.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -sil-print-function-isolation-info -enable-objc-interop -enable-sil-verify-all=true %s | %target-sil-opt -sil-print-function-isolation-info -enable-objc-interop -enable-sil-verify-all=true | %FileCheck %s
+
+// REQUIRES: asserts
+
+// CHECK: // func_with_caller_isolation_inheriting
+// CHECK: // Isolation: caller_isolation_inheriting
+// CHECK: sil [isolation "caller_isolation_inheriting"] @func_with_caller_isolation_inheriting : $@convention(thin) () -> () {
+sil [isolation "caller_isolation_inheriting"] @func_with_caller_isolation_inheriting : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK: // func_with_global_actor_isolation
+// CHECK: // Isolation: global_actor. type: <null>
+// CHECK: sil [isolation "global_actor"] @func_with_global_actor_isolation : $@convention(thin) () -> () {
+sil [isolation "global_actor"] @func_with_global_actor_isolation : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK: // func_with_actor_instance_isolation
+// CHECK: // Isolation: actor_instance
+// CHECK: sil [isolation "actor_instance"] @func_with_actor_instance_isolation : $@convention(thin) () -> () {
+sil [isolation "actor_instance"] @func_with_actor_instance_isolation : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK: // func_with_nonisolated_isolation
+// CHECK: // Isolation: nonisolated
+// CHECK: sil [isolation "nonisolated"] @func_with_nonisolated_isolation : $@convention(thin) () -> () {
+sil [isolation "nonisolated"] @func_with_nonisolated_isolation : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -optimize-hop-to-executor  | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-function-isolation-info -enable-sil-verify-all %s -optimize-hop-to-executor  | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 sil_stage canonical
 
@@ -13,6 +14,7 @@ actor MyActor {
 
 sil [ossa] @requiredToRunOnActor : $@convention(method) (@guaranteed MyActor) -> ()
 sil [ossa] @anotherAsyncFunction : $@convention(thin) @async () -> ()
+sil [ossa] @syncFunction : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [ossa] @simpleRedundantActor : $@convention(method) @async (@guaranteed MyActor) -> () {
 // CHECK:       bb0(%0 : @guaranteed $MyActor):
@@ -301,4 +303,139 @@ bb0(%0 : @guaranteed $MyActor):
   end_borrow %b : $MyActor
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simpleDCEAsync : $@convention(thin) @async (@guaranteed MyActor) -> () {
+// CHECK-NOT: hop_to_executor
+// CHECK: } // end sil function 'simpleDCEAsync'
+sil [ossa] @simpleDCEAsync : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply %f() : $@convention(thin) @async () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simpleCallerIsolationInheritingStopsDCE : $@convention(thin) @async (@guaranteed MyActor) -> () {
+// CHECK: hop_to_executor
+// CHECK: } // end sil function 'simpleCallerIsolationInheritingStopsDCE'
+sil [ossa] @simpleCallerIsolationInheritingStopsDCE : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// We should eliminate none of the hop_to_executor here since
+// caller_isolation_inheriting @async apply sites do not cross isolation
+// boundaries.
+//
+// CHECK-LABEL: sil [ossa] @simpleCallerIsolationInheritingStopsDCE2 : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK: hop_to_executor
+// CHECK: hop_to_executor
+// CHECK: hop_to_executor
+// CHECK: } // end sil function 'simpleCallerIsolationInheritingStopsDCE2'
+sil [ossa] @simpleCallerIsolationInheritingStopsDCE2 : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %1
+  %f2 = function_ref @syncFunction : $@convention(thin) () -> ()
+  apply %f2() : $@convention(thin) () -> ()
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %2
+  apply %f2() : $@convention(thin) () -> () 
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simpleWithoutCallerIsolationInheritingHaveDCE : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK: bb0([[ARG1:%.*]] : @guaranteed $MyActor, [[ARG2:%.*]] : @guaranteed $MyActor, [[ARG3:%.*]] : @guaranteed $MyActor):
+// CHECK-NEXT:  // function_ref anotherAsyncFunction
+// CHECK-NEXT:  [[FUNC:%.*]] = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+// CHECK-NEXT:  apply [[FUNC]]() : $@convention(thin) @async () -> ()
+// CHECK-NEXT:  hop_to_executor [[ARG2]]
+// CHECK-NEXT:  // function_ref syncFunction
+// CHECK-NEXT:  [[FUNC2:%.*]] = function_ref @syncFunction : $@convention(thin) () -> ()
+// CHECK-NEXT:  apply [[FUNC2]]() : $@convention(thin) () -> ()
+// CHECK-NEXT:  apply [[FUNC]]() : $@convention(thin) @async () -> ()
+// CHECK-NEXT:  hop_to_executor [[ARG3]]
+// CHECK-NEXT:  apply [[FUNC2]]() : $@convention(thin) () -> () 
+// CHECK-NEXT:  apply [[FUNC]]() : $@convention(thin) @async () -> ()
+// CHECK-NEXT:  apply [[FUNC]]() : $@convention(thin) @async () -> ()
+// CHECK: } // end sil function 'simpleWithoutCallerIsolationInheritingHaveDCE'
+sil [ossa] @simpleWithoutCallerIsolationInheritingHaveDCE : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %1
+  %f2 = function_ref @syncFunction : $@convention(thin) () -> ()
+  apply %f2() : $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %2
+  apply %f2() : $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %2
+  apply %f() : $@convention(thin) @async () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// We do not allow for these to be propagated yet through caller isolation
+// inheriting, so we should have all of the hop_to_executor.
+//
+// CHECK-LABEL: sil [ossa] @callerIsolationInheritingStopsAllowsPropagating : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK: bb0(
+// CHECK: hop_to_executor
+// CHECK: hop_to_executor
+// CHECK: hop_to_executor
+// CHECK: } // end sil function 'callerIsolationInheritingStopsAllowsPropagating'
+sil [ossa] @callerIsolationInheritingStopsAllowsPropagating : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %0
+  %f2 = function_ref @syncFunction : $@convention(thin) () -> ()
+  apply %f2() : $@convention(thin) () -> ()
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  hop_to_executor %0
+  apply %f2() : $@convention(thin) () -> () 
+  apply [callee_isolation=caller_isolation_inheriting] [caller_isolation=caller_isolation_inheriting] %f() : $@convention(thin) @async () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Since we are caller isolation inheriting, make sure that we leave around the
+// hop_to_executor due to ehre elase. We do eliminate one of the hop_to_executor
+// though.
+//
+// CHECK: sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK: bb0(
+// CHECK-NEXT: hop_to_executor
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'callerIsolationInheritingStopsReturnDeadEnd'
+sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  hop_to_executor %0
+  hop_to_executor %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @noIsolationStillRemoves : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK-NOT: hop_to_executor
+// CHECK: } // end sil function 'noIsolationStillRemoves'
+sil [ossa] @noIsolationStillRemoves : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  hop_to_executor %0
+  %9999 = tuple ()
+  return %9999 : $()
 }


### PR DESCRIPTION
Specifically for 6.2, we are making optimize hop to executor more conservative around caller isolation inheriting functions. This means that we are:

1. No longer treating calls to caller isolation inheriting functions as having a hop in their prologue. In terms of this pass, it means that when determining dead hop to executors, we no longer think that a caller isolation inheriting function means that an earlier hop to executor is not required.

2. Treating returns from caller isolation inheriting callees as requiring a hop. The reason why we are doing this is that we can no longer assume that our caller will hop after we return.

Post 6.2, there are three main changes we are going to make:

* Forward Dataflow

Caller isolation inheriting functions will no longer be treated as suspension points meaning that we will be able to propagate hops over them and can assume that we know the actor that we are on when we enter the function. Practically this means that trees of calls that involve just nonisolated(nonsending) async functions will avoid /all/ hop to executor calls since we will be able to eliminate all of them since the dataflow will just propagate forward from the entrance that we are already on the actor.

* Backwards Dataflow

A caller isolation inheriting call site will still cause preceding hop_to_executor functions to be live. This is because we need to ensure that we are on the caller isolation inheriting actor before we hit the call site. If we are already on that actor, the hop will be eliminated by the forward pass. But if the hop has not been eliminated, then the hop must be needed to return us to the appropriate actor.

We will also keep the behavior that returns from a caller isolation inheriting function are considered to keep hop to executors alive. If we were able to propagate to a hop to executor before the return inst with the forward dataflow, then we know that we are guaranteed to still be on the relevant actor. If the hop to executor is still there, then we need it to ensure that our caller can treat the caller isolation inheriting function as a non-suspension point.

rdar://155905383
