### PR TITLE
Embedded WASI: fix `storeEnumTagSinglePayload` type mismatch

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -243,7 +243,7 @@ struct ResultTypeInfo {
   size_t alignMask = 0;
   void (*initializeWithCopy)(OpaqueValue *result, OpaqueValue *src) = nullptr;
   void (*storeEnumTagSinglePayload)(OpaqueValue *v, unsigned whichCase,
-                                    unsigned emptyCases) = nullptr;
+                                    unsigned emptyCases, void *type) = nullptr;
   void (*destroy)(OpaqueValue *, void *) = nullptr;
 
   bool isNull() {
@@ -260,7 +260,7 @@ struct ResultTypeInfo {
   }
   void vw_storeEnumTagSinglePayload(OpaqueValue *v, unsigned whichCase,
                                     unsigned emptyCases) {
-    storeEnumTagSinglePayload(v, whichCase, emptyCases);
+    storeEnumTagSinglePayload(v, whichCase, emptyCases, nullptr);
   }
   void vw_destroy(OpaqueValue *v) {
     destroy(v, nullptr);

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -221,7 +221,7 @@ class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
 
   void (*__ptrauth_swift_value_witness_function_pointer(
       SpecialPointerAuthDiscriminators::StoreEnumTagSinglePayload)
-            storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned);
+            storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned, void *);
 
   void (*__ptrauth_swift_value_witness_function_pointer(
       SpecialPointerAuthDiscriminators::Destroy) destroy)(OpaqueValue *, void *);

--- a/test/embedded/concurrency-discardingtaskgroup.swift
+++ b/test/embedded/concurrency-discardingtaskgroup.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-taskgroup.swift
+++ b/test/embedded/concurrency-taskgroup.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency


### PR DESCRIPTION
This is a follow up to https://github.com/swiftlang/swift/pull/80862, where `storeEnumTagSinglePayload` in a special implementation of `ResultTypeInfo` for Embedded Swift had a mismatching number of arguments. The actual declaration of it in `ABI/ValueWitness.def` clearly includes one more argument.

```
/// void (*storeEnumTagSinglePayload)(T* enum, UINT_TYPE whichCase,
///                                   UINT_TYPE emptyCases, M *self);
/// Given uninitialized memory for an instance of a single payload enum with a
/// payload of this witness table's type (e.g Optional<ThisType>), store the
/// tag.
FUNCTION_VALUE_WITNESS(storeEnumTagSinglePayload,
                       StoreEnumTagSinglePayload,
                       VOID_TYPE,
                       (MUTABLE_VALUE_TYPE, UINT_TYPE, UINT_TYPE, TYPE_TYPE))
```

This function type mismatch is illegal when targeting Wasm and traps at run time.

Similarly to #80862, we're passing `nullptr` as the newly added argument, which is equivalent to the existing behavior on other platforms.

rdar://157219474