### PR TITLE
PrintAsClang: Add support for custom availability domains

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -220,6 +220,7 @@ CLANG_MACRO("SWIFT_UNAVAILABLE", , "__attribute__((unavailable))")
 CLANG_MACRO("SWIFT_UNAVAILABLE_MSG", "(msg)", "__attribute__((unavailable(msg)))")
 
 CLANG_MACRO("SWIFT_AVAILABILITY", "(plat, ...)", "__attribute__((availability(plat, __VA_ARGS__)))")
+CLANG_MACRO("SWIFT_AVAILABILITY_DOMAIN", "(dom, ...)", "__attribute__((availability(domain: dom, __VA_ARGS__)))")
 
 CLANG_MACRO("SWIFT_WEAK_IMPORT", , "__attribute__((weak_import))")
 

--- a/test/ClangImporter/Inputs/availability_domains_bridging_header.h
+++ b/test/ClangImporter/Inputs/availability_domains_bridging_header.h
@@ -6,3 +6,65 @@ static struct __AvailabilityDomain bay_bridge
 static struct __AvailabilityDomain golden_gate_bridge
     __attribute__((availability_domain(GoldenGateBridge))) = {
         __AVAILABILITY_DOMAIN_DISABLED, 0};
+
+#define AVAIL 0
+#define UNAVAIL 1
+
+
+#if __OBJC__
+@import Foundation;
+
+__attribute__((availability(domain:BayBridge, AVAIL)))
+@interface BayBridgeAvailable : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:BayBridge, UNAVAIL)))
+@interface BayBridgeUnavailable : NSObject
+- (instancetype)init;
+@end
+
+@interface ImplementMe : NSObject
+- (instancetype)init;
+- (void)availableInBayBridge __attribute__((availability(domain:BayBridge, AVAIL)));
+- (void)unavailableInBayBridge __attribute__((availability(domain:BayBridge, UNAVAIL)));
+
+- (void)availableInGoldenGateBridge __attribute__((availability(domain:GoldenGateBridge, AVAIL)));
+- (void)unavailableInGoldenGateBridge __attribute__((availability(domain:GoldenGateBridge, UNAVAIL)));
+
+@end
+
+__attribute__((availability(domain:BayBridge, AVAIL)))
+@interface ImplementMeBayBridgeAvailable : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:BayBridge, UNAVAIL)))
+@interface ImplementMeBayBridgeUnavailable : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:GoldenGateBridge, AVAIL)))
+@interface ImplementMeGoldenGateBridgeAvailable : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:GoldenGateBridge, AVAIL)))
+@interface ImplementMeGoldenGateBridgeAvailable2 : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:GoldenGateBridge, AVAIL)))
+@interface ImplementMeGoldenGateBridgeAvailable3 : NSObject
+- (instancetype)init;
+@end
+
+__attribute__((availability(domain:GoldenGateBridge, UNAVAIL)))
+@interface ImplementMeGoldenGateBridgeUnavailable : NSObject
+- (instancetype)init;
+@end
+
+#endif // __OBJC__
+
+#undef UNAVAIL
+#undef AVAIL

--- a/test/ClangImporter/Inputs/availability_domains_bridging_header.h
+++ b/test/ClangImporter/Inputs/availability_domains_bridging_header.h
@@ -1,8 +1,8 @@
 #include <feature-availability.h>
 
-static struct __AvailabilityDomain __BayBridge
+static struct __AvailabilityDomain bay_bridge
     __attribute__((availability_domain(BayBridge))) = {
         __AVAILABILITY_DOMAIN_ENABLED, 0};
-static struct __AvailabilityDomain __GoldenGateBridge
+static struct __AvailabilityDomain golden_gate_bridge
     __attribute__((availability_domain(GoldenGateBridge))) = {
         __AVAILABILITY_DOMAIN_DISABLED, 0};

--- a/test/ClangImporter/availability_custom_domains_objc.swift
+++ b/test/ClangImporter/availability_custom_domains_objc.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify \
+// RUN:   -import-objc-header %S/Inputs/availability_domains_bridging_header.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   %s %S/Inputs/availability_custom_domains_other.swift
+
+// Re-test with the bridging header precompiled into a .pch.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch \
+// RUN:   -o %t/bridging-header.pch %S/Inputs/availability_domains_bridging_header.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify \
+// RUN:   -import-objc-header %t/bridging-header.pch \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   %s %S/Inputs/availability_custom_domains_other.swift
+
+// REQUIRES: swift_feature_CustomAvailability
+// REQUIRES: objc_interop
+
+import Oceans // re-exports Rivers
+
+func testObjCClasses( // expected-note {{add '@available' attribute to enclosing global function}}
+  _ bayBridgeAvailable: BayBridgeAvailable, // expected-error {{'BayBridgeAvailable' is only available in BayBridge}}
+  _ bayBridgeUnavailable: BayBridgeUnavailable, // expected-error {{'BayBridgeUnavailable' is unavailable}}
+) { }
+
+@objc @implementation
+extension ImplementMe {
+  // FIXME: [availability] @available(BayBridge) should be required
+  func availableInBayBridge() { }
+
+  // FIXME: [availability] Should match and suggest @available(BayBridge, unavailable)
+  func unavailableInBayBridge() { } // expected-error {{instance method 'unavailableInBayBridge()' does not match any instance method declared in the headers for 'ImplementMe'}}
+  // expected-note@-1 {{add 'private' or 'fileprivate'}}
+  // expected-note@-2 {{add 'final' to define a Swift-only instance method}}
+
+  @available(GoldenGateBridge)
+  func availableInGoldenGateBridge() { }
+
+  // FIXME: [availability] This should be accepted
+  @available(GoldenGateBridge, unavailable)
+  func unavailableInGoldenGateBridge() { } // expected-error {{instance method 'unavailableInGoldenGateBridge()' does not match any instance method declared in the headers for 'ImplementMe'}}
+  // expected-note@-1 {{add 'private' or 'fileprivate'}}
+  // expected-note@-2 {{add 'final' to define a Swift-only instance method}}
+}
+
+@objc @implementation
+extension ImplementMeBayBridgeAvailable { // expected-error {{'ImplementMeBayBridgeAvailable' is only available in BayBridge}}
+  // expected-note@-1 {{add '@available' attribute to enclosing extension}}
+}
+
+@objc @implementation
+extension ImplementMeBayBridgeUnavailable { // expected-error {{'ImplementMeBayBridgeUnavailable' is unavailable}}
+}
+
+@available(GoldenGateBridge)
+@objc @implementation
+extension ImplementMeGoldenGateBridgeAvailable {
+}
+
+@available(BayBridge)
+@objc @implementation
+extension ImplementMeGoldenGateBridgeAvailable2 { // expected-error {{'ImplementMeGoldenGateBridgeAvailable2' is only available in GoldenGateBridge}}
+  // expected-note@-1 {{add '@available' attribute to enclosing extension}}
+}
+
+// FIXME: [availability] This implementation should be rejected because its less
+// available than the original class declaration.
+@available(BayBridge)
+@available(GoldenGateBridge)
+@objc @implementation
+extension ImplementMeGoldenGateBridgeAvailable3 {
+}
+
+@available(GoldenGateBridge, unavailable)
+@objc @implementation
+extension ImplementMeGoldenGateBridgeUnavailable {
+}

--- a/test/Inputs/custom-modules/availability-domains/Oceans.h
+++ b/test/Inputs/custom-modules/availability-domains/Oceans.h
@@ -4,10 +4,10 @@
 int arctic_pred(void);
 int pacific_pred(void);
 
-static struct __AvailabilityDomain __Arctic
+static struct __AvailabilityDomain arctic_domain
     __attribute__((availability_domain(Arctic))) = {
         __AVAILABILITY_DOMAIN_DYNAMIC, arctic_pred};
-static struct __AvailabilityDomain __Pacific
+static struct __AvailabilityDomain pacific_domain
     __attribute__((availability_domain(Pacific))) = {
         __AVAILABILITY_DOMAIN_DYNAMIC, pacific_pred};
 

--- a/test/Inputs/custom-modules/availability-domains/Rivers.h
+++ b/test/Inputs/custom-modules/availability-domains/Rivers.h
@@ -1,6 +1,6 @@
 #include <feature-availability.h>
 
-static struct __AvailabilityDomain __Colorado __attribute__((
+static struct __AvailabilityDomain colorado_domain __attribute__((
     availability_domain(Colorado))) = {__AVAILABILITY_DOMAIN_DISABLED, 0};
 
 #define AVAIL 0

--- a/test/Inputs/custom-modules/availability-domains/Seas.h
+++ b/test/Inputs/custom-modules/availability-domains/Seas.h
@@ -1,8 +1,8 @@
 #include <feature-availability.h>
 
-static struct __AvailabilityDomain __Baltic __attribute__((
+static struct __AvailabilityDomain baltic_domain __attribute__((
     availability_domain(Baltic))) = {__AVAILABILITY_DOMAIN_ENABLED, 0};
-static struct __AvailabilityDomain __Mediterranean __attribute__((
+static struct __AvailabilityDomain _mediterranean __attribute__((
     availability_domain(Mediterranean))) = {__AVAILABILITY_DOMAIN_ENABLED, 0};
 
 #define AVAIL 0

--- a/test/PrintAsObjC/availability_custom_domains.swift
+++ b/test/PrintAsObjC/availability_custom_domains.swift
@@ -1,0 +1,232 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/func.h -DFUNC
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-FUNC --input-file %t/func.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/func.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/class.h -DCLASS
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-CLASS --input-file %t/class.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/class.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/class_member.h -DCLASS_MEMBER
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-CLASS-MEMBER --input-file %t/class_member.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/class_member.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/protocol.h -DPROTOCOL
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-PROTOCOL --input-file %t/protocol.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/protocol.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/protocol_member.h -DPROTOCOL_MEMBER
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-PROTOCOL-MEMBER --input-file %t/protocol_member.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/protocol_member.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/extension.h -DEXTENSION
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-EXTENSION --input-file %t/extension.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/extension.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/extension_member.h -DEXTENSION_MEMBER
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-EXTENSION-MEMBER --input-file %t/extension_member.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/extension_member.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/enum.h -DENUM
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-ENUM --input-file %t/enum.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/enum.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/enum_member.h -DENUM_MEMBER
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-ENUM-MEMBER --input-file %t/enum_member.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/enum_member.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck \
+// RUN:   -verify -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-objc-header %S/../Inputs/empty.h \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -emit-objc-header-path %t/private.h -DPRIVATE
+
+// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE --input-file %t/private.h
+// RUN: %check-in-clang -I %S/../Inputs/custom-modules/availability-domains %t/private.h
+
+// REQUIRES: swift_feature_CustomAvailability
+// REQUIRES: objc_interop
+
+import Oceans
+
+#if FUNC
+
+// CHECK-FUNC: SWIFT_EXTERN void arctic_func(void) SWIFT_NOEXCEPT SWIFT_AVAILABILITY_DOMAIN(Arctic,0);
+@available(Arctic)
+@_cdecl("arctic_func") func arcticFunc() { }
+
+#elseif CLASS
+
+// CHECK-CLASS: SWIFT_AVAILABILITY_DOMAIN(Arctic,0)
+// CHECK-CLASS-LABEL: @interface ArcticClass{{$}}
+@available(Arctic)
+@objc class ArcticClass {
+  // CHECK-CLASS-NEXT: - (void)alwaysAvailable;
+  @objc func alwaysAvailable() { }
+}
+// CHECK-CLASS-LABEL: @end
+
+#elseif CLASS_MEMBER
+
+// CHECK-CLASS-MEMBER-LABEL: @interface AvailableClass{{$}}
+@objc class AvailableClass {
+  // CHECK-CLASS-MEMBER-NEXT: - (void)availableInArctic SWIFT_AVAILABILITY_DOMAIN(Arctic,0);
+  @available(Arctic)
+  @objc func availableInArctic() { }
+
+  // CHECK-CLASS-MEMBER-NEXT: @property (nonatomic) NSInteger unavailableInArctic SWIFT_AVAILABILITY_DOMAIN(Arctic,1);
+  @available(Arctic, unavailable)
+  @objc var unavailableInArctic: Int {
+    get { 0 }
+    set { }
+  }
+}
+// CHECK-CLASS-MEMBER-LABEL: @end
+
+#elseif PROTOCOL
+
+// CHECK-PROTOCOL: SWIFT_AVAILABILITY_DOMAIN(Arctic,0)
+// CHECK-PROTOCOL-LABEL: @protocol ArcticProtocol{{$}}
+@available(Arctic)
+@objc protocol ArcticProtocol {
+  // CHECK-PROTOCOL-NEXT: - (void)requirement;
+  func requirement()
+}
+// CHECK-PROTOCOL-LABEL: @end
+
+#elseif PROTOCOL_MEMBER
+
+// CHECK-PROTOCOL-MEMBER-LABEL: @protocol AvailableProtocol{{$}}
+@objc protocol AvailableProtocol {
+  // CHECK-PROTOCOL-MEMBER-NEXT: - (void)availableInArctic SWIFT_AVAILABILITY_DOMAIN(Arctic,0);
+  @available(Arctic)
+  func availableInArctic()
+
+  func requirement()
+}
+// CHECK-PROTOCOL-MEMBER-LABEL: @end
+
+#elseif EXTENSION
+
+// CHECK-EXTENSION-LABEL: @interface AvailableClass{{$}}
+@objc class AvailableClass {
+}
+// CHECK-EXTENSION-LABEL: @end
+
+// CHECK-EXTENSION-LABEL: SWIFT_AVAILABILITY_DOMAIN(Arctic,0)
+// CHECK-EXTENSION-NEXT: @interface AvailableClass (SWIFT_EXTENSION(availability_custom_domains))
+@available(Arctic)
+extension AvailableClass {
+  // CHECK-EXTENSION-NEXT: - (void)alwaysAvailable;
+  @objc func alwaysAvailable() { }
+}
+// CHECK-EXTENSION-LABEL: @end
+
+#elseif EXTENSION_MEMBER
+
+// CHECK-EXTENSION-MEMBER-LABEL: @interface AvailableClass{{$}}
+@objc class AvailableClass {
+}
+// CHECK-EXTENSION-MEMBER-LABEL: @end
+
+// CHECK-EXTENSION-MEMBER-LABEL: @interface AvailableClass (SWIFT_EXTENSION(availability_custom_domains))
+extension AvailableClass {
+  // CHECK-EXTENSION-MEMBER-NEXT: - (void)availableInArctic SWIFT_AVAILABILITY_DOMAIN(Arctic,0);
+  @available(Arctic)
+  @objc func availableInArctic() { }
+}
+// CHECK-EXTENSION-MEMBER-LABEL: @end
+
+#elseif ENUM
+
+// FIXME: [availability] Availability attribute is missing
+// CHECK-ENUM-LABEL: typedef SWIFT_ENUM(NSInteger, ArcticEnum, closed)
+@available(Arctic)
+@objc enum ArcticEnum: Int {
+  // CHECK-ENUM-NEXT: ArcticEnumAvailable = 0,
+  case available
+}
+// CHECK-ENUM-NEXT: };
+
+#elseif ENUM_MEMBER
+
+// FIXME: [availability] Availability attribute is missing
+// CHECK-ENUM-MEMBER-LABEL: typedef SWIFT_ENUM(NSInteger, AvailableEnum, closed)
+@objc enum AvailableEnum: Int {
+  // CHECK-ENUM-MEMBER-NEXT: AvailableEnumAvailableInArctic = 0,
+  @available(Arctic)
+  case availableInArctic
+}
+// CHECK-ENUM-MEMBER-NEXT: };
+
+#elseif PRIVATE
+
+// CHECK-PRIVATE-NOT: @import Oceans;
+// CHECK-PRIVATE-NOT: @interface PrivateClass
+@available(Arctic)
+@objc private class PrivateClass { }
+
+// CHECK-PRIVATE-LABEL: @interface ClassWithPrivateMember{{$}}
+@objc class ClassWithPrivateMember {
+  // CHECK-PRIVATE-NOT: - (void)member;
+  @available(Arctic)
+  @objc private func member() { }
+}
+
+#endif


### PR DESCRIPTION
Also, add `@objc @implementation` tests for custom availability domains. These tests reveal that the `@objc @implementation` checker does not verify the availability of implementations. It should reject implementations where the extension or its members are more or less available than the class or method that they implement (rdar://156564928).

Resolves rdar://154510571.