### PR TITLE
Address `llvm::PointerUnion::{is,get}` deprecations

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -45,9 +45,15 @@ namespace swift {
   enum class PatternKind : uint8_t;
   enum class StmtKind;
 
-  struct ASTNode
-      : public llvm::PointerUnion<Expr *, Stmt *, Decl *, Pattern *, TypeRepr *,
-                                  StmtConditionElement *, CaseLabelItem *> {
+  namespace detail {
+  using ASTNodeBase =
+      llvm::PointerUnion<Expr *, Stmt *, Decl *, Pattern *, TypeRepr *,
+                         StmtConditionElement *, CaseLabelItem *>;
+  } // end namespace detail
+
+  struct ASTNode : public detail::ASTNodeBase {
+    using Base = detail::ASTNodeBase;
+
     // Inherit the constructors from PointerUnion.
     using PointerUnion::PointerUnion;
 
@@ -109,6 +115,14 @@ namespace swift {
 
 namespace llvm {
   using swift::ASTNode;
+
+  /// `isa`, `dyn_cast`, `cast` for `ASTNode`.
+  template <typename To>
+  struct CastInfo<To, ASTNode> : public CastInfo<To, ASTNode::Base> {};
+  template <typename To>
+  struct CastInfo<To, const ASTNode>
+      : public CastInfo<To, const ASTNode::Base> {};
+
   template <> struct DenseMapInfo<ASTNode> {
     static inline ASTNode getEmptyKey() {
       return DenseMapInfo<swift::Expr *>::getEmptyKey();

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -72,13 +72,13 @@ public:
   CaptureInfo getCaptureInfo() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getCaptureInfo();
-    return TheFunction.get<AbstractClosureExpr *>()->getCaptureInfo();
+    return cast<AbstractClosureExpr *>(TheFunction)->getCaptureInfo();
   }
 
   ParameterList *getParameters() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getParameters();
-    return TheFunction.get<AbstractClosureExpr *>()->getParameters();
+    return cast<AbstractClosureExpr *>(TheFunction)->getParameters();
   }
 
   bool hasExternalPropertyWrapperParameters() const {
@@ -90,7 +90,7 @@ public:
   Type getType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getInterfaceType();
-    return TheFunction.get<AbstractClosureExpr *>()->getType();
+    return cast<AbstractClosureExpr *>(TheFunction)->getType();
   }
 
   Type getBodyResultType() const {
@@ -99,7 +99,7 @@ public:
         return FD->mapTypeIntoContext(FD->getResultInterfaceType());
       return TupleType::getEmpty(AFD->getASTContext());
     }
-    return TheFunction.get<AbstractClosureExpr *>()->getResultType();
+    return cast<AbstractClosureExpr *>(TheFunction)->getResultType();
   }
 
   ArrayRef<AnyFunctionType::Yield>
@@ -115,7 +115,7 @@ public:
   BraceStmt *getBody() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getBody();
-    auto *ACE = TheFunction.get<AbstractClosureExpr *>();
+    auto *ACE = cast<AbstractClosureExpr *>(TheFunction);
     if (auto *CE = dyn_cast<ClosureExpr>(ACE))
       return CE->getBody();
     return cast<AutoClosureExpr>(ACE)->getBody();
@@ -127,7 +127,7 @@ public:
       return;
     }
 
-    auto *ACE = TheFunction.get<AbstractClosureExpr *>();
+    auto *ACE = cast<AbstractClosureExpr *>(TheFunction);
     if (auto *CE = dyn_cast<ClosureExpr>(ACE)) {
       CE->setBody(stmt);
       CE->setBodyState(ClosureExpr::BodyState::Parsed);
@@ -143,7 +143,7 @@ public:
       return;
     }
 
-    auto *ACE = TheFunction.get<AbstractClosureExpr *>();
+    auto *ACE = cast<AbstractClosureExpr *>(TheFunction);
     if (auto *CE = dyn_cast<ClosureExpr>(ACE)) {
       CE->setBody(stmt);
       CE->setBodyState(ClosureExpr::BodyState::TypeChecked);
@@ -168,7 +168,7 @@ public:
   DeclContext *getAsDeclContext() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD;
-    return TheFunction.get<AbstractClosureExpr *>();
+    return cast<AbstractClosureExpr *>(TheFunction);
   }
   
   AbstractFunctionDecl *getAbstractFunctionDecl() const {

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -120,9 +120,9 @@ private:
   AvailabilityDomain(Storage storage) : storage(storage) {};
 
   std::optional<InlineDomain> getInlineDomain() const {
-    return storage.is<InlineDomainPtr>()
+    return isa<InlineDomainPtr>(storage)
                ? static_cast<std::optional<InlineDomain>>(
-                     storage.get<InlineDomainPtr>())
+                     cast<InlineDomainPtr>(storage))
                : std::nullopt;
   }
 
@@ -203,7 +203,7 @@ public:
   /// the domain. Returns `nullptr` otherwise.
   const CustomAvailabilityDomain *getCustomDomain() const {
     if (isCustom())
-      return storage.get<const CustomAvailabilityDomain *>();
+      return cast<const CustomAvailabilityDomain *>(storage);
     return nullptr;
   }
 
@@ -401,9 +401,9 @@ public:
       : storage(domain) {};
 
   bool isDomain() const {
-    return storage.getPointer().is<AvailabilityDomain>();
+    return isa<AvailabilityDomain>(storage.getPointer());
   }
-  bool isIdentifier() const { return storage.getPointer().is<Identifier>(); }
+  bool isIdentifier() const { return isa<Identifier>(storage.getPointer()); }
 
   /// Overwrites the existing domain or identifier with the given domain.
   void setDomain(AvailabilityDomain domain) { storage = Storage(domain); }
@@ -411,7 +411,7 @@ public:
   /// Returns the resolved domain, or `std::nullopt` if there isn't one.
   std::optional<AvailabilityDomain> getAsDomain() const {
     if (isDomain())
-      return storage.getPointer().get<AvailabilityDomain>();
+      return cast<AvailabilityDomain>(storage.getPointer());
     return std::nullopt;
   }
 
@@ -419,7 +419,7 @@ public:
   /// been resolved.
   std::optional<Identifier> getAsIdentifier() const {
     if (isIdentifier())
-      return storage.getPointer().get<Identifier>();
+      return cast<Identifier>(storage.getPointer());
     return std::nullopt;
   }
 

--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -22,12 +22,16 @@
 
 namespace swift {
 
+namespace detail {
+using CatchNodeBase = llvm::PointerUnion<AbstractFunctionDecl *, ClosureExpr *,
+                                         DoCatchStmt *, AnyTryExpr *>;
+} // end namespace detail
+
 /// An AST node that represents a point where a thrown error can be caught and
 /// or rethrown, which includes functions do...catch statements.
-class CatchNode: public llvm::PointerUnion<
-    AbstractFunctionDecl *, ClosureExpr *, DoCatchStmt *, AnyTryExpr *
-  > {
+class CatchNode : public detail::CatchNodeBase {
 public:
+  using Base = detail::CatchNodeBase;
   using PointerUnion::PointerUnion;
 
   /// Determine the thrown error type within the region of this catch node
@@ -61,5 +65,18 @@ void simple_display(llvm::raw_ostream &out, CatchNode catchNode);
 SourceLoc extractNearestSourceLoc(CatchNode catchNode);
 
 } // end namespace swift
+
+namespace llvm {
+
+using swift::CatchNode;
+
+/// `isa`, `dyn_cast`, `cast` for `CatchNode`.
+template <typename To>
+struct CastInfo<To, CatchNode> : public CastInfo<To, CatchNode::Base> {};
+template <typename To>
+struct CastInfo<To, const CatchNode>
+    : public CastInfo<To, const CatchNode::Base> {};
+
+} // end namespace llvm
 
 #endif // SWIFT_AST_CATCHNODE_H

--- a/include/swift/AST/ClangNode.h
+++ b/include/swift/AST/ClangNode.h
@@ -14,6 +14,7 @@
 #define SWIFT_CLANGNODE_H
 
 #include "swift/Basic/Debug.h"
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/PointerUnion.h"
 
 namespace clang {
@@ -76,16 +77,16 @@ public:
   }
 
   const clang::Decl *castAsDecl() const {
-    return Ptr.get<Box<clang::Decl>>().value;
+    return cast<Box<clang::Decl>>(Ptr).value;
   }
   const clang::MacroInfo *castAsMacroInfo() const {
-    return Ptr.get<Box<clang::MacroInfo>>().value;
+    return cast<Box<clang::MacroInfo>>(Ptr).value;
   }
   const clang::ModuleMacro *castAsModuleMacro() const {
-    return Ptr.get<Box<clang::ModuleMacro>>().value;
+    return cast<Box<clang::ModuleMacro>>(Ptr).value;
   }
   const clang::Module *castAsModule() const {
-    return Ptr.get<Box<clang::Module>>().value;
+    return cast<Box<clang::Module>>(Ptr).value;
   }
 
   // Get the MacroInfo for a local definition, one imported from a

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1021,7 +1021,7 @@ public:
     if (auto dc = Context.dyn_cast<DeclContext *>())
       return dc->getASTContext();
 
-    return *Context.get<ASTContext *>();
+    return *cast<ASTContext *>(Context);
   }
 
   const DeclAttributes &getAttrs() const {

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -573,7 +573,7 @@ public:
     if (auto compound = BaseNameOrCompound.dyn_cast<CompoundDeclName*>())
       return compound->BaseName;
 
-    return BaseNameOrCompound.get<DeclBaseName>();
+    return cast<DeclBaseName>(BaseNameOrCompound);
   }
 
   /// Assert that the base name is not special and return its identifier.
@@ -597,13 +597,11 @@ public:
   explicit operator bool() const {
     if (BaseNameOrCompound.dyn_cast<CompoundDeclName*>())
       return true;
-    return !BaseNameOrCompound.get<DeclBaseName>().empty();
+    return !cast<DeclBaseName>(BaseNameOrCompound).empty();
   }
   
   /// True if this is a simple one-component name.
-  bool isSimpleName() const {
-    return BaseNameOrCompound.is<DeclBaseName>();
-  }
+  bool isSimpleName() const { return isa<DeclBaseName>(BaseNameOrCompound); }
 
   /// True if this is a compound name.
   bool isCompoundName() const {

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -651,7 +651,7 @@ public:
   DeclContext *getDC() const {
     if (auto *module = getModule())
       return module;
-    return fileOrModule.get<FileUnit *>();
+    return cast<FileUnit *>(fileOrModule);
   }
 
   friend llvm::hash_code hash_value(const OperatorLookupDescriptor &desc) {

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -617,10 +617,10 @@ public:
   }
 
   Expr *getUnresolvedOriginalExpr() const {
-    return ElementDeclOrUnresolvedOriginalExpr.get<Expr*>();
+    return cast<Expr *>(ElementDeclOrUnresolvedOriginalExpr);
   }
   bool hasUnresolvedOriginalExpr() const {
-    return ElementDeclOrUnresolvedOriginalExpr.is<Expr*>();
+    return isa<Expr *>(ElementDeclOrUnresolvedOriginalExpr);
   }
   void setUnresolvedOriginalExpr(Expr *e) {
     ElementDeclOrUnresolvedOriginalExpr = e;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -120,28 +120,26 @@ public:
                                             ProtocolDecl *protocol);
 
   bool isConcrete() const {
-    return !isInvalid() && Union.is<ProtocolConformance*>();
+    return !isInvalid() && isa<ProtocolConformance *>(Union);
   }
   ProtocolConformance *getConcrete() const {
     ASSERT(isConcrete());
-    return Union.get<ProtocolConformance*>();
+    return cast<ProtocolConformance *>(Union);
   }
 
-  bool isPack() const {
-    return !isInvalid() && Union.is<PackConformance*>();
-  }
+  bool isPack() const { return !isInvalid() && isa<PackConformance *>(Union); }
   PackConformance *getPack() const {
     ASSERT(isPack());
-    return Union.get<PackConformance*>();
+    return cast<PackConformance *>(Union);
   }
 
   bool isAbstract() const {
-    return !isInvalid() && Union.is<AbstractConformance*>();
+    return !isInvalid() && isa<AbstractConformance *>(Union);
   }
 
   AbstractConformance *getAbstract() const {
     ASSERT(isAbstract());
-    return Union.get<AbstractConformance *>();
+    return cast<AbstractConformance *>(Union);
   }
 
   /// Determine whether this conformance (or a conformance it depends on)

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -626,13 +626,13 @@ public:
   };
 
   ConditionKind getKind() const {
-    if (Condition.is<Expr *>())
+    if (isa<Expr *>(Condition))
       return CK_Boolean;
-    if (Condition.is<ConditionalPatternBindingInfo *>())
+    if (isa<ConditionalPatternBindingInfo *>(Condition))
       return CK_PatternBinding;
-    if (Condition.is<PoundAvailableInfo *>())
+    if (isa<PoundAvailableInfo *>(Condition))
       return CK_Availability;
-    if (Condition.is<PoundHasSymbolInfo *>())
+    if (isa<PoundHasSymbolInfo *>(Condition))
       return CK_HasSymbol;
     return CK_Boolean;
   }
@@ -642,7 +642,7 @@ public:
 
   Expr *getBoolean() const {
     assert(getKind() == CK_Boolean && "Not a condition");
-    return Condition.get<Expr *>();
+    return cast<Expr *>(Condition);
   }
   void setBoolean(Expr *E) {
     assert(getKind() == CK_Boolean && "Not a condition");
@@ -656,7 +656,7 @@ public:
 
   ConditionalPatternBindingInfo *getPatternBinding() const {
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
-    return Condition.get<ConditionalPatternBindingInfo *>();
+    return cast<ConditionalPatternBindingInfo *>(Condition);
   }
 
   SourceLoc getIntroducerLoc() const {
@@ -690,7 +690,7 @@ public:
   // Availability Accessors
   PoundAvailableInfo *getAvailability() const {
     assert(getKind() == CK_Availability && "Not an #available condition");
-    return Condition.get<PoundAvailableInfo *>();
+    return cast<PoundAvailableInfo *>(Condition);
   }
 
   void setAvailability(PoundAvailableInfo *Info) {
@@ -701,7 +701,7 @@ public:
   // #_hasSymbol Accessors
   PoundHasSymbolInfo *getHasSymbolInfo() const {
     assert(getKind() == CK_HasSymbol && "Not a #_hasSymbol condition");
-    return Condition.get<PoundHasSymbolInfo *>();
+    return cast<PoundHasSymbolInfo *>(Condition);
   }
 
   void setHasSymbolInfo(PoundHasSymbolInfo *Info) {

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -319,7 +319,7 @@ private:
     if (auto customAttr = attr.dyn_cast<CustomAttr*>()) {
       return customAttr->getStartLoc();
     } else {
-      return attr.get<TypeAttribute*>()->getStartLoc();
+      return cast<TypeAttribute *>(attr)->getStartLoc();
     }
   }
   SourceLoc getEndLocImpl() const { return Ty->getEndLoc(); }

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_BASIC_SIMPLE_DISPLAY_H
 #define SWIFT_BASIC_SIMPLE_DISPLAY_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include <tuple>
@@ -167,7 +168,7 @@ namespace swift {
     if (const auto t = ptrUnion.template dyn_cast<T>())
       simple_display(out, t);
     else
-      simple_display(out, ptrUnion.template get<U>());
+      simple_display(out, cast<U>(ptrUnion));
   }
 }
 

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -411,10 +411,10 @@ template <typename T, typename U>
 FrontendStatsTracer make_tracer_pointerunion(UnifiedStatsReporter *Reporter,
                                              StringRef Name,
                                              llvm::PointerUnion<T, U> Value) {
-  if (Value.template is<T>())
-    return make_tracer_direct(Reporter, Name, Value.template get<T>());
+  if (isa<T>(Value))
+    return make_tracer_direct(Reporter, Name, cast<T>(Value));
   else
-    return make_tracer_direct(Reporter, Name, Value.template get<U>());
+    return make_tracer_direct(Reporter, Name, cast<U>(Value));
 }
 
 template <typename T>

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -38,9 +38,9 @@ struct LoadOperation {
   explicit operator bool() const { return !value.isNull(); }
 
   SingleValueInstruction *getLoadInst() const {
-    if (value.is<LoadInst *>())
-      return value.get<LoadInst *>();
-    return value.get<LoadBorrowInst *>();
+    if (isa<LoadInst *>(value))
+      return cast<LoadInst *>(value);
+    return cast<LoadBorrowInst *>(value);
   }
 
   SingleValueInstruction *operator*() const { return getLoadInst(); }
@@ -50,9 +50,9 @@ struct LoadOperation {
   SingleValueInstruction *operator->() { return getLoadInst(); }
 
   SILValue getOperand() const {
-    if (value.is<LoadInst *>())
-      return value.get<LoadInst *>()->getOperand();
-    return value.get<LoadBorrowInst *>()->getOperand();
+    if (isa<LoadInst *>(value))
+      return cast<LoadInst *>(value)->getOperand();
+    return cast<LoadBorrowInst *>(value)->getOperand();
   }
 
   /// Return the ownership qualifier of the underlying load if we have a load or
@@ -65,7 +65,7 @@ struct LoadOperation {
       return std::nullopt;
     }
 
-    return value.get<LoadInst *>()->getOwnershipQualifier();
+    return cast<LoadInst *>(value)->getOwnershipQualifier();
   }
 };
 
@@ -180,19 +180,19 @@ public:
   operator SingleValueInstruction *() const {
     if (auto *seai = value.dyn_cast<SelectEnumAddrInst *>())
       return seai;
-    return value.get<SelectEnumInst *>();
+    return cast<SelectEnumInst *>(value);
   }
 
   SingleValueInstruction *operator*() const {
     if (auto *seai = value.dyn_cast<SelectEnumAddrInst *>())
       return seai;
-    return value.get<SelectEnumInst *>();
+    return cast<SelectEnumInst *>(value);
   }
 
   SingleValueInstruction *operator->() const {
     if (auto *seai = value.dyn_cast<SelectEnumAddrInst *>())
       return seai;
-    return value.get<SelectEnumInst *>();
+    return cast<SelectEnumInst *>(value);
   }
 
   operator bool() const { return bool(value); }
@@ -200,7 +200,7 @@ public:
   SILValue getOperand() {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getOperand();
-    return value.get<SelectEnumAddrInst *>()->getOperand();
+    return cast<SelectEnumAddrInst *>(value)->getOperand();
   }
 
   SILValue getEnumOperand() { return getOperand(); }
@@ -208,25 +208,25 @@ public:
   const Operand &getEnumOperandRef() {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getEnumOperandRef();
-    return value.get<SelectEnumAddrInst *>()->getEnumOperandRef();
+    return cast<SelectEnumAddrInst *>(value)->getEnumOperandRef();
   }
 
   unsigned getNumCases() const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getNumCases();
-    return value.get<SelectEnumAddrInst *>()->getNumCases();
+    return cast<SelectEnumAddrInst *>(value)->getNumCases();
   }
 
   std::pair<EnumElementDecl *, SILValue> getCase(unsigned i) const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getCase(i);
-    return value.get<SelectEnumAddrInst *>()->getCase(i);
+    return cast<SelectEnumAddrInst *>(value)->getCase(i);
   }
 
   std::pair<EnumElementDecl *, Operand *> getCaseOperand(unsigned i) const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getCaseOperand(i);
-    return value.get<SelectEnumAddrInst *>()->getCaseOperand(i);
+    return cast<SelectEnumAddrInst *>(value)->getCaseOperand(i);
   }
 
   /// Return the value that will be used as the result for the specified enum
@@ -234,13 +234,13 @@ public:
   SILValue getCaseResult(EnumElementDecl *D) {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getCaseResult(D);
-    return value.get<SelectEnumAddrInst *>()->getCaseResult(D);
+    return cast<SelectEnumAddrInst *>(value)->getCaseResult(D);
   }
 
   Operand *getCaseResultOperand(EnumElementDecl *D) {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getCaseResultOperand(D);
-    return value.get<SelectEnumAddrInst *>()->getCaseResultOperand(D);
+    return cast<SelectEnumAddrInst *>(value)->getCaseResultOperand(D);
   }
 
   /// If the default refers to exactly one case decl, return it.
@@ -249,19 +249,19 @@ public:
   bool hasDefault() const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->hasDefault();
-    return value.get<SelectEnumAddrInst *>()->hasDefault();
+    return cast<SelectEnumAddrInst *>(value)->hasDefault();
   }
 
   SILValue getDefaultResult() const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getDefaultResult();
-    return value.get<SelectEnumAddrInst *>()->getDefaultResult();
+    return cast<SelectEnumAddrInst *>(value)->getDefaultResult();
   }
 
   Operand *getDefaultResultOperand() const {
     if (auto *sei = value.dyn_cast<SelectEnumInst *>())
       return sei->getDefaultResultOperand();
-    return value.get<SelectEnumAddrInst *>()->getDefaultResultOperand();
+    return cast<SelectEnumAddrInst *>(value)->getDefaultResultOperand();
   }
 };
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2828,9 +2828,9 @@ public:
   /// instruction, it returns it, otherwise it returns null.
   DestroyAddrInst *emitDestroyAddrAndFold(SILLocation Loc, SILValue Operand) {
     auto U = emitDestroyAddr(Loc, Operand);
-    if (U.isNull() || !U.is<DestroyAddrInst *>())
+    if (U.isNull() || !isa<DestroyAddrInst *>(U))
       return nullptr;
-    return U.get<DestroyAddrInst *>();
+    return cast<DestroyAddrInst *>(U);
   }
 
   /// Perform a strong_release instruction at the current location, attempting
@@ -2844,7 +2844,7 @@ public:
       return nullptr;
     if (auto *SRI = U.dyn_cast<StrongReleaseInst *>())
       return SRI;
-    U.get<StrongRetainInst *>()->eraseFromParent();
+    cast<StrongRetainInst *>(U)->eraseFromParent();
     return nullptr;
   }
 
@@ -2861,7 +2861,7 @@ public:
       return nullptr;
     if (auto *RVI = U.dyn_cast<ReleaseValueInst *>())
       return RVI;
-    U.get<RetainValueInst *>()->eraseFromParent();
+    cast<RetainValueInst *>(U)->eraseFromParent();
     return nullptr;
   }
 
@@ -2878,7 +2878,7 @@ public:
       return nullptr;
     if (auto *DVI = U.dyn_cast<DestroyValueInst *>())
       return DVI;
-    auto *CVI = U.get<CopyValueInst *>();
+    auto *CVI = cast<CopyValueInst *>(U);
     CVI->replaceAllUsesWith(CVI->getOperand());
     CVI->eraseFromParent();
     return nullptr;
@@ -3392,10 +3392,10 @@ public:
   ~SavedInsertionPointRAII() {
     if (savedInsertionPoint.isNull()) {
       builder.clearInsertionPoint();
-    } else if (savedInsertionPoint.is<SILInstruction *>()) {
-      builder.setInsertionPoint(savedInsertionPoint.get<SILInstruction *>());
+    } else if (isa<SILInstruction *>(savedInsertionPoint)) {
+      builder.setInsertionPoint(cast<SILInstruction *>(savedInsertionPoint));
     } else {
-      builder.setInsertionPoint(savedInsertionPoint.get<SILBasicBlock *>());
+      builder.setInsertionPoint(cast<SILBasicBlock *>(savedInsertionPoint));
     }
   }
 };

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -210,27 +210,27 @@ struct SILDeclRef {
 
   /// Returns the type of AST node location being stored by the SILDeclRef.
   LocKind getLocKind() const {
-    if (loc.is<ValueDecl *>())
+    if (isa<ValueDecl *>(loc))
       return LocKind::Decl;
-    if (loc.is<AbstractClosureExpr *>())
+    if (isa<AbstractClosureExpr *>(loc))
       return LocKind::Closure;
-    if (loc.is<FileUnit *>())
+    if (isa<FileUnit *>(loc))
       return LocKind::File;
     llvm_unreachable("Unhandled location kind!");
   }
 
   /// The derivative function identifier.
   AutoDiffDerivativeFunctionIdentifier * getDerivativeFunctionIdentifier() const {
-    if (!pointer.is<AutoDiffDerivativeFunctionIdentifier *>())
+    if (!isa<AutoDiffDerivativeFunctionIdentifier *>(pointer))
       return nullptr;
-    return pointer.get<AutoDiffDerivativeFunctionIdentifier *>();
+    return cast<AutoDiffDerivativeFunctionIdentifier *>(pointer);
   }
 
   GenericSignature getSpecializedSignature() const {
-    if (!pointer.is<const GenericSignatureImpl *>())
+    if (!isa<const GenericSignatureImpl *>(pointer))
       return GenericSignature();
     else
-      return GenericSignature(pointer.get<const GenericSignatureImpl *>());
+      return GenericSignature(cast<const GenericSignatureImpl *>(pointer));
   }
 
   /// Produces a null SILDeclRef.
@@ -288,8 +288,8 @@ struct SILDeclRef {
   bool isNull() const { return loc.isNull(); }
   explicit operator bool() const { return !isNull(); }
 
-  bool hasDecl() const { return loc.is<ValueDecl *>(); }
-  bool hasFileUnit() const { return loc.is<FileUnit *>(); }
+  bool hasDecl() const { return isa<ValueDecl *>(loc); }
+  bool hasFileUnit() const { return isa<FileUnit *>(loc); }
   bool hasClosureExpr() const;
   bool hasAutoClosureExpr() const;
   bool hasFuncDecl() const;
@@ -302,9 +302,7 @@ struct SILDeclRef {
   AutoClosureExpr *getAutoClosureExpr() const;
   FuncDecl *getFuncDecl() const;
   AbstractFunctionDecl *getAbstractFunctionDecl() const;
-  FileUnit *getFileUnit() const {
-    return loc.get<FileUnit *>();
-  }
+  FileUnit *getFileUnit() const { return cast<FileUnit *>(loc); }
 
   /// Get ModuleDecl that contains the SILDeclRef
   ModuleDecl *getModuleContext() const;
@@ -433,7 +431,7 @@ struct SILDeclRef {
                       /*knownToBeLocal=*/false,
                       /*runtimeAccessible=*/false, backDeploymentKind,
                       defaultArgIndex, isAsyncLetClosure,
-                      pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
+                      cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
   /// Returns the distributed entry point corresponding to the same decl.
   SILDeclRef asDistributed(bool distributed = true) const {
@@ -442,7 +440,7 @@ struct SILDeclRef {
                       /*distributed=*/distributed,
                       /*knownToBeLocal=*/false, isRuntimeAccessible,
                       backDeploymentKind, defaultArgIndex, isAsyncLetClosure,
-                      pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
+                      cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
 
   /// Returns the distributed known-to-be-local entry point corresponding to
@@ -454,7 +452,7 @@ struct SILDeclRef {
                       /*distributedKnownToBeLocal=*/isLocal,
                       isRuntimeAccessible, backDeploymentKind, defaultArgIndex,
                       isAsyncLetClosure,
-                      pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
+                      cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
 
   /// Returns the runtime accessible entry point corresponding to the same decl.
@@ -469,7 +467,7 @@ struct SILDeclRef {
     return SILDeclRef(loc.getOpaqueValue(), kind, isForeign, distributedThunk,
                       isKnownToBeLocal, isRuntimeAccessible, backDeploymentKind,
                       defaultArgIndex, isAsyncLetClosure,
-                      pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
+                      cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
 
   /// Returns the entry point for the corresponding autodiff derivative
@@ -485,7 +483,7 @@ struct SILDeclRef {
   /// Returns the entry point for the original function corresponding to an
   /// autodiff derivative function.
   SILDeclRef asAutoDiffOriginalFunction() const {
-    assert(pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
+    assert(cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
     SILDeclRef declRef = *this;
     declRef.pointer = (AutoDiffDerivativeFunctionIdentifier *)nullptr;
     return declRef;
@@ -594,14 +592,14 @@ struct SILDeclRef {
   bool canBeDynamicReplacement() const;
 
   bool isAutoDiffDerivativeFunction() const {
-    return pointer.is<AutoDiffDerivativeFunctionIdentifier *>() &&
-           pointer.get<AutoDiffDerivativeFunctionIdentifier *>() != nullptr;
+    return isa<AutoDiffDerivativeFunctionIdentifier *>(pointer) &&
+           cast<AutoDiffDerivativeFunctionIdentifier *>(pointer) != nullptr;
   }
 
   AutoDiffDerivativeFunctionIdentifier *
   getAutoDiffDerivativeFunctionIdentifier() const {
     assert(isAutoDiffDerivativeFunction());
-    return pointer.get<AutoDiffDerivativeFunctionIdentifier *>();
+    return cast<AutoDiffDerivativeFunctionIdentifier *>(pointer);
   }
   
   bool hasAsync() const;

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -231,14 +231,14 @@ private:
   bool isNode(ASTNodeTy Node) const {
     assert(isASTNode());
     ASTNodeTy primaryNd = getPrimaryASTNode();
-    if (primaryNd.getPointer().is<typename base_type<T>::type*>())
-      return isa<T>(Node.getPointer().get<typename base_type<T>::type*>());
+    if (isa<typename base_type<T>::type *>(primaryNd.getPointer()))
+      return isa<T>(cast<typename base_type<T>::type *>(Node.getPointer()));
     return false;
   }
 
   template <typename T>
   T *castNodeTo(ASTNodeTy Node) const {
-    return cast<T>(Node.getPointer().get<typename base_type<T>::type*>());
+    return cast<T>(cast<typename base_type<T>::type *>(Node.getPointer()));
   }
 
   SourceLoc getSourceLoc(ASTNodeTy N) const;

--- a/include/swift/SIL/TerminatorUtils.h
+++ b/include/swift/SIL/TerminatorUtils.h
@@ -56,19 +56,19 @@ public:
   operator TermInst *() const {
     if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
       return seai;
-    return value.get<SwitchEnumInst *>();
+    return cast<SwitchEnumInst *>(value);
   }
 
   TermInst *operator*() const {
     if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
       return seai;
-    return value.get<SwitchEnumInst *>();
+    return cast<SwitchEnumInst *>(value);
   }
 
   TermInst *operator->() const {
     if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
       return seai;
-    return value.get<SwitchEnumInst *>();
+    return cast<SwitchEnumInst *>(value);
   }
 
   operator bool() const { return bool(value); }
@@ -76,62 +76,62 @@ public:
   SILValue getOperand() {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getOperand();
-    return value.get<SwitchEnumAddrInst *>()->getOperand();
+    return cast<SwitchEnumAddrInst *>(value)->getOperand();
   }
 
   unsigned getNumCases() {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getNumCases();
-    return value.get<SwitchEnumAddrInst *>()->getNumCases();
+    return cast<SwitchEnumAddrInst *>(value)->getNumCases();
   }
 
   std::pair<EnumElementDecl *, SILBasicBlock *> getCase(unsigned i) const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getCase(i);
-    return value.get<SwitchEnumAddrInst *>()->getCase(i);
+    return cast<SwitchEnumAddrInst *>(value)->getCase(i);
   }
 
   SILBasicBlock *getCaseDestination(EnumElementDecl *decl) const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getCaseDestination(decl);
-    return value.get<SwitchEnumAddrInst *>()->getCaseDestination(decl);
+    return cast<SwitchEnumAddrInst *>(value)->getCaseDestination(decl);
   }
 
   ProfileCounter getCaseCount(unsigned i) const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getCaseCount(i);
-    return value.get<SwitchEnumAddrInst *>()->getCaseCount(i);
+    return cast<SwitchEnumAddrInst *>(value)->getCaseCount(i);
   }
 
   ProfileCounter getDefaultCount() const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getDefaultCount();
-    return value.get<SwitchEnumAddrInst *>()->getDefaultCount();
+    return cast<SwitchEnumAddrInst *>(value)->getDefaultCount();
   }
 
   bool hasDefault() const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->hasDefault();
-    return value.get<SwitchEnumAddrInst *>()->hasDefault();
+    return cast<SwitchEnumAddrInst *>(value)->hasDefault();
   }
 
   SILBasicBlock *getDefaultBB() const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getDefaultBB();
-    return value.get<SwitchEnumAddrInst *>()->getDefaultBB();
+    return cast<SwitchEnumAddrInst *>(value)->getDefaultBB();
   }
 
   NullablePtr<SILBasicBlock> getDefaultBBOrNull() const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getDefaultBBOrNull();
-    return value.get<SwitchEnumAddrInst *>()->getDefaultBBOrNull();
+    return cast<SwitchEnumAddrInst *>(value)->getDefaultBBOrNull();
   }
 
   /// If the default refers to exactly one case decl, return it.
   NullablePtr<EnumElementDecl> getUniqueCaseForDefault() const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getUniqueCaseForDefault();
-    return value.get<SwitchEnumAddrInst *>()->getUniqueCaseForDefault();
+    return cast<SwitchEnumAddrInst *>(value)->getUniqueCaseForDefault();
   }
 
   /// If the given block only has one enum element decl matched to it,
@@ -140,7 +140,7 @@ public:
   getUniqueCaseForDestination(SILBasicBlock *BB) const {
     if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
       return sei->getUniqueCaseForDestination(BB);
-    return value.get<SwitchEnumAddrInst *>()->getUniqueCaseForDestination(BB);
+    return cast<SwitchEnumAddrInst *>(value)->getUniqueCaseForDestination(BB);
   }
 };
 

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -690,9 +690,9 @@ public:
   LoopTy *getLoop() const;
   FunctionTy *getFunction() const;
 
-  bool isBlock() const { return Ptr.is<BlockTy *>(); }
-  bool isLoop() const { return Ptr.is<LoopTy *>(); }
-  bool isFunction() const { return Ptr.is<FunctionTy *>(); }
+  bool isBlock() const { return isa<BlockTy *>(Ptr); }
+  bool isLoop() const { return isa<LoopTy *>(Ptr); }
+  bool isFunction() const { return isa<FunctionTy *>(Ptr); }
 
   /// Is this the head of an edge that causes unknown control flow.
   ///

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -121,14 +121,14 @@ public:
       return;
     }
 
-    os << *value.get<SILValue>();
+    os << *cast<SILValue>(value);
   }
 
-  SILValue getValue() const { return value.get<SILValue>(); }
+  SILValue getValue() const { return cast<SILValue>(value); }
   SILValue maybeGetValue() const { return value.dyn_cast<SILValue>(); }
-  bool hasRegionIntroducingInst() const { return value.is<SILInstruction *>(); }
+  bool hasRegionIntroducingInst() const { return isa<SILInstruction *>(value); }
   SILInstruction *getActorRegionIntroducingInst() const {
-    return value.get<SILInstruction *>();
+    return cast<SILInstruction *>(value);
   }
 
   bool operator==(SILValue other) const {
@@ -665,14 +665,14 @@ public:
   }
 
   SILInstruction *getSourceInst() const {
-    if (source.is<Operand *>())
-      return source.get<Operand *>()->getUser();
-    return source.get<SILInstruction *>();
+    if (isa<Operand *>(source))
+      return cast<Operand *>(source)->getUser();
+    return cast<SILInstruction *>(source);
   }
 
-  bool hasSourceInst() const { return source.is<SILInstruction *>(); }
+  bool hasSourceInst() const { return isa<SILInstruction *>(source); }
 
-  Operand *getSourceOp() const { return source.get<Operand *>(); }
+  Operand *getSourceOp() const { return cast<Operand *>(source); }
 
   SILLocation getSourceLoc() const { return getSourceInst()->getLoc(); }
 

--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -223,14 +223,14 @@ private:
     if (auto *inst = defValue.dyn_cast<SILInstruction *>()) {
       return inst->getFunction();
     }
-    return defValue.get<SILArgument *>()->getFunction();
+    return cast<SILArgument *>(defValue)->getFunction();
   }
 
   SILBasicBlock *getDefValueParentBlock() const {
     if (auto *inst = defValue.dyn_cast<SILInstruction *>()) {
       return inst->getParent();
     }
-    return defValue.get<SILArgument *>()->getParent();
+    return cast<SILArgument *>(defValue)->getParent();
   }
 
   /// Propagates the liveness information up the control flow graph.

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -118,10 +118,10 @@ struct PotentialBinding {
   ConstraintLocator *getLocator() const {
     if (auto *constraint = BindingSource.dyn_cast<Constraint *>())
       return constraint->getLocator();
-    return BindingSource.get<ConstraintLocator *>();
+    return cast<ConstraintLocator *>(BindingSource);
   }
 
-  Constraint *getSource() const { return BindingSource.get<Constraint *>(); }
+  Constraint *getSource() const { return cast<Constraint *>(BindingSource); }
 
   PotentialBinding withType(Type type) const {
     return {type, Kind, BindingSource};

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -853,12 +853,12 @@ public:
     // produce another diagnostic for the contextual mismatch complaining that
     // a type is not convertible to a placeholder type.
     if (auto fromPlaceholder = getFromType()->getAs<PlaceholderType>()) {
-      if (fromPlaceholder->getOriginator().is<ErrorExpr *>()) {
+      if (isa<ErrorExpr *>(fromPlaceholder->getOriginator())) {
         return true;
       }
     }
     if (auto toPlaceholder = getToType()->getAs<PlaceholderType>()) {
-      if (toPlaceholder->getOriginator().is<ErrorExpr *>()) {
+      if (isa<ErrorExpr *>(toPlaceholder->getOriginator())) {
         return true;
       }
     }

--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -93,7 +93,7 @@ public:
 
   CodeCompletionExpr *getCompletionExpr() const {
     assert(hasCompletionExpr());
-    return CompletionNode.get<CodeCompletionExpr *>();
+    return cast<CodeCompletionExpr *>(CompletionNode);
   }
 
   bool hasCompletionKeyPathComponent() const {
@@ -108,7 +108,7 @@ public:
   /// the code completion component.
   const KeyPathExpr *getKeyPathContainingCompletionComponent() const {
     assert(hasCompletionKeyPathComponent());
-    return CompletionNode.get<const KeyPathExpr *>();
+    return cast<const KeyPathExpr *>(CompletionNode);
   }
 
   /// If we are completing in a key path, returns the index at which the key

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1110,7 +1110,7 @@ public:
 
   Stmt *asStmt() const {
     auto node = ASTNode::getFromOpaqueValue(getStoredPointer());
-    return node.get<Stmt *>();
+    return cast<Stmt *>(node);
   }
 
   static bool classof(const LocatorPathElt *elt) {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -415,12 +415,12 @@ public:
   /// is not itself or has a fixed type binding.
   bool hasRepresentativeOrFixed() const {
     // If we have a fixed type, we're done.
-    if (!ParentOrFixed.is<TypeVariableType *>())
+    if (!isa<TypeVariableType *>(ParentOrFixed))
       return true;
 
     // Check whether the representative is different from our own type
     // variable.
-    return ParentOrFixed.get<TypeVariableType *>() != getTypeVariable();
+    return cast<TypeVariableType *>(ParentOrFixed) != getTypeVariable();
   }
 
   /// Low-level accessor; use getRepresentative() or getFixedType() instead.
@@ -519,9 +519,9 @@ public:
     // Find the representative type variable.
     auto result = getTypeVariable();
     Implementation *impl = this;
-    while (impl->ParentOrFixed.is<TypeVariableType *>()) {
+    while (isa<TypeVariableType *>(impl->ParentOrFixed)) {
       // Extract the representative.
-      auto nextTV = impl->ParentOrFixed.get<TypeVariableType *>();
+      auto nextTV = cast<TypeVariableType *>(impl->ParentOrFixed);
       if (nextTV == result)
         break;
 
@@ -534,9 +534,9 @@ public:
 
     // Perform path compression.
     impl = this;
-    while (impl->ParentOrFixed.is<TypeVariableType *>()) {
+    while (isa<TypeVariableType *>(impl->ParentOrFixed)) {
       // Extract the representative.
-      auto nextTV = impl->ParentOrFixed.get<TypeVariableType *>();
+      auto nextTV = cast<TypeVariableType *>(impl->ParentOrFixed);
       if (nextTV == result)
         break;
 
@@ -709,7 +709,7 @@ private:
 namespace constraints {
 
 template <typename T = Expr> T *castToExpr(ASTNode node) {
-  return cast<T>(node.get<Expr *>());
+  return cast<T>(cast<Expr *>(node));
 }
 
 template <typename T = Expr> T *getAsExpr(ASTNode node) {
@@ -723,10 +723,10 @@ template <typename T = Expr> T *getAsExpr(ASTNode node) {
 }
 
 template <typename T> bool isExpr(ASTNode node) {
-  if (node.isNull() || !node.is<Expr *>())
+  if (node.isNull() || !isa<Expr *>(node))
     return false;
 
-  auto *E = node.get<Expr *>();
+  auto *E = cast<Expr *>(node);
   return isa<T>(E);
 }
 
@@ -758,7 +758,7 @@ T *getAsPattern(ASTNode node) {
 }
 
 template <typename T = Stmt> T *castToStmt(ASTNode node) {
-  return cast<T>(node.get<Stmt *>());
+  return cast<T>(cast<Stmt *>(node));
 }
 
 SourceLoc getLoc(ASTNode node);

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -232,8 +232,8 @@ public:
                  ? OverloadChoiceKind::KeyPathDynamicMemberLookup
                  : OverloadChoiceKind::DynamicMemberLookup;
     }
-    
-    if (DeclOrKind.is<ValueDecl*>()) {
+
+    if (isa<ValueDecl *>(DeclOrKind)) {
       switch (BaseAndDeclKind.getInt()) {
       case IsDeclViaBridge: return OverloadChoiceKind::DeclViaBridge;
       case IsDeclViaDynamic: return OverloadChoiceKind::DeclViaDynamic;
@@ -243,7 +243,7 @@ public:
       default: return OverloadChoiceKind::Decl;
       }
     }
-    uint32_t kind = DeclOrKind.get<OverloadChoiceKindWithTupleIndex>();
+    uint32_t kind = cast<OverloadChoiceKindWithTupleIndex>(DeclOrKind);
     if (kind >= (uint32_t)OverloadChoiceKind::TupleIndex)
       return OverloadChoiceKind::TupleIndex;
 
@@ -268,14 +268,10 @@ public:
   }
 
   /// Determine whether this choice is for a declaration.
-  bool isDecl() const {
-    return DeclOrKind.is<ValueDecl*>();
-  }
+  bool isDecl() const { return isa<ValueDecl *>(DeclOrKind); }
 
   /// Retrieve the declaration that corresponds to this overload choice.
-  ValueDecl *getDecl() const {
-    return DeclOrKind.get<ValueDecl*>();
-  }
+  ValueDecl *getDecl() const { return cast<ValueDecl *>(DeclOrKind); }
 
   /// Retrieves the declaration that corresponds to this overload choice, or
   /// \c nullptr if this choice is not for a declaration.
@@ -312,7 +308,7 @@ public:
   /// choice.
   unsigned getTupleIndex() const {
     assert(getKind() == OverloadChoiceKind::TupleIndex);
-    uint32_t kind = DeclOrKind.get<OverloadChoiceKindWithTupleIndex>();
+    uint32_t kind = cast<OverloadChoiceKindWithTupleIndex>(DeclOrKind);
     return kind-(uint32_t)OverloadChoiceKind::TupleIndex;
   }
 

--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -450,7 +450,7 @@ public:
   /// For a pattern initialization target, retrieve the pattern.
   Pattern *getInitializationPattern() const {
     if (kind == Kind::uninitializedVar)
-      return uninitializedVar.declaration.get<Pattern *>();
+      return cast<Pattern *>(uninitializedVar.declaration);
 
     assert(isForInitialization());
     return expression.pattern;
@@ -589,7 +589,7 @@ public:
 
   void setPattern(Pattern *pattern) {
     if (kind == Kind::uninitializedVar) {
-      assert(uninitializedVar.declaration.is<Pattern *>());
+      assert(isa<Pattern *>(uninitializedVar.declaration));
       uninitializedVar.declaration = pattern;
       return;
     }
@@ -833,7 +833,7 @@ public:
               uninitializedVar.declaration.dyn_cast<VarDecl *>()) {
         return wrappedVar->getSourceRange();
       }
-      return uninitializedVar.declaration.get<Pattern *>()->getSourceRange();
+      return cast<Pattern *>(uninitializedVar.declaration)->getSourceRange();
     }
 
     // For-in preamble target doesn't cover the body.
@@ -877,7 +877,7 @@ public:
               uninitializedVar.declaration.dyn_cast<VarDecl *>()) {
         return wrappedVar->getLoc();
       }
-      return uninitializedVar.declaration.get<Pattern *>()->getLoc();
+      return cast<Pattern *>(uninitializedVar.declaration)->getLoc();
     }
 
     case Kind::forEachPreamble:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1078,7 +1078,7 @@ namespace {
       else if (auto *SubStmt = Elt.dyn_cast<Stmt*>())
         printRec(SubStmt, Ctx, label);
       else
-        printRec(Elt.get<Decl*>(), label);
+        printRec(cast<Decl *>(Elt), label);
     }
 
     /// Print a statement condition element as a child node.
@@ -1935,7 +1935,7 @@ namespace {
         printWhereClause(GC->getTrailingWhereClause(),
                          Label::always("where_requirements"));
       } else {
-        const auto ATD = Owner.get<const AssociatedTypeDecl *>();
+        const auto ATD = cast<const AssociatedTypeDecl *>(Owner);
         printWhereClause(ATD->getTrailingWhereClause(),
                          Label::always("where_requirements"));
       }
@@ -2507,7 +2507,7 @@ namespace {
             } else if (auto stmt = item.dyn_cast<Stmt *>()) {
               printRec(stmt, &SF.getASTContext(), label);
             } else {
-              auto expr = item.get<Expr *>();
+              auto expr = cast<Expr *>(item);
               printRec(expr, label);
             }
           },
@@ -6072,11 +6072,11 @@ namespace {
       } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
         printFieldQuotedRaw([&](raw_ostream &OS) { VD->dumpRef(OS); },
                             Label::optional("originating_var"), DeclColor);
-      } else if (originator.is<ErrorExpr *>()) {
+      } else if (isa<ErrorExpr *>(originator)) {
         printFlag("error_expr");
       } else if (auto *DMT = originator.dyn_cast<DependentMemberType *>()) {
         printRec(DMT, Label::always("dependent_member_type"));
-      } else if (originator.is<TypeRepr *>()) {
+      } else if (isa<TypeRepr *>(originator)) {
         printFlag("type_repr");
       } else {
         assert(false && "unknown originator");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4933,7 +4933,7 @@ void ASTMangler::appendMacroExpansionContext(
       discriminator = expr->getDiscriminator();
       outerExpansionDC = expr->getDeclContext();
     } else {
-      auto decl = cast<MacroExpansionDecl>(parent.get<Decl *>());
+      auto decl = cast<MacroExpansionDecl>(cast<Decl *>(parent));
       outerExpansionLoc = decl->getLoc();
       baseName = decl->getMacroName().getBaseName();
       discriminator = decl->getDiscriminator();
@@ -4948,8 +4948,8 @@ void ASTMangler::appendMacroExpansionContext(
     case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   {
-    auto decl = ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode)
-      .get<Decl *>();
+    auto decl =
+        cast<Decl *>(ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode));
     auto attr = generatedSourceInfo->attachedMacroCustomAttr;
     outerExpansionLoc = decl->getLoc();
     outerExpansionDC = decl->getDeclContext();
@@ -5113,17 +5113,34 @@ namespace {
 /// Stores either a declaration or its enclosing context, for use in mangling
 /// of macro expansion contexts.
 struct DeclOrEnclosingContext: llvm::PointerUnion<const Decl *, const DeclContext *> {
+  using Base = llvm::PointerUnion<const Decl *, const DeclContext *>;
   using PointerUnion::PointerUnion;
 
-  const DeclContext *getEnclosingContext() const {
-    if (auto decl = dyn_cast<const Decl *>()) {
-      return decl->getDeclContext();
-    }
-
-    return get<const DeclContext *>();
-  }
+  const DeclContext *getEnclosingContext() const;
 };
 
+} // namespace
+
+namespace llvm {
+
+using ::DeclOrEnclosingContext;
+
+/// `isa`, `dyn_cast`, `cast` for `DeclOrEnclosingContext`.
+template <typename To>
+struct CastInfo<To, DeclOrEnclosingContext>
+    : CastInfo<To, DeclOrEnclosingContext::Base> {};
+template <typename To>
+struct CastInfo<To, const DeclOrEnclosingContext>
+    : CastInfo<To, const DeclOrEnclosingContext::Base> {};
+
+} // end namespace llvm
+
+const DeclContext *DeclOrEnclosingContext::getEnclosingContext() const {
+  if (auto decl = dyn_cast<const Decl *>()) {
+    return decl->getDeclContext();
+  }
+
+  return cast<const DeclContext *>(*this);
 }
 
 /// Given a declaration, find the declaration or enclosing context that is

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -60,9 +60,9 @@ DeclContext *ASTNode::getAsDeclContext() const {
   if (auto *E = this->dyn_cast<Expr*>()) {
     if (isa<AbstractClosureExpr>(E))
       return static_cast<AbstractClosureExpr*>(E);
-  } else if (is<Stmt*>()) {
+  } else if (isa<Stmt *>(*this)) {
     return nullptr;
-  } else if (auto *D = this->dyn_cast<Decl*>()) {
+  } else if (auto *D = this->dyn_cast<Decl *>()) {
     if (isa<DeclContext>(D))
       return cast<DeclContext>(D);
   } else if (getOpaqueValue())
@@ -79,11 +79,11 @@ bool ASTNode::isImplicit() const {
     return D->isImplicit();
   if (const auto *P = this->dyn_cast<Pattern*>())
     return P->isImplicit();
-  if (this->is<TypeRepr *>())
+  if (isa<TypeRepr *>(*this))
     return false;
-  if (this->is<StmtConditionElement *>())
+  if (isa<StmtConditionElement *>(*this))
     return false;
-  if (this->is<CaseLabelItem *>())
+  if (isa<CaseLabelItem *>(*this))
     return false;
   llvm_unreachable("unsupported AST node");
 }
@@ -124,9 +124,9 @@ void ASTNode::dump(raw_ostream &OS, unsigned Indent) const {
     P->dump(OS, Indent);
   else if (auto T = dyn_cast<TypeRepr*>())
     T->print(OS);
-  else if (is<StmtConditionElement *>())
+  else if (isa<StmtConditionElement *>(*this))
     OS.indent(Indent) << "(statement condition)";
-  else if (is<CaseLabelItem *>()) {
+  else if (isa<CaseLabelItem *>(*this)) {
     OS.indent(Indent) << "(case label item)";
   } else
     llvm_unreachable("unsupported AST node");
@@ -146,12 +146,12 @@ StringRef swift::getTokenText(tok kind) {
   }
 }
 
-#define FUNC(T)                                                               \
-bool ASTNode::is##T(T##Kind Kind) const {                                     \
-  if (!is<T*>())                                                              \
-    return false;                                                             \
-  return get<T*>()->getKind() == Kind;                                        \
-}
+#define FUNC(T)                                                                \
+  bool ASTNode::is##T(T##Kind Kind) const {                                    \
+    if (!isa<T *>(*this))                                                      \
+      return false;                                                            \
+    return cast<T *>(*this)->getKind() == Kind;                                \
+  }
 FUNC(Stmt)
 FUNC(Expr)
 FUNC(Decl)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -438,7 +438,7 @@ TypeTransformContext::TypeTransformContext(TypeOrExtensionDecl D)
   if (auto NTD = Decl.Decl.dyn_cast<NominalTypeDecl *>())
     BaseType = NTD->getDeclaredTypeInContext().getPointer();
   else {
-    auto *ED = Decl.Decl.get<ExtensionDecl *>();
+    auto *ED = cast<ExtensionDecl *>(Decl.Decl);
     BaseType = ED->getDeclaredTypeInContext().getPointer();
   }
 }
@@ -2772,7 +2772,7 @@ static void addNamespaceMembers(Decl *decl,
             ctx.evaluator, ClangDirectLookupRequest({decl, redecl, name}), {});
 
         for (auto found : allResults) {
-          auto clangMember = found.get<clang::NamedDecl *>();
+          auto clangMember = cast<clang::NamedDecl *>(found);
           if (auto importedDecl =
                   ctx.getClangModuleLoader()->importDeclDirectly(clangMember)) {
             if (addedMembers.insert(importedDecl).second) {
@@ -4246,7 +4246,7 @@ bool PrintAST::printASTNodes(const ArrayRef<ASTNode> &Elements,
     } else if (auto stmt = element.dyn_cast<Stmt*>()) {
       visit(stmt);
     } else {
-      visit(element.get<Expr*>());
+      visit(cast<Expr *>(element));
     }
   }
   return PrintedSomething;
@@ -6201,11 +6201,11 @@ public:
       } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
         Printer << "decl = ";
         Printer << VD->getName();
-      } else if (originator.is<ErrorExpr *>()) {
+      } else if (isa<ErrorExpr *>(originator)) {
         Printer << "error_expr";
       } else if (auto *DMT = originator.dyn_cast<DependentMemberType *>()) {
         visit(DMT);
-      } else if (originator.is<TypeRepr *>()) {
+      } else if (isa<TypeRepr *>(originator)) {
         Printer << "type_repr";
       } else {
         assert(false && "unknown originator");

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -339,12 +339,12 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     }
     case MacroRole::Body: {
       auto expansion = SF->getMacroExpansion();
-      if (expansion.is<Decl *>()) {
+      if (isa<Decl *>(expansion)) {
         // Use the end location of the function decl itself as the parentLoc
         // for the new function body scope. This is different from the end
         // location of the original source range, which is after the end of the
         // function decl.
-        bodyForDecl = cast<AbstractFunctionDecl>(expansion.get<Decl *>());
+        bodyForDecl = cast<AbstractFunctionDecl>(cast<Decl *>(expansion));
         parentLoc = expansion.getEndLoc();
         break;
       }
@@ -633,7 +633,7 @@ ASTScopeImpl *ScopeCreator::addToScopeTreeAndReturnInsertionPoint(
     return adder.visit(p, parent, *this);
   if (auto *p = n.dyn_cast<Expr *>())
     return adder.visit(p, parent, *this);
-  auto *p = n.get<Stmt *>();
+  auto *p = cast<Stmt *>(n);
   return adder.visit(p, parent, *this);
 }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -248,8 +248,8 @@ class Verifier : public ASTWalker {
 
   Verifier(PointerUnion<ModuleDecl *, SourceFile *> M, DeclContext *DC)
       : M(M),
-        Ctx(M.is<ModuleDecl *>() ? M.get<ModuleDecl *>()->getASTContext()
-                                 : M.get<SourceFile *>()->getASTContext()),
+        Ctx(isa<ModuleDecl *>(M) ? cast<ModuleDecl *>(M)->getASTContext()
+                                 : cast<SourceFile *>(M)->getASTContext()),
         Out(llvm::errs()), HadError(Ctx.hadError()) {
     pushScope(DC);
   }
@@ -269,7 +269,7 @@ class Verifier : public ASTWalker {
     if (auto sourceFile = M.dyn_cast<SourceFile *>())
       return sourceFile->getParentModule();
 
-    return M.get<ModuleDecl *>();
+    return cast<ModuleDecl *>(M);
   }
 
 public:
@@ -295,12 +295,12 @@ public:
 #define EXPR(ID, PARENT) \
       case ExprKind::ID: \
         DISPATCH(ID);
-#define UNCHECKED_EXPR(ID, PARENT) \
-      case ExprKind::ID: \
-        assert((HadError || !M.is<SourceFile*>() || \
-                M.get<SourceFile*>()->ASTStage < SourceFile::TypeChecked) && \
-               #ID "in wrong phase");\
-        DISPATCH(ID);
+#define UNCHECKED_EXPR(ID, PARENT)                                             \
+  case ExprKind::ID:                                                           \
+    assert((HadError || !isa<SourceFile *>(M) ||                               \
+            cast<SourceFile *>(M)->ASTStage < SourceFile::TypeChecked) &&      \
+           #ID "in wrong phase");                                              \
+    DISPATCH(ID);
 #include "swift/AST/ExprNodes.def"
 #undef DISPATCH
       }
@@ -313,12 +313,12 @@ public:
 #define EXPR(ID, PARENT) \
       case ExprKind::ID: \
         DISPATCH(ID);
-#define UNCHECKED_EXPR(ID, PARENT) \
-      case ExprKind::ID: \
-        assert((HadError || !M.is<SourceFile*>() || \
-                M.get<SourceFile*>()->ASTStage < SourceFile::TypeChecked) && \
-               #ID "in wrong phase");\
-        DISPATCH(ID);
+#define UNCHECKED_EXPR(ID, PARENT)                                             \
+    case ExprKind::ID:                                                         \
+      assert((HadError || !isa<SourceFile *>(M) ||                             \
+              cast<SourceFile *>(M)->ASTStage < SourceFile::TypeChecked) &&    \
+             #ID "in wrong phase");                                            \
+      DISPATCH(ID);
 #include "swift/AST/ExprNodes.def"
 #undef DISPATCH
       }
@@ -723,13 +723,13 @@ public:
       Scopes.push_back(scope);
     }
     void popScope(DeclContext *scope) {
-      assert(Scopes.back().get<DeclContext*>() == scope);
+      assert(cast<DeclContext *>(Scopes.back()) == scope);
       assert(Generics.back() == scope);
       Scopes.pop_back();
       Generics.pop_back();
     }
     void popScope(BraceStmt *scope) {
-      assert(Scopes.back().get<BraceStmt*>() == scope);
+      assert(cast<BraceStmt *>(Scopes.back()) == scope);
       Scopes.pop_back();
     }
 
@@ -1345,7 +1345,7 @@ public:
     void verifyChecked(AbstractClosureExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying closure", E);
 
-      assert(Scopes.back().get<DeclContext*>() == E);
+      assert(cast<DeclContext *>(Scopes.back()) == E);
       assert(E->getParent()->isLocalContext() &&
              "closure expression was not in local context!");
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -59,6 +59,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Assertions.h"
+
 using namespace swift;
 
 void ASTWalker::anchor() {}
@@ -516,7 +517,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         } else if (auto *stmt = expandedNode.dyn_cast<Stmt *>()) {
           alreadyFailed = doIt(stmt) == nullptr;
         } else {
-          auto decl = expandedNode.get<Decl *>();
+          auto decl = cast<Decl *>(expandedNode);
           if (!isa<VarDecl>(decl))
             alreadyFailed = doIt(decl);
         }
@@ -1908,7 +1909,7 @@ Stmt *Traversal::visitBraceStmt(BraceStmt *BS) {
       continue;
     }
 
-    auto *D = Elem.get<Decl*>();
+    auto *D = cast<Decl *>(Elem);
     if (doIt(D))
       return nullptr;
 

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -121,7 +121,7 @@ NominalTypeDecl *ActorIsolation::getActor() const {
     return actorType->getReferenceStorageReferent()->getAnyActor();
   }
 
-  return actorInstance.get<NominalTypeDecl *>();
+  return cast<NominalTypeDecl *>(actorInstance);
 }
 
 VarDecl *ActorIsolation::getActorInstance() const {

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -293,7 +293,7 @@ static bool isSendableFunctionType(EitherFunctionType eitherFnTy) {
     representation = *converted;
 
   } else {
-    auto functionType = eitherFnTy.get<const AnyFunctionType *>();
+    auto functionType = cast<const AnyFunctionType *>(eitherFnTy);
 
     if (functionType->isSendable())
       return true;
@@ -319,7 +319,7 @@ static bool isEscapableFunctionType(EitherFunctionType eitherFnTy) {
 //    return !silFnTy->isNoEscape();
 //  }
 //
-//  auto functionType = eitherFnTy.get<const FunctionType *>();
+// auto functionType = cast<const FunctionType *>(eitherFnTy);
 //
 //  // TODO: what about autoclosures?
 //  return !functionType->isNoEscape();
@@ -337,7 +337,7 @@ static bool isBitwiseCopyableFunctionType(EitherFunctionType eitherFnTy) {
   if (auto silFnTy = eitherFnTy.dyn_cast<const SILFunctionType *>()) {
     representation = silFnTy->getRepresentation();
   } else {
-    auto fnTy = eitherFnTy.get<const AnyFunctionType *>();
+    auto fnTy = cast<const AnyFunctionType *>(eitherFnTy);
     representation = convertRepresentation(fnTy->getRepresentation());
   }
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -58,7 +58,7 @@ ProtocolDecl *ConformanceLookupTable::ConformanceEntry::getProtocol() const {
   if (auto protocol = Conformance.dyn_cast<ProtocolDecl *>())
     return protocol;
 
-  return Conformance.get<ProtocolConformance *>()->getProtocol();
+  return cast<ProtocolConformance *>(Conformance)->getProtocol();
 }
 
 void ConformanceLookupTable::ConformanceEntry::markSupersededBy(
@@ -1031,7 +1031,7 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     }
   }
 
-  return entry->Conformance.get<ProtocolConformance *>();
+  return cast<ProtocolConformance *>(entry->Conformance);
 }
 
 void ConformanceLookupTable::addSynthesizedConformance(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1955,7 +1955,7 @@ InheritedTypes::InheritedTypes(
   if (auto *typeDecl = decl.dyn_cast<const TypeDecl *>()) {
     Entries = typeDecl->Inherited;
   } else {
-    Entries = decl.get<const ExtensionDecl *>()->Inherited;
+    Entries = cast<const ExtensionDecl *>(decl)->Inherited;
   }
 }
 
@@ -1976,7 +1976,7 @@ ASTContext &InheritedTypes::getASTContext() const {
   if (auto typeDecl = Decl.dyn_cast<const TypeDecl *>()) {
     return typeDecl->getASTContext();
   } else {
-    return Decl.get<const ExtensionDecl *>()->getASTContext();
+    return cast<const ExtensionDecl *>(Decl)->getASTContext();
   }
 }
 
@@ -1988,7 +1988,7 @@ SourceLoc InheritedTypes::getColonLoc() const {
   if (auto typeDecl = Decl.dyn_cast<const TypeDecl *>()) {
     precedingTok = typeDecl->getNameLoc();
   } else {
-    auto *ext = Decl.get<const ExtensionDecl *>();
+    auto *ext = cast<const ExtensionDecl *>(Decl);
     precedingTok = ext->getSourceRange().End;
   }
 
@@ -2029,9 +2029,9 @@ SourceRange InheritedTypes::getRemovalRange(unsigned i) const {
 
 Type InheritedTypes::getResolvedType(unsigned i,
                                      TypeResolutionStage stage) const {
-  ASTContext &ctx = Decl.is<const ExtensionDecl *>()
-                        ? Decl.get<const ExtensionDecl *>()->getASTContext()
-                        : Decl.get<const TypeDecl *>()->getASTContext();
+  ASTContext &ctx = isa<const ExtensionDecl *>(Decl)
+                        ? cast<const ExtensionDecl *>(Decl)->getASTContext()
+                        : cast<const TypeDecl *>(Decl)->getASTContext();
   return evaluateOrDefault(ctx.evaluator, InheritedTypeRequest{Decl, i, stage},
                            InheritedTypeResult::forDefault())
       .getInheritedTypeOrNull(getASTContext());
@@ -9420,7 +9420,7 @@ void ParamDecl::setDefaultExpr(Expr *E) {
   auto *defaultInfo = DefaultValueAndFlags.getPointer();
   if (defaultInfo) {
     assert(defaultInfo->DefaultArg.isNull() ||
-           defaultInfo->DefaultArg.is<Expr *>());
+           isa<Expr *>(defaultInfo->DefaultArg));
 
     auto *const oldE = defaultInfo->DefaultArg.dyn_cast<Expr *>();
     assert((bool)E == (bool)oldE && "Overwrite of non-null default with null");
@@ -9475,7 +9475,7 @@ void ParamDecl::setStoredProperty(VarDecl *var) {
 
   auto *defaultInfo = DefaultValueAndFlags.getPointer();
   assert(defaultInfo->DefaultArg.isNull() ||
-         defaultInfo->DefaultArg.is<VarDecl *>());
+         isa<VarDecl *>(defaultInfo->DefaultArg));
   defaultInfo->DefaultArg = var;
 }
 
@@ -12177,7 +12177,7 @@ Decl *TypeOrExtensionDecl::getAsDecl() const {
   if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
     return NTD;
 
-  return Decl.get<ExtensionDecl *>();
+  return cast<ExtensionDecl *>(Decl);
 }
 DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
   return getAsDecl()->getInnermostDeclContext();
@@ -12187,7 +12187,7 @@ IterableDeclContext *TypeOrExtensionDecl::getAsIterableDeclContext() const {
   if (auto nominal = Decl.dyn_cast<NominalTypeDecl *>())
     return nominal;
 
-  return Decl.get<ExtensionDecl *>();
+  return cast<ExtensionDecl *>(Decl);
 }
 
 NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
@@ -12832,10 +12832,10 @@ void MacroExpansionDecl::forEachExpandedNode(
     // expressions, declaration macros can only produce declarations,
     // and code item macros can produce expressions, declarations, and
     // statements.
-    if (roles.contains(MacroRole::Expression) && !node.is<Expr *>())
+    if (roles.contains(MacroRole::Expression) && !isa<Expr *>(node))
       continue;
 
-    if (roles.contains(MacroRole::Declaration) && !node.is<Decl *>())
+    if (roles.contains(MacroRole::Declaration) && !isa<Decl *>(node))
       continue;
 
     callback(node);
@@ -12914,7 +12914,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
       if (!origDC->isChildContextOf(expansion->getDeclContext()))
         return MacroDiscriminatorContext(expansion);
     } else {
-      auto expansionDecl = cast<MacroExpansionDecl>(node.get<Decl *>());
+      auto expansionDecl = cast<MacroExpansionDecl>(cast<Decl *>(node));
       if (!origDC->isChildContextOf(expansionDecl->getDeclContext()))
         return MacroDiscriminatorContext(expansionDecl);
     }
@@ -12976,7 +12976,7 @@ CatchNode::getThrownErrorTypeInContext(ASTContext &ctx) const {
     return ctx.getErrorExistentialType();
   }
 
-  auto tryExpr = get<AnyTryExpr *>();
+  auto tryExpr = cast<AnyTryExpr *>(*this);
   if (auto forceTry = llvm::dyn_cast<ForceTryExpr>(tryExpr)) {
     if (auto thrownError = forceTry->getThrownError())
       return thrownError;
@@ -13029,7 +13029,7 @@ bool ExplicitCaughtTypeRequest::isCached() const {
   auto catchNode = std::get<1>(getStorage());
 
   // try? and try! never need to be cached.
-  if (catchNode.is<AnyTryExpr *>())
+  if (isa<AnyTryExpr *>(catchNode))
     return false;
 
   // Functions with explicitly-written thrown types need the result cached.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1484,7 +1484,7 @@ getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info) {
       }
 
       auto expansionDecl =
-          cast<MacroExpansionDecl>(expansionNode.get<Decl *>());
+          cast<MacroExpansionDecl>(cast<Decl *>(expansionNode));
       return expansionDecl->getMacroName().getFullName();
     }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2224,7 +2224,7 @@ void AutoClosureExpr::setBody(Expr *E) {
 }
 
 Expr *AutoClosureExpr::getSingleExpressionBody() const {
-  return cast<ReturnStmt>(Body->getLastElement().get<Stmt *>())->getResult();
+  return cast<ReturnStmt>(cast<Stmt *>(Body->getLastElement()))->getResult();
 }
 
 Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
@@ -2638,7 +2638,7 @@ SingleValueStmtExpr *SingleValueStmtExpr::createWithWrappedBranches(
       continue;
 
     auto &result = BS->getElements().back();
-    assert(result.is<Expr *>() || result.is<Stmt *>());
+    assert(isa<Expr *>(result) || isa<Stmt *>(result));
 
     // Wrap a statement in a SingleValueStmtExpr.
     if (auto *S = result.dyn_cast<Stmt *>()) {
@@ -2711,7 +2711,7 @@ bool SingleValueStmtExpr::isLastElementImplicitResult(
   auto elt = BS->getLastElement();
 
   // Expressions are always valid.
-  if (elt.is<Expr *>())
+  if (isa<Expr *>(elt))
     return true;
 
   if (auto *S = elt.dyn_cast<Stmt *>()) {
@@ -2907,7 +2907,7 @@ TypeJoinExpr::TypeJoinExpr(llvm::PointerUnion<DeclRefExpr *, TypeBase *> result,
     assert(varRef);
     Var = varRef;
   } else {
-    auto joinType = Type(result.get<TypeBase *>());
+    auto joinType = Type(cast<TypeBase *>(result));
     assert(joinType && "expected non-null type");
     setType(joinType);
   }
@@ -3093,7 +3093,7 @@ Type ThrownErrorDestination::getThrownErrorType() const {
   if (auto type = storage.dyn_cast<TypeBase *>())
     return Type(type);
 
-  auto conversion = storage.get<Conversion *>();
+  auto conversion = cast<Conversion *>(storage);
   return conversion->thrownError->getType();
 }
 
@@ -3104,7 +3104,7 @@ Type ThrownErrorDestination::getContextErrorType() const {
   if (auto type = storage.dyn_cast<TypeBase *>())
     return Type(type);
 
-  auto conversion = storage.get<Conversion *>();
+  auto conversion = cast<Conversion *>(storage);
   return conversion->conversion->getType();
 }
 

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -242,7 +242,7 @@ bool fine_grained_dependencies::withReferenceDependencies(
         ModuleDepGraphFactory(backend, MD, alsoEmitDotFile).construct();
     return cont(std::move(g));
   } else {
-    auto *SF = MSF.get<const SourceFile *>();
+    auto *SF = cast<const SourceFile *>(MSF);
     SourceFileDepGraph g =
         FrontendSourceFileDepGraphFactory(SF, backend, outputPath, depTracker,
                                           alsoEmitDotFile)

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -246,7 +246,7 @@ bool GenericSignatureImpl::isEqual(GenericSignature Other) const {
 }
 
 bool GenericSignatureImpl::isCanonical() const {
-  if (CanonicalSignatureOrASTContext.is<ASTContext *>())
+  if (isa<ASTContext *>(CanonicalSignatureOrASTContext))
     return true;
   return getCanonicalSignature().getPointer() == this;
 }
@@ -300,12 +300,12 @@ CanGenericSignature GenericSignatureImpl::getCanonicalSignature() const {
 
   // A stored ASTContext indicates that this is the canonical
   // signature.
-  if (CanonicalSignatureOrASTContext.is<ASTContext *>())
+  if (isa<ASTContext *>(CanonicalSignatureOrASTContext))
     return CanGenericSignature(this);
 
   // Otherwise, return the stored canonical signature.
   return CanGenericSignature(
-      CanonicalSignatureOrASTContext.get<const GenericSignatureImpl *>());
+      cast<const GenericSignatureImpl *>(CanonicalSignatureOrASTContext));
 }
 
 GenericEnvironment *GenericSignature::getGenericEnvironment() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1820,7 +1820,7 @@ StringRef ModuleDecl::ReverseFullNameIterator::operator*() const {
     return swiftModule->getRealName().str();
 
   auto *clangModule =
-      static_cast<const clang::Module *>(current.get<const void *>());
+      static_cast<const clang::Module *>(cast<const void *>(current));
   if (!clangModule->isSubModule() && clangModule->Name == "std")
     return "CxxStdlib";
   return clangModule->Name;
@@ -1831,13 +1831,13 @@ ModuleDecl::ReverseFullNameIterator::operator++() {
   if (!current)
     return *this;
 
-  if (current.is<const ModuleDecl *>()) {
+  if (isa<const ModuleDecl *>(current)) {
     current = nullptr;
     return *this;
   }
 
   auto *clangModule =
-      static_cast<const clang::Module *>(current.get<const void *>());
+      static_cast<const clang::Module *>(cast<const void *>(current));
   if (clangModule->Parent)
     current = clangModule->Parent;
   else
@@ -3985,7 +3985,7 @@ StringRef LoadedFile::getFilename() const {
 
 static const clang::Module *
 getClangModule(llvm::PointerUnion<const ModuleDecl *, const void *> Union) {
-  return static_cast<const clang::Module *>(Union.get<const void *>());
+  return static_cast<const clang::Module *>(cast<const void *>(Union));
 }
 
 StringRef ModuleEntity::getName(bool useRealNameIfAliased) const {
@@ -4033,7 +4033,7 @@ const ModuleDecl* ModuleEntity::getAsSwiftModule() const {
 
 const clang::Module* ModuleEntity::getAsClangModule() const {
   assert(!Mod.isNull());
-  if (Mod.is<const ModuleDecl*>())
+  if (isa<const ModuleDecl *>(Mod))
     return nullptr;
   return getClangModule(Mod);
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3406,7 +3406,7 @@ DirectlyReferencedTypeDecls InheritedDeclsReferencedRequest::evaluate(
     if (auto typeDecl = decl.dyn_cast<const TypeDecl *>())
       dc = typeDecl->getInnermostDeclContext();
     else
-      dc = (DeclContext *)decl.get<const ExtensionDecl *>();
+      dc = (DeclContext *)cast<const ExtensionDecl *>(decl);
 
     // If looking at a protocol's inheritance list,
     // do not look at protocol members to avoid circularity.

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -717,7 +717,7 @@ DeclContext *ContextualPattern::getDeclContext() const {
   if (auto pbd = getPatternBindingDecl())
     return pbd->getDeclContext();
 
-  return declOrContext.get<DeclContext *>();
+  return cast<DeclContext *>(declOrContext);
 }
 
 PatternBindingDecl *ContextualPattern::getPatternBindingDecl() const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4292,10 +4292,10 @@ bool TypeBase::isNoEscape() const {
 }
 
 Identifier DependentMemberType::getName() const {
-  if (NameOrAssocType.is<Identifier>())
-    return NameOrAssocType.get<Identifier>();
+  if (isa<Identifier>(NameOrAssocType))
+    return cast<Identifier>(NameOrAssocType);
 
-  return NameOrAssocType.get<AssociatedTypeDecl *>()->getName();
+  return cast<AssociatedTypeDecl *>(NameOrAssocType)->getName();
 }
 
 Type Type::transformRec(

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -235,10 +235,10 @@ const TypeRepr *DeclRefTypeRepr::getRoot() const {
 DeclNameLoc DeclRefTypeRepr::getNameLoc() const { return NameLoc; }
 
 DeclNameRef DeclRefTypeRepr::getNameRef() const {
-  if (NameOrDecl.is<DeclNameRef>())
-    return NameOrDecl.get<DeclNameRef>();
+  if (isa<DeclNameRef>(NameOrDecl))
+    return cast<DeclNameRef>(NameOrDecl);
 
-  return NameOrDecl.get<TypeDecl *>()->createNameRef();
+  return cast<TypeDecl *>(NameOrDecl)->createNameRef();
 }
 
 void DeclRefTypeRepr::overwriteNameRef(DeclNameRef newId) {
@@ -246,7 +246,7 @@ void DeclRefTypeRepr::overwriteNameRef(DeclNameRef newId) {
   NameOrDecl = newId;
 }
 
-bool DeclRefTypeRepr::isBound() const { return NameOrDecl.is<TypeDecl *>(); }
+bool DeclRefTypeRepr::isBound() const { return isa<TypeDecl *>(NameOrDecl); }
 
 TypeDecl *DeclRefTypeRepr::getBoundDecl() const {
   return NameOrDecl.dyn_cast<TypeDecl *>();
@@ -413,7 +413,7 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
       customAttr->getTypeRepr()->print(Printer, Options, std::nullopt);
       Printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
     } else {
-      auto typeAttr = attr.get<TypeAttribute*>();
+      auto typeAttr = cast<TypeAttribute *>(attr);
       if (Options.excludeAttrKind(typeAttr->getKind()))
         continue;
       typeAttr->print(Printer, Options);

--- a/lib/ClangImporter/CFTypeInfo.h
+++ b/lib/ClangImporter/CFTypeInfo.h
@@ -16,6 +16,7 @@
 #ifndef SWIFT_IMPORTER_CFTYPEINFO_H
 #define SWIFT_IMPORTER_CFTYPEINFO_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -91,20 +92,20 @@ public:
 
   bool isRecord() const {
     assert(isValid());
-    return !Decl.isNull() && Decl.is<const clang::RecordDecl *>();
+    return !Decl.isNull() && isa<const clang::RecordDecl *>(Decl);
   }
   const clang::RecordDecl *getRecord() const {
     assert(isRecord());
-    return Decl.get<const clang::RecordDecl *>();
+    return cast<const clang::RecordDecl *>(Decl);
   }
 
   bool isTypedef() const {
     assert(isValid());
-    return !Decl.isNull() && Decl.is<const clang::TypedefNameDecl *>();
+    return !Decl.isNull() && isa<const clang::TypedefNameDecl *>(Decl);
   }
   const clang::TypedefNameDecl *getTypedef() const {
     assert(isTypedef());
-    return Decl.get<const clang::TypedefNameDecl *>();
+    return cast<const clang::TypedefNameDecl *>(Decl);
   }
 };
 }

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -51,7 +51,7 @@ namespace {
       if (auto *activeDiag = info.dyn_cast<const clang::Diagnostic *>())
         ID = activeDiag->getID();
       else
-        ID = info.get<const clang::StoredDiagnostic *>()->getID();
+        ID = cast<const clang::StoredDiagnostic *>(info)->getID();
       return ID == clang::diag::note_module_import_here ||
              ID == clang::diag::err_module_not_built;
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1964,7 +1964,7 @@ namespace {
               }
             } else {
               enumeratorDecl =
-                  canonicalCaseIter->second.get<EnumElementDecl *>();
+                  cast<EnumElementDecl *>(canonicalCaseIter->second);
               canonConstant =
                   cast<clang::EnumConstantDecl>(enumeratorDecl->getClangDecl());
             }
@@ -10861,7 +10861,7 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(
 
   // Load the members.
   for (auto entry : table->allGlobalsAsMembersInContext(effectiveClangContext)) {
-    auto decl = entry.get<clang::NamedDecl *>();
+    auto decl = cast<clang::NamedDecl *>(entry);
 
     // Only include members in the same submodule as this extension.
     if (getClangSubmoduleForDecl(decl) != submodule)

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -623,7 +623,7 @@ ConstValueTypeInfo ConstantValueInfoRequest::evaluate(
   auto shouldExtract = [&](DeclContext *decl) {
     if (auto SF = extractionScope.dyn_cast<const SourceFile *>())
       return decl->getOutermostParentSourceFile() == SF;
-    return decl->getParentModule() == extractionScope.get<ModuleDecl *>();
+    return decl->getParentModule() == cast<ModuleDecl *>(extractionScope);
   };
 
   std::vector<ConstValueTypePropertyInfo> Properties;

--- a/lib/Frontend/Serialization.cpp
+++ b/lib/Frontend/Serialization.cpp
@@ -26,7 +26,7 @@ using namespace swift;
 static ModuleDecl *getModule(ModuleOrSourceFile DC) {
   if (auto M = DC.dyn_cast<ModuleDecl *>())
     return M;
-  return DC.get<SourceFile *>()->getParentModule();
+  return cast<SourceFile *>(DC)->getParentModule();
 }
 
 static ASTContext &getContext(ModuleOrSourceFile DC) {
@@ -37,7 +37,7 @@ static void emitABIDescriptor(ModuleOrSourceFile DC,
                               const SerializationOptions &options) {
   using namespace swift::ide::api;
   if (!options.ABIDescriptorPath.empty()) {
-    if (DC.is<ModuleDecl *>()) {
+    if (isa<ModuleDecl *>(DC)) {
       auto &OutputBackend = getContext(DC).getOutputBackend();
       auto ABIDesFile = OutputBackend.createFile(options.ABIDescriptorPath);
       if (!ABIDesFile) {
@@ -54,7 +54,7 @@ static void emitABIDescriptor(ModuleOrSourceFile DC,
           return;
         }
       };
-      dumpModuleContent(DC.get<ModuleDecl *>(), *ABIDesFile, true,
+      dumpModuleContent(cast<ModuleDecl *>(DC), *ABIDesFile, true,
                         options.emptyABIDescriptor);
     }
   }
@@ -178,8 +178,8 @@ void swift::serialize(
   }
 
   if (!symbolGraphOptions.OutputDir.empty()) {
-    if (DC.is<ModuleDecl *>()) {
-      auto *M = DC.get<ModuleDecl *>();
+    if (isa<ModuleDecl *>(DC)) {
+      auto *M = cast<ModuleDecl *>(DC);
       FrontendStatsTracer tracer(getContext(DC).Stats,
                                  "Serialization, symbolgraph");
       symbolgraphgen::emitSymbolGraphForModule(M, symbolGraphOptions);

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -125,7 +125,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
               NullTerminatedStringRef(C->getFullModuleName(), Allocator);
         } else {
           ModuleName = NullTerminatedStringRef(
-              CurrentModule.get<const swift::ModuleDecl *>()->getName().str(),
+              cast<const swift::ModuleDecl *>(CurrentModule)->getName().str(),
               Allocator);
         }
         Sink.LastModule.first = CurrentModule.getOpaqueValue();

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -466,7 +466,7 @@ bool CodeCompletionResultType::isBackedByUSRs() const {
   return llvm::all_of(
       getResultTypes(),
       [](const PointerUnion<Type, const USRBasedType *> &ResultType) {
-        return ResultType.is<const USRBasedType *>();
+        return isa<const USRBasedType *>(ResultType);
       });
 }
 
@@ -481,7 +481,7 @@ CodeCompletionResultType::getUSRBasedResultTypes(
       USRBasedTypes.push_back(USRType);
     } else {
       USRBasedTypes.push_back(
-          USRBasedType::fromType(ResultType.get<Type>(), Arena));
+          USRBasedType::fromType(cast<Type>(ResultType), Arena));
     }
   }
   return USRBasedTypes;
@@ -514,7 +514,7 @@ TypeRelation CodeCompletionResultType::calculateTypeRelation(
       Res = std::max(Res, USRTypeContext->typeRelation(USRType));
     } else {
       Res = std::max(
-          Res, calculateMaxTypeRelation(Ty.get<Type>(), *TypeContext, *DC));
+          Res, calculateMaxTypeRelation(cast<Type>(Ty), *TypeContext, *DC));
     }
   }
   return Res;

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -406,7 +406,7 @@ private:
       return {};
     }
 
-    if (Node.is<Expr *>()) {
+    if (isa<Expr *>(Node)) {
       // If we are performing cursor info on an expression, type check the
       // referenced decls so that all their parent closures are type-checked
       // (see comment in typeCheckDeclAndParentClosures).

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -743,7 +743,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
       if (auto macroDecl = D->getResolvedMacro(mutableAttr)) {
         Type macroRefType = macroDecl->getDeclaredInterfaceType();
         auto customAttrRef =
-            std::make_pair(customAttr, expansion ? expansion.get<Decl *>() : D);
+            std::make_pair(customAttr, expansion ? cast<Decl *>(expansion) : D);
         auto refMetadata =
             ReferenceMetaData(SemaReferenceKind::DeclRef, std::nullopt,
                               /*isImplicit=*/false, customAttrRef);
@@ -796,10 +796,10 @@ bool SemaAnnotator::handleClosureAttributes(ClosureExpr *E) {
 
 bool SemaAnnotator::handleTypeAttributes(AttributedTypeRepr *T) {
   for (auto attr : T->getAttrs()) {
-    if (!attr.is<CustomAttr *>())
+    if (!isa<CustomAttr *>(attr))
       continue;
 
-    CustomAttr *customAttr = attr.get<CustomAttr *>();
+    CustomAttr *customAttr = cast<CustomAttr *>(attr);
     if (!handleCustomTypeAttribute(customAttr))
       return false;
   }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1196,7 +1196,7 @@ bool ModelASTWalker::handleAttrs(ArrayRef<TypeOrCustomAttr> Attrs) {
     if (auto CA = Attr.dyn_cast<CustomAttr*>()) {
       DeclRanges.push_back(std::make_pair(CA, CA->getRangeWithAt()));
     } else {
-      auto TA = Attr.get<TypeAttribute*>();
+      auto TA = cast<TypeAttribute *>(Attr);
       // TODO: Use the structure in the TypeAttribute
       DeclRanges.push_back(std::make_pair(nullptr, SourceRange(TA->getStartLoc())));
     }

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -425,7 +425,7 @@ void SyntacticMacroExpansionInstance::expand(
     // Attached macros.
     MacroDecl *macro = getSynthesizedMacroDecl(
         getCustomAttrName(getASTContext(), attr), expansion);
-    auto *attachedTo = expansionNode->node.get<Decl *>();
+    auto *attachedTo = cast<Decl *>(expansionNode->node);
     bufferIDs = expandAttachedMacro(macro, attr, attachedTo);
 
     // For an attached macro, remove the custom attribute; it's been fully
@@ -437,10 +437,10 @@ void SyntacticMacroExpansionInstance::expand(
     // Freestanding macros.
     FreestandingMacroExpansion *freestanding;
     auto node = expansionNode->node;
-    if (node.is<Expr *>()) {
-      freestanding = cast<MacroExpansionExpr>(node.get<Expr *>());
+    if (isa<Expr *>(node)) {
+      freestanding = cast<MacroExpansionExpr>(cast<Expr *>(node));
     } else {
-      freestanding = cast<MacroExpansionDecl>(node.get<Decl *>());
+      freestanding = cast<MacroExpansionDecl>(cast<Decl *>(node));
     }
 
     MacroDecl *macro = getSynthesizedMacroDecl(

--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -70,7 +70,7 @@ public:
           // underlying Clang function that was also synthesized.
           BraceStmt *body = defaultArgGenerator->getTypecheckedBody();
           auto returnStmt =
-              cast<ReturnStmt>(body->getSingleActiveElement().get<Stmt *>());
+              cast<ReturnStmt>(cast<Stmt *>(body->getSingleActiveElement()));
           auto callExpr = cast<CallExpr>(returnStmt->getResult());
           auto calledFuncDecl = cast<FuncDecl>(callExpr->getCalledValue());
           auto calledClangFuncDecl =

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -78,7 +78,7 @@ getAccessorLinking(ThunkOrRequirement accessorFor) {
     return LinkEntity::forDistributedTargetAccessor(method);
   }
 
-  auto *requirement = accessorFor.get<AbstractFunctionDecl *>();
+  auto *requirement = cast<AbstractFunctionDecl *>(accessorFor);
   return LinkEntity::forDistributedTargetAccessor(requirement);
 }
 
@@ -152,7 +152,7 @@ public:
     if (auto *thunk = target.dyn_cast<SILFunction *>()) {
       Type = thunk->getLoweredFunctionType();
     } else {
-      auto *requirement = target.get<AbstractFunctionDecl *>();
+      auto *requirement = cast<AbstractFunctionDecl *>(target);
       Type = IGF.IGM.getSILTypes().getConstantFunctionType(
           IGF.IGM.getMaximalTypeExpansionContext(),
           SILDeclRef(requirement).asDistributed());
@@ -162,7 +162,7 @@ public:
   DeclContext *getDeclContext() const {
     if (auto *thunk = Target.dyn_cast<SILFunction *>())
       return thunk->getDeclContext();
-    return Target.get<AbstractFunctionDecl *>();
+    return cast<AbstractFunctionDecl *>(Target);
   }
 
   CanSILFunctionType getType() const { return Type; }
@@ -867,7 +867,7 @@ FunctionPointer AccessorTarget::getPointerToTarget(llvm::Value *actorSelf) {
         IGM.getAddrOfSILFunction(thunk, NotForDefinition), signature);
   }
 
-  auto *requirementDecl = Target.get<AbstractFunctionDecl *>();
+  auto *requirementDecl = cast<AbstractFunctionDecl *>(Target);
   auto *protocol = requirementDecl->getDeclContext()->getSelfProtocolDecl();
   SILDeclRef requirementRef = SILDeclRef(requirementDecl).asDistributed();
 
@@ -902,13 +902,13 @@ Callee AccessorTarget::getCallee(llvm::Value *actorSelf) {
 }
 
 WitnessMetadata *AccessorTarget::getWitnessMetadata(llvm::Value *actorSelf) {
-  if (Target.is<SILFunction *>())
+  if (isa<SILFunction *>(Target))
     return nullptr;
 
   if (!Witness) {
     WitnessMetadata witness;
 
-    auto *requirement = Target.get<AbstractFunctionDecl *>();
+    auto *requirement = cast<AbstractFunctionDecl *>(Target);
     auto *protocol = requirement->getDeclContext()->getSelfProtocolDecl();
     assert(protocol);
 

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -503,10 +503,10 @@ public:
   ~SavedInsertionPointRAII() {
     if (savedInsertionPoint.isNull()) {
       builder.ClearInsertionPoint();
-    } else if (savedInsertionPoint.is<llvm::Instruction *>()) {
-      builder.SetInsertPoint(savedInsertionPoint.get<llvm::Instruction *>());
+    } else if (isa<llvm::Instruction *>(savedInsertionPoint)) {
+      builder.SetInsertPoint(cast<llvm::Instruction *>(savedInsertionPoint));
     } else {
-      builder.SetInsertPoint(savedInsertionPoint.get<llvm::BasicBlock *>());
+      builder.SetInsertPoint(cast<llvm::BasicBlock *>(savedInsertionPoint));
     }
   }
 };

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3096,7 +3096,7 @@ llvm::DIScope *IRGenDebugInfoImpl::getOrCreateScope(const SILDebugScope *DS) {
     return SP;
   }
 
-  auto *ParentScope = DS->Parent.get<const SILDebugScope *>();
+  auto *ParentScope = cast<const SILDebugScope *>(DS->Parent);
   llvm::DIScope *Parent = getOrCreateScope(ParentScope);
   assert(isa<llvm::DILocalScope>(Parent) && "not a local scope");
 
@@ -3706,7 +3706,7 @@ struct DbgIntrinsicEmitter {
       return insert(Addr, VarInfo, Expr, DL, Inst);
     } else {
       return insert(Addr, VarInfo, Expr, DL,
-                    InsertPt.get<llvm::BasicBlock *>());
+                    cast<llvm::BasicBlock *>(InsertPt));
     }
   }
 
@@ -3856,7 +3856,7 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
       inserter.insert(Storage, Var, Expr, DL, InsertBefore);
     } else {
       inserter.insert(Storage, Var, Expr, DL,
-                      InsertPt.get<llvm::BasicBlock *>());
+                      cast<llvm::BasicBlock *>(InsertPt));
     }
     return;
   }

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -42,7 +42,7 @@ void swift::simple_display(llvm::raw_ostream &out,
   if (MD) {
     out << "IR Generation for module " << MD->getName();
   } else {
-    auto *file = desc.Ctx.get<FileUnit *>();
+    auto *file = cast<FileUnit *>(desc.Ctx);
     out << "IR Generation for file ";
     simple_display(out, file);
   }
@@ -64,7 +64,7 @@ TinyPtrVector<FileUnit *> IRGenDescriptor::getFilesToEmit() const {
 
   // For a primary file, we emit IR for both it and potentially its
   // SynthesizedFileUnit.
-  auto *primary = Ctx.get<FileUnit *>();
+  auto *primary = cast<FileUnit *>(Ctx);
   TinyPtrVector<FileUnit *> files;
   files.push_back(primary);
 
@@ -74,14 +74,14 @@ TinyPtrVector<FileUnit *> IRGenDescriptor::getFilesToEmit() const {
 ModuleDecl *IRGenDescriptor::getParentModule() const {
   if (auto *file = Ctx.dyn_cast<FileUnit *>())
     return file->getParentModule();
-  return Ctx.get<ModuleDecl *>();
+  return cast<ModuleDecl *>(Ctx);
 }
 
 TBDGenDescriptor IRGenDescriptor::getTBDGenDescriptor() const {
   if (auto *file = Ctx.dyn_cast<FileUnit *>()) {
     return TBDGenDescriptor::forFile(file, TBDOpts);
   } else {
-    auto *M = Ctx.get<ModuleDecl *>();
+    auto *M = cast<ModuleDecl *>(Ctx);
     return TBDGenDescriptor::forModule(M, TBDOpts);
   }
 }
@@ -97,11 +97,11 @@ evaluator::DependencySource IRGenRequest::readDependencySource(
   auto &desc = std::get<0>(getStorage());
 
   // We don't track dependencies in whole-module mode.
-  if (desc.Ctx.is<ModuleDecl *>()) {
+  if (isa<ModuleDecl *>(desc.Ctx)) {
     return nullptr;
   }
 
-  auto *primary = desc.Ctx.get<FileUnit *>();
+  auto *primary = cast<FileUnit *>(desc.Ctx);
   return dyn_cast<SourceFile>(primary);
 }
 

--- a/lib/IRGen/TBDGenRequests.cpp
+++ b/lib/IRGen/TBDGenRequests.cpp
@@ -45,7 +45,7 @@ FileUnit *TBDGenDescriptor::getSingleFile() const {
 ModuleDecl *TBDGenDescriptor::getParentModule() const {
   if (auto *module = Input.dyn_cast<ModuleDecl *>())
     return module;
-  return Input.get<FileUnit *>()->getParentModule();
+  return cast<FileUnit *>(Input)->getParentModule();
 }
 
 const StringRef TBDGenDescriptor::getDataLayoutString() const {
@@ -74,7 +74,7 @@ void swift::simple_display(llvm::raw_ostream &out,
     simple_display(out, module);
   } else {
     out << "file ";
-    simple_display(out, desc.getFileOrModule().get<FileUnit *>());
+    simple_display(out, cast<FileUnit *>(desc.getFileOrModule()));
   }
 }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -125,18 +125,18 @@ public:
   ModuleDecl &getModule() const {
     if (auto SF = SFOrMod.dyn_cast<SourceFile *>())
       return *SF->getParentModule();
-    return *SFOrMod.get<ModuleDecl *>();
+    return *cast<ModuleDecl *>(SFOrMod);
   }
 
   ArrayRef<FileUnit *> getFiles() const {
-    return SFOrMod.is<SourceFile *>() ? *SFOrMod.getAddrOfPtr1()
-                                      : SFOrMod.get<ModuleDecl *>()->getFiles();
+    return isa<SourceFile *>(SFOrMod) ? *SFOrMod.getAddrOfPtr1()
+                                      : cast<ModuleDecl *>(SFOrMod)->getFiles();
   }
 
   StringRef getFilename() const {
     if (auto *SF = SFOrMod.dyn_cast<SourceFile *>())
       return SF->getFilename();
-    return SFOrMod.get<ModuleDecl *>()->getModuleFilename();
+    return cast<ModuleDecl *>(SFOrMod)->getModuleFilename();
   }
 
   void
@@ -147,7 +147,7 @@ public:
     if (auto *SF = SFOrMod.dyn_cast<SourceFile *>()) {
       SF->getImportedModules(Modules, ImportFilter);
     } else {
-      SFOrMod.get<ModuleDecl *>()->getImportedModules(Modules, ImportFilter);
+      cast<ModuleDecl *>(SFOrMod)->getImportedModules(Modules, ImportFilter);
     }
   }
 };
@@ -245,7 +245,7 @@ public:
         if (auto *D = C.dyn_cast<const Decl *>()) {
           tryContainer(D);
         } else {
-          auto *P = C.get<const Pattern *>();
+          auto *P = cast<const Pattern *>(C);
           P->forEachVariable([&](VarDecl *VD) {
             tryContainer(VD);
           });

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1403,10 +1403,10 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto *BS = dyn_cast<BraceStmt>(S)) {
         for(auto Ele: BS->getElements()) {
-          if (Ele.is<Expr*>() && isSuperExpr(Ele.get<Expr*>())) {
+          if (isa<Expr *>(Ele) && isSuperExpr(cast<Expr *>(Ele))) {
             Editor.remove(Ele.getSourceRange());
           }
-	}
+        }
       }
       // We only handle top-level expressions, so avoid visiting further.
       return Action::SkipNode(S);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1507,8 +1507,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
              SF.getParsingOptions().contains(
                  SourceFile::ParsingFlags::PoundIfAllActive));
       // FIXME: 'PoundIfAllActive' mode should keep all the parsed AST nodes.
-      assert(activeElements[0].is<Expr *>());
-      auto expr = activeElements[0].get<Expr *>();
+      assert(isa<Expr *>(activeElements[0]));
+      auto *expr = cast<Expr *>(activeElements[0]);
       ParserStatus status(ICD);
       auto charRange = Lexer::getCharSourceRangeFromSourceRange(
           SourceMgr, expr->getSourceRange());

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -494,7 +494,7 @@ SourceFileParsingResult parseSourceFile(SourceFile &SF) {
 
     case GeneratedSourceInfo::AccessorMacroExpansion: {
       ASTNode astNode = ASTNode::getFromOpaqueValue(generatedInfo->astNode);
-      auto attachedDecl = astNode.get<Decl *>();
+      auto attachedDecl = cast<Decl *>(astNode);
       auto accessorsForStorage = dyn_cast<AbstractStorageDecl>(attachedDecl);
 
       parser.parseTopLevelAccessors(accessorsForStorage, items);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -462,9 +462,8 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       if (Status.isErrorOrHasCompletion())
         NeedParseErrorRecovery = true;
       else if (!allowTopLevelCode()) {
-        diagnose(StartLoc,
-                 Result.is<Stmt*>() ? diag::illegal_top_level_stmt
-                                    : diag::illegal_top_level_expr);
+        diagnose(StartLoc, isa<Stmt *>(Result) ? diag::illegal_top_level_stmt
+                                               : diag::illegal_top_level_expr);
       }
 
       if (!Result.isNull()) {

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -246,7 +246,7 @@ static int compareImportModulesByName(const ImportModuleTy *left,
   if (leftSwiftModule && rightSwiftModule)
     return leftSwiftModule->getName().compare(rightSwiftModule->getName());
 
-  auto *leftClangModule = left->get<const clang::Module *>();
+  auto *leftClangModule = cast<const clang::Module *>(*left);
   assert((isCxx || leftClangModule->isSubModule()) &&
          "top-level modules should use a normal swift::ModuleDecl");
   if (rightSwiftModule) {
@@ -260,7 +260,7 @@ static int compareImportModulesByName(const ImportModuleTy *left,
     return 1;
   }
 
-  auto *rightClangModule = right->get<const clang::Module *>();
+  auto *rightClangModule = cast<const clang::Module *>(*right);
   assert((isCxx || rightClangModule->isSubModule()) &&
          "top-level modules should use a normal swift::ModuleDecl");
 
@@ -518,7 +518,7 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
         }
       }
     } else {
-      const auto *clangModule = import.get<const clang::Module *>();
+      const auto *clangModule = cast<const clang::Module *>(import);
       assert((useCxxImport || clangModule->isSubModule()) &&
              "top-level modules should use a normal swift::ModuleDecl");
       out << importDirective << ' ';

--- a/lib/Refactoring/Async/AsyncConverter.cpp
+++ b/lib/Refactoring/Async/AsyncConverter.cpp
@@ -48,7 +48,7 @@ bool AsyncConverter::createLegacyBody() {
   if (!canCreateLegacyBody())
     return false;
 
-  FuncDecl *FD = cast<FuncDecl>(StartNode.get<Decl *>());
+  FuncDecl *FD = cast<FuncDecl>(cast<Decl *>(StartNode));
   OS << tok::l_brace << "\n"; // start function body
   OS << "Task " << tok::l_brace << "\n";
   addHoistedNamedCallback(FD, TopHandler, TopHandler.getNameStr(), [&]() {
@@ -71,7 +71,7 @@ bool AsyncConverter::createLegacyBody() {
 
 bool AsyncConverter::createAsyncWrapper() {
   assert(Buffer.empty() && "AsyncConverter can only be used once");
-  auto *FD = cast<FuncDecl>(StartNode.get<Decl *>());
+  auto *FD = cast<FuncDecl>(cast<Decl *>(StartNode));
 
   // First add the new async function declaration.
   addFuncDecl(FD);
@@ -1429,7 +1429,7 @@ void AsyncConverter::addAwaitCall(const CallExpr *CE,
         convertPattern(P);
         return;
       }
-      OS << newNameFor(Elt.get<const Decl *>());
+      OS << newNameFor(cast<const Decl *>(Elt));
     });
     OS << " " << tok::equal << " ";
   }

--- a/lib/Refactoring/Async/AsyncRefactoring.h
+++ b/lib/Refactoring/Async/AsyncRefactoring.h
@@ -439,7 +439,7 @@ public:
     if (!hasTrailingReturnOrBreak())
       return;
 
-    auto *Node = Nodes.back().get<Stmt *>();
+    auto *Node = cast<Stmt *>(Nodes.back());
 
     // If this is a return statement with return expression, let's preserve it.
     if (auto *RS = dyn_cast<ReturnStmt>(Node)) {

--- a/lib/Refactoring/Async/AsyncRefactorings.cpp
+++ b/lib/Refactoring/Async/AsyncRefactorings.cpp
@@ -35,7 +35,7 @@ static CallExpr *findOuterCall(ResolvedCursorInfoPtr CursorInfo) {
   if (Contexts.empty())
     return nullptr;
 
-  CallExpr *CE = dyn_cast<CallExpr>(Contexts[0].get<Expr *>());
+  CallExpr *CE = dyn_cast<CallExpr>(cast<Expr *>(Contexts[0]));
   if (!CE)
     return nullptr;
 
@@ -65,7 +65,7 @@ static FuncDecl *findFunction(ResolvedCursorInfoPtr CursorInfo) {
   if (Contexts.back().isDecl(DeclKind::Param))
     Contexts = Contexts.drop_back();
 
-  auto *FD = dyn_cast_or_null<FuncDecl>(Contexts.back().get<Decl *>());
+  auto *FD = dyn_cast_or_null<FuncDecl>(cast<Decl *>(Contexts.back()));
   if (!FD || isa<AccessorDecl>(FD))
     return nullptr;
 
@@ -121,7 +121,7 @@ bool RefactoringActionConvertCallToAsyncAlternative::performChange() {
   auto Scopes = Finder.getContexts();
   BraceStmt *Scope = nullptr;
   if (!Scopes.empty())
-    Scope = cast<BraceStmt>(Scopes.back().get<Stmt *>());
+    Scope = cast<BraceStmt>(cast<Stmt *>(Scopes.back()));
 
   AsyncConverter Converter(TheFile, SM, DiagEngine, CE, Scope);
   if (!Converter.convert())

--- a/lib/Refactoring/ConvertStringConcatenationToInterpolation.cpp
+++ b/lib/Refactoring/ConvertStringConcatenationToInterpolation.cpp
@@ -21,7 +21,7 @@ findConcatenatedExpressions(const ResolvedRangeInfo &Info, ASTContext &Ctx) {
 
   switch (Info.Kind) {
   case RangeKind::SingleExpression:
-    E = Info.ContainedNodes[0].get<Expr *>();
+    E = cast<Expr *>(Info.ContainedNodes[0]);
     break;
   case RangeKind::PartOfExpression:
     E = Info.CommonExprParent;

--- a/lib/Refactoring/ExpandSwitchCases.cpp
+++ b/lib/Refactoring/ExpandSwitchCases.cpp
@@ -62,8 +62,8 @@ static bool performCasesExpansionInSwitchStmt(SwitchStmt *SwitchS,
 static SwitchStmt *findEnclosingSwitchStmt(CaseStmt *CS, SourceFile *SF,
                                            DiagnosticEngine &DiagEngine) {
   auto IsSwitch = [](ASTNode Node) {
-    return Node.is<Stmt *>() &&
-           Node.get<Stmt *>()->getKind() == StmtKind::Switch;
+    return isa<Stmt *>(Node) &&
+           cast<Stmt *>(Node)->getKind() == StmtKind::Switch;
   };
   ContextFinder Finder(*SF, CS, IsSwitch);
   Finder.resolve();
@@ -74,7 +74,7 @@ static SwitchStmt *findEnclosingSwitchStmt(CaseStmt *CS, SourceFile *SF,
     return nullptr;
   }
   auto *SwitchS =
-      static_cast<SwitchStmt *>(Finder.getContexts().back().get<Stmt *>());
+      static_cast<SwitchStmt *>(cast<Stmt *>(Finder.getContexts().back()));
   // Make sure that CaseStmt is included in switch that was found.
   auto Cases = SwitchS->getCases();
   auto Default = std::find(Cases.begin(), Cases.end(), CS);

--- a/lib/Refactoring/ExtractExprBase.cpp
+++ b/lib/Refactoring/ExtractExprBase.cpp
@@ -158,7 +158,7 @@ swift::refactoring::checkExtractConditions(const ResolvedRangeInfo &RangeInfo,
 
   // Disallow extracting certain kinds of statements.
   if (RangeInfo.Kind == RangeKind::SingleStatement) {
-    Stmt *S = RangeInfo.ContainedNodes[0].get<Stmt *>();
+    Stmt *S = cast<Stmt *>(RangeInfo.ContainedNodes[0]);
 
     // These aren't independent statement.
     if (isa<BraceStmt>(S) || isa<CaseStmt>(S))
@@ -167,7 +167,7 @@ swift::refactoring::checkExtractConditions(const ResolvedRangeInfo &RangeInfo,
 
   // Disallow extracting literals.
   if (RangeInfo.Kind == RangeKind::SingleExpression) {
-    Expr *E = RangeInfo.ContainedNodes[0].get<Expr *>();
+    Expr *E = cast<Expr *>(RangeInfo.ContainedNodes[0]);
 
     // Until implementing the performChange() part of extracting trailing
     // closures, we disable them for now.
@@ -211,7 +211,7 @@ bool RefactoringActionExtractExprBase::performChange() {
   ContextFinder Finder(*TheFile, RangeInfo.ContainedNodes.front(),
                        [](ASTNode N) { return N.isStmt(StmtKind::Brace); });
 
-  auto *SelectedExpr = RangeInfo.ContainedNodes[0].get<Expr *>();
+  auto *SelectedExpr = cast<Expr *>(RangeInfo.ContainedNodes[0]);
   Finder.resolve();
   SourceLoc InsertLoc;
   llvm::SetVector<ValueDecl *> AllVisibleDecls;
@@ -231,7 +231,7 @@ bool RefactoringActionExtractExprBase::performChange() {
 
     // Get the innermost brace statement.
     auto BS =
-        static_cast<BraceStmt *>(Finder.getContexts().back().get<Stmt *>());
+        static_cast<BraceStmt *>(cast<Stmt *>(Finder.getContexts().back()));
 
     // Collect all value decls inside the brace statement.
     Collector.walk(BS);

--- a/lib/Refactoring/TrailingClosure.cpp
+++ b/lib/Refactoring/TrailingClosure.cpp
@@ -34,13 +34,13 @@ static CallExpr *findTrailingClosureTarget(SourceManager &SM,
 
   // If the innermost context is a statement (which will be a BraceStmt per
   // the filtering condition above), drop it.
-  if (contexts.back().is<Stmt *>()) {
+  if (isa<Stmt *>(contexts.back())) {
     contexts = contexts.drop_back();
   }
 
-  if (contexts.empty() || !contexts.back().is<Expr *>())
+  if (contexts.empty() || !isa<Expr *>(contexts.back()))
     return nullptr;
-  CallExpr *CE = cast<CallExpr>(contexts.back().get<Expr *>());
+  CallExpr *CE = cast<CallExpr>(cast<Expr *>(contexts.back()));
 
   // The last argument is a non-trailing closure?
   auto *Args = CE->getArgs();

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -388,7 +388,7 @@ ScopeCloner::ScopeCloner(SILFunction &NewFn) : NewFn(NewFn) {
   // debug scope. Create a new one here.
   // FIXME: Audit all call sites and make them create the function
   // debug scope.
-  auto *SILFn = NewFn.getDebugScope()->Parent.get<SILFunction *>();
+  auto *SILFn = cast<SILFunction *>(NewFn.getDebugScope()->Parent);
   if (SILFn != &NewFn) {
     SILFn->setInlined();
     NewFn.setDebugScope(getOrCreateClonedScope(NewFn.getDebugScope()));

--- a/lib/SIL/IR/SILDebugScope.cpp
+++ b/lib/SIL/IR/SILDebugScope.cpp
@@ -43,10 +43,10 @@ SILFunction *SILDebugScope::getInlinedFunction() const {
     return nullptr;
 
   const SILDebugScope *Scope = this;
-  while (Scope->Parent.is<const SILDebugScope *>())
-    Scope = Scope->Parent.get<const SILDebugScope *>();
-  assert(Scope->Parent.is<SILFunction *>() && "orphaned scope");
-  return Scope->Parent.get<SILFunction *>();
+  while (isa<const SILDebugScope *>(Scope->Parent))
+    Scope = cast<const SILDebugScope *>(Scope->Parent);
+  assert(isa<SILFunction *>(Scope->Parent) && "orphaned scope");
+  return cast<SILFunction *>(Scope->Parent);
 }
 
 SILFunction *SILDebugScope::getParentFunction() const {
@@ -54,7 +54,7 @@ SILFunction *SILDebugScope::getParentFunction() const {
     return InlinedCallSite->getParentFunction();
   if (auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>())
     return ParentScope->getParentFunction();
-  return Parent.get<SILFunction *>();
+  return cast<SILFunction *>(Parent);
 }
 
 /// Determine whether an instruction may not have a SILDebugScope.

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -751,17 +751,17 @@ SILDeclRef SILDeclRef::getMainFileEntryPoint(FileUnit *file) {
 }
 
 bool SILDeclRef::hasClosureExpr() const {
-  return loc.is<AbstractClosureExpr *>()
-    && isa<ClosureExpr>(getAbstractClosureExpr());
+  return isa<AbstractClosureExpr *>(loc) &&
+         isa<ClosureExpr>(getAbstractClosureExpr());
 }
 
 bool SILDeclRef::hasAutoClosureExpr() const {
-  return loc.is<AbstractClosureExpr *>()
-    && isa<AutoClosureExpr>(getAbstractClosureExpr());
+  return isa<AbstractClosureExpr *>(loc) &&
+         isa<AutoClosureExpr>(getAbstractClosureExpr());
 }
 
 bool SILDeclRef::hasFuncDecl() const {
-  return loc.is<ValueDecl *>() && isa<FuncDecl>(getDecl());
+  return isa<ValueDecl *>(loc) && isa<FuncDecl>(getDecl());
 }
 
 ClosureExpr *SILDeclRef::getClosureExpr() const {

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -121,7 +121,7 @@ SILModule::SILModule(llvm::PointerUnion<FileUnit *, ModuleDecl *> context,
   if (auto *file = context.dyn_cast<FileUnit *>()) {
     AssociatedDeclContext = file;
   } else {
-    AssociatedDeclContext = context.get<ModuleDecl *>();
+    AssociatedDeclContext = cast<ModuleDecl *>(context);
   }
   TheSwiftModule = AssociatedDeclContext->getParentModule();
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1206,7 +1206,7 @@ public:
       if (auto *F = DS->Parent.dyn_cast<SILFunction *>())
         *this << "@" << F->getName() << " : $" << F->getLoweredFunctionType();
       else {
-        auto *PS = DS->Parent.get<const SILDebugScope *>();
+        auto *PS = cast<const SILDebugScope *>(DS->Parent);
         *this << Ctx.getScopeID(PS);
       }
       if (auto *CS = DS->InlinedCallSite)

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1285,10 +1285,10 @@ bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
     P, FullName[0], /*typeLookup=*/FullName.size() > 1);
   // It is possible that the last member lookup can return multiple lookup
   // results. One example is the overloaded member functions.
-  if (Res.is<ModuleDecl*>()) {
+  if (isa<ModuleDecl *>(Res)) {
     assert(FullName.size() > 1 &&
            "A single module is not a full path to SILDeclRef");
-    auto Mod = Res.get<ModuleDecl*>();
+    auto Mod = cast<ModuleDecl *>(Res);
     values.clear();
     VD = lookupMember(P, ModuleType::get(Mod), FullName[1], Locs[1], values,
                       FullName.size() == 2/*ExpectMultipleResults*/);
@@ -1298,7 +1298,7 @@ bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
                         I == FullName.size() - 1/*ExpectMultipleResults*/);
     }
   } else {
-    VD = Res.get<ValueDecl*>();
+    VD = cast<ValueDecl *>(Res);
     for (unsigned I = 1, E = FullName.size(); I < E; ++I) {
       values.clear();
       VD = lookupMember(P, VD->getInterfaceType(), FullName[I], Locs[I], values,
@@ -7750,8 +7750,8 @@ bool SILParserState::parseSILVTable(Parser &P) {
     // Find the class decl.
     llvm::PointerUnion<ValueDecl*, ModuleDecl *> Res =
       lookupTopDecl(P, Name, /*typeLookup=*/true);
-    assert(Res.is<ValueDecl*>() && "Class look-up should return a Decl");
-    ValueDecl *VD = Res.get<ValueDecl*>();
+    assert(isa<ValueDecl *>(Res) && "Class look-up should return a Decl");
+    ValueDecl *VD = cast<ValueDecl *>(Res);
     if (!VD) {
       P.diagnose(Loc, diag::sil_vtable_class_not_found, Name);
       return true;
@@ -7870,8 +7870,8 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
   // Find the nominal decl.
   llvm::PointerUnion<ValueDecl *, ModuleDecl *> res =
       lookupTopDecl(parser, name, /*typeLookup=*/true);
-  assert(res.is<ValueDecl *>() && "Class Nominal-up should return a Decl");
-  ValueDecl *varDecl = res.get<ValueDecl *>();
+  assert(isa<ValueDecl *>(res) && "Class Nominal-up should return a Decl");
+  ValueDecl *varDecl = cast<ValueDecl *>(res);
   if (!varDecl) {
     parser.diagnose(loc, diag::sil_moveonlydeinit_nominal_not_found, name);
     return true;
@@ -7926,8 +7926,8 @@ static ClassDecl *parseClassDecl(Parser &P, SILParser &SP) {
   // Find the protocol decl. The protocol can be imported.
   llvm::PointerUnion<ValueDecl *, ModuleDecl *> Res =
       lookupTopDecl(P, DeclName, /*typeLookup=*/true);
-  assert(Res.is<ValueDecl *>() && "Protocol look-up should return a Decl");
-  ValueDecl *VD = Res.get<ValueDecl *>();
+  assert(isa<ValueDecl *>(Res) && "Protocol look-up should return a Decl");
+  ValueDecl *VD = cast<ValueDecl *>(Res);
   if (!VD) {
     P.diagnose(DeclLoc, diag::sil_default_override_class_not_found, DeclName);
     return nullptr;
@@ -7947,8 +7947,8 @@ static ProtocolDecl *parseProtocolDecl(Parser &P, SILParser &SP) {
   // Find the protocol decl. The protocol can be imported.
   llvm::PointerUnion<ValueDecl*, ModuleDecl *> Res =
     lookupTopDecl(P, DeclName, /*typeLookup=*/true);
-  assert(Res.is<ValueDecl*>() && "Protocol look-up should return a Decl");
-  ValueDecl *VD = Res.get<ValueDecl*>();
+  assert(isa<ValueDecl *>(Res) && "Protocol look-up should return a Decl");
+  ValueDecl *VD = cast<ValueDecl *>(Res);
   if (!VD) {
     P.diagnose(DeclLoc, diag::sil_witness_protocol_not_found, DeclName);
     return nullptr;

--- a/lib/SIL/Utils/DebugUtils.cpp
+++ b/lib/SIL/Utils/DebugUtils.cpp
@@ -34,7 +34,7 @@ bool swift::hasNonTrivialNonDebugTransitiveUsers(
       Worklist.push_back(User);
     }
   } else {
-    auto *I = V.get<SILInstruction *>();
+    auto *I = cast<SILInstruction *>(V);
     SeenInsts.insert(I);
     Worklist.push_back(I);
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1235,7 +1235,7 @@ public:
 
     auto *DebugScope = F.getDebugScope();
     require(DebugScope, "All SIL functions must have a debug scope");
-    require(DebugScope->Parent.get<SILFunction *>() == &F,
+    require(cast<SILFunction *>(DebugScope->Parent) == &F,
             "Scope of SIL function points to different function");
   }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1715,7 +1715,7 @@ void SILGenFunction::visitMacroExpansionDecl(MacroExpansionDecl *D) {
     else if (auto *stmt = node.dyn_cast<Stmt *>())
       emitStmt(stmt);
     else
-      visit(node.get<Decl *>());
+      visit(cast<Decl *>(node));
   });
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2498,7 +2498,7 @@ visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *E,
   auto parent = SGF.getPGOParent(E);
   if (parent) {
     auto &Node = parent.value();
-    auto *NodeS = Node.get<Stmt *>();
+    auto *NodeS = cast<Stmt *>(Node);
     if (auto *IS = dyn_cast<IfStmt>(NodeS)) {
       trueCount = SGF.loadProfilerCount(IS->getThenStmt());
       if (auto *ElseStmt = IS->getElseStmt()) {
@@ -7350,7 +7350,7 @@ RValue RValueEmitter::visitMacroExpansionExpr(MacroExpansionExpr *E,
       else if (auto *stmt = node.dyn_cast<Stmt *>())
         SGF.emitStmt(stmt);
       else
-        SGF.visit(node.get<Decl *>());
+        SGF.visit(cast<Decl *>(node));
     });
     return RValue();
   }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -334,7 +334,7 @@ static MacroInfo getMacroInfo(const GeneratedSourceInfo &Info,
       Result.ExpansionLoc = RegularLocation(expr);
       Result.Name = mangler.mangleMacroExpansion(expr);
     } else {
-      auto decl = cast<MacroExpansionDecl>(parent.get<Decl *>());
+      auto decl = cast<MacroExpansionDecl>(cast<Decl *>(parent));
       Result.ExpansionLoc = RegularLocation(decl);
       Result.Name = mangler.mangleMacroExpansion(decl);
     }
@@ -350,7 +350,7 @@ static MacroInfo getMacroInfo(const GeneratedSourceInfo &Info,
   case GeneratedSourceInfo::DeclarationMacroExpansion: 
   case GeneratedSourceInfo::CodeItemMacroExpansion: {
     auto expansion = cast<MacroExpansionDecl>(
-        ASTNode::getFromOpaqueValue(Info.astNode).get<Decl *>());
+        cast<Decl *>(ASTNode::getFromOpaqueValue(Info.astNode)));
     Result.ExpansionLoc = RegularLocation(expansion);
     Result.Name = mangler.mangleMacroExpansion(expansion);
     Result.Freestanding = true;
@@ -367,7 +367,7 @@ static MacroInfo getMacroInfo(const GeneratedSourceInfo &Info,
   case GeneratedSourceInfo::ExtensionMacroExpansion:
   case GeneratedSourceInfo::PreambleMacroExpansion:
   case GeneratedSourceInfo::BodyMacroExpansion: {
-    auto decl = ASTNode::getFromOpaqueValue(Info.astNode).get<Decl *>();
+    auto decl = cast<Decl *>(ASTNode::getFromOpaqueValue(Info.astNode));
     auto attr = Info.attachedMacroCustomAttr;
     if (auto *macroDecl = decl->getResolvedMacro(attr)) {
       Result.ExpansionLoc = RegularLocation(macroDecl);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -530,8 +530,8 @@ public:
       }
 
       State *getState() {
-        ASSERT(!stateOrAlias.is<VarDecl*>()
-               && "must get state from original AddressableBuffer");
+        ASSERT(!isa<VarDecl *>(stateOrAlias) &&
+               "must get state from original AddressableBuffer");
         return stateOrAlias.dyn_cast<State*>();
       }
       

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -143,18 +143,16 @@ public:
   }
 
   SILType getType() const {
-    if (value.is<SILValue>()) {
-      return value.get<SILValue>()->getType();
+    if (isa<SILValue>(value)) {
+      return cast<SILValue>(value)->getType();
     } else {
-      return value.get<SILType>();
+      return cast<SILType>(value);
     }
   }
 
-  bool hasAddress() const { return value.is<SILValue>(); }
+  bool hasAddress() const { return isa<SILValue>(value); }
 
-  SILValue getAddress() const {
-    return value.get<SILValue>();
-  }
+  SILValue getAddress() const { return cast<SILValue>(value); }
 
   SILValue allocate(SILGenFunction &SGF, SILLocation loc) const {
     if (hasAddress()) return getAddress();

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -52,12 +52,12 @@ evaluator::DependencySource ASTLoweringRequest::readDependencySource(
   auto &desc = std::get<0>(getStorage());
 
   // We don't track dependencies in whole-module mode.
-  if (desc.context.is<ModuleDecl *>()) {
+  if (isa<ModuleDecl *>(desc.context)) {
     return nullptr;
   }
 
   // If we have a single source file, it's the source of dependencies.
-  return dyn_cast<SourceFile>(desc.context.get<FileUnit *>());
+  return dyn_cast<SourceFile>(cast<FileUnit *>(desc.context));
 }
 
 ArrayRef<FileUnit *> ASTLoweringDescriptor::getFilesToEmit() const {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -427,7 +427,7 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
     } else if (auto *E = ESD.dyn_cast<Expr*>()) {
       SGF.emitIgnoredExpr(E);
     } else {
-      auto *D = ESD.get<Decl*>();
+      auto *D = cast<Decl *>(ESD);
       assert((isa<PatternBindingDecl>(D) || isa<VarDecl>(D)) &&
              "other decls should be handled before the reachability check");
       SGF.visit(D);

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -458,7 +458,7 @@ void SILGenTopLevel::visitTopLevelCodeDecl(TopLevelCodeDecl *TD) {
     } else if (auto *E = ESD.dyn_cast<Expr *>()) {
       SGF.emitIgnoredExpr(E);
     } else {
-      SGF.visit(ESD.get<Decl *>());
+      SGF.visit(cast<Decl *>(ESD));
     }
   }
 }

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -35,15 +35,13 @@ LoopRegion::~LoopRegion() {
 }
 
 LoopRegion::BlockTy *LoopRegion::getBlock() const {
-  return Ptr.get<BlockTy *>();
+  return cast<BlockTy *>(Ptr);
 }
 
-LoopRegion::LoopTy *LoopRegion::getLoop() const {
-  return Ptr.get<LoopTy *>();
-}
+LoopRegion::LoopTy *LoopRegion::getLoop() const { return cast<LoopTy *>(Ptr); }
 
 LoopRegion::FunctionTy *LoopRegion::getFunction() const {
-  return Ptr.get<FunctionTy *>();
+  return cast<FunctionTy *>(Ptr);
 }
 
 void LoopRegion::dump(bool isVerbose) const {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2380,7 +2380,7 @@ public:
 
     // If we didn't find a partial_apply, then we must have had a
     // thin_to_thick_function meaning we did not capture anything.
-    if (source->is<ThinToThickFunctionInst *>())
+    if (isa<ThinToThickFunctionInst *>(source.value()))
       return;
 
     // If our partial_apply was Sendable, then Sema should have checked that
@@ -2388,7 +2388,7 @@ public:
     // error earlier.
     assert(bool(source.value()) &&
            "AsyncLet Get should always have a derivable partial_apply");
-    auto *pai = source->get<PartialApplyInst *>();
+    auto *pai = cast<PartialApplyInst *>(source.value());
     if (pai->getFunctionType()->isSendable())
       return;
 

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -299,7 +299,7 @@ class DeadFunctionAndGlobalElimination {
     for (FuncImpl &FImpl : mi->implementingFunctions) {
       if (!isAlive(FImpl.F) &&
           canHaveSameImplementation(FD, MethodCl,
-                                    FImpl.Impl.get<ClassDecl *>())) {
+                                    cast<ClassDecl *>(FImpl.Impl))) {
         ensureAlive(FImpl.F);
       } else {
         allImplsAreCalled = false;

--- a/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
+++ b/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
@@ -125,8 +125,8 @@ struct DebugInfoCanonicalizer {
       SILBasicBlock *startBlock,
       llvm::SmallDenseSet<SILDebugVariable, 8> &seenDebugVars) {
     LLVM_DEBUG(llvm::dbgs() << "==> PROPAGATING VALUE\n");
-    if (insertPt.is<SILInstruction *>()) {
-      LLVM_DEBUG(llvm::dbgs() << "Inst: " << *insertPt.get<SILInstruction *>());
+    if (isa<SILInstruction *>(insertPt)) {
+      LLVM_DEBUG(llvm::dbgs() << "Inst: " << *cast<SILInstruction *>(insertPt));
     }
 
     auto *dt = getDominance();
@@ -172,7 +172,7 @@ struct DebugInfoCanonicalizer {
         if (auto *inst = insertPt.dyn_cast<SILInstruction *>()) {
           cloneDebugValue(pred.second, inst);
         } else {
-          cloneDebugValue(pred.second, insertPt.get<SILBasicBlock *>());
+          cloneDebugValue(pred.second, cast<SILBasicBlock *>(insertPt));
         }
 
         madeChange = true;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -368,7 +368,7 @@ static SILValue cleanupLoadedCalleeValue(SILValue calleeValue) {
                                                           calleeValue);
         sri->eraseFromParent();
       } else {
-        auto *dvi = destroy.get<DestroyValueInst *>();
+        auto *dvi = cast<DestroyValueInst *>(destroy);
         SILBuilderWithScope(dvi).emitDestroyValueAndFold(dvi->getLoc(),
                                                          calleeValue);
         dvi->eraseFromParent();

--- a/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
@@ -175,11 +175,11 @@ bool swift::semanticarc::tryConvertOwnedPhisToGuaranteedPhis(Context &ctx) {
       std::function<Operand *(const Context::ConsumingOperandState)> lambda =
         [&](const Context::ConsumingOperandState &state) -> Operand * {
             unsigned opNum = state.operandNumber;
-            if (state.parent.is<SILBasicBlock *>()) {
-              SILBasicBlock *block = state.parent.get<SILBasicBlock *>();
+            if (isa<SILBasicBlock *>(state.parent)) {
+              SILBasicBlock *block = cast<SILBasicBlock *>(state.parent);
               return &block->getTerminator()->getAllOperands()[opNum];
             }
-            SILInstruction *inst = state.parent.get<SILInstruction *>();
+            SILInstruction *inst = cast<SILInstruction *>(state.parent);
             return &inst->getAllOperands()[opNum];
         };
       auto operandsTransformed = makeTransformRange(pair.second, lambda);

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -107,7 +107,7 @@ static bool isVisibleExternally(DisjointAccessLocationKey key, SILModule *mod) {
   if (auto *decl = key.dyn_cast<const VarDecl *>())
     return mod->isVisibleExternally(decl);
 
-  auto *global = key.get<const SILGlobalVariable *>();
+  auto *global = cast<const SILGlobalVariable *>(key);
   return isPossiblyUsedExternally(global->getLinkage(), mod->isWholeModule());
 }
 
@@ -115,7 +115,7 @@ static StringRef getName(DisjointAccessLocationKey key) {
   if (auto *decl = key.dyn_cast<const VarDecl *>())
     return decl->getNameStr();
 
-  return key.get<const SILGlobalVariable *>()->getName();
+  return cast<const SILGlobalVariable *>(key)->getName();
 }
 
 namespace {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1029,7 +1029,7 @@ void swift::emitDestroyOperation(SILBuilder &builder, SILLocation loc,
       return;
     }
 
-    callbacks.createdNewInst(u.get<StrongReleaseInst *>());
+    callbacks.createdNewInst(cast<StrongReleaseInst *>(u));
     return;
   }
 
@@ -1042,7 +1042,7 @@ void swift::emitDestroyOperation(SILBuilder &builder, SILLocation loc,
     return;
   }
 
-  callbacks.createdNewInst(u.get<ReleaseValueInst *>());
+  callbacks.createdNewInst(cast<ReleaseValueInst *>(u));
 }
 
 // NOTE: The ownership of the partial_apply argument does not match the

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -216,7 +216,7 @@ protected:
       return std::nullopt;
     }
 
-    auto *expr = element.get<Expr *>();
+    auto *expr = cast<Expr *>(element);
     if (auto *SVE = dyn_cast<SingleValueStmtExpr>(expr)) {
       // This should never be treated as an expression in a result builder, it
       // should have statement semantics.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -640,7 +640,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
           auto path = fix->getLocator()->getPath();
           SourceRange range;
           simplifyLocator(anchor, path, range);
-          if (anchor && anchor.is<Expr *>())
+          if (anchor && isa<Expr *>(anchor))
             anchors.insert(getAsExpr(anchor));
         }
       }
@@ -4861,7 +4861,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
   auto anchor = getAnchor();
 
-  if (!anchor.is<Expr *>())
+  if (!isa<Expr *>(anchor))
     return false;
 
   Expr *expr = findParentExpr(castToExpr(anchor));
@@ -5960,7 +5960,7 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
         nameOS << "<#Result#>";
     }
 
-    if (auto stmt = bodyStmts.front().get<Stmt *>()) {
+    if (auto *stmt = cast<Stmt *>(bodyStmts.front())) {
       // If the body is a single expression with implicit return.
       if (isa<ReturnStmt>(stmt) && stmt->isImplicit()) {
         // And there is non-void expected result type,
@@ -6855,7 +6855,7 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
     return;
 
   auto *GTD = dyn_cast<GenericTypeDecl>(paramDC);
-  if (!GTD || anchor.is<Expr *>())
+  if (!GTD || isa<Expr *>(anchor))
     return;
 
   auto getParamDecl =
@@ -6995,7 +6995,7 @@ SourceLoc SkipUnhandledConstructInResultBuilderFailure::getLoc() const {
   if (auto stmt = unhandled.dyn_cast<Stmt *>())
     return stmt->getStartLoc();
 
-  return unhandled.get<Decl *>()->getLoc();
+  return cast<Decl *>(unhandled)->getLoc();
 }
 
 /// Determine whether the given "if" chain has a missing "else".

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11498,7 +11498,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
             // `key path` constraint can't be retired until all components
             // are simplified.
             addTypeVariableConstraintsToWorkList(memberTypeVar);
-          } else if (locator->getAnchor().is<Expr *>() &&
+          } else if (isa<Expr *>(locator->getAnchor()) &&
                      !getSemanticsProvidingParentExpr(
                          getAsExpr(locator->getAnchor()))) {
             // If there are no contextual expressions that could provide

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -671,7 +671,7 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     }
     else {
       out << " to fixed type ";
-      parentOrFixed.get<TypeBase *>()->print(out, PO);
+      cast<TypeBase *>(parentOrFixed)->print(out, PO);
     }
     out << " with options 0x";
     out.write_hex(Options);
@@ -917,7 +917,7 @@ void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,
         }
       }
 
-      if (typeVar->getImpl().ParentOrFixed.is<TypeBase *>())
+      if (isa<TypeBase *>(typeVar->getImpl().ParentOrFixed))
         assignments.push_back(typeVar);
     }
 
@@ -930,7 +930,7 @@ void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,
       for (auto *typeVar : assignments) {
         out.indent(indent + 4);
         out << "> $T" << typeVar->getImpl().getID() << " := ";
-        typeVar->getImpl().ParentOrFixed.get<TypeBase *>()->print(out, PO);
+        cast<TypeBase *>(typeVar->getImpl().ParentOrFixed)->print(out, PO);
         out << '\n';
       }
       out.indent(indent + 2);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -899,7 +899,7 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
       llvm_unreachable("unsupported storage kind");
     }
   } else {
-    distributedTarget = originator.get<AbstractFunctionDecl *>();
+    distributedTarget = cast<AbstractFunctionDecl *>(originator);
     if (!distributedTarget->isDistributed())
       return nullptr;
   }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -395,7 +395,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
     if (auto patternBindingElt =
             locator
                 ->getLastElementAs<LocatorPathElt::PatternBindingElement>()) {
-      auto *patternBinding = cast<PatternBindingDecl>(element.get<Decl *>());
+      auto *patternBinding = cast<PatternBindingDecl>(cast<Decl *>(element));
       Out << "pattern binding element @ ";
       Out << patternBindingElt->getIndex() << " : ";
       Out << '\n';

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -810,7 +810,7 @@ namespace {
 
       for (auto typeVar : typeVars) {
         auto &impl = typeVar->getImpl();
-        if (impl.getRepresentativeOrFixed().is<TypeBase *>()) {
+        if (isa<TypeBase *>(impl.getRepresentativeOrFixed())) {
           auto &node = cg[typeVar];
           for (auto otherTypeVar : node.getReferencedVars()) {
             unionSets(typeVar, otherTypeVar);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -71,7 +71,7 @@ SourceRange ExpressionTimer::getAffectedRange() const {
     if (!anchor)
       anchor = locator->getAnchor();
   } else {
-    anchor = Anchor.get<Expr *>();
+    anchor = cast<Expr *>(Anchor);
   }
 
   return anchor.getSourceRange();
@@ -88,7 +88,7 @@ ExpressionTimer::~ExpressionTimer() {
     if (auto *E = Anchor.dyn_cast<Expr *>()) {
       E->getLoc().print(llvm::errs(), Context.SourceMgr);
     } else {
-      auto *locator = Anchor.get<ConstraintLocator *>();
+      auto *locator = cast<ConstraintLocator *>(Anchor);
       locator->dump(&Context.SourceMgr, llvm::errs());
     }
     llvm::errs() << "\n";
@@ -523,7 +523,7 @@ void ConstraintSystem::recordPotentialThrowSite(
 
   // do..catch statements without an explicit `throws` clause do infer
   // thrown types.
-  if (catchNode.is<DoCatchStmt *>()) {
+  if (isa<DoCatchStmt *>(catchNode)) {
     PotentialThrowSite site{kind, type, getConstraintLocator(locator)};
     recordPotentialThrowSite(catchNode, site);
     return;
@@ -531,7 +531,7 @@ void ConstraintSystem::recordPotentialThrowSite(
 
   // Closures without an explicit `throws` clause, and which syntactically
   // appear that they can throw, do infer thrown types.
-  auto closure = catchNode.get<ClosureExpr *>();
+  auto closure = cast<ClosureExpr *>(catchNode);
 
   // Check whether the closure syntactically throws. If not, there is no
   // need to record a throw site.
@@ -3581,7 +3581,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
         path = path.slice(1);
         continue;
       }
-      if (anchor.is<Pattern *>()) {
+      if (isa<Pattern *>(anchor)) {
         path = path.slice(1);
         continue;
       }
@@ -3594,7 +3594,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
         continue;
       }
 
-      if (anchor.is<Pattern *>()) {
+      if (isa<Pattern *>(anchor)) {
         path = path.slice(1);
         continue;
       }
@@ -3814,7 +3814,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::PatternBindingElement: {
       auto pattern = path[0].castTo<LocatorPathElt::PatternBindingElement>();
-      auto *patternBinding = cast<PatternBindingDecl>(anchor.get<Decl *>());
+      auto *patternBinding = cast<PatternBindingDecl>(cast<Decl *>(anchor));
       anchor = patternBinding->getInit(pattern.getIndex());
       // If this pattern is uninitialized, let's use it as anchor.
       if (!anchor)
@@ -3824,7 +3824,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
     }
 
     case ConstraintLocator::NamedPatternDecl: {
-      auto pattern = cast<NamedPattern>(anchor.get<Pattern *>());
+      auto pattern = cast<NamedPattern>(cast<Pattern *>(anchor));
       anchor = pattern->getDecl();
       path = path.slice(1);
       break;
@@ -4873,7 +4873,7 @@ SourceLoc constraints::getLoc(ASTNode anchor) {
   } else if (auto *C = anchor.dyn_cast<StmtConditionElement *>()) {
     return C->getStartLoc();
   } else {
-    auto *I = anchor.get<CaseLabelItem *>();
+    auto *I = cast<CaseLabelItem *>(anchor);
     return I->getStartLoc();
   }
 }

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -72,13 +72,15 @@ struct UnboundImport {
       importOrUnderlyingModuleDecl;
 
   NullablePtr<ImportDecl> getImportDecl() const {
-    return importOrUnderlyingModuleDecl.is<NullablePtr<ImportDecl>>() ?
-           importOrUnderlyingModuleDecl.get<NullablePtr<ImportDecl>>() : nullptr;
+    return isa<NullablePtr<ImportDecl>>(importOrUnderlyingModuleDecl)
+               ? cast<NullablePtr<ImportDecl>>(importOrUnderlyingModuleDecl)
+               : nullptr;
   }
 
   NullablePtr<ModuleDecl> getUnderlyingModule() const {
-    return importOrUnderlyingModuleDecl.is<ModuleDecl *>() ?
-           importOrUnderlyingModuleDecl.get<ModuleDecl *>() : nullptr;
+    return isa<ModuleDecl *>(importOrUnderlyingModuleDecl)
+               ? cast<ModuleDecl *>(importOrUnderlyingModuleDecl)
+               : nullptr;
   }
 
   /// Create an UnboundImport for a user-written import declaration.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -580,7 +580,7 @@ static void lookupVisibleCxxNamespaceMemberDecls(
             {});
 
         for (auto found : allResults) {
-          auto clangMember = found.get<clang::NamedDecl *>();
+          auto clangMember = cast<clang::NamedDecl *>(found);
           if (auto importedDecl =
                   ctx.getClangModuleLoader()->importDeclDirectly(
                       cast<clang::NamedDecl>(clangMember))) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3372,9 +3372,9 @@ public:
       // If this is a TopLevelCodeDecl, scan for global variables
       auto *body = TLCD->getBody();
       for (auto node : body->getElements()) {
-        if (node.is<Decl *>()) {
+        if (isa<Decl *>(node)) {
           // Flag all variables in a PatternBindingDecl
-          Decl *D = node.get<Decl *>();
+          Decl *D = cast<Decl *>(node);
           auto *PBD = dyn_cast<PatternBindingDecl>(D);
           if (!PBD) continue;
           for (auto idx : range(PBD->getNumPatternEntries())) {
@@ -3382,9 +3382,9 @@ public:
               VarDecls[VD] = RK_Read|RK_Written|RK_Defined;
             });
           }
-        } else if (node.is<Stmt *>()) {
+        } else if (isa<Stmt *>(node)) {
           // Flag all variables in guard statements
-          Stmt *S = node.get<Stmt *>();
+          Stmt *S = cast<Stmt *>(node);
           auto *GS = dyn_cast<GuardStmt>(S);
           if (!GS) continue;
           for (StmtConditionElement SCE : GS->getCond()) {

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -133,7 +133,7 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
     // The only subclass that can be explicit is this one.
     closure = cast<ClosureExpr>(anyClosure);
   } else {
-    functionRepr = node.get<FunctionTypeRepr *>();
+    functionRepr = cast<FunctionTypeRepr *>(node);
   }
 
   // The execution behavior changes only for nonisolated functions.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -370,7 +370,7 @@ GlobalActorAttributeRequest::evaluate(
     // This is a workaround for rdar://79563942
     loc = decl->getLoc(/* SerializedOK */ false);
   } else {
-    auto closure = subject.get<ClosureExpr *>();
+    auto closure = cast<ClosureExpr *>(subject);
     dc = closure;
     declAttrs = &closure->getAttrs();
     loc = closure->getLoc();
@@ -389,13 +389,13 @@ GlobalActorAttributeRequest::evaluate(
     return std::nullopt;
 
   // Closures can always have a global actor attached.
-  if (subject.is<ClosureExpr *>()) {
+  if (isa<ClosureExpr *>(subject)) {
     return result;
   }
 
   // Check that a global actor attribute makes sense on this kind of
   // declaration.
-  auto decl = subject.get<Decl *>();
+  auto decl = cast<Decl *>(subject);
 
   // no further checking required if it's from a serialized module.
   if (decl->getDeclContext()->getParentSourceFile() == nullptr)
@@ -693,7 +693,7 @@ static bool isAsyncCall(
     return funcType->isAsync();
   }
 
-  auto *lookup = call.get<LookupExpr *>();
+  auto *lookup = cast<LookupExpr *>(call);
   if (lookup->isImplicitlyAsync())
     return true;
 
@@ -2563,9 +2563,9 @@ namespace {
       if (result != mutableLocalVarParent.end()) {
         MutableVarParent parent = result->second;
         assert(!parent.isNull());
-        if (parent.is<LoadExpr*>())
+        if (isa<LoadExpr *>(parent))
           return VarRefUseEnv::Read;
-        else if (parent.is<AssignExpr*>())
+        else if (isa<AssignExpr *>(parent))
           return VarRefUseEnv::Mutating;
         else if (auto inout = parent.dyn_cast<InOutExpr*>())
           return inout->isImplicit() ? VarRefUseEnv::Mutating
@@ -3496,7 +3496,7 @@ namespace {
       }
 
       if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
-        assert(applyStack.back().get<ApplyExpr *>() == apply);
+        assert(cast<ApplyExpr *>(applyStack.back()) == apply);
         applyStack.pop_back();
       }
 
@@ -3834,7 +3834,7 @@ namespace {
           return;
 
         if (isPartialApply) {
-          auto *apply = call.get<ApplyExpr *>();
+          auto *apply = cast<ApplyExpr *>(call);
           // The partially applied InoutArg is a property of actor. This
           // can really only happen when the property is a struct with a
           // mutating async method.
@@ -3855,7 +3855,7 @@ namespace {
         if (auto *apply = call.dyn_cast<ApplyExpr *>()) {
           isImplicitlyAsync = apply->isImplicitlyAsync().has_value();
         } else {
-          auto *lookup = call.get<LookupExpr *>();
+          auto *lookup = cast<LookupExpr *>(call);
           isImplicitlyAsync = lookup->isImplicitlyAsync().has_value();
         }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -308,7 +308,7 @@ Expr *ConstraintLocatorBuilder::trySimplifyToExpr() const {
   // Locators are not guaranteed to have an anchor
   // if constraint system is used to verify generic
   // requirements.
-  if (!anchor.is<Expr *>())
+  if (!isa<Expr *>(anchor))
     return nullptr;
 
   ArrayRef<LocatorPathElt> path = pathBuffer;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -185,7 +185,7 @@ static void checkInheritanceClause(
       }
     }
   } else {
-    typeDecl = declUnion.get<const TypeDecl *>();
+    typeDecl = cast<const TypeDecl *>(declUnion);
     decl = typeDecl;
   }
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -754,7 +754,7 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
   auto paramTy = defaultExpr->getType();
 
   // Re-create the default argument using the location info of the call site.
-  auto *dc = defaultExpr->ContextOrCallerSideExpr.get<DeclContext *>();
+  auto *dc = cast<DeclContext *>(defaultExpr->ContextOrCallerSideExpr);
   auto *initExpr = synthesizeCallerSideDefault(param, defaultExpr, dc);
   assert(dc && "Expected a DeclContext before type-checking caller-side arg");
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -892,7 +892,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
                                                   SourceManager &sourceMgr) {
   switch (role) {
   case MacroRole::Accessor: {
-    auto storage = cast<AbstractStorageDecl>(target.get<Decl *>());
+    auto storage = cast<AbstractStorageDecl>(cast<Decl *>(target));
     auto bracesRange = storage->getBracesRange();
 
     // Compute the location where the accessors will be added.
@@ -917,7 +917,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   }
   case MacroRole::MemberAttribute: {
     SourceLoc startLoc;
-    if (auto valueDecl = dyn_cast<ValueDecl>(target.get<Decl *>()))
+    if (auto valueDecl = dyn_cast<ValueDecl>(cast<Decl *>(target)))
       startLoc = valueDecl->getAttributeInsertionLoc(/*forModifier=*/true);
     else
       startLoc = target.getStartLoc();
@@ -927,10 +927,10 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   case MacroRole::Member: {
     // Semantically, we insert members right before the closing brace.
     SourceLoc rightBraceLoc;
-    if (auto nominal = dyn_cast<NominalTypeDecl>(target.get<Decl *>())) {
+    if (auto nominal = dyn_cast<NominalTypeDecl>(cast<Decl *>(target))) {
       rightBraceLoc = nominal->getBraces().End;
     } else {
-      auto ext = cast<ExtensionDecl>(target.get<Decl *>());
+      auto ext = cast<ExtensionDecl>(cast<Decl *>(target));
       rightBraceLoc = ext->getBraces().End;
     }
 
@@ -938,7 +938,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   }
   case MacroRole::Peer: {
     SourceLoc endLoc = target.getEndLoc();
-    if (auto var = dyn_cast<VarDecl>(target.get<Decl *>())) {
+    if (auto var = dyn_cast<VarDecl>(cast<Decl *>(target))) {
       if (auto binding = var->getParentPatternBinding())
         endLoc = binding->getEndLoc();
     }
@@ -955,7 +955,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
 
   case MacroRole::Extension: {
     // Extensions are expanded at the top-level.
-    auto *NTD = cast<NominalTypeDecl>(target.get<Decl *>());
+    auto *NTD = cast<NominalTypeDecl>(cast<Decl *>(target));
     auto *topLevelDecl = NTD->getTopmostDeclarationDeclContext();
 
     SourceLoc afterDeclLoc =
@@ -964,7 +964,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   }
 
   case MacroRole::Preamble: {
-    if (auto fn = dyn_cast<AbstractFunctionDecl>(target.get<Decl *>())) {
+    if (auto fn = dyn_cast<AbstractFunctionDecl>(cast<Decl *>(target))) {
       return getPreambleMacroOriginalRange(fn);
     }
 
@@ -986,7 +986,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
     }
 
     // If the function has a body, that's what's being replaced.
-    auto *AFD = cast<AbstractFunctionDecl>(target.get<Decl *>());
+    auto *AFD = cast<AbstractFunctionDecl>(cast<Decl *>(target));
     if (auto range = AFD->getBodySourceRange())
       return Lexer::getCharSourceRangeFromSourceRange(sourceMgr, range);
 
@@ -1037,7 +1037,7 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
                dyn_cast_or_null<MacroExpansionExpr>(target.dyn_cast<Expr *>()))
     expansionExpr->getMacroName().getFullName().getString(macroName);
   else if (auto expansionDecl =
-               dyn_cast_or_null<MacroExpansionDecl>(target.get<Decl *>()))
+               dyn_cast_or_null<MacroExpansionDecl>(cast<Decl *>(target)))
     expansionDecl->getMacroName().getFullName().getString(macroName);
 
   // Create a new source buffer with the contents of the expanded macro.

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -156,13 +156,13 @@ public:
   /// requirement, retrieve the requirement.
   ValueDecl *getObjCRequirement() const {
     assert(kind == WitnessToObjC);
-    return declOrAttr.get<ValueDecl *>();
+    return cast<ValueDecl *>(declOrAttr);
   }
 
   DeclAttribute *getAttr() const {
     if (!requiresAttr(kind))
       return nullptr;
-    return declOrAttr.get<DeclAttribute *>();
+    return cast<DeclAttribute *>(declOrAttr);
   }
 
   // The foreign language targeted by the context.

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -49,7 +49,7 @@ InheritedTypeResult InheritedTypeRequest::evaluate(
       }
     }
   } else {
-    dc = (DeclContext *)decl.get<const ExtensionDecl *>();
+    dc = (DeclContext *)cast<const ExtensionDecl *>(decl);
     context = TypeResolverContext::Inherited;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3217,7 +3217,7 @@ void TypeAttrSet::accumulate(ArrayRef<TypeOrCustomAttr> attrs) {
       continue;
     }
 
-    auto typeAttr = attr.get<TypeAttribute*>();
+    auto typeAttr = cast<TypeAttribute *>(attr);
     auto representativeKind = getRepresentative(typeAttr->getKind());
 
     // Try to insert the attribute in the set under its representative
@@ -6868,7 +6868,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
   ASTContext &ctx = *ctxPtr;
 
   // try!/try? always catch 'any Error'.
-  if (catchNode.is<AnyTryExpr *>()) {
+  if (isa<AnyTryExpr *>(catchNode)) {
     return ctx.getErrorExistentialType();
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3445,7 +3445,7 @@ class DeclDeserializer {
     if (auto *typeDecl = decl.dyn_cast<TypeDecl *>())
       typeDecl->setInherited(inherited);
     else
-      decl.get<ExtensionDecl *>()->setInherited(inherited);
+      cast<ExtensionDecl *>(decl)->setInherited(inherited);
   }
 
   llvm::Error finishRecursiveAttrs(Decl *decl, DeclAttribute *attrs);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -494,11 +494,11 @@ SILDeserializer::readDebugScopes(SILFunction *F,
 
     if (isFuncParent)
       Scope = new (SILMod) SILDebugScope(
-          Loc.value(), Parent.get<SILFunction *>(), nullptr, InlinedCallSite);
+          Loc.value(), cast<SILFunction *>(Parent), nullptr, InlinedCallSite);
     else
       Scope = new (SILMod)
           SILDebugScope(Loc.value(), nullptr,
-                        Parent.get<const SILDebugScope *>(), InlinedCallSite);
+                        cast<const SILDebugScope *>(Parent), InlinedCallSite);
 
     ParsedScopes.insert({ParsedScopes.size() + 1, Scope});
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -142,24 +142,20 @@ public:
   public:
     /*implicit*/ Serialized(serialization::BitOffset offset) : Value(offset) {}
 
-    bool isComplete() const {
-      return Value.template is<T>();
-    }
+    bool isComplete() const { return isa<T>(Value); }
 
-    T get() const {
-      return Value.template get<T>();
-    }
+    T get() const { return cast<T>(Value); }
 
     /*implicit*/ operator T() const {
       return get();
     }
 
     /*implicit*/ operator serialization::BitOffset() const {
-      return Value.template get<serialization::BitOffset>();
+      return cast<serialization::BitOffset>(Value);
     }
 
     /*implicit*/ operator RawBitOffset() const {
-      return Value.template get<serialization::BitOffset>();
+      return cast<serialization::BitOffset>(Value);
     }
 
     Serialized &operator=(T deserialized) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -492,7 +492,7 @@ namespace {
 static ModuleDecl *getModule(ModuleOrSourceFile DC) {
   if (auto M = DC.dyn_cast<ModuleDecl *>())
     return M;
-  return DC.get<SourceFile *>()->getParentModule();
+  return cast<SourceFile *>(DC)->getParentModule();
 }
 
 static bool shouldSerializeAsLocalContext(const DeclContext *DC) {

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -743,7 +743,7 @@ static void emitBasicLocsRecord(llvm::BitstreamWriter &Out,
   if (auto *SF = MSF.dyn_cast<SourceFile*>()) {
     SF->walk(Writer);
   } else {
-    MSF.get<ModuleDecl*>()->walk(Writer);
+    cast<ModuleDecl *>(MSF)->walk(Writer);
   }
 
   SmallVector<uint64_t, 8> scratch;
@@ -809,7 +809,7 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
   if (SourceFile *SF = MSF.dyn_cast<SourceFile *>()) {
     writer.emitSourceFileInfo(BasicSourceFileInfo(SF));
   } else {
-    auto *M = MSF.get<ModuleDecl *>();
+    auto *M = cast<ModuleDecl *>(MSF);
     M->collectBasicSourceFileInfo([&](const BasicSourceFileInfo &info) {
       writer.emitSourceFileInfo(info);
     });

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3310,13 +3310,13 @@ void SILSerializer::writeDebugScopes(const SILDebugScope *Scope,
 
   // A debug scope's parent can either be a function or a debug scope.
   // Handle both cases appropriately.
-  if (Scope->Parent.is<const SILDebugScope *>()) {
-    auto Parent = Scope->Parent.get<const SILDebugScope *>();
+  if (isa<const SILDebugScope *>(Scope->Parent)) {
+    auto Parent = cast<const SILDebugScope *>(Scope->Parent);
     if (DebugScopeMap.find(Parent) == DebugScopeMap.end())
       writeDebugScopes(Parent, SM);
     ParentID = DebugScopeMap[Parent];
   } else {
-    const SILFunction *ParentFn = Scope->Parent.get<SILFunction *>();
+    const SILFunction *ParentFn = cast<SILFunction *>(Scope->Parent);
     assert(ParentFn);
     isFuncParent = true;
     FuncsToEmitDebug.insert(ParentFn);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1163,7 +1163,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
             return;
         } else {
           if (clang::index::generateUSRForDecl(
-                  D.get<const clang::NamedDecl *>(), Buffer))
+                  cast<const clang::NamedDecl *>(D), Buffer))
             return;
         }
         Strings.push_back(copyAndClearString(Allocator, Buffer));


### PR DESCRIPTION
These were deprecated in https://github.com/llvm/llvm-project/pull/122623.

