### PR TITLE
[concurrency] Fix optimize_hop_to_executor so that we take advantage of the new nonisolated(nonsending) ABI in post 6.2.

### DIFF
--- a/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
+++ b/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
@@ -12,14 +12,10 @@ func take(iso: (any Actor)?) {}
 // CHECK-LABEL: // nonisolatedNonsending()
 // CHECK-NEXT: // Isolation: caller_isolation_inheriting
 // CHECK-NEXT: sil hidden @$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
-// CHECK:      bb0(%0 : $Optional<any Actor>):
-// CHECK-NEXT:   hop_to_executor %0 // id: %1
-// CHECK-NEXT:   retain_value %0 // id: %2
-// CHECK-NEXT:   debug_value %0, let, name "iso" // id: %3
-// CHECK-NEXT:   // function_ref take(iso:)
-// CHECK-NEXT:   %4 = function_ref @$s39isolated_nonsending_isolation_macro_sil4take3isoyScA_pSg_tF : $@convention(thin) (@guaranteed Optional<any Actor>) -> () // user: %5
-// CHECK-NEXT:   %5 = apply %4(%0) : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
-// CHECK-NEXT:   release_value %0 // id: %6
-// CHECK-NEXT:   %7 = tuple () // user: %8
-// CHECK-NEXT:   return %7 // id: %8
-// CHECK-NEXT: } // end sil function '$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF'
+// CHECK:      bb0([[ACTOR:%.*]] : $Optional<any Actor>):
+// CHECK:   retain_value [[ACTOR]]
+// CHECK:   debug_value [[ACTOR]], let, name "iso"
+// CHECK:   [[FUNC:%.*]] = function_ref @$s39isolated_nonsending_isolation_macro_sil4take3isoyScA_pSg_tF : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
+// CHECK:   apply [[FUNC]]([[ACTOR]]) : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
+// CHECK:   release_value [[ACTOR]]
+// CHECK: } // end sil function '$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF'

--- a/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
+++ b/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
@@ -3,14 +3,11 @@
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil hidden [noinline] @$s4testAAyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
-// CHECK: hop_to_executor
 // CHECK: } // end sil function '$s4testAAyyYaF'
 @inline(never)
 nonisolated(nonsending) func test() async {}
 
 // CHECK-LABEL: sil hidden [noinline] @$s4test5test2yyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
-// CHECK: hop_to_executor
-// CHECK: hop_to_executor
 // CHECK: } // end sil function '$s4test5test2yyYaF'
 @inline(never)
 nonisolated(nonsending) func test2() async {
@@ -24,7 +21,6 @@ func test3() async {
 // CHECK-LABEL: sil @$s4test6calleryyYaF : $@convention(thin) @async () -> () {
 // CHECK: hop_to_executor
 // CHECK: function_ref @$s4testAAyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
-// CHECK: hop_to_executor
 // CHECK: function_ref @$s4test5test2yyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
 // CHECK: } // end sil function '$s4test6calleryyYaF'
 public func caller() async {

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -393,8 +393,7 @@ bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyAc
 // CHECK-LABEL: sil [ossa] @callerIsolationInheritingStopsAllowsPropagating : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
 // CHECK: bb0(
 // CHECK: hop_to_executor
-// CHECK: hop_to_executor
-// CHECK: hop_to_executor
+// CHECK-NOT: hop_to_executor
 // CHECK: } // end sil function 'callerIsolationInheritingStopsAllowsPropagating'
 sil [ossa] @callerIsolationInheritingStopsAllowsPropagating : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
@@ -416,14 +415,13 @@ bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyAc
 // hop_to_executor due to ehre elase. We do eliminate one of the hop_to_executor
 // though.
 //
-// CHECK: sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK: sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
 // CHECK: bb0(
-// CHECK-NEXT: hop_to_executor
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 // CHECK: } // end sil function 'callerIsolationInheritingStopsReturnDeadEnd'
-sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@guaranteed MyActor, @guaranteed MyActor, @guaranteed MyActor) -> () {
-bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingStopsReturnDeadEnd : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
   hop_to_executor %0
   hop_to_executor %0
   %9999 = tuple ()


### PR DESCRIPTION
Specifically:

1. We assume in nonisolated(nonsending) that we are already on the relevant actor. This lets us always eliminate the initial hop_to_executor.

2. We stopped treating nonisolated(nonsending) functions as suspension points since we are guaranteed to always be on the same actor when we enter/return.

3. Now that nonisolated(nonsending) is no longer a suspension point, I could sink the needs executor nonisolated(nonsending) specific code into the needs executor code. For those unfamiliar it is that we: a. treat a nonisolated(nonsending) callee as a needs executor since we are no longer guaranteed to hop in callees and b. treat returns from nonisolated(nonsending) functions as being a needs executor instruction since we are no longer guaranteed to hop in the caller after such a function returns.

rdar://155465878

----

NOTE: I just had this locally already done, so I am uploading it now to main.