### PR TITLE
utils/wasm: Add Node.js WASI runner

### DIFF
--- a/utils/wasm/node-wasi-runner
+++ b/utils/wasm/node-wasi-runner
@@ -1,5 +1,17 @@
 #!/usr/bin/env node --disable-warning=ExperimentalWarning
 
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 const { readFile } = require('node:fs/promises');
 const { WASI } = require('node:wasi');
 const { argv, env } = require('node:process');

--- a/utils/wasm/node-wasi-runner
+++ b/utils/wasm/node-wasi-runner
@@ -1,0 +1,24 @@
+#!/usr/bin/env node --disable-warning=ExperimentalWarning
+
+const { readFile } = require('node:fs/promises');
+const { WASI } = require('node:wasi');
+const { argv, env } = require('node:process');
+
+const wasmFile = argv[2];
+
+const wasi = new WASI({
+  version: 'preview1',
+  args: argv.splice(2),
+  env,
+  preopens: {
+  },
+});
+
+(async () => {
+  const wasm = await WebAssembly.compile(
+    await readFile(wasmFile)
+  );
+  const instance = await WebAssembly.instantiate(wasm, wasi.getImportObject());
+
+  wasi.start(instance);
+})();


### PR DESCRIPTION
This runner can be utilized as an alternative to WasmKit when running tests or executables from Swift packages compiled to Wasm, when better performance or improved coverage of WASI 0.1 ABI is needed.

This script is meant to be running only locally at this time and doesn't assume presence of Node.js on CI, since no CI scripts were changed.