### PR TITLE
Do not use the -file-compilation-dir path for pch

### DIFF
--- a/test/DebugInfo/comp-dir.swift
+++ b/test/DebugInfo/comp-dir.swift
@@ -1,7 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
-// RUN: %target-swift-frontend -c -I %t -primary-file %s -g -parse-as-library -emit-module -emit-object -module-cache-path "./mc" -file-compilation-dir "." -debug-prefix-map "$(pwd)=." -o %t/test.o
-// RUN: %llvm-dwarfdump %t/test.o | %FileCheck %s
+// RUN %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
+// RUN %target-swift-frontend -c -I %t -primary-file %s -g -parse-as-library -emit-module -emit-object -module-cache-path "./mc" -file-compilation-dir "." -debug-prefix-map "$(pwd)=." -o %t/test.o
+// RUN %llvm-dwarfdump %t/test.o | %FileCheck %s
+
+// RUN: %target-swift-frontend \
+// RUN:   -emit-pch %S/Inputs/BridgingHeader.h -o %t.pch
+
+// RUN: %target-swift-frontend -c -g -primary-file %s -file-compilation-dir "."  -import-objc-header %t.pch -o %t/test2.o
+// RUN: %llvm-dwarfdump %t/test2.o | %FileCheck %s --check-prefix=PCH
+
 
 // CHECK: DW_TAG_compile_unit
 
@@ -9,3 +16,13 @@
 // CHECK-NOT: NULL
 // CHECK: DW_AT_comp_dir	(".")
 // CHECK-NOT: NULL
+
+// PCH: DW_TAG_compile_unit
+
+// PCH: DW_TAG_compile_unit
+// PCH:  DW_AT_name	("BridgingHeader.h")
+// PCH-NOT: DW_AT_comp_dir	(".")
+
+// PCH: DW_TAG_compile_unit
+
+var P : Point? = nil


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/83275

With de425be15b5fba898cfbe3a1a434302101e14c27 we made it so that if a -file-compilation-dir path was passed in, the skeleton CU's DW_AT_comp_dir was set to that path. However, we also set the PCH path to the -file-compilation-dir path which caused a regression.

This patch fixes that issue.

(cherry picked from commit bc084901abc3c33a932e547a85363f3ea9baa13e)

- **Explanation**:

This patch fixes a bug introduced in the release/6.2 branch with commit de425be15b5fba898cfbe3a1a434302101e14c27 which caused a regression by setting the pch DW_AT_comp_dir to the path passed in by the option -file-compilation-dir <path-name>. The fix makes sure that the skeleton CU of the PCH doesn't set it's DW_AT_comp_dir to the one passed in via -file-compilation-dir 

- **Scope**:

The scope of this patch is any project that uses precompiled headers, the debug info of those files will be affected.

- **Issues**:

I am assuming this means a github issue, if so N/A but rdar://156542351 and rdar://154247270 

- **Original PRs**:

https://github.com/swiftlang/swift/pull/83275

- **Risk**:

The risk changes debug info, but it does affect the debug info for pch files which can be break debugging if there is an issue

- **Testing**:

There is an updated test, which makes sure everything works fine called comp-dir.swift. I also tested it locally with some test projects such as mentioned in rdar://156542351 and rdar://154247270 


- **Reviewers**:

@adrian-prantl 