### PR TITLE
stdlib: Fix warning about superfluous 'const' on return type

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -83,7 +83,7 @@ _swift_stdlib_CreateIndirectTaggedPointerString(const __swift_uint8_t * _Nonnull
                                                 _swift_shims_CFIndex len);
 
 SWIFT_RUNTIME_STDLIB_API
-const _swift_shims_NSUInteger
+_swift_shims_NSUInteger
 _swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
                                                         unsigned long encoding);
 

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -107,7 +107,7 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 }
 
 SWIFT_RUNTIME_STDLIB_API
-const _swift_shims_NSUInteger
+_swift_shims_NSUInteger
 _swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
                                                         unsigned long encoding) {
   typedef _swift_shims_NSUInteger (*getLengthImplPtr)(id,


### PR DESCRIPTION
Resolves the following warnings:

```
stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h:86:1: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
   86 | const _swift_shims_NSUInteger
      | ^~~~~
stdlib/public/stubs/FoundationHelpers.mm:110:1: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
  110 | const _swift_shims_NSUInteger
      | ^~~~~
```
