### PR TITLE
[APINotes] Adapt miscellaneous Clang attribute queries to consider version-independent APINotes compilation mode

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -767,8 +767,12 @@ void importer::getNormalInvocationArguments(
 
   // Enable API notes alongside headers/in frameworks.
   invocationArgStrs.push_back("-fapinotes-modules");
-  invocationArgStrs.push_back("-fapinotes-swift-version=" +
-                              languageVersion.asAPINotesVersionString());
+  if (importerOpts.LoadVersionIndependentAPINotes)
+    invocationArgStrs.insert(invocationArgStrs.end(),
+                             {"-fswift-version-independent-apinotes"});
+  else
+    invocationArgStrs.push_back("-fapinotes-swift-version=" +
+                                languageVersion.asAPINotesVersionString());
 
   // Prefer `-sdk` paths.
   if (!searchPathOpts.getSDKPath().empty()) {
@@ -787,10 +791,6 @@ void importer::getNormalInvocationArguments(
     invocationArgStrs.push_back("-iapinotes-modules");
     invocationArgStrs.push_back(path.str().str());
   }
-
-  if (importerOpts.LoadVersionIndependentAPINotes)
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-fswift-version-independent-apinotes"});
 }
 
 static void
@@ -2526,7 +2526,8 @@ ClangImporter::getWrapperForModule(const clang::Module *mod,
 }
 
 PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
-    : platformKind(targetPlatform(langOpts)) {
+    : platformKind(targetPlatform(langOpts)),
+      currentVersion(ImportNameVersion::fromOptions(langOpts)) {
   switch (platformKind) {
   case PlatformKind::iOS:
   case PlatformKind::iOSApplicationExtension:
@@ -2643,10 +2644,10 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::macOSApplicationExtension:
     // Anything deprecated by macOS 10.14 is unavailable for async import
     // in Swift.
-    if (isAsync && !clangDecl->hasAttr<clang::SwiftAsyncAttr>()) {
+    if (isAsync && !swift::importer::hasSwiftAttr<clang::SwiftAsyncAttr>(
+                       clangDecl, currentVersion))
       return major < 10 ||
           (major == 10 && (!minor.has_value() || minor.value() <= 14));
-    }
 
     // Anything deprecated in OSX 10.9.x and earlier is unavailable in Swift.
     return major < 10 ||
@@ -2658,7 +2659,8 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::tvOSApplicationExtension:
     // Anything deprecated by iOS 12 is unavailable for async import
     // in Swift.
-    if (isAsync && !clangDecl->hasAttr<clang::SwiftAsyncAttr>()) {
+    if (isAsync && !swift::importer::hasSwiftAttr<clang::SwiftAsyncAttr>(
+                       clangDecl, currentVersion)) {
       return major <= 12;
     }
 
@@ -2674,7 +2676,8 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::watchOSApplicationExtension:
     // Anything deprecated by watchOS 5.0 is unavailable for async import
     // in Swift.
-    if (isAsync && !clangDecl->hasAttr<clang::SwiftAsyncAttr>()) {
+    if (isAsync && !swift::importer::hasSwiftAttr<clang::SwiftAsyncAttr>(
+                       clangDecl, currentVersion)) {
       return major <= 5;
     }
 
@@ -3008,7 +3011,8 @@ isPotentiallyConflictingSetter(const clang::ObjCProtocolDecl *proto,
   return false;
 }
 
-bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
+bool importer::shouldSuppressDeclImport(const clang::Decl *decl,
+                                        ImportNameVersion importVersion) {
   if (auto objcMethod = dyn_cast<clang::ObjCMethodDecl>(decl)) {
     // First check if we're actually in a Swift class.
     auto dc = decl->getDeclContext();
@@ -3025,7 +3029,8 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
       // Suppress the import of this method when the corresponding
       // property is not suppressed.
       return !shouldSuppressDeclImport(
-               objcMethod->findPropertyDecl(/*CheckOverrides=*/false));
+               objcMethod->findPropertyDecl(/*CheckOverrides=*/false),
+               importVersion);
     }
 
     // If the method was declared within a protocol, check that it
@@ -3044,7 +3049,7 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
       return true;
 
     // Suppress certain properties; import them as getter/setter pairs instead.
-    if (shouldImportPropertyAsAccessors(objcProperty))
+    if (shouldImportPropertyAsAccessors(objcProperty, importVersion))
       return true;
 
     // Check whether there is a superclass method for the getter that
@@ -3065,7 +3070,8 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
         auto getterMethod =
             objcSuperclass->lookupMethod(objcProperty->getGetterName(),
                                          objcProperty->isInstanceProperty());
-        if (getterMethod && !shouldSuppressDeclImport(getterMethod))
+        if (getterMethod && !shouldSuppressDeclImport(getterMethod,
+                                                      importVersion))
           return true;
       }
     }
@@ -4055,7 +4061,7 @@ void ClangModuleUnit::lookupObjCMethods(
     auto owningClangModule = getClangTopLevelOwningModule(objcMethod, clangCtx);
     if (owningClangModule != clangModule) continue;
 
-    if (shouldSuppressDeclImport(objcMethod))
+    if (shouldSuppressDeclImport(objcMethod, owner.CurrentVersion))
       continue;
 
     // If we found a property accessor, import the property.

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1906,7 +1906,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
       "while adding SwiftName lookup table entries for clang declaration");
 
   // Determine whether this declaration is suppressed in Swift.
-  if (shouldSuppressDeclImport(named))
+  if (shouldSuppressDeclImport(named, ImportNameVersion::fromOptions(
+                                          nameImporter.getLangOpts())))
     return;
 
   // Leave incomplete struct/enum/union types out of the table, unless they
@@ -1942,7 +1943,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
                          named, importedName.getEffectiveContext());
         }
 
-        if (auto swiftNameAttr = named->getAttr<clang::SwiftNameAttr>()) {
+        if (auto swiftNameAttr =
+                getSwiftAttr<clang::SwiftNameAttr>(named, currentVersion)) {
           auto parsedDeclName = parseDeclName(swiftNameAttr->getName());
           auto swiftDeclName =
               parsedDeclName.formDeclName(nameImporter.getContext());
@@ -2143,7 +2145,8 @@ void importer::finalizeLookupTable(
     // Complain about unresolved entries that remain.
     for (auto entry : unresolved) {
       auto *decl = cast<clang::NamedDecl *>(entry);
-      auto swiftName = decl->getAttr<clang::SwiftNameAttr>();
+      auto swiftName = getSwiftAttr<clang::SwiftNameAttr>(decl,
+          ImportNameVersion::fromOptions(nameImporter.getLangOpts()));
 
       if (swiftName
           // Clang didn't previously attach SwiftNameAttrs to forward


### PR DESCRIPTION
We need attribute queries which will look through the versioned-attribute-wrapped Clang attributes, for all the various Clang declarations which do not go through 'importDecl'
