### PR TITLE
lit: Fixing STDLIB_ENABLE_UNICODE_DATA check

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -143,7 +143,7 @@ if "@SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED@" == "TRUE":
     config.available_features.add('distributed')
 if "@SWIFT_STDLIB_STATIC_PRINT@" == "TRUE":
     config.available_features.add('stdlib_static_print')
-if "@SWIFT_STDLIB_ENABLE_UNICODE_DATA" == "TRUE":
+if "@SWIFT_STDLIB_ENABLE_UNICODE_DATA@" == "TRUE":
     config.available_features.add('stdlib_unicode_data')
 if "@SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING@" == "TRUE":
     config.available_features.add('string_processing')


### PR DESCRIPTION
Testing with unicode enabled was never actually enabled. The expansion was missing the closing `@` symbol on the configure file so it was never expanded, comparing "@STDLIB_ENABLE_UNICODE_DATA" with "TRUE" always evaluates to false, and `stdlib_unicode_data` was never enabled.