### PR TITLE
[CSOptimizer] Fix a conditional that ignores function type parameters…

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1598,7 +1598,7 @@ static void determineBestChoicesInContext(
             // FIXME: Let's skip matching function types for now
             // because they have special rules for e.g. Concurrency
             // (around @Sendable) and @convention(c).
-            if (paramType->is<FunctionType>())
+            if (paramType->lookThroughAllOptionalTypes()->is<FunctionType>())
               continue;
 
             // The idea here is to match the parameter type against

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -352,3 +352,11 @@ func recursionMatchingTypeArgs2<T: P, V: P>(_ t: T.Type, _ v: V.Type) {
   recursionMatchingTypeArgs2(T.self, V.self) // expected-warning {{function call causes an infinite recursion}}
 }
 
+func testNoInfiniteRecursionWithOverloadingOnOptional() {
+  func test(handler: @escaping (Bool) -> Void) {
+  }
+
+  func test(handler: ((Bool) -> Void)?) {
+    test(handler: handler ?? { _ in }) // Ok
+  }
+}


### PR DESCRIPTION
… to look through optionals

Since parameters that have function types don't participate in ranking, function types that are wrapped in optionals should be excluded as well, because it's possible to overload on that and such overloads with optional types would gain an undue advantage.

For example:

```
func test(_: (() -> Void)?) {}
func test(_: () -> Void) {}

func compute(handler: () -> Void) {
  test(handler)
}
```

Without this change the second overload would be ignored and the first one would be an exact match.

Resolves: rdar://157234317

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
