### PR TITLE
[ClangImporter] Prefer serialized bridging headers in LLDB.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1093,6 +1093,10 @@ namespace swift {
     /// When set, don't enforce warnings with -Werror.
     bool DebuggerSupport = false;
 
+    /// Prefer the serialized preprocessed header over the one on disk.
+    /// Used by LLDB.
+    bool PreferSerializedBridgingHeader = false;
+
     /// When set, ClangImporter is disabled, and all requests go to the
     /// DWARFImporter delegate.
     bool DisableSourceImport = false;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -163,8 +163,7 @@ private:
 
   bool requiresBuiltinHeadersInSystemModules = false;
 
-  ClangImporter(ASTContext &ctx,
-                DependencyTracker *tracker,
+  ClangImporter(ASTContext &ctx, DependencyTracker *tracker,
                 DWARFImporterDelegate *dwarfImporterDelegate);
 
   /// Creates a clone of Clang importer's compiler instance that has been
@@ -196,8 +195,8 @@ public:
   /// \returns a new Clang module importer, or null (with a diagnostic) if
   /// an error occurred.
   static std::unique_ptr<ClangImporter>
-  create(ASTContext &ctx,
-         std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
+  create(ASTContext &ctx, std::string swiftPCHHash = "",
+         DependencyTracker *tracker = nullptr,
          DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
          bool ignoreFileMapping = false);
 


### PR DESCRIPTION
Especially in an explicit modules project, LLDB might not know all the search paths needed to imported the on disk header.

(cherry picked from commit a6678476d806d26beb87ca1b78126f6f2a6a22e6)


Explanation:
Allow LLDB to prefer a serialized preprocessed bridging header over the on-disk header file. In order to import the on-disk header file, LLDB also needs all the search paths and defines, which in explicit modules world it may no longer have access to.

Scope:

Fix a debugging regression when using explicit modules with bridging headers. This patch has no effect on the Swift compiler.

Issues:

rdar://157063577

Original PRs:

https://github.com/swiftlang/swift/pull/83415

Risk:

Very Low. This change has no effect on the compiler, only allows LLDB to choose which bridging header to prefer.

Testing:

In LLDB.

Reviewers:

@cachemeifyoucan 