### PR TITLE
GenericSpecializer: don't pre-specialize C++ reference type for AnyObject

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1264,6 +1264,9 @@ public:
   /// representation, i.e. whether it is representable as a single,
   /// possibly nil pointer that can be unknown-retained and
   /// unknown-released.
+  /// This does not include C++ imported `SWIFT_SHARED_REFERENCE` classes.
+  /// They act as Swift classes but are not compatible with Swift's
+  /// retain/release runtime functions.
   bool hasRetainablePointerRepresentation();
 
   /// Given that this type is a reference type, which kind of reference

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -419,6 +419,9 @@ public:
   
   /// Returns true if the referenced type is guaranteed to have a
   /// single-retainable-pointer representation.
+  /// This does not include C++ imported `SWIFT_SHARED_REFERENCE` classes.
+  /// They act as Swift classes but are not compatible with Swift's
+  /// retain/release runtime functions.
   bool hasRetainablePointerRepresentation() const {
     return getASTType()->hasRetainablePointerRepresentation();
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2844,6 +2844,11 @@ static bool hasRetainablePointerRepresentation(CanType type) {
     type = objType;
   }
 
+  // C++ imported `SWIFT_SHARED_REFERENCE` classes are not compatible with
+  // Swift's retain/release runtime functions.
+  if (type.isForeignReferenceType())
+    return false;
+
   return isBridgeableObjectType(type);
 }
 

--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %swiftc_driver -O -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// UNSUPPORTED: back_deployment_runtime
+
+// Metadata for foreign reference types is not supported on Windows.
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Inputs/module.modulemap
+
+module Test {
+    header "reftype.h"
+    requires cplusplus
+}
+
+//--- Inputs/reftype.h
+
+#include "swift/bridging"
+
+class RefType {
+public:
+    static RefType* _Nonnull makeRefType() SWIFT_RETURNS_RETAINED {
+        return new RefType();
+    }
+
+private:
+    RefType() : _refCount(1) {
+    }
+    RefType(const RefType&) = delete;
+    RefType& operator=(const RefType&) = delete;
+    ~RefType() {
+    }
+    
+    inline friend void retainRefType(RefType* _Nonnull x) {
+        x->_refCount += 1;
+
+    }
+    inline friend void releaseRefType(RefType* _Nonnull x) {
+        x->_refCount -= 1;
+        if (x->_refCount == 0) {
+            delete x;
+        }
+    }
+    
+    int _refCount;
+} SWIFT_SHARED_REFERENCE(retainRefType, releaseRefType);
+
+//--- test.swift
+
+import Test
+
+@inline(never)
+func go() {
+    let x: RefType = RefType.makeRefType()
+    var y: [RefType] = []
+    y.append(x)
+// CHECK: 1
+    print(y.count)
+}
+
+go()
+


### PR DESCRIPTION
Reference counting is not compatible.
Fixes a runtime crash if a C++ reference type is put into an Array.

https://github.com/swiftlang/swift/issues/83082
rdar://155919841
