### PR TITLE
Reenable 32-bit tests: dead_array_elim & string_optimization

### DIFF
--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -4,10 +4,6 @@
 // REQUIRES: swift_in_compiler
 // XFAIL: OS=linux-androideabi
 
-// Test needs to be updated for 32bit.
-// rdar://74810823
-// UNSUPPORTED: PTRSIZE=32
-
 // These tests check whether DeadObjectElimination pass runs as a part of the
 // optimization pipeline and eliminates dead array literals in Swift code.
 // Note that DeadObjectElimination pass relies on @_semantics annotations on

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -7,9 +7,6 @@
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
-// Test needs to be updated for 32bit.
-// rdar://74810823
-// UNSUPPORTED: PTRSIZE=32
 
 #if _runtime(_ObjC)
 import Foundation


### PR DESCRIPTION
Fixes rdar://74359824 (SILOptimizer tests failing on watchsimulator-i386)
