### PR TITLE
[cxx-interop] Handle vector types in escapability analysis

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5346,6 +5346,14 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         ClangTypeEscapability({elemTy, desc.impl, desc.annotationOnly}),
         CxxEscapability::Unknown);
   }
+  if (const auto *vecTy = desugared->getAs<clang::VectorType>()) {
+    return evaluateOrDefault(
+        evaluator,
+        ClangTypeEscapability(
+            {vecTy->getElementType()->getUnqualifiedDesugaredType(), desc.impl,
+             desc.annotationOnly}),
+        CxxEscapability::Unknown);
+  }
 
   // Base cases
   if (desugared->isAnyPointerType() || desugared->isBlockPointerType() ||

--- a/test/Interop/Cxx/class/safe-interop-mode-darwin.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode-darwin.swift
@@ -1,0 +1,34 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -strict-memory-safety -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: OS=macosx
+
+//--- Inputs/module.modulemap
+module Test {
+    header "nonescapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/nonescapable.h
+#pragma once
+
+#include <simd/simd.h>
+#include <vector>
+
+using VecOfSimd = std::vector<simd::float3>;
+using MySimd = simd::float3;
+
+//--- test.swift
+import Test
+import CxxStdlib
+
+func simdConsideredSafe(x : MySimd) {
+    let _ = x
+}
+
+func simdVecConsideredSafe(x : VecOfSimd) {
+    let _ = x
+}


### PR DESCRIPTION
Whenever we have a vector type, the escpability depends on the escapability of the element type. This will enable us to consider more types like std::vector<simd::float3> as safe by default.

rdar://157141552
