### PR TITLE
Differentiation repair

### DIFF
--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
+
+if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+  cmake_policy(SET CMP0157 OLD)
+endif()
 
 if($ENV{BUILD_NUMBER})
   math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -8,48 +8,63 @@ project(SwiftDifferentiation
   LANGUAGES Swift C
   VERSION 6.1.0${BUILD_NUMBER})
 
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift Differentiation must build as a standalone project")
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 set(CMAKE_Swift_LANGUAGE_VERSION 5)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
-if(NOT PROJECT_IS_TOP_LEVEL)
-  message(SEND_ERROR "Swift Differentiation must build as a standalone project")
-endif()
-
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"
   CACHE FILEPATH "Path to the root source directory of the Swift compiler")
 
-find_package(SwiftCore)
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
+  CACHE FILEPATH "Location for private build system extension")
 
-include(gyb)
+find_package(SwiftCore REQUIRED)
+include(GNUInstallDirs)
+
 include(AvailabilityMacros)
-include(CatalystSupport)
 include(EmitSwiftInterface)
-include(ResourceEmbedding)
 include(InstallSwiftInterface)
+include(gyb)
+include(ResourceEmbedding)
+include(CatalystSupport)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
+
+option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
 
 option(${PROJECT_NAME}_ENABLE_VECTOR_TYPES "Enable vector support"
   ${SwiftCore_ENABLE_VECTOR_TYPES})
 
-option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Enable library evolution"
-  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
 
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level api>"
-  $<$<COMPILE_LANGUAGE:Swift>:-enforce-exclusivity=unchecked>
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-min-inlining-version min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
-  $<$<AND:$<BOOL:${SwiftDifferentiation_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>)
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
+  $<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>)
 
 if(SwiftDifferentiation_ENABLE_VECTOR_TYPES)
   gyb_expand(SIMDDifferentiation.swift.gyb SIMDDifferentiation.swift)
@@ -65,22 +80,22 @@ add_library(swift_Differentiation
   DifferentialOperators.swift
   DifferentiationUtilities.swift
   OptionalDifferentiation.swift
-  $<$<BOOL:${SwiftDifferentiation_ENABLE_VECTOR_TYPES}>:SIMDDifferentiation.swift>
+  $<$<BOOL:${${PROJECT_NAME}_ENABLE_VECTOR_TYPES}>:SIMDDifferentiation.swift>
   TgmathDerivatives.swift
   FloatingPointDifferentiation.swift
   linker-support/magic-symbols-for-install-name.c)
 
+if(APPLE AND BUILD_SHARED_LIBS)
+  target_link_options(swift_Differentiation PRIVATE
+    "SHELL:-Xlinker -headerpad_max_install_names")
+endif()
+
 set_target_properties(swift_Differentiation PROPERTIES
   Swift_MODULE_NAME _Differentiation)
 
-if(APPLE AND BUILD_SHARED_LIBS)
-  target_link_options(swift_Differentiation PRIVATE "SHELL:-Xlinker -headerpad_max_install_names")
-endif()
+target_link_libraries(swift_Differentiation PRIVATE
+  swiftCore)
 
-target_link_libraries(swift_Differentiation PRIVATE swiftCore)
-
-set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${Supplemental_INSTALL_NESTED_SUBDIR}>:/${Supplemental_PLATFORM_SUBDIR}/${Supplemental_ARCH_SUBDIR}>" CACHE STRING "")
-set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${Supplemental_INSTALL_NESTED_SUBDIR}>:/${Supplemental_PLATFORM_SUBDIR}>" CACHE STRING "")
 
 install(TARGETS swift_Differentiation
   EXPORT SwiftSupplementalTargets
@@ -94,3 +109,5 @@ install_swift_interface(swift_Differentiation)
 # Configure plist creation for Darwin platforms.
 generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swift_Differentiation)
 embed_manifest(swift_Differentiation)
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swift_Differentiation.cmake" OPTIONAL)


### PR DESCRIPTION
The underlying change here simply re-arranges the file and corrects a few of the flags. This allows more efficient diffing of the CMakeLists.txt to allow determine what is different.