### PR TITLE
[Build] Fix deployment version handling for StdlibDeploymentTarget.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -58,6 +58,10 @@ function(deployment_version result_var_name)
     set(DEPLOYMENT_VERSION ${SWIFT_ANDROID_API_LEVEL})
   endif()
 
+  if("${GETDEP_SDK}" STREQUAL "FREESTANDING")
+    set(DEPLOYMENT_VERSION "${SWIFT_SDK_${GETDEP_SDK}_DEPLOYMENT_VERSION}")
+  endif()
+
   set("${result_var_name}" "${DEPLOYMENT_VERSION}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
Where someone has told a target library to build for a _newer_ target than the current deployment target, we need to respect that newer target when setting StdlibDeploymentTarget for that target library.

This trips us up when testing against older systems.

rdar://155841439
