### PR TITLE
[Concurrency]: call AsyncStream's onCancel at most once

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -336,19 +336,11 @@ public struct AsyncStream<Element> {
     unfolding produce: @escaping @Sendable () async -> Element?,
     onCancel: (@Sendable () -> Void)? = nil
   ) {
-    let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>
-      = .create(produce)
+    let storage: _AsyncStreamCriticalStorage<_UnfoldingState?>
+      = .create(.init(produce: produce, onCancel: onCancel))
+
     context = _Context {
-      return await withTaskCancellationHandler {
-        guard let result = await storage.value?() else {
-          storage.value = nil
-          return nil
-        }
-        return result
-      } onCancel: {
-        storage.value = nil
-        onCancel?()
-      }
+      await _asyncStreamUnfold(from: storage)
     }
   }
 }

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -538,6 +538,50 @@ extension AsyncThrowingStream {
   }
 }
 
+// MARK: init(unfolding:) Support
+
+internal struct _AsyncStreamUnfoldingState<Element, Failure: Error> {
+  var produce: @Sendable () async throws(Failure) -> Element?
+  var onCancel: (@Sendable () -> Void)?
+}
+
+extension AsyncStream {
+  internal typealias _UnfoldingState = _AsyncStreamUnfoldingState<Element, Never>
+}
+
+extension AsyncThrowingStream where Failure == any Error {
+  internal typealias _UnfoldingState = _AsyncStreamUnfoldingState<Element, Failure>
+}
+
+nonisolated(nonsending)
+internal func _asyncStreamUnfold<Element, Failure: Error>(
+  from storage: _AsyncStreamCriticalStorage<_AsyncStreamUnfoldingState<Element, Failure>?>
+) async throws(Failure) -> Element? {
+  try await withTaskCancellationHandler { () async throws(Failure) -> Element? in
+    do throws(Failure) {
+      // TODO: why can't we return { $0?.produce } here?
+      // currently produces an error about runtime typed throws support...
+      guard let produce = storage.withLock({ $0 })?.produce else {
+        // Stream already finished.
+        return nil
+      }
+
+      guard let next = try await produce() else {
+        // Stream ended. Drop storage outside the lock.
+        _ = storage.withLock { $0.take() }
+        return nil
+      }
+      return next
+    } catch {
+      _ = storage.withLock { $0.take() }
+      throw error
+    }
+  } onCancel: {
+    let state = storage.withLock { $0.take() }
+    state?.onCancel?()
+  }
+}
+
 // this is used to store closures; which are two words
 final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
   var _value: Contents
@@ -557,21 +601,10 @@ final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
     unsafe _unlock(ptr)
   }
 
-  var value: Contents {
-    get {
-      lock()
-      let contents = _value
-      unlock()
-      return contents
-    }
-
-    set {
-      lock()
-      withExtendedLifetime(_value) {
-        _value = newValue
-        unlock()
-      }
-    }
+  internal func withLock<T>(_ body: (inout Contents) -> T) -> T {
+    self.lock()
+    defer { self.unlock() }
+    return body(&_value)
   }
 
   static func create(_ initial: Contents) -> _AsyncStreamCriticalStorage {

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -373,18 +373,13 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   public init(
     unfolding produce: @escaping @Sendable () async throws -> Element?
   ) where Failure == Error {
-    let storage: _AsyncStreamCriticalStorage<Optional<() async throws -> Element?>>
-      = .create(produce)
+    // FIXME: this should have a cancel handler
+    // https://github.com/swiftlang/swift/issues/77974
+    let storage: _AsyncStreamCriticalStorage<_UnfoldingState?>
+      = .create(.init(produce: produce))
+
     context = _Context {
-      return try await withTaskCancellationHandler {
-        guard let result = try await storage.value?() else {
-          storage.value = nil
-          return nil
-        }
-        return result
-      } onCancel: {
-        storage.value = nil
-      }
+      try await _asyncStreamUnfold(from: storage)
     }
   }
 }

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -489,6 +489,53 @@ class NotSendable {}
         _ = await consumer2.value
       }
 
+      // MARK: - Unfolding
+
+      tests.test("unfolding stream calls onCancel at most once") { @MainActor in
+        nonisolated(unsafe) var cancelCallbackCount = 0
+
+        var proceedOnCancelIter = AsyncStream<Void>{ _ in }.makeAsyncIterator()
+        let (controlStream, controlContinuation) = AsyncStream<String>.makeStream()
+        var controlIter = controlStream.makeAsyncIterator()
+
+        let task = Task { @MainActor in
+          let stream = AsyncStream<Int> { @MainActor in
+            controlContinuation.yield("started")
+            expectFalse(Task.isCancelled)
+            _ = await proceedOnCancelIter.next()
+            expectTrue(Task.isCancelled) // should be cancelled when we reach here
+            return 42
+          } onCancel: {
+            cancelCallbackCount += 1
+          }
+
+          var results = [Int]()
+          for await i in stream { results.append(i) }
+          return results
+        }
+
+        // wait for unfolding closure to start
+        do {
+          let next = await controlIter.next()
+          expectEqual(next, "started")
+        }
+
+        // cancel task
+        task.cancel()
+
+        // cancel callback should be invoked
+        expectEqual(cancelCallbackCount, 1)
+
+        // ensure task completes
+        let results = await task.value
+        expectEqual(results, [42])
+
+        // ensure the cancel callback wasn't invoked again
+        expectEqual(cancelCallbackCount, 1)
+      }
+
+      // MARK: -
+
       await runAllTestsAsync()
     }
   }


### PR DESCRIPTION
This change adds logic to prevent cases in which an AsyncStream created with the init(unfolding:onCancel:) initializer could cause the onCancel callback to be invoked more than one time.

resolves: https://github.com/swiftlang/swift/issues/83137
