### PR TITLE
[cxx-interop] Fix import virtual methods with rvalue ref params

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -67,3 +67,8 @@ module Printed {
   header "printed.h"
   requires cplusplus
 }
+
+module VirtMethodWithRvalRef {
+  header "virtual-methods-with-rvalue-reference.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-with-rvalue-reference.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-with-rvalue-reference.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "swift/bridging"
+
+class CxxForeignRef;
+
+void retain(CxxForeignRef * obj);
+void release(CxxForeignRef * obj);
+
+struct NonTrivial {
+  NonTrivial(const NonTrivial &other);
+  ~NonTrivial();
+};
+
+class CxxForeignRef {
+public:
+  CxxForeignRef(const CxxForeignRef &) = delete;
+  CxxForeignRef() = default;
+
+  virtual void takesRValRef(NonTrivial &&);
+} SWIFT_SHARED_REFERENCE(retain, release);
+

--- a/test/Interop/Cxx/foreign-reference/reference-in-virtual-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-in-virtual-methods.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging %s -cxx-interoperability-mode=default -disable-availability-checking
+
+import VirtMethodWithRvalRef
+
+func f(_ x: CxxForeignRef, _ y: NonTrivial) {
+    x.takesRValRef(consuming: y)
+}


### PR DESCRIPTION
We generate forwarding calls for virutal methods. These forwarding calls had a type error when the original parameter had an rvalue reference type. In those scenarios we need to insert a static cast to make the type checker happy.

rdar://154969620