### PR TITLE
[6.2][wasm] Fix installation paths for libxml2.a

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -80,7 +80,7 @@ class WasmSwiftSDK(product.Product):
         cmake_options.define('CMAKE_RANLIB', os.path.join(
             native_toolchain_path, 'bin', 'llvm-ranlib'))
 
-    def _build_libxml2(self, swift_host_triple, has_pthread, wasi_sysroot):
+    def _build_libxml2(self, swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot):
         libxml2 = CMakeProduct(
             args=self.args,
             toolchain=self.toolchain,
@@ -123,6 +123,10 @@ class WasmSwiftSDK(product.Product):
         libxml2.cmake_options.define('LIBXML2_WITH_XPTR', 'FALSE')
         libxml2.cmake_options.define('LIBXML2_WITH_ZLIB', 'FALSE')
         libxml2.cmake_options.define('BUILD_SHARED_LIBS', 'FALSE')
+        # Install libxml2.a under <sysroot>/lib/<clang_multiarch_triple>
+        # because Clang driver only passes arch-specific library paths as
+        # search paths to the linker for WebAssembly targets.
+        libxml2.cmake_options.define('CMAKE_INSTALL_LIBDIR', f'lib/{clang_multiarch_triple}')
 
         cmake_thread_enabled = 'TRUE' if has_pthread else 'FALSE'
         libxml2.cmake_options.define('LIBXML2_WITH_THREAD_ALLOC', cmake_thread_enabled)
@@ -135,7 +139,7 @@ class WasmSwiftSDK(product.Product):
             shell.call([self.toolchain.cmake, '--install', '.', '--prefix', '/', '--component', 'development'],
                        env={'DESTDIR': wasi_sysroot})
 
-    def _build_foundation(self, swift_host_triple, has_pthread, wasi_sysroot):
+    def _build_foundation(self, swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot):
         source_root = os.path.dirname(self.source_dir)
         host_toolchain = self.native_toolchain_path(self.args.host_target)
 
@@ -153,9 +157,13 @@ class WasmSwiftSDK(product.Product):
         foundation.cmake_options.define('_SwiftFoundation_SourceDIR', os.path.join(source_root, 'swift-foundation'))
         foundation.cmake_options.define('_SwiftFoundationICU_SourceDIR', os.path.join(source_root, 'swift-foundation-icu'))
         foundation.cmake_options.define('SwiftFoundation_MACRO', os.path.join(host_toolchain, 'lib', 'swift', 'host', 'plugins'))
-
-        foundation.cmake_options.define('LIBXML2_INCLUDE_DIR', os.path.join(wasi_sysroot, 'include', 'libxml2'))
-        foundation.cmake_options.define('LIBXML2_LIBRARY', os.path.join(wasi_sysroot, 'lib'))
+        # Teach CMake to use wasi-sysroot for finding packages through `find_package`.
+        # With `CMAKE_LIBRARY_ARCHITECTURE`, CMake will search for libraries in
+        # `<sysroot>/lib/<clang_multiarch_triple>/cmake/<name>*/<name>-config.cmake`,
+        # which is the location where libxml2 installs its CMake config files.
+        # See https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure
+        foundation.cmake_options.define('CMAKE_PREFIX_PATH', wasi_sysroot)
+        foundation.cmake_options.define('CMAKE_LIBRARY_ARCHITECTURE', clang_multiarch_triple)
 
         foundation.build_with_cmake([], self.args.build_variant, [],
                                      prefer_native_toolchain=True)
@@ -209,7 +217,7 @@ class WasmSwiftSDK(product.Product):
             shell.call([self.toolchain.cmake, '--install', '.', '--prefix', '/usr'],
                        env={'DESTDIR': dest_dir})
 
-    def _build_target_package(self, swift_host_triple, has_pthread,
+    def _build_target_package(self, swift_host_triple, clang_multiarch_triple, has_pthread,
                               stdlib_build_path, llvm_runtime_libs_build_path,
                               wasi_sysroot):
 
@@ -230,8 +238,8 @@ class WasmSwiftSDK(product.Product):
                             '--component', 'clang_rt.builtins-wasm32'],
                            env={'DESTDIR': clang_dir})
 
-        self._build_libxml2(swift_host_triple, has_pthread, wasi_sysroot)
-        self._build_foundation(swift_host_triple, has_pthread, wasi_sysroot)
+        self._build_libxml2(swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot)
+        self._build_foundation(swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot)
         # Build swift-testing
         self._build_swift_testing(swift_host_triple, has_pthread, wasi_sysroot)
         self._build_xctest(swift_host_triple, has_pthread, wasi_sysroot)
@@ -260,7 +268,7 @@ class WasmSwiftSDK(product.Product):
             wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
                 build_root, clang_multiarch_triple)
             package_path = self._build_target_package(
-                swift_host_triple, has_pthread, stdlib_build_path,
+                swift_host_triple, clang_multiarch_triple, has_pthread, stdlib_build_path,
                 llvm_runtime_libs_build_path, wasi_sysroot)
             if build_sdk:
                 target_packages.append((swift_host_triple, wasi_sysroot, package_path))


### PR DESCRIPTION
- **Explanation**: Clang driver only passes arch-specific library paths as search paths to the linker for WebAssembly targets but we were installing libxml2.a under `<sysroot>/lib` without the multiarch triple. It led to the linker not finding libxml2.a when importing FoundationXML
- **Scope**: Narrow, only affects Wasm Swift SDK.
- **Original PRs**: https://github.com/swiftlang/swift/pull/83356
- **Risk**: Low, just a change to Wasm Swift SDK
- **Testing**: CI
- **Reviewers**: @shahmishal  
