### PR TITLE
Add linker flag for compatibility with Android 15+ devices using 16KB memory pages

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2504,6 +2504,8 @@ function(add_swift_target_library name)
         list(APPEND swiftlib_link_flags_all "-shared")
         # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
         list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")
+        # Ensure compatibility with Android 15+ devices using 16KB memory pages.
+        list(APPEND swiftlib_link_flags_all "-Wl,-z,max-page-size=16384")
       endif()
 
       if (SWIFTLIB_BACK_DEPLOYMENT_LIBRARY)


### PR DESCRIPTION
This PR adds a linker flag to the Android build that will enable the libraries to be loaded on devices using 16KB memory pages. It is backwards-compatible with non-16KB devices. Without this flag, any attempt to load shared object files on a 16KB device will cause a crash.

For more details, see https://source.android.com/docs/core/architecture/16kb-page-size/16kb
