### PR TITLE
Runtimes: export the SwiftOverlay targets

### DIFF
--- a/Runtimes/Overlay/Android/Android/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Android/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(swiftAndroid PRIVATE
   swiftCore)
 
 install(TARGETS swiftAndroid
+  EXPORT SwiftOverlayTargets
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(swift_math PRIVATE
   swiftCore)
 
 install(TARGETS swift_math
+  EXPORT SwiftOverlayTargets
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -28,12 +28,13 @@ target_compile_options(SwiftAndroid INTERFACE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc --sysroot=\"${CMAKE_ANDROID_NDK_TOOLCHAIN_UNIFIED}/sysroot\">"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/android-ndk-overlay.yaml>")
 
+install(TARGETS SwiftAndroid
+  EXPORT SwiftOverlayTargets)
 install(FILES
   android.modulemap
   SwiftAndroidNDK.h
   SwiftBionic.h
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
-
 install(FILES
   posix_filesystem.apinotes
   spawn.apinotes

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -66,3 +66,22 @@ endif()
 if(WIN32)
   add_subdirectory(Windows)
 endif()
+
+# Inter-project install info
+export(EXPORT SwiftOverlayTargets
+  FILE "cmake/SwiftOverlay/SwiftOverlayTargets.cmake")
+install(EXPORT SwiftOverlayTargets
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftOverlay"
+  FILE "SwiftOverlayTargets.cmake"
+  COMPONENT SwiftOverlayCMake)
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/interface/SwiftOverlayConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftOverlay/SwiftOverlayConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftOverlay")
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftOverlay/SwiftOverlayConfigVersion.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY ExactVersion)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftOverlay/SwiftOverlayConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftOverlay/SwiftOverlayConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftOverlay")

--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(swiftCRT PRIVATE
   swiftCore)
 
 install(TARGETS swiftCRT
+  EXPORT SwiftOverlayTargets
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(swiftWinSDK PRIVATE
   swiftCore)
 
 install(TARGETS swiftWinSDK
+  EXPORT SwiftOverlayTargets
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(ClangModules INTERFACE)
 target_compile_options(ClangModules INTERFACE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-overlay.yaml>")
 
+install(TARGETS ClangModules
+  EXPORT SwiftOverlayTargets)
 install(FILES
   ucrt.modulemap
   vcruntime.apinotes

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(swift_Builtin_float PRIVATE
   swiftCore)
 
 install(TARGETS swift_Builtin_float
+  EXPORT SwiftOverlayTargets
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Runtimes/Overlay/cmake/interface/SwiftOverlayConfig.cmake.in
+++ b/Runtimes/Overlay/cmake/interface/SwiftOverlayConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/SwiftOverlayTargets.cmake")
+
+set(SwiftOverlay_ENABLE_REFLECTION  @SwiftOverlay_ENABLE_REFLECTION@)


### PR DESCRIPTION
This allows wiring up dependencies across the projects. In particular, this is needed to get the generated VFS mapping in the Android build for the explicit dependencies to work. The PCM emission does not receive the required mapping and thus is unable to load the modulemaps for the build of the PCM.