### PR TITLE
Miscellaneous availability cleanups

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -23,6 +23,7 @@
 #include "swift/AST/PlatformKindUtils.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 
@@ -140,6 +141,8 @@ public:
   /// Some availability constraints are active for type-checking but cannot
   /// be translated directly into an `if #available(...)` runtime query.
   bool isActiveForRuntimeQueries(const ASTContext &ctx) const;
+
+  void print(raw_ostream &os) const;
 };
 
 /// Represents a set of availability constraints that restrict use of a
@@ -161,6 +164,8 @@ public:
   using const_iterator = Storage::const_iterator;
   const_iterator begin() const { return constraints.begin(); }
   const_iterator end() const { return constraints.end(); }
+
+  void print(raw_ostream &os) const;
 };
 
 enum class AvailabilityConstraintFlag : uint8_t {
@@ -185,4 +190,21 @@ DeclAvailabilityConstraints getAvailabilityConstraintsForDecl(
     AvailabilityConstraintFlags flags = std::nullopt);
 } // end namespace swift
 
+namespace llvm {
+
+inline llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os,
+           const swift::AvailabilityConstraint &constraint) {
+  constraint.print(os);
+  return os;
+}
+
+inline llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os,
+           const swift::DeclAvailabilityConstraints &constraints) {
+  constraints.print(os);
+  return os;
+}
+
+} // end namespace llvm
 #endif

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -23,6 +23,7 @@
 #include "swift/AST/PlatformKindUtils.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 
 namespace swift {
@@ -147,5 +148,15 @@ public:
 };
 
 } // end namespace swift
+
+namespace llvm {
+
+inline llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const swift::AvailabilityContext &context) {
+  context.print(os);
+  return os;
+}
+
+} // end namespace llvm
 
 #endif

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 class ASTContext;
@@ -520,6 +521,12 @@ public:
         AvailabilityDomainOrIdentifier::Storage>::NumLowBitsAvailable
   };
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const swift::AvailabilityDomain &domain) {
+  domain.print(os);
+  return os;
+}
 
 } // end namespace llvm
 

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -47,9 +47,6 @@ public:
   /// Returns the range of platform versions in which the decl is available.
   static AvailabilityRange availableRange(const Decl *D);
 
-  /// Returns true is the declaration is `@_spi_available`.
-  static bool isAvailableAsSPI(const Decl *D);
-
   /// Returns the context for which the declaration
   /// is annotated as available, or None if the declaration
   /// has no availability annotation.

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -31,10 +31,6 @@ class SemanticAvailableAttr;
 
 class AvailabilityInference {
 public:
-  /// Returns the decl that should be considered the parent decl of the given
-  /// decl when looking for inherited availability annotations.
-  static const Decl *parentDeclForInferredAvailability(const Decl *D);
-
   /// Infers the common availability required to access an array of
   /// declarations and adds attributes reflecting that availability
   /// to ToDecl.

--- a/include/swift/AST/AvailabilityRange.h
+++ b/include/swift/AST/AvailabilityRange.h
@@ -21,7 +21,7 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/VersionTuple.h"
-#include <optional>
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 class ASTContext;
@@ -317,11 +317,20 @@ public:
 
   /// Returns a representation of this range as a string for debugging purposes.
   std::string getAsString() const {
-    return "AvailabilityRange(" + getVersionString() + ")";
+    return "AvailabilityRange(" + getVersionDescription() + ")";
   }
 
-  /// Returns a representation of the raw version range as a string for
+  /// Returns a representation of the version range as a string for
   /// debugging purposes.
+  std::string getVersionDescription() const {
+    if (Range.hasLowerEndpoint())
+      return Range.getLowerEndpoint().getAsString();
+    else
+      return Range.isEmpty() ? "never" : "always";
+  }
+
+  /// Returns a string representation of the raw version range. It is an error
+  /// to call this if the range is "always" or "never".
   std::string getVersionString() const {
     ASSERT(Range.hasLowerEndpoint());
     return Range.getLowerEndpoint().getAsString();
@@ -329,5 +338,21 @@ public:
 };
 
 } // end namespace swift
+
+namespace llvm {
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const swift::VersionRange &range) {
+  os << range.getAsString();
+  return os;
+}
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const swift::AvailabilityRange &range) {
+  os << range.getAsString();
+  return os;
+}
+
+} // namespace llvm
 
 #endif

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/VersionTuple.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 class ASTContext;
@@ -240,5 +241,21 @@ public:
 };
 
 } // end namespace swift
+
+namespace llvm {
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const swift::AvailabilitySpec *spec) {
+  spec->print(os);
+  return os;
+}
+
+inline llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const swift::SemanticAvailabilitySpec &spec) {
+  spec.print(os);
+  return os;
+}
+
+} // end namespace llvm
 
 #endif

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1521,6 +1521,10 @@ public:
   /// compatibility mode.
   bool requiresUnavailableDeclABICompatibilityStubs() const;
 
+  /// Returns the decl that should be considered the parent decl when looking
+  /// for inherited availability annotations.
+  const Decl *parentDeclForAvailability() const;
+
   // List the SPI groups declared with @_spi or inherited by this decl.
   //
   // SPI groups are inherited from the parent contexts only if the local decl

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -408,7 +408,10 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D) {
 }
 
 bool Decl::isAvailableAsSPI() const {
-  return AvailabilityInference::isAvailableAsSPI(this);
+  if (auto attr = getAvailableAttrForPlatformIntroduction())
+    return attr->isSPI();
+
+  return false;
 }
 
 SemanticAvailableAttributes
@@ -802,13 +805,6 @@ AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
         .value_or(AvailabilityRange::alwaysAvailable());
 
   return AvailabilityRange::alwaysAvailable();
-}
-
-bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
-  if (auto attr = D->getAvailableAttrForPlatformIntroduction())
-    return attr->isSPI();
-
-  return false;
 }
 
 std::optional<SemanticAvailableAttr>

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -197,7 +197,7 @@ void AvailabilityInference::applyInferredAvailableAttrs(
 
       // Walk up the enclosing declaration hierarchy to make sure we aren't
       // missing any inherited attributes.
-      D = AvailabilityInference::parentDeclForInferredAvailability(D);
+      D = D->parentDeclForAvailability();
     } while (D);
   }
 
@@ -213,32 +213,31 @@ void AvailabilityInference::applyInferredAvailableAttrs(
 
 /// Returns the decl that should be considered the parent decl of the given decl
 /// when looking for inherited availability annotations.
-const Decl *
-AvailabilityInference::parentDeclForInferredAvailability(const Decl *D) {
-  if (auto *AD = dyn_cast<AccessorDecl>(D))
+const Decl *Decl::parentDeclForAvailability() const {
+  if (auto *AD = dyn_cast<AccessorDecl>(this))
     return AD->getStorage();
 
-  if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+  if (auto *ED = dyn_cast<ExtensionDecl>(this)) {
     if (auto *NTD = ED->getExtendedNominal())
       return NTD;
   }
 
-  if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(this)) {
     if (PBD->getNumPatternEntries() < 1)
       return nullptr;
 
     return PBD->getAnchoringVarDecl(0);
   }
 
-  if (auto *OTD = dyn_cast<OpaqueTypeDecl>(D))
+  if (auto *OTD = dyn_cast<OpaqueTypeDecl>(this))
     return OTD->getNamingDecl();
 
   // Clang decls may be inaccurately parented rdar://53956555
-  if (D->hasClangNode())
+  if (hasClangNode())
     return nullptr;
 
   // Availability is inherited from the enclosing context.
-  return D->getDeclContext()->getInnermostDeclarationDeclContext();
+  return getDeclContext()->getInnermostDeclarationDeclContext();
 }
 
 /// Returns true if the introduced version in \p newAttr should be used instead
@@ -699,10 +698,8 @@ DeclRuntimeAvailability
 DeclRuntimeAvailabilityRequest::evaluate(Evaluator &evaluator,
                                          const Decl *decl) const {
   auto inherited = DeclRuntimeAvailability::PotentiallyAvailable;
-  if (auto *parent =
-          AvailabilityInference::parentDeclForInferredAvailability(decl)) {
+  if (auto *parent = decl->parentDeclForAvailability())
     inherited = getDeclRuntimeAvailability(parent);
-  }
 
   // If the inherited runtime availability is already maximally unavailable
   // then skip computing unavailability for this declaration.
@@ -788,8 +785,7 @@ Decl::getAvailableAttrForPlatformIntroduction(bool checkExtension) const {
   if (!checkExtension)
     return std::nullopt;
 
-  if (auto parent =
-          AvailabilityInference::parentDeclForInferredAvailability(this)) {
+  if (auto parent = parentDeclForAvailability()) {
     if (auto *ED = dyn_cast<ExtensionDecl>(parent)) {
       if (auto attr = getDeclAvailableAttrForPlatformIntroduction(ED))
         return attr;

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -13,7 +13,6 @@
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityContext.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Decl.h"
 
 using namespace swift;
@@ -319,7 +318,7 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
   if (decl->getClangNode())
     return constraints;
 
-  auto parent = AvailabilityInference::parentDeclForInferredAvailability(decl);
+  auto parent = decl->parentDeclForAvailability();
   if (auto extension = dyn_cast_or_null<ExtensionDecl>(parent))
     getAvailabilityConstraintsForDecl(constraints, extension, context, flags);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -591,8 +591,7 @@ const Decl *Decl::getInnermostDeclWithAvailability() const {
   if (getAttrs().hasAttribute<AvailableAttr>())
     return this;
 
-  if (auto parent =
-          AvailabilityInference::parentDeclForInferredAvailability(this))
+  if (auto parent = parentDeclForAvailability())
     return parent->getInnermostDeclWithAvailability();
 
   return nullptr;
@@ -1492,7 +1491,7 @@ AvailabilityRange Decl::getAvailabilityForLinkage() const {
     return *containingContext;
   }
 
-  // FIXME: Adopt AvailabilityInference::parentDeclForInferredAvailability()
+  // FIXME: Adopt Decl::parentDeclForAvailability()
   // here instead of duplicating the logic.
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->getAvailabilityForLinkage();

--- a/lib/IRGen/GenCoro.cpp
+++ b/lib/IRGen/GenCoro.cpp
@@ -110,10 +110,8 @@ class GetDeallocThroughFn {
         return emitNewLayoutOffsetIntoTask(task);
       }
       auto deploymentRange =
-          IGM.Context.getTargetAvailabilityDomain().getDeploymentRange(
-              IGM.Context);
-      if (!deploymentRange || deploymentRange->isContainedIn(
-                                  IGM.Context.getSwift57Availability())) {
+          AvailabilityRange::forDeploymentTarget(IGM.Context);
+      if (deploymentRange.isContainedIn(IGM.Context.getSwift57Availability())) {
         return emitNewLayoutOffsetIntoTask(task);
       }
 
@@ -229,13 +227,12 @@ class GetDeallocThroughFn {
     llvm::Value *emitSwift57VersionCheck() {
       auto availability = IGM.Context.getSwift57Availability();
       auto deploymentRange =
-          IGM.Context.getTargetAvailabilityDomain().getDeploymentRange(
-              IGM.Context);
-      assert(deploymentRange);
-      assert(!deploymentRange->isContainedIn(
-          IGM.Context.getSwift57Availability()));
+          AvailabilityRange::forDeploymentTarget(IGM.Context);
+      assert(!deploymentRange.isContainedIn(availability));
       (void)deploymentRange;
       assert(availability.hasMinimumVersion());
+      // FIXME: [availability] This does not generate the correct query for
+      // macCatalyst or zippered targets (rdar://155999964).
       auto version = availability.getRawMinimumVersion();
       auto *major = getInt32Constant(version.getMajor());
       auto *minor = getInt32Constant(version.getMinor());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2205,8 +2205,7 @@ getSemanticAvailableRangeDeclAndAttr(const Decl *decl) {
           /*checkExtension=*/false))
     return std::make_pair(*attr, decl);
 
-  if (auto *parent =
-          AvailabilityInference::parentDeclForInferredAvailability(decl))
+  if (auto *parent = decl->parentDeclForAvailability())
     return getSemanticAvailableRangeDeclAndAttr(parent);
 
   return std::nullopt;
@@ -5059,8 +5058,7 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   // Compute availability constraints for the decl, relative to its parent
   // declaration or to the deployment target.
   auto availabilityContext = AvailabilityContext::forDeploymentTarget(Ctx);
-  if (auto parent =
-          AvailabilityInference::parentDeclForInferredAvailability(D)) {
+  if (auto parent = D->parentDeclForAvailability()) {
     auto parentAvailability = AvailabilityContext::forDeclSignature(parent);
     availabilityContext.constrainWithContext(parentAvailability, Ctx);
   }
@@ -5237,8 +5235,7 @@ void AttributeChecker::checkBackDeployedAttrs(
           break;
         }
 
-        attrDecl =
-            AvailabilityInference::parentDeclForInferredAvailability(attrDecl);
+        attrDecl = attrDecl->parentDeclForAvailability();
       } while (attrDecl);
 
       continue;
@@ -5424,10 +5421,9 @@ std::optional<Diagnostic>
 TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
                                                  SemanticAvailableAttr attr) {
   auto parentIsUnavailable = [](const Decl *D) -> bool {
-    if (auto *parent =
-            AvailabilityInference::parentDeclForInferredAvailability(D)) {
+    if (auto *parent = D->parentDeclForAvailability())
       return AvailabilityContext::forDeclSignature(parent).isUnavailable();
-    }
+
     return false;
   };
 


### PR DESCRIPTION
- Replace more `AvailabilityInterface` utilities with methods directly on `Decl`.
- Use `AvailabilityRange::forDeploymentTarget()` instead of querying the deployment range from the availability
domain returned by `ASTContext::getTargetAvailabilityDomain()`.
- For debugging, add more printing conveniences to various availability related classes.

NFC.