### PR TITLE
Differentiation: add missing `Info.plist.in`

### DIFF
--- a/Runtimes/Supplemental/Differentiation/Info.plist.in
+++ b/Runtimes/Supplemental/Differentiation/Info.plist.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>@PLIST_INFO_UTI@</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>@PLIST_INFO_NAME@</string>
+        <key>CFBundleShortVersionString</key>
+        <string>@PLIST_INFO_VERSION@</string>
+        <key>CFBundleVersion</key>
+        <string>@PLIST_INFO_BUILD_VERSION@</string>
+</dict>
+</plist>


### PR DESCRIPTION
This is required to build the Differentiation module.