### PR TITLE
[Concurrency] Downgrade isolated conformances to `SendableMetatype` protocols to a warning for implicitly `@preconcurrency` protocols.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8343,6 +8343,7 @@ RawConformanceIsolationRequest::evaluate(
       if (proto->inheritsFrom(sendableMetatype)) {
         bool isPreconcurrency = moduleImportForPreconcurrency(
             proto, conformance->getDeclContext()) != nullptr;
+        isPreconcurrency |= proto->preconcurrency();
         ctx.Diags.diagnose(
             conformance->getLoc(),
             diag::isolated_conformance_to_sendable_metatype,

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -211,3 +211,7 @@ extension TestDR {
   @_dynamicReplacement(for: test(completion:))
   func __replaceObjCFunc(_: @escaping () -> Void) {} // Ok
 }
+
+@MainActor
+class InvalidIsolated: NSObject, @MainActor P {}
+// expected-warning@-1 {{cannot form main actor-isolated conformance of 'InvalidIsolated' to SendableMetatype-inheriting protocol 'P'}}


### PR DESCRIPTION
This error was accidentally not downgraded for implicitly `@preconcurrency` protocols, including all protocols imported from Objective-C.

Resolves: rdar://155821329