### PR TITLE
utils: add typing annotations to `migration.py`/`utils.py`

### DIFF
--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -12,6 +12,7 @@ Temporary module with functionality used to migrate away from build-script-impl.
 """
 
 
+from argparse import ArgumentParser
 import itertools
 import subprocess
 
@@ -97,7 +98,7 @@ def _process_disambiguation_arguments(args, unknown_args):
     return args, unknown_args
 
 
-def parse_args(parser, args, namespace=None):
+def parse_args(parser: ArgumentParser, args, namespace=None):
     """Parses a given argument list with the given argparse.ArgumentParser.
 
     Return a processed arguments object. Any unknown arguments are stored in

--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -16,7 +16,7 @@ import os
 import sys
 import time
 
-
+from typing import NoReturn
 from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 
 
@@ -30,7 +30,7 @@ def fatal_error(message, stream=sys.stderr):
     sys.exit(1)
 
 
-def exit_rejecting_arguments(message, parser=None):
+def exit_rejecting_arguments(message, parser=None) -> NoReturn:
     print(message, file=sys.stderr)
     if parser:
         parser.print_usage(sys.stderr)


### PR DESCRIPTION
These typing annotations are supported since Python 3.6, while the oldest Python we have to support is 3.7 on Amazon Linux 2.