### PR TITLE
[SE-0466] Extensions and members thereof can apply default isolation

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -334,6 +334,10 @@ EXPERIMENTAL_FEATURE(ConsumeSelfInDeinit, true)
 
 EXPERIMENTAL_FEATURE(AccessLevelOnImport, true)
 
+/// Disable the special behavior of of explicit 'nonisolated' vs. being
+/// implicitly nonisolated.
+EXPERIMENTAL_FEATURE(NoExplicitNonIsolated, true)
+
 /// Enables a module to allow non resilient access from other
 /// modules within a package if built from source.
 EXPERIMENTAL_FEATURE(AllowNonResilientAccessInPackage, false)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -125,6 +125,7 @@ UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 UNINTERESTING_FEATURE(ImportMacroAliases)
+UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 
 // TODO: Return true for inlinable function bodies with module selectors in them
 UNINTERESTING_FEATURE(ModuleSelector)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1852,8 +1852,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.DefaultIsolationBehavior = DefaultIsolation::Nonisolated;
   }
 
-  if (Opts.DefaultIsolationBehavior == DefaultIsolation::MainActor)
+  if (Opts.DefaultIsolationBehavior == DefaultIsolation::MainActor) {
     Opts.enableFeature(Feature::InferIsolatedConformances);
+    Opts.enableFeature(Feature::NoExplicitNonIsolated);
+  }
 
 #if !defined(NDEBUG) && SWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION
   /// Enable round trip parsing via the new swift parser unless it is disabled

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6276,6 +6276,39 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
   return {{ActorIsolation::forUnspecified(), {}}, nullptr, {}};
 }
 
+/// Determines when the given "self" isolation should override default
+/// isolation.
+static bool shouldSelfIsolationOverrideDefault(
+    ASTContext &ctx, const DeclContext *dc,
+    const ActorIsolation &selfIsolation) {
+  switch (selfIsolation) {
+  case ActorIsolation::ActorInstance:
+  case ActorIsolation::Erased:
+  case ActorIsolation::GlobalActor:
+    // Actor isolation always overrides.
+    return true;
+
+  case ActorIsolation::Unspecified:
+    // Unspecified isolation never overrides.
+    return false;
+
+  case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
+    // Explicit nonisolated used to overwrite default isolation all the time,
+    // but under NoExplicitNonIsolated it doesn't affect extensions.
+    if (isa<NominalTypeDecl>(dc))
+      return true;
+
+    // The NoExplicitNonIsolated feature
+    if (ctx.LangOpts.hasFeature(Feature::NoExplicitNonIsolated))
+      return false;
+
+    // Suppress when the default isolation is nonisolated.
+    return getDefaultIsolationForContext(dc) == DefaultIsolation::Nonisolated;
+  }
+}
+
 static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
                                                     ValueDecl *value) {
   // If this declaration has actor-isolated "self", it's isolated to that
@@ -6608,7 +6641,8 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     // has isolation, use that.
     if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
       auto selfTypeIsolation = getInferredActorIsolation(selfTypeDecl);
-      if (selfTypeIsolation.isolation) {
+      if (shouldSelfIsolationOverrideDefault(
+              ctx, value->getDeclContext(), selfTypeIsolation.isolation)) {
         auto isolation = selfTypeIsolation.isolation;
 
         if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6088,6 +6088,23 @@ static bool sendableConformanceRequiresNonisolated(NominalTypeDecl *nominal) {
   return requiresNonisolated;
 }
 
+/// Determine the default isolation for the given declaration context.
+static DefaultIsolation getDefaultIsolationForContext(const DeclContext *dc) {
+  // Check whether there is a file-specific setting.
+  if (auto *sourceFile = dc->getParentSourceFile()) {
+    if (auto defaultIsolationInFile = sourceFile->getDefaultIsolation())
+      return defaultIsolationInFile.value();
+  }
+
+  // If we're in the main module, check the language option.
+  ASTContext &ctx = dc->getASTContext();
+  if (dc->getParentModule() == ctx.MainModule)
+    return ctx.LangOpts.DefaultIsolationBehavior;
+
+  // Otherwise, default to nonisolated.
+  return DefaultIsolation::Nonisolated;
+}
+
 /// Determine the default isolation and isolation source for this declaration,
 /// which may still be overridden by other inference rules.
 static std::tuple<InferredActorIsolation, ValueDecl *,
@@ -6131,12 +6148,27 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
             return {};
 
           if (dc != dyn_cast<DeclContext>(value)) {
+            // If the nominal type is global-actor-isolated, there's nothing
+            // more to look for.
             if (getActorIsolation(nominal).isMainActor())
               break;
 
-            return {};
+            // If this is an extension of a nonisolated type, its isolation
+            // is independent of the type.
+            if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+              // If there were isolation attributes on the extension, respect
+              // them.
+              if (getIsolationFromAttributes(ext).has_value())
+                return {};
+
+              // Keep looking.
+            } else {
+              // The type is nonisolated, so its members are nonisolated.
+              return {};
+            }
           }
         }
+
         dc = dc->getParent();
       }
 
@@ -6166,12 +6198,8 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       return {};
     };
 
-    DefaultIsolation defaultIsolation = ctx.LangOpts.DefaultIsolationBehavior;
-    if (auto *SF = value->getDeclContext()->getParentSourceFile()) {
-      if (auto defaultIsolationInFile = SF->getDefaultIsolation())
-        defaultIsolation = defaultIsolationInFile.value();
-    }
-
+    DefaultIsolation defaultIsolation =
+        getDefaultIsolationForContext(value->getDeclContext());
     // If we are required to use main actor... just use that.
     if (defaultIsolation == DefaultIsolation::MainActor)
       if (auto result =
@@ -8426,6 +8454,19 @@ ActorIsolation swift::inferConformanceIsolation(
   // isolated to a global actor, we may use the conforming type's isolation.
   auto nominalIsolation = getActorIsolation(nominal);
   if (!nominalIsolation.isGlobalActor()) {
+    // If we are in an extension of the type, we might still infer an
+    // isolated conformance depending on default isolation and on the extension
+    // itself.
+    if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+      // If there's an isolation-related attribute on the extension, use it.
+      if (auto attrIsolation = getIsolationFromAttributes(ext))
+        return *attrIsolation;
+
+      // If we're defaulting to main-actor isolation, use that.
+      if (getDefaultIsolationForContext(dc) == DefaultIsolation::MainActor)
+        return ActorIsolation::forMainActor(ctx);
+    }
+
     return ActorIsolation::forNonisolated(false);
   }
 

--- a/test/Concurrency/Inputs/implicit_nonisolated_things.swift
+++ b/test/Concurrency/Inputs/implicit_nonisolated_things.swift
@@ -1,0 +1,7 @@
+public protocol ImportedSendableProto: Sendable { }
+
+@MainActor public struct ImportedStruct: ImportedSendableProto { }
+
+public struct ImportedOtherStruct { }
+
+public protocol ImportedP { }

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -227,24 +227,6 @@ actor MyActor2 {
   print("123")
 }
 
-// https://github.com/swiftlang/swift/issues/82168 - used to fail
-nonisolated protocol P {
-  associatedtype AT
-  static var at: AT { get }
-}
-
-nonisolated struct KP<R: P, V> {
-  init(keyPath: KeyPath<R, V>) {}
-}
-
-struct S: P {
-  let p: Int
-  struct AT {
-    let kp = KP(keyPath: \S.p)
-  }
-  static let at = AT() // used to fail here
-}
-
 nonisolated func localDeclIsolation() async {
   struct Local {
     static func f() {}

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -79,3 +79,24 @@ func testTaskDetached() async {
     await k.doSomething()
   }
 }
+
+// @MainActor
+extension Int {
+  func memberOfInt() { } // expected-note{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
+}
+
+nonisolated func testMemberOfInt(i: Int) {
+  i.memberOfInt() // expected-swift5-warning{{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
+  // expected-swift6-error@-1{{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
+}
+
+protocol SendableProto: Sendable { }
+
+struct MyStruct: SendableProto { }
+
+extension MyStruct: CustomStringConvertible {
+  var description: String {
+    17.memberOfInt() // okay, on main actor
+    return "hello"
+  }
+}

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -82,7 +82,7 @@ func testTaskDetached() async {
 
 // @MainActor
 extension Int {
-  func memberOfInt() { } // expected-note{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
+  func memberOfInt() { } // expected-note 2{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
 }
 
 nonisolated func testMemberOfInt(i: Int) {
@@ -98,5 +98,21 @@ extension MyStruct: CustomStringConvertible {
   var description: String {
     17.memberOfInt() // okay, on main actor
     return "hello"
+  }
+}
+
+nonisolated struct MyOtherStruct { }
+
+extension MyOtherStruct {
+  func f() {
+    17.memberOfInt() // okay, on main actor
+  }
+}
+
+nonisolated
+extension MyOtherStruct {
+  func g() {
+    17.memberOfInt() // expected-swift5-warning{{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
+  // expected-swift6-error@-1{{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
   }
 }


### PR DESCRIPTION
Extensions of nonisolated types can get default isolation from context (e.g., `@MainActor`) independently. This was previously true for members, but not conformances, and recently regressed for members. Fix the logic to consistently allow such extensions to be default main-actor isolated, which affects both their members and conformances.

Fixes rdar://156644976.
