### PR TITLE
[Test] Disable protocol-conformance-cache tests when tests are optimized.

### DIFF
--- a/test/Runtime/protocol-conformance-cache-objc.swift
+++ b/test/Runtime/protocol-conformance-cache-objc.swift
@@ -11,6 +11,11 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=xros
 // UNSUPPORTED: use_os_stdlib
 
+// The optimizer will remove many of these conformance checks due to statically
+// knowing the result.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
 import Foundation
 
 protocol Proto {}

--- a/test/Runtime/protocol-conformance-cache.swift
+++ b/test/Runtime/protocol-conformance-cache.swift
@@ -10,6 +10,11 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=xros
 // UNSUPPORTED: use_os_stdlib
 
+// The optimizer will remove many of these conformance checks due to statically
+// knowing the result.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
 protocol Proto {}
 extension Proto {
   static var selfType: Any.Type { Self.self }


### PR DESCRIPTION
These tests need to perform various conformance checks that can be statically known, and the optimizer removes them.

rdar://155924190