### PR TITLE
[CSSyntacticElement] Remove an assert that is too strict

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2159,14 +2159,10 @@ private:
       if (resultType->isVoid())
         return returnStmt;
 
-      // It's possible to infer e.g. `Void?` for cases where
-      // `return` doesn't have an expression. If contextual
-      // type is `Void` wrapped into N optional types, let's
-      // add an implicit `()` expression and let it be injected
-      // into optional required number of times.
-
-      assert(resultType->getOptionalObjectType() &&
-             resultType->lookThroughAllOptionalTypes()->isVoid());
+      // Constraint generation injects an implicit `()` expresion
+      // into return statements without one. This helps to match
+      // cases like `Void` and `Any` that could be wrapped into a
+      // number of optional types.
 
       auto target = *cs.getTargetFor(returnStmt);
       returnStmt->setResult(target.getAsExpr());

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1392,3 +1392,26 @@ func test_generic_closure_parameter_requirement_failure<Item: Idable>(
   Container(data: { (input: TestInput) in payload(input.value) })
   // expected-error@-1 {{generic struct 'TestInput' requires that 'Item.ID' conform to 'Collection'}}
 }
+
+// Since implicit result implies `()` it should be allowed to be converted to e.g. `Void` and `Any`
+func test_implicit_result_conversions() {
+  func test_optional(_ x: Int) {
+    let _: Any? = {
+      switch x {
+      case 0:
+        return 1
+      default:
+        return
+      }
+    }()
+  }
+
+  func testAny(_: () -> Any) {}
+
+  testAny { } // Ok
+  testAny { return } // Ok
+  testAny {
+    _ = 42
+    return // Ok
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/624dafcf406667e8.swift
+++ b/validation-test/compiler_crashers_2_fixed/624dafcf406667e8.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::SyntacticElementSolutionApplication::visitReturnStmt(swift::ReturnStmt*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a func b(c : a) {
 let:
   ()->Copyable = { c return


### PR DESCRIPTION
`return` statement withot an expression automatically gets an implicit `()` which is allowed to be converted to types like `()?` and `Any` or `Any?`. Let's remove a too strict assertion that expected a contextual type to always be `()?` even through in reality any type that `()` is convertible to is valid.

Resolves: rdar://152553143

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
