### PR TITLE
embedded: don't try to specialize witness tables for abstract conformances

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -116,6 +116,12 @@ func specializeWitnessTable(for conformance: Conformance,
     return
   }
 
+  guard conformance.isConcrete else {
+    // If the conformance is abstract the witness table is specialized elsewhere - at the
+    // place where the concrete conformance is referenced.
+    return
+  }
+
   let baseConf = conformance.isInherited ? conformance.inheritedConformance: conformance
   if !baseConf.isSpecialized {
     var visited = Set<Conformance>()

--- a/test/embedded/unowned-task-executor.swift
+++ b/test/embedded/unowned-task-executor.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -disable-availability-checking -module-name test -parse-as-library %s -emit-ir | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import _Concurrency
+
+public var e: (any TaskExecutor)? = nil
+
+// CHECK-LABEL: define {{.*}}@"$e4test6testits19UnownedTaskExecutorVyF"()
+// CHECK: [[EXISTENTIAL_ADDR:%.*]] = call {{.*}}"$e4test1eSch_pSgvau"
+// CHECK: [[INSTANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 0}}
+// CHECK: [[INSTANCE:%.*]] = load {{.*}}ptr [[INSTANCE_ADDR]]
+// CHECK: [[CONFORMANCE_ADDR:%.*]] = getelementptr {{.*}}[[EXISTENTIAL_ADDR]]{{, i[0-9]+ 0, i[0-9]+ 1}}
+// CHECK: [[CONFORMANCE:%.*]] = load {{.*}}ptr [[CONFORMANCE_ADDR]]
+// CHECK: {{^[0-9a-z]+:}}
+// CHECK: [[INSTANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[INSTANCE]]
+// CHECK: [[CONFORMANCE_PTR:%.*]] = inttoptr {{i[0-9]+}} [[CONFORMANCE]]
+// CHECK: [[INSTANCE_PHI:%.*]] = phi ptr [ [[INSTANCE_PTR]]
+// CHECK: [[CONFORMANCE_PHI:%.*]] = phi ptr [ [[CONFORMANCE_PTR]]
+// CHECK: [[INSTANCE_ISA:%.*]] = load ptr, ptr [[INSTANCE_PHI]]
+// CHECK: call {{.*}}@"$es19UnownedTaskExecutorVyABxhcSchRzlufC"(ptr [[INSTANCE_PHI]], ptr [[INSTANCE_ISA]], ptr [[CONFORMANCE_PHI]])
+// CHECK-LABEL: {{^}}}
+public func testit() -> UnownedTaskExecutor {
+  return unsafe UnownedTaskExecutor(e!)
+}
+


### PR DESCRIPTION
If the conformance is abstract the witness table is specialized elsewhere - at the place where the concrete conformance is referenced. Fixes a compiler crash.
