### PR TITLE
[6.2][Concurrency] Only apply default main actor to local and nested decls that are in a main actor isolated context.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6130,9 +6130,16 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       // in {distributed} actor-isolated contexts nor in nonisolated
       // contexts.
 
-      // Local declarations must check the isolation of their
-      // decl context.
       if (value->getDeclContext()->isLocalContext()) {
+        // Local storage is always nonisolated; region isolation computes
+        // whether the value is in an actor-isolated region based on
+        // the initializer expression.
+        auto *var = dyn_cast<VarDecl>(value);
+        if (var && var->hasStorage())
+          return {};
+
+        // Other local declarations must check the isolation of their
+        // decl context.
         auto contextIsolation =
             getActorIsolationOfContext(value->getDeclContext());
         if (!contextIsolation.isMainActor())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6125,9 +6125,22 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     auto globalActorHelper = [&](Type globalActor)
         -> std::optional<std::tuple<InferredActorIsolation, ValueDecl *,
                                     std::optional<ActorIsolation>>> {
-      // Default global actor isolation does not apply to any declarations
-      // within actors and distributed actors, nor does it apply in a
-      // nonisolated type.
+      // Default main actor only applies to top-level declarations and
+      // in contexts that are also main actor isolated. It does not apply
+      // in {distributed} actor-isolated contexts nor in nonisolated
+      // contexts.
+
+      // Local declarations must check the isolation of their
+      // decl context.
+      if (value->getDeclContext()->isLocalContext()) {
+        auto contextIsolation =
+            getActorIsolationOfContext(value->getDeclContext());
+        if (!contextIsolation.isMainActor())
+          return {};
+      }
+
+      // Members and nested types must check the isolation of the enclosing
+      // nominal type.
       auto *dc = value->getInnermostDeclContext();
       while (dc) {
         if (auto *nominal = dc->getSelfNominalTypeDecl()) {
@@ -6135,18 +6148,10 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
             return {};
 
           if (dc != dyn_cast<DeclContext>(value)) {
-            switch (getActorIsolation(nominal)) {
-            case ActorIsolation::Unspecified:
-            case ActorIsolation::ActorInstance:
-            case ActorIsolation::Nonisolated:
-            case ActorIsolation::NonisolatedUnsafe:
-            case ActorIsolation::Erased:
-            case ActorIsolation::CallerIsolationInheriting:
-              return {};
-
-            case ActorIsolation::GlobalActor:
+            if (getActorIsolation(nominal).isMainActor())
               break;
-            }
+
+            return {};
           }
         }
         dc = dc->getParent();

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -258,7 +258,13 @@ class CustomActorIsolated {
 
 var global = 0
 
-func onMain() {
+func onMain() async {
+  await withTaskGroup { group in
+    group.addTask { }
+
+    await group.next()
+  }
+
   struct Nested {
     // CHECK: // static useGlobal() in Nested #1 in onMain()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor


### PR DESCRIPTION
  - **Explanation**: `-default-isolation MainActor` mode was accidentally inferring `@MainActor` in contexts where main actor isolated code cannot be used, including in `nonisolated` function bodies and for types nested in other-global-actor-isolated types. This change prevents default `@MainActor` from applying in contexts that are not also main actor isolated.
  - **Scope**: Only impacts local declarations and nested types under `-default-isolation MainActor`. This mode is new in 6.2 so this change does not impact any existing code.
  - **Issues**: rdar://153561279
  - **Original PRs**: https://github.com/swiftlang/swift/pull/83175
  - **Risk**: Low due to the narrow scope. The main risk associated with this change is that it is not sufficient, e.g. the compiler continues to infer too much as `@MainActor` isolated, which will result in errors under `-default-isolation MainActor`.
  - **Testing**: Added tests.
  - **Reviewers**: @xedin 