### PR TITLE
Add brotli support to FoundationNetworking

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -840,6 +840,7 @@ enum Project {
   SourceKitLSP
   SymbolKit
   DocC
+  brotli
 
   LLVM
   Runtime
@@ -2429,6 +2430,21 @@ function Build-CompilerRuntime([Hashtable] $Platform) {
     }
 }
 
+function Build-Brotli([Hashtable] $Platform) {
+  Build-CMakeProject `
+    -Src $SourceCache\brotli `
+    -Bin "$(Get-ProjectBinaryCache $Platform brotli)" `
+    -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
+    -Platform $Platform `
+    -UseMSVCCompilers C `
+    -Defines @{
+      BUILD_SHARED_LIBS = "NO";
+      CMAKE_POSITION_INDEPENDENT_CODE = "YES";
+      CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
+    }
+}
+
+
 function Build-ZLib([Hashtable] $Platform) {
   Build-CMakeProject `
     -Src $SourceCache\zlib `
@@ -2517,7 +2533,7 @@ function Build-CURL([Hashtable] $Platform) {
       CURL_CA_BUNDLE = "none";
       CURL_CA_FALLBACK = "NO";
       CURL_CA_PATH = "none";
-      CURL_BROTLI = "NO";
+      CURL_BROTLI = "YES";
       CURL_DISABLE_ALTSVC = "NO";
       CURL_DISABLE_AWS = "YES";
       CURL_DISABLE_BASIC_AUTH = "NO";
@@ -2595,6 +2611,7 @@ function Build-CURL([Hashtable] $Platform) {
       USE_WIN32_LDAP = "NO";
       ZLIB_ROOT = "$BinaryCache\$($Platform.Triple)\usr";
       ZLIB_LIBRARY = "$BinaryCache\$($Platform.Triple)\usr\lib\zlibstatic.lib";
+      BROTLI_DIR = "$BinaryCache\$($Platform.Triple)\usr";
     })
 }
 
@@ -2992,6 +3009,7 @@ function Build-Foundation([Hashtable] $Platform) {
       };
       ZLIB_INCLUDE_DIR = "$BinaryCache\$($Platform.Triple)\usr\include";
       dispatch_DIR = (Get-ProjectCMakeModules $Platform Dispatch);
+      BROTLI_DIR = "$BinaryCache\$($Platform.Triple)\usr";
       _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
       _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
       _SwiftCollections_SourceDIR = "$SourceCache\swift-collections";
@@ -3016,6 +3034,7 @@ function Test-Foundation {
     $env:LIBXML_LIBRARY_PATH="$BinaryCache/$($Platform.Triple)/usr/lib"
     $env:LIBXML_INCLUDE_PATH="$BinaryCache/$($Platform.Triple)/usr/include/libxml2"
     $env:ZLIB_LIBRARY_PATH="$BinaryCache/$($Platform.Triple)/usr/lib"
+    $env:BROTLI_LIBRARY_PATH="$BinaryCache/$($Platform.Triple)/usr/lib"
     $env:CURL_LIBRARY_PATH="$BinaryCache/$($Platform.Triple)/usr/lib"
     $env:CURL_INCLUDE_PATH="$BinaryCache/$($Platform.Triple)/usr/include"
     Build-SPMProject `
@@ -4043,6 +4062,7 @@ if (-not $SkipBuild) {
       }
 
       Invoke-BuildStep Build-ZLib $Build
+      Invoke-BuildStep Build-Brotli $Build
       Invoke-BuildStep Build-XML2 $Build
       Invoke-BuildStep Build-CURL $Build
     }

--- a/utils/swift_build_support/swift_build_support/products/curl.py
+++ b/utils/swift_build_support/swift_build_support/products/curl.py
@@ -110,6 +110,7 @@ class LibCurl(cmake_product.CMakeProduct):
         self.cmake_options.define('CURL_DISABLE_SMTP', 'YES')
         self.cmake_options.define('CURL_DISABLE_GOPHER', 'YES')
         self.cmake_options.define('CURL_ZLIB', 'YES')
+        self.cmake_options.define('CURL_BROTLI', 'YES')
         self.cmake_options.define('ENABLE_CURL_MANUAL', 'NO')
         self.cmake_options.define('ENABLE_UNIX_SOCKETS', 'NO')
         self.cmake_options.define('ENABLE_THREADED_RESOLVER', 'NO')

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -118,6 +118,9 @@
         "zlib": {
           "remote": { "id": "madler/zlib" }
         },
+        "brotli": {
+          "remote": { "id": "google/brotli" }
+        },
         "mimalloc": {
           "remote": { "id": "microsoft/mimalloc" },
           "platforms": [ "Windows" ]
@@ -180,6 +183,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.1"
             }
@@ -291,6 +295,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.1"
             }
         },
@@ -608,6 +613,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.1"
             }
@@ -666,6 +672,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.1"
             }


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Add brotli as a dependency to enable brotli decoding for curl.

brotli is a general purpose compression algorithm used extensively on web. (https://datatracker.ietf.org/doc/html/rfc7932) 

brotli support for curl is enabled by integrating the brotli compression library (https://github.com/google/brotli). I've also added some tests for FoundationNetworking in https://github.com/swiftlang/swift-corelibs-foundation/pull/5251 which exercises this feature by 
- looking at the accept-encoding http header 
- decoding a brotli encoded payload
