### PR TITLE
rename the feature AddressOfProperty to AddressOfProperty2

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -268,7 +268,7 @@ LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)"
 LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(BuiltinInterleave, 0, "Builtin.interleave and Builtin.deinterleave")
 LANGUAGE_FEATURE(BuiltinVectorsExternC, 0, "Extern C support for Builtin vector types")
-LANGUAGE_FEATURE(AddressOfProperty, 0, "Builtin.unprotectedAddressOf properties")
+LANGUAGE_FEATURE(AddressOfProperty2, 0, "Builtin.unprotectedAddressOf properties")
 LANGUAGE_FEATURE(NonescapableAccessorOnTrivial, 0, "Support UnsafeMutablePointer.mutableSpan")
 BASELINE_LANGUAGE_FEATURE(LayoutPrespecialization, 0, "Layout pre-specialization")
 BASELINE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -440,7 +440,7 @@ static bool usesFeatureDefaultIsolationPerFile(Decl *D) {
 UNINTERESTING_FEATURE(BuiltinSelect)
 UNINTERESTING_FEATURE(BuiltinInterleave)
 UNINTERESTING_FEATURE(BuiltinVectorsExternC)
-UNINTERESTING_FEATURE(AddressOfProperty)
+UNINTERESTING_FEATURE(AddressOfProperty2)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -69,7 +69,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _address: UnsafePointer<Element> {
-#if $AddressOfProperty
+#if $AddressOfProperty2
     unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(_storage))
 #else
     unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(self))
@@ -93,7 +93,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _protectedAddress: UnsafePointer<Element> {
-#if $AddressOfProperty
+#if $AddressOfProperty2
     unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(_storage))
 #else
     unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
@@ -118,7 +118,7 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _mutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
-#if $AddressOfProperty
+#if $AddressOfProperty2
       unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&_storage))
 #else
       unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&self))
@@ -149,7 +149,7 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
-#if $AddressOfProperty
+#if $AddressOfProperty2
       unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&_storage))
 #else
       unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&self))


### PR DESCRIPTION
Fixes a build problem when using a mainline compiler with a 6.2 Swift.swiftinterface file. This was caused by mistakenly cherry-picking the `#if $AddressOfProperty` conditions in the stdlib into 6.2 without the required compiler change.
