### PR TITLE
IRGen: correct some type deletion

### DIFF
--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -76,6 +76,8 @@ add_swift_host_library(swiftIRGen STATIC
     transformutils
     irprinter
 )
+target_compile_options(swiftIRGen PRIVATE
+  $<$<AND:$<PLATFORM_ID:Linux>,$<CXX_COMPILER_ID:Clang>>:-fsized-deallocation>)
 target_link_libraries(swiftIRGen INTERFACE
   clangCodeGen
   clangAST)

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -157,6 +157,13 @@ public:
     return new(buffer) Impl(fields, std::forward<As>(args)...);
   }
 
+  void operator delete(void *ptr) {
+    const auto *pThis = static_cast<RecordTypeInfoImpl *>(ptr);
+    const size_t count = pThis->NumFields;
+    const size_t size = Impl::template totalSizeToAlloc<FieldImpl>(count);
+    ::operator delete(ptr, size);
+  }
+
   bool areFieldsABIAccessible() const {
     return AreFieldsABIAccessible;
   }

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -230,6 +230,13 @@ class ProtocolInfo final :
                                               ProtocolInfoKind kind);
 
 public:
+  void operator delete(void *ptr) {
+    const auto *pThis = static_cast<ProtocolInfo *>(ptr);
+    const size_t count = pThis->NumTableEntries;
+    const size_t size = totalSizeToAlloc<WitnessTableEntry>(count);
+    ::operator delete(ptr, size);
+  }
+
   /// The number of witness slots in a conformance to this protocol;
   /// in other words, the size of the table in words.
   unsigned getNumWitnesses() const {


### PR DESCRIPTION
ASAN identified mismatched `operator new` and `operator delete` on these types. The reason for this is the sized allocation for the tail packing involved. Provide the associated `operator delete` that releases the memory. Note that the `operator delete` is static and does not have the implicit `this` pointer, and we cannot use the name `this` for the variable.