### PR TITLE
utils: fix split-cmdline

### DIFF
--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -53,7 +53,6 @@ def main():
                 continue
             if not first:
                 # Print option arguments in the same line
-                is_arg_param = is_arg_param or not arg.startswith("-")
                 print(" " if is_arg_param else " \\\n  ", end="")
             first = False
 

--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -57,7 +57,7 @@ def main():
             first = False
 
             # Expand @ option files
-            m = re.match(r"^@(\S+\.txt)$", arg)
+            m = re.match(r"^@(\S+(\.txt|FileList))$", arg)
             if m:
                 cmd_file = m.group(1)
                 if os.path.isfile(cmd_file):


### PR DESCRIPTION
If an argument does not start with an "-", it's not necessarily an argument parameter. It can also be e.g. an input file name.

Also expand @-filelist files which end with "FileList" (so far only ".txt" were handled)