### PR TITLE
Revert "[Observation] Ensure deinitialized Observable types don't leave active observations in memory (#82752)"

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -110,27 +110,9 @@ public struct ObservationRegistrar: Sendable {
       }
     }
 
-    internal mutating func deinitialize() -> (@Sendable () -> Void)? {
-      func extractSelf<T>(_ ty: T.Type) -> AnyKeyPath {
-        return \T.self
-      }
-
-      var tracker: (@Sendable () -> Void)?
-      lookupIteration: for (keyPath, ids) in lookups {
-        for id in ids {
-          if let found = observations[id]?.willSetTracker {
-            // convert the keyPath into its \Self.self version 
-            let selfKp = _openExistential(type(of: keyPath).rootType, do: extractSelf)
-            tracker = {
-               found(selfKp)
-            }
-            break lookupIteration
-          }
-        }
-      }
+    internal mutating func cancelAll() {
       observations.removeAll()
       lookups.removeAll()
-      return tracker
     }
     
     internal mutating func willSet(keyPath: AnyKeyPath) -> [@Sendable (AnyKeyPath) -> Void] {
@@ -175,8 +157,8 @@ public struct ObservationRegistrar: Sendable {
       state.withCriticalRegion { $0.cancel(id) }
     }
 
-    internal func deinitialize() {
-      state.withCriticalRegion { $0.deinitialize() }?()
+    internal func cancelAll() {
+      state.withCriticalRegion { $0.cancelAll() }
     }
     
     internal func willSet<Subject: Observable, Member>(
@@ -207,7 +189,7 @@ public struct ObservationRegistrar: Sendable {
     }
 
     deinit {
-      context.deinitialize()
+      context.cancelAll()
     }
   }
   

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,22 +287,6 @@ final class CowTest {
   var container = CowContainer()
 }
 
-@Observable
-final class DeinitTriggeredObserver {
-  var property: Int = 3
-  var property2: Int = 4
-  let deinitTrigger: () -> Void
-
-  init(_ deinitTrigger: @escaping () -> Void) {
-    self.deinitTrigger = deinitTrigger
-  }
-
-  deinit {
-    deinitTrigger()
-  }
-}
-
-
 @main
 struct Validator {
   @MainActor
@@ -525,23 +509,6 @@ struct Validator {
       expectEqual(subject.container.id, startId)
       subject.container.mutate()
       expectEqual(subject.container.id, startId)
-    }
-
-    suite.test("weak container observation") {
-      let changed = CapturedState(state: false)
-      let deinitialized = CapturedState(state: 0)
-      var test = DeinitTriggeredObserver {
-        deinitialized.state += 1
-      }
-      withObservationTracking { [weak test] in
-        _blackHole(test?.property)
-        _blackHole(test?.property2)
-      } onChange: {
-        changed.state = true
-      }
-      test = DeinitTriggeredObserver { }
-      expectEqual(deinitialized.state, 1) // ensure only one invocation is done per deinitialization
-      expectEqual(changed.state, true)
     }
 
     runAllTests()


### PR DESCRIPTION
This reverts commit a349e64039eabb6f7639f9c25870fc9dabd9984a.

This is in concert of https://github.com/swiftlang/swift/pull/83436

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
