### PR TITLE
[Concurrency] Never apply default main actor isolation to local declarations.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6083,6 +6083,12 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     auto globalActorHelper = [&](Type globalActor)
         -> std::optional<std::tuple<InferredActorIsolation, ValueDecl *,
                                     std::optional<ActorIsolation>>> {
+      // Local declarations are always nonisolated by default
+      // so they can always be used in the isolation of the
+      // enclosing context.
+      if (value->getDeclContext()->isLocalContext())
+        return {};
+
       // Default global actor isolation does not apply to any declarations
       // within actors and distributed actors, nor does it apply in a
       // nonisolated type.

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -244,3 +244,17 @@ struct S: P {
   }
   static let at = AT() // used to fail here
 }
+
+nonisolated func localDeclIsolation() async {
+  struct Local {
+    static func f() {}
+  }
+
+  Local.f()
+
+  await withTaskGroup { group in
+    group.addTask { }
+
+    await group.next()
+  }
+}


### PR DESCRIPTION
Otherwise, code like this mysteriously fails in `-default-isolation MainActor` (in this case, because the `group` parameter is accidentally inferred as `@MainActor`):

```swift
func example() async {
  await withTaskGroup { group in
    group.addTask {}
    await group.next() // error
  }
}
```

Resolves: rdar://153561279