### PR TITLE
SILGen: Fix positioning of store_borrow for addressable references to closure captures.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -2337,7 +2337,12 @@ SILGenFunction::getLocalVariableAddressableBuffer(VarDecl *decl,
     } else if (auto inst = value->getDefiningInstruction()) {
       B.setInsertionPoint(inst->getParent(), std::next(inst->getIterator()));
     } else if (auto arg = dyn_cast<SILArgument>(value)) {
-      B.setInsertionPoint(arg->getParent()->begin());
+      if (auto farg = dyn_cast<SILFunctionArgument>(value);
+          farg && farg->isClosureCapture()) {
+        B.setInsertionPoint(allocStack->getNextInstruction());
+      } else {
+        B.setInsertionPoint(arg->getParent()->begin());
+      }
     } else {
       llvm_unreachable("unexpected value source!");
     }

--- a/test/SILGen/addressable_capture_2.swift
+++ b/test/SILGen/addressable_capture_2.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableParameters %s | %FileCheck %s
+// REQUIRES: swift_feature_AddressableParameters
+struct Foo {
+	var x, y, z: Int
+
+	init() { fatalError() }
+
+	@_addressableSelf
+	func foo() {}
+}
+
+func block(_: (Int) -> ()) {}
+
+func test() {
+	let x = Foo()
+	block { (_) in x.foo() }
+}
+// ensure the closure properly nests the store_borrow after the alloc_stack:
+// CHECK-LABEL: sil{{.*}} @${{.*}}4test{{.*}}U_ : $
+// CHECK: [[STACK:%.*]] = alloc_stack
+// CHECK-NEXT: store_borrow {{.*}} to [[STACK]]


### PR DESCRIPTION
These get passed to the closure body in SIL as function arguments to the entry point, so the alloc_stack necessarily has to appear inside of the value's lifetime, and the store_borrow needs to be placed after that alloc_stack.