### PR TITLE
Build-Script: FreeBSD Package Preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1348,6 +1348,67 @@ mixin-preset=buildbot_linux
 llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 
 #===------------------------------------------------------------------------===#
+# FreeBSD Builders
+#===------------------------------------------------------------------------===#
+[preset: mixin_freebsd_package_install]
+
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
+
+install-foundation
+install-libdispatch
+install-llbuild
+install-lldb
+install-llvm
+install-sourcekit-lsp
+install-swift
+install-swift-driver
+install-swift-testing
+install-swift-testing-macros
+install-swiftdocc
+install-swiftformat
+install-swiftpm
+install-swiftsyntax
+install-xctest
+
+install-prefix=/usr
+
+[preset: mixin_freebsd_package_test]
+
+build-swift-stdlib-unittest-extra
+
+lit-args=-v --time-test
+long-test
+stress-test
+test
+test-optimized
+validation-test
+test-installable-package
+
+lldb-test-swift-only
+skip-test-swiftdocc
+
+[preset: freebsd_package]
+mixin-preset=
+  mixin_freebsd_package_install
+  mixin_freebsd_package_test
+
+extra-llvm-cmake-options=
+  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
+
+release
+no-swift-stdlib-assertions
+
+build-swift-static-sdk-overlay
+build-swift-static-stdlib
+
+build-subdir=buildbot_freebsd
+install-destdir=%(install_destdir)s
+installable-package=%(installable_package)s
+
+reconfigure
+
+#===------------------------------------------------------------------------===#
 # OS X Package Builders
 #===------------------------------------------------------------------------===#
 [preset: mixin_osx_package_base]


### PR DESCRIPTION
Adding a preset for building the FreeBSD toolchain and runtime package. This is very similar to the Linux package build, but the main difference is the lack of WASM build. The WASM runtime build system uses GNU extensions in its makefiles that are not compatible with the make or gmake on FreeBSD and therefore cannot be built there.