### PR TITLE
swift-symbolgraph-extract: Fix `-target` inference test

### DIFF
--- a/test/SymbolGraph/infer-target.swift
+++ b/test/SymbolGraph/infer-target.swift
@@ -1,8 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Output)
 // RUN: %target-build-swift %s -module-name Basic -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name Basic -I %t -pretty-print -output-dir %t/Output
+
+// Verify that -target can be inferred
+// RUN: %empty-directory(%t/Output)
+// RUN: %swift-symbolgraph-extract -module-name Basic -I %t -pretty-print -output-dir %t/Output
 // RUN: %FileCheck %s --input-file %t/Output/Basic.symbols.json
+
+// This test can only work for test configurations that aren't cross-compiling.
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=windows-msvc
 
 public struct S {
   public var x: Int


### PR DESCRIPTION
Only test `-target` inference in CI configurations that are not cross-compiling. Fixes a regression from https://github.com/swiftlang/swift/pull/83377.

Resolves rdar://156991775.
