### PR TITLE
[stdlib] fix availability of `Span.bytes`

### DIFF
--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -503,7 +503,8 @@ extension Span where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
   public var bytes: RawSpan {


### PR DESCRIPTION
This extension was left behind in `Span`'s availability rewrite.

Addresses rdar://157064330