### PR TITLE
[6.2][Concurrency] Downgrade isolated conformances to `SendableMetatype` protocols to a warning for implicitly `@preconcurrency` protocols.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8355,6 +8355,7 @@ RawConformanceIsolationRequest::evaluate(
       if (proto->inheritsFrom(sendableMetatype)) {
         bool isPreconcurrency = moduleImportForPreconcurrency(
             proto, conformance->getDeclContext()) != nullptr;
+        isPreconcurrency |= proto->preconcurrency();
         ctx.Diags.diagnose(
             rootNormal->getLoc(),
             diag::isolated_conformance_to_sendable_metatype,

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -211,3 +211,7 @@ extension TestDR {
   @_dynamicReplacement(for: test(completion:))
   func __replaceObjCFunc(_: @escaping () -> Void) {} // Ok
 }
+
+@MainActor
+class InvalidIsolated: NSObject, @MainActor P {}
+// expected-warning@-1 {{cannot form main actor-isolated conformance of 'InvalidIsolated' to SendableMetatype-inheriting protocol 'P'}}


### PR DESCRIPTION
  - **Explanation**: It is invalid to form an isolated conformance to a protocol that requires `SendableMetatype`. This error follows the standard `@preconcurrency` downgrade so that `SendableMetatype` annotations can be retroactively added to protocols, but that downgrade mechanism did not account for implicitly `@preconcurrency` protocols, including all protocols imported from Objective-C. This change adds a minor adjustment to the downgrade logic for this error message.
  - **Scope**: Only impacts isolated conformances to `SendableMetatype`-conforming protocols. Isolated conformances are a new feature in 6.2 so this does not impact any existing code.
  - **Issues**: rdar://155821329
  - **Original PRs**: https://github.com/swiftlang/swift/pull/83136
  - **Risk**: Low; the only effect is downgrading one error to a warning.
  - **Testing**: Added tests.
  - **Reviewers**: @DougGregor