### PR TITLE
Revert "[Observation] ensure event triggers on deinitialization passes as if all properties that are being observed have changed (for weak storage) (#79823)"

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -110,20 +110,9 @@ public struct ObservationRegistrar: Sendable {
       }
     }
 
-    internal mutating func deinitialize() -> [@Sendable () -> Void] {
-      var trackers = [@Sendable () -> Void]()
-      for (keyPath, ids) in lookups {
-        for id in ids {
-          if let tracker = observations[id]?.willSetTracker {
-             trackers.append({
-               tracker(keyPath)
-             })
-          }
-        }
-      }
+    internal mutating func cancelAll() {
       observations.removeAll()
       lookups.removeAll()
-      return trackers
     }
     
     internal mutating func willSet(keyPath: AnyKeyPath) -> [@Sendable (AnyKeyPath) -> Void] {
@@ -168,11 +157,8 @@ public struct ObservationRegistrar: Sendable {
       state.withCriticalRegion { $0.cancel(id) }
     }
 
-    internal func deinitialize() {
-      let tracking = state.withCriticalRegion { $0.deinitialize() }
-      for action in tracking {
-        action()
-      }
+    internal func cancelAll() {
+      state.withCriticalRegion { $0.cancelAll() }
     }
     
     internal func willSet<Subject: Observable, Member>(
@@ -203,7 +189,7 @@ public struct ObservationRegistrar: Sendable {
     }
 
     deinit {
-      context.deinitialize()
+      context.cancelAll()
     }
   }
   

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,21 +287,6 @@ final class CowTest {
   var container = CowContainer()
 }
 
-@Observable
-final class DeinitTriggeredObserver {
-  var property: Int = 3
-  let deinitTrigger: () -> Void
-
-  init(_ deinitTrigger: @escaping () -> Void) {
-    self.deinitTrigger = deinitTrigger
-  }
-
-  deinit {
-    deinitTrigger()
-  }
-}
-
-
 @main
 struct Validator {
   @MainActor
@@ -524,22 +509,6 @@ struct Validator {
       expectEqual(subject.container.id, startId)
       subject.container.mutate()
       expectEqual(subject.container.id, startId)
-    }
-
-    suite.test("weak container observation") {
-      let changed = CapturedState(state: false)
-      let deinitialized = CapturedState(state: false)
-      var test = DeinitTriggeredObserver {
-        deinitialized.state = true
-      }
-      withObservationTracking { [weak test] in
-        _blackHole(test?.property)
-      } onChange: {
-        changed.state = true
-      }
-      test = DeinitTriggeredObserver { }
-      expectEqual(deinitialized.state, true)
-      expectEqual(changed.state, true)
     }
 
     runAllTests()


### PR DESCRIPTION
This reverts commit 9d1d917091d7395bf2b46b3274f4524956af2f26.
