### PR TITLE
Fix assertion in InstructionDeleter::trackIfDead.

### DIFF
--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -164,6 +164,8 @@ public:
   ///
   /// getInBlockProjectionOperandValues() can be called before or after cloning.
   bool cloneProjections();
+
+  SWIFT_DEBUG_DUMP;
 };
 
 /// Clone a single basic block and any required successor edges within the same

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -285,3 +285,16 @@ bool SinkAddressProjections::cloneProjections() {
   }
   return true;
 }
+
+void SinkAddressProjections::dump() const {
+  llvm::dbgs() << "Old projections: ";
+  for (auto *proj : oldProjections) {
+    proj->dump();
+  }
+  if (auto *np = newProjections) {
+    llvm::dbgs() << "New projections: ";
+    for (auto *proj : *np) {
+      proj->dump();
+    }
+  }
+}

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -187,9 +187,8 @@ bool InstructionDeleter::trackIfDead(SILInstruction *inst) {
   bool fixLifetime = inst->getFunction()->hasOwnership();
   if (isInstructionTriviallyDead(inst)
       || isScopeAffectingInstructionDead(inst, fixLifetime)) {
-    assert(!isIncidentalUse(inst) &&
-           (!isa<DestroyValueInst>(inst) ||
-            canTriviallyDeleteOSSAEndScopeInst(inst)) &&
+    assert(!isIncidentalUse(inst)
+           || canTriviallyDeleteOSSAEndScopeInst(inst) &&
            "Incidental uses cannot be removed in isolation. "
            "They would be removed iff the operand is dead");
     getCallbacks().notifyWillBeDeleted(inst);
@@ -354,6 +353,20 @@ static FunctionTest DeleterDeleteIfDeadTest(
       llvm::outs() << "Deleting-if-dead " << *inst;
       auto deleted = deleter.deleteIfDead(inst);
       llvm::outs() << "deleteIfDead returned " << deleted << "\n";
+      function.print(llvm::outs());
+    });
+
+// Arguments:
+// - instruction: the instruction to delete
+// Dumps:
+// - the function
+static FunctionTest DeleterTrackIfDeadTest(
+    "deleter_track_if_dead", [](auto &function, auto &arguments, auto &test) {
+      auto *inst = arguments.takeInstruction();
+      InstructionDeleter deleter;
+      llvm::outs() << "Tracking " << *inst;
+      deleter.trackIfDead(inst);
+      deleter.cleanupDeadInstructions();
       function.print(llvm::outs());
     });
 } // namespace swift::test

--- a/test/SILOptimizer/instruction_deleter.sil
+++ b/test/SILOptimizer/instruction_deleter.sil
@@ -57,3 +57,18 @@ sil [ossa] @doDeleteLoadTake : $() -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on trackEndBorrow
+// CHECK: Tracking   end_borrow undef : $C
+// CHECK: sil [ossa] @trackEndBorrow : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK-NOT: end_borrow
+// CHECK-LABEL: } // end sil function 'trackEndBorrow'
+// CHECK-LABEL: end running test {{.*}} on trackEndBorrow
+sil [ossa] @trackEndBorrow : $() -> () {
+bb0:
+  specify_test "deleter_track_if_dead @instruction"
+  end_borrow undef : $C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
This assertion was triggering when deleting scope-ending operations whose
operand had been replaced with an undef:

   end_borrow undef

Related to rdar://156431548

This was triggered during simplify-cfg by after adding blocks to the worklist,
then later cleaning up dead instructions in the worklist blocks. I'm unable to
create a test case based on simplify-cfg because the assertion is completely
unrelated to the optimization that adds blocks to the worklist.
