### PR TITLE
Enable `concurrency-deleted-method.swift` test for `wasip1`

### DIFF
--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: if [ %target-os != "wasip1" ]; then %target-run %t/a.out | %FileCheck %s; fi
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency
@@ -31,7 +31,7 @@ actor MyActor {
 }
 
 // CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
-// CHECK-IR:      @"$e4main7MyActorCN" = global <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ 
+// CHECK-IR:      @"$e4main7MyActorCN" = global <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
 // CHECK-IR-SAME:   ptr null,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD",
 // CHECK-IR-SAME:   ptr null,
@@ -41,10 +41,10 @@ actor MyActor {
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorC3fooyyYaFTu",
 // CHECK-IR-SAME:   ptr @got.swift_deletedAsyncMethodErrorTu,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCACycfC"
-// CHECK-IR-SAME: }>, align 8
+// CHECK-IR-SAME: }>, align {{[48]}}
 
 // CHECK-IR-NOT:  $e4main7MyActorC12thisIsUnusedyyYaF
 
-// CHECK-IR: define swifttailcc void @swift_deletedAsyncMethodError(ptr swiftasync %0)
+// CHECK-IR: define {{swifttailcc|swiftcc}} void @swift_deletedAsyncMethodError(ptr swiftasync %0)
 
 // CHECK: value: 42

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1286,6 +1286,7 @@ config.target_static_library_suffix = '.a'
 config.target_env_prefix = ''
 config.target_sdk_libcxx_path = ''
 config.target_clang_resource_dir_opt = ''
+config.target_swift_default_executor_opt = '-lswift_ConcurrencyDefaultExecutor'
 
 if run_vendor == 'apple':
     target_specific_module_triple = '{}-apple-{}'.format(
@@ -2065,6 +2066,7 @@ elif kIsWASI:
     config.target_runtime = "native"
     config.target_not_crash = "not"
     config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1"
+    config.target_swift_default_executor_opt = ''
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
@@ -3039,6 +3041,7 @@ config.substitutions.append(('%llvm-cov', config.llvm_cov))
 config.substitutions.append(('%hmaptool', os.path.join(config.llvm_src_root, '..', 'clang', 'utils', 'hmaptool', 'hmaptool')))
 config.substitutions.append(('%target-not-crash', config.target_not_crash))
 config.substitutions.insert(0, ('%target-clang-resource-dir-opt', config.target_clang_resource_dir_opt))
+config.substitutions.insert(0, ('%target-swift-default-executor-opt', config.target_swift_default_executor_opt))
 
 # Set up the host library environment.
 if hasattr(config, 'target_library_path_var'):


### PR DESCRIPTION
The test is only partially enabled: we only check for IR correctness and correct linking. We don't run the tests on WASI yet due to unrelated issues that are going to be resolved separately.