### PR TITLE
[Clang importer] Allow C structs to be noncopyable, too

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8232,6 +8232,9 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
 
   auto cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl);
   if (!cxxDecl) {
+    if (hasNonCopyableAttr(decl))
+      return CxxRecordSemanticsKind::MoveOnly;
+
     return CxxRecordSemanticsKind::Trivial;
   }
 

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -10,3 +10,7 @@ module ForeignReference {
 module StructAsOptionSet {
   header "struct-as-option-set.h"
 }
+
+module NoncopyableStructs {
+  header "noncopyable-struct.h"
+}

--- a/test/Interop/C/struct/Inputs/noncopyable-struct.h
+++ b/test/Interop/C/struct/Inputs/noncopyable-struct.h
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/
+
+typedef struct __attribute__((swift_attr("~Copyable"))) NonCopyable {
+  float x, y;
+} NonCopyable;

--- a/test/Interop/C/struct/noncopyable_structs.swift
+++ b/test/Interop/C/struct/noncopyable_structs.swift
@@ -1,0 +1,29 @@
+
+// Check that we get the expected errors for incorrect uses of noncopyable
+// imported types with both C and C++ interoperability.
+
+// RUN: %target-swift-frontend -emit-sil -I %S/Inputs/ %s -verify -DERRORS
+// RUN: %target-swift-frontend -emit-sil -I %S/Inputs/ %s -verify -DERRORS -cxx-interoperability-mode=default
+
+// Check that we get the expected IR
+
+// RUN: %target-swift-frontend -emit-ir -I %S/Inputs/ %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -I %S/Inputs/ %s -o - -cxx-interoperability-mode=default| %FileCheck %s
+
+import NoncopyableStructs
+
+// CHECK-LABEL: define hidden swiftcc void @"$s19noncopyable_structs9consumeNCyySo11NonCopyableVnF"(float %0, float %1) #0 {
+// CHECK: call ptr @"$sSo11NonCopyableVWOh"
+// CHECK: define linkonce_odr hidden ptr @"$sSo11NonCopyableVWOh"(ptr %0)
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret ptr
+func consumeNC(_ nc: consuming NonCopyable) { }
+
+func testNC() {
+  let nc = NonCopyable() // expected-error{{'nc' consumed more than once}}
+  consumeNC(nc) // expected-note{{consumed here}}
+
+  #if ERRORS
+  consumeNC(nc) // expected-note{{consumed again here}}
+  #endif
+}


### PR DESCRIPTION
In C interoperability mode, respect the ~Copyable annotation on C structs to import them as ~Copyable types.

Fixes rdar://156877772.