### PR TITLE
[SILOptimizer]: fix some missing use after consume diagnostics

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -157,6 +157,11 @@ bool CheckerLivenessInfo::compute() {
               return false;
             }
           }
+        } else if (isa<StoreBorrowInst>(user)) {
+          if (liveness->updateForBorrowingOperand(use) !=
+              InnerBorrowKind::Contained) {
+            return false;
+          }
         }
         // FIXME: this ignores all other forms of Borrow ownership, such as
         // partial_apply [onstack] and mark_dependence [nonescaping].


### PR DESCRIPTION
Updates ConsumeOperatorCopyableValuesChecker to identify store_borrow instructions as a liveness-affecting use so that patterns that would previously slip through undiagnosed are correctly identified. e.g.

```swift
func use<V>(_ v: borrowing V) {}

func f() {
  let a = A()
  _ = consume a
  use(a) // previously would not be diagnosed
}
```

Resolves https://github.com/swiftlang/swift/issues/83277
