### PR TITLE
[Clang importer] Handle Swift conformances on typedefs and C types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3150,96 +3150,7 @@ namespace {
         }
       }
 
-      if (auto *ntd = dyn_cast<NominalTypeDecl>(result))
-        addExplicitProtocolConformances(ntd, decl);
-
       return result;
-    }
-
-    using ProtocolSet = llvm::SmallSet<ProtocolDecl *, 4>;
-
-    void
-    addExplicitProtocolConformances(NominalTypeDecl *decl,
-                                    const clang::CXXRecordDecl *clangDecl) {
-      if (clangDecl->isCompleteDefinition()) {
-        // Propagate conforms_to attribute from public base classes.
-        for (auto base : clangDecl->bases()) {
-          if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
-            continue;
-          if (auto *baseClangDecl = base.getType()->getAsCXXRecordDecl())
-            addExplicitProtocolConformances(decl, baseClangDecl);
-        }
-      }
-
-      if (!clangDecl->hasAttrs())
-        return;
-
-      ProtocolSet alreadyAdded;
-      llvm::for_each(clangDecl->getAttrs(), [&](auto *attr) {
-        if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-          if (swiftAttr->getAttribute().starts_with("conforms_to:"))
-            addExplicitProtocolConformance(decl, swiftAttr, alreadyAdded);
-        }
-      });
-    }
-
-    void addExplicitProtocolConformance(NominalTypeDecl *decl,
-                                        clang::SwiftAttrAttr *conformsToAttr,
-                                        ProtocolSet &alreadyAdded) {
-      auto conformsToValue = conformsToAttr->getAttribute()
-                                 .drop_front(StringRef("conforms_to:").size())
-                                 .str();
-      auto names = StringRef(conformsToValue).split('.');
-      auto moduleName = names.first;
-      auto protocolName = names.second;
-      if (protocolName.empty()) {
-        HeaderLoc attrLoc(conformsToAttr->getLocation());
-        Impl.diagnose(attrLoc, diag::conforms_to_missing_dot, conformsToValue);
-        return;
-      }
-
-      auto *mod = Impl.SwiftContext.getModuleByIdentifier(
-          Impl.SwiftContext.getIdentifier(moduleName));
-      if (!mod) {
-        HeaderLoc attrLoc(conformsToAttr->getLocation());
-        Impl.diagnose(attrLoc, diag::cannot_find_conforms_to_module,
-                      conformsToValue, moduleName);
-        return;
-      }
-
-      SmallVector<ValueDecl *, 1> results;
-      mod->lookupValue(Impl.SwiftContext.getIdentifier(protocolName),
-                       NLKind::UnqualifiedLookup, results);
-      if (results.empty()) {
-        HeaderLoc attrLoc(conformsToAttr->getLocation());
-        Impl.diagnose(attrLoc, diag::cannot_find_conforms_to, protocolName,
-                      moduleName);
-        return;
-      }
-
-      if (results.size() != 1) {
-        HeaderLoc attrLoc(conformsToAttr->getLocation());
-        Impl.diagnose(attrLoc, diag::conforms_to_ambiguous, protocolName,
-                      moduleName);
-        return;
-      }
-
-      auto result = results.front();
-      if (auto protocol = dyn_cast<ProtocolDecl>(result)) {
-        auto [_, inserted] = alreadyAdded.insert(protocol);
-        if (!inserted) {
-          HeaderLoc attrLoc(conformsToAttr->getLocation());
-          Impl.diagnose(attrLoc, diag::redundant_conformance_protocol,
-                        decl->getDeclaredInterfaceType(), conformsToValue);
-        }
-
-        decl->getAttrs().add(
-            new (Impl.SwiftContext) SynthesizedProtocolAttr(protocol, &Impl, false));
-      } else {
-        HeaderLoc attrLoc((conformsToAttr)->getLocation());
-        Impl.diagnose(attrLoc, diag::conforms_to_not_protocol, result,
-                      conformsToValue);
-      }
     }
 
     bool isSpecializationDepthGreaterThan(
@@ -6633,6 +6544,20 @@ static bool conformsToProtocolInOriginalModule(NominalTypeDecl *nominal,
   return false;
 }
 
+/// Determine whether the given nominal type was imported with an OptionSet
+/// conformance.
+static bool isImportedOptionSet(NominalTypeDecl *nominal) {
+  for (auto attr : nominal->getAttrs()) {
+    if (auto synthesizedAttr = dyn_cast<SynthesizedProtocolAttr>(attr)) {
+      if (synthesizedAttr->getProtocol()->isSpecificProtocol(
+              KnownProtocolKind::OptionSet))
+        return true;
+    }
+  }
+
+  return false;
+}
+
 Decl *
 SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
                                        clang::SwiftNewTypeAttr *newtypeAttr,
@@ -6706,6 +6631,11 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
   // Add conformances that are always available.
   addKnown(KnownProtocolKind::RawRepresentable);
   addKnown(KnownProtocolKind::SwiftNewtypeWrapper);
+
+  // If this type was also imported as an OptionSet, include those typealiases.
+  if (isImportedOptionSet(structDecl)) {
+    Impl.addOptionSetTypealiases(structDecl);
+  }
 
   // Local function to add a known protocol only when the
   // underlying type conforms to it.
@@ -6961,8 +6891,6 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
 NominalTypeDecl *
 SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
                                           const clang::EnumDecl *decl) {
-  ASTContext &ctx = Impl.SwiftContext;
-
   auto Loc = Impl.importSourceLoc(decl->getLocation());
 
   // Create a struct with the underlying type as a field.
@@ -6981,10 +6909,7 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
 
   synthesizer.makeStructRawValued(structDecl, underlyingType,
                                   {KnownProtocolKind::OptionSet});
-  auto selfType = structDecl->getDeclaredInterfaceType();
-  Impl.addSynthesizedTypealias(structDecl, ctx.Id_Element, selfType);
-  Impl.addSynthesizedTypealias(structDecl, ctx.Id_ArrayLiteralElement,
-                               selfType);
+  Impl.addOptionSetTypealiases(structDecl);
   return structDecl;
 }
 
@@ -8882,6 +8807,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
 
   std::optional<const clang::SwiftAttrAttr *> seenMainActorAttr;
   const clang::SwiftAttrAttr *seenMutabilityAttr = nullptr;
+  llvm::SmallSet<ProtocolDecl *, 4> conformancesSeen;
 
   auto importAttrsFromDecl = [&](const clang::NamedDecl *ClangDecl) {
     //
@@ -8997,6 +8923,11 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         continue;
       }
 
+      if (swiftAttr->getAttribute().starts_with("conforms_to:")) {
+        if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl))
+          addExplicitProtocolConformance(nominal, swiftAttr, conformancesSeen);
+      }
+
       importNontrivialAttribute(MappedDecl, swiftAttr->getAttribute());
     }
 
@@ -9056,6 +8987,14 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
       diagnose(HeaderLoc(ClangDecl->getLocation()),
                diag::clang_error_code_must_be_sendable,
                ClangDecl->getNameAsString());
+    }
+  }
+
+  // Import explicit conformances from C++ base classes.
+  if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl)) {
+    if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
+      addExplicitProtocolConformancesFromBases(
+          nominal, cxxRecordDecl, /*isBase=*/false);
     }
   }
 
@@ -9326,6 +9265,102 @@ struct UnaliasedInstantiationVisitor
   }
 };
 } // namespace
+
+
+
+void ClangImporter::Implementation::addExplicitProtocolConformance(
+    NominalTypeDecl *decl,
+    clang::SwiftAttrAttr *conformsToAttr,
+    llvm::SmallSet<ProtocolDecl *, 4> &alreadyAdded) {
+  auto conformsToValue = conformsToAttr->getAttribute()
+                             .drop_front(StringRef("conforms_to:").size())
+                             .str();
+  auto names = StringRef(conformsToValue).split('.');
+  auto moduleName = names.first;
+  auto protocolName = names.second;
+  if (protocolName.empty()) {
+    HeaderLoc attrLoc(conformsToAttr->getLocation());
+    diagnose(attrLoc, diag::conforms_to_missing_dot, conformsToValue);
+    return;
+  }
+
+  auto *mod = SwiftContext.getModuleByIdentifier(
+      SwiftContext.getIdentifier(moduleName));
+  if (!mod) {
+    HeaderLoc attrLoc(conformsToAttr->getLocation());
+    diagnose(attrLoc, diag::cannot_find_conforms_to_module,
+             conformsToValue, moduleName);
+    return;
+  }
+
+  SmallVector<ValueDecl *, 1> results;
+  mod->lookupValue(SwiftContext.getIdentifier(protocolName),
+                   NLKind::UnqualifiedLookup, results);
+  if (results.empty()) {
+    HeaderLoc attrLoc(conformsToAttr->getLocation());
+    diagnose(attrLoc, diag::cannot_find_conforms_to, protocolName,
+             moduleName);
+    return;
+  }
+
+  if (results.size() != 1) {
+    HeaderLoc attrLoc(conformsToAttr->getLocation());
+    diagnose(attrLoc, diag::conforms_to_ambiguous, protocolName,
+             moduleName);
+    return;
+  }
+
+  auto result = results.front();
+  if (auto protocol = dyn_cast<ProtocolDecl>(result)) {
+    auto [_, inserted] = alreadyAdded.insert(protocol);
+    if (!inserted) {
+      HeaderLoc attrLoc(conformsToAttr->getLocation());
+      diagnose(attrLoc, diag::redundant_conformance_protocol,
+               decl->getDeclaredInterfaceType(), conformsToValue);
+    }
+
+    decl->getAttrs().add(
+        new (SwiftContext) SynthesizedProtocolAttr(protocol, this, false));
+  } else {
+    HeaderLoc attrLoc((conformsToAttr)->getLocation());
+    diagnose(attrLoc, diag::conforms_to_not_protocol, result,
+             conformsToValue);
+  }
+}
+
+void ClangImporter::Implementation::addExplicitProtocolConformancesFromBases(
+    NominalTypeDecl *nominal,
+    const clang::CXXRecordDecl *cxxRecordDecl,
+    bool isBase) {
+  if (cxxRecordDecl->isCompleteDefinition()) {
+    // Propagate conforms_to attribute from public base classes.
+    for (auto base : cxxRecordDecl->bases()) {
+      if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
+        continue;
+      if (auto *baseClangDecl = base.getType()->getAsCXXRecordDecl())
+        addExplicitProtocolConformancesFromBases(nominal, baseClangDecl,
+                                                 /*isBase=*/true);
+    }
+  }
+
+  if (isBase && cxxRecordDecl->hasAttrs()) {
+    llvm::SmallSet<ProtocolDecl *, 4> alreadyAdded;
+    llvm::for_each(cxxRecordDecl->getAttrs(), [&](auto *attr) {
+      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+        if (swiftAttr->getAttribute().starts_with("conforms_to:"))
+          addExplicitProtocolConformance(nominal, swiftAttr, alreadyAdded);
+      }
+    });
+  }
+}
+
+void ClangImporter::Implementation::addOptionSetTypealiases(
+    NominalTypeDecl *nominal) {
+  auto selfType = nominal->getDeclaredInterfaceType();
+  addSynthesizedTypealias(nominal, SwiftContext.Id_Element, selfType);
+  addSynthesizedTypealias(nominal, SwiftContext.Id_ArrayLiteralElement,
+                          selfType);
+}
 
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1227,7 +1227,8 @@ public:
   /// \returns The imported declaration context, or null if it could not
   /// be converted.
   DeclContext *importDeclContextOf(const clang::Decl *D,
-                                   EffectiveClangContext context);
+                                   EffectiveClangContext context,
+                                   bool allowForwardDeclaration = false);
 
   /// Determine whether the given declaration is considered
   /// 'unavailable' in Swift.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1794,6 +1794,25 @@ public:
   }
 
   void importSwiftAttrAttributes(Decl *decl);
+
+  /// Add the explicit protocol conformance specified by the given swift_attr
+  /// attribute to the given nominal type.
+  void addExplicitProtocolConformance(
+      NominalTypeDecl *decl,
+      clang::SwiftAttrAttr *conformsToAttr,
+      llvm::SmallSet<ProtocolDecl *, 4> &alreadyAdded);
+
+  /// Add explicit protocol conformances from the bases of the given C++ class
+  /// declaration's swift_attr attributes to the given nominal type.
+  void addExplicitProtocolConformancesFromBases(
+      NominalTypeDecl *nominal,
+      const clang::CXXRecordDecl *cxxRecordDecl,
+      bool isBase);
+
+  /// Add implicit typealiases required when turning the given nominal type
+  /// into an option set.
+  void addOptionSetTypealiases(NominalTypeDecl *nominal);
+
   void swiftify(AbstractFunctionDecl *MappedDecl);
 
   /// Find the lookup table that corresponds to the given Clang module.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2560,7 +2560,7 @@ llvm::SmallVector<clang::CXXMethodDecl *, 4>
 SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
     const clang::CXXRecordDecl *cxxRecordDecl) {
 
-  if (cxxRecordDecl->isAbstract())
+  if (!cxxRecordDecl->isCompleteDefinition() || cxxRecordDecl->isAbstract())
     return {};
 
   clang::ASTContext &clangCtx = cxxRecordDecl->getASTContext();

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1881,19 +1881,9 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   if (shouldSuppressDeclImport(named))
     return;
 
-  // Leave incomplete struct/enum/union types out of the table; Swift only
-  // handles pointers to them.
-  // FIXME: At some point we probably want to be importing incomplete types,
-  // so that pointers to different incomplete types themselves have distinct
-  // types. At that time it will be necessary to make the decision of whether
-  // or not to import an incomplete type declaration based on whether it's
-  // actually the struct backing a CF type:
-  //
-  //    typedef struct CGColor *CGColorRef;
-  //
-  // The best way to do this is probably to change CFDatabase.def to include
-  // struct names when relevant, not just pointer names. That way we can check
-  // both CFDatabase.def and the objc_bridge attribute and cover all our bases.
+  // Leave incomplete struct/enum/union types out of the table, unless they
+  // are types that will be imported as reference types (e.g., CF types or
+  // those that use SWIFT_SHARED_REFERENCE).
   if (auto *tagDecl = dyn_cast<clang::TagDecl>(named)) {
     // We add entries for ClassTemplateSpecializations that don't have
     // definition. It's possible that the decl will be instantiated by
@@ -1901,7 +1891,9 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     // ClassTemplateSPecializations here because we're currently writing the
     // AST, so we cannot modify it.
     if (!isa<clang::ClassTemplateSpecializationDecl>(named) &&
-        !tagDecl->getDefinition()) {
+        !tagDecl->getDefinition() &&
+        !(isa<clang::RecordDecl>(tagDecl) &&
+          hasImportAsRefAttr(cast<clang::RecordDecl>(tagDecl)))) {
       return;
     }
   }

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -6,3 +6,7 @@ module StructDeclContext {
 module ForeignReference {
   header "foreign-reference.h"
 }
+
+module StructAsOptionSet {
+  header "struct-as-option-set.h"
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/ReferenceCounted.apinotes
+++ b/test/Interop/Cxx/foreign-reference/Inputs/ReferenceCounted.apinotes
@@ -1,0 +1,8 @@
+---
+Name: ReferenceCounted
+Tags:
+- Name: OpaqueRefImpl
+  SwiftImportAs: reference
+  SwiftRetainOp: OPRetain
+  SwiftReleaseOp: OPRelease
+

--- a/test/Interop/Cxx/foreign-reference/Inputs/incomplete.c
+++ b/test/Interop/Cxx/foreign-reference/Inputs/incomplete.c
@@ -1,0 +1,55 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "reference-counted.h"
+
+typedef struct IncompleteImpl {
+  unsigned refCount;
+  double weight;
+} *Incomplete;
+
+
+Incomplete Incomplete_create(double weight) {
+  Incomplete result = (Incomplete)malloc(sizeof(struct IncompleteImpl));
+  result->refCount = 1;
+  result->weight = weight;
+  return result;
+}
+
+void INRetain(Incomplete i) {
+  i->refCount++;
+}
+
+void INRelease(Incomplete i) {
+  i->refCount--;
+  if (i->refCount == 0) {
+    printf("Destroyed instance containing weight %f\n", i->weight);
+    free(i);
+  }
+}
+
+double Incomplete_getWeight(Incomplete i) {
+  return i->weight;
+}
+
+struct OpaqueRefImpl {
+  unsigned refCount;
+};
+
+OpaqueRef Opaque_create(void) {
+  OpaqueRef result = (OpaqueRef)malloc(sizeof(struct OpaqueRefImpl));
+  result->refCount = 1;
+  return result;
+}
+
+void OPRetain(OpaqueRef i) {
+  i->refCount++;
+}
+
+void OPRelease(OpaqueRef i) {
+  i->refCount--;
+  if (i->refCount == 0) {
+    printf("Destroyed OpaqueRef instance\n");
+    free(i);
+  }
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -35,7 +35,6 @@ module WitnessTable {
 
 module ReferenceCounted {
   header "reference-counted.h"
-  requires cplusplus
 }
 
 module ReferenceCountedObjCProperty {

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -2,13 +2,18 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_REFERENCE_COUNTED_H
 
 #include <stdlib.h>
+
+#ifdef __cplusplus
 #include <new>
+#endif
 
 #include "visibility.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 static int finalLocalRefCount = 100;
+
+#ifdef __cplusplus
 
 namespace NS {
 
@@ -63,6 +68,30 @@ GlobalCountNullableInit {
 
 inline void GCRetainNullableInit(GlobalCountNullableInit *x) { globalCount++; }
 inline void GCReleaseNullableInit(GlobalCountNullableInit *x) { globalCount--; }
+#endif
+
+typedef struct __attribute__((swift_attr("import_as_ref")))
+__attribute__((swift_attr("retain:INRetain")))
+__attribute__((swift_attr("release:INRelease"))) IncompleteImpl *Incomplete;
+
+typedef struct OpaqueRefImpl *OpaqueRef;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Incomplete Incomplete_create(double weight) __attribute__((swift_attr("returns_retained"))) __attribute__((swift_name("IncompleteImpl.init(weight:)")));
+void INRetain(Incomplete i);
+void INRelease(Incomplete i);
+double Incomplete_getWeight(Incomplete i) __attribute__((swift_name("getter:IncompleteImpl.weight(self:)")));
+
+OpaqueRef Opaque_create(void);
+void OPRetain(OpaqueRef i);
+void OPRelease(OpaqueRef i);
+
+#ifdef __cplusplus
+}
+#endif
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -13,9 +13,6 @@
 
 // REQUIRES: executable_test
 
-// https://github.com/swiftlang/swift/issues/82643
-// XFAIL: OS=windows-msvc
-
 import ReferenceCounted
 
 func testIncomplete() {

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -x c -c %S/Inputs/incomplete.c -I %S/Inputs -o %t/incomplete-c.o
+
+// Build with C interoperatibility
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/incomplete %t/incomplete-c.o
+// RUN: %target-codesign %t/incomplete
+// RUN: %target-run %t/incomplete | %FileCheck %s
+
+// Build with C++ interoperability
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/incomplete %t/incomplete-c.o -Xfrontend -cxx-interoperability-mode=default
+// RUN: %target-codesign %t/incomplete
+// RUN: %target-run %t/incomplete | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import ReferenceCounted
+
+func testIncomplete() {
+  do {
+    let i = Incomplete(weight: 3.14159)
+    // CHECK: Incomplete weight = 3.14159
+    print("Incomplete weight = \(i.weight)")
+
+    // Instance destroyed at the end
+  }
+
+  // CHECK: Destroyed instance containing weight 3.14159
+}
+
+func testOpaqueRef() {
+  // CHECK: Creating OpaqueRef
+  print("Creating OpaqueRef")
+  let opaque = Opaque_create()
+  let opaque2 = opaque
+  _ = opaque
+  _ = opaque2
+  // let it go out of scope
+
+  // CHECK: Destroyed OpaqueRef instance
+  // CHECK-NOT: Destroyed OpaqueRef instance
+}
+
+testIncomplete()
+testOpaqueRef()
+
+// CHECK: DONE
+print("DONE")

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -13,6 +13,9 @@
 
 // REQUIRES: executable_test
 
+// https://github.com/swiftlang/swift/issues/82643
+// XFAIL: OS=windows-msvc
+
 import ReferenceCounted
 
 func testIncomplete() {


### PR DESCRIPTION
The code for handling Swift conforms_to attributes was specific to
C++ record types. Generalize it to work on typedefs imported as
nominal types, also in C.

Fixes rdar://156290361.