### PR TITLE
[cxx-interop] Avoid trying to instantiate copy constructors of explicitly non-copyable structs

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8008,7 +8008,7 @@ bool importer::hasIteratorAPIAttr(const clang::Decl *decl) {
   return hasSwiftAttribute(decl, "import_iterator");
 }
 
-static bool hasNonCopyableAttr(const clang::RecordDecl *decl) {
+bool importer::hasNonCopyableAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, "~Copyable");
 }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2137,7 +2137,7 @@ bool hasUnsafeAPIAttr(const clang::Decl *decl);
 bool hasIteratorAPIAttr(const clang::Decl *decl);
 
 bool hasNonEscapableAttr(const clang::RecordDecl *decl);
-
+bool hasNonCopyableAttr(const clang::RecordDecl *decl);
 bool hasEscapableAttr(const clang::RecordDecl *decl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -172,3 +172,8 @@ module ManySpecializations {
   header "many-specializations.h"
   requires cplusplus
 }
+
+module UninstantiatableSpecialMembers {
+  header "uninstantiatable-special-members.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/Inputs/uninstantiatable-special-members.h
+++ b/test/Interop/Cxx/templates/Inputs/uninstantiatable-special-members.h
@@ -1,0 +1,27 @@
+template <class T>
+struct __attribute__((swift_attr("~Copyable"))) HasUninstantiatableCopyConstructor {
+  template <class U>
+  void scaryPoison(U u) {
+    U::doesNotExist(u);
+  }
+
+  int value;
+  HasUninstantiatableCopyConstructor(int value) : value(value) {}
+  HasUninstantiatableCopyConstructor(
+      const HasUninstantiatableCopyConstructor &other) {
+    scaryPoison(other);
+  }
+  HasUninstantiatableCopyConstructor(
+      HasUninstantiatableCopyConstructor &&other) = default;
+};
+
+typedef HasUninstantiatableCopyConstructor<int> NonCopyableInst;
+
+template <class T>
+struct __attribute__((swift_attr("~Copyable"))) DerivedUninstantiatableCopyConstructor : HasUninstantiatableCopyConstructor<T> {
+  DerivedUninstantiatableCopyConstructor(int value) : HasUninstantiatableCopyConstructor<T>(value) {}
+  DerivedUninstantiatableCopyConstructor(const DerivedUninstantiatableCopyConstructor &other) = default;
+  DerivedUninstantiatableCopyConstructor(DerivedUninstantiatableCopyConstructor &&other) = default;
+};
+
+typedef DerivedUninstantiatableCopyConstructor<int> DerivedNonCopyableInst;

--- a/test/Interop/Cxx/templates/uninstantiatable-special-members-irgen.swift
+++ b/test/Interop/Cxx/templates/uninstantiatable-special-members-irgen.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-irgen %s -cxx-interoperability-mode=default -I %S/Inputs | %FileCheck %s
+
+import UninstantiatableSpecialMembers
+
+let nonCopyableValue = NonCopyableInst(123)
+let nonCopyableDerived = DerivedNonCopyableInst(567)
+
+// CHECK-NOT: scaryPoison

--- a/test/Interop/Cxx/templates/uninstantiatable-special-members-module-interface.swift
+++ b/test/Interop/Cxx/templates/uninstantiatable-special-members-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=UninstantiatableSpecialMembers -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: struct HasUninstantiatableCopyConstructor<CInt> {
+// CHECK: }
+// CHECK: typealias NonCopyableInst = HasUninstantiatableCopyConstructor<CInt>
+
+// CHECK: struct DerivedUninstantiatableCopyConstructor<CInt> {
+// CHECK: }
+// CHECK: typealias DerivedNonCopyableInst = DerivedUninstantiatableCopyConstructor<CInt>

--- a/test/Interop/Cxx/templates/uninstantiatable-special-members-typechecker.swift
+++ b/test/Interop/Cxx/templates/uninstantiatable-special-members-typechecker.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -I %S/Inputs
+
+import UninstantiatableSpecialMembers
+
+let nonCopyableValue = NonCopyableInst(123)
+let copy1 = copy nonCopyableValue // expected-error {{'copy' cannot be applied to noncopyable types}}
+
+let nonCopyableDerived = DerivedNonCopyableInst(567)
+let copy2 = copy nonCopyableDerived // expected-error {{'copy' cannot be applied to noncopyable types}}


### PR DESCRIPTION
If a C++ struct is annotated with `__attribute__((swift_attr("~Copyable")))`, Swift should not try to instantiate the copy constructor of the struct. This provides an escape hatch for C++ types that are designed to be non-copyable, but do not explicitly define a deleted copy constructor, and instead trigger complex template instantiation failures when a copy is attempted.

rdar://157034491

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
