### PR TITLE
[6.2][SILOptimizer]: fix some missing use after consume diagnostics

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -157,6 +157,11 @@ bool CheckerLivenessInfo::compute() {
               return false;
             }
           }
+        } else if (isa<StoreBorrowInst>(user)) {
+          if (liveness->updateForBorrowingOperand(use) !=
+              InnerBorrowKind::Contained) {
+            return false;
+          }
         }
         // FIXME: this ignores all other forms of Borrow ownership, such as
         // partial_apply [onstack] and mark_dependence [nonescaping].


### PR DESCRIPTION
**Explanation**:
Updates `ConsumeOperatorCopyableValuesChecker` to identify `store_borrow` instructions as a liveness-affecting use so that patterns that would previously slip through undiagnosed are correctly identified

**Scope**:
- addresses a regression with use-after-consume diagnostics 
- diagnostic pass handles more cases, so could plausibly break code that used to compile

**Issues**:
- https://github.com/swiftlang/swift/issues/83277

**Original PRs**:
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- https://github.com/swiftlang/swift/pull/83473

**Risk**:
- Low.  The patch only affects consume-checking of copyable values.  Furthermore, it only increases the strictness of that checking, so it shouldn't cause any previously diagnosed code to go undiagnosed.

**Testing**:
- new unit tests added

**Reviewers**:
- @nate-chandler 
