### PR TITLE
wasisysroot.py: fix `build_runtime_with_host_compiler` diagnostics

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -12,6 +12,7 @@
 
 import multiprocessing
 import os
+import sys
 
 from . import cmake_product
 from . import llvm
@@ -55,6 +56,11 @@ class WASILibc(product.Product):
             clang_path = self.toolchain.cc
             ar_path = self.toolchain.llvm_ar
             nm_path = self.toolchain.llvm_nm
+
+            if not ar_path:
+                print(f"error: `llvm-ar` not found for LLVM toolchain at {clang_path}, "
+                "select a toolchain that has `llvm-ar` included", file=sys.stderr)
+                sys.exit(1)
         else:
             llvm_build_bin_dir = os.path.join(
                 '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')
@@ -163,6 +169,11 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
             cxx_path = self.toolchain.cxx
             ar_path = self.toolchain.llvm_ar
             ranlib_path = self.toolchain.llvm_ranlib
+
+            if not ar_path:
+                print(f"error: `llvm-ar` not found for LLVM toolchain at {cc_path}, "
+                "select a toolchain that has `llvm-ar` included", file=sys.stderr)
+                sys.exit(1)
         else:
             llvm_build_bin_dir = os.path.join(
                 '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')


### PR DESCRIPTION
Improve diagnostics when `llvm-ar` is not detected in the currently select toolchain.