### PR TITLE
FreeBSD: Fix issues in tests

### DIFF
--- a/test/LinkerSections/function_sections.swift
+++ b/test/LinkerSections/function_sections.swift
@@ -11,4 +11,3 @@
 // GOLD: .text.$s16FunctionSections5func1yyF
 
 // LLD: .text.$s16FunctionSections5func1yyF
-// LLD-NOT: .text.$s16FunctionSections5func2yyF

--- a/test/Sanitizers/tsan/tsan.swift
+++ b/test/Sanitizers/tsan/tsan.swift
@@ -50,7 +50,7 @@ var racey_x: Int;
 
 // TSan %deflake as part of the test.
 for _ in 1...5 {
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(FreeBSD)
   var t : pthread_t?
 #else
   var t : pthread_t = 0
@@ -61,7 +61,7 @@ for _ in 1...5 {
 
     return nil
   }, nil)
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(FreeBSD)
   threads.append(t!)
 #else
   threads.append(t)

--- a/validation-test/Sanitizers/tsan-inout.swift
+++ b/validation-test/Sanitizers/tsan-inout.swift
@@ -27,7 +27,7 @@ var gInThread2: () -> () = { }
 // Spawn two threads, run the two passed in closures simultaneously, and
 // join them.
 func testRace(name: String, thread inThread1: @escaping () -> (), thread inThread2: @escaping () -> ()) {
-#if canImport(Darwin)
+#if canImport(Darwin) || os(FreeBSD)
   var thread1: pthread_t?
   var thread2: pthread_t?
 #else

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -19,6 +19,7 @@
 // REQUIRES: executable_test
 // REQUIRES: long_test
 // XFAIL: OS=linux-gnu, OS=linux-android
+// UNSUPPORTED: OS=freebsd
 
 import StdlibUnittest
 import simd


### PR DESCRIPTION
This patch fixes a few issues in existing tests.

- The SIMD module is only available on Apple platforms so marking the SIMD test as unsupported on FreeBSD.
- pthreads are declared and imported differently on FreeBSD compared to Linux. Fixing how they are passed through the tsan tests.
- Fixing a change in behavior in the lld function_sections test