### PR TITLE
Strengthen SILFunctionType's isolation preconditions

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -127,6 +127,26 @@ public:
     return getKind() == Kind::NonIsolatedCaller;
   }
 
+  /// Two function type isolations are equal if they have the same kind and
+  /// (when applicable) the same global actor types.
+  ///
+  /// Exact equality is the right thing to ask about when deciding whether
+  /// two isolations are the same statically, because we have to treat
+  /// different specializations of the same generic global actor type
+  /// as potentially different isolations. (Of course, you must be comparing
+  /// types that have been mapped into the same context.)
+  ///
+  /// Exact equality is *not* the right thing to ask about when deciding
+  /// whether two isolations might be the same dynamically, because two
+  /// different specializations of the same generic global actor type
+  /// could absolutely end up being the same in concrete specialization.
+  bool operator==(FunctionTypeIsolation other) const {
+    return value == other.value;
+  }
+  bool operator!=(FunctionTypeIsolation other) const {
+    return value != other.value;
+  }
+
   // The opaque accessors below are just for the benefit of ExtInfoBuilder,
   // which finds it convenient to break down the type separately.  Normal
   // clients should use the accessors above.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5350,8 +5350,13 @@ SILFunctionType::SILFunctionType(
              "Cannot return an @noescape function type");
     }
   }
+  bool hasIsolatedParameter = false; (void) hasIsolatedParameter;
   for (auto param : getParameters()) {
-    (void)param;
+    if (param.hasOption(SILParameterInfo::Isolated)) {
+      assert(!hasIsolatedParameter &&
+             "building SIL function type with multiple isolated parameters");
+      hasIsolatedParameter = true;
+    }
     assert(!isa<PackExpansionType>(param.getInterfaceType()) &&
            "Cannot have a pack expansion directly as a parameter");
     assert(param.isPack() == isa<SILPackType>(param.getInterfaceType()) &&


### PR DESCRIPTION
Also, add an equality operator to `FunctionTypeIsolation`.

I found myself doing both of these as part of a larger patch that I ended up throwing away, but there's no reason not to land them.