### PR TITLE
Test Interop/Cxx/stdlib/overlay/custom-collection.swift fails on iOS simulator bots

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar://156235951
+
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -1,4 +1,4 @@
-// REQUIRES: rdar156235951
+// REQUIRES: OS=macosx
 
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -1,4 +1,4 @@
-// REQUIRES: rdar://156235951
+// REQUIRES: rdar156235951
 
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)


### PR DESCRIPTION
I re-enabled this rest in the latest patch [PR-82502](https://github.com/swiftlang/swift/pull/82502), but unfortunately, some bots are still failing on this test. Therefore, I am temporarily xfailing this test to prevent the CI from failing.

rdar://156235951