### PR TITLE
[CSSimplify] Skip member access on existential checks if base is exis…

### DIFF
--- a/test/Interpreter/protocol_composition_with_markers.swift
+++ b/test/Interpreter/protocol_composition_with_markers.swift
@@ -58,3 +58,27 @@ do {
   generic(Int.self)
   // CHECK: D<Int>
 }
+
+protocol Q {
+  func update(_: [Self])
+}
+
+extension Q {
+  func update(_ arr: [Self]) { print(Self.self) }
+}
+
+do {
+  class Parent : Q {}
+  class Subclass: Parent {}
+
+  func test(_ v: Parent & Sendable) {
+    v.update([])
+  }
+
+  test(Subclass())
+  // CHECK: Subclass
+
+  let sendableV: any Subclass & Sendable = Subclass()
+  test(sendableV)
+  // CHECK: Subclass
+}


### PR DESCRIPTION
…tential only due to marker protocols

If the base type is composed with marker protocol(s) i.e. `<<Type>> & Sendable`, let's skip this check because such compositions are always opened and simplified down to a superclass bound post-Sema.

Resolves: rdar://148782046

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
