### PR TITLE
Overlay: perform micro-optimization on Windows, correct export

### DIFF
--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -12,10 +12,15 @@ set_target_properties(swiftCRT PROPERTIES
 target_compile_definitions(swiftCRT PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
 target_compile_options(swiftCRT PRIVATE
+  "SHELL:-Xfrontend -disable-force-load-symbols"
   "SHELL:-Xcc -D_USE_MATH_DEFINES")
 target_link_libraries(swiftCRT PRIVATE
   ClangModules
   swiftCore)
+
+# FIXME: Why is this not implicitly in the interface flags?
+target_include_directories(swiftCRT INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${SwiftCore_INSTALL_SWIFTMODULEDIR}>>")
 
 install(TARGETS swiftCRT
   EXPORT SwiftOverlayTargets

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -3,11 +3,17 @@ add_library(swiftWinSDK
   WinSDK.swift)
 set_target_properties(swiftWinSDK PROPERTIES
   Swift_MODULE_NAME WinSDK)
-target_compile_definitions(swiftCRT PRIVATE
+target_compile_definitions(swiftWinSDK PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
+target_compile_options(swiftWinSDK PRIVATE
+  "SHELL:-Xfrontend -disable-force-load-symbols")
 target_link_libraries(swiftWinSDK PRIVATE
   ClangModules
   swiftCore)
+
+# FIXME: Why is this not implicitly in the interface flags?
+target_include_directories(swiftWinSDK INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${SwiftCore_INSTALL_SWIFTMODULEDIR}>>")
 
 install(TARGETS swiftWinSDK
   EXPORT SwiftOverlayTargets


### PR DESCRIPTION
The `CRT` and `WinSDK` overlays do not expose protocols (and should not). Avoid force load symbols for these modules. This is a minor micro-optimization for clients.

Correct the exported interface to allow building against these modules by propagating the workaround from Core to expose the swift interface.