### PR TITLE
[cxx-interop] Simplify test for move-only types

### DIFF
--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -D HAS_NONCOPYABLE_GENERICS)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O -D HAS_NONCOPYABLE_GENERICS)
 
 // REQUIRES: executable_test
 
@@ -29,12 +27,10 @@ MoveOnlyCxxValueType.test("Test derived move only type member access") {
   var k = c.method(-3)
   expectEqual(k, -6)
   expectEqual(c.method(1), 2)
-#if HAS_NONCOPYABLE_GENERICS
   k = c.x
   expectEqual(k, 2)
   c.x = 11
   expectEqual(c.x, 11)
-#endif
   k = c.mutMethod(-13)
   expectEqual(k, -13)
 }
@@ -60,7 +56,6 @@ MoveOnlyCxxValueType.test("Test move only field access in holder") {
   expectEqual(c.x.x, 5)
 }
 
-#if HAS_NONCOPYABLE_GENERICS
 MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   var c = NonCopyableHolderDerivedDerived(-11)
   var k = borrowNC(c.x)
@@ -74,6 +69,5 @@ MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   c.x.mutMethod(5)
   expectEqual(c.x.x, 5)
 }
-#endif
 
 runAllTests()


### PR DESCRIPTION
Noncopyable generics have landed in Swift, so we can remove the `#if` now.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
