### PR TITLE
update-checkout-config.json: check out CMake on Darwin and Linux

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -66,8 +66,7 @@
             "remote": { "id": "jpsim/Yams" }
         },
         "cmake": {
-            "remote": { "id": "KitWare/CMake" },
-            "platforms": [ "Linux" ]
+            "remote": { "id": "KitWare/CMake" }
         },
         "swift-cmark-gfm": {
              "remote": { "id": "swiftlang/swift-cmark" } },

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -66,7 +66,8 @@
             "remote": { "id": "jpsim/Yams" }
         },
         "cmake": {
-            "remote": { "id": "KitWare/CMake" }
+            "remote": { "id": "KitWare/CMake" },
+            "platforms": [ "Darwin", "Linux" ]
         },
         "swift-cmark-gfm": {
              "remote": { "id": "swiftlang/swift-cmark" } },


### PR DESCRIPTION
Due to issues with CMake 4.0, it should be always checked out on macOS to build a compatible version.