### PR TITLE
wasmswiftsdk.py: consistently apply `build_runtime_with_host_compiler`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -130,7 +130,7 @@ class WasmSwiftSDK(product.Product):
         libxml2.cmake_options.define('HAVE_PTHREAD_H', cmake_thread_enabled)
 
         libxml2.build_with_cmake([], self.args.build_variant, [],
-                                 prefer_native_toolchain=True,
+                                 prefer_native_toolchain=not self.args.build_runtime_with_host_compiler,
                                  ignore_extra_cmake_options=True)
         with shell.pushd(libxml2.build_dir):
             shell.call([self.toolchain.cmake, '--install', '.', '--prefix', '/', '--component', 'development'],
@@ -159,7 +159,7 @@ class WasmSwiftSDK(product.Product):
         foundation.cmake_options.define('LIBXML2_LIBRARY', os.path.join(wasi_sysroot, 'lib'))
 
         foundation.build_with_cmake([], self.args.build_variant, [],
-                                    prefer_native_toolchain=True,
+                                    prefer_native_toolchain=not self.args.build_runtime_with_host_compiler,
                                     ignore_extra_cmake_options=True)
 
         dest_dir = self._target_package_path(swift_host_triple)
@@ -186,7 +186,7 @@ class WasmSwiftSDK(product.Product):
         swift_testing.cmake_options.define('SwiftTesting_MACRO', 'NO')
 
         swift_testing.build_with_cmake([], self.args.build_variant, [],
-                                       prefer_native_toolchain=True,
+                                       prefer_native_toolchain=not self.args.build_runtime_with_host_compiler,
                                        ignore_extra_cmake_options=True)
         dest_dir = self._target_package_path(swift_host_triple)
         with shell.pushd(swift_testing.build_dir):
@@ -206,7 +206,7 @@ class WasmSwiftSDK(product.Product):
         xctest.cmake_options.define('BUILD_SHARED_LIBS', 'FALSE')
 
         xctest.build_with_cmake([], self.args.build_variant, [],
-                                prefer_native_toolchain=True,
+                                prefer_native_toolchain=not self.args.build_runtime_with_host_compiler,
                                 ignore_extra_cmake_options=True)
         dest_dir = self._target_package_path(swift_host_triple)
         with shell.pushd(xctest.build_dir):

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -72,13 +72,14 @@ class WasmSwiftSDK(product.Product):
         cmake_options.define('CMAKE_CXX_COMPILER_FORCED', 'TRUE')
         cmake_options.define('CMAKE_BUILD_TYPE', self.args.build_variant)
 
-        # Explicitly choose ar and ranlib from just-built LLVM tools since tools in the host system
-        # unlikely support Wasm object format.
-        native_toolchain_path = self.native_toolchain_path(self.args.host_target)
-        cmake_options.define('CMAKE_AR', os.path.join(
-            native_toolchain_path, 'bin', 'llvm-ar'))
-        cmake_options.define('CMAKE_RANLIB', os.path.join(
-            native_toolchain_path, 'bin', 'llvm-ranlib'))
+        if not self.args.build_runtime_with_host_compiler:
+            # Explicitly choose ar and ranlib from just-built LLVM tools since tools in the host system
+            # unlikely support Wasm object format.
+            native_toolchain_path = self.native_toolchain_path(self.args.host_target)
+            cmake_options.define('CMAKE_AR', os.path.join(
+                native_toolchain_path, 'bin', 'llvm-ar'))
+            cmake_options.define('CMAKE_RANLIB', os.path.join(
+                native_toolchain_path, 'bin', 'llvm-ranlib'))
 
     def _build_libxml2(self, swift_host_triple, has_pthread, wasi_sysroot):
         libxml2 = CMakeProduct(


### PR DESCRIPTION
Following up on https://github.com/swiftlang/swift/pull/83134 https://github.com/swiftlang/swift/pull/82949 https://github.com/swiftlang/swift/pull/82946 https://github.com/swiftlang/swift/pull/82944.

With these changes I'm able to quickly build and test only Wasm Swift SDK without rebuilding the whole toolchain when latest development snapshot is installed, using this invocation:

```
./swift/utils/build-script --skip-build-benchmarks --release --skip-early-swift-driver \
  --skip-build-lldb --skip-build-cmark --skip-build-llvm --skip-build-swift \
  --build-runtime-with-host-compiler --build-wasm-stdlib 
```

Timing on M4 MacBook Pro:

```
--- Build Script Analyzer ---
Build Percentage         Build Duration (sec)    Build Phase
================         ====================    ===========
43.6%                    257.75                  Building wasmswiftsdk
20.6%                    121.91                  Building wasmthreadsstdlib
20.6%                    121.78                  Building wasmstdlib
5.4%                     32.03                   Building wasmllvmruntimelibs
3.6%                     21.39                   Running tests for wasmthreadsstdlib
3.5%                     20.91                   Running tests for wasmstdlib
2.7%                     15.74                   Building wasilibc
0.0%                     0.04                    macosx-arm64-extractsymbols
0.0%                     0.04                    macosx-arm64-package
0.0%                     0.03                    merged-hosts-lipo-core
0.0%                     0.03                    merged-hosts-lipo
Total Duration: 591.65 seconds (9m 51s)
``` 