### PR TITLE
[Sema] Set ReturnStmt result even if type-checking fails

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1091,6 +1091,9 @@ public:
     if (resultTarget) {
       RS->setResult(resultTarget->getAsExpr());
     } else {
+      // Update the expression even if type-checking failed as e.g pre-checking
+      // may have folded a sequence expr.
+      RS->setResult(target.getAsExpr());
       tryDiagnoseUnnecessaryCastOverOptionSet(getASTContext(), RS->getResult(),
                                               ResultTy);
     }

--- a/validation-test/IDE/crashers_fixed/59ed4db5bf91f452.swift
+++ b/validation-test/IDE/crashers_fixed/59ed4db5bf91f452.swift
@@ -1,0 +1,6 @@
+// {"kind":"complete","original":"089853e1","signature":"swift::TypeChecker::typeCheckForCodeCompletion(swift::constraints::SyntacticElementTarget&, bool, llvm::function_ref<void (swift::constraints::Solution const&)>)"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+struct a {
+b:
+func c -> UInt32 {
+0 ^ b#^^#


### PR DESCRIPTION
Make sure we set the updated expression since e.g pre-checking may have folded a top-level SequenceExpr that we need to remove from the AST.