### PR TITLE
build-presets: install `llvm-nm` on Linux as on all other platforms

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -848,7 +848,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-nm;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift/pull/82945 that makes `llvm-nm` installation consistent on all platforms.
