### PR TITLE
Supplemental: Android fixes for the Supplemental Runtimes

### DIFF
--- a/Runtimes/Overlay/Android/Android/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Android/CMakeLists.txt
@@ -11,9 +11,14 @@ set_target_properties(swiftAndroid PROPERTIES
   Swift_MODULE_NAME Android)
 target_compile_definitions(swiftAndroid PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
+target_link_libraries(swiftAndroid PUBLIC
+  SwiftAndroid)
 target_link_libraries(swiftAndroid PRIVATE
-  SwiftAndroid
   swiftCore)
+
+# FIXME: Why is this not implicitly in the interface flags?
+target_include_directories(swiftAndroid INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${SwiftCore_INSTALL_SWIFTMODULEDIR}>>")
 
 install(TARGETS swiftAndroid
   EXPORT SwiftOverlayTargets

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -107,6 +107,7 @@ set_target_properties(swift_Differentiation PROPERTIES
 
 target_link_libraries(swift_Differentiation PRIVATE
   swiftCore
+  $<$<PLATFORM_ID:Android>:swiftAndroid>
   $<$<PLATFORM_ID:Windows>:swiftCRT>)
 
 

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -130,19 +130,19 @@ target_include_directories(swiftDistributed PRIVATE
   "${PROJECT_SOURCE_DIR}/include")
 
 target_link_libraries(swiftDistributed PRIVATE
-    swiftShims
-    swiftCore
-    swift_Concurrency
-    swift_Builtin_float
-    $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
-    # swiftDarwin/Libc/Platform
+  swiftShims
+  swiftCore
+  swift_Concurrency
+  swift_Builtin_float
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
+  # swiftDarwin/Libc/Platform
 
 install(TARGETS swiftDistributed
-    EXPORT SwiftDistributedTargets
-    COMPONENT ${PROJECT_NAME}_runtime
-    ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
-    LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  EXPORT SwiftDistributedTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 emit_swift_interface(swiftDistributed)
 install_swift_interface(swiftDistributed)
 

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -134,6 +134,7 @@ target_link_libraries(swiftDistributed PRIVATE
   swiftCore
   swift_Concurrency
   swift_Builtin_float
+  $<$<PLATFORM_ID:Android>:swiftAndroid>
   $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
   # swiftDarwin/Libc/Platform
 

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -128,7 +128,7 @@ set_target_properties(swiftSynchronization PROPERTIES
 
 target_link_libraries(swiftSynchronization PRIVATE
   swiftCore
-  $<$<PLATFORM_ID:Android>:SwiftAndroid>
+  $<$<PLATFORM_ID:Android>:swiftAndroid>
   $<$<PLATFORM_ID:Darwin>:swiftDarwin>
   $<$<PLATFORM_ID:Windows>:ClangModules>)
 


### PR DESCRIPTION
This corrects two issues in the runtimes build which are preventative towards use of the builds:

1. We did not attach the interface include directory as a workaround for CMake not setting up the include path for the Swift module
2. Correcting the builds of the runtime libraries to use the proper `swiftAndroid` module to get the Swift overlay rather than just the clang module.

Together, these changes enable building the C++ Interop libraries for Android with the new support.