### PR TITLE
[Index] Fix a couple of `reportRelatedTypeRef` issues

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1028,17 +1028,46 @@ private:
 
   bool reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isImplicit, SymbolRoleSet Relations, Decl *Related);
 
-  /// Report references for dependent types
+  /// Report a related type relation for a given TypeRepr.
   ///
-  /// NOTE: If the dependent type is a typealias, report the underlying types as well.
+  /// NOTE: If the dependent type is a typealias, report the underlying types as
+  /// well.
+  ///
+  /// \param TR The type being referenced.
+  /// \param Relations The relationship between the referenced type and the
+  /// passed Decl.
+  /// \param Related The Decl that is referencing the type.
+  /// \param Implicit Whether the reference is implicit, such as for a
+  /// typealias' underlying type.
+  /// \param ParentLoc The parent location of the reference that should be used
+  /// for implicit references.
+  bool reportRelatedTypeRepr(const TypeRepr *TR, SymbolRoleSet Relations,
+                             Decl *Related, bool Implicit, SourceLoc ParentLoc);
+
+  /// Report a related type relation for a Type at a given location.
   ///
   /// \param Ty The type being referenced.
-  /// \param Relations The relationship between the referenced type and the passed Decl.
+  /// \param Relations The relationship between the referenced type and the
+  /// passed Decl.
   /// \param Related The Decl that is referencing the type.
-  /// \param isImplicit Whether the reference is implicit, such as for a typealias' underlying type.
-  /// \param Loc The location of the reference, otherwise the location of the TypeLoc is used.
-  bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related,
-                            bool isImplicit=false, SourceLoc Loc={});
+  /// \param Implicit Whether the reference is implicit, such as for a
+  /// typealias' underlying type.
+  /// \param Loc The location of the reference.
+  bool reportRelatedType(Type Ty, SymbolRoleSet Relations, Decl *Related,
+                         bool Implicit, SourceLoc Loc);
+
+  /// Report references for dependent types.
+  ///
+  /// NOTE: If the dependent type is a typealias, report the underlying types as
+  /// well.
+  ///
+  /// \param TL The type being referenced.
+  /// \param Relations The relationship between the referenced type and the
+  /// passed Decl.
+  /// \param Related The Decl that is referencing the type.
+  bool reportRelatedTypeRef(const TypeLoc &TL, SymbolRoleSet Relations,
+                            Decl *Related);
+
   bool reportInheritedTypeRefs(InheritedTypes Inherited, Decl *Inheritee);
 
   bool reportPseudoGetterDecl(VarDecl *D) {
@@ -1483,51 +1512,76 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(InheritedTypes Inherited,
   return true;
 }
 
-bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations,
-                                               Decl *Related, bool Implicit, SourceLoc Loc) {
-  if (auto *composite = llvm::dyn_cast_or_null<CompositionTypeRepr>(Ty.getTypeRepr())) {
+bool IndexSwiftASTWalker::reportRelatedTypeRepr(const TypeRepr *TR,
+                                                SymbolRoleSet Relations,
+                                                Decl *Related, bool Implicit,
+                                                SourceLoc ParentLoc) {
+  if (auto *composite = dyn_cast<CompositionTypeRepr>(TR)) {
     for (auto *Type : composite->getTypes()) {
-      if (!reportRelatedTypeRef(Type, Relations, Related, /*isImplicit=*/Implicit, Loc))
+      if (!reportRelatedTypeRepr(Type, Relations, Related, Implicit,
+                                 ParentLoc)) {
         return false;
-    }
-
-    return true;
-  } else if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
-    SourceLoc IdLoc = Loc.isValid() ? Loc : declRefTR->getLoc();
-    NominalTypeDecl *NTD = nullptr;
-    bool isImplicit = Implicit;
-    if (auto *VD = declRefTR->getBoundDecl()) {
-      if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
-        IndexSymbol Info;
-        if (isImplicit)
-          Info.roles |= (unsigned)SymbolRole::Implicit;
-        if (!reportRef(TAD, IdLoc, Info, std::nullopt))
-          return false;
-        if (auto Ty = TAD->getUnderlyingType()) {
-          NTD = Ty->getAnyNominal();
-          isImplicit = true;
-        }
-
-        if (isa_and_nonnull<CompositionTypeRepr>(TAD->getUnderlyingTypeRepr())) {
-          TypeLoc TL(TAD->getUnderlyingTypeRepr(), TAD->getUnderlyingType());
-          if (!reportRelatedTypeRef(TL, Relations, Related, /*isImplicit=*/true, IdLoc))
-            return false;
-        }
-      } else {
-        NTD = dyn_cast<NominalTypeDecl>(VD);
       }
     }
-    if (NTD) {
-      if (!reportRelatedRef(NTD, IdLoc, isImplicit, Relations, Related))
-        return false;
-    }
-    return true;
   }
+  auto *declRefTR = dyn_cast<DeclRefTypeRepr>(TR);
+  if (!declRefTR)
+    return true;
 
-  if (Ty.getType()) {
-    if (auto nominal = Ty.getType()->getAnyNominal())
-      if (!reportRelatedRef(nominal, Ty.getLoc(), /*isImplicit=*/false, Relations, Related))
-        return false;
+  auto *VD = declRefTR->getBoundDecl();
+  if (!VD)
+    return true;
+
+  SourceLoc IdLoc = ParentLoc.isValid() ? ParentLoc : declRefTR->getLoc();
+  if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
+    IndexSymbol Info;
+    if (Implicit)
+      Info.roles |= (unsigned)SymbolRole::Implicit;
+    if (!reportRef(TAD, IdLoc, Info, std::nullopt))
+      return false;
+
+    // Recurse into the underlying type and report any found references as
+    // implicit references at the location of the typealias reference.
+    if (auto *UTR = TAD->getUnderlyingTypeRepr()) {
+      return reportRelatedTypeRepr(UTR, Relations, Related,
+                                   /*Implicit*/ true, /*ParentLoc*/ IdLoc);
+    }
+    // If we don't have a TypeRepr available, this is a typealias in another
+    // module, consult the computed underlying type.
+    return reportRelatedType(TAD->getUnderlyingType(), Relations, Related,
+                             /*Implicit*/ true, /*ParentLoc*/ IdLoc);
+  }
+  if (auto *NTD = dyn_cast<NominalTypeDecl>(VD)) {
+    if (!reportRelatedRef(NTD, IdLoc, Implicit, Relations, Related))
+      return false;
+  }
+  return true;
+}
+
+bool IndexSwiftASTWalker::reportRelatedType(Type Ty, SymbolRoleSet Relations,
+                                            Decl *Related, bool Implicit,
+                                            SourceLoc Loc) {
+  if (auto *nominal = Ty->getAnyNominal()) {
+    if (!reportRelatedRef(nominal, Loc, Implicit, Relations, Related))
+      return false;
+  }
+  return true;
+}
+
+bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &TL,
+                                               SymbolRoleSet Relations,
+                                               Decl *Related) {
+  // If we have a TypeRepr, prefer that since it lets us match up source
+  // locations with the code the user wrote.
+  if (auto *TR = TL.getTypeRepr()) {
+    return reportRelatedTypeRepr(TR, Relations, Related, /*Implicit*/ false,
+                                 /*ParentLoc*/ SourceLoc());
+  }
+  // Otherwise fall back to reporting the Type, this is necessary when indexing
+  // swiftmodules.
+  if (auto Ty = TL.getType()) {
+    return reportRelatedType(Ty, Relations, Related,
+                             /*Implicit*/ false, SourceLoc());
   }
   return true;
 }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1486,9 +1486,8 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(InheritedTypes Inherited,
 bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations,
                                                Decl *Related, bool Implicit, SourceLoc Loc) {
   if (auto *composite = llvm::dyn_cast_or_null<CompositionTypeRepr>(Ty.getTypeRepr())) {
-    SourceLoc IdLoc = Loc.isValid() ? Loc : composite->getSourceLoc();
     for (auto *Type : composite->getTypes()) {
-      if (!reportRelatedTypeRef(Type, Relations, Related, /*isImplicit=*/Implicit, IdLoc))
+      if (!reportRelatedTypeRef(Type, Relations, Related, /*isImplicit=*/Implicit, Loc))
         return false;
     }
 

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -10,6 +10,24 @@ struct DirectConf: P1 { // CHECK: [[@LINE]]:8 | struct/Swift | DirectConf | [[Di
     // CHECK-NEXT: RelChild | struct/Swift | DirectConf | [[DirectConf_USR]]
 }
 
+struct LookThroughReprs: (@unchecked (Sendable)) {}
+// CHECK:      [[@LINE-1]]:39 | protocol/Swift | Sendable | s:s8SendableP | Ref,RelBase | rel: 1
+// CHECK-NEXT:   RelBase | struct/Swift | LookThroughReprs | s:14swift_ide_test16LookThroughReprsV
+
+// No RelBase relation here since `Copyable` isn't a base type. Also make sure
+// we don't put a reference at the `~`.
+struct NonCopyable: ~Copyable {}
+// CHECK-NOT: [[@LINE-1]]:21
+// CHECK:     [[@LINE-2]]:22 | protocol/Swift | Copyable | s:s8CopyableP | Ref | rel: 0
+// CHECK-NOT: [[@LINE-3]]:21
+
+protocol NonCopyableProto: ~Copyable {}
+
+struct AlsoNonCopyable: NonCopyableProto & ~Copyable {}
+// CHECK:      [[@LINE-1]]:25 | protocol/Swift | NonCopyableProto | s:14swift_ide_test16NonCopyableProtoP | Ref,RelBase | rel: 1
+// CHECK-NEXT:   RelBase | struct/Swift | AlsoNonCopyable | s:14swift_ide_test15AlsoNonCopyableV
+// CHECK-NEXT: [[@LINE-3]]:45 | protocol/Swift | Copyable | s:s8CopyableP | Ref | rel: 0
+
 struct ConfFromExtension {}
 extension ConfFromExtension: P1 { // CHECK: [[@LINE]]:11 | extension/ext-struct/Swift | ConfFromExtension | [[ConfFromExtension_ext_USR:.*]] | Def
   func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[ConfFromExtension_ext_foo_USR:.*]] | Def,RelChild,RelOver | rel: 2

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -81,7 +81,7 @@ class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class/Swift
 
 class CompositionType: BaseMultiConf & P1 { // CHECK: [[@LINE]]:7 | class/Swift | CompositionType | [[CompositionType_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:24 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,RelBase | rel: 1
-  // CHECK: [[@LINE-2]]:24 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelBase | rel: 1
+  // CHECK: [[@LINE-2]]:40 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelBase | rel: 1
   func foo() {}
 }
 

--- a/test/Index/index_imported.swift
+++ b/test/Index/index_imported.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/Lib.swiftmodule %t/Lib.swift -module-name Lib
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/main.swift -module-to-print Lib -I %t | %FileCheck %s --check-prefix LIB
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/main.swift -I %t | %FileCheck %s
+
+//--- Lib.swift
+
+public protocol P {}
+public protocol Q {}
+public protocol R {}
+
+public typealias X = Q & R
+
+public struct S: X & P {}
+// LIB:      0:0 | protocol/Swift | Q | s:3Lib1QP | Ref,RelBase | rel: 1
+// LIB-NEXT:   RelBase | struct/Swift | S | s:3Lib1SV
+// LIB-NEXT: 0:0 | protocol/Swift | R | s:3Lib1RP | Ref,RelBase | rel: 1
+// LIB-NEXT:   RelBase | struct/Swift | S | s:3Lib1SV
+// LIB-NEXT: 0:0 | protocol/Swift | P | s:3Lib1PP | Ref,RelBase | rel: 1
+// LIB-NEXT:   RelBase | struct/Swift | S | s:3Lib1SV
+
+public protocol NonCopyableProto: ~Copyable {}
+public struct NonCopyable: NonCopyableProto & ~Copyable {}
+// LIB:      0:0 | protocol/Swift | NonCopyableProto | s:3Lib16NonCopyableProtoP | Ref,RelBase | rel: 1
+// LIB-NEXT:   RelBase | struct/Swift | NonCopyable | s:3Lib11NonCopyableV
+
+// We don't currently have a relation for Copyable.
+// LIB-NOT: s:s8CopyableP
+
+//--- main.swift
+
+import Lib
+
+struct K: P & X {}
+// CHECK:      [[@LINE-1]]:11 | protocol/Swift | P | s:3Lib1PP | Ref,RelBase | rel: 1
+// CHECK-NEXT:   RelBase | struct/Swift | K | s:14swift_ide_test1KV
+// CHECK-NEXT: [[@LINE-3]]:15 | type-alias/Swift | X | s:3Lib1Xa | Ref | rel: 0
+// CHECK-NEXT: [[@LINE-4]]:15 | protocol/Swift | Q | s:3Lib1QP | Ref,Impl,RelBase | rel: 1
+// CHECK-NEXT:   RelBase | struct/Swift | K | s:14swift_ide_test1KV
+// CHECK-NEXT: [[@LINE-6]]:15 | protocol/Swift | R | s:3Lib1RP | Ref,Impl,RelBase | rel: 1
+// CHECK-NEXT:   RelBase | struct/Swift | K | s:14swift_ide_test1KV


### PR DESCRIPTION
- Avoid using the location of the protocol composition itself for members of the composition
- Look through attributed/specifier/paren TypeReprs
- Avoid reporting `RelBase` relations for suppressed conformances
- Handle protocol composition inherited types when indexing modules

rdar://146331982