### PR TITLE
[stdlib, 6.2] fix availability of `Span.bytes`

### DIFF
--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -506,7 +506,8 @@ extension Span where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
   public var bytes: RawSpan {


### PR DESCRIPTION
- Explanation: Makes the `Span.bytes` property back-deployed as intended.

- Resolves: rdar://157064330

- Risk: Low. This symbol is `@_alwaysEmitIntoClient`, so has no ABI.

- Main branch PR: https://github.com/swiftlang/swift/pull/83416

- Reviewed by: @Catfish-Man 

- Testing: same tests