### PR TITLE
Runtimes: wire up the overlay to the Synchornization library

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vend
   CACHE FILEPATH "Location for private build system extension")
 
 find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay)
 
 include(GNUInstallDirs)
 
@@ -111,7 +112,8 @@ add_library(swiftSynchronization
 
 # Determine Mutex definition
 if(${PROJECT_NAME}_SINGLE_THREADED_MODE)
-  target_sources(swiftSynchronization PRIVATE Mutex/MutexUnavailable.swift)
+  target_sources(swiftSynchronization PRIVATE
+    Mutex/MutexUnavailable.swift)
 else()
   target_sources(swiftSynchronization PRIVATE
     Mutex/Mutex.swift
@@ -126,6 +128,7 @@ set_target_properties(swiftSynchronization PROPERTIES
 
 target_link_libraries(swiftSynchronization PRIVATE
   swiftCore
+  $<$<PLATFORM_ID:Android>:SwiftAndroid>
   $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
 
 install(TARGETS swiftSynchronization

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2424,6 +2424,7 @@ function Build-ExperimentalRuntime {
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
 
         SwiftCore_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalRuntime)\cmake\SwiftCore";
+        SwiftOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalOverlay)\cmake\SwiftOverlay";
       }
   }
 }


### PR DESCRIPTION
This allows us to pass along the overlay VFS mappings to workaround the PCM compilation not receiving the builtin mapping from the compiler.