### PR TITLE
[6.2] SILGen: Have emitSemanticStore cast off concurrency annotations.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5227,6 +5227,14 @@ void SILGenFunction::emitSemanticStore(SILLocation loc,
     dest = B.createMoveOnlyWrapperToCopyableAddr(loc, dest);
   }
 
+  // If the dest type differs only in concurrency annotations, we can cast them
+  // off.
+  if (dest->getType().getObjectType() != rvalue->getType().getObjectType()
+      && dest->getType().stripConcurrency(/*recursive*/true, /*dropGlobal*/true)
+        == rvalue->getType().stripConcurrency(true, true)) {
+    dest = B.createUncheckedAddrCast(loc, dest, rvalue->getType().getAddressType());
+  }
+
   // Easy case: the types match.
   if (rvalue->getType().getObjectType() == dest->getType().getObjectType()) {
     assert(!silConv.useLoweredAddresses() ||

--- a/test/SILGen/Inputs/preconcurrency-bridged-return.h
+++ b/test/SILGen/Inputs/preconcurrency-bridged-return.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+#define NS_SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface TestClass: NSObject
+
+- (_Nullable id NS_SWIFT_SENDABLE)foo;
+
+@end

--- a/test/SILGen/preconcurrency-bridged-return.swift
+++ b/test/SILGen/preconcurrency-bridged-return.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/preconcurrency-bridged-return.h -swift-version 5 %s
+//
+// REQUIRES: objc_interop
+
+func test(x: TestClass) {
+	let foo = x.foo()
+}
+


### PR DESCRIPTION
Explanation: Fixes a compiler crash that can be induced when existing code compiles against new versions of Objective-C SDKs that adopt Swift concurrency annotations.

Scope: Fixes a regression where the compiler crashes on code that compiled with a previous version of an Objective-C SDK after upgrading the SDK.

Issue: Fixes rdar://154520999

Original PR: https://github.com/swiftlang/swift/pull/83107

Risk: Low. Modifies SILGen to be more forgiving of concurrency-related type mismatches in generated SIL.

Testing: Test case from bug report, Swift CI

Reviewer: @xedin 
