### PR TITLE
[TypeChecker] NFC: Rename `CallerIsolationInheriting` to `NonisolatedCaller`

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -73,7 +73,7 @@ public:
     ///
     /// DISCUSSION: This is used for nonisolated asynchronous functions that we
     /// want to inherit from their context the context's actor isolation.
-    CallerIsolationInheriting,
+    NonisolatedCaller,
   };
 
 private:
@@ -166,10 +166,10 @@ public:
     return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated);
   }
 
-  static ActorIsolation forCallerIsolationInheriting() {
+  static ActorIsolation forNonisolatedCaller() {
     // NOTE: We do not use parameter indices since the parameter is implicit
     // from the perspective of the AST.
-    return ActorIsolation(CallerIsolationInheriting);
+    return ActorIsolation(NonisolatedCaller);
   }
 
   static ActorIsolation forActorInstanceSelf(ValueDecl *decl);
@@ -217,7 +217,7 @@ public:
             .Case("global_actor", ActorIsolation::GlobalActor)
             .Case("global_actor_unsafe", ActorIsolation::GlobalActor)
             .Case("caller_isolation_inheriting",
-                  ActorIsolation::CallerIsolationInheriting)
+                  ActorIsolation::NonisolatedCaller)
             .Default(std::nullopt);
     if (kind == std::nullopt)
       return std::nullopt;
@@ -267,7 +267,7 @@ public:
     case Unspecified:
     case Nonisolated:
     case NonisolatedUnsafe:
-    case CallerIsolationInheriting:
+    case NonisolatedCaller:
       return false;
     }
   }
@@ -292,8 +292,8 @@ public:
 
   bool isDistributedActor() const;
 
-  bool isCallerIsolationInheriting() const {
-    return getKind() == CallerIsolationInheriting;
+  bool isNonisolatedCaller() const {
+    return getKind() == NonisolatedCaller;
   }
 
   Type getGlobalActor() const {

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -904,9 +904,9 @@ public:
     return calleeFunction->getActorIsolation();
   }
 
-  bool isCallerIsolationInheriting() const {
+  bool isNonisolatedCaller() const {
     auto isolation = getActorIsolation();
-    return isolation && isolation->isCallerIsolationInheriting();
+    return isolation && isolation->isNonisolatedCaller();
   }
 
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1293,7 +1293,7 @@ namespace {
         printFlag(true, "dynamically_isolated", CapturesColor);
         break;
 
-      case ActorIsolation::CallerIsolationInheriting:
+      case ActorIsolation::NonisolatedCaller:
         printFlag(true, "isolated_to_caller_isolation", CapturesColor);
         break;
 

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -182,7 +182,7 @@ bool ActorIsolation::isEqual(const ActorIsolation &lhs,
     // to answer.
     return false;
 
-  case CallerIsolationInheriting:
+  case NonisolatedCaller:
     // This returns false for the same reason as erased. The caller has to check
     // against the actual caller isolation.
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2975,7 +2975,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
 
             return true;
 
-          case ActorIsolation::CallerIsolationInheriting:
+          case ActorIsolation::NonisolatedCaller:
           case ActorIsolation::ActorInstance:
           case ActorIsolation::Nonisolated:
           case ActorIsolation::Erased: // really can't happen
@@ -12007,7 +12007,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
       case ActorIsolation::NonisolatedUnsafe:
       case ActorIsolation::GlobalActor:
       case ActorIsolation::Erased:
-      case ActorIsolation::CallerIsolationInheriting:
+      case ActorIsolation::NonisolatedCaller:
         return false;
 
       case ActorIsolation::ActorInstance:

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -649,7 +649,7 @@ static bool usesFeatureAsyncExecutionBehaviorAttributes(Decl *decl) {
 
   // The declaration is going to be printed with `nonisolated(nonsending)`
   // attribute.
-  if (getActorIsolation(VD).isCallerIsolationInheriting())
+  if (getActorIsolation(VD).isNonisolatedCaller())
     return true;
 
   // Check if any parameters that have `nonisolated(nonsending)` attribute.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1917,7 +1917,7 @@ SourceLoc MacroDefinitionRequest::getNearestLoc() const {
 
 bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
-  case CallerIsolationInheriting:
+  case NonisolatedCaller:
   case ActorInstance:
   case Nonisolated:
   case NonisolatedUnsafe:
@@ -1933,7 +1933,7 @@ bool ActorIsolation::requiresSubstitution() const {
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
-  case CallerIsolationInheriting:
+  case NonisolatedCaller:
   case Nonisolated:
   case NonisolatedUnsafe:
   case Unspecified:
@@ -1954,7 +1954,7 @@ void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
     os << "actor" << (asNoun ? " isolation" : "-isolated");
     break;
 
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
     os << "caller isolation inheriting"
        << (asNoun ? " isolation" : "-isolated");
     break;
@@ -1995,7 +1995,7 @@ void ActorIsolation::print(llvm::raw_ostream &os) const {
       os << ". name: '" << vd->getBaseIdentifier() << "'";
     }
     return;
-  case CallerIsolationInheriting:
+  case NonisolatedCaller:
     os << "caller_isolation_inheriting";
     return;
   case Nonisolated:
@@ -2022,7 +2022,7 @@ void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
   case ActorInstance:
     os << "actor_instance";
     return;
-  case CallerIsolationInheriting:
+  case NonisolatedCaller:
     os << "caller_isolation_inheriting";
     return;
   case Nonisolated:
@@ -2081,7 +2081,7 @@ void swift::simple_display(
       }
       break;
 
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
       out << "isolated to isolation of caller";
       break;
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -875,7 +875,7 @@ void CompletionLookup::analyzeActorIsolation(
     break;
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
     return;
   }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1702,7 +1702,7 @@ private:
     // NOTE: The parameter is not inserted for async functions imported
     // from ObjC because they are handled in a special way that doesn't
     // require it.
-    if (IsolationInfo && IsolationInfo->isCallerIsolationInheriting() &&
+    if (IsolationInfo && IsolationInfo->isNonisolatedCaller() &&
         extInfoBuilder.isAsync() && !Foreign.async) {
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);
       auto actorType =
@@ -2397,7 +2397,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
       if (auto *nonisolatedAttr =
               decl->getAttrs().getAttribute<NonisolatedAttr>()) {
         if (nonisolatedAttr->isNonSending())
-          return ActorIsolation::forCallerIsolationInheriting();
+          return ActorIsolation::forNonisolatedCaller();
       }
 
       if (decl->getAttrs().hasAttribute<ConcurrentAttr>()) {
@@ -2421,7 +2421,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
       if (auto *nonisolatedAttr =
               decl->getAttrs().getAttribute<NonisolatedAttr>()) {
         if (nonisolatedAttr->isNonSending())
-          return ActorIsolation::forCallerIsolationInheriting();
+          return ActorIsolation::forNonisolatedCaller();
       }
 
       if (decl->getAttrs().hasAttribute<ConcurrentAttr>()) {
@@ -2441,7 +2441,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
       substFnInterfaceType->getExtInfo().getIsolation().isNonIsolatedCaller()) {
     // If our function type is a nonisolated caller and we can not infer from
     // our constant, we must be caller isolation inheriting.
-    return ActorIsolation::forCallerIsolationInheriting();
+    return ActorIsolation::forNonisolatedCaller();
   }
 
   return {};

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3165,7 +3165,7 @@ done:
 
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
-      case ActorIsolation::CallerIsolationInheriting:
+      case ActorIsolation::NonisolatedCaller:
       case ActorIsolation::NonisolatedUnsafe:
         llvm_unreachable("Not isolated");
       }
@@ -6151,7 +6151,7 @@ RValue SILGenFunction::emitApply(
 
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
     case ActorIsolation::NonisolatedUnsafe:
       llvm_unreachable("Not isolated");
       break;

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1671,7 +1671,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
       args.push_back(emitNonIsolatedIsolation(loc).getValue());
       break;
     case ActorIsolation::ActorInstance:

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -73,7 +73,7 @@ setExpectedExecutorForParameterIsolation(SILGenFunction &SGF,
 
   // If we have caller isolation inheriting... just grab from our isolated
   // argument.
-  if (actorIsolation.getKind() == ActorIsolation::CallerIsolationInheriting) {
+  if (actorIsolation.getKind() == ActorIsolation::NonisolatedCaller) {
     auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
     ASSERT(isolatedArg &&
            "Caller Isolation Inheriting without isolated parameter");
@@ -110,7 +110,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
         case ActorIsolation::Nonisolated:
         case ActorIsolation::NonisolatedUnsafe:
         case ActorIsolation::Unspecified:
-        case ActorIsolation::CallerIsolationInheriting:
+        case ActorIsolation::NonisolatedCaller:
           return false;
 
         case ActorIsolation::Erased:
@@ -189,7 +189,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
       break;
     }
 
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
       assert(F.isAsync());
       setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
@@ -211,7 +211,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     case ActorIsolation::NonisolatedUnsafe:
       break;
 
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
       assert(F.isAsync());
       setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
@@ -643,7 +643,7 @@ SILGenFunction::emitClosureIsolation(SILLocation loc, SILDeclRef constant,
   switch (isolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
     return emitNonIsolatedIsolation(loc);
 
@@ -695,7 +695,7 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
   switch (isolation.getKind()) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
     return std::nullopt;
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -604,7 +604,7 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::GlobalActor:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
     return false;
   }
 }
@@ -1558,7 +1558,7 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
-    case ActorIsolation::CallerIsolationInheriting:
+    case ActorIsolation::NonisolatedCaller:
       break;
 
     case ActorIsolation::Erased:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2016,7 +2016,7 @@ RValueEmitter::emitFunctionCvtToExecutionCaller(FunctionConversionExpr *e,
     return RValue();
 
   auto *decl = dyn_cast<FuncDecl>(declRef->getDecl());
-  if (!decl || !getActorIsolation(decl).isCallerIsolationInheriting())
+  if (!decl || !getActorIsolation(decl).isNonisolatedCaller())
     return RValue();
 
   // Ok, we found our target.
@@ -2049,7 +2049,7 @@ RValue RValueEmitter::emitFunctionCvtForNonisolatedNonsendingClosureExpr(
   // inheriting, bail.
   auto *closureExpr = dyn_cast<ClosureExpr>(subExpr);
   if (!closureExpr ||
-      !closureExpr->getActorIsolation().isCallerIsolationInheriting())
+      !closureExpr->getActorIsolation().isNonisolatedCaller())
     return RValue();
 
   // Then grab our closure type... make sure it is non isolated and then make
@@ -2116,7 +2116,7 @@ RValue RValueEmitter::emitFunctionCvtFromExecutionCallerToGlobalActor(
   if (!declRef)
     return RValue();
   auto *decl = dyn_cast<FuncDecl>(declRef->getDecl());
-  if (!decl || !getActorIsolation(decl).isCallerIsolationInheriting())
+  if (!decl || !getActorIsolation(decl).isNonisolatedCaller())
     return RValue();
 
   // Make sure that subCvt/declRefType only differ by isolation and sendability.
@@ -7375,7 +7375,7 @@ RValue RValueEmitter::visitCurrentContextIsolationExpr(
       return RValue(SGF, E, isolationValue);
     }
 
-    if (isolation == ActorIsolation::CallerIsolationInheriting) {
+    if (isolation == ActorIsolation::NonisolatedCaller) {
       auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
       assert(isolatedArg &&
              "Caller Isolation Inheriting without isolated parameter");

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -7095,7 +7095,7 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
       break;
     }
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::CallerIsolationInheriting: {
+    case ActorIsolation::NonisolatedCaller: {
       auto derivedIsolation =
           swift::getActorIsolation(derived.getAbstractFunctionDecl());
       switch (derivedIsolation) {
@@ -7114,7 +7114,7 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
         break;
       }
       case ActorIsolation::ActorInstance:
-      case ActorIsolation::CallerIsolationInheriting: {
+      case ActorIsolation::NonisolatedCaller: {
         auto isolatedArg = F.maybeGetIsolatedArgument();
         assert(isolatedArg);
         args.push_back(isolatedArg);
@@ -7575,7 +7575,7 @@ void SILGenFunction::emitProtocolWitness(
       break;
     }
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::CallerIsolationInheriting: {
+    case ActorIsolation::NonisolatedCaller: {
       auto witnessIsolation =
           swift::getActorIsolation(witness.getAbstractFunctionDecl());
       switch (witnessIsolation) {
@@ -7594,7 +7594,7 @@ void SILGenFunction::emitProtocolWitness(
         break;
       }
       case ActorIsolation::ActorInstance:
-      case ActorIsolation::CallerIsolationInheriting: {
+      case ActorIsolation::NonisolatedCaller: {
         auto isolatedArg = F.maybeGetIsolatedArgument();
         assert(isolatedArg);
         args.push_back(isolatedArg);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1067,7 +1067,7 @@ void LifetimeChecker::injectActorHops() {
 
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::GlobalActor:
     return;

--- a/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
+++ b/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
@@ -327,7 +327,7 @@ void OptimizeHopToExecutor::updateNeedExecutor(int &needExecutor,
   // isolation inheriting functions as suspension points, meaning this code can
   // be deleted.
   if (auto fas = FullApplySite::isa(inst);
-      fas && fas.isAsync() && fas.isCallerIsolationInheriting()) {
+      fas && fas.isAsync() && fas.isNonisolatedCaller()) {
     needExecutor = BlockState::ExecutorNeeded;
     return;
   }
@@ -343,7 +343,7 @@ void OptimizeHopToExecutor::updateNeedExecutor(int &needExecutor,
   // considered suspension points, we will be able to sink this code into needs
   // executor.
   if (auto isolation = inst->getFunction()->getActorIsolation();
-      isolation && isolation->isCallerIsolationInheriting() &&
+      isolation && isolation->isNonisolatedCaller() &&
       isa<ReturnInst>(inst)) {
     needExecutor = BlockState::ExecutorNeeded;
     return;

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -939,7 +939,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   /// into another isolation domain.
   if (auto *mi = dyn_cast<MetatypeInst>(inst)) {
     if (auto funcIsolation = mi->getFunction()->getActorIsolation();
-        funcIsolation && funcIsolation->isCallerIsolationInheriting()) {
+        funcIsolation && funcIsolation->isNonisolatedCaller()) {
       return SILIsolationInfo::getTaskIsolated(mi)
           .withNonisolatedNonsendingTaskIsolated(true);
     }
@@ -1008,7 +1008,7 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
     // See if the function is nonisolated(nonsending). In such a case, return
     // task isolated.
     if (auto funcIsolation = fArg->getFunction()->getActorIsolation();
-        funcIsolation && funcIsolation->isCallerIsolationInheriting()) {
+        funcIsolation && funcIsolation->isNonisolatedCaller()) {
       return SILIsolationInfo::getTaskIsolated(fArg)
           .withNonisolatedNonsendingTaskIsolated(true);
     }
@@ -1264,7 +1264,7 @@ void SILIsolationInfo::printActorIsolationForDiagnostics(
   // @concurrent for nonisolated and nonisolated for caller isolation inherited.
   if (fn->isAsync() && fn->getASTContext().LangOpts.hasFeature(
                            Feature::NonisolatedNonsendingByDefault)) {
-    if (iso.isCallerIsolationInheriting()) {
+    if (iso.isNonisolatedCaller()) {
       os << "nonisolated";
       return;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1324,7 +1324,7 @@ namespace {
         return ActorIsolation::forGlobalActor(
             thunkTy->getIsolation().getGlobalActorType());
       case FunctionTypeIsolation::Kind::NonIsolatedCaller:
-        return ActorIsolation::forCallerIsolationInheriting();
+        return ActorIsolation::forNonisolatedCaller();
       }
     }
 
@@ -1560,7 +1560,7 @@ namespace {
         // 2. There is a strong invariant in the compiler today that caller
         // isolation inheriting is always async. By using nonisolated here, we
         // avoid breaking that invariant.
-        if (!outerThunkTy->isAsync() && f->isCallerIsolationInheriting())
+        if (!outerThunkTy->isAsync() && f->isNonisolatedCaller())
           return {};
         return f;
       }();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5195,7 +5195,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       switch (getActorIsolation(choice.getDecl())) {
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
-      case ActorIsolation::CallerIsolationInheriting:
+      case ActorIsolation::NonisolatedCaller:
       case ActorIsolation::NonisolatedUnsafe:
         break;
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -546,7 +546,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     llvm_unreachable("decl cannot have dynamic isolation");
 
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:
     return false;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -100,7 +100,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
 
   case ActorIsolation::GlobalActor:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
+  case ActorIsolation::NonisolatedCaller:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:
     break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -507,7 +507,7 @@ getActualActorIsolationKind(uint8_t raw) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
-  CASE(CallerIsolationInheriting)
+  CASE(NonisolatedCaller)
   CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
   CASE(Erased)
@@ -4244,8 +4244,8 @@ public:
         isolation = ActorIsolation::forUnspecified();
         break;
 
-      case ActorIsolation::CallerIsolationInheriting:
-        isolation = ActorIsolation::forCallerIsolationInheriting();
+      case ActorIsolation::NonisolatedCaller:
+        isolation = ActorIsolation::forNonisolatedCaller();
         break;
 
       case ActorIsolation::Erased:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -565,7 +565,7 @@ enum class ActorIsolation : uint8_t {
   GlobalActor,
   GlobalActorUnsafe,
   Erased,
-  CallerIsolationInheriting,
+  NonisolatedCaller,
 };
 using ActorIsolationField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1564,7 +1564,7 @@ getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
-  CASE(CallerIsolationInheriting)
+  CASE(NonisolatedCaller)
   CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
   CASE(Erased)
@@ -1944,7 +1944,7 @@ void Serializer::writeLocalNormalProtocolConformance(
   case swift::ActorIsolation::ActorInstance:
   case swift::ActorIsolation::NonisolatedUnsafe:
   case swift::ActorIsolation::Erased:
-  case swift::ActorIsolation::CallerIsolationInheriting:
+  case swift::ActorIsolation::NonisolatedCaller:
     llvm_unreachable("Conformances cannot have this kind of isolation");
   }
 


### PR DESCRIPTION
Aligns `ActorIsolation` and `FunctionTypeIsolation` spellings.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
