### PR TITLE
FreeBSD: Fix more compiler tests

### DIFF
--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -70,7 +70,9 @@ func test_pow() {
 // https://github.com/apple/swift/issues/51573
 // long doubles in AAPCS64 and 64-bit Android are 128 bits, which is not
 // supported by Swift, so don't test this.
-#if !((os(Android) && _pointerBitWidth(_64)) || (os(Linux) && arch(arm64)))
+#if !((os(Android) && _pointerBitWidth(_64)) ||
+  (os(Linux) && arch(arm64)) ||
+  (os(FreeBSD) && arch(arm64)))
 func test_powl() {
   powl(1.5, 2.5)
 }

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
@@ -79,7 +79,7 @@
 
 // Locating the built libraries failed on Linux (construction of test case),
 // but we primarily care about macOS in this test
-// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu || OS=freebsd
 
 // %env does not seem to work on Windows
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule_irgen.swift
@@ -50,7 +50,7 @@
 
 // Locating the built libraries failed on Linux (construction of test case),
 // but we primarily care about macOS in this test
-// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu || OS=freebsd
 
 // %env does not seem to work on Windows
 // UNSUPPORTED: OS=windows-msvc

--- a/test/IRGen/profiling_marker_thunks.swift
+++ b/test/IRGen/profiling_marker_thunks.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -module-name A -I %t -emit-ir %s | %FileCheck %s --check-prefix=NOTHUNK
 
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
+// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi, OS=freebsd
 
 // UNSUPPORTED: CPU=arm64e
 

--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -9,7 +9,7 @@
 
 /// Build and run a binary from Swift and C code.
 // RUN: %clang-no-modules -c %t/Client.c -o %t/Client.o -target %target-triple \
-// RUN:   -I %t -I %clang-include-dir -Werror -isysroot %sdk
+// RUN:   %target-pic-opt -I %t -I %clang-include-dir -Werror -isysroot %sdk
 // RUN: %target-build-swift %t/Lib.swift %t/Client.o -O -o %t/a.out \
 // RUN:   -enable-experimental-feature CDecl -parse-as-library
 // RUN: %target-codesign %t/a.out

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -200,7 +200,7 @@ import Darwin
 import Dispatch
 
 // FIXME: port to Linux.
-// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=freebsd, OS=openbsd, OS=linux-android
 
 // A wrapper for pthread_t with platform-independent interface.
 public struct _stdlib_pthread_t : Equatable, Hashable {

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,5 +1,10 @@
 // XFAIL: OS=windows-msvc
 
+// This test hangs on aarch64 FreeBSD
+// XFAIL will try to run the test and the verify that the test fails, which
+// still hits the hang.
+// UNSUPPORTED: OS=freebsd && CPU=aarch64
+
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run %t_asan-binary 2>&1 | %FileCheck %s


### PR DESCRIPTION
Fixes:
 - cdecl_official_run.swift  -- Clang on Linux defaults to the `PIC` relocation model, while on FreeBSD it defaults to static. Swift defaults to `PIC` everywhere. Passing `-fPIC` to clang to ensure that the built C object is compatible with the Swift object and avoid failing during the link.
 - cfuncs_parse.swift -- `powl` is a 128-bit long double on arm64 FreeBSD, which Swift does not have support for. Same issue as on Linux and Android. Once we have support, this part of the test should be re-enabled.

Disables:
 - distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
 - distributed_actor_remoteCall_accessibleFucntions_crossModule_irgen.swift
rpaths aren't set up correctly on these two tests and fail on Linux and FreeBSD in the same way. They should be re-enabled together.
 - profiling_marker_thunks.swift -- Looks like it only works on Apple platforms, disabling on FreeBSD like it is on all of the other platforms.
 - CollectionTransformers.swift -- Imports Darwin directly, which is only available on Apple platforms. There is a note that is several years old saying we should port it to all of the other platforms, but that is beyond the scope of bringing up the FreeBSD bot.
 - asan.swift -- This is the only one that is odd. I'm preemptively disabling it so that we don't cause a mess of CI. Created https://github.com/swiftlang/swift/issues/83318 to track fixing it.