### PR TITLE
[Concurrency] Remove deprecated `Task.startSynchronously` API

### DIFF
--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -30,22 +30,6 @@ import Swift
 %   THROWS = ''
 % end
 
-@available(SwiftStdlib 6.2, *)
-extension Task where Failure == ${FAILURE_TYPE} {
-
-  @available(SwiftStdlib 6.2, *)
-  @available(*, deprecated, message: "Deprecated spelling of Task.immediate. This method will be removed.")
-  @discardableResult
-  @_alwaysEmitIntoClient // moved to AEIC in order to eventually remove this function.
-  public static func startSynchronously(
-    name: String? = nil,
-    priority: TaskPriority? = nil,
-    @_implicitSelfCapture @_inheritActorContext(always) _ operation: sending @isolated(any) @escaping () async ${THROWS} -> Success
-  ) -> Task<Success, ${FAILURE_TYPE}> {
-    immediate(name: name, priority: priority, operation: operation)
-  }
-}
-
 % end
 
 // ==== Task.immediate(Detached) ---------------------------------------------------------

--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -436,11 +436,6 @@ print("call_taskImmediate_insideActor()")
 
 actor A {
   func f() {
-    Task.startSynchronously(name: "hello") { print("Task.startSynchronously (\(Task.name!))") }
-    Task.startSynchronously() { print("Task.startSynchronously") }
-  }
-
-  func f2() {
     Task.immediate(name: "hello") { print("Task.immediate (\(Task.name!))") }
     Task.immediate() { print("Task.immediate") }
 
@@ -449,11 +444,10 @@ actor A {
   }
 }
 
-func call_startSynchronously_insideActor() async {
+func call_immediate_insideActor() async {
   await A().f()
-  await A().f2()
 }
-await call_startSynchronously_insideActor()
+await call_immediate_insideActor()
 
 
 print("\n\n==== ------------------------------------------------------------------")


### PR DESCRIPTION
This is the original spelling which was not accepted. We kept it for a bit to give adopters time to switch but it's time to remove it now.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
