### PR TITLE
AST: Simplify and clarify `AvailabilityConstraint`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3927,11 +3927,11 @@ public:
 
   /// Returns the effective obsoletion range indicated by this attribute, along
   /// with the domain that it applies to (which may be different than the domain
-  /// which the attribute was written with if a remap is required). This always
-  /// corresponds to the version specified by the `obsoleted:` component
-  /// (remapped or canonicalized if necessary). Returns `std::nullopt` if the
-  /// attribute does not indicate obsoletion (note that unavailability is
-  /// separate from obsoletion.
+  /// which the attribute was written with if a remap is required). This may
+  /// correspond to the version specified by the `obsoleted:` component
+  /// (remapped or canonicalized if necessary) or it may be "always" if the
+  /// attribute represents unconditional unavailability. Returns `std::nullopt`
+  /// if the attribute does not indicate obsoletion.
   std::optional<AvailabilityDomainAndRange>
   getObsoletedDomainAndRange(const ASTContext &ctx) const;
 

--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -31,52 +31,96 @@ class ASTContext;
 class AvailabilityContext;
 class Decl;
 
-/// Represents the reason a declaration could be considered unavailable in a
-/// certain context.
+/// Represents the reason a declaration is considered not available in a
+/// specific `AvailabilityContext`.
 class AvailabilityConstraint {
 public:
-  /// The reason that the availability constraint is unsatisfied.
+  /// The reason that a declaration is not available in a context. Broadly, the
+  /// declaration may either be "unintroduced" or "unavailable" depending on its
+  /// `@available` attributes. A declaration that is unintroduced can become
+  /// available if availability constraints are added to the context. For
+  /// unavailable declarations, on the other hand, either changing the
+  /// deployment target or making the context itself unavailable are necessary
+  /// to satisfy the constraint.
+  ///
+  /// For example, take the following declaration `f()`:
+  ///
+  ///     @available(macOS, introduced: 11.0, obsoleted: 14.0)
+  ///     func f() { ... }
+  ///
+  /// In contexts that may run on earlier OSes, references to `f()` yield
+  /// an `Unintroduced` constraint:
+  ///
+  ///     @available(macOS 10.15, *)
+  ///     func g() {
+  ///       f() // error: 'f()' is only available in macOS 11.0 or newer
+  ///     }
+  ///
+  ///     macOS ...            11.0                   14.0               ...
+  ///     f()   |----------------[=======================)-----------------|
+  ///     g()   |-----------[==============================================)
+  ///                       ^
+  ///                  Unintroduced
+  ///
+  /// On the other hand, in contexts where deployment target is high enough to
+  /// make `f()` obsolete, references to it yield an `UnavailableObsolete`
+  /// constraint:
+  ///
+  ///     // compiled with -target arm64-apple-macos14
+  ///     func h() {
+  ///       f() // error: 'f()' is unavailable in macOS
+  ///     }
+  ///
+  ///     macOS ...            11.0                    14.0              ...
+  ///     f()   |----------------[=======================)-----------------|
+  ///     h()   |----------------------------------------[=================)
+  ///                                                    ^
+  ///                                           UnavailableObsolete
+  ///
+  /// References to declarations that are unavailable in all versions of a
+  /// domain generate `UnavailableUnconditional` constraints unless the context
+  /// is also unavailable under the same conditions:
+  ///
+  ///     @available(macOS, unavailable)
+  ///     func foo() { ... }
+  ///
+  ///     func bar() {
+  ///       foo() // error: 'foo()' is unavailable in macOS
+  ///     }
+  ///
+  ///     @available(macOS, unavailable)
+  ///     func baz() {
+  ///       foo() // OK
+  ///     }
+  ///
+  ///     @available(*, unavailable)
+  ///     func qux() {
+  ///       foo() // also OK
+  ///     }
   ///
   /// NOTE: The order of this enum matters. Reasons are defined in descending
   /// priority order.
   enum class Reason {
-    /// The declaration is referenced in a context in which it is generally
-    /// unavailable. For example, a reference to a declaration that is
-    /// unavailable on macOS from a context that may execute on macOS has this
-    /// constraint.
-    UnconditionallyUnavailable,
+    /// The declaration is unconditionally unavailable, e.g. because of
+    /// `@available(macOS, unavailable)`.
+    UnavailableUnconditionally,
 
-    /// The declaration is referenced in a context in which it is considered
-    /// obsolete. For example, a reference to a declaration that is obsolete in
-    /// macOS 13 from a context that may execute on macOS 13 or later has this
-    /// constraint.
-    Obsoleted,
+    /// The declaration is obsolete, e.g. because of
+    /// `@available(macOS, obsolete: 14.0)` in a program with a deployment
+    /// target of `macOS 14` or later.
+    UnavailableObsolete,
 
-    /// The declaration is not available in the deployment configuration
-    /// specified for this compilation. For example, the declaration might only
-    /// be introduced in the Swift 6 language mode while the module is being
-    /// compiled in the Swift 5 language mode. These availability constraints
-    /// cannot be satisfied by adding constraining contextual availability using
-    /// `@available` attributes or `if #available` queries.
-    UnavailableForDeployment,
+    /// The declaration is only available for later deployment configurations,
+    /// e.g. because of `@available(swift 6)` in a program compiled with
+    /// `-swift-version 5`.
+    UnavailableUnintroduced,
 
-    /// The declaration is referenced in a context that does not have adequate
-    /// availability constraints. For example, a reference to a declaration that
-    /// was introduced in macOS 13 from a context that may execute on earlier
-    /// versions of macOS cannot satisfy this constraint. The constraint
-    /// can be satisfied, though, by introducing an `@available` attribute or an
-    /// `if #available(...)` query.
-    PotentiallyUnavailable,
-  };
-
-  /// Classifies constraints into different high level categories.
-  enum class Kind {
-    /// There are no contexts in which the declaration would be available.
-    Unavailable,
-
-    /// There are some contexts in which the declaration would be available if
-    /// additional constraints were added.
-    PotentiallyAvailable,
+    /// The declaration has not yet been introduced, e.g. because of
+    /// `@available(macOS 14, *)` in a context that may run on macOS 13 or
+    /// later. The constraint may be satisfied adding an `@available` attribute
+    /// or an `if #available(...)` query with sufficient introduction
+    /// constraints to the context.
+    Unintroduced,
   };
 
 private:
@@ -87,22 +131,22 @@ private:
 
 public:
   static AvailabilityConstraint
-  unconditionallyUnavailable(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::UnconditionallyUnavailable, attr);
-  }
-
-  static AvailabilityConstraint obsoleted(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::Obsoleted, attr);
+  unavailableUnconditionally(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::UnavailableUnconditionally, attr);
   }
 
   static AvailabilityConstraint
-  unavailableForDeployment(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::UnavailableForDeployment, attr);
+  unavailableObsolete(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::UnavailableObsolete, attr);
   }
 
   static AvailabilityConstraint
-  potentiallyUnavailable(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::PotentiallyUnavailable, attr);
+  unavailableUnintroduced(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::UnavailableUnintroduced, attr);
+  }
+
+  static AvailabilityConstraint unintroduced(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::Unintroduced, attr);
   }
 
   Reason getReason() const { return attrAndReason.getInt(); }
@@ -110,24 +154,17 @@ public:
     return static_cast<SemanticAvailableAttr>(attrAndReason.getPointer());
   }
 
-  Kind getKind() const {
+  /// Returns true if the constraint cannot be satisfied using a runtime
+  /// availability query (`if #available(...)`).
+  bool isUnavailable() const {
     switch (getReason()) {
-    case Reason::UnconditionallyUnavailable:
-    case Reason::Obsoleted:
-    case Reason::UnavailableForDeployment:
-      return Kind::Unavailable;
-    case Reason::PotentiallyUnavailable:
-      return Kind::PotentiallyAvailable;
+    case Reason::UnavailableUnconditionally:
+    case Reason::UnavailableObsolete:
+    case Reason::UnavailableUnintroduced:
+      return true;
+    case Reason::Unintroduced:
+      return false;
     }
-  }
-
-  /// Returns true if the constraint cannot be satisfied at runtime.
-  bool isUnavailable() const { return getKind() == Kind::Unavailable; }
-
-  /// Returns true if the constraint is unsatisfied but could be satisfied at
-  /// runtime in a more constrained context.
-  bool isPotentiallyAvailable() const {
-    return getKind() == Kind::PotentiallyAvailable;
   }
 
   /// Returns the domain that the constraint applies to.

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -81,12 +81,14 @@ static bool constraintIsStronger(const AvailabilityConstraint &lhs,
 
   case AvailabilityConstraint::Reason::Obsoleted:
     // Pick the larger obsoleted range.
-    return *lhs.getAttr().getObsoleted() < *rhs.getAttr().getObsoleted();
+    return lhs.getAttr().getObsoleted().value() <
+           rhs.getAttr().getObsoleted().value();
 
   case AvailabilityConstraint::Reason::UnavailableForDeployment:
   case AvailabilityConstraint::Reason::PotentiallyUnavailable:
     // Pick the smaller introduced range.
-    return *lhs.getAttr().getIntroduced() > *rhs.getAttr().getIntroduced();
+    return lhs.getAttr().getIntroduced().value_or(llvm::VersionTuple()) >
+           rhs.getAttr().getIntroduced().value_or(llvm::VersionTuple());
   }
 }
 

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -361,12 +361,12 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
     auto attr = constraint.getAttr();
     auto domain = attr.getDomain();
     switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
-    case AvailabilityConstraint::Reason::Obsoleted:
-    case AvailabilityConstraint::Reason::UnavailableForDeployment:
+    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+    case AvailabilityConstraint::Reason::UnavailableObsolete:
+    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
       declDomainInfos.push_back(DomainInfo::unavailable(domain));
       break;
-    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
+    case AvailabilityConstraint::Reason::Unintroduced:
       if (auto introducedRange = attr.getIntroducedRange(ctx)) {
         if (domain.isActivePlatform(ctx)) {
           isConstrained |= constrainRange(platformRange, *introducedRange);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2489,7 +2489,7 @@ private:
 
       auto constraint = getUnsatisfiedAvailabilityConstraint(
           nominal, context.getAsDeclContext(), loc);
-      if (constraint && constraint->isPotentiallyAvailable()) {
+      if (constraint && !constraint->isUnavailable()) {
         auto &ctx = getASTContext();
         ctx.Diags.diagnose(loc,
                            diag::result_builder_missing_limited_availability,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1699,11 +1699,11 @@ bool shouldHideDomainNameForConstraintDiagnostic(
     return false;
   case AvailabilityDomain::Kind::SwiftLanguage:
     switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
-    case AvailabilityConstraint::Reason::UnavailableForDeployment:
+    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
       return false;
-    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
-    case AvailabilityConstraint::Reason::Obsoleted:
+    case AvailabilityConstraint::Reason::Unintroduced:
+    case AvailabilityConstraint::Reason::UnavailableObsolete:
       return true;
     }
   }
@@ -1745,24 +1745,24 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
       .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
 
   switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
+  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
     diags
         .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
                   proto)
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::UnavailableForDeployment:
+  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
                    type, proto, domainAndRange.getDomain(),
                    domainAndRange.getRange());
     break;
-  case AvailabilityConstraint::Reason::Obsoleted:
+  case AvailabilityConstraint::Reason::UnavailableObsolete:
     diags
         .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::PotentiallyUnavailable:
+  case AvailabilityConstraint::Reason::Unintroduced:
     llvm_unreachable("unexpected constraint");
   }
   return true;
@@ -2173,23 +2173,23 @@ bool diagnoseExplicitUnavailability(
 
   auto sourceRange = Attr.getParsedAttr()->getRange();
   switch (constraint.getReason()) {
-  case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
+  case AvailabilityConstraint::Reason::UnavailableUnconditionally:
     diags.diagnose(D, diag::availability_marked_unavailable, D)
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::UnavailableForDeployment:
+  case AvailabilityConstraint::Reason::UnavailableUnintroduced:
     diags
         .diagnose(D, diag::availability_introduced_in_version, D,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::Obsoleted:
+  case AvailabilityConstraint::Reason::UnavailableObsolete:
     diags
         .diagnose(D, diag::availability_obsoleted, D,
                   domainAndRange.getDomain(), domainAndRange.getRange())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::PotentiallyUnavailable:
+  case AvailabilityConstraint::Reason::Unintroduced:
     llvm_unreachable("unexpected constraint");
     break;
   }
@@ -2895,11 +2895,8 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
         && isa<ProtocolDecl>(D))
     return false;
 
-  if (!constraint)
-    return false;
-
   // Diagnose (and possibly signal) for potential unavailability
-  if (!constraint->isPotentiallyAvailable())
+  if (!constraint || constraint->isUnavailable())
     return false;
 
   auto domainAndRange = constraint->getDomainAndRange(ctx);
@@ -3429,14 +3426,12 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       }
 
       // Diagnose (and possibly signal) for potential unavailability
-      if (constraint->isPotentiallyAvailable()) {
-        auto domainAndRange = constraint->getDomainAndRange(ctx);
-        if (diagnosePotentialUnavailability(rootConf, ext, loc, DC,
-                                            domainAndRange.getDomain(),
-                                            domainAndRange.getRange())) {
-          maybeEmitAssociatedTypeNote();
-          return true;
-        }
+      auto domainAndRange = constraint->getDomainAndRange(ctx);
+      if (diagnosePotentialUnavailability(rootConf, ext, loc, DC,
+                                          domainAndRange.getDomain(),
+                                          domainAndRange.getRange())) {
+        maybeEmitAssociatedTypeNote();
+        return true;
       }
     }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -253,11 +253,11 @@ static bool isUnavailableInAllVersions(ValueDecl *decl) {
   auto constraints = getAvailabilityConstraintsForDecl(decl, deploymentContext);
   for (auto constraint : constraints) {
     switch (constraint.getReason()) {
-    case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
-    case AvailabilityConstraint::Reason::UnavailableForDeployment:
+    case AvailabilityConstraint::Reason::UnavailableUnconditionally:
+    case AvailabilityConstraint::Reason::UnavailableUnintroduced:
       return true;
-    case AvailabilityConstraint::Reason::Obsoleted:
-    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
+    case AvailabilityConstraint::Reason::UnavailableObsolete:
+    case AvailabilityConstraint::Reason::Unintroduced:
       break;
     }
   }

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -29,7 +29,15 @@ func unavailableInDynamicDomain() { } // expected-note * {{'unavailableInDynamic
 @available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
-func testDeployment() { // expected-note 2 {{add '@available' attribute to enclosing global function}}
+@available(EnabledDomain)
+@available(EnabledDomain)
+func availableInEnabledDomainTwice() { }
+
+@available(EnabledDomain)
+@available(EnabledDomain, unavailable)
+func availableAndUnavailableInEnabledDomain() { } // expected-note {{'availableAndUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+
+func testDeployment() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
   alwaysAvailable()
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
   // expected-note@-1 {{add 'if #available' version check}}
@@ -40,6 +48,9 @@ func testDeployment() { // expected-note 2 {{add '@available' attribute to enclo
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
   // expected-note@-1 {{add 'if #available' version check}}
   availableInUnknownDomain()
+  availableInEnabledDomainTwice() // expected-error {{'availableInEnabledDomainTwice()' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  availableAndUnavailableInEnabledDomain() // expected-error {{'availableAndUnavailableInEnabledDomain()' is unavailable}}
 }
 
 func testIfAvailable(_ truthy: Bool) { // expected-note 9 {{add '@available' attribute to enclosing global function}}

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -59,3 +59,11 @@ func availableInDynamicDomain() { }
 
 @available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
+
+@available(EnabledDomain)
+@available(EnabledDomain)
+func availableInEnabledDomainTwice() { }
+
+@available(EnabledDomain)
+@available(EnabledDomain, unavailable)
+func availableAndUnavailableInEnabledDomain() { }


### PR DESCRIPTION
Remove some unnecessary complexity from `AvailabilityConstraint`, rename some of its members, and add more complete documentation.

NFC.
