### PR TITLE
[6.2] test/CMakeLists.txt: run Embedded Swift for Wasm tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -408,6 +408,14 @@ foreach(SDK ${SWIFT_SDKS})
       set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
       set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
 
+      # Reset these values for WASI, as Embedded Swift for WASI requires separate lit configs.
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_old ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB})
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING_old ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING})
+      if(${SDK} STREQUAL "WASI")
+        set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB OFF)
+        set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING OFF)
+      endif()
+
       swift_configure_lit_site_cfg(
           "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
           "${test_bin_dir}/lit.site.cfg"
@@ -429,6 +437,10 @@ foreach(SDK ${SWIFT_SDKS})
         DEPENDS
           "${test_bin_dir}/lit.swift-features.cfg"
           "${validation_test_bin_dir}/lit.swift-features.cfg")
+
+      # Restore old values in case they were reset for WASI tests lit configs.
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_old})
+      set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING ${SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING_old})
 
       set(test_dependencies)
       get_test_dependencies("${SDK}" test_dependencies)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -298,7 +298,7 @@ function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_ov
   endif()
 
 
-  set(LIT_ARGS "${swift_lit_args_result} ${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
+  set(swift_lit_args_result "${swift_lit_args_result} ${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
   separate_arguments(swift_lit_args_result)
 
   set(${ARGS_VAR_OUT} ${swift_lit_args_result} PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -607,8 +607,7 @@ foreach(SDK ${SWIFT_SDKS})
             "test${VARIANT_SUFFIX}.lit.site.cfg")
         swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
 
-        set(test_target_name
-            "check-swift${VARIANT_SUFFIX}")
+        set(test_target_name "check-swift${VARIANT_SUFFIX}")
         set(directories "${test_bin_dir}")
 
         set(embedded_wasm_lit_args)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -677,6 +677,18 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
   swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+
+  set(VARIANT_SUFFIX "-embedded-wasi")
+  set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+  message(STATUS "SWIFT_LIT_ARGS is ${SWIFT_LIT_ARGS}")
 endif()
 
 # Add shortcuts for the default variant.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -180,51 +180,129 @@ set(SWIFT_LIT_ARGS "" CACHE STRING "Arguments to pass to lit")
 
 set(SWIFT_LIT_ENVIRONMENT "" CACHE STRING "Environment to use for lit invocations")
 
-if(NOT SWIFT_INCLUDE_TOOLS)
-  if(SWIFT_RUN_TESTS_WITH_HOST_COMPILER)
-    precondition(CMAKE_Swift_COMPILER MESSAGE "Can only run tests if a Swift compiler is specified")
-    get_filename_component(SWIFT_COMPILER_DIR "${CMAKE_Swift_COMPILER}" DIRECTORY)
-    precondition(SWIFT_COMPILER_DIR)
-    # We assume that we are building against a toolchain where all tools are
-    # next to swiftc.
-    list(APPEND SWIFT_LIT_ARGS
-      "--path=${SWIFT_COMPILER_DIR}")
-  else()
-    list(APPEND SWIFT_LIT_ARGS
-      "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
-      "--param" "swift_native_llvm_tools_path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
-      "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
-      "--param" "swift_native_clang_tools_path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
-      "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
-      "--param" "swift_native_swift_tools_path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
-      )
-  endif()
-  if(SWIFT_BUILD_STDLIB)
-    # If building only static stdlib, use `swift_static` resources directory.
-    if(NOT SWIFT_BUILD_DYNAMIC_STDLIB AND SWIFT_BUILD_STATIC_STDLIB)
-      list(APPEND SWIFT_LIT_ARGS
-           "--param" "test_resource_dir=${SWIFTSTATICLIB_DIR}")
+option(SWIFT_TEST_USE_LEAKS "Run Swift stdlib tests under leaks" FALSE)
+
+function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_override)
+  set(swift_lit_args_result)
+
+  if(NOT SWIFT_INCLUDE_TOOLS)
+    if(SWIFT_RUN_TESTS_WITH_HOST_COMPILER)
+      precondition(CMAKE_Swift_COMPILER MESSAGE "Can only run tests if a Swift compiler is specified")
+      get_filename_component(SWIFT_COMPILER_DIR "${CMAKE_Swift_COMPILER}" DIRECTORY)
+      precondition(SWIFT_COMPILER_DIR)
+      # We assume that we are building against a toolchain where all tools are
+      # next to swiftc.
+      list(APPEND swift_lit_args_result
+        "--path=${SWIFT_COMPILER_DIR}")
     else()
-      list(APPEND SWIFT_LIT_ARGS
-           "--param" "test_resource_dir=${SWIFTLIB_DIR}")
+      list(APPEND swift_lit_args_result
+        "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
+        "--param" "swift_native_llvm_tools_path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
+        "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
+        "--param" "swift_native_clang_tools_path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
+        "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
+        "--param" "swift_native_swift_tools_path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
+        )
+    endif()
+    if(SWIFT_BUILD_STDLIB)
+      if(resource_dir_override)
+        list(APPEND swift_lit_args_result
+             "--param" "test_resource_dir=${resource_dir_override}")
+      # If building only static stdlib, use `swift_static` resources directory.
+      elseif(NOT SWIFT_BUILD_DYNAMIC_STDLIB AND SWIFT_BUILD_STATIC_STDLIB)
+        list(APPEND swift_lit_args_result
+             "--param" "test_resource_dir=${SWIFTSTATICLIB_DIR}")
+      else()
+        list(APPEND swift_lit_args_result
+             "--param" "test_resource_dir=${SWIFTLIB_DIR}")
+      endif()
     endif()
   endif()
-endif()
 
-option(SWIFT_TEST_USE_LEAKS "Run Swift stdlib tests under leaks" FALSE)
-if (SWIFT_TEST_USE_LEAKS)
-  list(APPEND SWIFT_LIT_ARGS "--param" "leaks-all")
-endif()
+  if (SWIFT_TEST_USE_LEAKS)
+    list(APPEND swift_lit_args_result "--param" "leaks-all")
+  endif()
 
-if (SWIFT_ENABLE_ARRAY_COW_CHECKS)
-  list(APPEND SWIFT_LIT_ARGS
-       "--param" "array_cow_checks")
-endif()
+  if (SWIFT_ENABLE_ARRAY_COW_CHECKS)
+    list(APPEND swift_lit_args_result
+         "--param" "array_cow_checks")
+  endif()
 
-if(NOT CMAKE_CFG_INTDIR STREQUAL ".")
-  list(APPEND SWIFT_LIT_ARGS
-       "--param" "build_mode=${CMAKE_CFG_INTDIR}")
-endif()
+  if(NOT CMAKE_CFG_INTDIR STREQUAL ".")
+    list(APPEND swift_lit_args_result
+         "--param" "build_mode=${CMAKE_CFG_INTDIR}")
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
+    list(APPEND swift_lit_args_result "--param" "differentiable_programming")
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    list(APPEND swift_lit_args_result "--param" "concurrency")
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
+    list(APPEND swift_lit_args_result "--param" "distributed")
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+    list(APPEND swift_lit_args_result "--param" "string_processing")
+  endif()
+
+  if(SWIFT_ENABLE_BACKTRACING)
+    list(APPEND swift_lit_args_result "--param" "backtracing")
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
+    list(APPEND swift_lit_args_result "--param" "observation")
+  endif()
+
+  if(SWIFT_ENABLE_SYNCHRONIZATION)
+    list(APPEND swift_lit_args_result "--param" "synchronization")
+  endif()
+
+  if(SWIFT_ENABLE_VOLATILE)
+    list(APPEND swift_lit_args_result "--param" "volatile")
+  endif()
+
+  if(SWIFT_ENABLE_RUNTIME_MODULE)
+    list(APPEND swift_lit_args_result "--param" "runtime_module")
+  endif()
+
+  if(SWIFT_BUILD_REMOTE_MIRROR)
+    list(APPEND swift_lit_args_result "--param" "remote_mirror")
+  endif()
+
+  list(APPEND swift_lit_args_result "--param" "threading=${SWIFT_SDK_${tested_sdk}_THREADING_PACKAGE}")
+
+  # Enable on-crash backtracing if supported
+  if(("${tested_sdk}" STREQUAL "OSX" OR "${tested_sdk}" STREQUAL "LINUX")
+      AND NOT SWIFT_ASAN_BUILD)
+    list(APPEND swift_lit_args_result "--param" "backtrace_on_crash")
+  endif()
+
+  execute_process(COMMAND
+      $<TARGET_FILE:Python3::Interpreter> "-c" "import psutil"
+      RESULT_VARIABLE python_psutil_status
+      TIMEOUT 1 # second
+      ERROR_QUIET)
+  if(NOT python_psutil_status)
+    list(APPEND swift_lit_args_result "--timeout=3000") # 50 minutes
+  endif()
+
+  list(APPEND swift_lit_args_result "--xunit-xml-output=${test_results_dir}/lit-tests.xml")
+
+  if(NOT SWIFT_BUILD_STDLIB AND NOT SWIFT_PATH_TO_EXTERNAL_STDLIB_BUILD)
+    list(APPEND swift_lit_args_result
+        "--param" "test_sdk_overlay_dir=${SWIFTLIB_DIR}/${SWIFT_SDK_${tested_sdk}_LIB_SUBDIR}")
+  endif()
+
+
+  set(LIT_ARGS "${swift_lit_args_result} ${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
+  separate_arguments(swift_lit_args_result)
+
+  set(${ARGS_VAR_OUT} ${swift_lit_args_result} PARENT_SCOPE)
+endfunction()
 
 if (LLVM_USE_SANITIZER STREQUAL "Address")
   set(SWIFT_ASAN_BUILD TRUE)
@@ -429,73 +507,6 @@ foreach(SDK ${SWIFT_SDKS})
           COMMENT "Uploading stdlib")
 
       foreach(test_mode ${TEST_MODES})
-        set(LIT_ARGS "${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
-        separate_arguments(LIT_ARGS)
-
-        if(NOT SWIFT_BUILD_STDLIB AND NOT SWIFT_PATH_TO_EXTERNAL_STDLIB_BUILD)
-          list(APPEND LIT_ARGS
-              "--param" "test_sdk_overlay_dir=${SWIFTLIB_DIR}/${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
-        endif()
-
-        execute_process(COMMAND
-            $<TARGET_FILE:Python3::Interpreter> "-c" "import psutil"
-            RESULT_VARIABLE python_psutil_status
-            TIMEOUT 1 # second
-            ERROR_QUIET)
-        if(NOT python_psutil_status)
-          list(APPEND LIT_ARGS "--timeout=3000") # 50 minutes
-        endif()
-
-        list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
-          list(APPEND LIT_ARGS "--param" "differentiable_programming")
-        endif()
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
-          list(APPEND LIT_ARGS "--param" "concurrency")
-        endif()
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
-          list(APPEND LIT_ARGS "--param" "distributed")
-        endif()
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
-          list(APPEND LIT_ARGS "--param" "string_processing")
-        endif()
-
-        if(SWIFT_ENABLE_BACKTRACING)
-          list(APPEND LIT_ARGS "--param" "backtracing")
-        endif()
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
-          list(APPEND LIT_ARGS "--param" "observation")
-        endif()
-
-        if(SWIFT_ENABLE_SYNCHRONIZATION)
-          list(APPEND LIT_ARGS "--param" "synchronization")
-        endif()
-
-        if(SWIFT_ENABLE_VOLATILE)
-          list(APPEND LIT_ARGS "--param" "volatile")
-        endif()
-
-        if(SWIFT_ENABLE_RUNTIME_MODULE)
-          list(APPEND LIT_ARGS "--param" "runtime_module")
-        endif()
-
-        if(SWIFT_BUILD_REMOTE_MIRROR)
-          list(APPEND LIT_ARGS "--param" "remote_mirror")
-        endif()
-
-        list(APPEND LIT_ARGS "--param" "threading=${SWIFT_SDK_${SDK}_THREADING_PACKAGE}")
-
-        # Enable on-crash backtracing if supported
-        if(("${SDK}" STREQUAL "OSX" OR "${SDK}" STREQUAL "LINUX")
-            AND NOT SWIFT_ASAN_BUILD)
-          list(APPEND LIT_ARGS "--param" "backtrace_on_crash")
-        endif()
-
         foreach(test_subset ${TEST_SUBSETS})
           set(directories)
           set(dependencies ${test_dependencies})
@@ -535,6 +546,8 @@ foreach(SDK ${SWIFT_SDKS})
             set(maybe_command_upload_stdlib ${command_upload_stdlib})
           endif()
 
+          setup_lit_args(final_lit_args "${SDK}" "${SWIFT_TEST_RESULTS_DIR}" OFF)
+
           set(test_target_name
               "check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}")
           add_custom_target("${test_target_name}"
@@ -544,7 +557,7 @@ foreach(SDK ${SWIFT_SDKS})
               COMMAND
                 ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
                 $<TARGET_FILE:Python3::Interpreter> "${LIT}"
-                ${LIT_ARGS}
+                ${final_lit_args}
                 "--param" "swift_test_subset=${test_subset}"
                 "--param" "swift_test_mode=${test_mode}"
                 ${directories}
@@ -564,7 +577,7 @@ foreach(SDK ${SWIFT_SDKS})
               COMMAND
                 ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
                 $<TARGET_FILE:Python3::Interpreter> "${LIT}"
-                ${LIT_ARGS}
+                ${final_lit_args}
                 "--param" "swift_test_subset=${test_subset}"
                 "--param" "swift_test_mode=${test_mode}"
                 ${SWIFT_LIT_TEST_PATHS}
@@ -609,6 +622,17 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
   set(VARIANT_TRIPLE "riscv32-none-none-eabi")
   set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
   set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "riscv32-qemu-virt")
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+
+  set(VARIANT_SUFFIX "-embedded-wasi")
+  set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
   set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
   swift_configure_lit_site_cfg(
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -591,6 +591,44 @@ foreach(SDK ${SWIFT_SDKS})
               PROPERTY FOLDER "Tests/check-swift")
         endforeach()
       endforeach()
+
+      if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING AND (${ARCH} STREQUAL "wasm32"))
+        set(test_mode "optimize_none")
+        set(test_subset "primary")
+        set(VARIANT_SUFFIX "-embedded-wasi")
+        set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
+        set(test_bin_dir "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/embedded")
+        set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+        set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
+        set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+        swift_configure_lit_site_cfg(
+            "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+            "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+            "test${VARIANT_SUFFIX}.lit.site.cfg")
+        swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+
+        set(test_target_name
+            "check-swift${VARIANT_SUFFIX}")
+        set(directories "${test_bin_dir}")
+
+        set(embedded_wasm_lit_args)
+        setup_lit_args(embedded_wasm_lit_args "${SDK}" "${SWIFT_TEST_RESULTS_DIR}" "${SWIFTLIB_DIR}")
+
+        add_custom_target("${test_target_name}"
+            ${maybe_command_upload_stdlib}
+            ${command_upload_swift_reflection_test}
+            ${command_clean_test_results_dir}
+            COMMAND
+              ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
+              $<TARGET_FILE:Python3::Interpreter> "${LIT}"
+              ${embedded_wasm_lit_args}
+              "--param" "swift_test_subset=${test_subset}"
+              "--param" "swift_test_mode=${test_mode}"
+              ${directories}
+            DEPENDS ${dependencies}
+            COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
+            USES_TERMINAL)
+        endif()
     endforeach()
   endforeach()
 endforeach()
@@ -622,17 +660,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
   set(VARIANT_TRIPLE "riscv32-none-none-eabi")
   set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
   set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "riscv32-qemu-virt")
-  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
-  swift_configure_lit_site_cfg(
-      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
-      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
-      "test${VARIANT_SUFFIX}.lit.site.cfg")
-  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
-
-  set(VARIANT_SUFFIX "-embedded-wasi")
-  set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
-  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
-  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
   set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
   swift_configure_lit_site_cfg(
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -3,7 +3,7 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // `setjmp` is not available on WebAssembly/WASI
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 // https://github.com/apple/swift/issues/51632
 // In Android jmp_buf is int[16], which doesn't convert to &Int

--- a/test/Concurrency/Runtime/continuation_validation.swift
+++ b/test/Concurrency/Runtime/continuation_validation.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -6,7 +6,7 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 // UNSUPPORTED: back_deploy_concurrency
 
 // This test makes sure that:
@@ -365,7 +365,7 @@ struct Runner {
                 debugLog("==> Enter callee2")
                 debugLog("==> Exit callee2")
             }
-            
+
             // We add an inline never here to make sure that we do not eliminate
             // the dynamic access after inlining.
             @MainActor
@@ -374,7 +374,7 @@ struct Runner {
                 debugLog("==> Enter callee1")
                 let handle = Task { @MainActor in
                     debugLog("==> Enter callee1 Closure")
-                    
+
                     // These accesses end before we await in the task.
                     do {
                         callee2(&global1, &global2, &global3)
@@ -389,7 +389,7 @@ struct Runner {
                 await handle.value
                 debugLog("==> Exit callee1")
             }
-            
+
             debugLog("==> Enter 'testCase1'")
             await callee1()
             debugLog("==> Exit 'testCase1'")

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 
 // Crash expectations can't be implemented on WASI/WebAssembly.
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 // This test makes sure that we properly save/restore access when we
 // synchronously launch a task from a serial executor. The access from the task

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -4,7 +4,7 @@
 
 // WASI does not support the mandatory tail call, and needs to take the same
 // path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
-// XFAIL: OS=wasi
+// XFAIL: OS=wasip1
 
 sil_stage canonical
 

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -2,9 +2,9 @@
 
 // REQUIRES: concurrency
 
-// WASI does not support the mandatory tail call, and needs to take the same
+// Wasm does not support the mandatory tail call, and needs to take the same
 // path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
-// XFAIL: OS=wasip1
+// XFAIL: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -3,8 +3,6 @@
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 public struct LargeThing {

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend %s  -Xllvm -sil-print-types -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: PTRSIZE=64
 

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -5,8 +5,6 @@
 // REQUIRES: swift_feature_BuiltinModule
 
 // wasm currently disables aggressive reg2mem
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 import Builtin

--- a/test/IRGen/run-coroutine_accessors.swift
+++ b/test/IRGen/run-coroutine_accessors.swift
@@ -91,8 +91,6 @@
 // REQUIRES: concurrency_runtime
 
 // TODO: CoroutineAccessors: Enable on WASM.
-// UNSUPPORTED: wasm
-// UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
 
 // REQUIRES: swift_feature_CoroutineAccessors
@@ -243,7 +241,7 @@ struct Boxtional<T> : ResilientWrapping {
 
 @available(SwiftStdlib 9999, *)
 class NonresilientResilientWrappingSubclass<X : ResilientWrapping> : ResilientWrappingClass<X.Wrapped> {
-  init(_ impl: X) { 
+  init(_ impl: X) {
     self.impl = impl
     super.init()
   }

--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -enable-builtin-module -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -wmo -enable-builtin-module) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
@@ -41,7 +39,7 @@ func exerciseArrayValueWitnesses<T>(_ value: T) {
 
   (buf + 0).initialize(to: value)
   (buf + 1).initialize(to: value)
-  
+
   Builtin.copyArray(T.self, (buf + 2)._rawValue, buf._rawValue, 2._builtinWordValue)
   Builtin.takeArrayBackToFront(T.self, (buf + 1)._rawValue, buf._rawValue, 4._builtinWordValue)
   Builtin.takeArrayFrontToBack(T.self, buf._rawValue, (buf + 1)._rawValue, 4._builtinWordValue)

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -52,7 +52,7 @@ public func main() {
   protocolBoundFunc(GenericType<Bool>(Bool()))
 }
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)
 // CHECK: define {{.*}}void @"$e4Main4BoolVACycfC"()
 // CHECK: define {{.*}}void @"$e4Main4mainyyF"()
 // CHECK: define {{.*}}void @"$e8MyModule14nonGenericFuncyyF"()

--- a/test/embedded/basic-modules-no-stdlib.swift
+++ b/test/embedded/basic-modules-no-stdlib.swift
@@ -38,7 +38,7 @@ public func main() {
   moduleMain()
 }
 
-// CHECK: define {{.*}}@main{{.*}} {
+// CHECK: define {{.*}}@{{_*}}main{{.*}} {
 // CHECK: define {{.*}}void @"$e4Main4mainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$e8MyModule10moduleMainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$e8MyModule8ConcreteVACycfC"{{.*}} {

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -wmo) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
@@ -56,7 +54,7 @@ struct Main {
       // CHECK: MySubSubClass.foo
     }
     print("")
-    
+
     print("5") // CHECK: 5
     objects = []
     // CHECK: MyClass.deinit

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-IR
 
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
 
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/classes-multi-module.swift
+++ b/test/embedded/classes-multi-module.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModule.swift -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %t/Main.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
@@ -28,7 +28,7 @@ class X<T: BinaryInteger> {
   var x: T
 
   init(x: T) { self.x = x }
-  
+
   func bar() {
     print(x)
   }

--- a/test/embedded/classes-optional.swift
+++ b/test/embedded/classes-optional.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -module-name main -emit-irgen | %FileCheck %s --check-prefix CHECK-IR
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -77,7 +77,7 @@ struct Main {
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define {{.*}}@main
+// CHECK-IR:      define {{.*}}@{{_*}}main
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -84,7 +84,7 @@ struct Main {
     // CHECK: MySubClass.foo
     // CHECK: MySubSubClass.foo
     print("")
-    
+
     print("5") // CHECK: 5
     o.0 = nil
     // CHECK: MyClass.deinit

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -6,7 +6,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=wasip1
+// REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-release.swift
+++ b/test/embedded/deinit-release.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-release2.swift
+++ b/test/embedded/deinit-release2.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -3,8 +3,11 @@
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 
-// Linux/ELF doesn't use the "_" prefix in symbol mangling.
-// RUN: if [ %target-os == "linux-gnu" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+// Linux/ELF and Wasm don't use the "_" prefix in symbol mangling.
+// RUN: if [ %target-os == "linux-gnu" ] || [[ %target-os =~ "wasi" ]]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+
+// Wasm has additional dependencies
+// RUN: if [[ %target-os =~ "wasi" ]]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -25,7 +25,7 @@
 
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang -x c -c %S/Inputs/linux-rng-support.c -o %t/linux-rng-support.o
-// RUN: %target-clang %t/a.o %t/print.o %t/linux-rng-support.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %t/linux-rng-support.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -7,7 +7,7 @@
 // RUN: if [ %target-os == "linux-gnu" ] || [[ %target-os =~ "wasi" ]]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
 
 // Wasm has additional dependencies
-// RUN: if [[ %target-os =~ "wasi" ]]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
+// RUN: if [[ %target-os =~ "wasi" ]]; then sed -i '' -e '3 i\'$'\n''__stack_pointer' -e '1 i\'$'\n''__indirect_function_table' -e '1 i\'$'\n''__memory_base' %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -18,4 +18,4 @@ struct Main {
      }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/extensions.swift
+++ b/test/embedded/extensions.swift
@@ -19,6 +19,6 @@ struct MyStruct {}
 
 extension MyStruct: MyProtocol {}
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)
 // CHECK-NOT: MyStruct
 // CHECK-NOT: MyProtocol

--- a/test/embedded/failable-crash.swift
+++ b/test/embedded/failable-crash.swift
@@ -16,4 +16,4 @@ public class MyClass<T> {
     }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/float-abi-hard.swift
+++ b/test/embedded/float-abi-hard.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-ir %t/Main.swift -import-bridging-header %t/BridgingHeader.h -parse-as-library -enable-experimental-feature Embedded -wmo \
 // RUN:  -target armv7em-none-none-eabi -Xcc -mthumb -Xcc -mcpu=cortex-m7 -Xcc -mfloat-abi=hard -Xcc -mfpu=fpv5-sp-d16 -Xcc -D__FPU_USED=1 -Xcc -falign-functions=16
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -19,5 +19,5 @@ enum MyEnum: UInt8 {
     case a = 0
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(
 

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=none-wasm
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=none-wasm
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasi
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasi
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -20,7 +20,7 @@ public struct Binding<Value> {
 
 public struct State<Wrapped> {
   public var wrappedValue: Wrapped
-  
+
   public init(wrappedValue: Wrapped) {
     self.wrappedValue = wrappedValue
   }
@@ -51,4 +51,4 @@ public struct S<T> {
    }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/linkage-mergeable-dead-strip.swift
+++ b/test/embedded/linkage-mergeable-dead-strip.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -emit-ir | %FileCheck %s --check-prefix=CHECK-IR
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -dead_strip
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=CHECK-NM
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-mergeable.swift
+++ b/test/embedded/linkage-mergeable.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %t/a.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable2.swift
+++ b/test/embedded/linkage-mergeable2.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -O -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -O -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %t/a.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable3.swift
+++ b/test/embedded/linkage-mergeable3.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-embedded-link %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -20,7 +20,7 @@ if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
 # (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
-supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasi"]
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasip1"]
 if config.available_features.intersection(set(supported_test_os_list)) == set():
   config.unsupported = True
 

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -20,7 +20,7 @@ if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
 # (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
-supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf"]
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasi"]
 if config.available_features.intersection(set(supported_test_os_list)) == set():
   config.unsupported = True
 

--- a/test/embedded/modules-empty-object.swift
+++ b/test/embedded/modules-empty-object.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleB.swift -o %t/MyModuleB.o -emit-module -emit-module-path %t/MyModuleB.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleC.swift -o %t/MyModuleC.o -emit-module -emit-module-path %t/MyModuleC.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o -o %t/a.out
 // RUN: %target-run %t/a.out
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-used2.swift
+++ b/test/embedded/modules-used2.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -emit-sil | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/no-allocations-print.swift
+++ b/test/embedded/no-allocations-print.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-emit-ir -target armv7-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
 // RUN: %target-swift-emit-ir -target arm64-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -9,7 +9,7 @@
 
 public struct MyStructA {
   static var singleton = MyStructA()
-  
+
   init() {
     print("MyStructA.init")
     _ = MyStructB.singleton
@@ -19,7 +19,7 @@ public struct MyStructA {
 
 public struct MyStructB {
   static var singleton = MyStructB()
-  
+
   init() {
     print("MyStructB.init")
     _ = MyStructC.singleton
@@ -29,7 +29,7 @@ public struct MyStructB {
 
 public struct MyStructC {
   static var singleton = MyStructC()
-  
+
   init() {
     print("MyStructC.init")
     print("MyStructC.init done")

--- a/test/embedded/optionset2.swift
+++ b/test/embedded/optionset2.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/osize-genericspecializer.swift
+++ b/test/embedded/osize-genericspecializer.swift
@@ -15,4 +15,4 @@ public func baz<T>(n: T) {
     let x: ContiguousArray<Int> = .init(repeating: 0, count: 1)
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/osize-releasedevirt.swift
+++ b/test/embedded/osize-releasedevirt.swift
@@ -11,4 +11,4 @@ public func foo() {
 func bar(_: UnsafePointer<UInt?>) {
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -6,6 +6,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -19,4 +19,4 @@
 public func test() {}
 test()
 
-// CHECK: define {{.*}}i32 @main
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}

--- a/test/embedded/static-object-non-darwin.swift
+++ b/test/embedded/static-object-non-darwin.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-strings-interpolation3.swift
+++ b/test/embedded/stdlib-strings-interpolation3.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-types-riscv.swift
+++ b/test/embedded/stdlib-types-riscv.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target riscv32-none-none-eabi -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target riscv64-none-none-eabi -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=RISCV

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -O     -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -Osize -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 
+// XFAIL: CPU=wasm32
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/without-actually-escaping.swift
+++ b/test/embedded/without-actually-escaping.swift
@@ -2,7 +2,7 @@
 // RUN: %target-clang -x c -c %S/Inputs/unbuffered-putchar.c -o %t/unbuffered-putchar.o
 
 // RUN: %target-build-swift -enable-experimental-feature Embedded -wmo %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s
+// RUN: %target-not-crash %target-run %t/a.out 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -409,10 +409,10 @@ if run_vers.endswith('-simulator'):
 else:
     run_environment=''
 
-# Don't distinguish between wasi, wasip1, and so on to use OS=wasi condition in
-# the test suites.
-if run_os.startswith('wasi'):
-    run_os = 'wasi'
+# Allow using using same condition in WASI test suites.
+kIsWASI = run_os.startswith('wasi')
+if kIsWASI:
+  run_os = f"{run_os}{run_vers}"
 
 # Parse the host triple
 (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
@@ -2039,7 +2039,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
     config.available_features.discard('swift_interpreter')
-elif run_os == 'wasi':
+elif kIsWASI:
     lit_config.note("Testing WebAssembly/WASI " + config.variant_triple)
 
     config.target_object_format = "wasm"
@@ -2634,7 +2634,7 @@ if run_vendor != 'apple':
 
 if 'remote_run_host' in lit_config.params:
     configure_remote_run()
-elif not kIsWindows and not run_os == 'wasi':
+elif not kIsWindows and not kIsWASI:
     if 'use_os_stdlib' in lit_config.params:
         config.available_features.add('use_os_stdlib')
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1264,6 +1264,7 @@ target_specific_module_triple = config.variant_triple
 target_future = target_specific_module_triple
 
 config.target_run = ''
+config.target_not_crash = 'not --crash'
 config.target_rtti_opt = '-fno-rtti'
 config.target_pic_opt = ''
 config.target_cxx_lib = '-lc++'
@@ -1272,6 +1273,7 @@ config.target_static_library_prefix = 'lib'
 config.target_static_library_suffix = '.a'
 config.target_env_prefix = ''
 config.target_sdk_libcxx_path = ''
+config.target_clang_resource_dir_opt = ''
 
 if run_vendor == 'apple':
     target_specific_module_triple = '{}-apple-{}'.format(
@@ -2118,7 +2120,7 @@ elif kIsWASI:
 
 elif config.external_embedded_platform:
     lit_config.note("Testing embedded platform " + config.variant_triple)
-    
+
     config.target_object_format = "elf"
     config.target_sdk_name = "embedded"
     config.target_runtime = "native"
@@ -3023,6 +3025,8 @@ config.substitutions.append(('%target-resilience-test', config.target_resilience
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 config.substitutions.append(('%hmaptool', os.path.join(config.llvm_src_root, '..', 'clang', 'utils', 'hmaptool', 'hmaptool')))
+config.substitutions.append(('%target-not-crash', config.target_not_crash))
+config.substitutions.insert(0, ('%target-clang-resource-dir-opt', config.target_clang_resource_dir_opt))
 
 # Set up the host library environment.
 if hasattr(config, 'target_library_path_var'):
@@ -3144,7 +3148,7 @@ def linux_get_os_release():
     return os_id, os_release
 
 if platform.system() == 'Linux':
-    # Retrieve the Linux distro and version from `/etc/os-release`. 
+    # Retrieve the Linux distro and version from `/etc/os-release`.
     (distributor, release) = linux_get_os_release()
     if distributor == '' or release == '':
         # If `/etc/os-release` does not provide full results, fallback to `lsb_release`.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2047,6 +2047,8 @@ elif kIsWASI:
     config.target_shared_library_suffix = ".a"
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
+    config.target_not_crash = "not"
+    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1"
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -13,7 +13,7 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-run %t/Assert_Release
 // RUN: %target-run %t/Assert_Unchecked
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 
@@ -77,7 +77,7 @@ OptionalTraps.test("UnwrapNone/Message")
     reason: "this trap may not have an error message may not be printed in -O"))
   .code {
   var a: AnyObject? = returnNil()
-  expectCrashLater(withMessage: 
+  expectCrashLater(withMessage:
       "Unexpectedly found nil while unwrapping an Optional value")
   let unwrapped: AnyObject = a!
   _blackHole(unwrapped)
@@ -92,7 +92,7 @@ OptionalTraps.test("UnwrapNone/Message/Implicit")
     reason: "this trap may not have an error message may not be printed in -O"))
   .code {
   var a: AnyObject! = returnNil()
-  expectCrashLater(withMessage: 
+  expectCrashLater(withMessage:
       "Unexpectedly found nil while implicitly unwrapping an Optional value")
   let unwrapped: AnyObject = a
   _blackHole(unwrapped)

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 import SwiftPrivateLibcExtras

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 
 import StdlibUnittest
@@ -34,7 +34,7 @@ RangeTraps.test("HalfOpen")
   .code {
   var range = 1..<1
   expectType(CountableRange<Int>.self, &range)
-  
+
   expectCrashLater()
   _ = 1..<0
 }
@@ -67,7 +67,7 @@ RangeTraps.test("CountablePartialRangeFrom")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
-    
+
     let range = (Int.max - 1)...
     var it = range.makeIterator()
     _ = it.next()

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -11,7 +11,7 @@
 // 5.7 so that we can test new behavior even if the SDK we're using predates it.
 
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 #if _runtime(_ObjC)

--- a/test/stdlib/WASILibcAPI.swift
+++ b/test/stdlib/WASILibcAPI.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -swift-version 6 %s -verify
 // REQUIRES: executable_test
-// REQUIRES: OS=wasi
+// REQUIRES: OS=wasip1
 
 import WASILibc
 

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: OS=wasip1
 
 import StdlibUnittest
 #if canImport(Darwin)

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,8 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi
-// XFAIL: OS=wasi
+// XFAIL: OS=wasip1
 
 import simd
 

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: OS=wasip1
+// XFAIL: CPU=wasm32
 
 import simd
 

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi
 // XFAIL: CPU=wasm32
 
 import simd

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -222,7 +222,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
             'LIT_FILTER_OUT':
                 '(Concurrency/Runtime/clock.swift|stdlib/StringIndex.swift)',
         }
-        self.test_with_cmake(None, [test_target], self._build_variant, [], test_env=env)
+        self.test_with_cmake(None, [test_target, 'check-swift-embedded-wasi'], self._build_variant, [], test_env=env)
 
     def should_test_executable(self):
         return True

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -201,6 +201,9 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
 
     def test(self, host_target):
+        self._test(host_target, 'wasm32-wasip1')
+
+    def _test(self, host_target, target_triple):
         build_root = os.path.dirname(self.build_dir)
         bin_paths = [
             os.path.join(self._host_swift_build_dir(host_target), 'bin'),
@@ -222,7 +225,14 @@ class WasmStdlib(cmake_product.CMakeProduct):
             'LIT_FILTER_OUT':
                 '(Concurrency/Runtime/clock.swift|stdlib/StringIndex.swift)',
         }
-        self.test_with_cmake(None, [test_target, 'check-swift-embedded-wasi'], self._build_variant, [], test_env=env)
+
+        # Embedded stdlib is not built for the threads triple, don't include embedded tests for it.
+        if target_triple == 'wasm32-wasip1-threads':
+            test_targets = [test_target]
+        else:
+            test_targets = [test_target, 'check-swift-embedded-wasi']
+
+        self.test_with_cmake(None, test_targets, self._build_variant, [], test_env=env)
 
     def should_test_executable(self):
         return True
@@ -258,6 +268,9 @@ class WasmStdlib(cmake_product.CMakeProduct):
 class WasmThreadsStdlib(WasmStdlib):
     def build(self, host_target):
         self._build(host_target, 'wasm32-wasip1-threads', 'wasip1-threads-wasm32')
+
+    def test(self, host_target):
+        self._test(host_target, 'wasm32-wasip1-threads')
 
     def should_test_executable(self):
         # TODO(katei): Enable tests once WasmKit supports WASI threads

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -184,6 +184,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
             self.build_dir, 'test-wasi-wasm32', path) for path in lit_test_paths]
         self.cmake_options.define('SWIFT_LIT_TEST_PATHS:STRING',
                                   ';'.join(lit_test_paths))
+        self.cmake_options.define('LLVM_LIT_ARGS', self.args.lit_args)
         test_driver_options = [
             # compiler-rt is not installed in the final toolchain, so use one
             # in build dir


### PR DESCRIPTION
Cherry-pick of #83128, #82399, and #82878, merged as ea6ca2b5db511728fef33b919f552bdbe55eb76a, 0c4e56174b0814495aa291a69f788b98dc81f43f, and e34eb3331f5d8ee67afa1afecde00de74205bcd1 respectively.

**Explanation**: Currently `test/CMakeLists.txt` can only set `SWIFT_LIT_ARGS` for all tests uniformly. This means that we can't have tests for Embedded Swift with a different set of `lit.py` arguments.

Also, create new `check-swift-embedded-wasi` target from `test/CMakeLists.txt`, tweak `lit.cfg` to support WASI Clang resource dir, exclude unsupported tests based on `CPU=wasm32` instead of `OS=wasi`.

**Scope**: Limited to Embedded Swift test suite.
**Risk**: Low, due to limited scope.
**Testing**: #82878 was incubated on `main` for 2 weeks, #82399 for 3 weeks with no disruption, #83128 merged this week, but enables all these tests on CI, which are consistently passing.
**Issue**: rdar://156585717
**Reviewer**: @bnbarham
