### PR TITLE
[6.2] Use unsigned arithmetic for Span bounds checks

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -290,12 +290,18 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     unsafeAddress {
-      _precondition(indices.contains(position), "index out of bounds")
+      _precondition(
+        UInt(bitPattern: position) < UInt(bitPattern: _count),
+        "Index out of bounds"
+      )
       return unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: position))
     }
     @lifetime(self: copy self)
     unsafeMutableAddress {
-      _precondition(indices.contains(position), "index out of bounds")
+      _precondition(
+        UInt(bitPattern: position) < UInt(bitPattern: _count),
+        "Index out of bounds"
+      )
        return unsafe _unsafeAddressOfElement(unchecked: position)
     }
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -419,7 +419,10 @@ extension Span where Element: ~Copyable {
   @inline(__always)
   @_alwaysEmitIntoClient
   internal func _checkIndex(_ position: Index) {
-    _precondition(indices.contains(position), "Index out of bounds")
+    _precondition(
+      UInt(bitPattern: position) < UInt(bitPattern: _count),
+      "Index out of bounds"
+    )
   }
 
   /// Accesses the element at the specified position in the `Span`.


### PR DESCRIPTION
This allows us to eliminate a comparison; https://github.com/swiftlang/swift/pull/83172 will allow the compiler to do it for us instead in the future.

**Explanation:** Changes the implementation of Span's subscript bounds checks to use a single unsigned comparison instead of two signed compares.
**Scope:** Narrow. Does not apply to any other API.
**Issues:** rdar://156068535 
**Original PRs:** https://github.com/swiftlang/swift/pull/83150
**Risk:** Low. Minor implementation tweaks to API that is not widely adopted.
**Testing:** CI
**Reviewers:** @glessard @meg-gupta