### PR TITLE
tests: disable embedded/unowned-task-executor.swift for arm64e

### DIFF
--- a/test/embedded/unowned-task-executor.swift
+++ b/test/embedded/unowned-task-executor.swift
@@ -6,6 +6,9 @@
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 
+// check lines do not match ptrauch code
+// UNSUPPORTED: CPU=arm64e
+
 import _Concurrency
 
 public var e: (any TaskExecutor)? = nil


### PR DESCRIPTION
The check lines do not match ptrauch code
rdar://157170056
