### PR TITLE
[6.2] Fix lengthOfBytes(using:) semantics

### DIFF
--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -106,7 +106,7 @@ extension _AbstractStringStorage {
     case _cocoaUTF8Encoding:
       return UInt(count)
     case _cocoaUTF16Encoding:
-      return UInt(UTF16Length)
+      return UInt(UTF16Length) * 2
     case _cocoaMacRomanEncoding:
       if unsafe isASCII || _allASCII(UnsafeBufferPointer(start: start, count: count)) {
         return UInt(count)

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -174,5 +174,25 @@ StringBridgeTests.test("Character from NSString") {
   expectNil((ns3 as String).utf8.withContiguousStorageIfAvailable(returnOne))
 }
 
+StringBridgeTests.test("lengthOfBytes(using:)") {
+  let ascii = "The quick brown fox jumps over the lazy dog"
+  let utf8 = "The quick brown fox jümps over the lazy dog"
+  let asciiAsASCIILen = ascii.lengthOfBytes(using: .ascii)
+  let asciiAsUTF8Len = ascii.lengthOfBytes(using: .utf8)
+  let asciiAsUTF16Len = ascii.lengthOfBytes(using: .utf16)
+  let asciiAsMacRomanLen = ascii.lengthOfBytes(using: .macOSRoman)
+  let utf8AsASCIILen = utf8.lengthOfBytes(using: .ascii)
+  let utf8AsUTF8Len = utf8.lengthOfBytes(using: .utf8)
+  let utf8AsUTF16Len = utf8.lengthOfBytes(using: .utf16)
+  let utf8AsMacRomanLen = utf8.lengthOfBytes(using: .macOSRoman)
+  expectEqual(asciiAsASCIILen, 43)
+  expectEqual(asciiAsUTF8Len, 43)
+  expectEqual(asciiAsUTF16Len, 86)
+  expectEqual(asciiAsMacRomanLen, 43)
+  expectEqual(utf8AsASCIILen, 0)
+  expectEqual(utf8AsUTF8Len, 44)
+  expectEqual(utf8AsUTF16Len, 86)
+  expectEqual(utf8AsMacRomanLen, 43)
+}
 
 runAllTests()


### PR DESCRIPTION
(cherry picked from commit ea7c3d4ec840e727754da189b3d63e06e42fc214)

Explanation:
Due to an oversight the Foundation tests were run against the OS stdlib when testing a previous fix, so missed that I accidentally changed the semantics of this method from "byte count" to "code point count". This fixes it and adds stdlib tests so we don't have to rely on Foundation's tests.

Resolves: rdar://156675395

Risk: Low. Trivial changes, verified with a new test

Main branch PR: https://github.com/swiftlang/swift/pull/83334

Review by: @jrflat, @glessard 

Testing: new test for this method, verified using the old implementation