### PR TITLE
Revert "Preserve existing printing/mangling behavior for C++ specializations."

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -293,8 +293,7 @@ public:
   void printEscapedStringLiteral(StringRef str);
 
   void printName(Identifier Name,
-                 PrintNameContext Context = PrintNameContext::Normal,
-                 bool IsSpecializedCxxType = false);
+                 PrintNameContext Context = PrintNameContext::Normal);
 
   void setIndent(unsigned NumSpaces) {
     CurrentIndentation = NumSpaces;
@@ -448,8 +447,7 @@ void printWithCompatibilityFeatureChecks(ASTPrinter &printer,
 
 /// Determine whether we need to escape the given name within the given
 /// context, by wrapping it in backticks.
-bool escapeIdentifierInContext(Identifier name, PrintNameContext context,
-                               bool isSpecializedCxxType = false);
+bool escapeIdentifierInContext(Identifier name, PrintNameContext context);
 
 } // namespace swift
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3163,8 +3163,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // `ClassTemplateSpecializationDecl`'s name does not include information about
       // template arguments, and in order to prevent name clashes we use the
       // name of the Swift decl which does include template arguments.
-      appendIdentifier(nominal->getName().str(),
-                       /*allowRawIdentifiers=*/false);
+      appendIdentifier(nominal->getName().str());
     } else {
       appendIdentifier(namedDecl->getName());
     }
@@ -3189,8 +3188,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // imported as enums, be consistent.
       appendOperator("O");
     } else if (isa<clang::ClassTemplateDecl>(namedDecl)) {
-      appendIdentifier(nominal->getName().str(),
-                       /*allowRawIdentifiers=*/false);
+      appendIdentifier(nominal->getName().str());
     } else {
       llvm_unreachable("unknown imported Clang type");
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -488,13 +488,6 @@ void ASTPrinter::printEscapedStringLiteral(StringRef str) {
   printTextImpl(escapeBuf.str());
 }
 
-// Returns true if the given declaration is backed by a C++ template
-// specialization.
-static bool isSpecializedCxxDecl(const Decl *D) {
-  return D->hasClangNode() &&
-         isa<clang::ClassTemplateSpecializationDecl>(D->getClangDecl());
-}
-
 void ASTPrinter::printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name,
                               PrintNameContext Context) {
   if (isa<GenericTypeParamDecl>(RefTo)) {
@@ -505,7 +498,7 @@ void ASTPrinter::printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name,
     Context = PrintNameContext::ClassDynamicSelf;
   }
 
-  printName(Name, Context, isSpecializedCxxDecl(RefTo));
+  printName(Name, Context);
 }
 
 void ASTPrinter::printModuleRef(ModuleEntity Mod, Identifier Name) {
@@ -604,8 +597,8 @@ ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
 }
 
 /// Determine whether to escape the given keyword in the given context.
-bool swift::escapeIdentifierInContext(Identifier name, PrintNameContext context,
-                                      bool isSpecializedCxxTemplate) {
+bool swift::escapeIdentifierInContext(Identifier name,
+                                      PrintNameContext context) {
   StringRef keyword = name.str();
   bool isKeyword = llvm::StringSwitch<bool>(keyword)
 #define KEYWORD(KW) \
@@ -613,16 +606,10 @@ bool swift::escapeIdentifierInContext(Identifier name, PrintNameContext context,
 #include "swift/AST/TokenKinds.def"
       .Default(false);
 
-  // NB: ClangImporter synthesizes C++ template specializations with Identifiers
-  // that contain the full type signature; e.g., a type named literally
-  // `X<Y, Z>`. These would normally be interpreted as raw identifiers and
-  // escaped with backticks, but we need to avoid that for those specific decls.
-
   switch (context) {
   case PrintNameContext::Normal:
   case PrintNameContext::Attribute:
-    return isKeyword ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return isKeyword || name.mustAlwaysBeEscaped();
   case PrintNameContext::Keyword:
   case PrintNameContext::IntroducerKeyword:
     return false;
@@ -632,21 +619,18 @@ bool swift::escapeIdentifierInContext(Identifier name, PrintNameContext context,
     return isKeyword && keyword != "Self";
 
   case PrintNameContext::TypeMember:
-    return isKeyword || !canBeMemberName(keyword) ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return isKeyword || !canBeMemberName(keyword) || name.mustAlwaysBeEscaped();
 
   case PrintNameContext::FunctionParameterExternal:
   case PrintNameContext::FunctionParameterLocal:
   case PrintNameContext::TupleElement:
-    return !canBeArgumentLabel(keyword) ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return !canBeArgumentLabel(keyword) || name.mustAlwaysBeEscaped();
   }
 
   llvm_unreachable("Unhandled PrintNameContext in switch.");
 }
 
-void ASTPrinter::printName(Identifier Name, PrintNameContext Context,
-                           bool IsSpecializedCxxTemplate) {
+void ASTPrinter::printName(Identifier Name, PrintNameContext Context) {
   callPrintNamePre(Context);
 
   if (Name.empty()) {
@@ -655,8 +639,7 @@ void ASTPrinter::printName(Identifier Name, PrintNameContext Context,
     return;
   }
 
-  bool shouldEscapeIdentifier =
-      escapeIdentifierInContext(Name, Context, IsSpecializedCxxTemplate);
+  bool shouldEscapeIdentifier = escapeIdentifierInContext(Name, Context);
 
   if (shouldEscapeIdentifier)
     *this << "`";
@@ -3710,16 +3693,12 @@ void PrintAST::visitEnumDecl(EnumDecl *decl) {
   } else {
     Printer.printIntroducerKeyword("enum", Options, " ");
     printContextIfNeeded(decl);
-    recordDeclLoc(
-        decl,
-        [&] {
-          Printer.printName(decl->getName(),
-                            getTypeMemberPrintNameContext(decl),
-                            isSpecializedCxxDecl(decl));
-        },
-        [&] { // Signature
-          printGenericDeclGenericParams(decl);
-        });
+    recordDeclLoc(decl,
+      [&]{
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
+      }, [&]{ // Signature
+        printGenericDeclGenericParams(decl);
+      });
     printInherited(decl);
     printDeclGenericRequirements(decl);
   }
@@ -3741,16 +3720,12 @@ void PrintAST::visitStructDecl(StructDecl *decl) {
   } else {
     Printer.printIntroducerKeyword("struct", Options, " ");
     printContextIfNeeded(decl);
-    recordDeclLoc(
-        decl,
-        [&] {
-          Printer.printName(decl->getName(),
-                            getTypeMemberPrintNameContext(decl),
-                            isSpecializedCxxDecl(decl));
-        },
-        [&] { // Signature
-          printGenericDeclGenericParams(decl);
-        });
+    recordDeclLoc(decl,
+      [&]{
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
+      }, [&]{ // Signature
+        printGenericDeclGenericParams(decl);
+      });
     printInherited(decl);
     printDeclGenericRequirements(decl);
   }
@@ -3773,16 +3748,12 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
     Printer.printIntroducerKeyword(
         decl->isExplicitActor() ? "actor" : "class", Options, " ");
     printContextIfNeeded(decl);
-    recordDeclLoc(
-        decl,
-        [&] {
-          Printer.printName(decl->getName(),
-                            getTypeMemberPrintNameContext(decl),
-                            isSpecializedCxxDecl(decl));
-        },
-        [&] { // Signature
-          printGenericDeclGenericParams(decl);
-        });
+    recordDeclLoc(decl,
+      [&]{
+        Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
+      }, [&]{ // Signature
+        printGenericDeclGenericParams(decl);
+      });
 
     printInherited(decl);
     printDeclGenericRequirements(decl);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1298,7 +1298,6 @@ namespace {
       MetadataInitialization;
 
     StringRef UserFacingName;
-    bool IsCxxSpecializedTemplate;
     std::optional<TypeImportInfo<std::string>> ImportInfo;
 
     using super::IGM;
@@ -1444,7 +1443,6 @@ namespace {
     void computeIdentity() {
       // Remember the user-facing name.
       UserFacingName = Type->getName().str();
-      IsCxxSpecializedTemplate = false;
 
       // For related entities, set the original type name as the ABI name
       // and remember the related entity tag.
@@ -1465,11 +1463,9 @@ namespace {
         // that each specialization gets its own metadata. A class template
         // specialization's Swift name will always be the mangled name, so just
         // use that.
-        if (auto spec =
-                dyn_cast<clang::ClassTemplateSpecializationDecl>(clangDecl)) {
+        if (auto spec = dyn_cast<clang::ClassTemplateSpecializationDecl>(clangDecl))
           abiName = Type->getName().str();
-          IsCxxSpecializedTemplate = true;
-        } else
+        else
           abiName = clangDecl->getQualifiedNameAsString();
 
         // Typedefs and compatibility aliases that have been promoted to
@@ -1499,8 +1495,7 @@ namespace {
 
     void addName() {
       SmallString<32> name;
-      if (!IsCxxSpecializedTemplate &&
-          Lexer::identifierMustAlwaysBeEscaped(UserFacingName)) {
+      if (Lexer::identifierMustAlwaysBeEscaped(UserFacingName)) {
         Mangle::Mangler::appendRawIdentifierForRuntime(UserFacingName, name);
       } else {
         name += UserFacingName;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -679,9 +679,6 @@ bool Lexer::isIdentifier(StringRef string) {
 }
 
 bool Lexer::identifierMustAlwaysBeEscaped(StringRef str) {
-  if (str.empty())
-    return false;
-
   bool mustEscape =
       !isOperator(str) && !isIdentifier(str) &&
       str.front() != '$'; // a property wrapper does not need to be escaped


### PR DESCRIPTION
This reverts commit 97d9ca1a20b0c7184209465aedc9e0a255d5245d in attempt to fix https://github.com/swiftlang/swift/issues/83097.

I haven't tested this yet as I couldn't manage to compile `swiftc` - I think the `build-script` needs `llvm-project` locally, let me work on that ...

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
