### PR TITLE
Adopt `AvailabilityContext` in more places instead of `AvailabilityInference`

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -14,7 +14,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/AvailabilityInference.h"
+#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
@@ -1750,16 +1751,10 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
   if (ext == nullptr)
     return true;
 
-  if (ext->isUnavailable())
-    return false;
-
+  // Check whether the extension is always available relative to the deployment
+  // target.
   auto &ctx = getASTContext();
-
-  // FIXME: [availability] Query AvailabilityContext, not platform range.
-  AvailabilityRange conformanceAvailability{
-      AvailabilityInference::availableRange(ext)};
-
-  auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
-
-  return deploymentTarget.isContainedIn(conformanceAvailability);
+  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+  auto constraints = getAvailabilityConstraintsForDecl(ext, deploymentTarget);
+  return !constraints.getPrimaryConstraint();
 }

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -15,7 +15,7 @@
 #include "RValue.h"
 #include "Scope.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityInference.h"
+#include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -778,9 +778,9 @@ static bool isCheckExpectedExecutorIntrinsicAvailable(SILGenModule &SGM) {
   // in main-actor context.
   auto &C = checkExecutor->getASTContext();
   if (!C.LangOpts.DisableAvailabilityChecking) {
-    auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(C);
+    auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(C);
     auto declAvailability =
-        AvailabilityInference::availableRange(checkExecutor);
+        AvailabilityContext::forDeclSignature(checkExecutor);
     return deploymentAvailability.isContainedIn(declAvailability);
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -24,7 +24,6 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityDomain.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -3522,9 +3521,8 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
   if (decl->isUnavailable())
     return false;
 
-  // Warn on decls without an introduction version.
-  auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl);
-  return safeRangeUnderApprox.isAlwaysAvailable();
+  // Warn on decls without a platform introduction version.
+  return !decl->getAvailableAttrForPlatformIntroduction();
 }
 
 void swift::checkExplicitAvailability(Decl *decl) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -15,15 +15,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckConcurrency.h"
-#include "NonisolatedNonsendingByDefaultMigration.h"
 #include "MiscDiagnostics.h"
+#include "NonisolatedNonsendingByDefaultMigration.h"
 #include "TypeCheckDistributed.h"
 #include "TypeCheckInvertible.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTWalker.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Concurrency.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
@@ -1541,11 +1540,11 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
     canRemoveOldDecls = true;
   } else {
     // Check if the availability of nominal is high enough to be using the ExecutorJob version
-    AvailabilityRange requirementInfo =
-        AvailabilityInference::availableRange(moveOnlyEnqueueRequirement);
-    AvailabilityRange declInfo =
-        AvailabilityContext::forDeclSignature(nominal).getPlatformRange();
-    canRemoveOldDecls = declInfo.isContainedIn(requirementInfo);
+    auto requirementAvailability =
+        AvailabilityContext::forDeclSignature(moveOnlyEnqueueRequirement);
+    auto nominalAvailability = AvailabilityContext::forDeclSignature(nominal);
+    canRemoveOldDecls =
+        nominalAvailability.isContainedIn(requirementAvailability);
   }
 
   auto concurrencyModule = C.getLoadedModule(C.Id_Concurrency);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -33,7 +33,6 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -6433,12 +6432,11 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl) {
   // only statically initialize the Objective-C metadata when running on
   // a new-enough OS.
   if (classDecl->getParentSourceFile()) {
-    AvailabilityRange safeRangeUnderApprox{
-        AvailabilityInference::availableRange(classDecl)};
-    AvailabilityRange runningOSOverApprox =
+    auto classAvailability = AvailabilityContext::forDeclSignature(classDecl);
+    AvailabilityRange deploymentTarget =
         AvailabilityRange::forDeploymentTarget(ctx);
 
-    if (!runningOSOverApprox.isContainedIn(safeRangeUnderApprox))
+    if (!deploymentTarget.isContainedIn(classAvailability.getPlatformRange()))
       return;
   }
 

--- a/test/Profiler/unmapped.swift
+++ b/test/Profiler/unmapped.swift
@@ -47,6 +47,11 @@ struct TypeWithUnavailableMethods {
   func foo() -> Int {
     .random() ? 1 : 2
   }
+
+  @available(*, unavailable)
+  var qux: Int {
+    .random() ? 1 : 2
+  }
 }
 
 @available(*, unavailable)


### PR DESCRIPTION
The `AvailabilityContext` interfaces should be preferred over legacy `AvailabilityInference` interfaces since the former operates on all availability domains while the latter generally only operates on platform availability.