### PR TITLE
🍒 [6.2][windows][lldb] fix incorrect LLVM_HOST_TRIPLE when cross-compiling

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1750,7 +1750,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     LLVM_CONFIG_PATH = (Join-Path -Path $BuildTools -ChildPath "llvm-config.exe");
     LLVM_ENABLE_ASSERTIONS = $(if ($Variant -eq "Asserts") { "YES" } else { "NO" })
     LLVM_EXTERNAL_SWIFT_SOURCE_DIR = "$SourceCache\swift";
-    LLVM_HOST_TRIPLE = $BuildPlatform.Triple;
+    LLVM_HOST_TRIPLE = $Platform.Triple;
     LLVM_NATIVE_TOOL_DIR = $BuildTools;
     LLVM_TABLEGEN = (Join-Path $BuildTools -ChildPath "llvm-tblgen.exe");
     LLVM_USE_HOST_TOOLS = "NO";


### PR DESCRIPTION
- **Explanation**:
`LLVM_HOST_TRIPLE` does not have the correct value when cross compiling on Windows. This patch fixes the issue.
- **Scope**:
This change fixes an issue in the build script.
- **Issues**:

- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/83061
- **Risk**:
Low, this only sets the correct value in the build script. The x64 build has been building with the correct triple for over a year now. This only affects Windows.
- **Testing**:
Built at desk on an x64 machine cross compiling to ARM, then tested the toolchain on an ARM Windows VM.
- **Reviewers**:
  - @compnerd 