### PR TITLE
[cxx-interop] Import const-qualified indirect fields with private setters

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3437,6 +3437,12 @@ namespace {
       result->setInterfaceType(type);
       result->setIsObjC(false);
       result->setIsDynamic(false);
+      if (decl->getType().isConstQualified()) {
+        // Note that in C++ there are ways to change the values of const
+        // members, so we don't use WriteImplKind::Immutable storage.
+        assert(result->supportsMutation());
+        result->overwriteSetterAccess(AccessLevel::Private);
+      }
       Impl.recordImplicitUnwrapForDecl(result,
                                        importedType.isImplicitlyUnwrapped());
 

--- a/test/Interop/Cxx/union/anonymous-union-const-member.swift
+++ b/test/Interop/Cxx/union/anonymous-union-const-member.swift
@@ -28,5 +28,5 @@ func fooer(_ f: inout Foo) {
   let _ = f.variable
   let _ = f.constant
   f.variable = 42
-  // f.constant = 42 // FIXME: this should not work (but currently does)
+  f.constant = 42 // expected-error {{setter is inaccessible}}
 }


### PR DESCRIPTION
We already make imported computed properties' setters private in
VisitFieldDecl(), but not in VisitIndirectFieldDecl(), which handles
things like the members of an anonymous union in another struct.