### PR TITLE
[6.2] [Strict memory safety] "unsafe" expression never propagates unsafe outward

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3816,7 +3816,6 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     }
 
     void preserveCoverageFromUnsafeOperand() {
-      OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyUnsafe, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::asyncAwaitFlags(), Self.Flags);
       OldFlags.mergeFrom(ContextFlags::throwFlags(), Self.Flags);

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -374,3 +374,10 @@ func testInterpolation(ptr: UnsafePointer<Int>) {
   // expected-note@-1{{reference to unsafe type 'UnsafePointer<Int>'}}
   // expected-note@-2{{argument #0 in call to instance method 'appendInterpolation' has unsafe type 'UnsafePointer<Int>'}}
 }
+
+func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  let byte = unsafe unsafe bytes.first ?? 0
+  _ = byte
+  _ = unsafe bytes.first ?? 0
+}

--- a/test/Unsafe/unsafe_nonstrict.swift
+++ b/test/Unsafe/unsafe_nonstrict.swift
@@ -16,3 +16,10 @@ func testItAll(ut: UnsafeType, x: X, i: Int) {
   unsafe acceptP(x)
   _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 }
+
+func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  let byte = unsafe unsafe bytes.first ?? 0
+  _ = byte
+  _ = unsafe bytes.first ?? 0
+}


### PR DESCRIPTION
- **Explanation**: In the effects checker, we were propagating the "has an unsafe use site" outside of an `unsafe` expression. The result of this is that we would not produce a warning for silly expressions like `unsafe unsafe ptr.pointee`, where the first (outer) `unsafe` is unnecessary. Stop propagating that bit so we properly diagnose the spurious "unsafe".
- **Scope**: Very narrow change to the effects checker to suppress one bit coming out of `unsafe` expressions.
- **Issues**: Issue #82315 / rdar://153672668.
- **Original PRs**: https://github.com/swiftlang/swift/pull/83109
- **Risk**: Very low. Expands coverage for a warning about a new feature (`unsafe` expressions) to one more case.
- **Testing**: CI, new tests
- **Reviewers**: @xedin 
