### PR TITLE
[demangling] make printGenericSignature virtual

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -949,7 +949,7 @@ protected:
 
   void printImplFunctionType(NodePointer fn, unsigned depth);
 
-  void printGenericSignature(NodePointer Node, unsigned depth);
+  virtual void printGenericSignature(NodePointer Node, unsigned depth);
 
   void printFunctionSigSpecializationParams(NodePointer Node, unsigned depth);
 


### PR DESCRIPTION
Make `printGenericSignature` a virtual method, allowing it to be overridden in `lldb`'s `TrackingNodePrinter`.

This is a dependency of https://github.com/swiftlang/llvm-project/pull/11068.