### PR TITLE
[test] ClangImporter: Add missing header search path

### DIFF
--- a/test/ClangImporter/broken-modules.swift
+++ b/test/ClangImporter/broken-modules.swift
@@ -1,6 +1,6 @@
 // RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -D MISSING_FROM_MODULE -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK-MODULE-MAP %s
 // RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CHECK-DIRECT %s
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -D INDIRECT -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CHECK-INDIRECT %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -I %S/Inputs/custom-modules/more-custom-modules -enable-objc-interop -show-diagnostics-after-fatal -D INDIRECT -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CHECK-INDIRECT %s
 
 // FIXME: not every test here depends on Objective-C syntax, this test can be split.
 


### PR DESCRIPTION
`ImportsMissingHeaderIndirect` is in `custom-modules\more-custom-modules`, which is not on the header search path. Clang no longer recurses into subdirectories to find modules.