### PR TITLE
draft: Improve map performance through unsafe uninitialized capacity

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1199,7 +1199,7 @@ extension Collection {
       return []
     }
 
-    return try unsafe Array<T>(unsafeUninitializedCapacity: n) { (
+    return try unsafe Array(ContiguousArray<T>(unsafeUninitializedCapacity: n) { (
       storage: inout UnsafeMutableBufferPointer<T>,
       initializedCount: inout Int
     ) throws(E) -> Void in
@@ -1210,7 +1210,7 @@ extension Collection {
         initializedCount += 1
       }
       _expectEnd(of: self, is: collectionIndex)
-    }
+    })
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1204,7 +1204,7 @@ extension Collection {
       initializedCount: inout Int
     ) throws(E) -> Void in
       var collectionIndex = self.startIndex
-      for bufferIndex in 0 ..< n {
+      for bufferIndex in storage.indices {
         unsafe storage[bufferIndex] = try transform(self[collectionIndex])
         formIndex(after: &collectionIndex)
         initializedCount += 1

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1205,7 +1205,7 @@ extension Collection {
     ) throws(E) -> Void in
       var collectionIndex = self.startIndex
       for bufferIndex in storage.indices {
-        unsafe storage.initializeElement(at: bufferIndex, to: try transform(self[collectionIndex])
+        unsafe storage.initializeElement(at: bufferIndex, to: try transform(self[collectionIndex]))
         formIndex(after: &collectionIndex)
         initializedCount += 1
       }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1205,7 +1205,7 @@ extension Collection {
     ) throws(E) -> Void in
       var collectionIndex = self.startIndex
       for bufferIndex in storage.indices {
-        unsafe storage[bufferIndex] = try transform(self[collectionIndex])
+        unsafe storage.initializeElement(at: bufferIndex, to: try transform(self[collectionIndex])
         formIndex(after: &collectionIndex)
         initializedCount += 1
       }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1199,18 +1199,18 @@ extension Collection {
       return []
     }
 
-    var result = ContiguousArray<T>()
-    result.reserveCapacity(n)
-
-    var i = self.startIndex
-
-    for _ in 0..<n {
-      result.append(try transform(self[i]))
-      formIndex(after: &i)
+    return try unsafe Array<T>(unsafeUninitializedCapacity: n) { (
+      storage: inout UnsafeMutableBufferPointer<T>,
+      initializedCount: inout Int
+    ) throws(E) -> Void in
+      var collectionIndex = self.startIndex
+      for bufferIndex in 0 ..< n {
+        unsafe storage[bufferIndex] = try transform(self[collectionIndex])
+        formIndex(after: &collectionIndex)
+        initializedCount += 1
+      }
+      _expectEnd(of: self, is: collectionIndex)
     }
-
-    _expectEnd(of: self, is: i)
-    return Array(result)
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been


### PR DESCRIPTION
I analysing performance of a piece of code where a call to map was inside a hot path. Most time was spent inside the append method inside map's implementation. 
When replacing the implementation with the changes above we saw a significant performance increase (Will add numbers and a way to reproduce after running ci benchmarks)
These changes ofcourse need some additional work to make sure ABI is maintained which I'd like to pursue once the performance benefits of these changes are confirmed. 

