### PR TITLE
test/embedded: re-enable `hello.swift` for `wasip1`

### DIFF
--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasi
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")


### PR DESCRIPTION
This test was disabled by mistake after renaming `wasi` to `wasip1` component of WASI triples.