### PR TITLE
[AST] TypeSubstitution: Add a `nullptr` check before attempting to us…

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1157,7 +1157,8 @@ operator()(InFlightSubstitution &IFS, Type maybeOpaqueType,
   auto inContext = this->getContext();
   auto isContextWholeModule = this->isWholeModule();
   auto contextExpansion = this->contextExpansion;
-  if (partialSubstTy.findIf(
+  if (inContext &&
+      partialSubstTy.findIf(
           [inContext, substitutionKind, isContextWholeModule,
           contextExpansion](Type t) -> bool {
             if (!canSubstituteTypeInto(t, inContext, substitutionKind,


### PR DESCRIPTION
…e `inContext`

This fixes a crash in `ReplaceOpaqueTypesWithUnderlyingTypes::operator()` that I couldn't properly reduce because it has to do with `SwiftDeclCollector`.

`ReplaceOpaqueTypesWithUnderlyingTypes::operator()` has the check already and `canSubstituteTypeInto` expects `inContext` to be non-null.

Resolves: rdar://156896331

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
