### PR TITLE
[Parse] Ignore '(' on newline after attribute names

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -62,7 +62,7 @@ ERROR(pound_diagnostic_expected_string,none,
       "expected string literal in %select{#warning|#error}0 directive",(bool))
 ERROR(pound_diagnostic_expected,none,
       "expected '%0' in %select{#warning|#error}1 directive",(StringRef,bool))
-ERROR(pound_diagnostic_expected_parens,none,
+ERROR(pound_diagnostic_expected_parens,PointsToFirstBadToken,
       "%select{#warning|#error}0 directive requires parentheses",(bool))
 ERROR(pound_diagnostic_interpolation,none,
       "string interpolation is not allowed in %select{#warning|#error}0 directives",(bool))

--- a/test/Parse/attribute_spacing.swift
+++ b/test/Parse/attribute_spacing.swift
@@ -18,6 +18,10 @@ struct MyPropertyWrapper {
 struct PropertyWrapperTest {
   @MyPropertyWrapper (param: 2)  // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
   var x: Int
+
+  @MyPropertyWrapper
+  (param: 2) // expected-error {{expected 'var' keyword in property declaration}} expected-error {{property declaration does not bind any variables}} expected-error {{expected pattern}}
+  var y: Int
 }
 
 let closure1 = { @MainActor (a, b) in // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
@@ -31,3 +35,10 @@ let closure2 = { @MainActor
 @ 
 MainActor
 func mainActorFunc() {}
+
+
+@inline // expected-error {{expected '(' in 'inline' attribute}}
+(never) func neverInline() {} // expected-error {{expected declaration}}
+
+@objc
+(whatever) func whateverObjC() {} // expected-error {{expected declaration}}

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -84,3 +84,6 @@ class I55049 {
 // expected-error@+1 {{#line directive was renamed to #sourceLocation}}
 #line 1_000 "issue-55049.swift"
 class I55049_1 {}
+
+#sourceLocation
+(file: "nextLine.swift", line: 400) // expected-warning {{expression of type '(file: String, line: Int)' is unused}}

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -82,3 +82,6 @@ protocol MyProtocol {
          """) // expected-warning @-2 {{warnings support multi-line string literals}}
 
 #warning(#"warnings support \(custom string delimiters)"#) // expected-warning {{warnings support \\(custom string delimiters)}}
+
+#warning // expected-error {{#warning directive requires parentheses}} {{9-9=("<#message#>")}}
+("message") // expected-warning {{string literal is unused}}


### PR DESCRIPTION
Also '#error', '#warning', and '#sourceLocation'.

Other call-like syntax (call expression, macro expansion, custom attributes, and _some_ builtin attributes like `@available`) requires '(' on the same line as the callee name. For consistency, all built-in attributes and directives should also ignore '(' on next line.
