### PR TITLE
Override -_fastUTF8StringContents:utf8Length: to give bridged Strings O(1) access to their UTF8 contents

### DIFF
--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -228,6 +228,16 @@ extension __StringStorage {
     }
     return nil
   }
+  
+  @objc(_fastUTF8StringContents:utf8Length:)
+  @_effects(readonly)
+  final internal func _fastUTF8StringContents(
+    _ requiresNulTermination: Int8
+    _ outUTF8Length: UnsafeMutablePointer<UInt>
+  ) -> UnsafePointer<UInt8>? {
+    outUTF8Length.pointee = UInt(count)
+    return unsafe start
+  }
 
   @objc(UTF8String)
   @_effects(readonly)
@@ -345,6 +355,16 @@ extension __SharedStringStorage {
       return unsafe start._asCChar
     }
     return nil
+  }
+  
+  @objc(_fastUTF8StringContents:utf8Length:)
+  @_effects(readonly)
+  final internal func _fastUTF8StringContents(
+    _ requiresNulTermination: Int8
+    _ outUTF8Length: UnsafeMutablePointer<UInt>
+  ) -> UnsafePointer<UInt8>? {
+    outUTF8Length.pointee = UInt(count)
+    return unsafe start
   }
 
   @objc(UTF8String)

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -232,7 +232,7 @@ extension __StringStorage {
   @objc(_fastUTF8StringContents:utf8Length:)
   @_effects(readonly)
   final internal func _fastUTF8StringContents(
-    _ requiresNulTermination: Int8
+    _ requiresNulTermination: Int8,
     _ outUTF8Length: UnsafeMutablePointer<UInt>
   ) -> UnsafePointer<UInt8>? {
     outUTF8Length.pointee = UInt(count)
@@ -360,7 +360,7 @@ extension __SharedStringStorage {
   @objc(_fastUTF8StringContents:utf8Length:)
   @_effects(readonly)
   final internal func _fastUTF8StringContents(
-    _ requiresNulTermination: Int8
+    _ requiresNulTermination: Int8,
     _ outUTF8Length: UnsafeMutablePointer<UInt>
   ) -> UnsafePointer<UInt8>? {
     outUTF8Length.pointee = UInt(count)


### PR DESCRIPTION
Fixes rdar://157337605