### PR TITLE
[6.2][Distributed] diagnostics about unsupported typed throws in distributed

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -196,6 +196,7 @@ enum class DescriptiveDeclKind : uint8_t {
   StaticMethod,
   ClassMethod,
   DistributedMethod,
+  DistributedGetter,
   Getter,
   Setter,
   InitAccessor,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2354,6 +2354,7 @@ NOTE(inherited_search_path_resolves_module,none,
      "'%0' can be found using a search path that was specified when building module '%1' ('%2'). "
      "This search path was not explicitly specified on the current compilation.", (StringRef, StringRef, StringRef))
 
+
 ERROR(clang_dependency_scan_error, none, "Clang dependency scanner failure: %0", (StringRef))
 ERROR(clang_header_dependency_scan_error, none, "Bridging header dependency scan failure: %0", (StringRef))
 
@@ -5258,7 +5259,6 @@ GROUPED_ERROR(opaque_type_var_no_underlying_type,OpaqueTypeInference,none,
       "property declares an opaque return type, but cannot infer the "
       "underlying type from its initializer expression", ())
 
-
 //------------------------------------------------------------------------------
 // MARK: Discard Statement
 //------------------------------------------------------------------------------
@@ -5716,6 +5716,9 @@ ERROR(distributed_local_cannot_be_used,none,
 ERROR(distributed_actor_func_param_not_codable,none,
       "parameter '%0' of type %1 in %2 does not conform to serialization requirement '%3'",
       (StringRef, Type, DescriptiveDeclKind, StringRef))
+ERROR(distributed_func_typed_throws_unsupported,none,
+      "%0 cannot declare typed throw",
+      (DescriptiveDeclKind))
 ERROR(distributed_actor_target_result_not_codable,none,
       "result type %0 of %kindbase1 does not conform to serialization requirement '%2'",
       (Type, const ValueDecl *, StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -259,8 +259,13 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
 
      switch (accessor->getAccessorKind()) {
      case AccessorKind::Get:
-     case AccessorKind::DistributedGet:
+       if (auto storage = accessor->getStorage();
+           storage && storage->isDistributed()) {
+         return DescriptiveDeclKind::DistributedGetter;
+       }
        return DescriptiveDeclKind::Getter;
+     case AccessorKind::DistributedGet:
+       return DescriptiveDeclKind::DistributedGetter;
 
      case AccessorKind::Set:
        return DescriptiveDeclKind::Setter;
@@ -380,6 +385,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(ClassMethod, "class method");
   ENTRY(DistributedMethod, "distributed instance method");
   ENTRY(Getter, "getter");
+  ENTRY(DistributedGetter, "distributed getter");
   ENTRY(Setter, "setter");
   ENTRY(WillSet, "willSet observer");
   ENTRY(DidSet, "didSet observer");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5785,8 +5785,9 @@ static IndexSubset *computeDifferentiabilityParameters(
 static DescriptiveDeclKind getAccessorDescriptiveDeclKind(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Get:
-  case AccessorKind::DistributedGet:
     return DescriptiveDeclKind::Getter;
+  case AccessorKind::DistributedGet:
+    return DescriptiveDeclKind::DistributedGetter;
   case AccessorKind::Set:
     return DescriptiveDeclKind::Setter;
   case AccessorKind::Read:

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -60,6 +60,9 @@ bool checkDistributedFunction(AbstractFunctionDecl *decl);
 /// They are effectively checked the same way as argument-less methods.
 bool checkDistributedActorProperty(VarDecl *decl, bool diagnose);
 
+/// Check if the function has a 'throws' that we support in distributed functions.
+bool checkSupportedDistributedTypedThrow(AbstractFunctionDecl *decl, bool diagnose);
+
 /// Diagnose a distributed func declaration in a not-distributed actor protocol.
 void diagnoseDistributedFunctionInNonDistributedActorProtocol(
   const ProtocolDecl *proto, InFlightDiagnostic &diag);

--- a/test/Distributed/distributed_typed_throws.swift
+++ b/test/Distributed/distributed_typed_throws.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+protocol MyError: Error, Codable { }
+
+struct DistributedBoom: Error, Codable {
+  var message: String
+}
+
+distributed actor ThrowingActor {
+
+  distributed func nope() throws(DistributedBoom) { // expected-error{{distributed instance method cannot declare typed throw}}
+    throw DistributedBoom(message: "A message!")
+  }
+
+  distributed func nope2<E: MyError>() throws(E) { // expected-error{{distributed instance method cannot declare typed throw}}
+    fatalError()
+  }
+
+  distributed func ok1() throws {
+    throw DistributedBoom(message: "A message!")
+  }
+
+  distributed func ok2() throws(Error) {
+    fatalError()
+  }
+
+  distributed func never() throws(Never) {
+    return
+  }
+
+  distributed func ok2<E: Error>() throws(E) {
+    fatalError()
+  }
+}
+
+distributed actor Robo<E: Error, ErrBad: MyError> {
+
+  distributed var ok0: String {
+    get async throws {}
+  }
+
+  distributed var ok1: String {
+    get async throws(Error) {}
+  }
+
+  distributed var ok2: String {
+    get async throws(E) {}
+  }
+
+  distributed var bad1: String {
+    get async throws(ErrBad) {} // expected-error{{distributed getter cannot declare typed throw}}
+  }
+
+  distributed var bad2: String {
+    get async throws(DistributedBoom) {} // expected-error{{distributed getter cannot declare typed throw}}
+  }
+
+}


### PR DESCRIPTION
This makes explicit error messages about typed throws in distributed functions. We did never support them in distributed funcs however we didn't emit good errors, just something "somewhere" would eventually fail, this provides a better user experience -- until we actually provide the support for these errors.

Original PR: https://github.com/swiftlang/swift/pull/83279

Resolves: rdar://136467528