### PR TITLE
[6.2] [SE-0466] Nested types of nonisolated types don't infer main-actor isolation

### DIFF
--- a/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
@@ -9,8 +9,13 @@ enum CK: CodingKey {
   case one
 
   func f() { }
+
+  struct Nested {
+    func g() { }
+  }
 }
 
-nonisolated func testCK(x: CK) {
+nonisolated func testCK(x: CK, y: CK.Nested) {
   x.f() // okay, because CK and CK.f are not @MainActor.
+  y.g()
 }


### PR DESCRIPTION
- **Explanation**: Under discussion as part of an amendment to SE-0466, limit default main actor inference so it doesn't apply to a nested type within a nonisolated type.
- **Scope**: Narrow. Only affects main actor default isolation, a new feature.
- **Issues**: rdar://155931516
- **Original PRs**: https://github.com/swiftlang/swift/pull/83072
- **Risk**: Very low. Small change to a code path for an opt-in feature.
- **Testing**: CI
- **Reviewers**: @slavapestov 
