### PR TITLE
Runtimes: reworking Distributed build to work on Windows

### DIFF
--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
@@ -19,12 +24,15 @@ endif()
 set(CMAKE_Swift_LANGUAGE_VERSION 5)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
-set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+
+set(CMAKE_CXX_EXTENSIONS NO)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+
+set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
@@ -32,10 +40,17 @@ set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"
   CACHE FILEPATH "Path to the root source directory of the Swift compiler")
 
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
 set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
   CACHE FILEPATH "Location for private build system extension")
 
 find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay REQUIRED)
+
+include(GNUInstallDirs)
 
 include(AvailabilityMacros)
 include(EmitSwiftInterface)
@@ -46,7 +61,7 @@ include(CatalystSupport)
 include(SwiftCallingConventions)
 
 option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
-set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${Supplemental_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
 set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
@@ -56,6 +71,25 @@ option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime 
 
 option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
   ${SwiftCore_ENABLE_PRESPECIALIZATION})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
+
 
 add_library(swiftDistributed
   DistributedActor.cpp
@@ -67,37 +101,24 @@ add_library(swiftDistributed
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift)
 
-target_compile_options(swiftDistributed PRIVATE
-  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
-  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
-  $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
-  $<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>
-  $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level api>"
-  $<$<COMPILE_LANGUAGE:Swift>:-enforce-exclusivity=unchecked>
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
-
 set_target_properties(swiftDistributed PROPERTIES
-  Swift_MODULE_NAME Distributed
-  LINKER_LANGUAGE CXX)
-
-if(APPLE AND BUILD_SHARED_LIBS)
-  target_link_options(swiftDistributed PRIVATE "SHELL:-Xlinker -headerpad_max_install_names")
+  Swift_MODULE_NAME Distributed)
+cmake_policy(GET CMP0157 Policy157Enabled)
+if(Policy157Enabled STREQUAL NEW)
+  set_target_properties(swiftDistributed PROPERTIES
+    LINKER_LANGUAGE CXX)
 endif()
 
 target_compile_definitions(swiftDistributed PRIVATE
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_TARGET_LIBRARY_NAME=swiftDistributed>)
+target_compile_options(swiftDistributed PRIVATE
+  $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
+  $<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>)
+
+if(APPLE AND BUILD_SHARED_LIBS)
+  target_link_options(swiftDistributed PRIVATE
+    "SHELL:-Xlinker -headerpad_max_install_names")
+endif()
 
 target_include_directories(swiftDistributed PRIVATE
   # FIXME: Use of `swift/Runtime/...`, `swift/ABI/...`, and `swift/Demangling/...`
@@ -111,9 +132,9 @@ target_include_directories(swiftDistributed PRIVATE
 target_link_libraries(swiftDistributed PRIVATE
     swiftShims
     swiftCore
-    swift_Concurrency)
+    swift_Concurrency
+    builtin_float)
     # swiftDarwin/Libc/Platform
-    # builtin_float
 
 install(TARGETS swiftDistributed
     EXPORT SwiftDistributedTargets


### PR DESCRIPTION
The primary change required here is to remove the `LINKER_LANGUAGE` property on the target with policy CMP0157 set to `OLD`. Take the opportunity to re-order the flag handling to match the other runtime library CMakeLists making it easier to diff them. `-library-level api` is implicitly handled by the `emit_swift_interface` call, so remove that. The other runtimes use a centralised `ExperimentalFeatures` which would add in the unsafe support. While in the area, add in a dependency on `SwiftOverlay` to wire up the `builtin_float` module dependency as well.