### PR TITLE
Extract and use SILTypeProperties without a TypeLowering

### DIFF
--- a/include/swift/SIL/Lifetime.h
+++ b/include/swift/SIL/Lifetime.h
@@ -26,7 +26,7 @@ namespace swift {
 /// aggressively its destroys may be hoisted.
 ///
 /// By default, types have lifetimes inferred from their structure, see
-/// TypeLowering::RecursiveProperties::isLexical.  It can be overridden both on
+/// SILTypeProperties::isLexical.  It can be overridden both on
 /// the type level and the value level via attributes.
 struct Lifetime {
   enum Storage : uint8_t {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -42,6 +42,7 @@ class BasicBlockBitfield;
 class NodeBitfield;
 class OperandBitfield;
 class CalleeCache;
+class SILTypeProperties;
 class SILUndef;
 
 namespace Lowering {
@@ -784,10 +785,17 @@ public:
     return TypeExpansionContext(*this);
   }
 
+  SILTypeProperties getTypeProperties(Lowering::AbstractionPattern orig,
+                                      Type subst) const;
+  SILTypeProperties getTypeProperties(Type subst) const;
+  SILTypeProperties getTypeProperties(SILType type) const;
+
   const Lowering::TypeLowering &
-  getTypeLowering(Lowering::AbstractionPattern orig, Type subst);
+  getTypeLowering(Lowering::AbstractionPattern orig, Type subst) const;
 
   const Lowering::TypeLowering &getTypeLowering(Type t) const;
+
+  const Lowering::TypeLowering &getTypeLowering(SILType type) const;
 
   SILType getLoweredType(Lowering::AbstractionPattern orig, Type subst) const;
 
@@ -800,8 +808,6 @@ public:
   SILType getLoweredLoadableType(Type t) const;
 
   SILType getLoweredType(SILType t) const;
-
-  const Lowering::TypeLowering &getTypeLowering(SILType type) const;
 
   bool isTypeABIAccessible(SILType type) const;
 

--- a/include/swift/SIL/SILTypeProperties.h
+++ b/include/swift/SIL/SILTypeProperties.h
@@ -1,0 +1,254 @@
+//===--- SILTypeProperties.h - Properties of SIL types ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILTYPEPROPERTIES_H
+#define SWIFT_SIL_SILTYPEPROPERTIES_H
+
+namespace swift {
+
+/// Is a lowered SIL type trivial?  That is, are copies ultimately just
+/// bit-copies, and it takes no work to destroy a value?
+enum IsTrivial_t : bool {
+  IsNotTrivial = false,
+  IsTrivial = true
+};
+
+/// Is a lowered SIL type the Builtin.RawPointer or a struct/tuple/enum which
+/// contains a Builtin.RawPointer?
+/// HasRawPointer is true only for types that are known to contain
+/// Builtin.RawPointer. It is not assumed true for generic or resilient types.
+enum HasRawPointer_t : bool {
+  DoesNotHaveRawPointer = false,
+  HasRawPointer = true
+};
+
+/// Is a lowered SIL type fixed-ABI?  That is, can the current context
+/// assign it a fixed size and alignment and perform value operations on it
+/// (such as copies, destroys, constructions, and projections) without
+/// metadata?
+///
+/// Note that a fully concrete type can be non-fixed-ABI without being
+/// itself resilient if it contains a subobject which is not fixed-ABI.
+///
+/// Also note that we're only concerned with the external value ABI here:
+/// resilient class types are still fixed-ABI, indirect enum cases do not
+/// affect the fixed-ABI-ness of the enum, and so on.
+enum IsFixedABI_t : bool {
+  IsNotFixedABI = false,
+  IsFixedABI = true
+};
+
+/// Is a lowered SIL type address-only?  That is, is the current context
+/// required to keep the value in memory for some reason?
+///
+/// A type might be address-only because:
+///
+///   - it is not fixed-size (e.g. because it is a resilient type) and
+///     therefore cannot be loaded into a statically-boundable set of
+///     registers; or
+///
+///   - it is semantically bound to memory, either because its storage
+///     address is used by the language runtime to implement its semantics
+///     (as with a weak reference) or because its representation is somehow
+///     address-dependent (as with something like a relative pointer).
+///
+/// An address-only type can be fixed-layout and/or trivial.
+/// A non-fixed-layout type is always address-only.
+enum IsAddressOnly_t : bool {
+  IsNotAddressOnly = false,
+  IsAddressOnly = true
+};
+
+/// Is this type somewhat like a reference-counted type?
+enum IsReferenceCounted_t : bool {
+  IsNotReferenceCounted = false,
+  IsReferenceCounted = true
+};
+
+/// Is this type address only because it's resilient?
+enum IsResilient_t : bool {
+  IsNotResilient = false,
+  IsResilient = true
+};
+
+/// Does this type contain an opaque result type that affects type lowering?
+enum IsTypeExpansionSensitive_t : bool {
+  IsNotTypeExpansionSensitive = false,
+  IsTypeExpansionSensitive = true
+};
+
+/// Is the type infinitely defined in terms of itself? (Such types can never
+/// be concretely instantiated, but may still arise from generic specialization.)
+enum IsInfiniteType_t : bool {
+  IsNotInfiniteType = false,
+  IsInfiniteType = true,
+};
+
+/// Does this type contain any pack-like thing.
+enum HasPack_t : bool {
+  HasNoPack = false,
+  HasPack = true,
+};
+
+/// Is the type addressable-for-dependencies?
+///
+/// Values of an addressable-for-dependency type are passed indirectly into
+/// functions that specify a return value lifetime dependency on the value.
+/// This allows the dependent value to safely contain pointers to the in-memory
+/// representation of the source of the dependency.
+enum IsAddressableForDependencies_t : bool {
+  IsNotAddressableForDependencies = false,
+  IsAddressableForDependencies = true,
+};
+
+class SILTypeProperties {
+  // These are chosen so that bitwise-or merges the flags properly.
+  //
+  // clang-format off
+  enum : unsigned {
+    NonTrivialFlag                 = 1 << 0,
+    NonFixedABIFlag                = 1 << 1,
+    AddressOnlyFlag                = 1 << 2,
+    ResilientFlag                  = 1 << 3,
+    TypeExpansionSensitiveFlag     = 1 << 4,
+    InfiniteFlag                   = 1 << 5,
+    HasRawPointerFlag              = 1 << 6,
+    LexicalFlag                    = 1 << 7,
+    HasPackFlag                    = 1 << 8,
+    AddressableForDependenciesFlag = 1 << 9,
+  };
+  // clang-format on
+
+  uint16_t Flags;
+
+public:
+  /// Construct a default SILTypeProperties, which corresponds to
+  /// a trivial, loadable, fixed-layout type.
+  constexpr SILTypeProperties() : Flags(0) {}
+
+  constexpr SILTypeProperties(
+      IsTrivial_t isTrivial, IsFixedABI_t isFixedABI,
+      IsAddressOnly_t isAddressOnly, IsResilient_t isResilient,
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive =
+          IsNotTypeExpansionSensitive,
+      HasRawPointer_t hasRawPointer = DoesNotHaveRawPointer,
+      IsLexical_t isLexical = IsNotLexical, HasPack_t hasPack = HasNoPack,
+      IsAddressableForDependencies_t isAFD = IsNotAddressableForDependencies)
+      : Flags((isTrivial ? 0U : NonTrivialFlag) |
+              (isFixedABI ? 0U : NonFixedABIFlag) |
+              (isAddressOnly ? AddressOnlyFlag : 0U) |
+              (isResilient ? ResilientFlag : 0U) |
+              (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0U) |
+              (hasRawPointer ? HasRawPointerFlag : 0U) |
+              (isLexical ? LexicalFlag : 0U) |
+              (hasPack ? HasPackFlag : 0U) |
+              (isAFD ? AddressableForDependenciesFlag : 0U)) {}
+
+  constexpr bool operator==(SILTypeProperties p) const {
+    return Flags == p.Flags;
+  }
+
+  static constexpr SILTypeProperties forTrivial() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient};
+  }
+
+  static constexpr SILTypeProperties forTrivialOpaque() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, HasRawPointer, IsNotLexical,
+            HasNoPack, IsAddressableForDependencies};
+  }
+
+  static constexpr SILTypeProperties forRawPointer() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, HasRawPointer};
+  }
+
+  static constexpr SILTypeProperties forReference() {
+    return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, DoesNotHaveRawPointer, IsLexical};
+  }
+
+  static constexpr SILTypeProperties forOpaque() {
+    return {IsNotTrivial, IsNotFixedABI, IsAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, HasRawPointer, IsLexical,
+            HasNoPack, IsAddressableForDependencies};
+  }
+
+  static constexpr SILTypeProperties forResilient() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient,
+            IsNotTypeExpansionSensitive, HasRawPointer, IsNotLexical,
+            HasNoPack, IsNotAddressableForDependencies};
+  }
+
+  void addSubobject(SILTypeProperties other) {
+    Flags |= other.Flags;
+  }
+
+  IsTrivial_t isTrivial() const {
+    return IsTrivial_t((Flags & NonTrivialFlag) == 0);
+  }
+  HasRawPointer_t isOrContainsRawPointer() const {
+    return HasRawPointer_t((Flags & HasRawPointerFlag) != 0);
+  }
+  IsFixedABI_t isFixedABI() const {
+    return IsFixedABI_t((Flags & NonFixedABIFlag) == 0);
+  }
+  IsAddressOnly_t isAddressOnly() const {
+    return IsAddressOnly_t((Flags & AddressOnlyFlag) != 0);
+  }
+  bool isLoadable() const {
+    return !isAddressOnly();
+  }
+  IsResilient_t isResilient() const {
+    return IsResilient_t((Flags & ResilientFlag) != 0);
+  }
+  IsTypeExpansionSensitive_t isTypeExpansionSensitive() const {
+    return IsTypeExpansionSensitive_t(
+        (Flags & TypeExpansionSensitiveFlag) != 0);
+  }
+  IsInfiniteType_t isInfinite() const {
+    return IsInfiniteType_t((Flags & InfiniteFlag) != 0);
+  }
+  IsLexical_t isLexical() const {
+    return IsLexical_t((Flags & LexicalFlag) != 0);
+  }
+  HasPack_t isOrContainsPack() const {
+    return HasPack_t((Flags & HasPackFlag) != 0);
+  }
+  IsAddressableForDependencies_t isAddressableForDependencies() const {
+    return IsAddressableForDependencies_t(
+                              (Flags & AddressableForDependenciesFlag) != 0);
+  }
+
+  void setNonTrivial() { Flags |= NonTrivialFlag; }
+  void setIsOrContainsRawPointer() { Flags |= HasRawPointerFlag; }
+
+  void setNonFixedABI() { Flags |= NonFixedABIFlag; }
+  void setAddressOnly() { Flags |= AddressOnlyFlag; }
+  void setTypeExpansionSensitive(
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
+    Flags = (Flags & ~TypeExpansionSensitiveFlag) |
+            (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0);
+  }
+  void setInfinite() { Flags |= InfiniteFlag; }
+  void setLexical(IsLexical_t isLexical) {
+    Flags = (Flags & ~LexicalFlag) | (isLexical ? LexicalFlag : 0);
+  }
+  void setHasPack() { Flags |= HasPackFlag; }
+  void setAddressableForDependencies() {
+    Flags |= AddressableForDependenciesFlag;
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -20,6 +20,7 @@
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
+#include "swift/SIL/SILTypeProperties.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
@@ -92,240 +93,8 @@ adjustFunctionType(CanSILFunctionType t, SILFunctionType::Representation rep,
                             witnessMethodConformance);
 }
 
-/// Is a lowered SIL type trivial?  That is, are copies ultimately just
-/// bit-copies, and it takes no work to destroy a value?
-enum IsTrivial_t : bool {
-  IsNotTrivial = false,
-  IsTrivial = true
-};
-
-/// Is a lowered SIL type the Builtin.RawPointer or a struct/tuple/enum which
-/// contains a Builtin.RawPointer?
-/// HasRawPointer is true only for types that are known to contain
-/// Builtin.RawPointer. It is not assumed true for generic or resilient types.
-enum HasRawPointer_t : bool {
-  DoesNotHaveRawPointer = false,
-  HasRawPointer = true
-};
-
-/// Is a lowered SIL type fixed-ABI?  That is, can the current context
-/// assign it a fixed size and alignment and perform value operations on it
-/// (such as copies, destroys, constructions, and projections) without
-/// metadata?
-///
-/// Note that a fully concrete type can be non-fixed-ABI without being
-/// itself resilient if it contains a subobject which is not fixed-ABI.
-///
-/// Also note that we're only concerned with the external value ABI here:
-/// resilient class types are still fixed-ABI, indirect enum cases do not
-/// affect the fixed-ABI-ness of the enum, and so on.
-enum IsFixedABI_t : bool {
-  IsNotFixedABI = false,
-  IsFixedABI = true
-};
-
-/// Is a lowered SIL type address-only?  That is, is the current context
-/// required to keep the value in memory for some reason?
-///
-/// A type might be address-only because:
-///
-///   - it is not fixed-size (e.g. because it is a resilient type) and
-///     therefore cannot be loaded into a statically-boundable set of
-///     registers; or
-///
-///   - it is semantically bound to memory, either because its storage
-///     address is used by the language runtime to implement its semantics
-///     (as with a weak reference) or because its representation is somehow
-///     address-dependent (as with something like a relative pointer).
-///
-/// An address-only type can be fixed-layout and/or trivial.
-/// A non-fixed-layout type is always address-only.
-enum IsAddressOnly_t : bool {
-  IsNotAddressOnly = false,
-  IsAddressOnly = true
-};
-
-/// Is this type somewhat like a reference-counted type?
-enum IsReferenceCounted_t : bool {
-  IsNotReferenceCounted = false,
-  IsReferenceCounted = true
-};
-
-/// Is this type address only because it's resilient?
-enum IsResilient_t : bool {
-  IsNotResilient = false,
-  IsResilient = true
-};
-
-/// Does this type contain an opaque result type that affects type lowering?
-enum IsTypeExpansionSensitive_t : bool {
-  IsNotTypeExpansionSensitive = false,
-  IsTypeExpansionSensitive = true
-};
-
-/// Is the type infinitely defined in terms of itself? (Such types can never
-/// be concretely instantiated, but may still arise from generic specialization.)
-enum IsInfiniteType_t : bool {
-  IsNotInfiniteType = false,
-  IsInfiniteType = true,
-};
-
-/// Does this type contain any pack-like thing.
-enum HasPack_t : bool {
-  HasNoPack = false,
-  HasPack = true,
-};
-
-/// Is the type addressable-for-dependencies?
-///
-/// Values of an addressable-for-dependency type are passed indirectly into
-/// functions that specify a return value lifetime dependency on the value.
-/// This allows the dependent value to safely contain pointers to the in-memory
-/// representation of the source of the dependency.
-enum IsAddressableForDependencies_t : bool {
-  IsNotAddressableForDependencies = false,
-  IsAddressableForDependencies = true,
-};
-
 /// Extended type information used by SIL.
 class TypeLowering {
-public:
-  class RecursiveProperties {
-    // These are chosen so that bitwise-or merges the flags properly.
-    //
-    // clang-format off
-    enum : unsigned {
-      NonTrivialFlag                 = 1 << 0,
-      NonFixedABIFlag                = 1 << 1,
-      AddressOnlyFlag                = 1 << 2,
-      ResilientFlag                  = 1 << 3,
-      TypeExpansionSensitiveFlag     = 1 << 4,
-      InfiniteFlag                   = 1 << 5,
-      HasRawPointerFlag              = 1 << 6,
-      LexicalFlag                    = 1 << 7,
-      HasPackFlag                    = 1 << 8,
-      AddressableForDependenciesFlag = 1 << 9,
-    };
-    // clang-format on
-
-    uint16_t Flags;
-
-  public:
-    /// Construct a default RecursiveProperties, which corresponds to
-    /// a trivial, loadable, fixed-layout type.
-    constexpr RecursiveProperties() : Flags(0) {}
-
-    constexpr RecursiveProperties(
-        IsTrivial_t isTrivial, IsFixedABI_t isFixedABI,
-        IsAddressOnly_t isAddressOnly, IsResilient_t isResilient,
-        IsTypeExpansionSensitive_t isTypeExpansionSensitive =
-            IsNotTypeExpansionSensitive,
-        HasRawPointer_t hasRawPointer = DoesNotHaveRawPointer,
-        IsLexical_t isLexical = IsNotLexical, HasPack_t hasPack = HasNoPack,
-        IsAddressableForDependencies_t isAFD = IsNotAddressableForDependencies)
-        : Flags((isTrivial ? 0U : NonTrivialFlag) |
-                (isFixedABI ? 0U : NonFixedABIFlag) |
-                (isAddressOnly ? AddressOnlyFlag : 0U) |
-                (isResilient ? ResilientFlag : 0U) |
-                (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0U) |
-                (hasRawPointer ? HasRawPointerFlag : 0U) |
-                (isLexical ? LexicalFlag : 0U) |
-                (hasPack ? HasPackFlag : 0U) |
-                (isAFD ? AddressableForDependenciesFlag : 0U)) {}
-
-    constexpr bool operator==(RecursiveProperties p) const {
-      return Flags == p.Flags;
-    }
-
-    static constexpr RecursiveProperties forTrivial() {
-      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient};
-    }
-
-    static constexpr RecursiveProperties forTrivialOpaque() {
-      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
-              IsNotTypeExpansionSensitive, HasRawPointer, IsNotLexical,
-              HasNoPack, IsAddressableForDependencies};
-    }
-
-    static constexpr RecursiveProperties forRawPointer() {
-      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
-              IsNotTypeExpansionSensitive, HasRawPointer};
-    }
-
-    static constexpr RecursiveProperties forReference() {
-      return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
-              IsNotTypeExpansionSensitive, DoesNotHaveRawPointer, IsLexical};
-    }
-
-    static constexpr RecursiveProperties forOpaque() {
-      return {IsNotTrivial, IsNotFixedABI, IsAddressOnly, IsNotResilient,
-              IsNotTypeExpansionSensitive, HasRawPointer, IsLexical,
-              HasNoPack, IsAddressableForDependencies};
-    }
-
-    static constexpr RecursiveProperties forResilient() {
-      return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient,
-              IsNotTypeExpansionSensitive, HasRawPointer, IsNotLexical,
-              HasNoPack, IsNotAddressableForDependencies};
-    }
-
-    void addSubobject(RecursiveProperties other) {
-      Flags |= other.Flags;
-    }
-
-    IsTrivial_t isTrivial() const {
-      return IsTrivial_t((Flags & NonTrivialFlag) == 0);
-    }
-    HasRawPointer_t isOrContainsRawPointer() const {
-      return HasRawPointer_t((Flags & HasRawPointerFlag) != 0);
-    }
-    IsFixedABI_t isFixedABI() const {
-      return IsFixedABI_t((Flags & NonFixedABIFlag) == 0);
-    }
-    IsAddressOnly_t isAddressOnly() const {
-      return IsAddressOnly_t((Flags & AddressOnlyFlag) != 0);
-    }
-    IsResilient_t isResilient() const {
-      return IsResilient_t((Flags & ResilientFlag) != 0);
-    }
-    IsTypeExpansionSensitive_t isTypeExpansionSensitive() const {
-      return IsTypeExpansionSensitive_t(
-          (Flags & TypeExpansionSensitiveFlag) != 0);
-    }
-    IsInfiniteType_t isInfinite() const {
-      return IsInfiniteType_t((Flags & InfiniteFlag) != 0);
-    }
-    IsLexical_t isLexical() const {
-      return IsLexical_t((Flags & LexicalFlag) != 0);
-    }
-    HasPack_t isOrContainsPack() const {
-      return HasPack_t((Flags & HasPackFlag) != 0);
-    }
-    IsAddressableForDependencies_t isAddressableForDependencies() const {
-      return IsAddressableForDependencies_t(
-                                (Flags & AddressableForDependenciesFlag) != 0);
-    }
-
-    void setNonTrivial() { Flags |= NonTrivialFlag; }
-    void setIsOrContainsRawPointer() { Flags |= HasRawPointerFlag; }
-
-    void setNonFixedABI() { Flags |= NonFixedABIFlag; }
-    void setAddressOnly() { Flags |= AddressOnlyFlag; }
-    void setTypeExpansionSensitive(
-        IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
-      Flags = (Flags & ~TypeExpansionSensitiveFlag) |
-              (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0);
-    }
-    void setInfinite() { Flags |= InfiniteFlag; }
-    void setLexical(IsLexical_t isLexical) {
-      Flags = (Flags & ~LexicalFlag) | (isLexical ? LexicalFlag : 0);
-    }
-    void setHasPack() { Flags |= HasPackFlag; }
-    void setAddressableForDependencies() {
-      Flags |= AddressableForDependenciesFlag;
-    }
-  };
-
 private:
   friend class TypeConverter;
 
@@ -336,7 +105,7 @@ protected:
   mutable SILType LoweredType;
 
 private:
-  RecursiveProperties Properties;
+  SILTypeProperties Properties;
 
   /// The resilience expansion for this type lowering.
   /// If the type is not resilient at all, this is always Minimal.
@@ -349,7 +118,7 @@ private:
   mutable const TypeLowering *NextExpansion = nullptr;
 
 protected:
-  TypeLowering(SILType type, RecursiveProperties properties,
+  TypeLowering(SILType type, SILTypeProperties properties,
                IsReferenceCounted_t isRefCounted,
                TypeExpansionContext expansionContext)
       : LoweredType(type), Properties(properties),
@@ -367,7 +136,7 @@ public:
   /// Dump out the internal state of this type lowering to llvm::dbgs().
   SWIFT_DEBUG_DUMP;
 
-  RecursiveProperties getRecursiveProperties() const {
+  SILTypeProperties getRecursiveProperties() const {
     return Properties;
   }
 
@@ -382,7 +151,7 @@ public:
   /// full layout is available to the compiler. This is the inverse of
   /// isAddressOnly.
   bool isLoadable() const {
-    return !isAddressOnly();
+    return Properties.isLoadable();
   }
 
   /// isFixedABI - Returns true if the type has a known fixed layout.
@@ -1070,6 +839,14 @@ public:
         "unexpected address-only type");
     return ti.getLoweredType();
   }
+
+  SILTypeProperties getTypeProperties(AbstractionPattern origType,
+                                      Type substType,
+                                      TypeExpansionContext forExpansion);
+  SILTypeProperties getTypeProperties(Type substType,
+                                      TypeExpansionContext forExpansion);
+  SILTypeProperties getTypeProperties(SILType type,
+                                      TypeExpansionContext forExpansion);
 
   CanType getLoweredRValueType(TypeExpansionContext context, Type t) {
     return getLoweredType(t, context).getRawASTType();

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -829,7 +829,7 @@ void irgen::emitDestroyArrayCall(IRGenFunction &IGF,
                                  Address object,
                                  llvm::Value *count) {
   // If T is a trivial/POD type, nothing needs to be done.
-  if (IGF.IGM.getTypeLowering(T).isTrivial())
+  if (IGF.IGM.getTypeProperties(T).isTrivial())
     return;
 
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
@@ -1118,7 +1118,7 @@ void irgen::emitDestroyCall(IRGenFunction &IGF,
                             SILType T,
                             Address object) {
   // If T is a trivial/POD type, nothing needs to be done.
-  if (IGF.IGM.getTypeLowering(T).isTrivial())
+  if (IGF.IGM.getTypeProperties(T).isTrivial())
     return;
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1720,9 +1720,9 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
   // Treat infinitely-sized types as resilient as well, since they can never
   // be concretized.
   if (IGM.isResilient(D, ResilienceExpansion::Maximal)
-      || IGM.getSILTypes().getTypeLowering(SILType::getPrimitiveAddressType(type),
-                                            TypeExpansionContext::minimal())
-            .getRecursiveProperties().isInfinite()) {
+      || IGM.getSILTypes().getTypeProperties(SILType::getPrimitiveAddressType(type),
+                                             TypeExpansionContext::minimal())
+            .isInfinite()) {
     auto copyable = !D->canBeCopyable()
       ? IsNotCopyable : IsCopyable;
     auto structAccessible =

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1901,6 +1901,24 @@ const Lowering::TypeLowering &IRGenModule::getTypeLowering(SILType type) const {
       type, TypeExpansionContext::maximalResilienceExpansionOnly());
 }
 
+SILTypeProperties IRGenModule::getTypeProperties(SILType type) const {
+  return getTypeProperties(type,
+             TypeExpansionContext::maximalResilienceExpansionOnly());
+}
+
+SILTypeProperties
+IRGenModule::getTypeProperties(SILType type,
+                               TypeExpansionContext forExpansion) const {
+  return getSILTypes().getTypeProperties(type, forExpansion);
+}
+
+SILTypeProperties
+IRGenModule::getTypeProperties(AbstractionPattern origType,
+                               Type substType,
+                               TypeExpansionContext forExpansion) const {
+  return getSILTypes().getTypeProperties(origType, substType, forExpansion);
+}
+
 bool IRGenModule::isTypeABIAccessible(SILType type) const {
   return getSILModule().isTypeABIAccessible(
       type, TypeExpansionContext::maximalResilienceExpansionOnly());

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -845,9 +845,7 @@ ValueWitnessFlags getValueWitnessFlags(IRGenModule &IGM,
         fixedTI->isBitwiseBorrowable(ResilienceExpansion::Maximal);
     assert(isBitwiseTakable || !isInline);
     bool isAddressableForDependencies =
-        IGM.getSILModule().Types.getTypeLowering(concreteType,
-                                                TypeExpansionContext::minimal())
-          .getRecursiveProperties()
+        IGM.getTypeProperties(concreteType, TypeExpansionContext::minimal())
           .isAddressableForDependencies();
           
     flags = flags.withAlignment(fixedTI->getFixedAlignment().getValue())
@@ -1456,10 +1454,8 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type,
   // All of our standard value witness tables are bitwise-borrowable and not
   // addressable for dependencies.
   if (!ti.isBitwiseBorrowable(ResilienceExpansion::Maximal)
-      || IGM.getSILModule().Types
-            .getTypeLowering(AbstractionPattern::getOpaque(), type,
-                             TypeExpansionContext::minimal())
-            .getRecursiveProperties()
+      || IGM.getTypeProperties(AbstractionPattern::getOpaque(), type,
+                               TypeExpansionContext::minimal())
             .isAddressableForDependencies()) {
     return {};
   }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1075,6 +1075,12 @@ public:
   SILType getLoweredType(AbstractionPattern orig, Type subst) const;
   SILType getLoweredType(Type subst) const;
   const Lowering::TypeLowering &getTypeLowering(SILType type) const;
+  SILTypeProperties getTypeProperties(SILType type) const;
+  SILTypeProperties getTypeProperties(SILType type,
+                                      TypeExpansionContext forExpansion) const;
+  SILTypeProperties getTypeProperties(AbstractionPattern origType,
+                                      Type substType,
+                                      TypeExpansionContext forExpansion) const;
   bool isTypeABIAccessible(SILType type) const;
 
   const TypeInfo &getTypeInfoForUnlowered(AbstractionPattern orig,

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -499,13 +499,13 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedCopyAddrHelperFunction(
     llvm::GlobalValue::DefaultVisibility,
     llvm::GlobalValue::DefaultStorageClass,
   };
-  auto &TL =
-    getSILModule().Types.getTypeLowering(T, TypeExpansionContext::minimal());
+
   // Opaque result types might lead to different expansions in different files.
   // The default hidden linkonce_odr might lead to linking an implementation
   // from another file that head a different expansion/different
   // signature/different implementation.
-  if (TL.getRecursiveProperties().isTypeExpansionSensitive()) {
+  if (getTypeProperties(T, TypeExpansionContext::minimal())
+        .isTypeExpansionSensitive()) {
     linkage = &privateLinkage;
   }
 
@@ -528,7 +528,7 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedCopyAddrHelperFunction(
 void TypeInfo::callOutlinedDestroy(IRGenFunction &IGF,
                                    Address addr, SILType T) const {
   // Short-cut destruction of trivial values.
-  if (IGF.IGM.getTypeLowering(T).isTrivial())
+  if (IGF.IGM.getTypeProperties(T).isTrivial())
     return;
 
   if (withWitnessableMetadataCollector(
@@ -572,13 +572,13 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedDestroyFunction(
     llvm::GlobalValue::DefaultVisibility,
     llvm::GlobalValue::DefaultStorageClass,
   };
-  auto &TL =
-    getSILModule().Types.getTypeLowering(T, TypeExpansionContext::minimal());
+
   // Opaque result types might lead to different expansions in different files.
   // The default hidden linkonce_odr might lead to linking an implementation
   // from another file that head a different expansion/different
   // signature/different implementation.
-  if (TL.getRecursiveProperties().isTypeExpansionSensitive()) {
+  if (getTypeProperties(T, TypeExpansionContext::minimal())
+        .isTypeExpansionSensitive()) {
     linkage = &privateLinkage;
   }
 

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -288,7 +288,7 @@ static bool isTypeMetadataForLayoutAccessible(SILModule &M, SILType type) {
 bool SILModule::isTypeABIAccessible(SILType type,
                                     TypeExpansionContext forExpansion) {
   // Fixed-ABI types can have value operations done without metadata.
-  if (Types.getTypeLowering(type, forExpansion).isFixedABI())
+  if (Types.getTypeProperties(type, forExpansion).isFixedABI())
     return true;
 
   assert(!type.is<ReferenceStorageType>() &&

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -566,8 +566,24 @@ ResilienceExpansion SILFunction::getResilienceExpansion() const {
           : ResilienceExpansion::Maximal);
 }
 
+SILTypeProperties
+SILFunction::getTypeProperties(AbstractionPattern orig, Type subst) const {
+  return getModule().Types.getTypeProperties(orig, subst,
+                                             TypeExpansionContext(*this));
+}
+
+SILTypeProperties SILFunction::getTypeProperties(Type subst) const {
+  return getModule().Types.getTypeProperties(subst,
+                                             TypeExpansionContext(*this));
+}
+
+SILTypeProperties SILFunction::getTypeProperties(SILType type) const {
+  return getModule().Types.getTypeProperties(type,
+                                             TypeExpansionContext(*this));
+}
+
 const TypeLowering &
-SILFunction::getTypeLowering(AbstractionPattern orig, Type subst) {
+SILFunction::getTypeLowering(AbstractionPattern orig, Type subst) const {
   return getModule().Types.getTypeLowering(orig, subst,
                                            TypeExpansionContext(*this));
 }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1061,10 +1061,10 @@ MemoryBehavior SILInstruction::getMemoryBehavior() const {
     SILModule &M = ga->getFunction()->getModule();
     auto expansion = TypeExpansionContext::maximal(M.getAssociatedContext(),
                                                    M.isWholeModule());
-    const TypeLowering &tl =
-      M.Types.getTypeLowering(ga->getType().getObjectType(), expansion);
-    return tl.isFixedABI() ? MemoryBehavior::None :
-                             MemoryBehavior::MayHaveSideEffects;
+    SILTypeProperties props =
+      M.Types.getTypeProperties(ga->getType().getObjectType(), expansion);
+    return props.isFixedABI() ? MemoryBehavior::None
+                              : MemoryBehavior::MayHaveSideEffects;
   }
 
   if (auto *li = dyn_cast<LoadInst>(this)) {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -124,12 +124,12 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
                                               TypeExpansionContext expansion) {
   if (auto *expr = capture.getPackElement()) {
     auto contextTy = expr->getType();
-    auto &lowering = getTypeLowering(
+    auto props = getTypeProperties(
         contextTy, TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
                             expansion.getResilienceExpansion()));
 
     assert(!contextTy->isNoncopyable() && "Not implemented");
-    if (!lowering.isAddressOnly())
+    if (!props.isAddressOnly())
       return CaptureKind::Constant;
 
     return CaptureKind::Immutable;
@@ -141,7 +141,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
          "should not have attempted to directly capture this variable");
 
   auto contextTy = var->getTypeInContext();
-  auto &lowering = getTypeLowering(
+  auto props = getTypeProperties(
       contextTy, TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
                           expansion.getResilienceExpansion()));
 
@@ -161,7 +161,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
   // If this is a non-address-only stored 'let' constant, we can capture it
   // by value.  If it is address-only, then we can't load it, so capture it
   // by its address (like a var) instead.
-  if (!var->supportsMutation() && !lowering.isAddressOnly())
+  if (!var->supportsMutation() && !props.isAddressOnly())
       return CaptureKind::Constant;
 
   // In-out parameters are captured by address.
@@ -172,7 +172,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
 
   // For 'let' constants
   if (!var->supportsMutation()) {
-    assert(getTypeLowering(
+    assert(getTypeProperties(
                var->getTypeInContext(),
                TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
                    expansion.getResilienceExpansion()))
@@ -187,9 +187,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
           : CaptureKind::Box);
 }
 
-using RecursiveProperties = TypeLowering::RecursiveProperties;
-
-static RecursiveProperties
+static SILTypeProperties
 classifyType(AbstractionPattern origType, CanType type,
              TypeConverter &TC, TypeExpansionContext expansion);
 
@@ -213,78 +211,78 @@ namespace {
     // The subclass should implement:
     //   // Trivial, fixed-layout, and non-address-only.
     //   RetTy handleTrivial(CanType);
-    //   RetTy handleTrivial(CanType, RecursiveProperties properties);
+    //   RetTy handleTrivial(CanType, SILTypeProperties properties);
     //   // A reference type.
     //   RetTy handleReference(CanType);
-    //   RetTy handleReference(CanType, RecursiveProperties properties);
+    //   RetTy handleReference(CanType, SILTypeProperties properties);
     //   // Non-trivial, move only, loadable
-    //   RetTy handleMoveOnlyReference(CanType, RecursiveProperties properties);
+    //   RetTy handleMoveOnlyReference(CanType, SILTypeProperties properties);
     //   // Non-trivial, move only, address only
-    //   RetTy handleMoveOnlyAddressOnly(CanType, RecursiveProperties
+    //   RetTy handleMoveOnlyAddressOnly(CanType, SILTypeProperties
     //   properties);
     //   // Non-trivial and address-only.
-    //   RetTy handleAddressOnly(CanType, RecursiveProperties properties);
+    //   RetTy handleAddressOnly(CanType, SILTypeProperties properties);
     // and, if it doesn't override handleTupleType,
     //   // An aggregate type that's non-trivial.
-    //   RetTy handleNonTrivialAggregate(CanType, RecursiveProperties
+    //   RetTy handleNonTrivialAggregate(CanType, SILTypeProperties
     //   properties);
     //
     // Alternatively, it can just implement:
-    //   RetTy handle(CanType, RecursiveProperties properties);
+    //   RetTy handle(CanType, SILTypeProperties properties);
 
     /// Handle a trivial, fixed-size, loadable type.
-    RetTy handleTrivial(CanType type, RecursiveProperties properties) {
+    RetTy handleTrivial(CanType type, SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
-    RetTy handleAddressOnly(CanType type, RecursiveProperties properties) {
+    RetTy handleAddressOnly(CanType type, SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
     RetTy handleNonTrivialAggregate(CanType type,
-                                    RecursiveProperties properties) {
+                                    SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
     RetTy handleTrivial(CanType type) {
-      return asImpl().handleTrivial(type, RecursiveProperties::forTrivial());
+      return asImpl().handleTrivial(type, SILTypeProperties::forTrivial());
     }
 
     RetTy handleReference(CanType type) {
-      return handleReference(type, RecursiveProperties::forReference());
+      return handleReference(type, SILTypeProperties::forReference());
     }
 
-    RetTy handleReference(CanType type, RecursiveProperties properties) {
+    RetTy handleReference(CanType type, SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
     RetTy handleMoveOnlyReference(CanType type,
-                                  RecursiveProperties properties) {
+                                  SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
     RetTy handleMoveOnlyAddressOnly(CanType type,
-                                    RecursiveProperties properties) {
+                                    SILTypeProperties properties) {
       return asImpl().handle(type, properties);
     }
 
-    RecursiveProperties
+    SILTypeProperties
     mergeIsTypeExpansionSensitive(IsTypeExpansionSensitive_t isSensitive,
-                                  RecursiveProperties props) {
+                                  SILTypeProperties props) {
       if (isSensitive == IsTypeExpansionSensitive)
         props.setTypeExpansionSensitive(isSensitive);
       return props;
     }
 
-    RecursiveProperties mergeHasPack(HasPack_t hasPack,
-                                     RecursiveProperties props) {
+    SILTypeProperties mergeHasPack(HasPack_t hasPack,
+                                     SILTypeProperties props) {
       if (hasPack == HasPack)
         props.setHasPack();
       return props;
     }
 
-    RecursiveProperties applyLifetimeAnnotation(LifetimeAnnotation annotation,
-                                                RecursiveProperties props) {
+    SILTypeProperties applyLifetimeAnnotation(LifetimeAnnotation annotation,
+                                                SILTypeProperties props) {
       switch (annotation) {
       case LifetimeAnnotation::None:
         break;
@@ -298,28 +296,28 @@ namespace {
       return props;
     }
 
-    RecursiveProperties
-    getTrivialRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
+    SILTypeProperties
+    getTrivialSILTypeProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
-                                           RecursiveProperties::forTrivial());
+                                           SILTypeProperties::forTrivial());
     }
 
-    RecursiveProperties
-    getTrivialOpaqueRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
+    SILTypeProperties
+    getTrivialOpaqueSILTypeProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
-                                           RecursiveProperties::forTrivial());
+                                           SILTypeProperties::forTrivial());
     }
 
-    RecursiveProperties
-    getReferenceRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
+    SILTypeProperties
+    getReferenceSILTypeProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
-                                           RecursiveProperties::forReference());
+                                           SILTypeProperties::forReference());
     }
 
-    RecursiveProperties
-    getOpaqueRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
+    SILTypeProperties
+    getOpaqueSILTypeProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
-                                           RecursiveProperties::forOpaque());
+                                           SILTypeProperties::forOpaque());
     }
 
     RetTy visit(CanType substType, AbstractionPattern origType,
@@ -335,7 +333,7 @@ namespace {
     RetTy visit##TYPE##Type(Can##TYPE##Type type, AbstractionPattern orig,   \
                             IsTypeExpansionSensitive_t isSensitive) {        \
       return asImpl().handle##LOWERING(type,                                 \
-                           get##LOWERING##RecursiveProperties(isSensitive)); \
+                           get##LOWERING##SILTypeProperties(isSensitive)); \
     }
 
     IMPL(BuiltinInteger, Trivial)
@@ -361,11 +359,11 @@ namespace {
       llvm_unreachable("not a real type");
     }
     
-    RecursiveProperties getBuiltinFixedArrayProperties(
+    SILTypeProperties getBuiltinFixedArrayProperties(
                                       CanBuiltinFixedArrayType type,
                                       AbstractionPattern origType,
                                       IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties props;
+      SILTypeProperties props;
       
       // We get most of the type properties from the element type.
       AbstractionPattern origElementType = AbstractionPattern::getOpaque();
@@ -430,7 +428,7 @@ namespace {
     RetTy visitPackExpansionType(CanPackExpansionType type,
                                  AbstractionPattern origType,
                                  IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties props;
+      SILTypeProperties props;
       props.setAddressOnly();
       props.addSubobject(classifyType(origType.getPackExpansionPatternType(),
                                       type.getPatternType(),
@@ -443,8 +441,8 @@ namespace {
     RetTy visitBuiltinRawPointerType(CanBuiltinRawPointerType type,
                                      AbstractionPattern orig,
                                      IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties props = mergeIsTypeExpansionSensitive(isSensitive,
-                                          RecursiveProperties::forRawPointer());
+      SILTypeProperties props = mergeIsTypeExpansionSensitive(isSensitive,
+                                          SILTypeProperties::forRawPointer());
       return asImpl().handleTrivial(type, props);
     }
 
@@ -488,11 +486,11 @@ namespace {
       case AnyFunctionType::Representation::Swift:
       case AnyFunctionType::Representation::Block:
         return asImpl().handleReference(
-            type, getReferenceRecursiveProperties(isSensitive));
+            type, getReferenceSILTypeProperties(isSensitive));
       case AnyFunctionType::Representation::CFunctionPointer:
       case AnyFunctionType::Representation::Thin:
         return asImpl().handleTrivial(
-            type, getTrivialRecursiveProperties(isSensitive));
+            type, getTrivialSILTypeProperties(isSensitive));
       }
       llvm_unreachable("bad function representation");
     }
@@ -509,13 +507,13 @@ namespace {
         return asImpl().visitNormalDifferentiableSILFunctionType(
             type, mergeIsTypeExpansionSensitive(
                       isSensitive,
-                      getNormalDifferentiableSILFunctionTypeRecursiveProperties(
+                      getNormalDifferentiableSILFunctionTypeSILTypeProperties(
                           type, origType)));
       case DifferentiabilityKind::Linear:
         return asImpl().visitLinearDifferentiableSILFunctionType(
             type, mergeIsTypeExpansionSensitive(
                       isSensitive,
-                      getNormalDifferentiableSILFunctionTypeRecursiveProperties(
+                      getNormalDifferentiableSILFunctionTypeSILTypeProperties(
                           type, origType)));
       case DifferentiabilityKind::NonDifferentiable:
         break;
@@ -529,16 +527,16 @@ namespace {
         // TODO: Nonescaping closures should also be move-only to ensure we
         // eliminate copies.
         return asImpl().handleReference(
-            type, getReferenceRecursiveProperties(isSensitive));
+            type, getReferenceSILTypeProperties(isSensitive));
       }
       
       // Contextless function references are trivial types.
       return asImpl().handleTrivial(type,
-                                    getTrivialRecursiveProperties(isSensitive));
+                                    getTrivialSILTypeProperties(isSensitive));
     }
 
-    RecursiveProperties
-    getNormalDifferentiableSILFunctionTypeRecursiveProperties(
+    SILTypeProperties
+    getNormalDifferentiableSILFunctionTypeSILTypeProperties(
         CanSILFunctionType type, AbstractionPattern origType) {
       auto origTy = type->getWithoutDifferentiability();
       // Pass the original type of abstraction pattern to
@@ -558,33 +556,33 @@ namespace {
           AutoDiffDerivativeFunctionKind::VJP, TC,
           LookUpConformanceInModule(), CanGenericSignature(),
           false, origTypeOfAbstraction);
-      RecursiveProperties props;
+      SILTypeProperties props;
       props.addSubobject(classifyType(origType, origTy, TC, Expansion));
       props.addSubobject(classifyType(origType, jvpTy, TC, Expansion));
       props.addSubobject(classifyType(origType, vjpTy, TC, Expansion));
       return props;
     }
 
-    RecursiveProperties
-    getLinearDifferentiableSILFunctionTypeRecursiveProperties(
+    SILTypeProperties
+    getLinearDifferentiableSILFunctionTypeSILTypeProperties(
         CanSILFunctionType type, AbstractionPattern origType) {
       auto origTy = type->getWithoutDifferentiability();
       auto transposeTy = origTy->getAutoDiffTransposeFunctionType(
           type->getDifferentiabilityParameterIndices(), TC,
           LookUpConformanceInModule(), origType.getGenericSignatureOrNull());
-      RecursiveProperties props;
+      SILTypeProperties props;
       props.addSubobject(classifyType(origType, origTy, TC, Expansion));
       props.addSubobject(classifyType(origType, transposeTy, TC, Expansion));
       return props;
     }
 
     RetTy visitNormalDifferentiableSILFunctionType(
-        CanSILFunctionType type, RecursiveProperties props) {
+        CanSILFunctionType type, SILTypeProperties props) {
       return handleAggregateByProperties(type, props);
     }
 
     RetTy visitLinearDifferentiableSILFunctionType(
-        CanSILFunctionType type, RecursiveProperties props) {
+        CanSILFunctionType type, SILTypeProperties props) {
       return handleAggregateByProperties(type, props);
     }
 
@@ -602,7 +600,7 @@ namespace {
                          AbstractionPattern origType,
                          IsTypeExpansionSensitive_t isSensitive) {
       return asImpl().handleTrivial(type,
-                                    getTrivialRecursiveProperties(isSensitive));
+                                    getTrivialSILTypeProperties(isSensitive));
     }
 
     // Dependent types can be lowered according to their corresponding
@@ -614,10 +612,10 @@ namespace {
           origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
         if (origType.requiresClass()) {
           return asImpl().handleReference(
-              type, getReferenceRecursiveProperties(isSensitive));
+              type, getReferenceSILTypeProperties(isSensitive));
         } else {
           return asImpl().handleAddressOnly(
-              type, getOpaqueRecursiveProperties(isSensitive));
+              type, getOpaqueSILTypeProperties(isSensitive));
         }
       } else {
         // If the abstraction pattern provides a concrete type, lower as that
@@ -688,14 +686,14 @@ namespace {
                                    AbstractionPattern origType, \
                                    IsTypeExpansionSensitive_t isSensitive) { \
       return asImpl().handleReference(type, \
-                                getReferenceRecursiveProperties(isSensitive)); \
+                                getReferenceSILTypeProperties(isSensitive)); \
     }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     RetTy visitLoadable##Name##StorageType(Can##Name##StorageType type, \
                                            AbstractionPattern origType, \
                                      IsTypeExpansionSensitive_t isSensitive) { \
       return asImpl().handleReference(type, \
-                                getReferenceRecursiveProperties(isSensitive)); \
+                                getReferenceSILTypeProperties(isSensitive)); \
     } \
     RetTy visitAddressOnly##Name##StorageType(Can##Name##StorageType type, \
                                               AbstractionPattern origType, \
@@ -726,7 +724,7 @@ namespace {
                                    AbstractionPattern origType, \
                                    IsTypeExpansionSensitive_t isSensitive) { \
       return asImpl().handleTrivial(type, \
-                                  getTrivialRecursiveProperties(isSensitive)); \
+                                  getTrivialSILTypeProperties(isSensitive)); \
     }
 #include "swift/AST/ReferenceStorage.def"
 
@@ -750,22 +748,22 @@ namespace {
       if (LayoutInfo) {
         if (LayoutInfo->isFixedSizeTrivial()) {
           return asImpl().handleTrivial(
-              type, getTrivialOpaqueRecursiveProperties(isSensitive));
+              type, getTrivialOpaqueSILTypeProperties(isSensitive));
         }
 
         if (LayoutInfo->isAddressOnlyTrivial()) {
-          auto properties = getTrivialOpaqueRecursiveProperties(isSensitive);
+          auto properties = getTrivialOpaqueSILTypeProperties(isSensitive);
           properties.setAddressOnly();
           return asImpl().handleAddressOnly(type, properties);
         }
 
         if (LayoutInfo->isRefCounted()) {
           return asImpl().handleReference(
-              type, getReferenceRecursiveProperties(isSensitive));
+              type, getReferenceSILTypeProperties(isSensitive));
         }
       }
       return asImpl().handleAddressOnly(
-          type, getOpaqueRecursiveProperties(isSensitive));
+          type, getOpaqueSILTypeProperties(isSensitive));
     }
 
     RetTy visitExistentialType(CanType type,
@@ -788,11 +786,11 @@ namespace {
       case ExistentialRepresentation::Class:
       case ExistentialRepresentation::Boxed:
         return asImpl().handleReference(
-            type, getReferenceRecursiveProperties(isSensitive));
+            type, getReferenceSILTypeProperties(isSensitive));
       // Existential metatypes are trivial.
       case ExistentialRepresentation::Metatype:
         return asImpl().handleTrivial(
-            type, getTrivialRecursiveProperties(isSensitive));
+            type, getTrivialSILTypeProperties(isSensitive));
       }
 
       llvm_unreachable("Unhandled ExistentialRepresentation in switch.");
@@ -860,7 +858,7 @@ namespace {
     // Tuples depend on their elements.
     RetTy visitTupleType(CanTupleType type, AbstractionPattern origType,
                          IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties props;
+      SILTypeProperties props;
       origType.forEachExpandedTupleElement(type,
           [&](AbstractionPattern origEltType, CanType substEltType,
               const TupleTypeElt &elt) {
@@ -895,7 +893,7 @@ namespace {
                           IsTypeExpansionSensitive_t isSensitive) {
       // Should not be loaded.
       return asImpl().handleReference(
-          type, getReferenceRecursiveProperties(isSensitive));
+          type, getReferenceSILTypeProperties(isSensitive));
     }
 
     RetTy visitSILMoveOnlyWrappedType(CanSILMoveOnlyWrappedType type,
@@ -903,20 +901,20 @@ namespace {
                                       IsTypeExpansionSensitive_t isSensitive) {
       AbstractionPattern innerAbstraction = origType.removingMoveOnlyWrapper();
       CanType innerType = type->getInnerType();
-      auto &lowering =
-          TC.getTypeLowering(innerAbstraction, innerType, Expansion);
-      if (lowering.isAddressOnly()) {
+      auto props =
+          TC.getTypeProperties(innerAbstraction, innerType, Expansion);
+      if (props.isAddressOnly()) {
         return asImpl().handleMoveOnlyAddressOnly(
             type->getCanonicalType(),
-            getOpaqueRecursiveProperties(isSensitive));
+            getOpaqueSILTypeProperties(isSensitive));
       }
 
       return asImpl().handleMoveOnlyReference(
           type->getCanonicalType(),
-          getReferenceRecursiveProperties(isSensitive));
+          getReferenceSILTypeProperties(isSensitive));
     }
 
-    RetTy handleAggregateByProperties(CanType type, RecursiveProperties props) {
+    RetTy handleAggregateByProperties(CanType type, SILTypeProperties props) {
       if (props.isAddressOnly()) {
         return asImpl().handleAddressOnly(type, props);
       }
@@ -929,25 +927,25 @@ namespace {
   };
 
   class TypeClassifier :
-      public TypeClassifierBase<TypeClassifier, RecursiveProperties> {
+      public TypeClassifierBase<TypeClassifier, SILTypeProperties> {
   public:
     TypeClassifier(TypeConverter &TC,
                    TypeExpansionContext Expansion)
         : TypeClassifierBase(TC, Expansion) {}
 
-    RecursiveProperties handle(CanType type, RecursiveProperties properties) {
+    SILTypeProperties handle(CanType type, SILTypeProperties properties) {
       return properties;
     }
 
-    RecursiveProperties
+    SILTypeProperties
     visitAnyClassType(CanType type, AbstractionPattern origType, ClassDecl *D,
                       IsTypeExpansionSensitive_t isSensitive) {
-      // Consult the type lowering.
-      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
-      return handleClassificationFromLowering(type, lowering, isSensitive);
+      // Consult the type properties.
+      auto props = TC.getTypeProperties(origType, type, Expansion);
+      return handleClassificationFromLowering(type, props, isSensitive);
     }
 
-    RecursiveProperties visitAnyEnumType(CanType type,
+    SILTypeProperties visitAnyEnumType(CanType type,
                                          AbstractionPattern origType,
                                          EnumDecl *D,
                                        IsTypeExpansionSensitive_t isSensitive) {
@@ -960,31 +958,31 @@ namespace {
                      isSensitive);
       }
 
-      // Consult the type lowering.
-      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
-      return handleClassificationFromLowering(type, lowering, isSensitive);
+      // Consult the type properties.
+      auto props = TC.getTypeProperties(origType, type, Expansion);
+      return handleClassificationFromLowering(type, props, isSensitive);
     }
 
-    RecursiveProperties visitAnyStructType(CanType type,
+    SILTypeProperties visitAnyStructType(CanType type,
                                            AbstractionPattern origType,
                                            StructDecl *D,
                                        IsTypeExpansionSensitive_t isSensitive) {
-      // Consult the type lowering.
-      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
-      return handleClassificationFromLowering(type, lowering, isSensitive);
+      // Consult the type properties.
+      auto props = TC.getTypeProperties(origType, type, Expansion);
+      return handleClassificationFromLowering(type, props, isSensitive);
     }
 
   private:
-    RecursiveProperties
-    handleClassificationFromLowering(CanType type, const TypeLowering &lowering,
+    SILTypeProperties
+    handleClassificationFromLowering(CanType type,
+                                     SILTypeProperties props,
                                      IsTypeExpansionSensitive_t isSensitive) {
-      return handle(type, mergeIsTypeExpansionSensitive(
-                              isSensitive, lowering.getRecursiveProperties()));
+      return handle(type, mergeIsTypeExpansionSensitive(isSensitive, props));
     }
   };
 } // end anonymous namespace
 
-static RecursiveProperties classifyType(AbstractionPattern origType,
+static SILTypeProperties classifyType(AbstractionPattern origType,
                                         CanType type,
                                         TypeConverter &tc,
                                         TypeExpansionContext expansion) {
@@ -1009,7 +1007,7 @@ namespace {
   /// opaque values are passed by value.
   class LoadableTypeLowering : public TypeLowering {
   protected:
-    LoadableTypeLowering(SILType type, RecursiveProperties properties,
+    LoadableTypeLowering(SILType type, SILTypeProperties properties,
                          IsReferenceCounted_t isRefCounted,
                          TypeExpansionContext forExpansion)
       : TypeLowering(type, properties, isRefCounted, forExpansion) {}
@@ -1037,7 +1035,7 @@ namespace {
   /// A class for trivial, fixed-layout, loadable types.
   class TrivialTypeLowering final : public LoadableTypeLowering {
   public:
-    TrivialTypeLowering(SILType type, RecursiveProperties properties,
+    TrivialTypeLowering(SILType type, SILTypeProperties properties,
                         TypeExpansionContext forExpansion)
       : LoadableTypeLowering(type, properties, IsNotReferenceCounted,
                              forExpansion) {
@@ -1135,7 +1133,7 @@ namespace {
   class NonTrivialLoadableTypeLowering : public LoadableTypeLowering {
   public:
     NonTrivialLoadableTypeLowering(SILType type,
-                                   RecursiveProperties properties,
+                                   SILTypeProperties properties,
                                    IsReferenceCounted_t isRefCounted,
                                    TypeExpansionContext forExpansion)
       : LoadableTypeLowering(type, properties, isRefCounted, forExpansion) {
@@ -1277,7 +1275,7 @@ namespace {
       const = 0;
     
   public:
-    LoadableAggTypeLowering(CanType type, RecursiveProperties properties,
+    LoadableAggTypeLowering(CanType type, SILTypeProperties properties,
                             TypeExpansionContext forExpansion)
       : NonTrivialLoadableTypeLowering(SILType::getPrimitiveObjectType(type),
                                        properties, IsNotReferenceCounted,
@@ -1422,7 +1420,7 @@ namespace {
     using Super = LoadableAggTypeLowering<LoadableTupleTypeLowering, unsigned>;
 
   public:
-    LoadableTupleTypeLowering(CanType type, RecursiveProperties properties,
+    LoadableTupleTypeLowering(CanType type, SILTypeProperties properties,
                               TypeExpansionContext forExpansion)
       : LoadableAggTypeLowering(type, properties, forExpansion) {}
 
@@ -1487,7 +1485,7 @@ namespace {
         LoadableAggTypeLowering<LoadableStructTypeLowering, VarDecl *>;
 
   public:
-    LoadableStructTypeLowering(CanType type, RecursiveProperties properties,
+    LoadableStructTypeLowering(CanType type, SILTypeProperties properties,
                                TypeExpansionContext forExpansion)
       : LoadableAggTypeLowering(type, properties, forExpansion) {}
 
@@ -1541,7 +1539,7 @@ namespace {
   /// A lowering for loadable but non-trivial enum types.
   class LoadableEnumTypeLowering final : public NonTrivialLoadableTypeLowering {
   public:
-    LoadableEnumTypeLowering(CanType type, RecursiveProperties properties,
+    LoadableEnumTypeLowering(CanType type, SILTypeProperties properties,
                              TypeExpansionContext forExpansion)
       : NonTrivialLoadableTypeLowering(SILType::getPrimitiveObjectType(type),
                                        properties,
@@ -1649,7 +1647,7 @@ namespace {
 
   public:
     MoveOnlyLoadableStructTypeLowering(CanType type,
-                                       RecursiveProperties properties,
+                                       SILTypeProperties properties,
                                        TypeExpansionContext forExpansion)
         : LoadableAggTypeLowering(type, properties, forExpansion) {}
 
@@ -1718,7 +1716,7 @@ namespace {
       : public NonTrivialLoadableTypeLowering {
   public:
     MoveOnlyLoadableEnumTypeLowering(CanType type,
-                                     RecursiveProperties properties,
+                                     SILTypeProperties properties,
                                      TypeExpansionContext forExpansion)
         : NonTrivialLoadableTypeLowering(SILType::getPrimitiveObjectType(type),
                                          properties, IsNotReferenceCounted,
@@ -1803,7 +1801,7 @@ namespace {
 
   class LeafLoadableTypeLowering : public NonTrivialLoadableTypeLowering {
   public:
-    LeafLoadableTypeLowering(SILType type, RecursiveProperties properties,
+    LeafLoadableTypeLowering(SILType type, SILTypeProperties properties,
                              IsReferenceCounted_t isRefCounted,
                              TypeExpansionContext forExpansion)
       : NonTrivialLoadableTypeLowering(type, properties, isRefCounted,
@@ -1824,12 +1822,12 @@ namespace {
   /// A class for nonspecific loadable nontrivial types.
   class MiscNontrivialTypeLowering : public LeafLoadableTypeLowering {
   public:
-    MiscNontrivialTypeLowering(SILType type, RecursiveProperties properties,
+    MiscNontrivialTypeLowering(SILType type, SILTypeProperties properties,
                           TypeExpansionContext forExpansion)
         : LeafLoadableTypeLowering(type, properties, IsNotReferenceCounted,
                                    forExpansion) {}
 
-    MiscNontrivialTypeLowering(CanType type, RecursiveProperties properties,
+    MiscNontrivialTypeLowering(CanType type, SILTypeProperties properties,
                             TypeExpansionContext forExpansion)
       : MiscNontrivialTypeLowering(SILType::getPrimitiveObjectType(type),
                                    properties, forExpansion)
@@ -1863,7 +1861,7 @@ namespace {
   /// loadable.
   class ReferenceTypeLowering : public LeafLoadableTypeLowering {
   public:
-    ReferenceTypeLowering(SILType type, RecursiveProperties properties,
+    ReferenceTypeLowering(SILType type, SILTypeProperties properties,
                           TypeExpansionContext forExpansion)
         : LeafLoadableTypeLowering(type, properties, IsReferenceCounted,
                                    forExpansion) {}
@@ -1894,7 +1892,7 @@ namespace {
   /// A class for move only types which are non-trivial and loadable
   class MoveOnlyReferenceTypeLowering : public LeafLoadableTypeLowering {
   public:
-    MoveOnlyReferenceTypeLowering(SILType type, RecursiveProperties properties,
+    MoveOnlyReferenceTypeLowering(SILType type, SILTypeProperties properties,
                                   TypeExpansionContext forExpansion)
         : LeafLoadableTypeLowering(type, properties, IsReferenceCounted,
                                    forExpansion) {}
@@ -1928,7 +1926,7 @@ namespace {
   public: \
     Loadable##Name##TypeLowering(SILType type, \
                                  TypeExpansionContext forExpansion, \
-                                 RecursiveProperties props) \
+                                 SILTypeProperties props) \
       : LeafLoadableTypeLowering(type, props, \
                                  IsReferenceCounted, \
                                  forExpansion) {} \
@@ -1953,7 +1951,7 @@ namespace {
   /// A class for non-trivial, address-only types.
   class AddressOnlyTypeLowering : public TypeLowering {
   public:
-    AddressOnlyTypeLowering(SILType type, RecursiveProperties properties,
+    AddressOnlyTypeLowering(SILType type, SILTypeProperties properties,
                             TypeExpansionContext forExpansion)
       : TypeLowering(type, properties, IsNotReferenceCounted,
                      forExpansion) {
@@ -2039,7 +2037,7 @@ namespace {
   class MoveOnlyAddressOnlyTypeLowering : public TypeLowering {
   public:
     MoveOnlyAddressOnlyTypeLowering(SILType type,
-                                    RecursiveProperties properties,
+                                    SILTypeProperties properties,
                                     TypeExpansionContext forExpansion)
         : TypeLowering(type, properties, IsNotReferenceCounted, forExpansion) {
       assert(properties.isAddressOnly());
@@ -2159,7 +2157,7 @@ namespace {
       LoweredType = LoweredType.getAddressType();
     }
 
-    OpaqueValueTypeLowering(SILType type, RecursiveProperties properties,
+    OpaqueValueTypeLowering(SILType type, SILTypeProperties properties,
                             TypeExpansionContext forExpansion)
       : LeafLoadableTypeLowering(type, properties, IsNotReferenceCounted,
                                  forExpansion) {}
@@ -2221,7 +2219,7 @@ namespace {
   class MoveOnlyOpaqueValueTypeLowering : public LeafLoadableTypeLowering {
   public:
     MoveOnlyOpaqueValueTypeLowering(SILType type,
-                                    RecursiveProperties properties,
+                                    SILTypeProperties properties,
                                     TypeExpansionContext forExpansion)
         : LeafLoadableTypeLowering(type, properties, IsNotReferenceCounted,
                                    forExpansion) {}
@@ -2276,30 +2274,30 @@ namespace {
           loweredAddresses(loweredAddresses) {}
 
     TypeLowering *handleTrivial(CanType type) {
-      return handleTrivial(type, RecursiveProperties::forTrivial());
+      return handleTrivial(type, SILTypeProperties::forTrivial());
     }
 
     TypeLowering *handleTrivial(CanType type,
-                                RecursiveProperties properties) {
+                                SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC) TrivialTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleReference(CanType type,
-                                  RecursiveProperties properties) {
+                                  SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       if (type.isForeignReferenceType() &&
           type->getReferenceCounting() == ReferenceCounting::None)
         return new (TC) TrivialTypeLowering(
-            silType, RecursiveProperties::forTrivial(), Expansion);
+            silType, SILTypeProperties::forTrivial(), Expansion);
 
       return new (TC) ReferenceTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleMoveOnlyReference(CanType type,
-                                          RecursiveProperties properties) {
+                                          SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC)
@@ -2307,7 +2305,7 @@ namespace {
     }
 
     TypeLowering *handleMoveOnlyAddressOnly(CanType type,
-                                            RecursiveProperties properties) {
+                                            SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
           !TypeLoweringForceOpaqueValueLowering) {
@@ -2321,14 +2319,14 @@ namespace {
     }
 
     TypeLowering *handleReference(CanType type) {
-      auto properties = RecursiveProperties::forReference();
+      auto properties = SILTypeProperties::forReference();
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC) ReferenceTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleAddressOnly(CanType type,
-                                    RecursiveProperties properties) {
+                                    SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
           !TypeLoweringForceOpaqueValueLowering) {
@@ -2343,7 +2341,7 @@ namespace {
     }
     
     TypeLowering *handleInfinite(CanType type,
-                                 RecursiveProperties properties) {
+                                 SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       // Infinite types cannot actually be instantiated, so treat them as
       // opaque for code generation purposes.
@@ -2360,7 +2358,7 @@ namespace {
       return new (TC) Loadable##Name##TypeLowering( \
                                   SILType::getPrimitiveObjectType(type), \
                                   Expansion, \
-                                getReferenceRecursiveProperties(isSensitive)); \
+                                getReferenceSILTypeProperties(isSensitive)); \
     }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     TypeLowering * \
@@ -2370,7 +2368,7 @@ namespace {
       return new (TC) Loadable##Name##TypeLowering( \
                                   SILType::getPrimitiveObjectType(type), \
                                   Expansion, \
-                                getReferenceRecursiveProperties(isSensitive)); \
+                                getReferenceSILTypeProperties(isSensitive)); \
     }
 #include "swift/AST/ReferenceStorage.def"
 
@@ -2392,14 +2390,13 @@ namespace {
     TypeLowering *visitSILPackType(CanSILPackType packType,
                                    AbstractionPattern origType,
                                    IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties;
+      SILTypeProperties properties;
       properties.setAddressOnly();
       properties.setHasPack();
       for (auto i : indices(packType.getElementTypes())) {
-        auto &eltLowering =
-          TC.getTypeLowering(packType->getSILElementType(i),
-                             Expansion);
-        properties.addSubobject(eltLowering.getRecursiveProperties());
+        auto eltProps =
+          TC.getTypeProperties(packType->getSILElementType(i), Expansion);
+        properties.addSubobject(eltProps);
       }
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
@@ -2409,14 +2406,14 @@ namespace {
     TypeLowering *visitPackExpansionType(CanPackExpansionType packExpansionType,
                                          AbstractionPattern origType,
                                          IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties;
+      SILTypeProperties properties;
       properties.setAddressOnly();
       properties.setHasPack();
-      auto &patternLowering =
-        TC.getTypeLowering(origType.getPackExpansionPatternType(),
-                           packExpansionType.getPatternType(),
-                           Expansion);
-      properties.addSubobject(patternLowering.getRecursiveProperties());
+      auto patternProps =
+        TC.getTypeProperties(origType.getPackExpansionPatternType(),
+                             packExpansionType.getPatternType(),
+                             Expansion);
+      properties.addSubobject(patternProps);
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
       return handleAddressOnly(packExpansionType, properties);
@@ -2431,7 +2428,7 @@ namespace {
     TypeLowering *visitTupleType(CanTupleType tupleType,
                                  AbstractionPattern origType,
                                  IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties;
+      SILTypeProperties properties;
       origType.forEachExpandedTupleElement(tupleType,
           [&](AbstractionPattern origEltType, CanType substEltType,
               const TupleTypeElt &elt) {
@@ -2453,7 +2450,7 @@ namespace {
     }
 
     bool handleResilience(CanType type, NominalTypeDecl *D,
-                          RecursiveProperties &properties) {
+                          SILTypeProperties &properties) {
       if (D->isResilient()) {
         // If the type is resilient and defined in our module, make a note of
         // that, since our lowering now depends on the resilience expansion.
@@ -2463,7 +2460,7 @@ namespace {
         auto inSameResilienceDomain = D->getModuleContext() == &TC.M ||
                                       D->bypassResilienceInPackage(&TC.M);
         if (inSameResilienceDomain)
-          properties.addSubobject(RecursiveProperties::forResilient());
+          properties.addSubobject(SILTypeProperties::forResilient());
 
         // If the type is in a different module and not in the same package
         // resilience domain (with package-cmo), or if we're using a minimal
@@ -2476,7 +2473,7 @@ namespace {
         if (!inSameResilienceDomain ||
             Expansion.getResilienceExpansion() ==
                                ResilienceExpansion::Minimal) {
-          properties.addSubobject(RecursiveProperties::forOpaque());
+          properties.addSubobject(SILTypeProperties::forOpaque());
           return true;
         }
       }
@@ -2486,8 +2483,8 @@ namespace {
     TypeLowering *visitAnyClassType(CanType classType,
                                     AbstractionPattern origType, ClassDecl *C,
                                     IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties =
-          getReferenceRecursiveProperties(isSensitive);
+      SILTypeProperties properties =
+          getReferenceSILTypeProperties(isSensitive);
 
       if (C->getLifetimeAnnotation() == LifetimeAnnotation::EagerMove)
         properties.setLexical(IsNotLexical);
@@ -2501,7 +2498,7 @@ namespace {
                                      AbstractionPattern origType,
                                      StructDecl *D,
                                      IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties;
+      SILTypeProperties properties;
 
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
@@ -2624,7 +2621,7 @@ namespace {
                                    AbstractionPattern origType,
                                    EnumDecl *D,
                                    IsTypeExpansionSensitive_t isSensitive) {
-      RecursiveProperties properties;
+      SILTypeProperties properties;
 
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
@@ -2723,21 +2720,21 @@ namespace {
 
     TypeLowering *
     visitNormalDifferentiableSILFunctionType(CanSILFunctionType type,
-                                             RecursiveProperties props) {
+                                             SILTypeProperties props) {
       return handleAggregateByProperties
           <NormalDifferentiableSILFunctionTypeLowering>(type, props);
     }
 
     TypeLowering *
     visitLinearDifferentiableSILFunctionType(CanSILFunctionType type,
-                                             RecursiveProperties props) {
+                                             SILTypeProperties props) {
       return handleAggregateByProperties
           <LinearDifferentiableSILFunctionTypeLowering>(type, props);
     }
 
     template <class LoadableLoweringClass>
     TypeLowering *handleAggregateByProperties(CanType type,
-                                              RecursiveProperties props) {
+                                              SILTypeProperties props) {
       props = mergeHasPack(HasPack_t(type->hasAnyPack()), props);
       if (props.isAddressOnly()) {
         return handleAddressOnly(type, props);
@@ -2970,6 +2967,21 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
 #endif
 
   return *lowering;
+}
+
+SILTypeProperties
+TypeConverter::getTypeProperties(Type substType,
+                                 TypeExpansionContext forExpansion) {
+  return getTypeProperties(AbstractionPattern(substType->getCanonicalType()),
+                           substType, forExpansion);
+}
+
+SILTypeProperties
+TypeConverter::getTypeProperties(AbstractionPattern origType,
+                                 Type substType,
+                                 TypeExpansionContext forExpansion) {
+  return getTypeLowering(origType, substType, forExpansion)
+           .getRecursiveProperties();
 }
 
 namespace swift::test {
@@ -3702,6 +3714,12 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
 
   LoweredRValueTypeVisitor visitor(*this, forExpansion, origType);
   return visitor.visit(substType);
+}
+
+SILTypeProperties
+TypeConverter::getTypeProperties(SILType type,
+                                 TypeExpansionContext forExpansion) {
+  return getTypeLowering(type, forExpansion).getRecursiveProperties();
 }
 
 const TypeLowering &

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1465,7 +1465,7 @@ bool swift::shouldExpand(SILModule &module, SILType ty) {
   // FIXME: Expansion
   auto expansion = TypeExpansionContext::minimal();
 
-  if (module.Types.getTypeLowering(ty, expansion).isAddressOnly()) {
+  if (module.Types.getTypeProperties(ty, expansion).isAddressOnly()) {
     return false;
   }
   // A move-only-with-deinit type cannot be SROA.

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -353,10 +353,10 @@ bool BridgedGlobalVar::canBeInitializedStatically() const {
   if (hasPublicVisibility(global->getLinkage()))
     expansion = ResilienceExpansion::Minimal;
 
-  auto &tl = global->getModule().Types.getTypeLowering(
+  auto props = global->getModule().Types.getTypeProperties(
       global->getLoweredType(),
       TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(expansion));
-  return tl.isLoadable();
+  return props.isLoadable();
 }
 
 bool BridgedGlobalVar::mustBeInitializedStatically() const {

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -106,9 +106,9 @@ public:
 
           auto eltTy = tuple.getType().getTupleElementType(index);
           assert(eltTy.isAddress() == tuple.getType().isAddress());
-          auto &eltTI = SGF.getTypeLowering(eltTy);
-          (void)eltTI;
-          assert(eltTI.isLoadable() || !SGF.silConv.useLoweredAddresses());
+          auto eltProps = SGF.getTypeProperties(eltTy);
+          (void)eltProps;
+          assert(eltProps.isLoadable() || !SGF.silConv.useLoweredAddresses());
 
           // Project the element.
           visit(eltFormalType, elt);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1645,10 +1645,10 @@ bool SILGenModule::hasNonTrivialIVars(ClassDecl *cd) {
     auto *vd = dyn_cast<VarDecl>(member);
     if (!vd || !vd->hasStorage()) continue;
 
-    auto &ti = Types.getTypeLowering(
+    auto props = Types.getTypeProperties(
         vd->getTypeInContext(),
         TypeExpansionContext::maximalResilienceExpansionOnly());
-    if (!ti.isTrivial())
+    if (!props.isTrivial())
       return true;
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3685,9 +3685,9 @@ SILGenFunction::tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
     // request.
     auto addressorSelf = addressor->getImplicitSelfDecl();
     if (addressorSelf->isAddressable()
-        || getTypeLowering(lookupExpr->getBase()->getType()
-                                     ->getWithoutSpecifierType())
-            .getRecursiveProperties().isAddressableForDependencies()) {
+        || getTypeProperties(lookupExpr->getBase()->getType()
+                                       ->getWithoutSpecifierType())
+            .isAddressableForDependencies()) {
       ValueOwnership baseOwnership = addressorSelf->isInOut()
         ? ValueOwnership::InOut
         : ValueOwnership::Shared;
@@ -3834,9 +3834,9 @@ public:
             }
             
             if (scoped->contains(i)) {
-              addressable = SGF.getTypeLowering(origFormalParamType,
-                                                origFormalParamType.getType())
-                .getRecursiveProperties().isAddressableForDependencies();
+              addressable = SGF.getTypeProperties(origFormalParamType,
+                                                  origFormalParamType.getType())
+                .isAddressableForDependencies();
             }
           }
         }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -307,7 +307,7 @@ ManagedValue SILGenBuilder::createTupleExtract(SILLocation loc,
 
 ManagedValue SILGenBuilder::createLoadBorrow(SILLocation loc,
                                              ManagedValue base) {
-  if (SGF.getTypeLowering(base.getType()).isTrivial()) {
+  if (SGF.getTypeProperties(base.getType()).isTrivial()) {
     auto *i = createLoad(loc, base.getValue(), LoadOwnershipQualifier::Trivial);
     return ManagedValue::forBorrowedRValue(i);
   }
@@ -318,7 +318,7 @@ ManagedValue SILGenBuilder::createLoadBorrow(SILLocation loc,
 
 ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
                                                          ManagedValue base) {
-  if (SGF.getTypeLowering(base.getType()).isTrivial()) {
+  if (SGF.getTypeProperties(base.getType()).isTrivial()) {
     auto *i = createLoad(loc, base.getValue(), LoadOwnershipQualifier::Trivial);
     return ManagedValue::forBorrowedRValue(i);
   }
@@ -331,7 +331,7 @@ ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
 
 ManagedValue SILGenBuilder::createFormalAccessLoadTake(SILLocation loc,
                                                        ManagedValue base) {
-  if (SGF.getTypeLowering(base.getType()).isTrivial()) {
+  if (SGF.getTypeProperties(base.getType()).isTrivial()) {
     auto *i = createLoad(loc, base.getValue(), LoadOwnershipQualifier::Trivial);
     return ManagedValue::forObjectRValueWithoutOwnership(i);
   }
@@ -343,7 +343,7 @@ ManagedValue SILGenBuilder::createFormalAccessLoadTake(SILLocation loc,
 
 ManagedValue SILGenBuilder::createFormalAccessLoadCopy(SILLocation loc,
                                                        ManagedValue base) {
-  if (SGF.getTypeLowering(base.getType()).isTrivial()) {
+  if (SGF.getTypeProperties(base.getType()).isTrivial()) {
     auto *i = createLoad(loc, base.getValue(), LoadOwnershipQualifier::Trivial);
     return ManagedValue::forObjectRValueWithoutOwnership(i);
   }
@@ -492,9 +492,9 @@ ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v,
 ManagedValue SILGenBuilder::createLoadTrivial(SILLocation loc,
                                               ManagedValue addr) {
 #ifndef NDEBUG
-  auto &lowering = SGF.getTypeLowering(addr.getType());
-  assert(lowering.isTrivial());
-  assert((!lowering.isAddressOnly() || !SGF.silConv.useLoweredAddresses()) &&
+  auto props = SGF.getTypeProperties(addr.getType());
+  assert(props.isTrivial());
+  assert((!props.isAddressOnly() || !SGF.silConv.useLoweredAddresses()) &&
          "cannot load an unloadable type");
   assert(!addr.hasCleanup());
 #endif
@@ -666,9 +666,9 @@ ManagedValue SILGenBuilder::createUpcast(SILLocation loc, ManagedValue original,
 ManagedValue SILGenBuilder::createOptionalSome(SILLocation loc,
                                                ManagedValue arg) {
   CleanupCloner cloner(*this, arg);
-  auto &argTL = SGF.getTypeLowering(arg.getType());
+  auto argProps = SGF.getTypeProperties(arg.getType());
   SILType optionalType = SILType::getOptionalType(arg.getType());
-  if (argTL.isLoadable() || !SGF.silConv.useLoweredAddresses()) {
+  if (argProps.isLoadable() || !SGF.silConv.useLoweredAddresses()) {
     SILValue someValue =
         createOptionalSome(loc, arg.forward(SGF), optionalType);
     return cloner.clone(someValue);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -829,12 +829,26 @@ public:
     return TypeExpansionContext(getFunction());
   }
 
+  SILTypeProperties getTypeProperties(AbstractionPattern orig, Type subst) {
+    return F.getTypeProperties(orig, subst);
+  }
+  SILTypeProperties getTypeProperties(Type subst) {
+    return F.getTypeProperties(subst);
+  }
+  SILTypeProperties getTypeProperties(SILType type) {
+    return F.getTypeProperties(type);
+  }
+
   const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {
     return F.getTypeLowering(orig, subst);
   }
   const TypeLowering &getTypeLowering(Type t) {
     return F.getTypeLowering(t);
   }
+  const TypeLowering &getTypeLowering(SILType type) {
+    return F.getTypeLowering(type);
+  }
+
   CanSILFunctionType getSILFunctionType(TypeExpansionContext context,
                                         AbstractionPattern orig,
                                         CanFunctionType substFnType) {
@@ -870,9 +884,6 @@ public:
 
   SILType getLoweredLoadableType(Type t) {
     return F.getLoweredLoadableType(t);
-  }
-  const TypeLowering &getTypeLowering(SILType type) {
-    return F.getTypeLowering(type);
   }
 
   SILType getSILInterfaceType(SILParameterInfo param) const {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3112,9 +3112,7 @@ public:
     // If the access produces a dependent value, and the base is addressable,
     // then
     if (!formalRValueType->isEscapable()
-        && SGF.getTypeLowering(baseFormalType)
-              .getRecursiveProperties()
-              .isAddressableForDependencies()) {
+        && SGF.getTypeProperties(baseFormalType).isAddressableForDependencies()) {
       addressable = true;
       orig = AbstractionPattern::getOpaque();
     }
@@ -4050,9 +4048,7 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   // If the access produces a dependent value, and the base is addressable-for-
   // dependencies, then request an addressable base.
   if (!substFormalRValueType->isEscapable()
-      && SGF.getTypeLowering(baseTy)
-            .getRecursiveProperties()
-            .isAddressableForDependencies()) {
+      && SGF.getTypeProperties(baseTy).isAddressableForDependencies()) {
     addressable = true;
     orig = AbstractionPattern::getOpaque();
   }
@@ -4273,9 +4269,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   // If the access produces a dependent value, and the base is addressable,
   // then
   if (!formalRValueType->isEscapable()
-      && SGF.getTypeLowering(baseTy)
-            .getRecursiveProperties()
-            .isAddressableForDependencies()) {
+      && SGF.getTypeProperties(baseTy).isAddressableForDependencies()) {
     addressable = true;
     orig = AbstractionPattern::getOpaque();
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -734,8 +734,8 @@ private:
       
       isAddressable = pd->isAddressable()
         || (ScopedDependencies.contains(pd)
-            && SGF.getTypeLowering(origType, substType)
-                  .getRecursiveProperties().isAddressableForDependencies());
+            && SGF.getTypeProperties(origType, substType)
+                  .isAddressableForDependencies());
       if (isAddressable) {
         AddressableParams.insert(pd);
       }


### PR DESCRIPTION
Extract TypeLowering's recursive type properties into a header, add functions to compute them directly without a TypeLowering object, and change a lot of getTypeLowering call sites to just use that.

There is one subtle change here that I think is okay: SILBuilder used to use different TypeExpansionContexts when inserting into a global:
- getTypeLowering() always used a minimal context when inserting into a global
- getTypeExpansionContext() always returned a maximal context for the module scope The latter seems more correct, as AFAIK global initializers are never inlinable. If they are, we probably need to configure the builder with an actual context properly rather than making global assumptions.

This is incremental progress towards computing this for most types without a TypeLowering, and hopefully eventually removing TL entirely.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
