### PR TITLE
AST/Sema: Generalize availability fix-its to support custom availability domains

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -188,11 +188,20 @@ enum class AvailabilityConstraintFlag : uint8_t {
 };
 using AvailabilityConstraintFlags = OptionSet<AvailabilityConstraintFlag>;
 
-/// Returns the set of availability constraints that restrict use of \p decl
+/// Returns the set of availability constraints that restricts use of \p decl
 /// when it is referenced from the given context. In other words, it is the
-/// collection of of `@available` attributes with unsatisfied conditions.
+/// collection of `@available` attributes with unsatisfied conditions.
 DeclAvailabilityConstraints getAvailabilityConstraintsForDecl(
     const Decl *decl, const AvailabilityContext &context,
+    AvailabilityConstraintFlags flags = std::nullopt);
+
+/// Returns the availability constraints that restricts use of \p decl
+/// in \p domain when it is referenced from the given context. In other words,
+/// it is the unsatisfied `@available` attribute  that applies to \p domain in
+/// the given context.
+std::optional<AvailabilityConstraint> getAvailabilityConstraintForDeclInDomain(
+    const Decl *decl, const AvailabilityContext &context,
+    AvailabilityDomain domain,
     AvailabilityConstraintFlags flags = std::nullopt);
 } // end namespace swift
 

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -260,6 +260,12 @@ public:
   /// universal domain (`*`) is the bottom element.
   bool contains(const AvailabilityDomain &other) const;
 
+  /// Returns true if availability in `other` is a subset of availability in
+  /// this domain or vice-versa.
+  bool isRelated(const AvailabilityDomain &other) const {
+    return contains(other) || other.contains(*this);
+  }
+
   /// Returns true for domains that are not contained by any domain other than
   /// the universal domain.
   bool isRoot() const;

--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -272,8 +272,11 @@ public:
       AvailabilityDomain Domain, const llvm::VersionTuple &Version) const;
 
   /// Returns the availability version range that was explicitly written in
-  /// source, if applicable. Otherwise, returns null.
-  std::optional<const AvailabilityRange> getExplicitAvailabilityRange() const;
+  /// source for the given domain, if applicable. Otherwise, returns
+  /// `std::nullopt`.
+  std::optional<const AvailabilityRange>
+  getExplicitAvailabilityRange(AvailabilityDomain Domain,
+                               ASTContext &Ctx) const;
 
   /// Returns the source range this scope represents.
   SourceRange getSourceRange() const { return SrcRange; }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1464,6 +1464,27 @@ public:
   std::optional<SemanticAvailableAttr>
   getAvailableAttrForPlatformIntroduction(bool checkExtension = true) const;
 
+  /// Returns true if `decl` has any active `@available` attribute attached to
+  /// it.
+  bool hasAnyActiveAvailableAttr() const {
+    return hasAnyMatchingActiveAvailableAttr(
+        [](SemanticAvailableAttr attr) -> bool { return true; });
+  }
+
+  /// Returns true if `predicate` returns true for any active availability
+  /// attribute attached to `decl`. The predicate function should accept a
+  /// `SemanticAvailableAttr`.
+  template <typename F>
+  bool hasAnyMatchingActiveAvailableAttr(F predicate) const {
+    auto &ctx = getASTContext();
+    auto decl = getAbstractSyntaxDeclForAttributes();
+    for (auto attr : decl->getSemanticAvailableAttrs()) {
+      if (attr.isActive(ctx) && predicate(attr))
+        return true;
+    }
+    return false;
+  }
+
   /// Returns true if the declaration is deprecated at the current deployment
   /// target.
   bool isDeprecated() const { return getDeprecatedAttr().has_value(); }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7070,9 +7070,6 @@ NOTE(availability_guard_with_version_check, none,
 
 NOTE(availability_add_attribute, none,
      "add '@available' attribute to enclosing %kindonly0", (const Decl *))
-FIXIT(insert_available_attr,
-      "@available(%0 %1, *)\n%2",
-      (StringRef, StringRef, StringRef))
 
 ERROR(availability_inout_accessor_only_in, none,
       "cannot pass as inout because %0 is only available in %1"

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -331,3 +331,15 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
   return constraints;
 }
 
+std::optional<AvailabilityConstraint>
+swift::getAvailabilityConstraintForDeclInDomain(
+    const Decl *decl, const AvailabilityContext &context,
+    AvailabilityDomain domain, AvailabilityConstraintFlags flags) {
+  auto constraints = getAvailabilityConstraintsForDecl(decl, context, flags);
+  for (auto const &constraint : constraints) {
+    if (constraint.getDomain().isRelated(domain))
+      return constraint;
+  }
+
+  return std::nullopt;
+}

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1077,9 +1077,9 @@ private:
         // current scope is completely contained in the range for the spec, then
         // a version query can never be false, so the spec is useless.
         // If so, report this.
-        // FIXME: [availability] Diagnose non-platform queries as useless too.
-        auto explicitRange = currentScope->getExplicitAvailabilityRange();
-        if (domain.isPlatform() && explicitRange && trueRange &&
+        auto explicitRange =
+            currentScope->getExplicitAvailabilityRange(domain, Context);
+        if (explicitRange && trueRange &&
             explicitRange->isContainedIn(*trueRange)) {
           // Platform unavailability queries never refine availability so don't
           // diangose them.
@@ -1088,17 +1088,9 @@ private:
 
           DiagnosticEngine &diags = Context.Diags;
           if (currentScope->getReason() != AvailabilityScope::Reason::Root) {
-            PlatformKind bestPlatform = targetPlatform(Context.LangOpts);
-
-            // If possible, try to report the diagnostic in terms for the
-            // platform the user uttered in the '#available()'. For a platform
-            // that inherits availability from another platform it may be
-            // different from the platform specified in the target triple.
-            if (domain.getPlatformKind() != PlatformKind::none)
-              bestPlatform = domain.getPlatformKind();
             diags.diagnose(query->getLoc(),
                            diag::availability_query_useless_enclosing_scope,
-                           platformString(bestPlatform));
+                           domain.getNameForAttributePrinting());
             diags.diagnose(
                 currentScope->getIntroductionLoc(),
                 diag::availability_query_useless_enclosing_scope_here);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -685,7 +685,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     return false;
 
   // FIXME: [availability] Support fixing availability for versionless domains.
-  auto ExplicitAvailability = scope->getExplicitAvailabilityRange();
+  auto ExplicitAvailability =
+      scope->getExplicitAvailabilityRange(Domain, Context);
   if (ExplicitAvailability && !RequiredAvailability.isAlwaysAvailable() &&
       scope->getReason() != AvailabilityScope::Reason::Root &&
       RequiredAvailability.isContainedIn(*ExplicitAvailability)) {

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -231,18 +231,29 @@ func testFixIts() {
   // expected-note@-1 {{add 'if #available' version check}}{{3-29=if #available(EnabledDomain) {\n      availableInEnabledDomain()\n  \} else {\n      // Fallback\n  \}}}
 }
 
+struct Container { }
+
+@available(EnabledDomain)
+extension Container {
+  @available(EnabledDomain)
+  func redundantlyAvailableInEnabledDomain() { }
+
+  @available(EnabledDomain, unavailable)
+  func unavailableInEnabledDomain() { }
+}
+
 protocol P { }
 
 @available(EnabledDomain)
-struct AvailableInEnabledDomain: P { }
+struct AvailableConformsToP: P { }
 
 @available(EnabledDomain, unavailable)
-struct UnavailableInEnabledDomain: P { }
+struct UnavailableConformsToP: P { }
 
 func testOpaqueReturnType() -> some P {
   if #available(EnabledDomain) { // expected-error {{opaque return type cannot depend on EnabledDomain availability}}
-    return AvailableInEnabledDomain()
+    return AvailableConformsToP()
   } else {
-    return UnavailableInEnabledDomain()
+    return UnavailableConformsToP()
   }
 }

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -41,7 +41,7 @@ func testDeployment() {
 }
 
 func testIfAvailable(_ truthy: Bool) {
-  if #available(EnabledDomain) {
+  if #available(EnabledDomain) { // expected-note {{enclosing scope here}}
     availableInEnabledDomain()
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
@@ -59,7 +59,9 @@ func testIfAvailable(_ truthy: Bool) {
       unavailableInDynamicDomain()
     }
 
-    if #unavailable(EnabledDomain) {
+    if #available(EnabledDomain) {} // expected-warning {{unnecessary check for 'EnabledDomain'; enclosing scope ensures guard will always be true}}
+
+    if #unavailable(EnabledDomain) { // FIXME: [availability] Diagnose as unreachable
       // Unreachable.
       availableInEnabledDomain()
       unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
@@ -112,19 +114,25 @@ func testIfAvailable(_ truthy: Bool) {
 }
 
 func testWhileAvailable() {
-  while #available(EnabledDomain) {
+  while #available(EnabledDomain) { // expected-note {{enclosing scope here}}
     availableInEnabledDomain()
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+
+    if #available(EnabledDomain) {} // expected-warning {{unnecessary check for 'EnabledDomain'; enclosing scope ensures guard will always be true}}
+    if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
   }
 
   while #unavailable(EnabledDomain) {
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
     unavailableInEnabledDomain()
+
+    if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
+    if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
   }
 }
 
 func testGuardAvailable() {
-  guard #available(EnabledDomain) else {
+  guard #available(EnabledDomain) else { // expected-note {{enclosing scope here}}
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
     unavailableInEnabledDomain()
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
@@ -135,14 +143,17 @@ func testGuardAvailable() {
   availableInEnabledDomain()
   unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+
+  if #available(EnabledDomain) {} // expected-warning {{unnecessary check for 'EnabledDomain'; enclosing scope ensures guard will always be true}}
+  if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
 }
 
 @available(EnabledDomain)
-func testEnabledDomainAvailable() {
+func testEnabledDomainAvailable() { // expected-note {{enclosing scope here}}
   availableInEnabledDomain()
   unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
 
-  if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
+  if #available(EnabledDomain) {} // expected-warning {{unnecessary check for 'EnabledDomain'; enclosing scope ensures guard will always be true}}
   if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
 
   alwaysAvailable()

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -29,22 +29,25 @@ func unavailableInDynamicDomain() { } // expected-note * {{'unavailableInDynamic
 @available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
-func testDeployment() {
+func testDeployment() { // expected-note 2 {{add '@available' attribute to enclosing global function}}
   alwaysAvailable()
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   availableInUnknownDomain()
 }
 
-func testIfAvailable(_ truthy: Bool) {
+func testIfAvailable(_ truthy: Bool) { // expected-note 9 {{add '@available' attribute to enclosing global function}}
   if #available(EnabledDomain) { // expected-note {{enclosing scope here}}
     availableInEnabledDomain()
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
 
     if #available(DynamicDomain) {
@@ -56,6 +59,7 @@ func testIfAvailable(_ truthy: Bool) {
       availableInEnabledDomain()
       unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
       availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
       unavailableInDynamicDomain()
     }
 
@@ -66,12 +70,15 @@ func testIfAvailable(_ truthy: Bool) {
       availableInEnabledDomain()
       unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
       availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
       unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
     }
   } else {
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain()
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
   }
 
@@ -84,8 +91,10 @@ func testIfAvailable(_ truthy: Bool) {
     // In this branch, we only know that one of the domains is unavailable,
     // but we don't know which.
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
   }
 
@@ -96,11 +105,13 @@ func testIfAvailable(_ truthy: Bool) {
     // In this branch, the state of EnabledDomain remains unknown since
     // execution will reach here if "truthy" is false.
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   }
 
   if #unavailable(EnabledDomain) {
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain()
   } else {
     availableInEnabledDomain()
@@ -113,7 +124,7 @@ func testIfAvailable(_ truthy: Bool) {
   }
 }
 
-func testWhileAvailable() {
+func testWhileAvailable() { // expected-note {{add '@available' attribute to enclosing global function}}
   while #available(EnabledDomain) { // expected-note {{enclosing scope here}}
     availableInEnabledDomain()
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
@@ -124,6 +135,7 @@ func testWhileAvailable() {
 
   while #unavailable(EnabledDomain) {
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain()
 
     if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
@@ -131,11 +143,13 @@ func testWhileAvailable() {
   }
 }
 
-func testGuardAvailable() {
+func testGuardAvailable() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
   guard #available(EnabledDomain) else { // expected-note {{enclosing scope here}}
     availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain()
     availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
 
     return
   }
@@ -143,13 +157,14 @@ func testGuardAvailable() {
   availableInEnabledDomain()
   unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(EnabledDomain) {} // expected-warning {{unnecessary check for 'EnabledDomain'; enclosing scope ensures guard will always be true}}
   if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
 }
 
 @available(EnabledDomain)
-func testEnabledDomainAvailable() { // expected-note {{enclosing scope here}}
+func testEnabledDomainAvailable() { // expected-note {{add '@available' attribute to enclosing global function}} expected-note {{enclosing scope here}}
   availableInEnabledDomain()
   unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
 
@@ -160,12 +175,14 @@ func testEnabledDomainAvailable() { // expected-note {{enclosing scope here}}
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   availableInUnknownDomain()
 }
 
 @available(EnabledDomain, unavailable)
-func testEnabledDomainUnavailable() {
+func testEnabledDomainUnavailable() { // expected-note {{add '@available' attribute to enclosing global function}}
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInEnabledDomain()
 
   if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
@@ -175,6 +192,7 @@ func testEnabledDomainUnavailable() {
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   availableInUnknownDomain()
 }
 
@@ -184,9 +202,11 @@ func testUniversallyUnavailable() {
   // FIXME: [availability] Diagnostic consistency: potentially unavailable declaration shouldn't be diagnosed
   // in contexts that are unavailable to broader domains
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInDisabledDomain()
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
   availableInUnknownDomain()
 
   if #available(EnabledDomain) {} // FIXME: [availability] Diagnose?
@@ -203,6 +223,12 @@ struct EnabledDomainAvailable {
     alwaysAvailable()
     unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   }
+}
+
+func testFixIts() {
+  // expected-note@-1 {{add '@available' attribute to enclosing global function}}{{1-1=@available(EnabledDomain)\n}}
+  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}{{3-29=if #available(EnabledDomain) {\n      availableInEnabledDomain()\n  \} else {\n      // Fallback\n  \}}}
 }
 
 protocol P { }

--- a/test/Availability/availability_scopes.swift
+++ b/test/Availability/availability_scopes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -dump-availability-scopes %s -target %target-cpu-apple-macos50 > %t.dump 2>&1
+// RUN: %target-swift-frontend -typecheck -dump-availability-scopes %s -target %target-cpu-apple-macos50 -swift-version 5 > %t.dump 2>&1
 // RUN: %FileCheck --strict-whitespace %s < %t.dump
 
 // REQUIRES: OS=macosx
@@ -453,6 +453,23 @@ struct NeverAvailable {
 func deprecatedOnMacOS() {
   let x = 1
 }
+
+// Since availableOniOS() doesn't have any active @available attributes it
+// shouldn't create a scope.
+// CHECK-NOT: availableOniOS
+
+@available(iOS, introduced: 53)
+func availableOniOS() { }
+
+// CHECK-NEXT: {{^}}  (decl version=50 decl=availableInSwift5
+
+@available(swift 5)
+func availableInSwift5() { }
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=swift decl=availableInSwift6
+
+@available(swift 6)
+func availableInSwift6() { }
 
 // CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl
 

--- a/test/Availability/availability_target_min_inlining.swift
+++ b/test/Availability/availability_target_min_inlining.swift
@@ -1292,6 +1292,30 @@ extension BetweenTargets { // expected-note 2 {{add '@available' attribute to en
   ) {}
 }
 
+@available(iOS 8.0, *)
+extension BetweenTargets { // expected-note 2 {{add '@available' attribute to enclosing extension}}
+  public func publicFuncInExtensionWithExplicitiOSAvailability( // expected-note 2 {{add '@available' attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
+
+@available(swift 5)
+extension BetweenTargets { // expected-note 2 {{add '@available' attribute to enclosing extension}}
+  public func publicFuncInExtensionWithExplicitSwiftAvailability( // expected-note 2 {{add '@available' attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
+
 @available(macOS 10.15, *)
 extension BetweenTargets {
   public func publicFuncInExtensionWithExplicitAvailability( // expected-note {{add '@available' attribute to enclosing instance method}}

--- a/test/ClangImporter/Inputs/availability_custom_domains_other.swift
+++ b/test/ClangImporter/Inputs/availability_custom_domains_other.swift
@@ -6,6 +6,7 @@ func availableInArctic() { }
 @available(Mediterranean)
 func availableInMediterranean() { }
 
-func testOtherClangDecls() {
+func testOtherClangDecls() { // expected-note {{add '@available' attribute to enclosing global function}}
   available_in_baltic() // expected-error {{'available_in_baltic()' is only available in Baltic}}
+  // expected-note@-1 {{add 'if #available' version check}}
 }

--- a/test/ClangImporter/availability_custom_domains.swift
+++ b/test/ClangImporter/availability_custom_domains.swift
@@ -23,11 +23,14 @@
 
 import Oceans // re-exports Rivers
 
-func testClangDecls() {
+func testClangDecls() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
   available_in_arctic() // expected-error {{'available_in_arctic()' is only available in Arctic}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailable_in_pacific() // expected-error {{'unavailable_in_pacific()' is unavailable}}
   available_in_colorado_river_delta() // expected-error {{'available_in_colorado_river_delta()' is only available in Pacific}}
+  // expected-note@-1 {{add 'if #available' version check}}
   available_in_colorado() // expected-error {{'available_in_colorado()' is only available in Colorado}}
+  // expected-note@-1 {{add 'if #available' version check}}
   available_in_baltic() // expected-error {{cannot find 'available_in_baltic' in scope}}
 }
 
@@ -47,12 +50,15 @@ func unavailableInColorado() { } // expected-note {{'unavailableInColorado()' ha
 @available(Baltic) // expected-error {{unrecognized platform name 'Baltic'}}
 func availableInBaltic() { } // expected-note {{did you mean 'availableInBaltic'}}
 
-func testSwiftDecls() {
+func testSwiftDecls() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
   availableInBayBridge() // expected-error {{'availableInBayBridge()' is only available in BayBridge}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInBayBridge() // expected-error {{'unavailableInBayBridge()' is unavailable}}
   availableInArctic()
   availableInPacific() // expected-error {{'availableInPacific()' is only available in Pacific}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInColorado() // expected-error {{'unavailableInColorado()' is unavailable}}
   availableInBaltic()
   availableInMediterranean() // expected-error {{'availableInMediterranean()' is only available in Mediterranean}}
+  // expected-note@-1 {{add 'if #available' version check}}
 }

--- a/test/Serialization/availability_custom_domains.swift
+++ b/test/Serialization/availability_custom_domains.swift
@@ -31,7 +31,8 @@ public func unavailableInColorado() { }
 
 import lib
 
-func test() {
+func test() { // expected-note {{add '@available' attribute to enclosing global function}}
   availableInPacific() // expected-error {{'availableInPacific()' is only available in Pacific}}
+  // expected-note@-1 {{add 'if #available' version check}}
   unavailableInColorado() // expected-error {{'unavailableInColorado()' is unavailable}}
 }

--- a/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
+++ b/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
@@ -52,7 +52,7 @@ func testDeploymentTarget() {
   doSomething() // expected-error {{'doSomething()' is only available in visionOS 1.1 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}{{3-16=if #available(visionOS 1.1, *) {\n      doSomething()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   doSomethingFarFuture() // expected-error {{'doSomethingFarFuture()' is only available in iOS 99.0 or newer}}
-  // expected-note@-1 {{add 'if #available' version check}}{{3-25=if #available(visionOS 99.0, *) {\n      doSomethingFarFuture()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  // expected-note@-1 {{add 'if #available' version check}}{{3-25=if #available(iOS 99.0, *) {\n      doSomethingFarFuture()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in visionOS: you don't want to do that anyway}}
   doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in iOS 1.0: please don't}}
   doSomethingGood()
@@ -61,7 +61,7 @@ func testDeploymentTarget() {
   takesSomeProto(ConformsToProtoIniOS17_4()) // expected-warning {{conformance of 'ConformsToProtoIniOS17_4' to 'SomeProto' is only available in visionOS 1.1 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}{{3-45=if #available(visionOS 1.1, *) {\n      takesSomeProto(ConformsToProtoIniOS17_4())\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   takesSomeProto(ConformsToProtoIniOS99()) // expected-warning {{conformance of 'ConformsToProtoIniOS99' to 'SomeProto' is only available in iOS 99 or newer; this is an error in the Swift 6 language mode}}
-  // expected-note@-1 {{add 'if #available' version check}}{{3-43=if #available(visionOS 99, *) {\n      takesSomeProto(ConformsToProtoIniOS99())\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  // expected-note@-1 {{add 'if #available' version check}}{{3-43=if #available(iOS 99, *) {\n      takesSomeProto(ConformsToProtoIniOS99())\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   takesSomeProto(ConformsToProtoDeprecatedIniOS17()) // expected-warning {{conformance of 'ConformsToProtoDeprecatedIniOS17' to 'SomeProto' was deprecated in iOS 1.0: please don't}}
   takesSomeProto(ConformsToProtoObsoletedIniOS17()) // expected-error {{conformance of 'ConformsToProtoObsoletedIniOS17' to 'SomeProto' is unavailable in visionOS: you don't want to do that anyway}}
 


### PR DESCRIPTION
When the compiler emits a diagnostic like

```swift
func foo() {
  bar() // error: ‘bar()' is only available in MyFeature
}
```

there should be a fix-it emitted that suggests adding an `@available(MyFeature)` attribute to `foo()` and another fix-it that suggests adding `if #available(MyFeature) { … }`.

Resolves rdar://156118254.