### PR TITLE
[6.2] CI: Temporarily disable taskExecutor test with Task.immediate

### DIFF
--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -462,6 +462,7 @@ print("call_taskImmediate_taskExecutor()")
 @TaskLocal
 nonisolated(unsafe) var niceTaskLocalValueYouGotThere: String = ""
 
+// FIXME: rdar://155596073 Task executors execution may not always hop as expected
 func call_taskImmediate_taskExecutor(taskExecutor: NaiveQueueExecutor) async {
   await Task.immediate(executorPreference: taskExecutor) {
     print("Task.immediate(executorPreference:)")
@@ -560,7 +561,8 @@ func call_taskImmediate_taskExecutor(taskExecutor: NaiveQueueExecutor) async {
   }
 }
 
-await call_taskImmediate_taskExecutor(
-  taskExecutor: NaiveQueueExecutor(queue: DispatchQueue(label: "my-queue")))
+// FIXME: rdar://155596073 task executors can be somewhat racy it seems and not always hop as we'd want them to
+// await call_taskImmediate_taskExecutor(
+//  taskExecutor: NaiveQueueExecutor(queue: DispatchQueue(label: "my-queue")))
 
 print("DONE!") // CHECK: DONE!


### PR DESCRIPTION
This picks a test disable for a specific part of a test from main

---

rdar://155596073 Task executors execution may not always hop as expected

I'm investigating a fix here as we speak, but disabling the specific piece of the test while we work on it.