### PR TITLE
Optimizer: support statically initialized `Atomic` and `Mutex` globals

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -116,7 +116,9 @@ final public class AccessorDecl: FuncDecl {}
 
 final public class MacroDecl: ValueDecl {}
 
-final public class EnumElementDecl: ValueDecl {}
+final public class EnumElementDecl: ValueDecl {
+  public var hasAssociatedValues: Bool { bridged.EnumElementDecl_hasAssociatedValues() }
+}
 
 final public class ExtensionDecl: Decl {}
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -80,8 +80,11 @@ private indirect enum GlobalInitValue {
   // For example, a struct or vector which is initialized by storing its elements.
   case aggregate([GlobalInitValue])
 
-  // An enum with a payload which is not a SIL "constant".
-  case enumCase(caseIndex: Int, payload: GlobalInitValue)
+  // An enum case without a payload of an address-only enum.
+  case enumCase(caseIndex: Int)
+
+  // An enum case which is not a SIL "constant", e.g. because it's address-only
+  case enumCaseWithPayload(caseIndex: Int, payload: GlobalInitValue)
 
   init?(of globalInitFunction: Function, _ context: FunctionPassContext) {
     self = .undefined
@@ -133,10 +136,26 @@ private indirect enum GlobalInitValue {
     self = builder.initValue
   }
 
+  enum InitValue {
+    // The common case
+    case value(Value)
+
+    // For payload-less cases of address-only enums. Such cases are initialized purely with an `inject_enum_addr`,
+    // and we don't have a `Value` which represents the resulting enum(-case).
+    case enumCaseWithoutPayload(InjectEnumAddrInst)
+
+    var parentFunction: Function {
+      switch self {
+        case .value(let value):  return value.parentFunction
+        case .enumCaseWithoutPayload(let iea): return iea.parentFunction
+      }
+    }
+  }
+
   // Sets an element in the constant tree.
   // Returns true if this was successful. One reason for being not successful is if a certain
   // element is set twice, i.e. does not have a single defined value.
-  mutating func setElement(to value: Value, at path: SmallProjectionPath, type: Type) -> Bool {
+  mutating func setElement(to value: InitValue, at path: SmallProjectionPath, type: Type) -> Bool {
     let (kind, index, subPath) = path.pop()
     switch kind {
     case .root:
@@ -144,8 +163,16 @@ private indirect enum GlobalInitValue {
         // The element was set twice.
         return false
       }
-      self = .constant(value)
+      switch value {
+      case .value(let value):
+        self = .constant(value)
+      case .enumCaseWithoutPayload:
+        fatalError("should have been handled in the .enumCase of the SmallProjectionPath below")
+      }
       return true
+
+    case .enumCase:
+      return setEnumCase(to: value, at: subPath, index: index, type: type)
 
     case .structField:
       guard let structFields = type.getNominalFields(in: value.parentFunction) else {
@@ -186,7 +213,7 @@ private indirect enum GlobalInitValue {
   }
 
   private mutating func setField(
-    to value: Value, at path: SmallProjectionPath,
+    to value: InitValue, at path: SmallProjectionPath,
     index: Int, type: Type, numFields: Int
   ) -> Bool {
     if case .undefined = self {
@@ -203,6 +230,43 @@ private indirect enum GlobalInitValue {
       return true
     }
     return false
+  }
+
+  private mutating func setEnumCase(to value: InitValue, at path: SmallProjectionPath, index: Int, type: Type) -> Bool {
+    switch value {
+
+    case .enumCaseWithoutPayload(let iea):
+      guard case .undefined = self else {
+        // The enum was set twice.
+        return false
+      }
+      assert(index == iea.caseIndex)
+      self = .enumCase(caseIndex: index)
+
+    case .value:
+      guard let payloadType = type.getEnumCases(in: value.parentFunction)!.getPayloadType(ofCaseIndex: index) else {
+        return false
+      }
+      switch self {
+      case .undefined:
+        // It's the first time we set the payload or a sub-field of it.
+        var payload = GlobalInitValue.undefined
+        if !payload.setElement(to: value, at: path, type: payloadType) {
+          return false
+        }
+        self = .enumCaseWithPayload(caseIndex: index, payload: payload)
+      case .enumCaseWithPayload(let existingIndex, var payload) where index == existingIndex:
+        // Some sub-field of the enum-payload was already set.
+        self = .undefined // avoid copy-on-write
+        if !payload.setElement(to: value, at: path, type: payloadType) {
+          return false
+        }
+        self = .enumCaseWithPayload(caseIndex: index, payload: payload)
+      default:
+        return false
+      }
+    }
+    return true
   }
 
   /// Creates SIL for this global init value in the initializer of the `global`.
@@ -248,8 +312,11 @@ private indirect enum GlobalInitValue {
       }
       return builder.createVector(type: type, arguments: elementValues)
 
-    case .enumCase(let caseIndex, let payload):
-      let payloadType = type.getEnumCases(in: function)!.first(where: { $0.index == caseIndex })!.payload!
+    case .enumCase(let caseIndex):
+      return builder.createEnum(caseIndex: caseIndex, payload: nil, enumType: type)
+
+    case .enumCaseWithPayload(let caseIndex, let payload):
+      let payloadType = type.getEnumCases(in: function)!.getPayloadType(ofCaseIndex: caseIndex)!
       let payloadValue = payload.materializeRecursively(type: payloadType, &cloner, builder, function)
       return builder.createEnum(caseIndex: caseIndex, payload: payloadValue, enumType: type)
     }
@@ -272,7 +339,7 @@ private indirect enum GlobalInitValue {
     _ context: FunctionPassContext
   ) {
     switch self {
-    case .undefined:
+    case .undefined, .enumCase:
       break
     case .constant(let value):
       if value.containsLoad(context) {
@@ -281,7 +348,7 @@ private indirect enum GlobalInitValue {
           self = .aggregate((value as! Instruction).operands.lazy.map { .constant($0.value) })
           resolveLoadsRecursively(from: &stackValues, &resolvedAllocStacks, context)
         case let ei as EnumInst:
-          self = .enumCase(caseIndex: ei.caseIndex, payload: .constant(ei.payload!))
+          self = .enumCaseWithPayload(caseIndex: ei.caseIndex, payload: .constant(ei.payload!))
           resolveLoadsRecursively(from: &stackValues, &resolvedAllocStacks, context)
         case let li as LoadInst:
           guard let allocStack = li.address as? AllocStackInst,
@@ -306,10 +373,9 @@ private indirect enum GlobalInitValue {
         newFields[i].resolveLoadsRecursively(from: &stackValues, &resolvedAllocStacks, context)
       }
       self = .aggregate(newFields)
-    case .enumCase(let caseIndex, let payload):
-      var newPayload = payload
-      newPayload.resolveLoadsRecursively(from: &stackValues, &resolvedAllocStacks, context)
-      self = .enumCase(caseIndex: caseIndex, payload: newPayload)
+    case .enumCaseWithPayload(let caseIndex, var payload):
+      payload.resolveLoadsRecursively(from: &stackValues, &resolvedAllocStacks, context)
+      self = .enumCaseWithPayload(caseIndex: caseIndex, payload: payload)
     }
   }
 
@@ -321,7 +387,9 @@ private indirect enum GlobalInitValue {
       return value.isValidGlobalInitValue(context)
     case .aggregate(let fields):
       return fields.allSatisfy { $0.isValid(context) }
-    case .enumCase(_, let payload):
+    case .enumCase:
+      return true
+    case .enumCaseWithPayload(_, let payload):
       return payload.isValid(context)
     }
   }
@@ -361,7 +429,7 @@ private struct InitValueBuilder: AddressDefUseWalker {
       let accessPath = store.destination.lookThroughRawLayoutAddress.constantAccessPath
       switch accessPath.base {
       case .global, .stack:
-        if !initValue.setElement(to: store.source, at: accessPath.projectionPath, type: originalAddress.type) {
+        if !initValue.setElement(to: .value(store.source), at: accessPath.projectionPath, type: originalAddress.type) {
           return .abortWalk
         }
         return .continueWalk
@@ -376,13 +444,35 @@ private struct InitValueBuilder: AddressDefUseWalker {
           return .abortWalk
         }
         // The `nonConstAccessPath` now contains a single `.anyIndexedElement`.
-        if !initValue.setElement(to: store.source, at: nonConstAccessPath.projectionPath, type: originalAddress.type) {
+        if !initValue.setElement(to: .value(store.source), at: nonConstAccessPath.projectionPath, type: originalAddress.type) {
           return .abortWalk
         }
         return .continueWalk
       default:
         fatalError("could not compute access path")
       }
+    case let injectEnum as InjectEnumAddrInst:
+      if injectEnum.element.hasAssociatedValues {
+        if !injectEnum.operand.value.type.isLoadable(in: injectEnum.parentFunction) {
+          // TODO: we don't support non-loadable enum cases with payload yet, because IRGen support is missing.
+          //       e.g. `var global: Atomic<Int>? = Atomic<Int>(0)`
+          // FixedTypeInfo (= used for non-loadable types) is missing the ability to pack a payload into an enum.
+          return .abortWalk
+        }
+        return .continueWalk
+      }
+      let accessPath = injectEnum.enum.getAccessPath(fromInitialPath: SmallProjectionPath(.enumCase,
+                                                                                          index: injectEnum.caseIndex))
+      switch accessPath.base {
+      case .global, .stack:
+        if !initValue.setElement(to: .enumCaseWithoutPayload(injectEnum), at: accessPath.projectionPath, type: originalAddress.type) {
+          return .abortWalk
+        }
+        return .continueWalk
+      default:
+        return .abortWalk
+      }
+
     case is LoadInst, is DeallocStackInst:
       return .continueWalk
     case let bi as BuiltinInst:
@@ -477,6 +567,8 @@ private extension Function {
         return false
       case let store as StoreInst:
         return !store.destination.lookThroughRawLayoutAddress.isAddressOfStack(orGlobal: global)
+      case let injectEnum as InjectEnumAddrInst:
+        return !injectEnum.enum.isAddressOfStack(orGlobal: global)
       case let bi as BuiltinInst where bi.id == .PrepareInitialization:
         return false
       default:
@@ -531,5 +623,11 @@ private extension Value {
       return builtin.arguments[0]
     }
     return self
+  }
+}
+
+private extension EnumCases {
+  func getPayloadType(ofCaseIndex caseIndex: Int) -> Type? {
+    return first(where: { $0.index == caseIndex })!.payload
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -391,8 +391,7 @@ extension Instruction {
     case let bi as BuiltinInst:
       switch bi.id {
       case .ZeroInitializer:
-        let type = bi.type.isBuiltinVector ? bi.type.builtinVectorElementType(in: parentFunction) : bi.type
-        return type.isBuiltinInteger || type.isBuiltinFloat
+        return bi.arguments.count == 0
       case .PtrToInt:
         return bi.operands[0].value is StringLiteralInst
       case .IntToPtr:

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -673,6 +673,7 @@ final public class ExtendLifetimeInst : Instruction, UnaryInstruction {}
 final public class InjectEnumAddrInst : Instruction, UnaryInstruction, EnumInstruction {
   public var `enum`: Value { operand.value }
   public var caseIndex: Int { bridged.InjectEnumAddrInst_caseIndex() }
+  public var element: EnumElementDecl { bridged.InjectEnumAddrInst_element().getAs(EnumElementDecl.self) }
 }
 
 //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -103,6 +103,16 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     bridged.isAddressableForDeps(function.bridged)
   }
 
+  /// If this is a raw layout type, returns the substituted like-type.
+  public var rawLayoutSubstitutedLikeType: AST.`Type`? {
+    .init(bridgedOrNil: bridged.getRawLayoutSubstitutedLikeType())
+  }
+
+  /// If this is a raw layout type, returns the substituted count-type.
+  public var rawLayoutSubstitutedCountType: AST.`Type`? {
+    .init(bridgedOrNil: bridged.getRawLayoutSubstitutedCountType())
+  }
+
   //===--------------------------------------------------------------------===//
   //                Properties of lowered `SILFunctionType`s
   //===--------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -377,6 +377,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool ProtocolDecl_requiresClass() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;
+  BRIDGED_INLINE bool EnumElementDecl_hasAssociatedValues() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef AccessorDecl_getKindName() const;
 };
 

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -219,6 +219,10 @@ bool BridgedDeclObj::Destructor_isIsolated() const {
   return ai.isActorIsolated();
 }
 
+bool BridgedDeclObj::EnumElementDecl_hasAssociatedValues() const {
+  return getAs<swift::EnumElementDecl>()->hasAssociatedValues();
+}
+
 //===----------------------------------------------------------------------===//
 // MARK: BridgedASTNode
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -263,6 +263,8 @@ struct BridgedType {
   BRIDGED_INLINE bool isExactSuperclassOf(BridgedType t) const;
   BRIDGED_INLINE bool isMarkedAsImmortal() const;
   BRIDGED_INLINE bool isAddressableForDeps(BridgedFunction f) const;
+  BRIDGED_INLINE SWIFT_IMPORT_UNSAFE BridgedASTType getRawLayoutSubstitutedLikeType() const;
+  BRIDGED_INLINE SWIFT_IMPORT_UNSAFE BridgedASTType getRawLayoutSubstitutedCountType() const;
   BRIDGED_INLINE SwiftInt getCaseIdxOfEnumType(BridgedStringRef name) const;
   static BRIDGED_INLINE SwiftInt getNumBoxFields(BridgedCanType boxTy);
   static SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBoxFieldType(BridgedCanType boxTy,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -772,6 +772,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt InitEnumDataAddrInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt UncheckedTakeEnumDataAddrInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt InjectEnumAddrInst_caseIndex() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj InjectEnumAddrInst_element() const;
   BRIDGED_INLINE SwiftInt RefElementAddrInst_fieldIndex() const;
   BRIDGED_INLINE bool RefElementAddrInst_fieldIsLet() const;
   BRIDGED_INLINE bool RefElementAddrInst_isImmutable() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1277,6 +1277,10 @@ SwiftInt BridgedInstruction::InjectEnumAddrInst_caseIndex() const {
   return getAs<swift::InjectEnumAddrInst>()->getCaseIndex();
 }
 
+BridgedDeclObj BridgedInstruction::InjectEnumAddrInst_element() const {
+  return {getAs<swift::InjectEnumAddrInst>()->getElement()};
+}
+
 SwiftInt BridgedInstruction::RefElementAddrInst_fieldIndex() const {
   return getAs<swift::RefElementAddrInst>()->getFieldIndex();
 }

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -377,6 +377,14 @@ bool BridgedType::isAddressableForDeps(BridgedFunction f) const {
   return unbridged().isAddressableForDeps(*f.getFunction());
 }
 
+BridgedASTType BridgedType::getRawLayoutSubstitutedLikeType() const {
+  return {unbridged().getRawLayoutSubstitutedLikeType().getPointer()};
+}
+
+BridgedASTType BridgedType::getRawLayoutSubstitutedCountType() const {
+  return {unbridged().getRawLayoutSubstitutedCountType().getPointer()};
+}
+
 SwiftInt BridgedType::getCaseIdxOfEnumType(BridgedStringRef name) const {
   return unbridged().getCaseIdxOfEnumType(name.unbridged());
 }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1679,7 +1679,7 @@ public:
   StructInst *createStruct(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    ASSERT(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty) || isInsertingIntoGlobal());
     return insert(StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                      getModule(), forwardingOwnershipKind));
   }
@@ -1724,7 +1724,8 @@ public:
   EnumInst *createEnum(SILLocation Loc, SILValue Operand,
                        EnumElementDecl *Element, SILType Ty,
                        ValueOwnershipKind forwardingOwnershipKind) {
-    ASSERT(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty) ||
+           (isInsertingIntoGlobal() && getTypeLowering(Ty).isFixedABI()));
     // Assert that this works and does not crash.
     (void)getModule().getCaseIndex(Element);
 

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -27,9 +27,6 @@ namespace irgen {
 /// Construct a ConstantInt from an IntegerLiteralInst.
 llvm::Constant *emitConstantInt(IRGenModule &IGM, IntegerLiteralInst *ILI);
 
-/// Construct a zero from a zero initializer BuiltinInst.
-llvm::Constant *emitConstantZero(IRGenModule &IGM, BuiltinInst *Bi);
-
 /// Construct a ConstantFP from a FloatLiteralInst.
 llvm::Constant *emitConstantFP(IRGenModule &IGM, FloatLiteralInst *FLI);
 

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -43,6 +43,24 @@ SILGlobalVariable *SILGlobalVariable::create(SILModule &M, SILLinkage linkage,
   return var;
 }
 
+static bool isGlobalLet(SILModule &mod, VarDecl *decl, SILType type) {
+  if (!decl)
+    return false;
+
+  if (!decl->isLet())
+    return false;
+
+  // Raw-layout storage may be mutated even for let-variables. Therefore don't
+  // treat such variables as `let` in SIL.
+  auto teCtxt = TypeExpansionContext::maximal(mod.getSwiftModule(),
+                                              mod.isWholeModule());
+  auto typeProps = mod.Types.getTypeProperties(type, teCtxt);
+  if (typeProps.isOrContainsRawLayout())
+    return false;
+
+  return true;
+}
+
 SILGlobalVariable::SILGlobalVariable(SILModule &Module, SILLinkage Linkage,
                                      SerializedKind_t serializedKind,
                                      StringRef Name, SILType LoweredType,
@@ -53,7 +71,7 @@ SILGlobalVariable::SILGlobalVariable(SILModule &Module, SILLinkage Linkage,
       Linkage(unsigned(Linkage)), HasLocation(Loc.has_value()), VDecl(Decl) {
   setSerializedKind(serializedKind);
   IsDeclaration = isAvailableExternally(Linkage);
-  setLet(Decl ? Decl->isLet() : false);
+  setLet(isGlobalLet(Module, Decl, LoweredType));
   Module.silGlobals.push_back(this);
 }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2547,6 +2547,7 @@ namespace {
 
       // If the type has raw storage, it is move-only and address-only.
       if (D->getAttrs().hasAttribute<RawLayoutAttr>()) {
+        properties.setHasRawLayout();
         properties.setAddressOnly();
         properties.setAddressableForDependencies();
         properties.setNonTrivial();

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -356,7 +356,7 @@ bool BridgedGlobalVar::canBeInitializedStatically() const {
   auto props = global->getModule().Types.getTypeProperties(
       global->getLoweredType(),
       TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(expansion));
-  return props.isLoadable();
+  return props.isFixedABI();
 }
 
 bool BridgedGlobalVar::mustBeInitializedStatically() const {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -738,8 +738,13 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     // move only structs are non-trivial, so we need to handle this here.
     if (nominal->getAttrs().hasAttribute<RawLayoutAttr>()) {
       // Raw memory is not directly decomposable, but we still want to mark
-      // it as initialized. Use a zero initializer.
-      B.createZeroInitAddr(ctor, selfLV.getLValueAddress());
+      // it as initialized.
+      auto prepInit = getBuiltinValueDecl(getASTContext(),
+                getASTContext().getIdentifier("prepareInitialization"));
+      B.createBuiltin(ctor, prepInit->getBaseIdentifier(),
+                           SILType::getEmptyTupleType(getASTContext()),
+                           SubstitutionMap(),
+                           selfLV.getLValueAddress());
     } else if (isa<StructDecl>(nominal)
                && lowering.getLoweredType().isMoveOnly()
                && nominal->getStoredProperties().empty()) {

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -318,7 +318,8 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts,
   // The value form of zero init is not a user of any operand. The address
   // form however is easily zappable because it's always a trivial store.
   if (auto bi = dyn_cast<BuiltinInst>(Inst)) {
-    if (bi->getBuiltinKind() == BuiltinValueKind::ZeroInitializer) {
+    if (bi->getBuiltinKind() == BuiltinValueKind::ZeroInitializer ||
+        bi->getBuiltinKind() == BuiltinValueKind::PrepareInitialization) {
       return true;
     }
   }

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -721,3 +721,15 @@ bb0:
   %1 = tuple ()
   return %1 : $()
 }
+
+// CHECK-LABEL: @dead_prepare_init
+// CHECK-NOT: alloc_stack
+// // CHECK: } // end sil function 'dead_prepare_init'
+sil @dead_prepare_init : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Kl
+  %empty = builtin "prepareInitialization"(%0 : $*Kl) : $()
+  dealloc_stack %0 : $*Kl
+  %1 = tuple ()
+  return %1 : $()
+}

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -initialize-static-globals | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -enable-experimental-feature RawLayout -initialize-static-globals | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_RawLayout
 
 sil_stage canonical
 
@@ -35,6 +36,12 @@ struct TwoFields {
   let a: Int32
   let b: Int32
 }
+
+@_rawLayout(like: Int32)
+struct Raw: ~Copyable {}
+
+@_rawLayout(likeArrayOf: Int32, count: 2)
+struct RawArray: ~Copyable {}
 
 let nontrivialglobal: TClass
 
@@ -148,6 +155,18 @@ sil_global [let] @inline_array_empty_elements : $InlineArray<3, ()>
 // CHECK-NEXT:    %initval = struct $Int32 (%0)
 // CHECK-NEXT:  }
 sil_global [let] @gint : $Int32
+
+// CHECK-LABEL: sil_global [let] @graw : $Raw = {
+// CHECK-NEXT:    %0 = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    %initval = struct $Int32 (%0)
+// CHECK-NEXT:  }
+sil_global [let] @graw: $Raw
+
+// CHECK-LABEL: sil_global [let] @graw2 : $Raw{{$}}
+sil_global [let] @graw2: $Raw
+
+// CHECK-LABEL: sil_global [let] @grawArray : $RawArray{{$}}
+sil_global [let] @grawArray: $RawArray
 
 sil @unknownfunc : $@convention(thin) () -> ()
 
@@ -517,6 +536,45 @@ bb0(%0 : $Builtin.RawPointer):
   %19 = struct $InlineArray<3, ()> (%18)
   dealloc_stack %3
   store %19 to [trivial] %2
+  %21 = tuple ()
+  return %21
+}
+
+sil [global_init_once_fn] [ossa] @globalinit_raw_layout: $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @graw
+  %2 = global_addr @graw : $*Raw
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3)
+  %5 = builtin "addressOfRawLayout"<Raw>(%2) : $Builtin.RawPointer
+  %6 = pointer_to_address %5 to $*Int32
+  store %4 to [trivial] %6
+  %21 = tuple ()
+  return %21
+}
+
+sil [global_init_once_fn] [ossa] @no_globalinit_raw_layout_wrong_like_type: $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @graw
+  %2 = global_addr @graw : $*Raw
+  %3 = integer_literal $Builtin.Int16, 1
+  %4 = struct $Int16 (%3)
+  %5 = builtin "addressOfRawLayout"<Raw>(%2) : $Builtin.RawPointer
+  %6 = pointer_to_address %5 to $*Int16
+  store %4 to [trivial] %6
+  %21 = tuple ()
+  return %21
+}
+
+sil [global_init_once_fn] [ossa] @no_globalinit_raw_layout_array: $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @grawArray
+  %2 = global_addr @grawArray : $*RawArray
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3)
+  %5 = builtin "addressOfRawLayout"<RawArray>(%2) : $Builtin.RawPointer
+  %6 = pointer_to_address %5 to $*Int32
+  store %4 to [trivial] %6
   %21 = tuple ()
   return %21
 }

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -168,6 +168,21 @@ sil_global [let] @graw2: $Raw
 // CHECK-LABEL: sil_global [let] @grawArray : $RawArray{{$}}
 sil_global [let] @grawArray: $RawArray
 
+// CHECK-LABEL: sil_global [let] @gIndirectNone : $Optional<TwoFields> = {
+// CHECK-NEXT:    %initval = enum $Optional<TwoFields>, #Optional.none!enumelt
+// CHECK-NEXT:  }
+sil_global [let] @gIndirectNone: $Optional<TwoFields>
+
+// CHECK-LABEL: sil_global [let] @gIndirectSome : $Optional<TwoFields> = {
+// CHECK-NEXT:    %0 = integer_literal $Builtin.Int32, 11
+// CHECK-NEXT:    %1 = struct $Int32 (%0)
+// CHECK-NEXT:    %2 = integer_literal $Builtin.Int32, 10
+// CHECK-NEXT:    %3 = struct $Int32 (%2)
+// CHECK-NEXT:    %4 = struct $TwoFields (%1, %3)
+// CHECK-NEXT:    %initval = enum $Optional<TwoFields>, #Optional.some!enumelt, %4
+// CHECK-NEXT:  }
+sil_global [let] @gIndirectSome: $Optional<TwoFields>
+
 sil @unknownfunc : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_trivialglobal_func :
@@ -577,5 +592,31 @@ bb0(%0 : $Builtin.RawPointer):
   store %4 to [trivial] %6
   %21 = tuple ()
   return %21
+}
+
+sil [global_init_once_fn] [ossa] @globalinit_indirect_none: $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @gIndirectNone
+  %2 = global_addr @gIndirectNone : $*Optional<TwoFields>
+  inject_enum_addr %2, #Optional.none!enumelt
+  %21 = tuple ()
+  return %21
+}
+
+sil [global_init_once_fn] [ossa] @globalinit_indirect_some : $@convention(c) () -> () {
+bb0:
+  alloc_global @gIndirectSome
+  %1 = global_addr @gIndirectSome : $*Optional<TwoFields>
+  %2 = init_enum_data_addr %1, #Optional.some!enumelt
+  %3 = integer_literal $Builtin.Int32, 10
+  %4 = struct $Int32 (%3)
+  %5 = struct_element_addr %2, #TwoFields.b
+  store %4 to [trivial] %5
+  %7 = integer_literal $Builtin.Int32, 11
+  %8 = struct $Int32 (%7)
+  %9 = struct_element_addr %2, #TwoFields.a
+  store %8 to [trivial] %9
+  %10 = tuple ()
+  return %10 : $()
 }
 

--- a/test/SILOptimizer/moveonly_raw_layout.swift
+++ b/test/SILOptimizer/moveonly_raw_layout.swift
@@ -20,7 +20,7 @@ struct Lock: ~Copyable {
     // CHECK-NEXT: sil{{.*}} @[[INIT:\$.*4LockV.*fC]] :
     init() {
         // CHECK-NOT: destroy_addr
-        // CHECK: builtin "zeroInitializer"({{%.*}} : $*Lock)
+        // CHECK: builtin "prepareInitialization"({{%.*}} : $*Lock)
         // CHECK-NOT: destroy_addr
         // CHECK: [[F:%.*]] = function_ref @init_lock
         // CHECK: apply [[F]](

--- a/test/SILOptimizer/static_atomics.swift
+++ b/test/SILOptimizer/static_atomics.swift
@@ -1,0 +1,65 @@
+// RUN: %target-build-swift -parse-as-library -Xfrontend -disable-availability-checking -O %s -module-name=test -emit-sil | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -parse-as-library -Xfrontend -disable-availability-checking -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: synchronization
+// UNSUPPORTED: back_deployment_runtime
+
+import Synchronization
+
+
+struct TwoAtomics: ~Copyable {
+  let a: Atomic<UInt8>
+  let b: Atomic<UInt8>
+}
+
+// CHECK-LABEL: sil_global hidden @$s4test7atomic1AA10TwoAtomicsVSgvp : $Optional<TwoAtomics> = {
+var atomic1: TwoAtomics? = nil
+
+// CHECK-LABEL: sil_global hidden @$s4test7atomic2AA10TwoAtomicsVvp : $TwoAtomics = {
+let atomic2: TwoAtomics = TwoAtomics(a: Atomic(29), b: Atomic(30))
+
+// TODO: this is not initialized statically, because missing IRGen support
+var atomic3: TwoAtomics? = TwoAtomics(a: Atomic(27), b: Atomic(28))
+
+// CHECK-LABEL: sil_global hidden @$s4test5mutex15Synchronization5MutexVySiGvp : $Mutex<Int> = {
+let mutex = Mutex<Int>(123)
+
+@main
+struct Main {
+  static func main() {
+
+    precondition(atomic1 == nil)
+
+    // CHECK-OUTPUT: atomic2: 29 30
+    print("atomic2:", atomic2.a.load(ordering: .relaxed), atomic2.b.load(ordering: .relaxed))
+
+    // CHECK-OUTPUT: atomic3: 27 28
+    switch atomic3 {
+    case .some(let a):
+      print("atomic3:", a.a.load(ordering: .relaxed), a.b.load(ordering: .relaxed))
+    case .none:
+      break
+    }
+
+    atomic1 = TwoAtomics(a: Atomic(1), b: Atomic(2))
+
+    // CHECK-OUTPUT: atomic2: 29 30
+    print("atomic2:", atomic2.a.load(ordering: .relaxed), atomic2.b.load(ordering: .relaxed))
+
+
+    mutex.withLock {
+      $0 = $0 + 1
+    }
+
+    // CHECK-OUTPUT: mutex: 124
+    mutex.withLock {
+      print("mutex:", $0)
+    }
+  }
+}
+
+

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -20,7 +20,7 @@ public struct Cell<T: ~Copyable>: ~Copyable {
 
   // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARi_zrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
   // CHECK:       bb0({{%.*}} : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
-  // CHECK:         {{%.*}} = builtin "zeroInitializer"([[SELF:%.*]] : $*Cell<T>) : $()
+  // CHECK:         {{%.*}} = builtin "prepareInitialization"([[SELF:%.*]] : $*Cell<T>) : $()
   // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'


### PR DESCRIPTION
For example:
```
let global = Atomic<Int>(0)
```

This PR adds support for `@_rawLayout` structs and non-loadable types in InitializeStaticGlobals.
