### PR TITLE
Observation: wire up SwiftOverlay to the build

### DIFF
--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vend
   CACHE FILEPATH "Location for private build system extension")
 
 find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay REQUIRED)
 
 include(GNUInstallDirs)
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2595,6 +2595,7 @@ function Build-ExperimentalRuntime {
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
 
         SwiftCore_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalRuntime)\cmake\SwiftCore";
+        SwiftOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalOverlay)\cmake\SwiftOverlay";
       }
   }
 }


### PR DESCRIPTION
Ensure that we are building against the right overlay libraries and wire them up into the build.