### PR TITLE
[Distributed] diagnostics about unsupported typed throws in distributed

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -196,6 +196,7 @@ enum class DescriptiveDeclKind : uint8_t {
   StaticMethod,
   ClassMethod,
   DistributedMethod,
+  DistributedGetter,
   Getter,
   Setter,
   InitAccessor,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5772,6 +5772,9 @@ ERROR(distributed_actor_func_param_not_codable,none,
       "parameter %0 of type %1 in %kindonly2 does not conform to "
       "serialization requirement '%3'",
       (Identifier, Type, const AbstractFunctionDecl *, StringRef))
+ERROR(distributed_func_typed_throws_unsupported,none,
+      "%0 cannot declare typed throw",
+      (DescriptiveDeclKind))
 ERROR(distributed_actor_target_result_not_codable,none,
       "result type %0 of %kindbase1 does not conform to serialization requirement '%2'",
       (Type, const ValueDecl *, StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -263,8 +263,13 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
 
      switch (accessor->getAccessorKind()) {
      case AccessorKind::Get:
-     case AccessorKind::DistributedGet:
+       if (auto storage = accessor->getStorage();
+           storage && storage->isDistributed()) {
+         return DescriptiveDeclKind::DistributedGetter;
+       }
        return DescriptiveDeclKind::Getter;
+     case AccessorKind::DistributedGet:
+       return DescriptiveDeclKind::DistributedGetter;
 
      case AccessorKind::Set:
        return DescriptiveDeclKind::Setter;
@@ -384,6 +389,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(ClassMethod, "class method");
   ENTRY(DistributedMethod, "distributed instance method");
   ENTRY(Getter, "getter");
+  ENTRY(DistributedGetter, "distributed getter");
   ENTRY(Setter, "setter");
   ENTRY(WillSet, "willSet observer");
   ENTRY(DidSet, "didSet observer");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5836,8 +5836,9 @@ static IndexSubset *computeDifferentiabilityParameters(
 static DescriptiveDeclKind getAccessorDescriptiveDeclKind(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Get:
-  case AccessorKind::DistributedGet:
     return DescriptiveDeclKind::Getter;
+  case AccessorKind::DistributedGet:
+    return DescriptiveDeclKind::DistributedGetter;
   case AccessorKind::Set:
     return DescriptiveDeclKind::Setter;
   case AccessorKind::Read:

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -13,24 +13,26 @@
 // This file implements type checking support for Swift's concurrency model.
 //
 //===----------------------------------------------------------------------===//
-#include "TypeCheckConcurrency.h"
 #include "TypeCheckDistributed.h"
+#include "TypeCheckConcurrency.h"
+
+#include "TypeCheckEffects.h"
 #include "TypeChecker.h"
-#include "swift/Strings.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/DistributedDecl.h"
+#include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
-#include "swift/AST/DistributedDecl.h"
-#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
-#include "swift/AST/ImportCache.h"
-#include "swift/AST/ExistentialLayout.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
-#include "swift/AST/ASTPrinter.h"
+#include "swift/Strings.h"
 
 using namespace swift;
 
@@ -609,7 +611,12 @@ bool CheckDistributedFunctionRequest::evaluate(
           func
       );
     }
-  }
+  } // for parameters
+
+  // For now, we do not support typed throws since the call-site would need to
+  // combine error type of the system (transport) and the target dist. function.
+  auto unsupportedThrows = checkSupportedDistributedTypedThrow(func, /*diagnose=*/true);
+  if (unsupportedThrows) return unsupportedThrows;
 
   // --- Result type must be either void or a serialization requirement conforming type
   if (checkDistributedTargetResultType(func, serializationReqType,
@@ -619,6 +626,61 @@ bool CheckDistributedFunctionRequest::evaluate(
 
   return false;
 }
+
+bool swift::checkSupportedDistributedTypedThrow(AbstractFunctionDecl *decl, bool diagnose) {
+  auto &C = decl->getASTContext();
+
+  if (!decl->hasThrows())
+    return false; // no 'throws' is supported always
+
+  // It must have a thrown error type...
+  auto thrownError = decl->getThrownInterfaceType();
+  if (!thrownError)
+    return false;
+
+  auto errorType = C.getErrorExistentialType();
+  if (thrownError->isEqual(errorType)) {
+    // we support explicitly throwing 'Error'
+    return false;
+  }
+
+  auto neverType = C.getNeverType();
+  if (thrownError->isEqual(neverType)) {
+    // throws(Never) is equivalent to not throwing, so we allow it
+    return false;
+  }
+
+  // Otherwise, it may be some other type, or a generic type param...
+  auto thrownErrorGP = thrownError->getAs<GenericTypeParamType>();
+  if (!thrownErrorGP) {
+    // it wasn't a generic param, so it would be some type that we don't support!
+    if (diagnose) {
+      decl->diagnose(
+        diag::distributed_func_typed_throws_unsupported,
+        decl->getDescriptiveKind())
+      .fixItReplace(decl->getThrowsLoc(), "throws");
+    }
+    return true;
+  }
+
+  // E: Error must be the only conformance requirement on the generic parameter.
+  if (auto genericSig = decl->getGenericSignature()) {
+    // If we're throwing exactly 'E: Error' this is supported because equivalent to 'throws'
+    auto requiredProtocols = genericSig->getRequiredProtocols(thrownErrorGP);
+    if (requiredProtocols.size() == 1 &&
+        requiredProtocols[0]->getKnownProtocolKind() == KnownProtocolKind::Error)
+      return false;
+  }
+
+    if (diagnose) {
+      decl->diagnose(
+        diag::distributed_func_typed_throws_unsupported,
+        decl->getDescriptiveKind())
+      .fixItReplace(decl->getThrowsLoc(), "throws");
+    }
+    return true;
+}
+
 
 /// Check whether the function is a proper distributed computed property
 ///
@@ -659,6 +721,10 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
       getDistributedActorSerializationType(var->getDeclContext());
 
   if (checkDistributedTargetResultType(var, serializationRequirement, diagnose)) {
+    return true;
+  }
+
+  if (checkSupportedDistributedTypedThrow(var->getAccessor(AccessorKind::Get), diagnose)) {
     return true;
   }
 

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -60,6 +60,9 @@ bool checkDistributedFunction(AbstractFunctionDecl *decl);
 /// They are effectively checked the same way as argument-less methods.
 bool checkDistributedActorProperty(VarDecl *decl, bool diagnose);
 
+/// Check if the function has a 'throws' that we support in distributed functions.
+bool checkSupportedDistributedTypedThrow(AbstractFunctionDecl *decl, bool diagnose);
+
 /// Diagnose a distributed func declaration in a not-distributed actor protocol.
 void diagnoseDistributedFunctionInNonDistributedActorProtocol(
   const ProtocolDecl *proto, InFlightDiagnostic &diag);

--- a/test/Distributed/distributed_typed_throws.swift
+++ b/test/Distributed/distributed_typed_throws.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+protocol MyError: Error, Codable { }
+
+struct DistributedBoom: Error, Codable {
+  var message: String
+}
+
+distributed actor ThrowingActor {
+
+  distributed func nope() throws(DistributedBoom) { // expected-error{{distributed instance method cannot declare typed throw}}
+    throw DistributedBoom(message: "A message!")
+  }
+
+  distributed func nope2<E: MyError>() throws(E) { // expected-error{{distributed instance method cannot declare typed throw}}
+    fatalError()
+  }
+
+  distributed func ok1() throws {
+    throw DistributedBoom(message: "A message!")
+  }
+
+  distributed func ok2() throws(Error) {
+    fatalError()
+  }
+
+  distributed func never() throws(Never) {
+    return
+  }
+
+  distributed func ok2<E: Error>() throws(E) {
+    fatalError()
+  }
+}
+
+distributed actor Robo<E: Error, ErrBad: MyError> {
+
+  distributed var ok0: String {
+    get async throws {}
+  }
+
+  distributed var ok1: String {
+    get async throws(Error) {}
+  }
+
+  distributed var ok2: String {
+    get async throws(E) {}
+  }
+
+  distributed var bad1: String {
+    get async throws(ErrBad) {} // expected-error{{distributed getter cannot declare typed throw}}
+  }
+
+  distributed var bad2: String {
+    get async throws(DistributedBoom) {} // expected-error{{distributed getter cannot declare typed throw}}
+  }
+
+}


### PR DESCRIPTION
Distributed funcs cannot support typed throws until we do more work on it, so for now we should be explicitly erroring on typed throws use, otherwise error messages can be pretty confusing.

This is a feature we may want to enable in the future, but for now, just ban it explicitly rather than rely on failures happening elsewhere and being confusing.

Resolves rdar://136467528