### PR TITLE
AST: Allow overloads to be disambiguated by obsoletion version

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -926,6 +926,9 @@ SemanticAvailableAttr::getIntroducedDomainAndRange(
   auto *attr = getParsedAttr();
   auto domain = getDomain();
 
+  if (domain.isUniversal())
+    return std::nullopt;
+
   if (!attr->getRawIntroduced().has_value()) {
     // For versioned domains, an "introduced:" version is always required to
     // indicate introduction.

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -144,10 +144,10 @@ func globalFuncDeprecatedAndAvailableOn51() -> Int { return 51 }
 func globalFuncAvailableOn51Deprecated52() -> Int { return 51 }
 
 @available(OSX, introduced: 51, obsoleted: 52)
-func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 }
+func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 } // expected-note {{'globalFuncAvailableOn51Obsoleted52()' was obsoleted in macOS 52}}
 
 @available(OSX, unavailable, introduced: 51)
-func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 } // expected-note 2 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
+func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 } // expected-note 3 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
 
 let _ = globalFuncDeprecatedAndAvailableOn51() // expected-error {{'globalFuncDeprecatedAndAvailableOn51()' is only available in macOS 51 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
@@ -164,6 +164,14 @@ if #available(OSX 51, *) {
   let _ = globalFuncAvailableOn51Obsoleted52()
   let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
 }
+
+if #available(OSX 52, *) {
+  let _ = globalFuncDeprecatedAndAvailableOn51() // expected-warning {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
+  let _ = globalFuncAvailableOn51Deprecated52()
+  let _ = globalFuncAvailableOn51Obsoleted52() // expected-error {{'globalFuncAvailableOn51Obsoleted52()' is unavailable in macOS}}
+  let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+}
+
 
 // Potentially unavailable methods
 

--- a/test/Availability/availability_with_overloading.swift
+++ b/test/Availability/availability_with_overloading.swift
@@ -16,9 +16,10 @@ extension View {
   }
 }
 
+// CHECK-LABEL: sil {{.*}} @$s29availability_with_overloading30test_disfavored_vs_unavailableyyAA4View_pF :
 func test_disfavored_vs_unavailable(_ view: View) {
   view.frame(width: 100) // Ok
-  // CHECK: function_ref @$s29availability_with_overloading4ViewPAAE5frame5width6heightySdSg_AGtF
+  // CHECK: function_ref @$s29availability_with_overloading4ViewPAAE5frame5width6heightySdSg_AGtF :
 }
 
 struct S {
@@ -32,9 +33,36 @@ extension S {
   func bar(_: Int) {}
 }
 
+// CHECK-LABEL: sil {{.*}} @$s29availability_with_overloading27test_generic_vs_unavailableyyAA1SVF :
 func test_generic_vs_unavailable(_ s: S) {
   s.foo("") // Ok (picks available generic overload)
-  // CHECK: function_ref @$s29availability_with_overloading1SV3fooyyxSyRzlF
+  // CHECK: function_ref @$s29availability_with_overloading1SV3fooyyxSyRzlF :
   s.bar(42) // Ok (picks overload with defaulted argument)
-  // CHECK: function_ref @$s29availability_with_overloading1SV3baryySi_SitF
+  // CHECK: function_ref @$s29availability_with_overloading1SV3baryySi_SitF :
+}
+
+extension S {
+  @available(macOS, obsoleted: 999)
+  func baz(_: Int) {}
+
+  @available(macOS, introduced: 999)
+  func baz(_: Int, _: Int = 0) {}
+}
+
+// CHECK-LABEL: sil {{.*}} @$s29availability_with_overloading28test_introduced_vs_obsoletedyyAA1SVF :
+func test_introduced_vs_obsoleted(_ s: S) {
+  // CHECK: function_ref @$s29availability_with_overloading1SV3bazyySiF :
+  s.baz(42)
+  // CHECK: function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF :
+  if #available(macOS 999, *) {
+    // CHECK: function_ref @$s29availability_with_overloading1SV3bazyySi_SitF :
+    s.baz(42)
+  }
+}
+
+// CHECK-LABEL: sil {{.*}} @$s29availability_with_overloading29test_introduced_vs_obsoleted2yyAA1SVF :
+@available(macOS 999, *)
+func test_introduced_vs_obsoleted2(_ s: S) {
+  // CHECK: function_ref @$s29availability_with_overloading1SV3bazyySi_SitF :
+  s.baz(42)
 }


### PR DESCRIPTION
Previously, whether a declaration is unavailable because it is obsolete was determined based solely on the deployment target and not based on contextual availability. Taking contextual availability into account makes availability checking more internally consistent and allows library authors to evolve APIs by obsoleting the previous declaration while introducing a new declaration in the same version:

```
@available(macOS, obsoleted: 15)
func foo(_ x: Int) { }

@available(macOS, introduced: 15)
func foo(_ x: Int, y: Int = 0) { }

foo(42) // unambiguous, regardless of contextual version of macOS
```

This change primarily accepts more code that wasn't accepted previously, but it could also be source breaking for some code that was previously allowed to use obsoleted declarations in contexts that will always run on OS versions where the declaration is obsolete. That code was clearly taking advantage of an availabilty loophole, though, and in practice I don't expect it to be common.

Resolves rdar://144647964.
