### PR TITLE
[ASTVerifier] Allow `inout` and `Array` to pointer conversion in vari…

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1897,6 +1897,18 @@ public:
           continue;
         }
 
+        // If the argument is a concrete variadic expansion, let's check its
+        // every element.
+        if (auto *variadicExpansion = dyn_cast<VarargExpansionExpr>(subExpr)) {
+          if (auto *implicitArray =
+                  dyn_cast<ArrayExpr>(variadicExpansion->getSubExpr())) {
+            for (auto *element : implicitArray->getElements()) {
+              maybeRecordValidPointerConversionForArg(element);
+            }
+            return;
+          }
+        }
+
         break;
       }
 

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -481,3 +481,21 @@ public struct RefObj {
 public func objectFieldToPointer(rc: RefObj) {
   takeObjectPointer(&rc.o.object)
 }
+
+// CHECK-LABEL: sil [ossa] @$s18pointer_conversion21testVariadicParameter1aySaySiGz_tF : $@convention(thin) (@inout Array<Int>) -> ()
+// CHECK: [[ARRAY_REF:%.*]] = begin_access [modify] [unknown] %0 : $*Array<Int>
+// CHECK: [[CONVERT_ARRAY_TO_POINTER:%.*]] = function_ref @$ss37_convertMutableArrayToPointerArgumentyyXlSg_q_tSayxGzs01_E0R_r0_lF
+// CHECK: apply [[CONVERT_ARRAY_TO_POINTER]]<Int, UnsafeMutableRawPointer>({{.*}}, [[ARRAY_REF]])
+// CHECK: [[V_REF:%.*]] = begin_access [modify] [unknown] %28 : $*Double
+// CHECK: [[DOUBLE_AS_PTR:%.*]] = address_to_pointer [stack_protection] [[V_REF]] : $*Double to $Builtin.RawPointer
+// CHECK: [[INOUT_TO_PTR:%.*]] = function_ref @$ss30_convertInOutToPointerArgumentyxBps01_E0RzlF
+// CHECK: apply [[INOUT_TO_PTR]]<UnsafeMutableRawPointer>(%39, [[DOUBLE_AS_PTR]])
+// CHECK: } // end sil function '$s18pointer_conversion21testVariadicParameter1aySaySiGz_tF'
+public func testVariadicParameter(a: inout [Int]) {
+  func test(_ : UnsafeMutableRawPointer?...) {}
+
+  test(&a)
+
+  var v: Double
+  test(&v)
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-73454.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-73454.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/73454
+
+func object_method_bind_ptrcall_v(
+  _: UnsafeMutableRawPointer?...
+) {
+}
+
+func setDensity(_ density: Double, ptr: UnsafeMutableRawPointer) {
+  var copy_density = density
+  var arr: [Int] = []
+
+  object_method_bind_ptrcall_v(&copy_density)
+  object_method_bind_ptrcall_v(&arr)
+
+  object_method_bind_ptrcall_v(&arr, &copy_density)
+
+  object_method_bind_ptrcall_v(ptr, &copy_density, &arr)
+  object_method_bind_ptrcall_v(&copy_density, ptr, &arr)
+}

--- a/validation-test/compiler_crashers_2_fixed/2ae771dc466f1acc.swift
+++ b/validation-test/compiler_crashers_2_fixed/2ae771dc466f1acc.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"f0cca09d","signature":"swift::ASTWalker::PostWalkResult<swift::ArrayToPointerExpr*> (anonymous namespace)::Verifier::dispatchVisitPost<swift::ArrayToPointerExpr*>(swift::ArrayToPointerExpr*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: %target-typecheck-verify-swift
 struct a {
   var b: String
 }


### PR DESCRIPTION
…adic parameter positions

Fixes a verifier crash that prevented use of valid conversions.

Resolves: https://github.com/apple/swift/issues/73454
Resolves: rdar://128109889

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
