### PR TITLE
[NFC][RemoteInspection] Make MemoryReader::readRemoteAddress virtual

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -64,12 +64,10 @@ public:
   /// Returns false if the operator failed.
   template <typename IntegerType>
   bool readRemoteAddress(RemoteAddress address, RemoteAddress &out) {
-    IntegerType buf;
-    if (!readInteger(address, &buf))
-      return false;
-
-    out = RemoteAddress((uint64_t)buf, address.getAddressSpace());
-    return true;
+    constexpr std::size_t integerSize = sizeof(IntegerType);
+    static_assert((integerSize == 4 || integerSize == 8) &&
+                  "Only 32 or 64 bit architectures are supported!");
+    return readRemoteAddressImpl(address, out, integerSize);
   }
 
   /// Attempts to read an integer from the given address in the remote
@@ -280,6 +278,40 @@ public:
   }
 
   virtual ~MemoryReader() = default;
+
+protected:
+  /// Implementation detail of remoteRemoteAddress. This exists because
+  /// templated functions cannot be virtual.
+  ///
+  /// Attempts to read a remote address of a given size from the given address
+  /// in the remote process.
+  ///
+  /// Returns false if the operator failed.
+  virtual bool readRemoteAddressImpl(RemoteAddress address, RemoteAddress &out,
+                                     std::size_t integerSize) {
+    assert((integerSize == 4 || integerSize == 8) &&
+           "Only 32 or 64 bit architectures are supported!");
+    auto Buf = std::malloc(integerSize);
+    if (!Buf)
+      return false;
+
+    // Free Buf when this function return.
+    ReadBytesResult Result(
+        Buf, [](const void *ptr) { free(const_cast<void *>(ptr)); });
+    if (!readBytes(address, reinterpret_cast<uint8_t *>(Buf), integerSize))
+      return false;
+
+    if (integerSize == 4)
+      out = RemoteAddress(*reinterpret_cast<uint32_t *>(Buf),
+                          address.getAddressSpace());
+    else if (integerSize == 8)
+      out = RemoteAddress(*reinterpret_cast<uint64_t *>(Buf),
+                          address.getAddressSpace());
+    else
+      return false;
+
+    return true;
+  }
 };
 
 } // end namespace remote

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -801,8 +801,8 @@ public:
     // Non-inline (box'ed) representation.
     // The first word of the container stores the address to the box.
     RemoteAddress BoxAddress;
-    if (!Reader->readRemoteAddress<StoredPointer>(ExistentialAddress,
-                                                  BoxAddress))
+    if (!Reader->template readRemoteAddress<StoredPointer>(ExistentialAddress,
+                                                           BoxAddress))
       return std::nullopt;
 
     auto AlignmentMask = VWT->getAlignmentMask();
@@ -1694,7 +1694,7 @@ public:
             StoredPointer tag) -> std::optional<RemoteAddress> {
       RemoteAddress addr = base + tag * sizeof(StoredPointer);
       RemoteAddress isa;
-      if (!Reader->readRemoteAddress<StoredPointer>(addr, isa))
+      if (!Reader->template readRemoteAddress<StoredPointer>(addr, isa))
         return std::nullopt;
       return isa;
     };
@@ -1724,7 +1724,7 @@ public:
       return readMetadataFromTaggedPointer(objectAddress);
 
     RemoteAddress isa;
-    if (!Reader->readRemoteAddress<StoredPointer>(objectAddress, isa))
+    if (!Reader->template readRemoteAddress<StoredPointer>(objectAddress, isa))
       return std::nullopt;
 
     switch (getIsaEncoding()) {
@@ -1773,8 +1773,8 @@ public:
         RemoteAddress(IndexedClassesPointer
                         + classIndex * sizeof(StoredPointer));
       RemoteAddress metadataPointer;
-      if (!Reader->readRemoteAddress<StoredPointer>(eltPointer,
-                                                    metadataPointer))
+      if (!Reader->template readRemoteAddress<StoredPointer>(eltPointer,
+                                                             metadataPointer))
         return std::nullopt;
 
       return metadataPointer;
@@ -1922,7 +1922,7 @@ public:
 
     case TypeReferenceKind::IndirectObjCClass: {
       RemoteAddress classRef;
-      if (!Reader->readRemoteAddress<StoredPointer>(ref, classRef))
+      if (!Reader->template readRemoteAddress<StoredPointer>(ref, classRef))
         return std::nullopt;
 
       auto metadata = readMetadata(classRef);
@@ -1970,8 +1970,8 @@ public:
       return std::nullopt;
 
     RemoteAddress genericArgAddress;
-    if (!Reader->readRemoteAddress<StoredPointer>(addressOfGenericArgAddress,
-                                                  genericArgAddress))
+    if (!Reader->template readRemoteAddress<StoredPointer>(
+            addressOfGenericArgAddress, genericArgAddress))
       return std::nullopt;
 
     return genericArgAddress;
@@ -2107,8 +2107,8 @@ protected:
 
     // Read the name pointer.
     RemoteAddress namePtr;
-    if (!Reader->readRemoteAddress<StoredPointer>(roDataPtr + OffsetToName,
-                                                  namePtr))
+    if (!Reader->template readRemoteAddress<StoredPointer>(
+            roDataPtr + OffsetToName, namePtr))
       return false;
 
     // If the name pointer is null, treat that as an error.
@@ -2172,8 +2172,8 @@ protected:
         // the generalization arguments are.
         RemoteAddress shapeAddress = address + sizeof(StoredPointer);
         RemoteAddress signedShapePtr;
-        if (!Reader->readRemoteAddress<StoredPointer>(shapeAddress,
-                                                      signedShapePtr))
+        if (!Reader->template readRemoteAddress<StoredPointer>(shapeAddress,
+                                                               signedShapePtr))
           return nullptr;
         auto shapePtr = stripSignedPointer(signedShapePtr);
 
@@ -2637,8 +2637,8 @@ private:
     // Low bit set in the offset indicates that the offset leads to the absolute
     // address in memory.
     if (indirect) {
-      if (!Reader->readRemoteAddress<StoredPointer>(resultAddress,
-                                                    resultAddress))
+      if (!Reader->template readRemoteAddress<StoredPointer>(resultAddress,
+                                                             resultAddress))
         return RemoteAddress();
     }
 
@@ -3152,7 +3152,8 @@ private:
           --numGenericArgs;
 
           RemoteAddress arg;
-          if (!Reader->readRemoteAddress<StoredPointer>(genericArgsAddr, arg)) {
+          if (!Reader->template readRemoteAddress<StoredPointer>(
+                  genericArgsAddr, arg)) {
             return {};
           }
           genericArgsAddr += sizeof(StoredPointer);
@@ -3281,7 +3282,7 @@ private:
 
 #if SWIFT_OBJC_INTEROP
     RemoteAddress dataPtr;
-    if (!Reader->readRemoteAddress<StoredPointer>(
+    if (!Reader->template readRemoteAddress<StoredPointer>(
             classAddress + TargetClassMetadataObjCInterop::offsetToData(),
             dataPtr))
       return RemoteAddress();

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -56,7 +56,7 @@ public:
   }
 
   bool inRange(const RemoteAddress &begin, const RemoteAddress &end) const {
-    assert(begin.AddressSpace != end.AddressSpace &&
+    assert(begin.AddressSpace == end.AddressSpace &&
            "Unexpected address spaces");
     if (AddressSpace != begin.AddressSpace)
       return false;


### PR DESCRIPTION
- **Explanation**: 
There are two commits in this PR:
- The first commit adds "template" before calls to `readRemoteAddress`, because older clangs cannot compile this code without it. This is NFC.
- The second commit adds a hook for implementations of MemoryReader to override `readRemoteAddress`, since LLDB needs this hook.
- **Scope**: This patch is limited to Remote Mirrors, and both changes are NFC and fairly simple.
- **Issues**:  rdar://148361743
- **Original PRs**: https://github.com/swiftlang/swift/pull/83122, https://github.com/swiftlang/swift/pull/82982
  - The main PR: https://github.com/swiftlang/swift/pull/82638. 
- **Risk**: Low. These are very simple NFC changes that only affect remote mirrors.
- **Testing**: Test suite, manual testing with tools that use remote mirrors as well as LLDB debugging large applications.
- **Reviewers**: @mikeash 
