### PR TITLE
[cxx-interop] Enable addressable-self unconditionally

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4036,9 +4036,13 @@ namespace {
           }
           if (selfIdx) {
             func->setSelfIndex(selfIdx.value());
-            if (Impl.SwiftContext.LangOpts.hasFeature(
-                    Feature::AddressableParameters))
-              func->getImplicitSelfDecl()->setAddressable();
+            // FIXME: Make this work when SIL Opaque Values are enabled.
+            // Currently, addressable parameters and opaque values are at odds.
+            if (!dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
+                !importedName.importAsMember() &&
+                !Impl.SwiftContext.SILOpts.EnableSILOpaqueValues)
+              func->getAttrs().add(new (Impl.SwiftContext)
+                                       AddressableSelfAttr(true));
           } else {
             func->setStatic();
             func->setImportAsStaticMember();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3717,7 +3717,10 @@ SILGenFunction::tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
     // Materialize the base outside of the scope of the addressor call,
     // since the returned address may depend on the materialized
     // representation, even if it isn't transitively addressable.
-    auto baseTy = lookupExpr->getBase()->getType()->getCanonicalType();
+    auto baseTy = lookupExpr->getBase()
+                      ->getType()
+                      ->getWithoutSpecifierType()
+                      ->getCanonicalType();
     ArgumentSource baseArg = prepareAccessorBaseArgForFormalAccess(
       lookupExpr->getBase(), base, baseTy, addressorRef);
     

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,9 +1,5 @@
 // RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions | %FileCheck %s
 
-// https://github.com/apple/swift/issues/55575
-// We can't yet call member functions correctly on Windows.
-// XFAIL: OS=windows-msvc
-
 import CXXInterop
 
 // CHECK-LABEL: define hidden swiftcc void @"$s6cxx_ir13indirectUsageyyF"()
@@ -42,8 +38,8 @@ func basicMethods(a: UnsafeMutablePointer<Methods>) -> Int32 {
 }
 
 // CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir17basicMethodsConst1as5Int32VSpySo0D0VG_tF"(ptr %0)
-// CHECK: [[THIS_PTR1:%.*]] = alloca %TSo7MethodsV, align {{4|8}}
-// CHECK: [[RESULT:%.*]] = call {{(signext )?}}i32 @{{_ZNK7Methods17SimpleConstMethodEi|"\?SimpleConstMethod@Methods@@QEBAHH@Z"}}(ptr [[THIS_PTR1]], i32 {{%?[0-9]+}})
+// CHECK: [[THIS_PTR1:%.*]] = alloca ptr, align {{4|8}}
+// CHECK: [[RESULT:%.*]] = call {{(signext )?}}i32 @{{_ZNK7Methods17SimpleConstMethodEi|"\?SimpleConstMethod@Methods@@QEBAHH@Z"}}(ptr %0, i32 {{%?[0-9]+}})
 // CHECK: ret i32 [[RESULT]]
 func basicMethodsConst(a: UnsafeMutablePointer<Methods>) -> Int32 {
   return a.pointee.SimpleConstMethod(3)

--- a/test/Interop/Cxx/class/method/methods-addressable-silgen.swift
+++ b/test/Interop/Cxx/class/method/methods-addressable-silgen.swift
@@ -17,7 +17,7 @@ public func addressableTest(x: borrowing @_addressable NonTrivialInWrapper, y: i
   // CHECK: %{{[0-9]+}} = apply %{{[0-9]+}}([[UNWRAPPED]], %{{[0-9]+}}) : $@convention(cxx_method) (@in_guaranteed NonTrivialInWrapper, @in_guaranteed HasMethods) -> ()
   var m2 = HasMethods()
   // CHECK: [[ACCESS:%[0-9]+]] = begin_access [modify] [unknown] [[INPUT2]]
-  // CHECK: %{{[0-9]+}} = apply %32([[ACCESS]], %{{[0-9]+}}) : $@convention(cxx_method) (@inout NonTrivialInWrapper, @in_guaranteed HasMethods) -> ()
+  // CHECK: %{{[0-9]+}} = apply %{{[0-9]+}}([[ACCESS]], %{{[0-9]+}}) : $@convention(cxx_method) (@inout NonTrivialInWrapper, @in_guaranteed HasMethods) -> ()
   // CHECK-NEXT: end_access [[ACCESS]]
   m2.nonTrivialTakesRef(&y)
 }


### PR DESCRIPTION
This was behind a feature flag. Unfortunately, this flag is viral, if the module we consume and the consuming module had inconsistent settings that could lead to deserialization errors. To avoid this, we need to move this out of the flag and apply the attribute unconditionally. This PR moves addressable-self out of the experimental flag and addresses a couple of the fallouts:
* This attribute should not be applied to types with reference semantics like foreign reference types or Obj-C classes.
* There was a SILGen assertion failure which is solved by pealing off the @lvalue specifier from the type behind a load expression.

This fixes part of rdar://155971658
