### PR TITLE
Fix OSSA RAUW utility for move_value that changes ownership.

### DIFF
--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1241,13 +1241,14 @@ SILValue OwnershipRAUWPrepare::prepareReplacement(SILValue newValue) {
       OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue,
                                                  ctx.guaranteedUsePoints) &&
       "Should have checked if can perform this operation before calling it?!");
-  // If our new value is just none, we can pass anything to it so just RAUW
+  // If our new value is just none, we can pass it to anything so just RAUW
   // and return.
   //
   // NOTE: This handles RAUWing with undef.
-  if (newValue->getOwnershipKind() == OwnershipKind::None)
+  if (newValue->getOwnershipKind() == OwnershipKind::None) {
+    cleanupOperandsBeforeDeletion(getConsumingPoint(), ctx.callbacks);
     return newValue;
-
+  }
   assert(oldValue->getOwnershipKind() != OwnershipKind::None);
 
   switch (oldValue->getOwnershipKind()) {

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1062,7 +1062,7 @@ bb0(%0 : $*Builtin.Int64, %1 : @guaranteed $Builtin.NativeObject):
   return %6 : $(Builtin.Int64, Builtin.Int64)
 }
 
-protocol Proto : class {
+protocol Proto : AnyObject {
   func doThis()
   func doThat()
 }

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -1126,3 +1126,41 @@ bb0:
   %res = tuple ()
   return %res : $()
 }
+
+// testMoveEnumChangesOwnership requires HasOptC and HasOptC to declare
+// their properties with @_hasStorage.
+public struct HasOptKlass {
+  @_hasStorage let c: Klass? { get }
+}
+
+public struct HasOptKlassHolder {
+  @_hasStorage public var hasOptKlass: HasOptKlass { get set }
+}
+
+// CHECK-LABEL: sil [ossa] @testMoveEnumChangesOwnership : $@convention(thin) () -> () {
+// CHECK:   [[E1:%[0-9]+]] = enum $Optional<Klass>, #Optional.none!enumelt
+// CHECK:   [[MV1:%[0-9]+]] = move_value [lexical] [[E1]] : $Optional<Klass>
+// CHECK:   [[S:%[0-9]+]] = struct $HasOptKlass (%0 : $Optional<Klass>)
+// CHECK:   store [[S]] to [init]
+// CHECK:   destroy_value [[MV1]] : $Optional<Klass>
+// CHECK:   [[MV2:%[0-9]+]] = move_value [lexical] [[S]] : $HasOptKlass
+// CHECK:   store [[MV2]] to [assign]
+// CHECK: } // end sil function 'testMoveEnumChangesOwnership'
+sil [ossa] @testMoveEnumChangesOwnership : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $Optional<Klass>, #Optional.none!enumelt
+  %1 = move_value [lexical] %0
+  %2 = alloc_stack [lexical] [var_decl] $HasOptKlassHolder
+  %3 = enum $Optional<Klass>, #Optional.none!enumelt
+  %4 = struct $HasOptKlass (%3)
+  %5 = struct_element_addr %2, #HasOptKlassHolder.hasOptKlass
+  store %4 to [init] %5
+  %7 = struct $HasOptKlass (%1)
+  %8 = move_value [lexical] %7
+  store %8 to [assign] %5
+  %10 = load [take] %2
+  dealloc_stack %2
+  destroy_value %10
+  %13 = tuple ()
+  return %13
+}


### PR DESCRIPTION
CSE "looks through" ownership operations, which can lead to problematic substitutions. This fix cleans up owned operands even when the newly substituted value has no ownership.

For example:

    %0 = enum $Optional<Interface>, #Optional.none!enumelt
    %1 = move_value [lexical] %0
    %2 = enum $Optional<Interface>, #Optional.none!enumelt
    %3 = struct $EndpointCommon (%2)
    %4 = struct $EndpointCommon (%1)

CSE combines the two .none enums:

    %0 = enum $Optional<Interface>, #Optional.none!enumelt
    %2 = enum $Optional<Interface>, #Optional.none!enumelt

Then combines the two structs:

    %3 = struct $EndpointCommon (%2)
    %4 = struct $EndpointCommon (%1)

Leaving a dead move_value:

    %1 = move_value [lexical] %0

which is invalid OSSA. Now, when replacing the owned struct, we add destroys for its operands.

Fixes rdar://156431548 Error! Found a leaked owned value that was never consumed.
