### PR TITLE
build.ps1: begin isolating the SDK builds

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -69,9 +69,9 @@ if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 set SkipPackagingArg=-SkipPackaging
 if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 
-:: Build the -WindowsSDKs argument, if any, otherwise build all the SDKs.
-set "WindowsSDKsArg= "
-if not "%WINDOWS_SDKS%"=="" set "WindowsSDKsArg=-WindowsSDKs %WINDOWS_SDKS%"
+:: Build the -WindowsSDKArchitectures argument, if any, otherwise build all the SDKs.
+set "WindowsSDKArchitecturesArg= "
+if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-WindowsSDKArchitectures %WINDOWS_SDKS%"
 
 call :CloneRepositories || (exit /b 1)
 
@@ -81,7 +81,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
-  %WindowsSDKsArg% ^
+  %WindowsSDKArchitecturesArg% ^
   %TestArg% ^
   -Stage %PackageRoot% ^
   -IncludeSBoM ^

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -38,8 +38,14 @@ The API Level to target when building the Android SDKs
 .PARAMETER Android
 When set, build android SDKs.
 
+.PARAMETER AndroidSDKVersions
+An array of SDKs to build for the Android OS.
+
 .PARAMETER AndroidSDKArchitectures
 An array of architectures for which the Android Swift SDK should be built.
+
+.PARAMETER WindowsSDKVersions
+An array of SDKs to build for the Windows OS.
 
 .PARAMETER WindowsSDKArchitectures
 An array of architectures for which the Windows Swift SDK should be built.
@@ -106,7 +112,7 @@ Whether to run swift-foundation and swift-corelibs-foundation tests in a debug o
 PS> .\Build.ps1
 
 .EXAMPLE
-PS> .\Build.ps1 -WindowsSDKs x64 -ProductVersion 1.2.3 -Test foundation,xctest
+PS> .\Build.ps1 -WindowsSDKArchitectures x64 -ProductVersion 1.2.3 -Test foundation,xctest
 #>
 [CmdletBinding(PositionalBinding = $false)]
 param
@@ -120,7 +126,9 @@ param
   [string] $SwiftDebugFormat = "dwarf",
   [ValidateRange(1, 36)]
   [int] $AndroidAPILevel = 28,
+  [string[]] $AndroidSDKVersions = @("Android", "AndroidExperimental"),
   [string[]] $AndroidSDKArchitectures = @(),
+  [string[]] $WindowsSDKVersions = @("Windows", "WindowsExperimental"),
   [string[]] $WindowsSDKArchitectures = @("X64","X86","Arm64"),
   [string] $ProductVersion = "0.0.0",
   [string] $ToolchainIdentifier = $(if ($env:TOOLCHAIN_VERSION) { $env:TOOLCHAIN_VERSION } else { "$env:USERNAME.development" }),

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -127,7 +127,7 @@ param
   [ValidateRange(1, 36)]
   [int] $AndroidAPILevel = 28,
   [string[]] $AndroidSDKVersions = @("Android", "AndroidExperimental"),
-  [string[]] $AndroidSDKArchitectures = @(),
+  [string[]] $AndroidSDKArchitectures = @("aarch64", "armv7", "i686", "x86_64"),
   [string[]] $WindowsSDKVersions = @("Windows", "WindowsExperimental"),
   [string[]] $WindowsSDKArchitectures = @("X64","X86","Arm64"),
   [string] $ProductVersion = "0.0.0",
@@ -190,11 +190,6 @@ if (($PinnedBuild -or $PinnedSHA256 -or $PinnedVersion) -and -not ($PinnedBuild 
   throw "If any of PinnedBuild, PinnedSHA256, or PinnedVersion is set, all three must be set."
 }
 
-if ($Android -and ($AndroidSDKArchitectures.Length -eq 0)) {
-  # Enable all android SDKs by default.
-  $AndroidSDKArchitectures = @("aarch64","armv7","i686","x86_64")
-}
-
 # Work around limitations of cmd passing in array arguments via powershell.exe -File
 if ($AndroidSDKVersions.Length -eq 1) { $AndroidSDKVersions = $AndroidSDKVersions[0].Split(",") }
 if ($AndroidSDKArchitectures.Length -eq 1) { $AndroidSDKArchitectures = $AndroidSDKArchitectures[0].Split(",") }
@@ -203,11 +198,6 @@ if ($WindowsSDKVersions.Length -eq 1) { $WindowsSDKVersions = $WindowsSDKVersion
 if ($WindowsSDKArchitectures.Length -eq 1) { $WindowsSDKArchitectures = $WindowsSDKArchitectures[0].Split(",") }
 
 if ($Test.Length -eq 1) { $Test = $Test[0].Split(",") }
-
-if ($AndroidSDKArchitectures.Length -gt 0) {
-  # Always enable android when one of the SDKs is specified.
-  $Android = $true
-}
 
 if ($Test -contains "*") {
   # Explicitly don't include llbuild yet since tests are known to fail on Windows

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -38,10 +38,10 @@ The API Level to target when building the Android SDKs
 .PARAMETER Android
 When set, build android SDKs.
 
-.PARAMETER AndroidSDKs
+.PARAMETER AndroidSDKArchitectures
 An array of architectures for which the Android Swift SDK should be built.
 
-.PARAMETER WindowsSDKs
+.PARAMETER WindowsSDKArchitectures
 An array of architectures for which the Windows Swift SDK should be built.
 
 .PARAMETER ProductVersion
@@ -120,8 +120,8 @@ param
   [string] $SwiftDebugFormat = "dwarf",
   [ValidateRange(1, 36)]
   [int] $AndroidAPILevel = 28,
-  [string[]] $AndroidSDKs = @(),
-  [string[]] $WindowsSDKs = @("X64","X86","Arm64"),
+  [string[]] $AndroidSDKArchitectures = @(),
+  [string[]] $WindowsSDKArchitectures = @("X64","X86","Arm64"),
   [string] $ProductVersion = "0.0.0",
   [string] $ToolchainIdentifier = $(if ($env:TOOLCHAIN_VERSION) { $env:TOOLCHAIN_VERSION } else { "$env:USERNAME.development" }),
   [string] $PinnedBuild = "",
@@ -182,17 +182,17 @@ if (($PinnedBuild -or $PinnedSHA256 -or $PinnedVersion) -and -not ($PinnedBuild 
   throw "If any of PinnedBuild, PinnedSHA256, or PinnedVersion is set, all three must be set."
 }
 
-if ($Android -and ($AndroidSDKs.Length -eq 0)) {
+if ($Android -and ($AndroidSDKArchitectures.Length -eq 0)) {
   # Enable all android SDKs by default.
-  $AndroidSDKs = @("aarch64","armv7","i686","x86_64")
+  $AndroidSDKArchitectures = @("aarch64","armv7","i686","x86_64")
 }
 
 # Work around limitations of cmd passing in array arguments via powershell.exe -File
-if ($AndroidSDKs.Length -eq 1) { $AndroidSDKs = $AndroidSDKs[0].Split(",") }
-if ($WindowsSDKs.Length -eq 1) { $WindowsSDKs = $WindowsSDKs[0].Split(",") }
+if ($AndroidSDKArchitectures.Length -eq 1) { $AndroidSDKArchitectures = $AndroidSDKArchitectures[0].Split(",") }
+if ($WindowsSDKArchitectures.Length -eq 1) { $WindowsSDKArchitectures = $WindowsSDKArchitectures[0].Split(",") }
 if ($Test.Length -eq 1) { $Test = $Test[0].Split(",") }
 
-if ($AndroidSDKs.Length -gt 0) {
+if ($AndroidSDKArchitectures.Length -gt 0) {
   # Always enable android when one of the SDKs is specified.
   $Android = $true
 }
@@ -492,7 +492,7 @@ if ($Android -and ($HostPlatform -ne $KnownPlatforms["WindowsX64"])) {
 }
 
 # Resolve the architectures received as argument
-$AndroidSDKBuilds = @($AndroidSDKs | ForEach-Object {
+$AndroidSDKBuilds = @($AndroidSDKArchitectures | ForEach-Object {
   switch ($_) {
     "aarch64" { $KnownPlatforms["AndroidARM64"] }
     "armv7" { $KnownPlatforms["AndroidARMv7"] }
@@ -502,7 +502,7 @@ $AndroidSDKBuilds = @($AndroidSDKs | ForEach-Object {
   }
 })
 
-$WindowsSDKBuilds = @($WindowsSDKs | ForEach-Object {
+$WindowsSDKBuilds = @($WindowsSDKArchitectures | ForEach-Object {
   switch ($_) {
     "X64" { $KnownPlatforms["WindowsX64"] }
     "X86" { $KnownPlatforms["WindowsX86"] }


### PR DESCRIPTION
This reworks build parameters to support isolation of the runtimes builds and the SDKs. The old SDK parameters are now reworked such that `-WindowsSDKs` now is a set of SDKs to build (e.g. `Windows`, `WindowsExperimental`), the previous value of architectures being renamed to `-WindowsSDKArchitectures`.