### PR TITLE
build.ps1: be more explicit about SwiftSDK for `Differentiation`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2602,6 +2602,7 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
       -UseBuiltCompilers C,CXX,Swift `
+      -SwiftSDK $null `
       -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };


### PR DESCRIPTION
Ensure that we indicate that we are not using a Swift SDK when building this module as part of the SDK.