### PR TITLE
DebugInfo: Bring back accidentally dropped `DIFlagArtificial` flag

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1946,7 +1946,7 @@ private:
           /* DWARFAddressSpace */ std::nullopt, MangledName);
 
       // FIXME: Set DIFlagObjectPointer and make sure it is only set for `self`.
-      return PTy;
+      return DBuilder.createArtificialType(PTy);
     }
     case TypeKind::BuiltinExecutor: {
       return createDoublePointerSizedStruct(

--- a/test/DebugInfo/EagerTypeMetadata.swift
+++ b/test/DebugInfo/EagerTypeMetadata.swift
@@ -13,6 +13,6 @@ public class C<T>
 }
 // CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "T",
 // CHECK-SAME:           baseType: ![[PTRTY:[0-9]+]]
-// CHECK: ![[PTRTY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: {{64|32}})
+// CHECK: ![[PTRTY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: {{64|32}}, flags: DIFlagArtificial)
 // CHECK: ![[LOC]] = !DILocation(line: 0,
 


### PR DESCRIPTION
Patches up https://github.com/swiftlang/swift/pull/83283.