### PR TITLE
[NFC] Stack allocate buffer in readRemoteAddressImpl instead of malloc

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -349,26 +349,21 @@ protected:
                                      std::size_t integerSize) {
     assert((integerSize == 4 || integerSize == 8) &&
            "Only 32 or 64 bit architectures are supported!");
-    auto Buf = std::malloc(integerSize);
-    if (!Buf)
-      return false;
-
-    // Free Buf when this function return.
-    ReadBytesResult Result(
-        Buf, [](const void *ptr) { free(const_cast<void *>(ptr)); });
-    if (!readBytes(address, reinterpret_cast<uint8_t *>(Buf), integerSize))
-      return false;
-
-    if (integerSize == 4)
-      out = RemoteAddress(*reinterpret_cast<uint32_t *>(Buf),
-                          address.getAddressSpace());
-    else if (integerSize == 8)
-      out = RemoteAddress(*reinterpret_cast<uint64_t *>(Buf),
-                          address.getAddressSpace());
-    else
-      return false;
-
-    return true;
+    if (integerSize == 4) {
+      uint32_t buf;
+      if (!readBytes(address, reinterpret_cast<uint8_t *>(&buf), integerSize))
+        return false;
+      out = RemoteAddress(buf, address.getAddressSpace());
+      return true;
+    }
+    if (integerSize == 8) {
+      uint64_t buf;
+      if (!readBytes(address, reinterpret_cast<uint8_t *>(&buf), integerSize))
+        return false;
+      out = RemoteAddress(buf, address.getAddressSpace());
+      return true;
+    }
+    return false;
   }
 };
 


### PR DESCRIPTION
Since this is only 4 or 8 bytes, it makes more sense (and is more readable) to stack allocate the buffer instead of mallocking it.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
