### PR TITLE
tests: fix Interop/Cxx/foreign-reference/array-of-classes.swift

### DIFF
--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -4,6 +4,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: executable_test
 // UNSUPPORTED: back_deployment_runtime
 


### PR DESCRIPTION
This test can only run on the host OS

rdar://156051900
