### PR TITLE
test/CMakeLists.txt: fix `--lit-args` unhandled in Wasm tests

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -196,6 +196,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
             self.build_dir, 'test-wasi-wasm32', path) for path in lit_test_paths]
         self.cmake_options.define('SWIFT_LIT_TEST_PATHS:STRING',
                                   ';'.join(lit_test_paths))
+        self.cmake_options.define('LLVM_LIT_ARGS', self.args.lit_args)
         test_driver_options = [
             # compiler-rt is not installed in the final toolchain, so use one
             # in build dir


### PR DESCRIPTION
Due to the fact that Wasm testing targets are configured by Python `build-script` unlike `build-script-impl` for the rest of testing targets, `--lit-args` value was ignored and not recorded in these targets. These are configured as `LLVM_LIT_ARGS` in CMake.

Let's assign the `LLVM_LIT_ARGS` configuration value in Python `build-script` to handle `--lit-args` consistently for all testing targets.