### PR TITLE
swift-synthesize-interface: Infer target triple

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -83,8 +83,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   if (auto *A = ParsedArgs.getLastArg(OPT_target)) {
     Target = llvm::Triple(A->getValue());
   } else {
-    Diags.diagnose(SourceLoc(), diag::error_option_required, "-target");
-    return EXIT_FAILURE;
+    Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
   }
 
   std::string OutputDir;

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -84,8 +84,7 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   if (auto *A = ParsedArgs.getLastArg(OPT_target)) {
     Target = llvm::Triple(A->getValue());
   } else {
-    Diags.diagnose(SourceLoc(), diag::error_option_required, "-target");
-    return EXIT_FAILURE;
+    Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
   }
 
   std::string OutputFile;

--- a/test/SymbolGraph/Relationships/MemberOf/Basic.swift
+++ b/test/SymbolGraph/Relationships/MemberOf/Basic.swift
@@ -1,7 +1,14 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Output)
 // RUN: %target-build-swift %s -module-name Basic -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name Basic -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/Basic.symbols.json 
+// RUN: %target-swift-symbolgraph-extract -module-name Basic -I %t -pretty-print -output-dir %t/Output
+// RUN: %FileCheck %s --input-file %t/Output/Basic.symbols.json
+
+// Verify that -target can be inferred
+// RUN: %empty-directory(%t/Output)
+// RUN: %swift-symbolgraph-extract -module-name Basic -I %t -pretty-print -output-dir %t/Output
+// RUN: %FileCheck %s --input-file %t/Output/Basic.symbols.json
+
 public struct S {
   public var x: Int
 }

--- a/test/SynthesizeInterfaceTool/synthesize-interface.swift
+++ b/test/SynthesizeInterfaceTool/synthesize-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-synthesize-interface -module-name m1 -I %S/Inputs -o - | %FileCheck %s
+// RUN: %swift-synthesize-interface -module-name m1 -I %S/Inputs -o - | %FileCheck %s
 
 // CHECK:     public struct MyStruct {
 // CHECK-DAG:     public init()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -755,6 +755,7 @@ config.substitutions.append( ('%swift-path', config.swift) )
 config.substitutions.append( ('%swift-plugin-server', config.swift_plugin_server) )
 config.substitutions.append( ('%swift-parse-test', config.swift_parse_test) )
 config.substitutions.append( ('%swift-scan-test', config.swift_scan_test) )
+config.substitutions.append( ('%swift-synthesize-interface', config.swift_synthesize_interface) )
 config.substitutions.append( ('%validate-json', f"{config.python} -m json.tool") )
 
 config.clang_include_dir = make_path(config.llvm_obj_root, 'include')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -755,6 +755,7 @@ config.substitutions.append( ('%swift-path', config.swift) )
 config.substitutions.append( ('%swift-plugin-server', config.swift_plugin_server) )
 config.substitutions.append( ('%swift-parse-test', config.swift_parse_test) )
 config.substitutions.append( ('%swift-scan-test', config.swift_scan_test) )
+config.substitutions.append( ('%swift-symbolgraph-extract', config.swift_symbolgraph_extract) )
 config.substitutions.append( ('%swift-synthesize-interface', config.swift_synthesize_interface) )
 config.substitutions.append( ('%validate-json', f"{config.python} -m json.tool") )
 


### PR DESCRIPTION
Infer the `-target` argument to `swift-synthesize-interface` to be the host triple when unspecified instead of emitting an error.

Resolves rdar://156353450.
