### PR TITLE
lit.cfg: copy back deployed concurrency library from Xcode

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2304,7 +2304,10 @@ concurrency_back_deploy_path = ''
 if run_vendor == 'apple':
     if 'back_deploy_concurrency' in lit_config.params:
         config.available_features.add('back_deploy_concurrency')
-        concurrency_back_deploy_path = os.path.join(os.path.dirname(swift_obj_root), os.path.basename(swift_obj_root).replace("swift-", "backdeployconcurrency-"), 'lib', 'swift-5.5', xcrun_sdk_name)
+        toolchain_swiftc_path = subprocess.check_output(['xcrun', '--find', 'swiftc']).rstrip().decode('utf-8')
+        concurrency_back_deploy_path =  os.path.join(os.path.dirname(toolchain_swiftc_path), '..', 'lib', 'swift-5.5', xcrun_sdk_name)
+        if not os.path.isdir(concurrency_back_deploy_path):
+            lit_config.fatal(f"Concurrency back deploy libraries not found at {concurrency_back_deploy_path}")
 
 backtracer_path = make_path(config.swift_libexec_dir, 'swift',
                             config.target_sdk_name, 'swift-backtrace')


### PR DESCRIPTION
We are no longer building it with `build-script`.

Addresses rdar://157495803