### PR TITLE
benchmark script tests: make the match string for invalid option errors more flexible

### DIFF
--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -112,7 +112,7 @@ class Test_parse_args(unittest.TestCase):
             [
                 "error:",
                 "argument -o/--optimization: invalid choice: 'bogus'",
-                "(choose from 'O', 'Onone', 'Osize')",
+                "(choose from ",
             ],
             err.getvalue(),
         )

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -860,7 +860,7 @@ class Test_parse_args(unittest.TestCase):
             )
         self.assertIn(
             "error: argument --format: invalid choice: 'bogus' "
-            "(choose from 'markdown', 'git', 'html')",
+            "(choose from ",
             err.getvalue(),
         )
 


### PR DESCRIPTION
Because the actual output depends on the python version
