### PR TITLE
[cxx-interop] Modularize xsmf_control on Windows

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -757,6 +757,11 @@ module std [system] {
       export *
     }
 
+    explicit module xsmf_control {
+      header "xsmf_control.h"
+      export *
+    }
+
     explicit module xstring {
       header "xstring"
       export *


### PR DESCRIPTION
This adds `xsmf_control.h` into the STL modulemap on Windows.

Fixes the following compiler error emitted by Clang when trying to use `std::variant` from Swift with C++ interop:
```
...\MSVC\14.42.34433\include\variant:923:25: error: missing '#include <xsmf_control.h>'; '_Non_trivial_move_assign' must be defined before it is used
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
