### PR TITLE
[6.2][wasm] Build and install XCTest for Wasm Swift SDK

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -203,8 +203,7 @@ class WasmSwiftSDK(product.Product):
         xctest.cmake_options.define('BUILD_SHARED_LIBS', 'FALSE')
 
         xctest.build_with_cmake([], self.args.build_variant, [],
-                                prefer_native_toolchain=True,
-                                ignore_extra_cmake_options=True)
+                                prefer_native_toolchain=True)
         dest_dir = self._target_package_path(swift_host_triple)
         with shell.pushd(xctest.build_dir):
             shell.call([self.toolchain.cmake, '--install', '.', '--prefix', '/usr'],


### PR DESCRIPTION
- **Explanation**: Install static XCTest library and its Swift module files into Swift SDK for Wasm
- **Scope**: Narrow, only affects Wasm Swift SDK.
- **Original PRs**: https://github.com/swiftlang/swift/pull/83191
- **Risk**: Low, just a change to Wasm Swift SDK
- **Testing**: CI
- **Reviewers**: @MaxDesiatov 
