### PR TITLE
CMake: ensure we can build compatibility libraries with macOS 14.0 SDK

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -1,5 +1,13 @@
 # Toolchain-only build products
 
+# `-fsized-deallocation` would cause a build failure
+# when targeting macOS 14.0 SDK used in some configuration
+get_property(directory_compile_options
+  DIRECTORY
+  PROPERTY COMPILE_OPTIONS)
+list(FILTER directory_compile_options EXCLUDE REGEX ".*-fsized-deallocation.*")
+set_property(DIRECTORY PROPERTY COMPILE_OPTIONS ${directory_compile_options})
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules)
 include(StdlibOptions)
 include(AddSwiftStdlib)


### PR DESCRIPTION
In particular, fix the Apple Silicon benchmark job by not propagating the flag added in #83399.

Addresses rdar://157188603