### PR TITLE
Revert https://github.com/swiftlang/swift/pull/82747

### DIFF
--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -100,24 +100,6 @@ public let benchmarks = [
   BenchmarkInfo(name: "NSDictionary.bridged.enumerate",
                   runFunction: run_BridgedNSDictionaryEnumerate, tags: t,
                   setUpFunction: setup_bridgedDictionaries),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.ascii",
-                  runFunction: run_BridgedNSStringLengthASCII_ASCII, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.utf8",
-                  runFunction: run_BridgedNSStringLengthASCII_UTF8, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.utf16",
-                  runFunction: run_BridgedNSStringLengthASCII_UTF16, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.macroman",
-                  runFunction: run_BridgedNSStringLengthASCII_MacRoman, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.utf8.utf8",
-                  runFunction: run_BridgedNSStringLengthUTF8_UTF8, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
-  BenchmarkInfo(name: "NSString.bridged.byteCount.utf8.utf16",
-                  runFunction: run_BridgedNSStringLengthUTF8_UTF16, tags: ts,
-                  setUpFunction: setup_bridgedStrings),
 ]
 
 #if _runtime(_ObjC)
@@ -819,8 +801,6 @@ var bridgedDictionaryOfNumbersToNumbers:NSDictionary! = nil
 var bridgedArrayMutableCopy:NSMutableArray! = nil
 var nsArray:NSArray! = nil
 var nsArrayMutableCopy:NSMutableArray! = nil
-var bridgedASCIIString:NSString! = nil
-var bridgedUTF8String:NSString! = nil
 #endif
 
 public func setup_bridgedArrays() {
@@ -842,14 +822,6 @@ public func setup_bridgedDictionaries() {
   bridgedDictionaryOfNumbersToNumbers = numDict as NSDictionary
 }
 
-public func setup_bridgedStrings() {
-  #if _runtime(_ObjC)
-  let str = Array(repeating: "The quick brown fox jumps over the lazy dog.", count: 100).joined()
-  bridgedASCIIString = str as NSString
-  let str2 = Array(repeating: "The quick brown fox jumps over the lazy dög.", count: 100).joined()
-  bridgedUTF8String = str2 as NSString
-  #endif
-}
 
 @inline(never)
 public func run_BridgedNSArrayObjectAtIndex(_ n: Int) {
@@ -942,40 +914,3 @@ public func run_RealNSArrayMutableCopyObjectAtIndex(_ n: Int) {
   #endif
 }
 
-@inline(__always)
-fileprivate func run_BridgedNSStringLength(_ asciiBase: Bool, _ enc: UInt, _ n: Int) {
-  let str = asciiBase ? bridgedASCIIString : bridgedUTF8String
-  for _ in 0 ..< n * 100 {
-    blackHole(str!.lengthOfBytes(using: enc))
-  }
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthASCII_ASCII(_ n: Int) {
-  run_BridgedNSStringLength(true, 1 /* NSASCIIStringEncoding */, n)
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthASCII_UTF8(_ n: Int) {
-  run_BridgedNSStringLength(true, 4 /* NSUTF8StringEncoding */, n)
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthASCII_UTF16(_ n: Int) {
-  run_BridgedNSStringLength(true, 10 /* NSUnicodeStringEncoding */, n)
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthASCII_MacRoman(_ n: Int) {
-  run_BridgedNSStringLength(true, 30 /* NSMacOSRomanStringEncoding */, n)
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthUTF8_UTF8(_ n: Int) {
-  run_BridgedNSStringLength(false, 4 /* NSUTF8StringEncoding */, n)
-}
-
-@inline(never)
-public func run_BridgedNSStringLengthUTF8_UTF16(_ n: Int) {
-  run_BridgedNSStringLength(false, 10 /* NSUnicodeStringEncoding */, n)
-}

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -35,8 +35,6 @@ typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
 #endif
 
-typedef unsigned long _swift_shims_NSUInteger;
-
 // Consider creating SwiftMacTypes.h for these
 typedef unsigned char _swift_shims_Boolean;
 typedef __swift_uint8_t _swift_shims_UInt8;
@@ -81,11 +79,6 @@ SWIFT_RUNTIME_STDLIB_API
 const void * _Nullable
 _swift_stdlib_CreateIndirectTaggedPointerString(const __swift_uint8_t * _Nonnull bytes,
                                                 _swift_shims_CFIndex len);
-
-SWIFT_RUNTIME_STDLIB_API
-const _swift_shims_NSUInteger
-_swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
-                                                        unsigned long encoding);
 
 #endif // __OBJC2__
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -287,13 +287,6 @@ internal func _cocoaCStringUsingEncodingTrampoline(
   return _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
 }
 
-@_effects(readonly)
-internal func _cocoaLengthOfBytesInEncodingTrampoline(
-  _ string: _CocoaString, _ encoding: UInt
-) -> UInt {
-  return _swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(string, encoding)
-}
-
 @_effects(releasenone)
 internal func _cocoaGetCStringTrampoline(
   _ string: _CocoaString,

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -16,8 +16,6 @@ import SwiftShims
 
 internal var _cocoaASCIIEncoding:UInt { 1 } /* NSASCIIStringEncoding */
 internal var _cocoaUTF8Encoding:UInt { 4 } /* NSUTF8StringEncoding */
-internal var _cocoaUTF16Encoding:UInt { 10 } /* NSUTF16StringEncoding and NSUnicodeStringEncoding*/
-internal var _cocoaMacRomanEncoding:UInt { 30 } /* NSMacOSRomanStringEncoding */
 
 extension String {
   @available(SwiftStdlib 5.6, *)
@@ -71,14 +69,13 @@ extension _AbstractStringStorage {
   ) -> Int8 {
     switch (encoding, isASCII) {
     case (_cocoaASCIIEncoding, true),
-         (_cocoaMacRomanEncoding, true),
          (_cocoaUTF8Encoding, _):
       guard maxLength >= count + 1 else { return 0 }
       unsafe outputPtr.initialize(from: start, count: count)
       unsafe outputPtr[count] = 0
       return 1
     default:
-      return unsafe _cocoaGetCStringTrampoline(self, outputPtr, maxLength, encoding)
+      return  unsafe _cocoaGetCStringTrampoline(self, outputPtr, maxLength, encoding)
     }
   }
 
@@ -87,33 +84,10 @@ extension _AbstractStringStorage {
   internal func _cString(encoding: UInt) -> UnsafePointer<UInt8>? {
     switch (encoding, isASCII) {
     case (_cocoaASCIIEncoding, true),
-         (_cocoaMacRomanEncoding, true),
          (_cocoaUTF8Encoding, _):
       return unsafe start
     default:
       return _cocoaCStringUsingEncodingTrampoline(self, encoding)
-    }
-  }
-  
-  @_effects(readonly)
-  internal func _lengthOfBytes(using encoding: UInt) -> UInt {
-    switch encoding {
-    case _cocoaASCIIEncoding:
-      if unsafe isASCII || _allASCII(UnsafeBufferPointer(start: start, count: count)) {
-        return UInt(count)
-      }
-      return 0
-    case _cocoaUTF8Encoding:
-      return UInt(count)
-    case _cocoaUTF16Encoding:
-      return UInt(UTF16Length)
-    case _cocoaMacRomanEncoding:
-      if unsafe isASCII || _allASCII(UnsafeBufferPointer(start: start, count: count)) {
-        return UInt(count)
-      }
-      fallthrough
-    default:
-      return _cocoaLengthOfBytesInEncodingTrampoline(self, encoding)
     }
   }
 
@@ -258,12 +232,6 @@ extension __StringStorage {
       return _cocoaUTF8Encoding
     }
   }
-  
-  @objc(lengthOfBytesUsingEncoding:)
-  @_effects(readonly)
-  final internal func lengthOfBytes(using encoding: UInt) -> UInt {
-    _lengthOfBytes(using: encoding)
-  }
 
   @objc(isEqualToString:)
   @_effects(readonly)
@@ -328,12 +296,6 @@ extension __SharedStringStorage {
       }
       return _cocoaUTF8Encoding
     }
-  }
-  
-  @objc(lengthOfBytesUsingEncoding:)
-  @_effects(readonly)
-  final internal func lengthOfBytes(using encoding: UInt) -> UInt {
-    _lengthOfBytes(using: encoding)
   }
 
   @objc(_fastCStringContents:)

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -106,19 +106,6 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 
 }
 
-SWIFT_RUNTIME_STDLIB_API
-const _swift_shims_NSUInteger
-_swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
-                                                        unsigned long encoding) {
-  typedef _swift_shims_NSUInteger (*getLengthImplPtr)(id,
-                                                      SEL,
-                                                      unsigned long);
-  SEL sel = @selector(lengthOfBytesUsingEncoding:);
-  getLengthImplPtr imp = (getLengthImplPtr)class_getMethodImplementation([obj superclass], sel);
-  
-  return imp(obj, sel, encoding);
-}
-
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
   return (SWIFT_RUNTIME_WEAK_CHECK(_dyld_is_objc_constant)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1113,6 +1113,3 @@ Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
 // var InlineArray._protectedAddress
 Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
 Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV
-
-// lengthOfBytes(using:)
-Added: __swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1113,6 +1113,3 @@ Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
 // var InlineArray._protectedAddress
 Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
 Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV
-
-// lengthOfBytes(using:)
-Added: __swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline


### PR DESCRIPTION
Explanation:
Due to the bulk of the semantic tests for lengthOfBytes being in Foundation, I missed that I had correctly implemented the wrong semantics (I suspect I messed up the DYLD_LIBRARY_PATH to run with the rebuilt stdlib). Rather than take additional risk fixing it we should just revert for 6.2 and fix on main.

Resolves: rdar://156675395

Risk: Low. Reverting a previous improvement

Main branch PR: 6.2-only revert, will do an actual fix on main

Review by: in progress

Testing: just a revert