### PR TITLE
Embedded Swift: Fix === and !== with existential

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -671,15 +671,17 @@ bool MissingConformanceFailure::diagnoseAsError() {
     };
 
     // Limit this to `Equatable` and `Comparable` protocols for now.
-    auto *protocol = getRHS()->castTo<ProtocolType>()->getDecl();
-    if (isEnumWithAssociatedValues(getLHS()) &&
-        (protocol->isSpecificProtocol(KnownProtocolKind::Equatable) ||
-         protocol->isSpecificProtocol(KnownProtocolKind::Comparable))) {
-      if (RequirementFailure::diagnoseAsError()) {
-        auto opName = getOperatorName(expr);
-        emitDiagnostic(diag::no_binary_op_overload_for_enum_with_payload,
-                       opName->str());
-        return true;
+    if (auto *protocolTy = getRHS()->getAs<ProtocolType>()) {
+      auto *protocol = protocolTy->getDecl();
+      if (isEnumWithAssociatedValues(getLHS()) &&
+          (protocol->isSpecificProtocol(KnownProtocolKind::Equatable) ||
+           protocol->isSpecificProtocol(KnownProtocolKind::Comparable))) {
+        if (RequirementFailure::diagnoseAsError()) {
+          auto opName = getOperatorName(expr);
+          emitDiagnostic(diag::no_binary_op_overload_for_enum_with_payload,
+                         opName->str());
+          return true;
+        }
       }
     }
   }

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -271,7 +271,7 @@ public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
 #else
 @inlinable // trivial-implementation
 @safe
-public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
+public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return Builtin.bridgeToRawPointer(l) == Builtin.bridgeToRawPointer(r)
@@ -293,14 +293,7 @@ public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
-#if !$Embedded
 @inlinable // trivial-implementation
 public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   return !(lhs === rhs)
 }
-#else
-@inlinable // trivial-implementation
-public func !==<T: AnyObject, U: AnyObject>(lhs: T, rhs: U) -> Bool {
-  return !(lhs === rhs)
-}
-#endif

--- a/test/embedded/anyobject.swift
+++ b/test/embedded/anyobject.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -swift-version 5) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -O -swift-version 5) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -Osize -swift-version 5) | %FileCheck %s
+
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -swift-version 6) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -O -swift-version 6) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -Osize -swift-version 6) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+protocol P: AnyObject {}
+
+class C: P {}
+
+@main
+struct Main {
+    static func main() {
+        let p1: any P = C()
+        let p2: any P = C()
+        let p3 = p1
+
+        // CHECK: false
+        print(p1 === p2)
+        print(p2 === p1)
+        // CHECK: true
+        print(p1 === p3)
+        print(p3 === p1)
+        // CHECK: false
+        print(p2 === p3)
+        print(p3 === p2)
+   }
+}
+


### PR DESCRIPTION
There were two unrelated issues:
- A diagnostics crash if an AnyObject requirement failed in a very specific case
- Embedded Swift had a generic implementation of ===, because of limitations that have been fixed since. However we only open existentials when passed to a method with this signature in -swift-version 6 mode.

As a result, attempting === on two class-bound existentials would just crash.

Fixes rdar://156095800.