### PR TITLE
Runtimes: fixes for dependencies

### DIFF
--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -7,8 +7,9 @@ target_compile_definitions(swiftWinSDK PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
 target_compile_options(swiftWinSDK PRIVATE
   "SHELL:-Xfrontend -disable-force-load-symbols")
+target_link_libraries(swiftWinSDK PUBLIC
+  ClangModules)
 target_link_libraries(swiftWinSDK PRIVATE
-  ClangModules
   swiftCore)
 
 # FIXME: Why is this not implicitly in the interface flags?

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -129,7 +129,8 @@ set_target_properties(swiftSynchronization PROPERTIES
 target_link_libraries(swiftSynchronization PRIVATE
   swiftCore
   $<$<PLATFORM_ID:Android>:SwiftAndroid>
-  $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
+  $<$<PLATFORM_ID:Darwin>:swiftDarwin>
+  $<$<PLATFORM_ID:Windows>:ClangModules>)
 
 install(TARGETS swiftSynchronization
   EXPORT SwiftSynchronizationTargets


### PR DESCRIPTION
2 small fixes:
1. expose the ClangModules from WinSDK to allow building without a SDK
2. grow a dependency on ClangModules in Synchronization as it directly uses the C headers

This is needed to ensure that we are able to completely cleave the dependency on an existing SDK build.