### PR TITLE
[6.2] Make sure SwiftObject doesn't crash when compared to tagged pointers

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -439,10 +439,11 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
     return NO; // We know the ids are different
   }
   if (isObjCTaggedPointer(other)) {
-    // Rather than try to figure out how to deal with each possible tagged
-    // pointer type, just assume equality is symmetric and let the tagged object
-    // figure out what to do
-    return [other isEqual: self];
+    // Swift class types cannot be tagged, and a Swift Equatable conformance
+    // cannot validly be called for an object of a different type, so this can
+    // only be incorrect if someone has an Equatable that's invalid in an
+    // extremely specific way (unsafeBitCasting `other` to an unrelated type)
+    return NO;
   }
 
   // Get Swift type for self and other

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -438,7 +438,12 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
     // Legacy behavior: Don't proxy to Swift Hashable or Equatable
     return NO; // We know the ids are different
   }
-
+  if (isObjCTaggedPointer(other)) {
+    // Rather than try to figure out how to deal with each possible tagged
+    // pointer type, just assume equality is symmetric and let the tagged object
+    // figure out what to do
+    return [other isEqual: self];
+  }
 
   // Get Swift type for self and other
   auto selfMetadata = _swift_getClassOfAllocated(self);

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -22,6 +22,10 @@ struct MyNonEquatableStruct {
   var text: String
 }
 
+class MyEquatableClass: Equatable {
+  static func == (lhs: Foo, rhs: Foo) -> Bool { true }
+}
+
 BridgeEquatableToObjC.test("Bridge equatable struct") {
   let swiftA = MyEquatableStruct(text: "xABC")
   let swiftB = swiftA
@@ -46,5 +50,13 @@ BridgeEquatableToObjC.test("Bridge non-equatable struct") {
   expectEqual(objcResult, false)
 }
 
+BridgeEquatableToObjC.test("Compare tagged pointer to equatable SwiftObject") {
+  let literal = "The quick brown fox jumps over the lazy dog"
+  let bridgedLiteral = literal as NSString
+  let foo = Foo()
+  let bridgedFoo = foo as AnyObject
+  let result = bridgedFoo.isEqual(bridgedLiteral)
+  expectEqual(result, false)
+}
 
 runAllTests()

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -23,7 +23,7 @@ struct MyNonEquatableStruct {
 }
 
 class MyEquatableClass: Equatable {
-  static func == (lhs: Foo, rhs: Foo) -> Bool { true }
+  static func == (lhs: MyEquatableClass, rhs: MyEquatableClass) -> Bool { true }
 }
 
 BridgeEquatableToObjC.test("Bridge equatable struct") {
@@ -53,7 +53,7 @@ BridgeEquatableToObjC.test("Bridge non-equatable struct") {
 BridgeEquatableToObjC.test("Compare tagged pointer to equatable SwiftObject") {
   let literal = "The quick brown fox jumps over the lazy dog"
   let bridgedLiteral = literal as NSString
-  let foo = Foo()
+  let foo = MyEquatableClass()
   let bridgedFoo = foo as AnyObject
   let result = bridgedFoo.isEqual(bridgedLiteral)
   expectEqual(result, false)


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift/pull/83269

Explanation: This fixes a pre-existing crash that is now being hit in practice due to increased usage of tagged pointers
Scope: Only changes the behavior of Equatable Swift classes that are bridged to ObjC and then compared to a tagged pointer via -isEqual:
Issue: rdar://152912840
Risk: Low. Very straightforward change, and the only situation it changes behavior in was guaranteed to crash before
Testing: Added a new test covering this scenario
Reviewer: @glessard 