### PR TITLE
[6.2][test] startImmediately was missing explicit plugins path

### DIFF
--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s %import-libdispatch -swift-version 6 -o %t/a.out
+// RUN: %target-build-swift -plugin-path %swift-plugin-dir -Xfrontend -disable-availability-checking %s %import-libdispatch -swift-version 6 -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
 


### PR DESCRIPTION
picks test fix https://github.com/swiftlang/swift/pull/83226

On some configurations otherwise we were seeing: `startImmediately.swift:462:1: error: macro type 'SwiftMacros.TaskLocalMacro' not found when expanding macro 'TaskLocal' (from macro 'TaskLocal')`, so the explicit plugin path should help here

rdar://153167478