### PR TITLE
Test: add some missing plugin paths to distributed tests

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
@@ -7,6 +7,7 @@
 // RUN:     -parse-as-library -emit-library                                    \
 // RUN:     -emit-module-path %t/FakeDistributedActorSystems.swiftmodule       \
 // RUN:     -module-name FakeDistributedActorSystems                           \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
 // RUN:      %S/../Inputs/FakeDistributedActorSystems.swift                    \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -Xfrontend -validate-tbd-against-ir=all                            \

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
@@ -7,6 +7,7 @@
 // RUN:     -parse-as-library -emit-library                                    \
 // RUN:     -emit-module-path %t/FakeDistributedActorSystems.swiftmodule       \
 // RUN:     -module-name FakeDistributedActorSystems                           \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
 // RUN:      %S/../Inputs/FakeDistributedActorSystems.swift                    \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -Xfrontend -validate-tbd-against-ir=all                            \


### PR DESCRIPTION
Seems we had some more instances of missing -plugin-path