### PR TITLE
[cxx-interop] Move back addressability behind a flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -500,6 +500,7 @@ EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
+EXPERIMENTAL_FEATURE(AddressableInterop, true)
 
 /// Allow custom availability domains to be defined and referenced.
 EXPERIMENTAL_FEATURE(CustomAvailability, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -270,6 +270,7 @@ static bool usesFeatureAddressableTypes(Decl *d) {
   return false;
 }
 
+UNINTERESTING_FEATURE(AddressableInterop)
 UNINTERESTING_FEATURE(IsolatedAny2)
 UNINTERESTING_FEATURE(GlobalActorIsolatedTypesUsability)
 UNINTERESTING_FEATURE(ObjCImplementation)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4045,7 +4045,9 @@ namespace {
             func->setSelfIndex(selfIdx.value());
             // FIXME: Make this work when SIL Opaque Values are enabled.
             // Currently, addressable parameters and opaque values are at odds.
-            if (!dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
+            if (Impl.SwiftContext.LangOpts.hasFeature(
+                    Feature::AddressableInterop) &&
+                !dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
                 !importedName.importAsMember() &&
                 !Impl.SwiftContext.SILOpts.EnableSILOpaqueValues)
               func->getAttrs().add(new (Impl.SwiftContext)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2725,7 +2725,8 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   // subobject of the referenced storage. In those cases we need to prevent the
   // Swift compiler to pass in a temporary copy to prevent dangling.
   auto paramContext = param->getDeclContext();
-  if (!param->getType().isNull() && param->getType()->isLValueReferenceType() &&
+  if (impl->SwiftContext.LangOpts.hasFeature(Feature::AddressableInterop) &&
+      !param->getType().isNull() && param->getType()->isLValueReferenceType() &&
       !swiftParamTy->isForeignReferenceType() &&
       !(isa<clang::FunctionDecl>(paramContext) &&
         cast<clang::FunctionDecl>(paramContext)->isOverloadedOperator()) &&

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions -enable-experimental-feature AddressableInterop | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableInterop
 
 import CXXInterop
 

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -1,9 +1,10 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature AddressableInterop -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature AddressableInterop -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableInterop
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -7,6 +7,20 @@
 
 // REQUIRES: executable_test
 
+// libstdc++11 declares a templated constructor of std::function with an rvalue-reference parameter,
+// which aren't yet supported in Swift. Therefore initializing a std::function from Swift closures
+// will not work on the platforms that are shipped with this version of libstdc++ (rdar://125816354).
+// XFAIL: LinuxDistribution=ubuntu-24.04
+// XFAIL: LinuxDistribution=ubuntu-22.04
+// XFAIL: LinuxDistribution=rhel-9.3
+// XFAIL: LinuxDistribution=rhel-9.4
+// XFAIL: LinuxDistribution=rhel-9.5
+// XFAIL: LinuxDistribution=rhel-9.6
+// XFAIL: LinuxDistribution=fedora-39
+// XFAIL: LinuxDistribution=fedora-41
+// XFAIL: LinuxDistribution=debian-12
+// XFAIL: LinuxDistribution=amzn-2023
+
 import StdlibUnittest
 import StdFunction
 import CxxStdlib


### PR DESCRIPTION
There was another crash found by the bootstrap build bots.

This reverts commit 37ae8a22f40566c9bbfd0656c2a288960f3d8da6, reversing changes made to 6c8da764e242d892cf5c4f0b76f0ced5649ba692.
