### PR TITLE
[stdlib] Handle arguments with alignment larger than a word in KeyPath

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1130,7 +1130,8 @@ internal struct ComputedArgumentSize {
 #elseif _pointerBitWidth(_32)
     0x1FFF_FFFF
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+    fatalError()
 #endif
   }
 
@@ -1141,7 +1142,8 @@ internal struct ComputedArgumentSize {
 #elseif _pointerBitWidth(_32)
     0x6000_0000
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+    fatalError()
 #endif
   }
 
@@ -1152,7 +1154,8 @@ internal struct ComputedArgumentSize {
 #elseif _pointerBitWidth(_32)
     29
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+    fatalError()
 #endif
   }
 
@@ -1164,7 +1167,8 @@ internal struct ComputedArgumentSize {
 #elseif _pointerBitWidth(_32)
     31
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+    fatalError()
 #endif
   }
 
@@ -1226,7 +1230,8 @@ internal struct ComputedArgumentSize {
       let shift = value &>> Self.alignmentShift
       return shift == 1 ? 16 : 8
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+      fatalError()
 #endif
     }
 
@@ -1241,7 +1246,8 @@ internal struct ComputedArgumentSize {
       value &= ~(1 &<< Self.alignmentShift)
       value |= shift
 #else
-#error("Unsupported platform")
+#warning("Unsupported platform")
+      fatalError()
 #endif
     }
   }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -24,6 +24,11 @@ internal func _abstract(
 #endif
 }
 
+@_alignment(16)
+struct _SixteenAligned {
+  let x: UInt8
+}
+
 // MARK: Type-erased abstract base classes
 
 // NOTE: older runtimes had Swift.AnyKeyPath as the ObjC name.
@@ -179,7 +184,7 @@ public class AnyKeyPath: _AppendKeyPath {
       // above. The result of this tail element should just be the 16 byte
       // pointer aligned requirement and no extra bytes allocated.
       0._builtinWordValue,
-      SIMD16<Int8>.self,
+      _SixteenAligned.self,
 
       (bytesWithoutHeader/4)._builtinWordValue,
       Int32.self

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1280,11 +1280,11 @@ internal struct ComputedArgumentSize {
     }
 
     set {
-#if _pointerBitWidth(_64)
-      let reduced: UInt = newValue == 16 ? 1 : 0
-#elseif _pointerBitWidth(_32)
-      let reduced: UInt
+      var reduced: UInt = 0
 
+#if _pointerBitWidth(_64)
+      reduced = newValue == 16 ? 1 : 0
+#elseif _pointerBitWidth(_32)
       switch newValue {
       case 8:
         reduced = 1

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1123,6 +1123,7 @@ internal enum KeyPathComputedIDResolution {
 internal struct ComputedArgumentSize {
   var value: UInt
 
+  @_unavailableInEmbedded
   static var sizeMask: UInt {
 #if _pointerBitWidth(_64)
     0x7FFF_FFFF_FFFF_FFFF
@@ -1133,6 +1134,7 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
+  @_unavailableInEmbedded
   static var paddingMask: UInt {
 #if _pointerBitWidth(_64)
     0x8000_0000_0000_0000
@@ -1143,6 +1145,7 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
+  @_unavailableInEmbedded
   static var paddingShift: UInt {
 #if _pointerBitWidth(_64)
     63
@@ -1153,6 +1156,7 @@ internal struct ComputedArgumentSize {
 #endif
   }
 
+  @_unavailableInEmbedded
   static var alignmentShift: UInt {
 #if _pointerBitWidth(_64)
     // On 64 bit platforms, we don't need to record alignment in this structure.
@@ -1204,6 +1208,7 @@ internal struct ComputedArgumentSize {
   // platforms, we don't actually record this in the bit pattern anywhere, but
   // on 32 bit platforms we use the top bit to indicate either 8 or 16 byte
   // alignment. This returns 0 if no padding was recorded.
+  @_unavailableInEmbedded
   var alignment: Int {
     get {
       // If we didn't record a padding value, then this argument's alignment was

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2860,6 +2860,7 @@ internal func _tryToAppendKeyPaths<Result: AnyKeyPath>(
   return _openExistential(rootRoot, do: open)
 }
 
+@_unavailableInEmbedded
 internal func calculateAppendedKeyPathSize(
   _ root: AnyKeyPath,
   _ leaf: AnyKeyPath,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1119,6 +1119,7 @@ internal enum KeyPathComputedIDResolution {
   case functionCall
 }
 
+@_unavailableInEmbedded
 internal struct ComputedArgumentSize {
   let value: UInt
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2380,6 +2380,7 @@ internal struct KeyPathBuffer {
     }
   }
   
+  @inline(never)
   internal mutating func next() -> (RawKeyPathComponent, Any.Type?) {
     let header = unsafe _pop(from: &data, as: RawKeyPathComponent.Header.self)
     // Track if this is the last component of the reference prefix.
@@ -3663,7 +3664,7 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
   var size: Int = MemoryLayout<Int>.size
   var sizeWithMaxSize: Int = 0
   var sizeWithObjectHeaderAndKvc: Int {
-    size &+ MemoryLayout<Int>.size * 3
+    unsafe size &+ MemoryLayout<Int>.size &* 3
   }
 
   var capability: KeyPathKind = .value

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1210,17 +1210,17 @@ internal struct ComputedArgumentSize {
         return 0
       }
 
-  #if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
       // On 64 bit, the only higher alignment a type could have is 16 byte.
       return 16
-  #elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32)
       // 0 = 8 byte
       // 1 = 16 byte
       let shift = value &>> Self.alignmentShift
       return shift == 1 ? 16 : 8
-  #else
-  #error("Unsupported platform")
-  #endif
+#else
+#error("Unsupported platform")
+#endif
     }
 
     // The setter should only be called when there is or will be padding.
@@ -1232,6 +1232,9 @@ internal struct ComputedArgumentSize {
       let reduced = newValue == 16 ? 1 : 0
       let shift = reduced &<< Self.alignmentShift
       value |= shift
+#else
+#error("Unsupported platform")
+#endif
     }
   }
 }

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -378,7 +378,11 @@ public func _forEachFieldWithKeyPath<Root>(
            body: UnsafeRawBufferPointer(start: nil, count: 0))
       unsafe component.clone(
         into: &destBuilder.buffer,
-        endOfReferencePrefix: false)
+        endOfReferencePrefix: false,
+
+        // We are just storing offset components and not computed ones.
+        adjustForAlignment: false
+      )
     }
 
     if let name = unsafe field.name {

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1159,5 +1159,117 @@ if #available(SwiftStdlib 5.9, *) {
   }
 }
 
+@_alignment(8)
+struct EightAligned {
+  let x = 0
+}
+
+extension EightAligned: Equatable {}
+extension EightAligned: Hashable {}
+
+@_alignment(16)
+struct SixteenAligned {
+  let x = 0
+}
+
+extension SixteenAligned: Equatable {}
+extension SixteenAligned: Hashable {}
+
+struct OveralignedForEight {
+  subscript(getter getter: EightAligned) -> Int {
+    128
+  }
+
+  subscript(setter setter: EightAligned) -> Int {
+    get {
+      128
+    }
+
+    set {
+      fatalError()
+    }
+  }
+}
+
+struct OveralignedForSixteen {
+  subscript(getter getter: SixteenAligned) -> Int {
+    128
+  }
+
+  subscript(setter setter: SixteenAligned) -> Int {
+    get {
+      128
+    }
+
+    set {
+      fatalError()
+    }
+  }
+}
+
+struct SimpleEight {
+  let oa = OveralignedForEight()
+}
+
+struct SimpleSixteen {
+  let oa = OveralignedForSixteen()
+}
+
+#if _pointerBitWidth(_32)
+if #available(SwiftStdlib 6.3, *) {
+  keyPath.test("eight byte overaligned arguments") {
+    let oa = OveralignedForEight()
+    let kp = \OveralignedForEight.[getter: EightAligned()]
+
+    let value = oa[keyPath: kp]
+    expectEqual(value, 128)
+
+    // Test that appends where the argument is no longer overaligned work
+    let simple = SimpleEight()
+    let kp11 = \SimpleEight.oa
+    let kp12 = \OveralignedForEight.[getter: EightAligned()]
+    let kp1 = kp11.appending(path: kp12)
+
+    let value1 = simple[keyPath: kp1]
+    expectEqual(value1, 128)
+
+    // Test that appends where the argument is still overaligned works
+    let kp21 = \SimpleEight.oa
+    let kp22 = \OveralignedForEight.[setter: EightAligned()]
+    let kp2 = kp21.appending(path: kp22)
+
+    let value2 = simple[keyPath: kp2]
+    expectEqual(value2, 128)
+  }
+}
+#endif
+
+if #available(SwiftStdlib 6.3, *) {
+  keyPath.test("sixteen byte overaligned arguments") {
+    let oa = OveralignedForSixteen()
+    let kp = \OveralignedForSixteen.[SixteenAligned()]
+
+    let value = oa[keyPath: kp]
+    expectEqual(value, 128)
+
+    // Test that appends where the argument is no longer overaligned work
+    let simple = SimpleSixteen()
+    let kp11 = \SimpleSixteen.oa
+    let kp12 = \OveralignedForSixteen.[getter: SixteenAligned()]
+    let kp1 = kp11.appending(path: kp12)
+
+    let value1 = simple[keyPath: kp1]
+    expectEqual(value1, 128)
+
+    // Test that appends where the argument is still overaligned works
+    let kp21 = \SimpleSixteen.oa
+    let kp22 = \OveralignedForSixteen.[setter: SixteenAligned()]
+    let kp2 = kp21.appending(path: kp22)
+
+    let value2 = simple[keyPath: kp2]
+    expectEqual(value2, 128)
+  }
+}
+
 runAllTests()
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1247,7 +1247,7 @@ if #available(SwiftStdlib 6.3, *) {
 if #available(SwiftStdlib 6.3, *) {
   keyPath.test("sixteen byte overaligned arguments") {
     let oa = OveralignedForSixteen()
-    let kp = \OveralignedForSixteen.[SixteenAligned()]
+    let kp = \OveralignedForSixteen.[getter: SixteenAligned()]
 
     let value = oa[keyPath: kp]
     expectEqual(value, 128)


### PR DESCRIPTION
When passing arguments to a key path subscript component, we put the arguments into pointer aligned memory. This is a problem when the argument itself has an alignment larger than the platform's pointer alignment. We may end up magically putting on correctly aligned memory, but in most cases we won't. Handle this issue here by putting down padding for these over aligned arguments and recording the amount of padding and what alignment the argument is. Types in Swift are guaranteed to have lower than 16 byte alignment on all current platforms, so 64 bit platforms only need to worry about the 16 byte case whereas 32 bit needs to handle 8 byte and 16 byte aligned arguments.

Resolves: rdar://155108633