### PR TITLE
tests: require optimized stdlib for `SILOptimizer/package-cmo-serialize-tables.swift`

### DIFF
--- a/test/SILOptimizer/package-cmo-serialize-tables.swift
+++ b/test/SILOptimizer/package-cmo-serialize-tables.swift
@@ -16,6 +16,7 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-MAIN < %t/Main.sil
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // Temporarily disabling on watchOS (both arm64_32 & armv7k):
 // rdar://140330692 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed...


### PR DESCRIPTION
rdar://156362878
