### PR TITLE
[stdlib] fix warnings from extra `unsafe` keywords

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -190,6 +190,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:-disable-autolinking-runtime-compatibility-dynamic-replacements>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-autolinking-runtime-compatibility-concurrency>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-strict-memory-safety>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
   "$<$<AND:$<BOOL:${SwiftCore_OPTIMIZATION_REMARKS}>,$<COMPILE_LANGUAGE:Swift>>:-save-optimization-record=${SwiftCore_OPTIMIZATION_REMARKS}>"
   "$<$<COMPILE_LANGUAGE:Swift>:-warn-implicit-overrides>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -346,6 +346,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Addressab
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AddressableTypes")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AllowUnsafeAttribute")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
+list(APPEND swift_stdlib_compile_flags "-Werror" "StrictMemorySafety")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -415,7 +415,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 
       unsafe unmanagedObjects[i] = unsafe _key(at: bucket, bridgedKeys: bridgedKeys)
       stored += 1
-      bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -160,7 +160,7 @@ extension _NativeDictionary {
         target = b
       } else {
         let hashValue = unsafe self.hashValue(for: _keys[bucket.offset])
-        target = unsafe hashTable.insertNew(hashValue: hashValue)
+        unsafe target = unsafe hashTable.insertNew(hashValue: hashValue)
       }
 
       if target > bucket {

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -249,7 +249,7 @@ extension __RawDictionaryStorage {
         if unsafe uncheckedKey(at: bucket) == key {
           return (bucket, true)
         }
-        bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
+        unsafe bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
       }
       return (bucket, false)
   }
@@ -364,7 +364,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
       unsafe unmanagedObjects[i] = _bridgeAnythingToObjectiveC(key)
 
       stored += 1
-      bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -148,7 +148,7 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(word: Int, bit: Int) {
-      self.offset = unsafe _UnsafeBitset.join(word: word, bit: bit)
+      unsafe self.offset = unsafe _UnsafeBitset.join(word: word, bit: bit)
     }
 
     @inlinable
@@ -501,7 +501,7 @@ extension _HashTable {
         delegate.moveEntry(from: candidate, to: hole)
         hole = candidate
       }
-      candidate = unsafe self.bucket(wrappedAfter: candidate)
+      unsafe candidate = unsafe self.bucket(wrappedAfter: candidate)
     }
 
     unsafe words[hole.word].uncheckedRemove(hole.bit)

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3308,7 +3308,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
         unsafe _resolveRelativeIndirectableAddress(descriptorBase, descriptorOffset)
       let descriptorHeader: RawKeyPathComponent.Header
       if unsafe descriptor != UnsafeRawPointer(bitPattern: 0) {
-        descriptorHeader = unsafe descriptor.load(as: RawKeyPathComponent.Header.self)
+        unsafe descriptorHeader = unsafe descriptor.load(as: RawKeyPathComponent.Header.self)
         if descriptorHeader.isTrivialPropertyDescriptor {
           // If the descriptor is trivial, then use the local candidate.
           // Skip the external generic parameter accessors to get to it.

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -177,7 +177,7 @@ extension _NativeSet { // Low-level lookup operations
       if unsafe uncheckedElement(at: bucket) == element {
         return (bucket, true)
       }
-      bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
+      unsafe bucket = unsafe hashTable.bucket(wrappedAfter: bucket)
     }
     return (bucket, false)
   }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -279,7 +279,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       if bucket == endBucket { break }
       unsafe unmanagedObjects[i] = unsafe bridgedElements[bucket]
       stored += 1
-      bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -293,7 +293,7 @@ final internal class _SetStorage<Element: Hashable>
       let element = unsafe _elements[bucket.offset]
       unsafe unmanagedObjects[i] = _bridgeAnythingToObjectiveC(element)
       stored += 1
-      bucket = unsafe hashTable.occupiedBucket(after: bucket)
+      unsafe bucket = unsafe hashTable.occupiedBucket(after: bucket)
     }
     unsafe theState.extra.0 = CUnsignedLong(bucket.offset)
     unsafe state.pointee = theState


### PR DESCRIPTION
This changes turns extraneous `unsafe` annotations into errors rather than warnings, for the standard library module.