### PR TITLE
DebugInfo: Stop setting `FlagObjectPointer` without being certain tha…

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1941,7 +1941,8 @@ private:
           nullptr, PtrSize, 0,
           /* DWARFAddressSpace */ std::nullopt, MangledName);
 
-      return DBuilder.createObjectPointerType(PTy, /*Implicit=*/true);
+      // FIXME: Set DIFlagObjectPointer and make sure it is only set for `self`.
+      return PTy;
     }
     case TypeKind::BuiltinExecutor: {
       return createDoublePointerSizedStruct(


### PR DESCRIPTION
…t the parameter is `self`

The stable/21.x branch is not happy with us setting the object pointer flag here because it now asserts that this flag is set for at most one function parameter. We should add a dedicated routine for instance method parameters. For now, stop setting the flag altogether to unblock the stdlib build on rebranch.