### PR TITLE
SILGen: Have emitSemanticStore cast off concurrency annotations.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5227,6 +5227,14 @@ void SILGenFunction::emitSemanticStore(SILLocation loc,
     dest = B.createMoveOnlyWrapperToCopyableAddr(loc, dest);
   }
 
+  // If the dest type differs only in concurrency annotations, we can cast them
+  // off.
+  if (dest->getType().getObjectType() != rvalue->getType().getObjectType()
+      && dest->getType().stripConcurrency(/*recursive*/true, /*dropGlobal*/true)
+        == rvalue->getType().stripConcurrency(true, true)) {
+    dest = B.createUncheckedAddrCast(loc, dest, rvalue->getType().getAddressType());
+  }
+
   // Easy case: the types match.
   if (rvalue->getType().getObjectType() == dest->getType().getObjectType()) {
     assert(!silConv.useLoweredAddresses() ||

--- a/test/SILGen/Inputs/preconcurrency-bridged-return.h
+++ b/test/SILGen/Inputs/preconcurrency-bridged-return.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+#define NS_SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface TestClass: NSObject
+
+- (_Nullable id NS_SWIFT_SENDABLE)foo;
+
+@end

--- a/test/SILGen/preconcurrency-bridged-return.swift
+++ b/test/SILGen/preconcurrency-bridged-return.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/preconcurrency-bridged-return.h -swift-version 5 %s
+//
+// REQUIRES: objc_interop
+
+func test(x: TestClass) {
+	let foo = x.foo()
+}
+


### PR DESCRIPTION
If a function is being semantically treated as having different concurrency annotations because of a `@preconcurrency` import or language mode setting, then SILGen may try to store an argument or result for a call using a value that differs only in concurrency annotations, which can be safely bitcast away.

Fixes rdar://154520999