### PR TITLE
Distributed: correct dependency handling

### DIFF
--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -133,7 +133,8 @@ target_link_libraries(swiftDistributed PRIVATE
     swiftShims
     swiftCore
     swift_Concurrency
-    builtin_float)
+    swift_Builtin_float
+    $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
     # swiftDarwin/Libc/Platform
 
 install(TARGETS swiftDistributed


### PR DESCRIPTION
The `Builtin_float` module is exported as `swift_Bultin_float`. Correct the linkage on all targets.

Address part of the listed TODO and add a dependency on `swiftWinSDK` on Windows. This allows us to build `Distributed` properly in dynamic mode.