### PR TITLE
[CSApply] Key path dynamic member lookup argument is Sendable only if its captures are

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3687,6 +3687,8 @@ namespace {
       if (!argExpr)
         return nullptr;
 
+      solution.recordSingleArgMatchingChoice(cs.getConstraintLocator(expr));
+
       // Build an argument list.
       auto *argList =
           ArgumentList::forImplicitSingle(ctx, ctx.Id_dynamicMember, argExpr);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2556,18 +2556,39 @@ namespace {
     /// Build an implicit argument for keypath based dynamic lookup,
     /// which consists of KeyPath expression and a single component.
     ///
-    /// \param argType The type of the keypath subscript argument.
+    /// \param paramType The type of the keypath subscript parameter
+    ///                  this argument is passed to.
     /// \param dotLoc The location of the '.' preceding member name.
     /// \param memberLoc The locator to be associated with new argument.
-    Expr *buildKeyPathDynamicMemberArgExpr(Type argType, SourceLoc dotLoc,
+    Expr *buildKeyPathDynamicMemberArgExpr(Type paramType, SourceLoc dotLoc,
                                            ConstraintLocator *memberLoc) {
       using Component = KeyPathExpr::Component;
       auto *anchor = getAsExpr(memberLoc->getAnchor());
 
       auto makeKeyPath = [&](ArrayRef<Component> components) -> Expr * {
+        Type keyPathTy = paramType;
+
+        // If parameter of a dynamic member lookup is `& Sendable` type
+        // we need to check key path captures to determine whether the
+        // argument could be `& Sendable` as well or not.
+        if (paramType->isExistentialType() && paramType->isSendableType()) {
+          auto allCapturesAreSendable = [&](const Component &component) {
+            auto *argList = component.getArgs();
+            if (!argList)
+              return true;
+
+            return llvm::all_of(*argList, [&](const auto &arg) {
+              return solution.getResolvedType(arg.getExpr())->isSendableType();
+            });
+          };
+
+          if (!llvm::all_of(components, allCapturesAreSendable))
+            keyPathTy = paramType->getSuperclass();
+        }
+
         auto *kp = KeyPathExpr::createImplicit(ctx, /*backslashLoc*/ dotLoc,
                                                components, anchor->getEndLoc());
-        kp->setType(argType);
+        kp->setType(keyPathTy);
         cs.cacheExprTypes(kp);
 
         // See whether there's an equivalent ObjC key path string we can produce
@@ -2576,7 +2597,7 @@ namespace {
         return kp;
       };
 
-      Type keyPathTy = argType;
+      Type keyPathTy = paramType;
       if (auto *existential = keyPathTy->getAs<ExistentialType>()) {
         keyPathTy = existential->getSuperclass();
         assert(isKnownKeyPathType(keyPathTy));

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -258,3 +258,22 @@ do {
   // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
   let _: () -> Void = forward(Test.fn) // expected-error {{conflicting arguments to generic parameter 'T' ('@Sendable () -> ()' vs. '() -> Void')}}
 }
+
+// https://github.com/swiftlang/swift/issues/77105
+do {
+  @dynamicMemberLookup
+  struct S<T> {
+    subscript<U>(dynamicMember keyPath: KeyPath<T, U> & Sendable) -> U {
+      fatalError()
+    }
+  }
+
+  struct Foo {
+    subscript<T>(bar bar: T) -> Int { 42 }
+  }
+
+  func test(s: S<Foo>) {
+    _ = s[bar: NonSendable()]
+    // expected-warning@-1 {{type 'KeyPath<Foo, Int>' does not conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  }
+}


### PR DESCRIPTION
Previously dynamic member subscript wasn't allowed to use `& Sendable`,
since this restriction was lifted the argument cannot simply assume
the parameter type any longer, the key path captures have to be checked
to determine whether it could be marked as Sendable or not.

Resolves: https://github.com/swiftlang/swift/issues/77105
Resolves: rdar://138227393

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
