### PR TITLE
[AST] Clear module lookup cache in `SourceFile::addTopLevelDecl`

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -916,11 +916,9 @@ public:
   void lookupTopLevelDeclsByObjCName(SmallVectorImpl<Decl *> &Results,
                                      DeclName name);
 
-  /// This is a hack for 'main' file parsing and the integrated REPL.
-  ///
-  /// FIXME: Refactor main file parsing to not pump the parser incrementally.
-  /// FIXME: Remove the integrated REPL.
-  void clearLookupCache();
+  /// This is a hack for SynthesizedFileUnit and code completion. Do not add new
+  /// uses of it.
+  void clearLookupCache(bool includingImports = true);
 
   /// Finds all class members defined in this module.
   ///

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3239,8 +3239,9 @@ bool SourceFile::shouldCrossImport() const {
          getASTContext().LangOpts.EnableCrossImportOverlays;
 }
 
-void ModuleDecl::clearLookupCache() {
-  getASTContext().getImportCache().clear();
+void ModuleDecl::clearLookupCache(bool includingImports) {
+  if (includingImports)
+    getASTContext().getImportCache().clear();
 
   setIsObjCNameLookupCachePopulated(false);
   ObjCNameLookupCache.clear();
@@ -3495,6 +3496,8 @@ void SourceFile::addTopLevelDecl(Decl *d) {
   auto &ctx = getASTContext();
   auto *mutableThis = const_cast<SourceFile *>(this);
   ctx.evaluator.clearCachedOutput(ParseTopLevelDeclsRequest{mutableThis});
+
+  getParentModule()->clearLookupCache(/*includingImports*/isa<ImportDecl>(d));
 }
 
 void SourceFile::prependTopLevelDecl(Decl *d) {

--- a/test/IDE/pr83369.swift
+++ b/test/IDE/pr83369.swift
@@ -1,0 +1,9 @@
+// RUN: %batch-code-completion -module-name main
+
+extension Int {}
+
+// Make sure we can resolve P here.
+protocol P<X> where X: main.#^COMPLETE^# {
+  associatedtype X
+}
+// COMPLETE: Decl[Protocol]/CurrModule: P[#P#]; name=P


### PR DESCRIPTION
Completion unfortunately relies on this to add a top-level decl after the lookup table has been built, make sure the decl gets added to it. We ought to fix completion to avoid needing to mutate the AST like this after-the-fact, but this should work around the issue for now.