### PR TITLE
[6.2] SIL: allow casts to class-bound archetypes to be done as scalar-casts instead of address-casts

### DIFF
--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -211,7 +211,8 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
 
   // If the destination type is known to have a Swift-compatible
   // implementation, use the most specific entrypoint.
-  if (destClass && destClass->hasKnownSwiftImplementation()) {
+  if ((destClass && destClass->hasKnownSwiftImplementation()) ||
+      IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
     metadataRef = IGF.emitTypeMetadataRef(toType);
 
     switch (mode) {

--- a/test/IRGen/dynamic_self_cast.swift
+++ b/test/IRGen/dynamic_self_cast.swift
@@ -35,7 +35,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD0xyRlzClFZ"(ptr %T, ptr swiftself %0)
-  // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %0, ptr %T, {{.*}})
+  // CHECK: call ptr @swift_dynamicCastUnknownClassUnconditional(ptr {{%.*}}, ptr %T, ptr null, i32 0, i32 0) #4
   // CHECK: ret
   public static func classGenericFromSelf<T : AnyObject>() -> T {
     let s = Self()
@@ -72,7 +72,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD11ConditionalxSgyRlzClFZ"(ptr %T, ptr swiftself %0)
-  // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %0, ptr %T, {{.*}})
+  // CHECK: call ptr @swift_dynamicCastUnknownClass(ptr {{%.*}}, ptr %T)
   // CHECK: ret
   public static func classGenericFromSelfConditional<T : AnyObject>() -> T? {
     let s = Self()

--- a/test/SILGen/dynamic_self_cast_objc.swift
+++ b/test/SILGen/dynamic_self_cast_objc.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-types -disable-objc-interop -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -module-name=dynamic_self_cast -emit-silgen %s | %FileCheck %s
+
+// REQUIRES: objc_interop
 
 public class SelfCasts {
   // CHECK-LABEL: sil [ossa] @$s17dynamic_self_cast9SelfCastsC02toD0yACXDACFZ : $@convention(method) (@guaranteed SelfCasts, @thick SelfCasts.Type) -> @owned SelfCasts {
@@ -31,7 +33,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: sil [ossa] @$s17dynamic_self_cast9SelfCastsC016classGenericFromD0xyRlzClFZ : $@convention(method) <T where T : AnyObject> (@thick SelfCasts.Type) -> @owned T
-  // CHECK: unconditional_checked_cast {{.*}} : $SelfCasts to T
+  // CHECK: unconditional_checked_cast_addr @dynamic_self SelfCasts in {{.*}} : $*SelfCasts to T in {{.*}} : $*T
   // CHECK: }
   public static func classGenericFromSelf<T : AnyObject>() -> T {
     let s = Self()
@@ -68,7 +70,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: sil [ossa] @$s17dynamic_self_cast9SelfCastsC016classGenericFromD11ConditionalxSgyRlzClFZ : $@convention(method) <T where T : AnyObject> (@thick SelfCasts.Type) -> @owned Optional<T> {
-  // CHECK: checked_cast_br @dynamic_self SelfCasts in {{.*}} : $SelfCasts to T
+  // CHECK: checked_cast_addr_br take_always @dynamic_self SelfCasts in {{.*}} : $*SelfCasts to T in {{.*}} : $*T
   // CHECK: }
   public static func classGenericFromSelfConditional<T : AnyObject>() -> T? {
     let s = Self()
@@ -77,3 +79,4 @@ public class SelfCasts {
 
   public required init() {}
 }
+

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -disable-objc-interop -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 protocol ClassBound : class {}
 protocol NotClassBound {}
@@ -59,8 +59,7 @@ func class_archetype_to_class_archetype
 <T:ClassBound, U:ClassBound>(_ t:T) -> U {
   return t as! U
   // Error bridging can change the identity of class-constrained archetypes.
-  // CHECK: unconditional_checked_cast_addr T in {{%.*}} : $*T to U in [[DOWNCAST_ADDR:%.*]] : $*U
-  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]]
+  // CHECK: [[DOWNCAST:%.*]] = unconditional_checked_cast {{%.*}} : $T to U
   // CHECK: return [[DOWNCAST]] : $U
 }
 
@@ -69,7 +68,7 @@ func class_archetype_is_class_archetype
 <T:ClassBound, U:ClassBound>(_ t:T, u:U.Type) -> Bool {
   return t is U
   // Error bridging can change the identity of class-constrained archetypes.
-  // CHECK: checked_cast_addr_br {{.*}} T in {{%.*}} : $*T to U in {{%.*}} : $*U
+  // CHECK: checked_cast_br T in {{%.*}} : $T to U
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s13generic_casts38opaque_archetype_to_addr_only_concrete{{[_0-9a-zA-Z]*}}F
@@ -158,8 +157,7 @@ func opaque_existential_is_class_archetype
 func class_existential_to_class_archetype
 <T:ClassBound>(_ p:ClassBound) -> T {
   return p as! T
-  // CHECK: unconditional_checked_cast_addr any ClassBound in {{%.*}} : $*any ClassBound to T in [[DOWNCAST_ADDR:%.*]] : $*T
-  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]]
+  // CHECK: [[DOWNCAST:%.*]] = unconditional_checked_cast {{%.*}} : $any ClassBound to T
   // CHECK: return [[DOWNCAST]] : $T
 }
 
@@ -167,7 +165,7 @@ func class_existential_to_class_archetype
 func class_existential_is_class_archetype
 <T:ClassBound>(_ p:ClassBound, _: T) -> Bool {
   return p is T
-  // CHECK: checked_cast_addr_br {{.*}} any ClassBound in {{%.*}} : $*any ClassBound to T in {{%.*}} : $*T
+  // CHECK: checked_cast_br any ClassBound in {{%.*}} : $any ClassBound to T
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s13generic_casts40opaque_existential_to_addr_only_concrete{{[_0-9a-zA-Z]*}}F

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: OS=macosx
 
 ///////////////////
 // Generic Casts //

--- a/test/SILOptimizer/rcidentity_opaque.sil
+++ b/test/SILOptimizer/rcidentity_opaque.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -rc-id-dumper -enable-sil-opaque-values -module-name Swift %s -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt -rc-id-dumper -enable-sil-opaque-values -disable-objc-interop -module-name Swift %s -o /dev/null | %FileCheck %s
 
 import Builtin
 
@@ -295,7 +295,7 @@ bb0(%0 : @owned $T):
 //
 // CHECK-LABEL: @testClassToClassArchetypeIsBridged
 // CHECK: RESULT #0: 0 = 0
-// CHECK: RESULT #1: 1 = 1
+// CHECK: RESULT #1: 1 = 0
 sil [ossa] @testClassToClassArchetypeIsBridged : $@convention(thin) <U : AnyObject>(@owned Base) -> @owned U {
 bb0(%0 : @owned $Base):
   %1 = unconditional_checked_cast %0 : $Base to U

--- a/test/embedded/existential-class-bound1.swift
+++ b/test/embedded/existential-class-bound1.swift
@@ -10,6 +10,7 @@
 protocol ClassBound: AnyObject {
     func foo()
     func bar()
+    func predicate() -> Bool
 }
 
 class MyClass {}
@@ -230,6 +231,22 @@ func testP4() -> any P4 {
   return C4(t: K4(x: 437))
 }
 
+var gg: any ClassBound = MyClass()
+
+extension ClassBound {
+  public func isSame(_ rhs: some ClassBound) -> Bool {
+    if let rhs = rhs as? Self {
+      return rhs.predicate()
+    }
+    return false 
+  }
+  public func predicate() -> Bool { true }
+}
+
+@inline(never)
+func testIsSame(_ p: any ClassBound) -> Bool {
+  return p.isSame(gg)
+}
 
 
 @main
@@ -261,6 +278,11 @@ struct Main {
         // CHECK: 102
         testP4().foo()
         // CHECK: 437
+
+        print(testIsSame(MyClass()))
+        // CHECK: true
+        print(testIsSame(MyOtherClass()))
+        // CHECK: false
     }
 }
 


### PR DESCRIPTION
* **Explanation**: This allows such casts to be done in embedded swift. There is no change when objc interop is enabled (e.g. macos). But on other platforms - most importantly embedded swift - this change allows scalar casts to class-bound archetypes. Originally, such scalar casts were only allowed if the archetype had a superclass constraint. This change allows using concurrency features in embedded Swift.
* **Risk**: Very low for macOS, because it only affects platforms without ObjectiveC-interoperability. Low for other platforms (it's a simple, well understood change).
* **Testing**: Tested by lit tests.
* **Issue**: rdar://156302495
* **Reviewer**:  @jckarter
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/83213


