### PR TITLE
Revert "Merge pull request #82455 from eeckstein/adress-of-borrow-feature"

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -268,7 +268,6 @@ LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)"
 LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(BuiltinInterleave, 0, "Builtin.interleave and Builtin.deinterleave")
 LANGUAGE_FEATURE(BuiltinVectorsExternC, 0, "Extern C support for Builtin vector types")
-LANGUAGE_FEATURE(AddressOfProperty, 0, "Builtin.unprotectedAddressOf properties")
 LANGUAGE_FEATURE(NonescapableAccessorOnTrivial, 0, "Support UnsafeMutablePointer.mutableSpan")
 BASELINE_LANGUAGE_FEATURE(LayoutPrespecialization, 0, "Layout pre-specialization")
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -694,7 +694,6 @@ static bool usesFeatureDefaultIsolationPerFile(Decl *D) {
 UNINTERESTING_FEATURE(BuiltinSelect)
 UNINTERESTING_FEATURE(BuiltinInterleave)
 UNINTERESTING_FEATURE(BuiltinVectorsExternC)
-UNINTERESTING_FEATURE(AddressOfProperty)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -69,11 +69,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _address: UnsafePointer<Element> {
-#if $AddressOfProperty
     unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(_storage))
-#else
-    unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(self))
-#endif
   }
 
   /// Returns a buffer pointer over the entire array.
@@ -118,11 +114,7 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _mutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
-#if $AddressOfProperty
       unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&_storage))
-#else
-      unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&self))
-#endif
     }
   }
 


### PR DESCRIPTION
It seems there are some older stdlib interfaces that haven't fully been updated, and in this case it's changing the stored property of `InlineArray` from `let` to `var`. Newer compilers who understand this feature but don't have that updated stdlib interface will complain about trying to take the inout of a non-mutable property. Revert the feature so newer compilers don't take that path.