### PR TITLE
test/embedded/avr: `testStdlibFunctioning.swift` is unsupported on Wasm

### DIFF
--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -3,6 +3,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: CODEGENERATOR=AVR
 // REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: CPU=wasm32
 
 import Swift
 


### PR DESCRIPTION
This test should not run as a part of Embedded Swift for Wasm test suite, but somehow it does in this run: https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/3262/console