### PR TITLE
[cxx-interop] Configure requires ObjC from frontend option

### DIFF
--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_NAME_TRANSLATION_H
 #define SWIFT_NAME_TRANSLATION_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -113,7 +114,7 @@ inline bool isExposableToCxx(
 }
 
 bool isObjCxxOnly(const ValueDecl *VD);
-bool isObjCxxOnly(const clang::Decl *D);
+bool isObjCxxOnly(const clang::Decl *D, const ASTContext &ctx);
 
 /// Returns true if the given value decl D is visible to C++ of its
 /// own accord (i.e. without considering its context)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -640,6 +640,10 @@ namespace swift {
     /// All block list configuration files to be honored in this compilation.
     std::vector<std::string> BlocklistConfigFilePaths;
 
+    /// List of top level modules to be considered as if they had require ObjC
+    /// in their module map.
+    llvm::SmallVector<StringRef> ModulesRequiringObjC;
+
     /// Whether to ignore checks that a module is resilient during
     /// type-checking, SIL verification, and IR emission,
     bool BypassResilienceChecks = false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -850,7 +850,8 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
     // Collect some special case pseudo-features which should be processed
     // separately.
     if (argValue.starts_with("StrictConcurrency") ||
-        argValue.starts_with("AvailabilityMacro=")) {
+        argValue.starts_with("AvailabilityMacro=") ||
+        argValue.starts_with("RequiresObjC=")) {
       if (isEnableFeatureFlag)
         psuedoFeatures.push_back(argValue);
       continue;
@@ -976,6 +977,11 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
       auto availability = featureName->split("=").second;
       Opts.AvailabilityMacros.push_back(availability.str());
       continue;
+    }
+
+    if (featureName->starts_with("RequiresObjC")) {
+      auto modules = featureName->split("=").second;
+      modules.split(Opts.ModulesRequiringObjC, ",");
     }
   }
 

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -16,6 +16,7 @@
 #include "OutputLanguageMode.h"
 #include "PrimitiveTypeMapping.h"
 #include "SwiftToClangInteropContext.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/Type.h"
@@ -619,7 +620,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
 
   bool objCxxOnly = false;
   if (const auto *clangDecl = typeDecl->getClangDecl()) {
-    if (cxx_translation::isObjCxxOnly(clangDecl))
+    if (cxx_translation::isObjCxxOnly(clangDecl, typeDecl->getASTContext()))
       objCxxOnly = true;
   }
 

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %s -module-name UseFoundation -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseFoundation.h
+// RUN: %target-swift-frontend %s -module-name UseFoundation -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseFoundation.h -enable-experimental-feature RequiresObjC=CoreGraphics,Foundation
 // RUN: %FileCheck %s < %t/UseFoundation.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/UseFoundation.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -21,6 +21,8 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("test/ModuleInterface/swift-export-as.swift"),
     # Uses the pseudo-feature AvailabilityMacro=
     pathlib.Path("test/Availability/availability_define.swift"),
+    # Uses the pseudo-feature RequiresObjC=
+    pathlib.Path("test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift"),
     # Tests behavior when you try to use a feature without enabling it
     pathlib.Path("test/attr/feature_requirement.swift"),
     # Tests completion with features both enabled and disabled


### PR DESCRIPTION
We sometimes don't have the information in the modulemaps whether a module requires ObjC or not. This info is useful for reverse interop. This PR introduces a frontend flag to have a comma separated list of modules that we should import as if they had "requires ObjC" in their modulemaps.