### PR TITLE
Bump swift-collections version to 1.1.6 for swift-foundation

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -139,7 +139,7 @@
                 "swiftpm": "main",
                 "swift-argument-parser": "1.5.1",
                 "swift-atomics": "1.2.0",
-                "swift-collections": "1.1.5",
+                "swift-collections": "1.1.6",
                 "swift-crypto": "3.12.5",
                 "swift-certificates": "1.10.1",
                 "swift-asn1": "1.3.2",


### PR DESCRIPTION
This PR updates the version of `swift-collections` to `1.2.1`.

This is necessary to provide the `DequeModule` to `swift-foundation`, which was previously excluded in the CMake configuration of `swift-collections` when exporting the module specifically used by `swift-foundation`.

https://github.com/apple/swift-collections/pull/495