### PR TITLE
Add presets for OpenBSD bootstrapping.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3331,6 +3331,31 @@ install-swift-testing
 install-swift-testing-macros
 install-xctest
 
+# Bootstrap presets for OpenBSD.
+[preset: bootstrap_stage0_openbsd]
+mixin-preset=bootstrap_stage0
+native-clang-tools-path=/usr/bin
+install-llvm=0
+install-prefix=/usr/local
+extra-swift-cmake-options=
+  -DBRIDGING_MODE=PURE
+
+[preset: bootstrap_stage1_openbsd]
+mixin-preset=bootstrap_stage1
+native-clang-tools-path=/usr/bin
+install-llvm=0
+install-prefix=/usr/local
+extra-swift-cmake-options=
+  -DBRIDGING_MODE=PURE
+
+[preset: bootstrap_stage2_openbsd]
+mixin-preset=bootstrap_stage2
+native-clang-tools-path=/usr/bin
+install-llvm=0
+install-prefix=/usr/local
+extra-swift-cmake-options=
+  -DBRIDGING_MODE=PURE
+
 [preset: wasm_stdlib,macos]
 
 mixin-preset=mixin_buildbot_install_components_with_clang


### PR DESCRIPTION
OpenBSD requires a minor quirk that differ from the standard bootstrapping presets, namely, that because OpenBSD has a modified LLVM toolchain by default, the build process should use that platform toolchain and not the one just-built by the Swift process.

More specifically, Swift will still build against the Swift fork of LLVM, but host binaries will be built with the platform toolchain. This also necessitates using pure bridging instead of the default inline bridging.

In my limited testing this has not proven to be problematic, and it will be useful for future documentation updates to embed actual presets for shared use.

Finally, we ensure that the destdir for these presets are /usr/local, not /usr, as is conventional for software sourced outside of the platform; these are not critical for bootstrapping but will ensure that less changes will need to be made for creating installable packages.