### PR TITLE
[cxx-interop] Use the correct access for synthesized setterDecl

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -132,7 +132,7 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   setterDecl->setIsDynamic(false);
   if (!isa<ClassDecl>(importedDecl))
     setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-  setterDecl->setAccess(importedFieldDecl->getFormalAccess());
+  setterDecl->setAccess(importedFieldDecl->getSetterFormalAccess());
 
   return setterDecl;
 }

--- a/test/Interop/Cxx/union/anonymous-union-const-member.swift
+++ b/test/Interop/Cxx/union/anonymous-union-const-member.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend   -typecheck -verify -I %t/Inputs %t/main.swift
+// RUN: %target-swiftxx-frontend -typecheck -verify -I %t/Inputs %t/main.swift
+
+// Import an anonymous union with const and non-const members. Constant members
+// appear within Foo as clang::IndirectFieldDecl and should be imported in Swift
+// as computed properties with private setters (since it is possible to change
+// the values of const members in C/C++).
+
+//--- Inputs/module.modulemap
+module CxxModule { header "header.h" }
+
+//--- Inputs/header.h
+#pragma once
+
+struct Foo {
+  union {
+    const int constant;
+    int variable;
+  };
+};
+
+//--- main.swift
+import CxxModule
+
+func fooer(_ f: inout Foo) {
+  let _ = f.variable
+  let _ = f.constant
+  f.variable = 42
+  // f.constant = 42 // FIXME: this should not work (but currently does)
+}


### PR DESCRIPTION
Not setting this correctly can lead to an assertion failure in the AST verifier:

    AbstractStorageDecl's setter access is out of sync with the access actually on the setter

Fixes #82637

rdar://154685710
