### PR TITLE
build: check and add `-fsized-deallocation`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,6 +834,19 @@ if(CMAKE_C_COMPILER_ID MATCHES Clang)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=c++98-compat-extra-semi>)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  include(CheckCXXCompilerFlag)
+  # Check for '-fsized-deallocation', which we need in IRGen. Clang presumably
+  # adds this flag as a requirement for C++14+ to avoid a potential source
+  # compatibility issue with C++11 where the 2-parameter `operator delete` was
+  # used for placement deletion.
+  check_cxx_compiler_flag("-fsized-deallocation"
+    CXX_SUPPORTS_FSIZED_DEALLOCATION)
+  if(CXX_SUPPORTS_FSIZED_DEALLOCATION)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>)
+  endif()
+endif()
+
 option(SWIFT_BUILD_SWIFT_SYNTAX
   "Enable building swift syntax"
   FALSE)

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -76,8 +76,6 @@ add_swift_host_library(swiftIRGen STATIC
     transformutils
     irprinter
 )
-target_compile_options(swiftIRGen PRIVATE
-  $<$<AND:$<PLATFORM_ID:Linux>,$<CXX_COMPILER_ID:Clang>>:-fsized-deallocation>)
 target_link_libraries(swiftIRGen INTERFACE
   clangCodeGen
   clangAST)


### PR DESCRIPTION
We use C++17 for the Swift compiler and IRGen uses the sized deallocation for releasing memory it creates with over-allocation. That triggers ASAN warnings due to the mismatched
`operator new`/`operator delete`.