### PR TITLE
Revert "DebugInfo: Bring back accidentally dropped `DIFlagArtificial` flag

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1946,7 +1946,7 @@ private:
           /* DWARFAddressSpace */ std::nullopt, MangledName);
 
       // FIXME: Set DIFlagObjectPointer and make sure it is only set for `self`.
-      return DBuilder.createArtificialType(PTy);
+      return PTy;
     }
     case TypeKind::BuiltinExecutor: {
       return createDoublePointerSizedStruct(

--- a/test/DebugInfo/EagerTypeMetadata.swift
+++ b/test/DebugInfo/EagerTypeMetadata.swift
@@ -13,6 +13,6 @@ public class C<T>
 }
 // CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "T",
 // CHECK-SAME:           baseType: ![[PTRTY:[0-9]+]]
-// CHECK: ![[PTRTY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: {{64|32}}, flags: DIFlagArtificial)
+// CHECK: ![[PTRTY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: {{64|32}})
 // CHECK: ![[LOC]] = !DILocation(line: 0,
 


### PR DESCRIPTION
Michael advised to revert this optimistic correction of mine [here](https://github.com/swiftlang/swift/pull/83445#discussion_r2244429034).

> I don't think we need to mark these artificial either tbh
>
> There is no harm it leaving it off. The artificial flag shouldn't be driven by the TypeKind, but rather the variable being emitted (similar to the DIFlagObjectPointer)