### PR TITLE
[Concurrency] Fix task switch performance issue.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -116,6 +116,12 @@ func specializeWitnessTable(for conformance: Conformance,
     return
   }
 
+  guard conformance.isConcrete else {
+    // If the conformance is abstract the witness table is specialized elsewhere - at the
+    // place where the concrete conformance is referenced.
+    return
+  }
+
   let baseConf = conformance.isInherited ? conformance.inheritedConformance: conformance
   if !baseConf.isSpecialized {
     var visited = Set<Conformance>()

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -105,6 +105,8 @@ public:
                            SILLinkage::HiddenExternal);
     linkUsedFunctionByName("swift_createDefaultExecutors",
                            SILLinkage::HiddenExternal);
+    linkUsedFunctionByName("swift_getDefaultExecutor",
+                           SILLinkage::HiddenExternal);
     linkEmbeddedRuntimeWitnessTables();
   }
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2391,13 +2391,15 @@ static bool mustSwitchToRun(SerialExecutorRef currentSerialExecutor,
   }
 
   // else, we may have to switch if the preferred task executor is different
-  auto differentTaskExecutor =
-      currentTaskExecutor.getIdentity() != newTaskExecutor.getIdentity();
-  if (differentTaskExecutor) {
-    return true;
-  }
+  if (currentTaskExecutor.getIdentity() == newTaskExecutor.getIdentity())
+    return false;
 
-  return false;
+  if (currentTaskExecutor.isUndefined())
+    currentTaskExecutor = swift_getDefaultExecutor();
+  if (newTaskExecutor.isUndefined())
+    newTaskExecutor = swift_getDefaultExecutor();
+
+  return currentTaskExecutor.getIdentity() != newTaskExecutor.getIdentity();
 }
 
 /// Given that we've assumed control of an executor on this thread,

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -625,6 +625,13 @@ extension MainActor {
     _createDefaultExecutorsOnce()
     return _executor!
   }
+
+  /// An unowned version of the above, for performance
+  @available(StdlibDeploymentTarget 6.2, *)
+  static var unownedExecutor: UnownedSerialExecutor {
+    _createDefaultExecutorsOnce()
+    return unsafe UnownedSerialExecutor(ordinary: _executor!)
+  }
 }
 #endif // os(WASI) || (!$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY)
 
@@ -642,6 +649,13 @@ extension Task where Success == Never, Failure == Never {
     // It would be good if there was a Swift way to do this
     _createDefaultExecutorsOnce()
     return _defaultExecutor!
+  }
+
+  /// An unowned version of the above, for performance
+  @available(StdlibDeploymentTarget 6.2, *)
+  static var unownedDefaultExecutor: UnownedTaskExecutor {
+    _createDefaultExecutorsOnce()
+    return unsafe UnownedTaskExecutor(_defaultExecutor!)
   }
 }
 

--- a/stdlib/public/Concurrency/ExecutorBridge.h
+++ b/stdlib/public/Concurrency/ExecutorBridge.h
@@ -23,6 +23,9 @@ namespace swift {
 extern "C" SWIFT_CC(swift)
 SerialExecutorRef swift_getMainExecutor();
 
+extern "C" SWIFT_CC(swift)
+TaskExecutorRef swift_getDefaultExecutor();
+
 #if !SWIFT_CONCURRENCY_EMBEDDED
 extern "C" SWIFT_CC(swift)
 void *swift_createDispatchEventC(void (*handler)(void *), void *context);

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -95,21 +95,21 @@ internal func _jobGetExecutorPrivateData(
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
-internal func _getMainExecutorAsSerialExecutor() -> (any SerialExecutor)? {
-  return MainActor.executor
+internal func _getMainExecutorAsSerialExecutor() -> UnownedSerialExecutor {
+  return unsafe MainActor.unownedExecutor
 }
 #else
 // For task-to-thread model, this is implemented in C++
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
-internal func _getMainExecutorAsSerialExecutor() -> (any SerialExecutor)?
+internal func _getMainExecutorAsSerialExecutor() -> UnownedSerialExecutor
 #endif // SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 #endif // os(WASI) || !$Embedded
 
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getDefaultExecutor")
-internal func _getDefaultExecutorAsTaskExecutor() -> (any TaskExecutor)? {
-  return Task.defaultExecutor
+internal func _getDefaultExecutorAsTaskExecutor() -> UnownedTaskExecutor {
+  return unsafe Task.unownedDefaultExecutor
 }
 
 @available(StdlibDeploymentTarget 6.2, *)

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -107,6 +107,12 @@ internal func _getMainExecutorAsSerialExecutor() -> (any SerialExecutor)?
 #endif // os(WASI) || !$Embedded
 
 @available(StdlibDeploymentTarget 6.2, *)
+@_silgen_name("swift_getDefaultExecutor")
+internal func _getDefaultExecutorAsTaskExecutor() -> (any TaskExecutor)? {
+  return Task.defaultExecutor
+}
+
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchMain")
 internal func _dispatchMain()
 

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -47,11 +47,7 @@ internal func donateToGlobalExecutor(
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getMainExecutorImpl")
 internal func getMainExecutor() -> UnownedSerialExecutor {
-  let executor = _getMainExecutorAsSerialExecutor()
-  if let executor {
-    return unsafe executor.asUnownedSerialExecutor()
-  }
-  return unsafe unsafeBitCast(executor, to: UnownedSerialExecutor.self)
+  return _getMainExecutorAsSerialExecutor()
 }
 
 @available(SwiftStdlib 6.2, *)

--- a/test/Concurrency/Runtime/custom_task_executor_fast_path.swift
+++ b/test/Concurrency/Runtime/custom_task_executor_fast_path.swift
@@ -9,6 +9,7 @@
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 // REQUIRES: synchronization
+// REQUIRES: libdispatch
 
 import StdlibUnittest
 import Synchronization

--- a/test/Concurrency/Runtime/custom_task_executor_fast_path.swift
+++ b/test/Concurrency/Runtime/custom_task_executor_fast_path.swift
@@ -1,0 +1,116 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -g %import-libdispatch -parse-as-library) | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+// rdar://106849189 move-only types should be supported in freestanding mode
+// UNSUPPORTED: freestanding
+
+// UNSUPPORTED: back_deployment_runtime
+// REQUIRES: concurrency_runtime
+// REQUIRES: synchronization
+
+import StdlibUnittest
+import Synchronization
+import Dispatch
+
+typealias DefaultExecutorFactory = SimpleExecutorFactory
+
+struct SimpleExecutorFactory: ExecutorFactory {
+  public static var mainExecutor: any MainExecutor {
+    return SimpleMainExecutor()
+  }
+  public static var defaultExecutor: any TaskExecutor {
+    return SimpleTaskExecutor()
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+final class SimpleMainExecutor: MainExecutor, @unchecked Sendable {
+  public var isRunning: Bool = false
+
+  var shouldStop: Bool = false
+  let queue = Mutex<[UnownedJob]>([])
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    let unownedJob = UnownedJob(job)
+    queue.withLock {
+      $0.append(unownedJob)
+    }
+  }
+
+  func run() throws {
+    isRunning = true
+    while !shouldStop {
+      let jobs = queue.withLock {
+        let jobs = $0
+        $0.removeAll()
+        return jobs
+      }
+      for job in jobs {
+        job.runSynchronously(on: self.asUnownedSerialExecutor())
+      }
+    }
+    isRunning = false
+  }
+
+  func stop() {
+    shouldStop = true
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+final class SimpleTaskExecutor: TaskExecutor, @unchecked Sendable {
+  let queue = Mutex<[UnownedJob]>([])
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    print("Enqueued")
+    let unownedJob = UnownedJob(job)
+    queue.withLock {
+      $0.append(unownedJob)
+    }
+  }
+
+  func run() throws {
+    while true {
+      let jobs = queue.withLock {
+        let jobs = $0
+        $0.removeAll()
+        return jobs
+      }
+      for job in jobs {
+        job.runSynchronously(on: self.asUnownedTaskExecutor())
+      }
+    }
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+@main struct Main {
+  static func main() async {
+    DispatchQueue.global().async {
+      try! (Task.defaultExecutor as! SimpleTaskExecutor).run()
+    }
+
+    await withTaskGroup { group in
+      for _ in 0..<3 {
+        group.addTask() {
+          for _ in 0..<100 {
+            await withUnsafeContinuation { cont in
+              cont.resume()
+            }
+          }
+        }
+      }
+    }
+
+  }
+}
+
+// If we're on the fast path, we'll only enqueue four times (once per group)
+
+// CHECK: Enqueued
+// CHECK: Enqueued
+// CHECK: Enqueued
+// CHECK: Enqueued
+// CHECK-NOT: Enqueued

--- a/test/embedded/unowned-task-executor.swift
+++ b/test/embedded/unowned-task-executor.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -disable-availability-checking -module-name test -parse-as-library %s -emit-ir | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import _Concurrency
+
+public var e: (any TaskExecutor)? = nil
+
+// CHECK-LABEL: define {{.*}}@"$e4test6testits19UnownedTaskExecutorVyF"()
+// CHECK: [[EXISTENTIAL_ADDR:%.*]] = call {{.*}}"$e4test1eSch_pSgvau"
+// CHECK: [[INSTANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 0}}
+// CHECK: [[INSTANCE:%.*]] = load {{.*}}ptr [[INSTANCE_ADDR]]
+// CHECK: [[CONFORMANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 1}}
+// CHECK: [[CONFORMANCE:%.*]] = load {{.*}}ptr [[CONFORMANCE_ADDR]]
+// CHECK: {{^[0-9a-z]+:}}
+// CHECK: [[INSTANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[INSTANCE]]
+// CHECK: [[CONFORMANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[CONFORMANCE]]
+// CHECK: [[INSTANCE_PHI:%.*]] = phi ptr [ [[INSTANCE_PTR]]
+// CHECK: [[CONFORMANCE_PHI:%.*]] = phi ptr [ [[CONFORMANCE_PTR]]
+// CHECK: [[INSTANCE_ISA:%.*]] = load ptr, ptr [[INSTANCE_PHI]]
+// CHECK: call {{.*}}@"$es19UnownedTaskExecutorVyABxhcSchRzlufC"(ptr [[INSTANCE_PHI]], ptr [[INSTANCE_ISA]], ptr [[CONFORMANCE_PHI]])
+// CHECK-LABEL: {{^}}}
+public func testit() -> UnownedTaskExecutor {
+  return unsafe UnownedTaskExecutor(e!)
+}
+


### PR DESCRIPTION
When using the new custom default executors, sometimes we end up taking a long time to do a task switch.  This is happening because the path the new code takes sometimes results in a concrete pointer to the default global executor being in the executor tracking information in `swift_task_switch()`, and if we try to switch to a `nil` task executor (which _also_ means the default global executor), we aren’t spotting that and we’re taking the slow path.

Essentially, we want to take the fast path in cases where we switch from `nil` to the concrete default global executor and vice-versa.

rdar://156701386
