### PR TITLE
Remove some redundant `unsafe` markings

### DIFF
--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -415,7 +415,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 
       unsafe unmanagedObjects[i] = unsafe _key(at: bucket, bridgedKeys: bridgedKeys)
       stored += 1
-      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -160,7 +160,7 @@ extension _NativeDictionary {
         target = b
       } else {
         let hashValue = unsafe self.hashValue(for: _keys[bucket.offset])
-        unsafe target = unsafe hashTable.insertNew(hashValue: hashValue)
+        target = unsafe hashTable.insertNew(hashValue: hashValue)
       }
 
       if target > bucket {

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -249,7 +249,7 @@ extension __RawDictionaryStorage {
         if unsafe uncheckedKey(at: bucket) == key {
           return (bucket, true)
         }
-        unsafe bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
+        bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
       }
       return (bucket, false)
   }
@@ -364,7 +364,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
       unsafe unmanagedObjects[i] = _bridgeAnythingToObjectiveC(key)
 
       stored += 1
-      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -148,7 +148,7 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(word: Int, bit: Int) {
-      unsafe self.offset = unsafe _UnsafeBitset.join(word: word, bit: bit)
+      self.offset = unsafe _UnsafeBitset.join(word: word, bit: bit)
     }
 
     @inlinable
@@ -501,7 +501,7 @@ extension _HashTable {
         delegate.moveEntry(from: candidate, to: hole)
         hole = candidate
       }
-      unsafe candidate = unsafe self.bucket(wrappedAfter: candidate)
+      candidate = unsafe self.bucket(wrappedAfter: candidate)
     }
 
     unsafe words[hole.word].uncheckedRemove(hole.bit)

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3308,7 +3308,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
         unsafe _resolveRelativeIndirectableAddress(descriptorBase, descriptorOffset)
       let descriptorHeader: RawKeyPathComponent.Header
       if unsafe descriptor != UnsafeRawPointer(bitPattern: 0) {
-        unsafe descriptorHeader = unsafe descriptor.load(as: RawKeyPathComponent.Header.self)
+        descriptorHeader = unsafe descriptor.load(as: RawKeyPathComponent.Header.self)
         if descriptorHeader.isTrivialPropertyDescriptor {
           // If the descriptor is trivial, then use the local candidate.
           // Skip the external generic parameter accessors to get to it.

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -177,7 +177,7 @@ extension _NativeSet { // Low-level lookup operations
       if unsafe uncheckedElement(at: bucket) == element {
         return (bucket, true)
       }
-      unsafe bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
+      bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
     }
     return (bucket, false)
   }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -279,7 +279,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       if bucket == endBucket { break }
       unsafe unmanagedObjects[i] = unsafe bridgedElements[bucket]
       stored += 1
-      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -293,7 +293,7 @@ final internal class _SetStorage<Element: Hashable>
       let element = unsafe _elements[bucket.offset]
       unsafe unmanagedObjects[i] = _bridgeAnythingToObjectiveC(element)
       stored += 1
-      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState


### PR DESCRIPTION
We were getting warnings about these; remove them to cut down on noise.