### PR TITLE
[build.ps1] Make sure mimalloc is built before we build noasserts toolchain

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3694,12 +3694,12 @@ if (-not $SkipBuild) {
 
 Install-HostToolchain
 
-if (-not $SkipBuild -and $IncludeNoAsserts) {
-  Build-NoAssertsToolchain
-}
-
 if (-not $SkipBuild) {
   Invoke-BuildStep Build-mimalloc $HostPlatform
+}
+
+if (-not $SkipBuild -and $IncludeNoAsserts) {
+  Build-NoAssertsToolchain
 }
 
 if (-not $SkipBuild -and -not $IsCrossCompiling) {


### PR DESCRIPTION
Missed from my last change. mimalloc binaries were not included in no-assert toolchain
