### PR TITLE
[Sema]: fix @discardableResult interaction with implicit @Sendable conversions

### DIFF
--- a/test/Concurrency/attr_discardableResult_async_await.swift
+++ b/test/Concurrency/attr_discardableResult_async_await.swift
@@ -14,3 +14,23 @@ func mainActorAsyncDiscardable() async -> Int { 0 }
 func consumesMainActorAsyncDiscardable() async {
   await mainActorAsyncDiscardable() // ok
 }
+
+// https://github.com/swiftlang/swift/issues/83463
+
+@MainActor
+@discardableResult
+func returnsDiscardableFunc() -> () -> Void { return {} }
+
+@MainActor
+func testDiscardsSyncFuncWithImplicitSendableConversion() {
+    returnsDiscardableFunc()
+}
+
+@MainActor
+@discardableResult
+func mainActorAsyncReturnsDiscardableFunc() async -> () -> Void { return {} }
+
+@MainActor
+func discardsAsyncFuncWithImplicitSendableConversion() async {
+  await mainActorAsyncReturnsDiscardableFunc()
+}


### PR DESCRIPTION
Updates existing diagnostic handling to look through function conversions when suppressing diagnostics for unused functions that are return values from callees marked with `@discardableResult`.

Resolves https://github.com/swiftlang/swift/issues/83463
