### PR TITLE
[C++ Interop] Deprecate Optional argument overloads of std.string initializer in Swift’s C++ Stdlib Overlay

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -35,7 +35,7 @@ extension std.string {
 
 
   @_alwaysEmitIntoClient
-  @available(*, unavailable, message: "Passing Optional String to the initializer of std::string is not supported. Please unwrap the value before passing to std.string()")
+  @available(*, unavailable, message: "initializing std::string with an optional String is not supported; unwrap the optional value before passing it to std.string()")
   public init(_ string: String?) {
       fatalError("This initializer is unavailable and should never be called.")
   }
@@ -54,7 +54,7 @@ extension std.string {
 
   @_alwaysEmitIntoClient
   @_disfavoredOverload
-  @available(*, deprecated, message: "Replaced by public init(_ string: UnsafePointer<CChar>) which takes a non-optional argument.")
+  @available(*, deprecated, message: "unwrap the optional value and use init(_ string: UnsafePointer<CChar>) instead")
   public init(_ string: UnsafePointer<CChar>?) {
     guard let str = unsafe string else {
       self.init()

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -54,7 +54,7 @@ extension std.string {
 
   @_alwaysEmitIntoClient
   @_disfavoredOverload
-  @available(*, deprecated, message: "Passing an optional C string pointer is discouraged. Use the non-nullable overload or wrap in a String first.")
+  @available(*, deprecated, message: "Replaced by public init(_ string: UnsafePointer<CChar>) which takes a non-optional argument.")
   public init(_ string: UnsafePointer<CChar>?) {
     if let str = unsafe string {
 #if os(Windows)

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -34,7 +34,24 @@ extension std.string {
   }
 
   @_alwaysEmitIntoClient
-  public init(_ string: UnsafePointer<CChar>?) {
+  public init(_ string: String?) {
+    if let s = string {
+      unsafe self = unsafe s.withCString(encodedAs: UTF8.self) { buffer in
+  #if os(Windows)
+        // Use the 2 parameter constructor.
+        unsafe std.string(buffer, s.utf8.count)
+  #else
+        unsafe std.string(buffer, s.utf8.count, .init())
+  #endif
+      }
+    } else {
+      // Initializes as empty std::string
+      self.init()
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public init(@_nonEphemeral _ string: UnsafePointer<CChar>?) {
     if let str = unsafe string {
 #if os(Windows)
       // Use the 2 parameter constructor.

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -56,18 +56,11 @@ extension std.string {
   @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by public init(_ string: UnsafePointer<CChar>) which takes a non-optional argument.")
   public init(_ string: UnsafePointer<CChar>?) {
-    if let str = unsafe string {
-#if os(Windows)
-      // Use the 2 parameter constructor.
-      // The MSVC standard library has a enable_if template guard
-      // on the 3 parameter constructor, and thus it's not imported into Swift.
-      unsafe self.init(str, UTF8._nullCodeUnitOffset(in: str))
-#else
-      unsafe self.init(str, UTF8._nullCodeUnitOffset(in: str), .init())
-#endif
-    } else {
+    guard let str = unsafe string else {
       self.init()
+      return
     }
+    self.init(str)
   }
 }
 

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -34,24 +34,14 @@ extension std.string {
   }
 
   @_alwaysEmitIntoClient
+  @available(*, unavailable, message: "Passing Optional String to the initializer of std::string is not supported. Please unwrap the value before passing to std.string()")
   public init(_ string: String?) {
-    if let s = string {
-      unsafe self = unsafe s.withCString(encodedAs: UTF8.self) { buffer in
-  #if os(Windows)
-        // Use the 2 parameter constructor.
-        unsafe std.string(buffer, s.utf8.count)
-  #else
-        unsafe std.string(buffer, s.utf8.count, .init())
-  #endif
-      }
-    } else {
-      // Initializes as empty std::string
-      self.init()
-    }
+      fatalError("This initializer is unavailable and should never be called.")
   }
 
   @_alwaysEmitIntoClient
-  public init(@_nonEphemeral _ string: UnsafePointer<CChar>?) {
+  @_disfavoredOverload
+  public init(_ string: UnsafePointer<CChar>?) {
     if let str = unsafe string {
 #if os(Windows)
       // Use the 2 parameter constructor.

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -33,6 +33,7 @@ extension std.string {
     }
   }
 
+
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Passing Optional String to the initializer of std::string is not supported. Please unwrap the value before passing to std.string()")
   public init(_ string: String?) {
@@ -40,7 +41,20 @@ extension std.string {
   }
 
   @_alwaysEmitIntoClient
+  public init(_ string: UnsafePointer<CChar>) {
+  #if os(Windows)
+      // Use the 2 parameter constructor.
+      // The MSVC standard library has a enable_if template guard
+      // on the 3 parameter constructor, and thus it's not imported into Swift.
+    unsafe self.init(string, UTF8._nullCodeUnitOffset(in: string))
+  #else
+    unsafe self.init(string, UTF8._nullCodeUnitOffset(in: string), .init())
+  #endif
+  }
+
+  @_alwaysEmitIntoClient
   @_disfavoredOverload
+  @available(*, deprecated, message: "Passing an optional C string pointer is discouraged. Use the non-nullable overload or wrap in a String first.")
   public init(_ string: UnsafePointer<CChar>?) {
     if let str = unsafe string {
 #if os(Windows)

--- a/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
@@ -1,5 +1,8 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 import CxxStdlib
 
-let tmp: String? = "üüüüüüü"
-let cppString = std.string(tmp) // expected-error {{'init(_:)' is unavailable: Passing Optional String to the initializer of std::string is not supported. Please unwrap the value before passing to std.string()}}
+let tmpOpt: String? = "üüüüüüü"
+let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: Passing an optional C string pointer is discouraged. Use the non-nullable overload or wrap in a String first.}}
+
+let tmpNonOpt: String = "üüüüüüü"
+let cppString2 = std.string(tmpNonOpt)

--- a/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
@@ -2,7 +2,7 @@
 import CxxStdlib
 
 let tmpOpt: String? = "üüüüüüü"
-let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: Replaced by public init(_ string: UnsafePointer<CChar>) which takes a non-optional argument.}}
+let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: unwrap the optional value and use init(_ string: UnsafePointer<CChar>) instead.}}
 
 let tmpNonOpt: String = "üüüüüüü"
 let cppString2 = std.string(tmpNonOpt)

--- a/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
@@ -2,7 +2,7 @@
 import CxxStdlib
 
 let tmpOpt: String? = "üüüüüüü"
-let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: unwrap the optional value and use init(_ string: UnsafePointer<CChar>) instead.}}
+let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: unwrap the optional value and use init(_ string: UnsafePointer<CChar>) instead}}
 
 let tmpNonOpt: String = "üüüüüüü"
 let cppString2 = std.string(tmpNonOpt)

--- a/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
@@ -2,7 +2,7 @@
 import CxxStdlib
 
 let tmpOpt: String? = "üüüüüüü"
-let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: Passing an optional C string pointer is discouraged. Use the non-nullable overload or wrap in a String first.}}
+let cppString1 = std.string(tmpOpt) // expected-warning {{'init(_:)' is deprecated: Replaced by public init(_ string: UnsafePointer<CChar>) which takes a non-optional argument.}}
 
 let tmpNonOpt: String = "üüüüüüü"
 let cppString2 = std.string(tmpNonOpt)

--- a/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-optional-error.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+import CxxStdlib
+
+let tmp: String? = "üüüüüüü"
+let cppString = std.string(tmp) // expected-error {{'init(_:)' is unavailable: Passing Optional String to the initializer of std::string is not supported. Please unwrap the value before passing to std.string()}}

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -77,14 +77,17 @@ StdStringTestSuite.test("std::string <=> Optional<String>") {
     let ascii: String? = "aaaaaaa"
     let nonAscii: String? = "üüüüüüü"
     let nilString: String? = nil
+    let emptyString: String? = ""
 
     let s1 = std.string(ascii)
     let s2 = std.string(nonAscii)
     let s3 = std.string(nilString)
+    let s4 = std.string(emptyString)
 
     expectEqual(String(s1), "aaaaaaa")
     expectEqual(String(s2), "üüüüüüü")
-    expectTrue(s3.empty())
+    expectEqual(String(s3), "")
+    expectEqual(String(s4), "")
 }
 
 StdStringTestSuite.test("std::string operators") {

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -79,10 +79,10 @@ StdStringTestSuite.test("std::string <=> Optional<String>") {
     let nilString: String? = nil
     let emptyString: String? = ""
 
-    let s1 = std.string(ascii)
-    let s2 = std.string(nonAscii)
-    let s3 = std.string(nilString)
-    let s4 = std.string(emptyString)
+    let s1 = std.string(ascii!)
+    let s2 = std.string(nonAscii!)
+    let s3 = std.string(nilString ?? "")
+    let s4 = std.string(emptyString!)
 
     expectEqual(String(s1), "aaaaaaa")
     expectEqual(String(s2), "üüüüüüü")

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -73,6 +73,20 @@ StdStringTestSuite.test("std::string <=> Swift.String") {
     expectEqual(swift8, "Hello, World!")
 }
 
+StdStringTestSuite.test("std::string <=> Optional<String>") {
+    let ascii: String? = "aaaaaaa"
+    let nonAscii: String? = "üüüüüüü"
+    let nilString: String? = nil
+
+    let s1 = std.string(ascii)
+    let s2 = std.string(nonAscii)
+    let s3 = std.string(nilString)
+
+    expectEqual(String(s1), "aaaaaaa")
+    expectEqual(String(s2), "üüüüüüü")
+    expectTrue(s3.empty())
+}
+
 StdStringTestSuite.test("std::string operators") {
     var s1 = std.string("something")
     let s2 = std.string("123")


### PR DESCRIPTION
This patch addresses potential ambiguity and unsafe behavior by deprecating initializer overloads for `std.string` that accept optional arguments (`string?`). These overloads previously allowed implicit initialization from optional pointers (`UnsafePointer<CChar>?`), causing unclear or unintended behavior.

- Deprecated: `init(_ string: UnsafePointer<CChar>?)`, guiding users toward the explicit, non-optional initializer.
- Unavailable: `init(_ string: String?)`, explicitly preventing misuse from optional Swift strings.

rdar://148041893

