### PR TITLE
[Strict memory safety] "unsafe" expression never propagates unsafe outward

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3851,7 +3851,6 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     }
 
     void preserveCoverageFromUnsafeOperand() {
-      OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafe, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::asyncAwaitFlags(), Self.Flags);
       OldFlags.mergeFrom(ContextFlags::throwFlags(), Self.Flags);

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -384,3 +384,10 @@ func testInterpolation(ptr: UnsafePointer<Int>) {
   // expected-note@-1{{reference to unsafe type 'UnsafePointer<Int>'}}
   // expected-note@-2{{argument #0 in call to instance method 'appendInterpolation' has unsafe type 'UnsafePointer<Int>'}}
 }
+
+func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  let byte = unsafe unsafe bytes.first ?? 0
+  _ = byte
+  _ = unsafe bytes.first ?? 0
+}

--- a/test/Unsafe/unsafe_nonstrict.swift
+++ b/test/Unsafe/unsafe_nonstrict.swift
@@ -16,3 +16,10 @@ func testItAll(ut: UnsafeType, x: X, i: Int) {
   unsafe acceptP(x)
   _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 }
+
+func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  let byte = unsafe unsafe bytes.first ?? 0
+  _ = byte
+  _ = unsafe bytes.first ?? 0
+}


### PR DESCRIPTION
In the effects checker, we were propagating the "has an unsafe use site" outside of an `unsafe` expression. The result of this is that we would not produce a warning for silly expressions like `unsafe unsafe ptr.pointee`, where the first (outer) `unsafe` is unnecessary. Stop propagating that bit so we properly diagnose the spurious "unsafe".

Fixes issue #82315 / rdar://153672668.