### PR TITLE
[Sema] Increase depth and count limits for opaque result type substit…

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -614,11 +614,11 @@ namespace swift {
 
     /// Maximum nesting depth for type substitution operations, to prevent
     /// runaway recursion.
-    unsigned MaxSubstitutionDepth = 50;
+    unsigned MaxSubstitutionDepth = 1000;
 
     /// Maximum step count for type substitution operations, to prevent
     /// runaway recursion.
-    unsigned MaxSubstitutionCount = 2000;
+    unsigned MaxSubstitutionCount = 32000;
 
     /// Enable implicit lifetime dependence for ~Escapable return types.
     bool EnableExperimentalLifetimeDependenceInference = false;


### PR DESCRIPTION
…utions

Let's set the limits to high end of what we'd expect to prevent regressions. These still require some profiling to fine-tune but the original limits are far too small for SwiftUI views we see in pactice.

Resolves: rdar://156896778

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
