### PR TITLE
Sema: Consolidate requirement check failures and refactor `RequirementCheck`

### DIFF
--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -217,10 +217,6 @@ enum class CheckKind : unsigned {
   /// The witness is less accessible than the requirement.
   Access,
 
-  /// The witness is storage whose setter is less accessible than the
-  /// requirement.
-  AccessOfSetter,
-
   /// The witness needs to be @usableFromInline.
   UsableFromInline,
 
@@ -228,7 +224,7 @@ enum class CheckKind : unsigned {
   Availability,
 
   /// The requirement was marked explicitly unavailable.
-  Unavailable,
+  RequirementUnavailable,
 
   /// The witness requires optional adjustments.
   OptionalityConflict,
@@ -237,39 +233,71 @@ enum class CheckKind : unsigned {
   /// requirement.
   ConstructorFailability,
 
-  /// The witness itself is inaccessible.
-  WitnessUnavailable,
-
   /// The witness is a deprecated default implementation provided by the
   /// protocol.
   DefaultWitnessDeprecated,
 };
+
 /// Describes the suitability of the chosen witness for
 /// the requirement.
-struct RequirementCheck {
+class RequirementCheck {
   CheckKind Kind;
 
-  /// The required access scope, if the check failed due to the
-  /// witness being less accessible than the requirement.
-  AccessScope RequiredAccessScope;
+  union {
+    /// Storage for `CheckKind::Access`.
+    struct {
+      AccessScope requiredScope;
+      bool forSetter;
+    } Access;
 
-  /// The required availability, if the check failed due to the
-  /// witness being less available than the requirement.
-  AvailabilityRange RequiredAvailability;
+    /// Storage for `CheckKind::Availability`.
+    struct {
+      AvailabilityRange requiredRange;
+    } Availability;
+  };
 
-  RequirementCheck(CheckKind kind)
-      : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
-        RequiredAvailability(AvailabilityRange::alwaysAvailable()) {}
+public:
+  RequirementCheck(CheckKind kind) : Kind(kind) {
+    // These kinds have their own constructors.
+    ASSERT(kind != CheckKind::Access);
+    ASSERT(kind != CheckKind::Availability);
+  }
 
-  RequirementCheck(CheckKind kind, AccessScope requiredAccessScope)
-      : Kind(kind), RequiredAccessScope(requiredAccessScope),
-        RequiredAvailability(AvailabilityRange::alwaysAvailable()) {}
+  RequirementCheck(AccessScope requiredAccessScope, bool forSetter)
+      : Kind(CheckKind::Access), Access{requiredAccessScope, forSetter} {}
 
-  RequirementCheck(CheckKind kind, AvailabilityRange requiredAvailability)
-      : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
-        RequiredAvailability(requiredAvailability) {}
+  RequirementCheck(AvailabilityRange requiredRange)
+      : Kind(CheckKind::Availability), Availability{requiredRange} {}
+
+  CheckKind getKind() const { return Kind; }
+
+  /// True if the witness is storage whose setter is less accessible than the
+  /// requirement.
+  bool isForSetterAccess() const {
+    return (Kind == CheckKind::Access) ? Access.forSetter : false;
+  }
+
+  /// True if the witness is less available than the requirement.
+  bool isLessAvailable() const {
+    return (Kind == CheckKind::Availability)
+               ? !Availability.requiredRange.isKnownUnreachable()
+               : false;
+  }
+
+  /// The required access scope for checks that failed due to the witness being
+  /// less accessible than the requirement.
+  AccessScope getRequiredAccessScope() const {
+    ASSERT(Kind == CheckKind::Access);
+    return Access.requiredScope;
+  }
+
+  /// The required availability range for checks that failed due to the witness
+  /// being less available than the requirement.
+  AvailabilityRange getRequiredAvailabilityRange() const {
+    ASSERT(Kind == CheckKind::Availability);
+    return Availability.requiredRange;
+  }
 };
-
 
 /// Describes a match between a requirement and a witness.
 struct RequirementMatch {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -53,7 +53,7 @@ SmallVector<ValueDecl *, 4> lookupValueWitnesses(DeclContext *DC,
                                                  ValueDecl *req,
                                                  bool *ignoringNames);
 
-struct RequirementCheck;
+class RequirementCheck;
 
 class WitnessChecker {
 public:


### PR DESCRIPTION
Consolidate some of the closely related protocol requirement check failures and then turn `RequirementCheck` into a proper wrapper around a union of associated values for `CheckKind`.

NFC.
