### PR TITLE
Differentiation: add missing overlay search and link

### DIFF
--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -38,6 +38,8 @@ set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vend
   CACHE FILEPATH "Location for private build system extension")
 
 find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay REQUIRED)
+
 include(GNUInstallDirs)
 
 include(AvailabilityMacros)
@@ -103,7 +105,8 @@ set_target_properties(swift_Differentiation PROPERTIES
   Swift_MODULE_NAME _Differentiation)
 
 target_link_libraries(swift_Differentiation PRIVATE
-  swiftCore)
+  swiftCore
+  $<$<PLATFORM_ID:Windows>:swiftCRT>)
 
 
 install(TARGETS swift_Differentiation


### PR DESCRIPTION
Add the missing dependency on swiftCRT on Windows. This requires that we also wire up the SwiftOverlay to the module.