### PR TITLE
[cxx-interop] Support conforming to protocols with default assoc types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10148,6 +10148,15 @@ static void finishTypeWitnesses(
       break;
     }
 
+    if (!satisfied && assocType->hasDefaultDefinitionType()) {
+      auto defaultType = assocType->getDefaultDefinitionType();
+      auto subMap =
+          selfType->getContextSubstitutionMap(assocType->getDeclContext());
+      defaultType = defaultType.subst(subMap);
+      conformance->setTypeWitness(assocType, defaultType, assocType);
+      satisfied = true;
+    }
+
     if (!satisfied) {
       ABORT([&](auto &out) {
         out << "Cannot look up associated type for imported conformance:\n";

--- a/test/Interop/Cxx/class/conforms-to-associated-types.swift
+++ b/test/Interop/Cxx/class/conforms-to-associated-types.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/include)
+// RUN: split-file %s %t
+//
+// RUN: %target-swift-frontend -typecheck -module-name a -cxx-interoperability-mode=default -I %t/include %t/a.swift
+
+//--- include/module.modulemap
+module cxx {
+  header "header.h"
+  export *
+}
+
+//--- include/header.h
+struct S {
+  S() {}
+} __attribute__((swift_attr("conforms_to:a.P")));
+
+struct S2 {
+  S2() {}
+  using A = S2;
+} __attribute__((swift_attr("conforms_to:a.P")));
+
+//--- a.swift
+import cxx
+public protocol P {
+  associatedtype A = Int
+  func foo(_: A)
+}
+extension P {
+  func foo(_: A) {}
+}
+func test(s: S) {
+  let _ = s.foo(0)
+}
+func test2(s: S2) {
+  let _ = s.foo(s)
+}


### PR DESCRIPTION
In case the type does not define a type alias with the same name fall back to the default type of the associated type in the protocol. Previously, the compiler crashed.

Unfortunately, we are still crashing when we do not find the right conformance. In a follow-up PR I plan to add more graceful handling of the case when the lookup fails.

rdar://154098495
