### PR TITLE
[IRGen] Conditionalise use of sized deallocation.

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -168,7 +168,11 @@ namespace {
       const size_t count = pThis->NumStoredProtocols;
       const size_t size =
           Tail::template totalSizeToAlloc<const ProtocolDecl *>(count);
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
       ::operator delete(ptr, size);
+#else
+      ::operator delete(ptr);
+#endif
     }
 
     /// Returns the number of protocol witness tables directly carried

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -161,7 +161,11 @@ public:
     const auto *pThis = static_cast<RecordTypeInfoImpl *>(ptr);
     const size_t count = pThis->NumFields;
     const size_t size = Impl::template totalSizeToAlloc<FieldImpl>(count);
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
     ::operator delete(ptr, size);
+#else
+    ::operator delete(ptr);
+#endif
   }
 
   bool areFieldsABIAccessible() const {

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -234,7 +234,11 @@ public:
     const auto *pThis = static_cast<ProtocolInfo *>(ptr);
     const size_t count = pThis->NumTableEntries;
     const size_t size = totalSizeToAlloc<WitnessTableEntry>(count);
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
     ::operator delete(ptr, size);
+#else
+    ::operator delete(ptr);
+#endif
   }
 
   /// The number of witness slots in a conformance to this protocol;


### PR DESCRIPTION
Sized deallocation isn't enabled everywhere, so we need to check for it before using it.
