### PR TITLE
[Dependency Scanning][C++ Interop] Avoid `CxxStdlib` overlay lookup for binary Swift dependencies which were not built with C++ interop

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -393,8 +393,8 @@ public:
       ArrayRef<LinkLibrary> linkLibraries,
       ArrayRef<serialization::SearchPath> serializedSearchPaths,
       StringRef headerImport, StringRef definingModuleInterface,
-      bool isFramework, bool isStatic, StringRef moduleCacheKey,
-      StringRef userModuleVersion)
+      bool isFramework, bool isStatic, bool isBuiltWithCxxInterop,
+      StringRef moduleCacheKey, StringRef userModuleVersion)
       : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftBinary,
                                         moduleImports, optionalModuleImports,
                                         linkLibraries, moduleCacheKey),
@@ -403,6 +403,7 @@ public:
         definingModuleInterfacePath(definingModuleInterface),
         serializedSearchPaths(serializedSearchPaths),
         isFramework(isFramework), isStatic(isStatic),
+        isBuiltWithCxxInterop(isBuiltWithCxxInterop),
         userModuleVersion(userModuleVersion) {}
 
   ModuleDependencyInfoStorageBase *clone() const override {
@@ -439,6 +440,10 @@ public:
 
   /// A flag that indicates this dependency is associated with a static archive
   const bool isStatic;
+
+  /// A flag that indicates this dependency module was built
+  /// with C++ interop enabled
+  const bool isBuiltWithCxxInterop;
 
   /// The user module version of this binary module.
   const std::string userModuleVersion;
@@ -573,14 +578,14 @@ public:
       ArrayRef<LinkLibrary> linkLibraries,
       ArrayRef<serialization::SearchPath> serializedSearchPaths,
       StringRef headerImport, StringRef definingModuleInterface,
-      bool isFramework, bool isStatic, StringRef moduleCacheKey,
-      StringRef userModuleVer) {
+      bool isFramework, bool isStatic, bool isBuiltWithCxxInterop,
+      StringRef moduleCacheKey, StringRef userModuleVer) {
     return ModuleDependencyInfo(
         std::make_unique<SwiftBinaryModuleDependencyStorage>(
             compiledModulePath, moduleDocPath, sourceInfoPath, moduleImports,
             optionalModuleImports, linkLibraries, serializedSearchPaths,
             headerImport, definingModuleInterface,isFramework, isStatic,
-            moduleCacheKey, userModuleVer));
+            isBuiltWithCxxInterop, moduleCacheKey, userModuleVer));
   }
 
   /// Describe the main Swift module.

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -56,6 +56,8 @@ using IsFrameworkField = BCFixed<1>;
 using IsSystemField = BCFixed<1>;
 /// A bit that indicates whether or not a module is that of a static archive
 using IsStaticField = BCFixed<1>;
+/// A bit that indicates whether or not a module is built with C++ interop
+using IsBuiltWithCxxInteropField = BCFixed<1>;
 /// A bit that indicates whether or not a link library is a force-load one
 using IsForceLoadField = BCFixed<1>;
 /// A bit that indicates whether or not an import statement is optional
@@ -267,6 +269,7 @@ using SwiftBinaryModuleDetailsLayout =
                    SearchPathArrayIDField,           // serializedSearchPaths
                    IsFrameworkField,                 // isFramework
                    IsStaticField,                    // isStatic
+                   IsBuiltWithCxxInteropField,       // IsBuiltWithCxxInterop
                    IdentifierIDField,                // moduleCacheKey
                    IdentifierIDField                 // UserModuleVersion
                    >;

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -679,13 +679,14 @@ bool ModuleDependenciesCacheDeserializer::readGraph(
       unsigned compiledModulePathID, moduleDocPathID, moduleSourceInfoPathID,
           headerImportID, definingInterfacePathID, searchPathArrayID,
           headerModuleDependenciesArrayID, headerImportsSourceFilesArrayID,
-          isFramework, isStatic, moduleCacheKeyID, userModuleVersionID;
+          isFramework, isStatic, isBuiltWithCxxInterop, moduleCacheKeyID,
+          userModuleVersionID;
       SwiftBinaryModuleDetailsLayout::readRecord(
           Scratch, compiledModulePathID, moduleDocPathID,
           moduleSourceInfoPathID, headerImportID, definingInterfacePathID,
           headerModuleDependenciesArrayID, headerImportsSourceFilesArrayID,
-          searchPathArrayID, isFramework, isStatic, moduleCacheKeyID,
-          userModuleVersionID);
+          searchPathArrayID, isFramework, isStatic, isBuiltWithCxxInterop,
+          moduleCacheKeyID, userModuleVersionID);
 
       auto compiledModulePath = getIdentifier(compiledModulePathID);
       if (!compiledModulePath)
@@ -720,7 +721,7 @@ bool ModuleDependenciesCacheDeserializer::readGraph(
           *compiledModulePath, *moduleDocPath, *moduleSourceInfoPath,
           importStatements, optionalImportStatements, linkLibraries,
           *searchPaths, *headerImport, *definingInterfacePath, isFramework,
-          isStatic, *moduleCacheKey, *userModuleVersion);
+          isStatic, isBuiltWithCxxInterop, *moduleCacheKey, *userModuleVersion);
 
       addCommonDependencyInfo(moduleDep);
       addSwiftCommonDependencyInfo(moduleDep);
@@ -1629,6 +1630,7 @@ void ModuleDependenciesCacheSerializer::writeModuleInfo(
             ModuleIdentifierArrayKind::HeaderInputDependencySourceFiles),
         getSearchPathArrayID(moduleID),
         swiftBinDeps->isFramework, swiftBinDeps->isStatic,
+        swiftBinDeps->isBuiltWithCxxInterop,
         getIdentifier(swiftBinDeps->moduleCacheKey),
         getIdentifier(swiftBinDeps->userModuleVersion));
     break;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -653,6 +653,11 @@ public:
     return Bits.IsStaticLibrary;
   }
 
+  /// Was this module built with C++ interop enabled.
+  bool isBuiltWithCxxInterop() const {
+    return Bits.HasCxxInteroperability;
+  }
+
   llvm::VersionTuple getUserModuleVersion() const {
     return UserModuleVersion;
   }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -340,6 +340,7 @@ llvm::ErrorOr<ModuleDependencyInfo> SwiftModuleScanner::scanBinaryModuleFile(
       binaryModuleOptionalImports->moduleImports, linkLibraries,
       serializedSearchPaths, binaryModuleImports->headerImport,
       definingModulePath, isFramework, loadedModuleFile->isStaticLibrary(),
+      loadedModuleFile->isBuiltWithCxxInterop(),
       /*module-cache-key*/ "", userModuleVer);
 
   for (auto &macro : loadedModuleFile->getExternalMacros()) {


### PR DESCRIPTION
In addition to [skipping](https://github.com/swiftlang/swift/pull/81908) it on textual Swift module dependencies which were built without C++ interop enabled, also skip it over similarly on binary Swift dependencies.