### PR TITLE
PrintAsClang: Fix crash and document `Unicode.Scalar` printing behavior

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2406,7 +2406,8 @@ private:
   }
 
   void maybePrintTagKeyword(const TypeDecl *NTD) {
-    if (auto *ED = dyn_cast<EnumDecl>(NTD); !NTD->hasClangNode()) {
+    auto *ED = dyn_cast<EnumDecl>(NTD);
+    if (ED && !NTD->hasClangNode()) {
       if (ED->getAttrs().hasAttribute<CDeclAttr>()) {
         // We should be able to use the tag macro for all printed enums but
         // for now restrict it to @cdecl to guard it behind the feature flag.

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// Test the behavior of printing Unicode.Scalar in the compatibility header.
+// This is wrong, it should either be rejected and considered non-representable
+// or actually be printed using a C / Objective-C compatible type.
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %s -emit-module -verify -o %t \
+// RUN:   -emit-clang-header-path %t/compat.h
+// RUN: %FileCheck %s --input-file %t/compat.h
+
+@_cdecl("referencesScalar")
+func referencesScalar() -> Unicode.Scalar { fatalError() }
+// CHECK: SWIFT_EXTERN Scalar referencesScalar(void)


### PR DESCRIPTION
Fix a null dereference failure when printing references to Swift structs, notably `Unicode.Scalar`, in the compatibility header.

`Unicode.Scalar` should not be printed, it's a Swift struct. It should either be considered non-representable or printed as a C / Objective-C type if that's the intent. For now, let's document the current behavior and use it to verify the fix.

rdar://157120538