### PR TITLE
[Concurrency] Only apply default main actor to local and nested decls that are in a main actor isolated context.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6083,9 +6083,22 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     auto globalActorHelper = [&](Type globalActor)
         -> std::optional<std::tuple<InferredActorIsolation, ValueDecl *,
                                     std::optional<ActorIsolation>>> {
-      // Default global actor isolation does not apply to any declarations
-      // within actors and distributed actors, nor does it apply in a
-      // nonisolated type.
+      // Default main actor only applies to top-level declarations and
+      // in contexts that are also main actor isolated. It does not apply
+      // in {distributed} actor-isolated contexts nor in nonisolated
+      // contexts.
+
+      // Local declarations must check the isolation of their
+      // decl context.
+      if (value->getDeclContext()->isLocalContext()) {
+        auto contextIsolation =
+            getActorIsolationOfContext(value->getDeclContext());
+        if (!contextIsolation.isMainActor())
+          return {};
+      }
+
+      // Members and nested types must check the isolation of the enclosing
+      // nominal type.
       auto *dc = value->getInnermostDeclContext();
       while (dc) {
         if (auto *nominal = dc->getSelfNominalTypeDecl()) {
@@ -6093,18 +6106,10 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
             return {};
 
           if (dc != dyn_cast<DeclContext>(value)) {
-            switch (getActorIsolation(nominal)) {
-            case ActorIsolation::Unspecified:
-            case ActorIsolation::ActorInstance:
-            case ActorIsolation::Nonisolated:
-            case ActorIsolation::NonisolatedUnsafe:
-            case ActorIsolation::Erased:
-            case ActorIsolation::CallerIsolationInheriting:
-              return {};
-
-            case ActorIsolation::GlobalActor:
+            if (getActorIsolation(nominal).isMainActor())
               break;
-            }
+
+            return {};
           }
         }
         dc = dc->getParent();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6088,9 +6088,16 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       // in {distributed} actor-isolated contexts nor in nonisolated
       // contexts.
 
-      // Local declarations must check the isolation of their
-      // decl context.
       if (value->getDeclContext()->isLocalContext()) {
+        // Local storage is always nonisolated; region isolation computes
+        // whether the value is in an actor-isolated region based on
+        // the initializer expression.
+        auto *var = dyn_cast<VarDecl>(value);
+        if (var && var->hasStorage())
+          return {};
+
+        // Other local declarations must check the isolation of their
+        // decl context.
         auto contextIsolation =
             getActorIsolationOfContext(value->getDeclContext());
         if (!contextIsolation.isMainActor())

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -276,7 +276,13 @@ class CustomActorIsolated {
 
 var global = 0
 
-func onMain() {
+func onMain() async {
+  await withTaskGroup { group in
+    group.addTask { }
+
+    await group.next()
+  }
+
   struct Nested {
     // CHECK: // static useGlobal() in Nested #1 in onMain()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -244,3 +244,46 @@ struct S: P {
   }
   static let at = AT() // used to fail here
 }
+
+nonisolated func localDeclIsolation() async {
+  struct Local {
+    static func f() {}
+  }
+
+  Local.f()
+
+  await withTaskGroup { group in
+    group.addTask { }
+
+    await group.next()
+  }
+}
+
+@CustomActor
+class CustomActorIsolated {
+  struct Nested {
+    // CHECK: // static CustomActorIsolated.Nested.f()
+    // CHECK-NEXT: // Isolation: unspecified
+    static func f() {}
+  }
+
+  // CHECK: // CustomActorIsolated.customIsolated()
+  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  func customIsolated() {
+    Nested.f()
+  }
+}
+
+var global = 0
+
+func onMain() {
+  struct Nested {
+    // CHECK: // static useGlobal() in Nested #1 in onMain()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    static func useGlobal() -> Int {
+      global
+    }
+  }
+
+  _ = Nested.useGlobal()
+}


### PR DESCRIPTION
This prevents `@MainActor` from being inferred in a context where it cannot be used, while still allowing main actor code to be used in local contexts that are also main actor isolated.

This is an alternative fix to https://github.com/swiftlang/swift/pull/83166 that has slightly more nuanced semantics, but better matches the spirit of main actor by default mode. This applies the same defaulting rules to local declarations as nested declarations in main actor mode, and fixes an issue where `@MainActor` was inferred for declarations nested in other-global-actor-isolated contexts.

Resolves: rdar://153561279