### PR TITLE
AST: Skip serializing non-public accessors of `@backDeployed` properties

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1121,9 +1121,8 @@ public:
   getBackDeployedAttrAndRange(ASTContext &Ctx,
                               bool forTargetVariant = false) const;
 
-  /// Returns true if the decl has an active `@backDeployed` attribute for the
-  /// given context.
-  bool isBackDeployed(ASTContext &Ctx) const;
+  /// Returns true if the decl has a valid and active `@backDeployed` attribute.
+  bool isBackDeployed() const;
 
   /// Returns the starting location of the entire declaration.
   SourceLoc getStartLoc() const { return getSourceRange().Start; }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3075,7 +3075,14 @@ void ValueDecl::dumpRef(raw_ostream &os) const {
     printContext(os, getDeclContext());
     os << ".";
     // Print name.
-    getName().printPretty(os);
+    if (auto accessor = dyn_cast<AccessorDecl>(this)) {
+      // If it's an accessor, print the name of the storage and then the
+      // accessor kind.
+      accessor->getStorage()->getName().printPretty(os);
+      os << "." << Decl::getDescriptiveKindName(accessor->getDescriptiveKind());
+    } else {
+      getName().printPretty(os);
+    }
   } else {
     auto moduleName = cast<ModuleDecl>(this)->getRealName();
     os << moduleName;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -562,7 +562,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
         return {FragileFunctionKind::AlwaysEmitIntoClient};
       }
 
-      if (AFD->isBackDeployed(context->getASTContext())) {
+      if (AFD->isBackDeployed()) {
         return {FragileFunctionKind::BackDeploy};
       }
 
@@ -576,7 +576,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
         if (storage->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
           return {FragileFunctionKind::AlwaysEmitIntoClient};
         }
-        if (storage->isBackDeployed(context->getASTContext())) {
+        if (storage->isBackDeployed()) {
           return {FragileFunctionKind::BackDeploy};
         }
       }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1084,7 +1084,7 @@ bool SILDeclRef::isBackDeployed() const {
             && "should not get backDeployed from ABI-only decl");
 
   if (auto afd = dyn_cast<AbstractFunctionDecl>(decl))
-    return afd->isBackDeployed(getASTContext());
+    return afd->isBackDeployed();
 
   return false;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1527,7 +1527,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
 
   emitDistributedThunkForDecl(AFD);
 
-  if (AFD->isBackDeployed(M.getASTContext())) {
+  if (AFD->isBackDeployed()) {
     // Emit the fallback function that will be used when the original function
     // is unavailable at runtime.
     auto fallback = SILDeclRef(AFD).asBackDeploymentKind(

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -64,7 +64,7 @@ public func publicFuncWithOpaqueReturnType() -> some PublicProto {
 
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient public func publicAEICFuncWithOpaqueReturnType() -> some Any {
-  if #available(macOS 20, *) {
+  if #available(macOS 99, *) {
     return 3
   } else {
     return "hi"
@@ -108,6 +108,30 @@ public var (publicGlobalVarInferredTuplePatX, publicGlobalVarInferredTuplePatY) 
 var internalGlobalVar: NoTypecheck = NoTypecheck()
 var internalGlobalVarInferredType = NoTypecheck()
 var internalGlobalTypealiasVar: PublicIntAlias = NoTypecheck.int
+
+@backDeployed(before: macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99)
+public private(set) var publicGlobalVarBackDeployedWithPrivateSetter: Int {
+  get { 0 }
+  set { // Implicitly not @backDeployed.
+    _ = NoTypecheck()
+  }
+}
+
+@backDeployed(before: macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99)
+public internal(set) var publicGlobalVarBackDeployedWithInternalSetter: Int {
+  get { 0 }
+  set { // Implicitly not @backDeployed.
+    _ = NoTypecheck()
+  }
+}
+
+@backDeployed(before: macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99)
+public package(set) var publicGlobalVarBackDeployedWithPackageSetter: Int {
+  get { 0 }
+  set { // Implicitly not @backDeployed.
+    _ = NoTypecheck()
+  }
+}
 
 // MARK: - Nominal types
 

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -35,6 +35,18 @@ public struct TopLevelStruct {
   }
 
   @backDeployed(before: macOS 12.0)
+  public private(set) var readWritePropertyPrivateSet: Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  @backDeployed(before: macOS 12.0)
+  public internal(set) var readWritePropertyInternalSet: Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  @backDeployed(before: macOS 12.0)
   public subscript(at index: Int) -> Int {
     get { 42 }
     set(newValue) {}
@@ -234,7 +246,6 @@ public final class CannotBackDeployClassDeinit {
   deinit {}
 }
 
-// Ok, final decls in a non-final, derived class
 public class CannotBackDeployOverride: TopLevelClass {
   @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' cannot be combined with 'override'}}
   final public override func hook() {}
@@ -291,6 +302,40 @@ public var cannotBackDeployVarWithOpaqueResultType: some TopLevelProtocol {
 @backDeployed(before: macOS 12.0) // expected-warning {{'@backDeployed' cannot be applied to global function 'cannotBackDeployFuncWithOpaqueResultType()' because it has a 'some' return type}}
 public func cannotBackDeployFuncWithOpaqueResultType() -> some TopLevelProtocol {
   return ConformsToTopLevelProtocol()
+}
+
+public struct CannotBackDeployNonPublicAccessors {
+  private var privateVar: Int {
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on private declarations}}
+    get { 0 }
+
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on private declarations}}
+    set { }
+  }
+
+  internal var internalVar: Int {
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on internal declarations}}
+    get { 0 }
+
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on internal declarations}}
+    set { }
+  }
+
+  public private(set) var publicVarPrivateSet: Int {
+    @backDeployed(before: macOS 12.0)
+    get { 0 }
+
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on private declarations}}
+    set { }
+  }
+
+  public internal(set) var publicVarInternalSet: Int {
+    @backDeployed(before: macOS 12.0)
+    get { 0 }
+
+    @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' may not be used on internal declarations}}
+    set { }
+  }
 }
 
 // MARK: - Function body diagnostics


### PR DESCRIPTION
Avoids a crash in SILGen when skipping non-inlinable function bodies.

Resolves rdar://136853454.
