### PR TITLE
[cxx-interop] Do not consider extensions blessed by SWIFT_PRIVATE_FILEID to be retroactive

### DIFF
--- a/test/Interop/Cxx/class/access/private-fileid-conformance.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-conformance.swift
@@ -1,0 +1,53 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Cxx/include %t/PrivateFile.swift -cxx-interoperability-mode=default -module-name Module
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Cxx/include %t/HasRetroactive.swift -cxx-interoperability-mode=default -module-name Module
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Cxx/include %t/NoRetroactive.swift -cxx-interoperability-mode=default -module-name Module
+
+//--- Cxx/include/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "cxx-header.h"
+}
+
+//--- Cxx/include/cxx-header.h
+#pragma once
+
+#define SWIFT_PRIVATE_FILEID(_fileID) \
+  __attribute__((swift_attr("private_fileid:" _fileID)))
+
+class SWIFT_PRIVATE_FILEID("Module/PrivateFile.swift") Foo { void privateMethod(void) const {} };
+
+//--- PrivateFile.swift
+import CxxModule
+
+extension Foo : ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+    public init(integerLiteral: Self.IntegerLiteralType) {
+        self.init()
+        self.privateMethod()
+    }
+}
+
+//--- HasRetroactive.swift
+import CxxModule
+
+extension Foo : @retroactive ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+    public init(integerLiteral: Self.IntegerLiteralType) {
+        self.init()
+        self.privateMethod() // expected-error {{'privateMethod' is inaccessible due to 'private' protection level}}
+    }
+}
+
+//--- NoRetroactive.swift
+import CxxModule
+
+// expected-warning@+2 {{extension declares a conformance of imported type 'Foo' to imported protocol 'ExpressibleByIntegerLiteral'}}
+// expected-note@+1 {{add '@retroactive' to silence this warning}}
+extension Foo : ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+    public init(integerLiteral: Self.IntegerLiteralType) {
+        self.init()
+        self.privateMethod() // expected-error {{'privateMethod' is inaccessible due to 'private' protection level}}
+    }
+}


### PR DESCRIPTION
Swift warns users when they conform an imported type to an imported protocol, because such retroactive conformances are prone to producing conflicting conformances in multiple modules.

When a user annotates a class as SWIFT_PRIVATE_FILEID, they are explicitly conveying that extensions in the blessed file are part of the class's private implementation (and thus privy to elevated access), so we should also not treat conformances in that file as retroactive.

This patch fixes that and adds a test case.

rdar://148083096

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
