### PR TITLE
Embedded WASI: fix `InitializeWithCopy` VWT type mismatch

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -241,7 +241,7 @@ struct ResultTypeInfo {
 #else
   size_t size = 0;
   size_t alignMask = 0;
-  void (*initializeWithCopy)(OpaqueValue *result, OpaqueValue *src) = nullptr;
+  OpaqueValue * (*initializeWithCopy)(OpaqueValue *result, OpaqueValue *src, void *type) = nullptr;
   void (*storeEnumTagSinglePayload)(OpaqueValue *v, unsigned whichCase,
                                     unsigned emptyCases) = nullptr;
   void (*destroy)(OpaqueValue *, void *) = nullptr;
@@ -256,7 +256,7 @@ struct ResultTypeInfo {
     return alignMask + 1;
   }
   void vw_initializeWithCopy(OpaqueValue *result, OpaqueValue *src) {
-    initializeWithCopy(result, src);
+    initializeWithCopy(result, src, nullptr);
   }
   void vw_storeEnumTagSinglePayload(OpaqueValue *v, unsigned whichCase,
                                     unsigned emptyCases) {

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -215,9 +215,9 @@ class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
   size_t size;
   size_t alignMask;
 
-  void (*__ptrauth_swift_value_witness_function_pointer(
+  OpaqueValue *(*__ptrauth_swift_value_witness_function_pointer(
       SpecialPointerAuthDiscriminators::InitializeWithCopy)
-            initializeWithCopy)(OpaqueValue *, OpaqueValue *);
+            initializeWithCopy)(OpaqueValue *, OpaqueValue *, void *);
 
   void (*__ptrauth_swift_value_witness_function_pointer(
       SpecialPointerAuthDiscriminators::StoreEnumTagSinglePayload)

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency
@@ -64,7 +64,7 @@ actor Number {
         let n1 = await Number()
         await n1.task!.value
 
-        let n2 = await Number(iterations: 1000)
+        let n2 = await Number(iterations: 500)
         let val = await n2.val
         guard val == 1 else {
             fatalError("wrong val setting")

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import Builtin

--- a/test/embedded/concurrency-currenttask.swift
+++ b/test/embedded/concurrency-currenttask.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-leaks.swift
+++ b/test/embedded/concurrency-leaks.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -g -O
 // RUN: %target-clang -x c -std=c11 -c %S/Inputs/debug-malloc.c -o %t/debug-malloc.o -g
-// RUN: %target-clang %t/a.o %t/debug-malloc.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip -g
+// RUN: %target-clang %t/a.o %t/debug-malloc.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt %target-swift-default-executor-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -g
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency


### PR DESCRIPTION
This is a follow up to https://github.com/swiftlang/swift/pull/80862, where `initializeWithCopy` in a special implementation of `ResultTypeInfo` for Embedded Swift had a mismatching number of arguments and `void` result. The actual declaration of it in `ABI/ValueWitness.def` clearly includes one more argument and a result.

```
///   T *(*initializeWithCopy)(T *dest, T *src, M *self);
///
/// Given an invalid object of this type, initialize it as a copy of
/// the source object.  Returns the dest object.
FUNCTION_VALUE_WITNESS(initializeWithCopy,
                       InitializeWithCopy,
                       MUTABLE_VALUE_TYPE,
                       (MUTABLE_VALUE_TYPE, MUTABLE_VALUE_TYPE, TYPE_TYPE))
```

This function type mismatch is illegal when targeting Wasm and traps at run time.

Similarly to #80862, we're passing `nullptr` as the third argument, which is equivalent to the existing behavior on other platforms. The newly declared return value for Embedded Swift is ignored.

rdar://157218853