### PR TITLE
[build][android] Use a CMake toolchain file to cross-compile Testing

### DIFF
--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -4,6 +4,7 @@
 
 // We have a separate test for 64-bit architectures.
 // REQUIRES: PTRSIZE=32
+// XFAIL: OS=linux-androideabi
 
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
 // CHECK-LABEL: test_ascii_scalar_scalar2

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
-// XFAIL: OS=linux-androideabi
 
 // These tests check whether DeadObjectElimination pass runs as a part of the
 // optimization pipeline and eliminates dead array literals in Swift code.

--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -127,3 +127,11 @@ class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
         install_prefix = install_destdir + self.args.install_prefix
 
         self.install_with_cmake(['install'], install_prefix)
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_before_build_script_impl_product(cls):
+        return False

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -72,7 +72,7 @@ class Platform(object):
                 return True
         return False
 
-    def swift_flags(self, args):
+    def swift_flags(self, args, resource_path=None):
         """
         Swift compiler flags for a platform, useful for cross-compiling
         """
@@ -154,12 +154,15 @@ class AndroidPlatform(Platform):
         """
         return True
 
-    def swift_flags(self, args):
+    def swift_flags(self, args, resource_path=None):
         flags = '-target %s-unknown-linux-android%s ' % (args.android_arch,
                                                          args.android_api_level)
 
-        flags += '-resource-dir %s/swift-%s-%s/lib/swift ' % (
-                 args.build_root, self.name, args.android_arch)
+        if resource_path is not None:
+            flags += '-resource-dir %s ' % (resource_path)
+        else:
+            flags += '-resource-dir %s/swift-%s-%s/lib/swift ' % (
+                     args.build_root, self.name, args.android_arch)
 
         android_toolchain_path = self.ndk_toolchain_path(args)
 

--- a/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
+++ b/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
@@ -1,9 +1,13 @@
 # REQUIRES: standalone_build
-# REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ 2>&1 | %FileCheck --check-prefix=ANDROID %s
 
 # CHECK: DRY_RUN! Writing Toolchain file to path:{{.*}}BuildScriptToolchain.cmake
 # CHECK: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}BuildScriptToolchain.cmake {{.*}}cmark
+
+# ANDROID: DRY_RUN! Writing Toolchain file to path:{{.*}}cmark-android-aarch64/BuildScriptToolchain.cmake
+# ANDROID: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}cmark-android-aarch64/BuildScriptToolchain.cmake
+# ANDROID: -DCMAKE_Swift_FLAGS=-target aarch64-unknown-linux-android


### PR DESCRIPTION
@gottesmm and @etcwilde, I believe you two are most familiar with this `build-script` feature, let me know what you think. I reused the linux toolchain file generation for Android, as they have a lot in common, but can separate the two if wanted. This pull was tested by [cross-compiling on my Android CI](https://github.com/finagolfin/swift-android-sdk/actions/runs/16462280321), and natively on Android in the Termux app.

I will look at cross-compiling Foundation dependencies like libcurl with this new Android toolchain file in a subsequent pull.