### PR TITLE
[IDE] Fix assertion failure in `PostfixCompletionCallback::Result::tryMerge`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6093,6 +6093,7 @@ bool isAutoClosureArgument(Expr *argExpr);
 /// parameter being applied, meaning that it's dropped from the type of the
 /// reference.
 bool hasAppliedSelf(ConstraintSystem &cs, const OverloadChoice &choice);
+bool hasAppliedSelf(const Solution &S, const OverloadChoice &choice);
 bool hasAppliedSelf(const OverloadChoice &choice,
                     llvm::function_ref<Type(Type)> getFixedType);
 

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -27,8 +27,7 @@ bool PostfixCompletionCallback::Result::tryMerge(const Result &Other,
   if (BaseDecl != Other.BaseDecl)
     return false;
 
-  // These properties should match if we are talking about the same BaseDecl.
-  assert(IsBaseDeclUnapplied == Other.IsBaseDeclUnapplied);
+  // This should match if we are talking about the same BaseDecl.
   assert(BaseIsStaticMetaType == Other.BaseIsStaticMetaType);
 
   auto baseTy = tryMergeBaseTypeForCompletionLookup(BaseTy, Other.BaseTy, DC);
@@ -56,6 +55,12 @@ bool PostfixCompletionCallback::Result::tryMerge(const Result &Other,
   ExpectsNonVoid &= Other.ExpectsNonVoid;
   IsImpliedResult |= Other.IsImpliedResult;
   IsInAsyncContext |= Other.IsInAsyncContext;
+
+  // Note this may differ if we pre-check multiple times since pre-checking
+  // changes the recorded apply level.
+  // FIXME: We ought to fix completion to not pre-check multiple times.
+  IsBaseDeclUnapplied |= Other.IsBaseDeclUnapplied;
+
   return true;
 }
 

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -119,25 +119,26 @@ getClosureActorIsolation(const Solution &S, AbstractClosureExpr *ACE) {
                                         getClosureActorIsolationThunk);
 }
 
-/// Returns \c true if \p Choice refers to a function that hasn't been called
-/// yet.
-static bool isUnappliedFunctionRef(const OverloadChoice &Choice) {
-  if (!Choice.isDecl()) {
+/// Returns \c true if \p Choice refers to a function that has been fully
+/// applied, including the curried self if present.
+static bool isFullyAppliedFunctionRef(const Solution &S,
+                                      const OverloadChoice &Choice) {
+  auto *D = Choice.getDeclOrNull();
+  if (!D)
     return false;
-  }
-  auto fnRefKind = Choice.getFunctionRefInfo();
 
-  if (fnRefKind.isUnapplied())
+  switch (Choice.getFunctionRefInfo().getApplyLevel()) {
+  case FunctionRefInfo::ApplyLevel::Unapplied:
+    // No argument lists have been applied.
+    return false;
+  case FunctionRefInfo::ApplyLevel::SingleApply:
+    // The arguments have been applied, check to see if the curried self has
+    // been applied if present.
+    return !D->hasCurriedSelf() || hasAppliedSelf(S, Choice);
+  case FunctionRefInfo::ApplyLevel::DoubleApply:
+    // All argument lists have been applied.
     return true;
-
-  // We consider curried member calls as unapplied. E.g.
-  //   MyStruct.someInstanceFunc(theInstance)#^COMPLETE^#
-  // is unapplied.
-  if (fnRefKind.isSingleApply()) {
-    if (auto BaseTy = Choice.getBaseType())
-      return BaseTy->is<MetatypeType>() && !Choice.getDeclOrNull()->isStatic();
   }
-  return false;
 }
 
 void PostfixCompletionCallback::sawSolutionImpl(
@@ -166,7 +167,8 @@ void PostfixCompletionCallback::sawSolutionImpl(
   bool IsBaseDeclUnapplied = false;
   if (auto SelectedOverload = S.getOverloadChoiceIfAvailable(CalleeLocator)) {
     ReferencedDecl = SelectedOverload->choice.getDeclOrNull();
-    IsBaseDeclUnapplied = isUnappliedFunctionRef(SelectedOverload->choice);
+    IsBaseDeclUnapplied = ReferencedDecl && !isFullyAppliedFunctionRef(
+                                                S, SelectedOverload->choice);
   }
 
   bool BaseIsStaticMetaType = S.isStaticallyDerivedMetatype(ParsedExpr);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2831,10 +2831,7 @@ bool ContextualFailure::diagnoseAsError() {
     auto params = fnType->getParams();
 
     ParameterListInfo info(
-        params, choice,
-        hasAppliedSelf(overload->choice, [&solution](Type type) {
-          return solution.simplifyType(type);
-        }));
+        params, choice, hasAppliedSelf(solution, overload->choice));
     auto numMissingArgs = llvm::count_if(
         indices(params), [&info](const unsigned paramIdx) -> bool {
           return !info.hasDefaultArgument(paramIdx);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3891,6 +3891,13 @@ bool constraints::hasAppliedSelf(ConstraintSystem &cs,
   });
 }
 
+bool constraints::hasAppliedSelf(const Solution &S,
+                                 const OverloadChoice &choice) {
+  return hasAppliedSelf(choice, [&](Type type) -> Type {
+    return S.simplifyType(type);
+  });
+}
+
 bool constraints::hasAppliedSelf(const OverloadChoice &choice,
                                  llvm::function_ref<Type(Type)> getFixedType) {
   auto *decl = choice.getDeclOrNull();
@@ -4206,8 +4213,7 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
     fnInterfaceType = callee->getInterfaceType();
 
     // Strip off the curried self parameter if necessary.
-    if (hasAppliedSelf(
-            *choice, [this](Type type) -> Type { return simplifyType(type); }))
+    if (hasAppliedSelf(*this, *choice))
       fnInterfaceType = fnInterfaceType->castTo<AnyFunctionType>()->getResult();
 
 #ifndef NDEBUG

--- a/validation-test/IDE/crashers_fixed/700c7172dd0e486.swift
+++ b/validation-test/IDE/crashers_fixed/700c7172dd0e486.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","signature":"swift::ide::PostfixCompletionCallback::Result::tryMerge(swift::ide::PostfixCompletionCallback::Result const&, swift::DeclContext*)"}
-// RUN: not --crash %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
 Int { switch { case Optional.some()#^COMPLETE^#

--- a/validation-test/IDE/issues_fixed/issue-75845.swift
+++ b/validation-test/IDE/issues_fixed/issue-75845.swift
@@ -15,3 +15,28 @@ struct Foo {
 // B: Begin completions
 // C: Decl[LocalVar]/Local: error[#any Error#]; name=error
 // D: Begin completions
+
+enum E {
+  case e(Error)
+
+  func foo() {
+    var x = self
+    do {
+    } catch {
+      x = .e(error)#^E^#
+      // E: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: .foo()[#Void#]; name=foo()
+    }
+  }
+
+  static func bar() {
+    do {
+    } catch {
+      _ = foo(.e(error))#^F^#
+      // F: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ()[#Void#]; name=()
+
+      _ = foo(.e(error))()#^G^#
+      // G: Begin completions, 1 items
+      // G: Keyword[self]/CurrNominal: .self[#Void#]; name=self
+    }
+  }
+}


### PR DESCRIPTION
Unfortunately due to pre-checking multiple times the recorded application level can change. Just OR the bits together. While here, switch over to using `hasAppliedSelf` to match the constraint system logic.

This should fix the remaining stress tester failures for #75845