### PR TITLE
Revert "[cxx-interop] Move addressable parameters in interop behind a flag"

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -502,7 +502,6 @@ EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
-EXPERIMENTAL_FEATURE(AddressableInterop, true)
 
 /// Allow custom availability domains to be defined and referenced.
 EXPERIMENTAL_FEATURE(CustomAvailability, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -409,7 +409,6 @@ static bool usesFeatureAddressableTypes(Decl *d) {
   return false;
 }
 
-UNINTERESTING_FEATURE(AddressableInterop)
 UNINTERESTING_FEATURE(IsolatedAny2)
 UNINTERESTING_FEATURE(GlobalActorIsolatedTypesUsability)
 UNINTERESTING_FEATURE(ObjCImplementation)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4045,9 +4045,7 @@ namespace {
             func->setSelfIndex(selfIdx.value());
             // FIXME: Make this work when SIL Opaque Values are enabled.
             // Currently, addressable parameters and opaque values are at odds.
-            if (Impl.SwiftContext.LangOpts.hasFeature(
-                    Feature::AddressableInterop) &&
-                !dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
+            if (!dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
                 !importedName.importAsMember() &&
                 !Impl.SwiftContext.SILOpts.EnableSILOpaqueValues)
               func->getAttrs().add(new (Impl.SwiftContext)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2725,8 +2725,7 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   // subobject of the referenced storage. In those cases we need to prevent the
   // Swift compiler to pass in a temporary copy to prevent dangling.
   auto paramContext = param->getDeclContext();
-  if (impl->SwiftContext.LangOpts.hasFeature(Feature::AddressableInterop) &&
-      !param->getType().isNull() && param->getType()->isLValueReferenceType() &&
+  if (!param->getType().isNull() && param->getType()->isLValueReferenceType() &&
       !swiftParamTy->isForeignReferenceType() &&
       !(isa<clang::FunctionDecl>(paramContext) &&
         cast<clang::FunctionDecl>(paramContext)->isOverloadedOperator()) &&

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions -enable-experimental-feature AddressableInterop | %FileCheck %s
-
-// REQUIRES: swift_feature_AddressableInterop
+// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import CXXInterop
 

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -1,10 +1,9 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature AddressableInterop -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature AddressableInterop -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_AddressableInterop
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -7,20 +7,6 @@
 
 // REQUIRES: executable_test
 
-// libstdc++11 declares a templated constructor of std::function with an rvalue-reference parameter,
-// which aren't yet supported in Swift. Therefore initializing a std::function from Swift closures
-// will not work on the platforms that are shipped with this version of libstdc++ (rdar://125816354).
-// XFAIL: LinuxDistribution=ubuntu-24.04
-// XFAIL: LinuxDistribution=ubuntu-22.04
-// XFAIL: LinuxDistribution=rhel-9.3
-// XFAIL: LinuxDistribution=rhel-9.4
-// XFAIL: LinuxDistribution=rhel-9.5
-// XFAIL: LinuxDistribution=rhel-9.6
-// XFAIL: LinuxDistribution=fedora-39
-// XFAIL: LinuxDistribution=fedora-41
-// XFAIL: LinuxDistribution=debian-12
-// XFAIL: LinuxDistribution=amzn-2023
-
 import StdlibUnittest
 import StdFunction
 import CxxStdlib


### PR DESCRIPTION
Now that #83381 landed, hopefully we no longer need this flag. 

This reverts commit f270e36aa5036ad55bb91669aaf9b4ecb9b7000b.
