### PR TITLE
Overlay: adjust flags and VFS overlay

### DIFF
--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -14,8 +14,9 @@ target_compile_definitions(swiftCRT PRIVATE
 target_compile_options(swiftCRT PRIVATE
   "SHELL:-Xfrontend -disable-force-load-symbols"
   "SHELL:-Xcc -D_USE_MATH_DEFINES")
+target_link_libraries(swiftCRT PUBLIC
+  ClangModules)
 target_link_libraries(swiftCRT PRIVATE
-  ClangModules
   swiftCore)
 
 # FIXME: Why is this not implicitly in the interface flags?

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -25,7 +25,7 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/ucrt.modulemap"
-  - name: "@VCToolsInstallDir@include"
+  - name: "@VCToolsInstallDir@/include"
     type: directory
     contents:
       - name: module.modulemap


### PR DESCRIPTION
Adjust the transitive flags for `CRT` and adjust the VFS generation. These were causing trouble for building the C++ interop libraries on Windows without an existing SDK.