### PR TITLE
[cxx-interop] Test trivial usage of `std::variant` from Swift

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8357,7 +8357,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
         // Hack for a base type of std::optional from the Microsoft standard
         // library.
         if (recordDecl->getIdentifier() &&
-            recordDecl->getName() == "_Optional_construct_base")
+            (recordDecl->getName() == "_Optional_construct_base" ||
+             recordDecl->getName() == "_Variant_base"))
           return;
       }
       stack.push_back(recordDecl);

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -88,6 +88,12 @@ module StdFunction {
   export *
 }
 
+module StdVariant {
+  header "std-variant.h"
+  requires cplusplus
+  export *
+}
+
 module NoCXXStdlib {
   header "no-cxx-stdlib.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-variant.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-variant.h
@@ -1,0 +1,16 @@
+#include <string>
+#include <variant>
+
+using StdVariantIntOrString = std::variant<int, std::string>;
+inline StdVariantIntOrString getStdVariantInt() { return {123}; }
+inline StdVariantIntOrString getStdVariantString() { return {"abc"}; }
+
+struct HasDeletedCopyCtor {
+  int value;
+  HasDeletedCopyCtor(int value) : value(value) {}
+  HasDeletedCopyCtor(const HasDeletedCopyCtor &other) = delete;
+  HasDeletedCopyCtor(HasDeletedCopyCtor &&other) = default;
+};
+
+using StdVariantIntOrNonCopyable = std::variant<HasDeletedCopyCtor, int>;
+inline StdVariantIntOrNonCopyable getStdVariantNonCopyable() { return HasDeletedCopyCtor(123); }

--- a/test/Interop/Cxx/stdlib/use-std-variant.swift
+++ b/test/Interop/Cxx/stdlib/use-std-variant.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdVariant
+import CxxStdlib
+
+var StdVariantTestSuite = TestSuite("StdVariant")
+
+StdVariantTestSuite.test("index()") {
+  let variantInt = getStdVariantInt()
+  expectEqual(variantInt.index(), 0)
+
+  let variantString = getStdVariantString()
+  expectEqual(variantString.index(), 1)
+  
+  let variantNonCopyable = getStdVariantNonCopyable()
+  expectEqual(variantNonCopyable.index(), 0)
+}
+
+runAllTests()


### PR DESCRIPTION
For now, Swift doesn't provide a way to extract an element out of `std::variant`. This adds a test to check that we still import instantiations of `std::variant` into Swift.

rdar://155050719

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
