### PR TITLE
[Concurrency] InferSendableFromCaptures: Rework check to delay lookup

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar143586718.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar143586718.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// rdar://143586718 - crash due to lookup not delayed on partially resolved base with Sendable requirements
+
+_ = { () -> Array? in .max }
+// expected-error@-1 {{unable to infer closure type without a type annotation}}


### PR DESCRIPTION
The current implementation of the check accounts only for the overload choices present in the initial lookup but for some situations, like bridged or optional base types, `performMemberLookup` uses a secondary lookup as well, results of which are ignored.

Let's fold the check into `addChoice` instead and set the the flag there to make sure that all of the choices are considered.

Resolves: rdar://143586718

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
