### PR TITLE
Serialization: Consider C++ interop use in module cache hash, preventing collisions

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2880,7 +2880,11 @@ static std::string getContextHash(const CompilerInvocation &CI,
       //
       // If OSSA modules are enabled, we use a separate namespace of modules to
       // ensure that we compile all swift interface files with the option set.
-      unsigned(CI.getSILOptions().EnableOSSAModules));
+      unsigned(CI.getSILOptions().EnableOSSAModules),
+
+      // Is the C++ interop enabled?
+      unsigned(CI.getLangOptions().EnableCXXInterop)
+  );
 
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);
 }

--- a/test/ModuleInterface/ModuleCache/cxx-interop-caching.swift
+++ b/test/ModuleInterface/ModuleCache/cxx-interop-caching.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Build one library module
+// RUN: %target-swift-frontend -parse-stdlib -emit-module \
+// RUN:   -o %t/Lib.swiftmodule %t/Lib.swift \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -swift-version 5 -enable-library-evolution -module-name Lib
+
+/// Distributed scenario with only the swiftinterface
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %empty-directory(%t/ModuleCache)
+
+/// Rebuild from the swiftinterface just once for non-C++ users
+// RUN: %target-swift-frontend -parse-stdlib -typecheck %t/Rebuild.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify
+// RUN: %target-swift-frontend -parse-stdlib -typecheck %t/UseExisting.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify
+
+/// Rebuild from the swiftinterface just once for C++ users
+// RUN: %target-swift-frontend -parse-stdlib -typecheck %t/Rebuild.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify \
+// RUN:   -cxx-interoperability-mode=default
+// RUN: %target-swift-frontend -parse-stdlib -typecheck %t/UseExisting.swift -I %t \
+// RUN:   -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -verify \
+// RUN:   -cxx-interoperability-mode=default
+
+//--- Lib.swift
+public func publicFunction() {}
+
+//--- UseExisting.swift
+import Lib
+
+//--- Rebuild.swift
+import Lib // expected-remark {{rebuilding module 'Lib' from interface}}


### PR DESCRIPTION
The use of the C++ interop changes dependencies imported by Swift modules, as such the binary swiftmodule produced for the same Swift code is different when the interop is enabled or not. This was partially enforced by rebuilding from swiftinterface when the C++ interop is enabled in clients. However a few pieces of the puzzle were missing with implicit module builds which lead to loading incompatible swiftmodule files.

This PR fixes the module cache collision by considering the C++ interop mode in the module cache key. This preserves the rebuilt swiftmodules separately for clients with and without the C++ interop.

Not in this PR is rejecting swiftmodules built in a different C++ interop modes outside of the cache, both local and distributed modules. Rejecting them would force rebuilding them from swiftinterface or error non non-library-evolution modules. We should consider this in the future.