### PR TITLE
[Distributed] Disable irgen test on iOS

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
@@ -59,6 +59,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: remote_run || device_run
+// UNSUPPORTED: OS=watchos
 
 //--- ResilientAPILib.swift
 


### PR DESCRIPTION
Or rather, the simulator. but there's no need to run it there to begin
with.

We'll be getting failures like:

```
line 2: .../llvm-macosx-x86_64/./bin/split-file: No such file or directory
```
if we try

resolves rdar://155987313
