### PR TITLE
test/CMakeLists.txt: run Embedded Swift for Wasm tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -404,6 +404,14 @@ foreach(SDK ${SWIFT_SDKS})
       set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
       set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
 
+      # Reset these values for WASI, as Embedded Swift for WASI requires separate lit configs.
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_old ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB})
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING_old ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING})
+      if(${SDK} STREQUAL "WASI")
+        set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB OFF)
+        set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING OFF)
+      endif()
+
       swift_configure_lit_site_cfg(
           "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
           "${test_bin_dir}/lit.site.cfg"
@@ -425,6 +433,10 @@ foreach(SDK ${SWIFT_SDKS})
         DEPENDS
           "${test_bin_dir}/lit.swift-features.cfg"
           "${validation_test_bin_dir}/lit.swift-features.cfg")
+
+      # Restore old values in case they were reset for WASI tests lit configs.
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_old})
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING_old})
 
       set(test_dependencies)
       get_test_dependencies("${SDK}" test_dependencies)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -603,8 +603,7 @@ foreach(SDK ${SWIFT_SDKS})
             "test${VARIANT_SUFFIX}.lit.site.cfg")
         swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
 
-        set(test_target_name
-            "check-swift${VARIANT_SUFFIX}")
+        set(test_target_name "check-swift${VARIANT_SUFFIX}")
         set(directories "${test_bin_dir}")
 
         set(embedded_wasm_lit_args)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -587,6 +587,44 @@ foreach(SDK ${SWIFT_SDKS})
               PROPERTY FOLDER "Tests/check-swift")
         endforeach()
       endforeach()
+
+      if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING AND (${ARCH} STREQUAL "wasm32"))
+        set(test_mode "optimize_none")
+        set(test_subset "primary")
+        set(VARIANT_SUFFIX "-embedded-wasi")
+        set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
+        set(test_bin_dir "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/embedded")
+        set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+        set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
+        set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+        swift_configure_lit_site_cfg(
+            "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+            "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+            "test${VARIANT_SUFFIX}.lit.site.cfg")
+        swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+
+        set(test_target_name
+            "check-swift${VARIANT_SUFFIX}")
+        set(directories "${test_bin_dir}")
+
+        set(embedded_wasm_lit_args)
+        setup_lit_args(embedded_wasm_lit_args "${SDK}" "${SWIFT_TEST_RESULTS_DIR}" "${SWIFTLIB_DIR}")
+
+        add_custom_target("${test_target_name}"
+            ${maybe_command_upload_stdlib}
+            ${command_upload_swift_reflection_test}
+            ${command_clean_test_results_dir}
+            COMMAND
+              ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
+              $<TARGET_FILE:Python3::Interpreter> "${LIT}"
+              ${embedded_wasm_lit_args}
+              "--param" "swift_test_subset=${test_subset}"
+              "--param" "swift_test_mode=${test_mode}"
+              ${directories}
+            DEPENDS ${dependencies}
+            COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
+            USES_TERMINAL)
+        endif()
     endforeach()
   endforeach()
 endforeach()
@@ -618,17 +656,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
   set(VARIANT_TRIPLE "riscv32-none-none-eabi")
   set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
   set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "riscv32-qemu-virt")
-  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
-  swift_configure_lit_site_cfg(
-      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
-      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
-      "test${VARIANT_SUFFIX}.lit.site.cfg")
-  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
-
-  set(VARIANT_SUFFIX "-embedded-wasi")
-  set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
-  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
-  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
   set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
   swift_configure_lit_site_cfg(
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -3,7 +3,7 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // `setjmp` is not available on WebAssembly/WASI
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 // https://github.com/apple/swift/issues/51632
 // In Android jmp_buf is int[16], which doesn't convert to &Int

--- a/test/Concurrency/Runtime/continuation_validation.swift
+++ b/test/Concurrency/Runtime/continuation_validation.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -6,7 +6,7 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 // UNSUPPORTED: back_deploy_concurrency
 
 // This test makes sure that:
@@ -365,7 +365,7 @@ struct Runner {
                 debugLog("==> Enter callee2")
                 debugLog("==> Exit callee2")
             }
-            
+
             // We add an inline never here to make sure that we do not eliminate
             // the dynamic access after inlining.
             @MainActor
@@ -374,7 +374,7 @@ struct Runner {
                 debugLog("==> Enter callee1")
                 let handle = Task { @MainActor in
                     debugLog("==> Enter callee1 Closure")
-                    
+
                     // These accesses end before we await in the task.
                     do {
                         callee2(&global1, &global2, &global3)
@@ -389,7 +389,7 @@ struct Runner {
                 await handle.value
                 debugLog("==> Exit callee1")
             }
-            
+
             debugLog("==> Enter 'testCase1'")
             await callee1()
             debugLog("==> Exit 'testCase1'")

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 
 // Crash expectations can't be implemented on WASI/WebAssembly.
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 // This test makes sure that we properly save/restore access when we
 // synchronously launch a task from a serial executor. The access from the task

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -4,7 +4,7 @@
 
 // WASI does not support the mandatory tail call, and needs to take the same
 // path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
-// XFAIL: OS=wasi
+// XFAIL: OS=wasip1
 
 sil_stage canonical
 

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -2,9 +2,9 @@
 
 // REQUIRES: concurrency
 
-// WASI does not support the mandatory tail call, and needs to take the same
+// Wasm does not support the mandatory tail call, and needs to take the same
 // path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
-// XFAIL: OS=wasip1
+// XFAIL: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -3,8 +3,6 @@
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 public struct LargeThing {

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend %s  -Xllvm -sil-print-types -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: PTRSIZE=64
 

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -5,8 +5,6 @@
 // REQUIRES: swift_feature_BuiltinModule
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 import Builtin

--- a/test/IRGen/run-coroutine_accessors.swift
+++ b/test/IRGen/run-coroutine_accessors.swift
@@ -91,8 +91,6 @@
 // REQUIRES: concurrency_runtime
 
 // TODO: CoroutineAccessors: Enable on WASM.
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 // REQUIRES: swift_feature_CoroutineAccessors
@@ -243,7 +241,7 @@ struct Boxtional<T> : ResilientWrapping {
 
 @available(SwiftStdlib 9999, *)
 class NonresilientResilientWrappingSubclass<X : ResilientWrapping> : ResilientWrappingClass<X.Wrapped> {
-  init(_ impl: X) { 
+  init(_ impl: X) {
     self.impl = impl
     super.init()
   }

--- a/test/embedded/builtin-float.swift
+++ b/test/embedded/builtin-float.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -4,10 +4,10 @@
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 
 // Linux/ELF and Wasm don't use the "_" prefix in symbol mangling.
-// RUN: if [ %target-os == "linux-gnu" ] || [ %target-os == "wasi" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+// RUN: if [ %target-os == "linux-gnu" ] || [[ %target-os =~ "wasi" ]]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
 
 // Wasm has additional dependencies
-// RUN: if [ %target-os == "wasi" ]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
+// RUN: if [[ %target-os =~ "wasi" ]]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -7,7 +7,7 @@
 // RUN: if [ %target-os == "linux-gnu" ] || [[ %target-os =~ "wasi" ]]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
 
 // Wasm has additional dependencies
-// RUN: if [[ %target-os =~ "wasi" ]]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
+// RUN: if [[ %target-os =~ "wasi" ]]; then sed -i '' -e '3 i\'$'\n''__stack_pointer' -e '1 i\'$'\n''__indirect_function_table' -e '1 i\'$'\n''__memory_base' %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -1,21 +1,21 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern %s -c -o %t/a.o
 
-// RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
+// RUN: if [[ %target-os =~ "wasi" ]]; then pattern="DEP\:\|DEP-WASM\:"; else pattern="DEP\:"; fi; grep "$pattern" %s | sed "s#// .*\: ##" | sort > %t/allowed-dependencies.txt
 
 // Linux/ELF and Wasm don't use the "_" prefix in symbol mangling.
 // RUN: if [ %target-os == "linux-gnu" ] || [[ %target-os =~ "wasi" ]]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
-
-// Wasm has additional dependencies
-// RUN: if [[ %target-os =~ "wasi" ]]; then sed -i '' -e '3 i\'$'\n''__stack_pointer' -e '1 i\'$'\n''__indirect_function_table' -e '1 i\'$'\n''__memory_base' %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
 // Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
 // RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
 
+// DEP-WASM: ___indirect_function_table
+// DEP-WASM: ___memory_base
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
+// DEP-WASM: ___stack_pointer
 // DEP: _arc4random_buf
 // DEP: _free
 // DEP: _memmove

--- a/test/embedded/float-abi-hard.swift
+++ b/test/embedded/float-abi-hard.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-emit-ir %t/Main.swift -import-bridging-header %t/BridgingHeader.h -parse-as-library -enable-experimental-feature Embedded -wmo \
 // RUN:  -target armv7em-none-none-eabi -Xcc -mthumb -Xcc -mcpu=cortex-m7 -Xcc -mfloat-abi=hard -Xcc -mfpu=fpv5-sp-d16 -Xcc -D__FPU_USED=1 -Xcc -falign-functions=16
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/no-allocations-print.swift
+++ b/test/embedded/no-allocations-print.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-emit-ir -target armv7-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
 // RUN: %target-swift-emit-ir -target arm64-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/optionset2.swift
+++ b/test/embedded/optionset2.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/static-object-non-darwin.swift
+++ b/test/embedded/static-object-non-darwin.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-strings-interpolation3.swift
+++ b/test/embedded/stdlib-strings-interpolation3.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-types-riscv.swift
+++ b/test/embedded/stdlib-types-riscv.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -target riscv32-none-none-eabi -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target riscv64-none-none-eabi -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=RISCV
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded
-// UNSUPPORTED: OS=wasi
 
 class MyClass {}
 

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -O     -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -Osize -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 
-// XFAIL: OS=wasi
+// XFAIL: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_stdlib_no_asserts

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -409,10 +409,10 @@ if run_vers.endswith('-simulator'):
 else:
     run_environment=''
 
-# Don't distinguish between wasi, wasip1, and so on to use OS=wasi condition in
-# the test suites.
-if run_os.startswith('wasi'):
-    run_os = 'wasi'
+# Allow using using same condition in WASI test suites.
+kIsWASI = run_os.startswith('wasi')
+if kIsWASI:
+  run_os = f"{run_os}{run_vers}"
 
 # Parse the host triple
 (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
@@ -2055,7 +2055,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
     config.available_features.discard('swift_interpreter')
-elif run_os == 'wasi':
+elif kIsWASI:
     lit_config.note("Testing WebAssembly/WASI " + config.variant_triple)
 
     config.target_object_format = "wasm"
@@ -2651,7 +2651,7 @@ if run_vendor != 'apple':
 
 if 'remote_run_host' in lit_config.params:
     configure_remote_run()
-elif not kIsWindows and not run_os == 'wasi':
+elif not kIsWindows and not kIsWASI:
     if 'use_os_stdlib' in lit_config.params:
         config.available_features.add('use_os_stdlib')
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2064,7 +2064,7 @@ elif kIsWASI:
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
     config.target_not_crash = "not"
-    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasi"
+    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1"
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -13,7 +13,7 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-run %t/Assert_Release
 // RUN: %target-run %t/Assert_Unchecked
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 
@@ -77,7 +77,7 @@ OptionalTraps.test("UnwrapNone/Message")
     reason: "this trap may not have an error message may not be printed in -O"))
   .code {
   var a: AnyObject? = returnNil()
-  expectCrashLater(withMessage: 
+  expectCrashLater(withMessage:
       "Unexpectedly found nil while unwrapping an Optional value")
   let unwrapped: AnyObject = a!
   _blackHole(unwrapped)
@@ -92,7 +92,7 @@ OptionalTraps.test("UnwrapNone/Message/Implicit")
     reason: "this trap may not have an error message may not be printed in -O"))
   .code {
   var a: AnyObject! = returnNil()
-  expectCrashLater(withMessage: 
+  expectCrashLater(withMessage:
       "Unexpectedly found nil while implicitly unwrapping an Optional value")
   let unwrapped: AnyObject = a
   _blackHole(unwrapped)

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 // UNSUPPORTED: OS=freebsd
 
 import StdlibUnittest

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 
 import StdlibUnittest
@@ -34,7 +34,7 @@ RangeTraps.test("HalfOpen")
   .code {
   var range = 1..<1
   expectType(CountableRange<Int>.self, &range)
-  
+
   expectCrashLater()
   _ = 1..<0
 }
@@ -67,7 +67,7 @@ RangeTraps.test("CountablePartialRangeFrom")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
-    
+
     let range = (Int.max - 1)...
     var it = range.makeIterator()
     _ = it.next()

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -11,7 +11,7 @@
 // 5.7 so that we can test new behavior even if the SDK we're using predates it.
 
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 #if _runtime(_ObjC)

--- a/test/stdlib/WASILibcAPI.swift
+++ b/test/stdlib/WASILibcAPI.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -swift-version 6 %s -verify
 // REQUIRES: executable_test
-// REQUIRES: OS=wasi
+// REQUIRES: OS=wasip1
 
 import WASILibc
 

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 #if canImport(Darwin)

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -2,7 +2,7 @@
 
 // FIXME: No simd module on linux rdar://problem/20795411
 // XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi, OS=freebsd
-// XFAIL: OS=wasip1
+// XFAIL: CPU=wasm32
 
 import simd
 

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -2,7 +2,7 @@
 
 // FIXME: No simd module on linux rdar://problem/20795411
 // XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi, OS=freebsd
-// XFAIL: OS=wasi
+// XFAIL: OS=wasip1
 
 import simd
 

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -213,6 +213,9 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
 
     def test(self, host_target):
+        self._test(host_target, 'wasm32-wasip1')
+
+    def _test(self, host_target, target_triple):
         build_root = os.path.dirname(self.build_dir)
         bin_paths = [
             os.path.join(self._host_swift_build_dir(host_target), 'bin'),
@@ -234,7 +237,14 @@ class WasmStdlib(cmake_product.CMakeProduct):
             'LIT_FILTER_OUT':
                 '(Concurrency/Runtime/clock.swift|stdlib/StringIndex.swift)',
         }
-        self.test_with_cmake(None, [test_target, 'check-swift-embedded-wasi'], self._build_variant, [], test_env=env)
+
+        # Embedded stdlib is not built for the threads triple, don't include embedded tests for it.
+        if target_triple == 'wasm32-wasip1-threads':
+            test_targets = [test_target]
+        else:
+            test_targets = [test_target, 'check-swift-embedded-wasi']
+
+        self.test_with_cmake(None, test_targets, self._build_variant, [], test_env=env)
 
     def should_test_executable(self) -> bool:
         return True
@@ -270,6 +280,9 @@ class WasmStdlib(cmake_product.CMakeProduct):
 class WasmThreadsStdlib(WasmStdlib):
     def build(self, host_target):
         self._build(host_target, 'wasm32-wasip1-threads', 'wasip1-threads-wasm32')
+
+    def test(self, host_target):
+        self._test(host_target, 'wasm32-wasip1-threads')
 
     def should_test_executable(self):
         # TODO(katei): Enable tests once WasmKit supports WASI threads

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -234,7 +234,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
             'LIT_FILTER_OUT':
                 '(Concurrency/Runtime/clock.swift|stdlib/StringIndex.swift)',
         }
-        self.test_with_cmake(None, [test_target], self._build_variant, [], test_env=env)
+        self.test_with_cmake(None, [test_target, 'check-swift-embedded-wasi'], self._build_variant, [], test_env=env)
 
     def should_test_executable(self) -> bool:
         return True


### PR DESCRIPTION
Run new `check-swift-embedded-wasi` target from `test/CMakeLists.txt`, tweak `lit.cfg` to support WASI Clang resource dir, exclude unsupported tests based on `CPU=wasm32` instead of `OS=wasi`.
