### PR TITLE
[6.2][stdlib] Define actual platform version numbers for SwiftStdlib 6.2

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -160,7 +160,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 2),
-  FUTURE
+  PLATFORM(macOS,   (26, 0, 0))
+  PLATFORM(iOS,     (26, 0, 0))
+  PLATFORM(watchOS, (26, 0, 0))
+  PLATFORM(visionOS,(26, 0, 0))
 )
 
 END_MAJOR_VERSION(6)

--- a/test/Availability/value_generics_availability.swift
+++ b/test/Availability/value_generics_availability.swift
@@ -2,13 +2,13 @@
 
 // REQUIRES: OS=macosx
 
-struct A<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+struct A<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                         // expected-note@-1 {{add '@available' attribute to enclosing generic struct}}
 
-class B<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+class B<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                        // expected-note@-1 {{add '@available' attribute to enclosing generic class}}
 
-enum C<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+enum C<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                       // expected-note@-1 {{add '@available' attribute to enclosing generic enum}}
 
 func something<let N: Int>(_: A<N>) {} // OK, because A can't reference value generics.

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -45,7 +45,7 @@ SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
-SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0
 
 # Like SwiftStdlib 5.0, but also the oldest visionOS.
 SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0


### PR DESCRIPTION
Cherry pick of #83316.

Explanation: Swift 6.2 is scheduled to ship in macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0.
Scope: Downloadable swift.org toolchains will have proper availability annotations for new API introduced in 6.2.
Issues: rdar://156651158
Risk: Minimal
Testing: Regular local & CI tests
Reviewer: pending
