### PR TITLE
utils: Do not set the Android C/C++ compilers

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1520,12 +1520,6 @@ function Build-CMakeProject {
         }
 
         if ($UseC) {
-          $CC = if ($UseBuiltCompilers.Contains("C")) {
-            [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang.exe")
-          } else {
-            Join-Path -Path $AndroidPrebuiltRoot -ChildPath "bin\clang.exe"
-          }
-          Add-KeyValueIfNew $Defines CMAKE_C_COMPILER $CC
           Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Platform.Triple
           # FIXME(compnerd) why is this needed?
           Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_WORKS YES
@@ -1538,12 +1532,6 @@ function Build-CMakeProject {
         }
 
         if ($UseCXX) {
-          $CXX = if ($UseBuiltCompilers.Contains("CXX")) {
-            [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang++.exe")
-          } else {
-            Join-Path -Path $AndroidPrebuiltRoot -ChildPath "bin\clang++.exe"
-          }
-          Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER $CXX
           Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Platform.Triple
           # FIXME(compnerd) why is this needed?
           Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_WORKS YES


### PR DESCRIPTION
Due to a bug in CMake, the `project()` invocation for Android projects always overrides the `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` passed on the command line with the compilers from the NDK installation.

Since the values we passed on the command line were not taking effect, these changes remove them from the cmake invocation. This fixes incremental Android builds.