### PR TITLE
[Clang importer] Import incomplete SWIFT_SHARED_REFERENCE types 

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1227,7 +1227,8 @@ public:
   /// \returns The imported declaration context, or null if it could not
   /// be converted.
   DeclContext *importDeclContextOf(const clang::Decl *D,
-                                   EffectiveClangContext context);
+                                   EffectiveClangContext context,
+                                   bool allowForwardDeclaration = false);
 
   /// Determine whether the given declaration is considered
   /// 'unavailable' in Swift.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2560,7 +2560,7 @@ llvm::SmallVector<clang::CXXMethodDecl *, 4>
 SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
     const clang::CXXRecordDecl *cxxRecordDecl) {
 
-  if (cxxRecordDecl->isAbstract())
+  if (!cxxRecordDecl->isCompleteDefinition() || cxxRecordDecl->isAbstract())
     return {};
 
   clang::ASTContext &clangCtx = cxxRecordDecl->getASTContext();

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1881,19 +1881,9 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   if (shouldSuppressDeclImport(named))
     return;
 
-  // Leave incomplete struct/enum/union types out of the table; Swift only
-  // handles pointers to them.
-  // FIXME: At some point we probably want to be importing incomplete types,
-  // so that pointers to different incomplete types themselves have distinct
-  // types. At that time it will be necessary to make the decision of whether
-  // or not to import an incomplete type declaration based on whether it's
-  // actually the struct backing a CF type:
-  //
-  //    typedef struct CGColor *CGColorRef;
-  //
-  // The best way to do this is probably to change CFDatabase.def to include
-  // struct names when relevant, not just pointer names. That way we can check
-  // both CFDatabase.def and the objc_bridge attribute and cover all our bases.
+  // Leave incomplete struct/enum/union types out of the table, unless they
+  // are types that will be imported as reference types (e.g., CF types or
+  // those that use SWIFT_SHARED_REFERENCE).
   if (auto *tagDecl = dyn_cast<clang::TagDecl>(named)) {
     // We add entries for ClassTemplateSpecializations that don't have
     // definition. It's possible that the decl will be instantiated by
@@ -1901,7 +1891,9 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     // ClassTemplateSPecializations here because we're currently writing the
     // AST, so we cannot modify it.
     if (!isa<clang::ClassTemplateSpecializationDecl>(named) &&
-        !tagDecl->getDefinition()) {
+        !tagDecl->getDefinition() &&
+        !(isa<clang::RecordDecl>(tagDecl) &&
+          hasImportAsRefAttr(cast<clang::RecordDecl>(tagDecl)))) {
       return;
     }
   }

--- a/test/Interop/Cxx/foreign-reference/Inputs/ReferenceCounted.apinotes
+++ b/test/Interop/Cxx/foreign-reference/Inputs/ReferenceCounted.apinotes
@@ -1,0 +1,8 @@
+---
+Name: ReferenceCounted
+Tags:
+- Name: OpaqueRefImpl
+  SwiftImportAs: reference
+  SwiftRetainOp: OPRetain
+  SwiftReleaseOp: OPRelease
+

--- a/test/Interop/Cxx/foreign-reference/Inputs/incomplete.c
+++ b/test/Interop/Cxx/foreign-reference/Inputs/incomplete.c
@@ -1,0 +1,55 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "reference-counted.h"
+
+typedef struct IncompleteImpl {
+  unsigned refCount;
+  double weight;
+} *Incomplete;
+
+
+Incomplete Incomplete_create(double weight) {
+  Incomplete result = (Incomplete)malloc(sizeof(struct IncompleteImpl));
+  result->refCount = 1;
+  result->weight = weight;
+  return result;
+}
+
+void INRetain(Incomplete i) {
+  i->refCount++;
+}
+
+void INRelease(Incomplete i) {
+  i->refCount--;
+  if (i->refCount == 0) {
+    printf("Destroyed instance containing weight %f\n", i->weight);
+    free(i);
+  }
+}
+
+double Incomplete_getWeight(Incomplete i) {
+  return i->weight;
+}
+
+struct OpaqueRefImpl {
+  unsigned refCount;
+};
+
+OpaqueRef Opaque_create(void) {
+  OpaqueRef result = (OpaqueRef)malloc(sizeof(struct OpaqueRefImpl));
+  result->refCount = 1;
+  return result;
+}
+
+void OPRetain(OpaqueRef i) {
+  i->refCount++;
+}
+
+void OPRelease(OpaqueRef i) {
+  i->refCount--;
+  if (i->refCount == 0) {
+    printf("Destroyed OpaqueRef instance\n");
+    free(i);
+  }
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -35,7 +35,6 @@ module WitnessTable {
 
 module ReferenceCounted {
   header "reference-counted.h"
-  requires cplusplus
 }
 
 module ReferenceCountedObjCProperty {

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -2,13 +2,18 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_REFERENCE_COUNTED_H
 
 #include <stdlib.h>
+
+#ifdef __cplusplus
 #include <new>
+#endif
 
 #include "visibility.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 static int finalLocalRefCount = 100;
+
+#ifdef __cplusplus
 
 namespace NS {
 
@@ -63,6 +68,30 @@ GlobalCountNullableInit {
 
 inline void GCRetainNullableInit(GlobalCountNullableInit *x) { globalCount++; }
 inline void GCReleaseNullableInit(GlobalCountNullableInit *x) { globalCount--; }
+#endif
+
+typedef struct __attribute__((swift_attr("import_as_ref")))
+__attribute__((swift_attr("retain:INRetain")))
+__attribute__((swift_attr("release:INRelease"))) IncompleteImpl *Incomplete;
+
+typedef struct OpaqueRefImpl *OpaqueRef;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Incomplete Incomplete_create(double weight) __attribute__((swift_attr("returns_retained"))) __attribute__((swift_name("IncompleteImpl.init(weight:)")));
+void INRetain(Incomplete i);
+void INRelease(Incomplete i);
+double Incomplete_getWeight(Incomplete i) __attribute__((swift_name("getter:IncompleteImpl.weight(self:)")));
+
+OpaqueRef Opaque_create(void);
+void OPRetain(OpaqueRef i);
+void OPRelease(OpaqueRef i);
+
+#ifdef __cplusplus
+}
+#endif
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -13,9 +13,6 @@
 
 // REQUIRES: executable_test
 
-// https://github.com/swiftlang/swift/issues/82643
-// XFAIL: OS=windows-msvc
-
 import ReferenceCounted
 
 func testIncomplete() {

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -x c -c %S/Inputs/incomplete.c -I %S/Inputs -o %t/incomplete-c.o
+
+// Build with C interoperatibility
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/incomplete %t/incomplete-c.o
+// RUN: %target-codesign %t/incomplete
+// RUN: %target-run %t/incomplete | %FileCheck %s
+
+// Build with C++ interoperability
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/incomplete %t/incomplete-c.o -Xfrontend -cxx-interoperability-mode=default
+// RUN: %target-codesign %t/incomplete
+// RUN: %target-run %t/incomplete | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import ReferenceCounted
+
+func testIncomplete() {
+  do {
+    let i = Incomplete(weight: 3.14159)
+    // CHECK: Incomplete weight = 3.14159
+    print("Incomplete weight = \(i.weight)")
+
+    // Instance destroyed at the end
+  }
+
+  // CHECK: Destroyed instance containing weight 3.14159
+}
+
+func testOpaqueRef() {
+  // CHECK: Creating OpaqueRef
+  print("Creating OpaqueRef")
+  let opaque = Opaque_create()
+  let opaque2 = opaque
+  _ = opaque
+  _ = opaque2
+  // let it go out of scope
+
+  // CHECK: Destroyed OpaqueRef instance
+  // CHECK-NOT: Destroyed OpaqueRef instance
+}
+
+testIncomplete()
+testOpaqueRef()
+
+// CHECK: DONE
+print("DONE")

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -13,6 +13,9 @@
 
 // REQUIRES: executable_test
 
+// https://github.com/swiftlang/swift/issues/82643
+// XFAIL: OS=windows-msvc
+
 import ReferenceCounted
 
 func testIncomplete() {


### PR DESCRIPTION
Normally, Swift cannot import an incomplete type. However, when we are importing a SWIFT_SHARED_REFERENCE type, we're always dealing with pointers to the type, and there is no need for the underlying type to be complete. This permits a common pattern in C libraries where the actual underlying storage is opaque and all APIs traffic in the pointer, e.g.,

    typedef struct MyTypeImpl *MyType;
    void MyTypeRetain(MyType ptr);
    void MyTypeRelease(MyType ptr);

to use SWIFT_SHARED_REFERENCE to import such types as foreign references, rather than as OpaquePointer.

Fixes rdar://155970441.