### PR TITLE
[cxx-interop] Support overriding pure virtual methods from value types

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -76,7 +76,7 @@ GROUPED_WARNING(inconsistent_swift_name, ClangDeclarationImport, none,
 WARNING(swift_name_attr_ignored, none,
         "ignoring swift_name attribute %0; swift_name attributes have no "
         "effect on method overrides",
-        (DeclName))
+        (StringRef))
 
 GROUPED_WARNING(swift_name_circular_context_import, ClangDeclarationImport, none,
         "cycle detected while resolving '%0' in swift_name attribute for '%1'",

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4348,42 +4348,11 @@ namespace {
             // TODO: we don't have to import the actual `method` in this case,
             // we can just synthesize a thunk and import that instead.
 
-            FuncDecl *result;
-            if (decl->size_overridden_methods() > 0) {
-              if (auto swiftNameAttr = decl->getAttr<clang::SwiftNameAttr>()) {
-                auto parsedDeclName = parseDeclName(swiftNameAttr->getName());
-                auto swiftDeclName =
-                    parsedDeclName.formDeclName(method->getASTContext());
-                ImportedName importedName;
-                std::tie(importedName, std::ignore) = importFullName(decl);
+            llvm::SmallString<64> swiftName;
+            funcDecl->getName().getString(swiftName);
+            FuncDecl *result =
+                synthesizer.makeVirtualMethod(decl, swiftName.str());
 
-                result = synthesizer.makeVirtualMethod(decl);
-
-                if (swiftDeclName != importedName.getDeclName()) {
-                  Impl.diagnose(HeaderLoc(swiftNameAttr->getLoc()),
-                                diag::swift_name_attr_ignored, swiftDeclName);
-
-                  Impl.markUnavailable(
-                      result, (llvm::Twine("ignoring swift_name '") +
-                               swiftNameAttr->getName() + "' in '" +
-                               decl->getParent()->getName() +
-                               "'; swift_name attributes have no effect "
-                               "on method overrides")
-                                  .str());
-                }
-              } else {
-                // If there's no swift_name attribute, we don't import this method. 
-                // This is because if the overridden method was renamed and
-                // this one is not, we want to use the overridden method's name. 
-                // This is reasonable because `makeVirtualMethod` returns
-                // a thunk that will perform dynamic dispatch, and consequently
-                // the correct instance of the method will get executed.
-                return nullptr;
-              }
-            } else {
-              result = synthesizer.makeVirtualMethod(decl);
-            }
-              
             if (result) {
               return result;
             } else {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
@@ -2283,7 +2284,7 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
 // MARK: C++ virtual methods
 
 FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
-    const clang::CXXMethodDecl *clangMethodDecl) {
+    const clang::CXXMethodDecl *clangMethodDecl, StringRef swiftName) {
   auto clangDC = clangMethodDecl->getParent();
   auto &ctx = ImporterImpl.SwiftContext;
 
@@ -2294,6 +2295,25 @@ FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
       clangDC, clangDC, clangMethodDecl, ForwardingMethodKind::Virtual,
       ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
       /*forceConstQualifier*/ false);
+  
+  // If the override has a swift_name different from the base
+  // method, we ignore the swift_name attribute and instead use the base method's name.
+  // In this case, swiftName holds the correct derived method name obtained through NameImporter
+  if (clangMethodDecl->size_overridden_methods() > 0) {
+    if (auto oldSwiftNameAttr = newMethod->getAttr<clang::SwiftNameAttr>()) {
+      auto oldSwiftName = oldSwiftNameAttr->getName();
+      
+      if (swiftName != oldSwiftName) {
+        ImporterImpl.diagnose(HeaderLoc(oldSwiftNameAttr->getLoc()),
+                              diag::swift_name_attr_ignored,
+                              oldSwiftName);
+        oldSwiftNameAttr->setName(newMethod->getASTContext(), swiftName);
+      }
+    } else {
+      newMethod->addAttr(clang::SwiftNameAttr::CreateImplicit(
+          newMethod->getASTContext(), swiftName));
+    }
+  }
 
   auto result = dyn_cast_or_null<FuncDecl>(
       ctx.getClangModuleLoader()->importDeclDirectly(newMethod));

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -322,7 +322,8 @@ public:
 
   /// Given an overload of a C++ virtual method on a reference type, create a
   /// method that dispatches the call dynamically.
-  FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl);
+  FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl,
+                              StringRef swiftName);
 
   FuncDecl *makeInstanceToStaticOperatorCallMethod(
       const clang::CXXMethodDecl *clangMethodDecl);

--- a/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
@@ -181,7 +181,8 @@ struct B2 : A1 {
 
   int fooRename() const { return 222; }
 
-  __attribute__((swift_name("B2BarRename()"))) int barRename() const {
+  __attribute__((swift_name("B2BarRename()"))) 
+  int barRename() const {
     return 223;
   }
 
@@ -274,3 +275,93 @@ struct D2 : B1, A2 {
 struct D3 : B1, B2 {};
 
 struct D4 : C1, B2 {};
+
+struct ValueType {
+  virtual int virtualMethod() const { return 111; }
+
+  __attribute__((swift_name("swiftRenameMethodBase()")))
+  virtual int renameMethodBase() const {
+    return 112;
+  }
+
+  virtual int renameMethodDerived() const { return 113; }
+
+  virtual int pureVirtualMethod() const = 0;
+
+  __attribute__((swift_name("swiftPureRenameBase()")))
+  virtual int pureRenameBase() const = 0;
+
+  virtual int pureRenameDerived() const = 0;
+};
+
+struct IMMORTAL_FRT DerivedFRTValueType : ValueType {
+  virtual int virtualMethod() const override { return 211; }
+
+  virtual int renameMethodBase() const override { return 212; }
+
+  __attribute__((swift_name("swiftRenameMethodDerived()")))
+  virtual int renameMethodDerived() const override {
+    return 213;
+  }
+
+  virtual int pureVirtualMethod() const override { return 214; }
+
+  virtual int pureRenameBase() const override { return 215; }
+
+  __attribute__((swift_name("swiftPureRenameDerived()"))) 
+  virtual int pureRenameDerived() const override {
+    return 216;
+  }
+
+  static DerivedFRTValueType *_Nonnull create() {
+    return new DerivedFRTValueType();
+  }
+};
+
+struct IMMORTAL_FRT EmptyDerivedFRTValueType : ValueType {};
+
+struct DerivedValueType : ValueType {
+  virtual int virtualMethod() const override { return 311; }
+
+  virtual int renameMethodBase() const override { return 312; }
+
+  __attribute__((swift_name("swiftRenameMethodDerived()"))) virtual int
+  renameMethodDerived() const override {
+    return 313;
+  }
+
+  virtual int pureVirtualMethod() const override { return 314; }
+
+  virtual int pureRenameBase() const override { return 315; }
+
+  __attribute__((swift_name("swiftPureRenameDerived()"))) virtual int
+  pureRenameDerived() const override {
+    return 316;
+  }
+};
+
+struct IMMORTAL_FRT AbstractFRT {
+  virtual int pureVirtualMethod() const = 0;
+
+  __attribute__((swift_name("swiftPureRenameBase()")))
+  virtual int pureRenameBase() const = 0;
+
+  virtual int pureRenameDerived() const = 0;
+};
+
+struct DerivedAbstractFRT : AbstractFRT {
+  virtual int pureVirtualMethod() const override { return 211; }
+
+  virtual int pureRenameBase() const override { return 212; }
+
+  __attribute__((swift_name("swiftPureRenameDerived()"))) 
+  virtual int pureRenameDerived() const override {
+    return 213;
+  }
+
+  static DerivedAbstractFRT *_Nonnull create() {
+    return new DerivedAbstractFRT();
+  }
+};
+
+struct EmptyDerivedAbstractFRT : AbstractFRT {};

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -24,12 +24,6 @@
 // CHECK: }
 
 // CHECK: class B1 {
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
 // CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
@@ -37,8 +31,6 @@
 // CHECK: }
 
 // CHECK: class B2 {
-// CHECK:    @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:   final func B2BarRename() -> Int32
 // CHECK:   final func virtualMethod() -> Int32
 // CHECK:   final func swiftFooRename() -> Int32
 // CHECK:   final func swiftBarRename() -> Int32
@@ -48,25 +40,11 @@
 // CHECK: class C1 {
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
-// CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK:  final func virtualMethod() -> Int32
 // CHECK: }
 
 // CHECK: class C2 {
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func C2FooRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
 // CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
@@ -91,19 +69,15 @@
 // CHECK: }
 
 // CHECK: class D2 {
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
+// CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
 // CHECK:  final func virtualMethod() -> Int32
-// CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
 // CHECK:  final func swiftBarRename() -> Int32
 // CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
+// CHECK:  final func swiftVirtualMethod() -> Int32
 // CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
 // CHECK:  final func A2BarRename() -> Int32
 // CHECK:  @available(*, unavailable, message: "overrides{{.*}}")
@@ -111,12 +85,6 @@
 // CHECK: }
 
 // CHECK: struct D3 {
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
 // CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
@@ -126,12 +94,67 @@
 // CHECK: struct D4 {
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftVirtualMethod() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func B1BarRename() -> Int32
-// CHECK:  @available(*, unavailable, message: "ignoring{{.*}}")
-// CHECK:  final func swiftParamsRename(b1 i: Int32) -> Int32
-// CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK:  final func virtualMethod() -> Int32
+// CHECK: }
+
+// CHECK: struct ValueType {
+// CHECK:   func virtualMethod() -> Int32
+// CHECK:   func swiftRenameMethodBase() -> Int32
+// CHECK:   func renameMethodDerived() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func pureVirtualMethod() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func swiftPureRenameBase() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: class DerivedFRTValueType {
+// CHECK:   final func virtualMethod() -> Int32
+// CHECK:   final func swiftRenameMethodBase() -> Int32
+// CHECK:   final func renameMethodDerived() -> Int32
+// CHECK:   final func pureVirtualMethod() -> Int32
+// CHECK:   final func swiftPureRenameBase() -> Int32
+// CHECK:   final func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: class EmptyDerivedFRTValueType {
+// CHECK:   func virtualMethod() -> Int32
+// CHECK:   func swiftRenameMethodBase() -> Int32
+// CHECK:   func renameMethodDerived() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func pureVirtualMethod() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func swiftPureRenameBase() -> Int32
+// CHECK:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK:   func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: struct DerivedValueType {
+// CHECK:   func virtualMethod() -> Int32
+// CHECK:   func swiftRenameMethodBase() -> Int32
+// CHECK:   func renameMethodDerived() -> Int32
+// CHECK:   func pureVirtualMethod() -> Int32
+// CHECK:   func swiftPureRenameBase() -> Int32
+// CHECK:   func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: class AbstractFRT {
+// CHECK:   final func pureVirtualMethod() -> Int32
+// CHECK:   final func swiftPureRenameBase() -> Int32
+// CHECK:   final func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: class DerivedAbstractFRT {
+// CHECK:   init()
+// CHECK:   final func pureVirtualMethod() -> Int32
+// CHECK:   final func swiftPureRenameBase() -> Int32
+// CHECK:   final func pureRenameDerived() -> Int32
+// CHECK: }
+
+// CHECK: class EmptyDerivedAbstractFRT {
+// CHECK:   final func pureVirtualMethod() -> Int32
+// CHECK:   final func swiftPureRenameBase() -> Int32
+// CHECK:   final func pureRenameDerived() -> Int32
 // CHECK: }

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
@@ -37,89 +37,139 @@ func callsRenamedVirtualMethodsInFRT(_ i: Immortal2) {
 func callsOverridesOfRenamedVirtualMethods(
   _ a1: A1, _ a2: A2, _ b1: B1, _ b2: B2, _ c1: C1, _ c2: C2, _ d1: D1, _ d2: D2, _ d3: D3, _ d4: D4
 ) {
-  a1.virtualMethod()
-  a1.fooRename()  // expected-error {{value of type 'A1' has no member 'fooRename'}}
-  a1.swiftFooRename()
-  a1.swiftParamsRename(a1: 42)
+  let _ = a1.virtualMethod()
+  let _ = a1.fooRename()  // expected-error {{value of type 'A1' has no member 'fooRename'}}
+  let _ = a1.swiftFooRename()
+  let _ = a1.swiftParamsRename(a1: 42)
 
-  b1.virtualMethod()
-  b1.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: ignoring swift_name 'swiftVirtualMethod()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  b1.fooRename()  // expected-error {{value of type 'B1' has no member 'fooRename'}}
-  b1.swiftFooRename()
-  b1.barRename()  // expected-error {{value of type 'B1' has no member 'barRename'}}
-  b1.swiftBarRename()
-  b1.B1BarRename()  // expected-error {{'B1BarRename()' is unavailable: ignoring swift_name 'B1BarRename()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  b1.swiftParamsRename(a1: 42)
-  b1.swiftParamsRename(b1: 42)  // expected-error {{'swiftParamsRename(b1:)' is unavailable: ignoring swift_name 'swiftParamsRename(b1:)' in 'B1'; swift_name attributes have no effect on method overrides}}
+  let _ = b1.virtualMethod()
+  let _ = b1.swiftVirtualMethod()  // expected-error {{value of type 'B1' has no member 'swiftVirtualMethod'}}
+  let _ = b1.fooRename()  // expected-error {{value of type 'B1' has no member 'fooRename'}}
+  let _ = b1.swiftFooRename()
+  let _ = b1.barRename()  // expected-error {{value of type 'B1' has no member 'barRename'}}
+  let _ = b1.swiftBarRename()
+  let _ = b1.B1BarRename()  // expected-error {{value of type 'B1' has no member 'B1BarRename'; did you mean 'swiftBarRename'}}
+  let _ = b1.swiftParamsRename(a1: 42)
+  let _ = b1.swiftParamsRename(b1: 42)  // expected-error {{incorrect argument label in call (have 'b1:', expected 'a1:')}}
 
-  b2.virtualMethod()
-  b2.fooRename()  // expected-error {{value of type 'B2' has no member 'fooRename'; did you mean 'swiftFooRename'?}}
-  b2.swiftFooRename()
-  b2.B2BarRename()  // expected-error {{'B2BarRename()' is unavailable: ignoring swift_name 'B2BarRename()' in 'B2'; swift_name attributes have no effect on method overrides}}
-  b2.swiftParamsRename(a1: 42)
+  let _ = b2.virtualMethod()
+  let _ = b2.fooRename()  // expected-error {{value of type 'B2' has no member 'fooRename'; did you mean 'swiftFooRename'?}}
+  let _ = b2.swiftFooRename()
+  let _ = b2.B2BarRename()  // expected-error {{value of type 'B2' has no member 'B2BarRename'; did you mean 'swiftBarRename'}}
+  let _ = b2.swiftParamsRename(a1: 42)
 
-  c1.virtualMethod()
-  c1.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: ignoring swift_name 'swiftVirtualMethod()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  c1.fooRename()  // expected-error {{value of type 'C1' has no member 'fooRename'}}
-  c1.swiftFooRename()
-  c1.barRename()  // expected-error {{value of type 'C1' has no member 'barRename'}}
-  c1.swiftBarRename()
-  c1.B1BarRename()  // expected-error {{'B1BarRename()' is unavailable: ignoring swift_name 'B1BarRename()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  c1.paramsRename(42)  // expected-error {{value of type 'C1' has no member 'paramsRename'}}
-  c1.swiftParamsRename(42)  // expected-error {{missing argument label 'a1:' in call}}
-  c1.swiftParamsRename(a1: 42)
+  let _ = c1.virtualMethod()
+  let _ = c1.swiftVirtualMethod()  // expected-error {{value of type 'C1' has no member 'swiftVirtualMethod'}}
+  let _ = c1.fooRename()  // expected-error {{value of type 'C1' has no member 'fooRename'}}
+  let _ = c1.swiftFooRename()
+  let _ = c1.barRename()  // expected-error {{value of type 'C1' has no member 'barRename'}}
+  let _ = c1.swiftBarRename()
+  let _ = c1.B1BarRename()  // expected-error {{value of type 'C1' has no member 'B1BarRename'}}
+  let _ = c1.paramsRename(42)  // expected-error {{value of type 'C1' has no member 'paramsRename'}}
+  let _ = c1.swiftParamsRename(42)  // expected-error {{missing argument label 'a1:' in call}}
+  let _ = c1.swiftParamsRename(a1: 42)
 
-  c2.virtualMethod()
-  c2.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: ignoring swift_name 'swiftVirtualMethod()' in 'C2'; swift_name attributes have no effect on method overrides}}
-  c2.fooRename()  // expected-error {{value of type 'C2' has no member 'fooRename'}}
-  c2.swiftFooRename()
-  c2.C2FooRename()  // expected-error {{'C2FooRename()' is unavailable: ignoring swift_name 'C2FooRename()' in 'C2'; swift_name attributes have no effect on method overrides}}
-  c2.barRename()  // expected-error {{value of type 'C2' has no member 'barRename'}}
-  c2.swiftBarRename()
-  c2.B1BarRename()  // expected-error {{'B1BarRename()' is unavailable: ignoring swift_name 'B1BarRename()' in 'C2'; swift_name attributes have no effect on method overrides}}
-  c2.paramsRename(42)  // expected-error {{value of type 'C2' has no member 'paramsRename'}}
-  c2.swiftParamsRename(a1: 42)
-  c2.swiftParamsRename(b1: 42)  // expected-error {{'swiftParamsRename(b1:)' is unavailable: ignoring swift_name 'swiftParamsRename(b1:)' in 'C2'; swift_name attributes have no effect on method overrides}}
+  let _ = c2.virtualMethod()
+  let _ = c2.swiftVirtualMethod()  // expected-error {{value of type 'C2' has no member 'swiftVirtualMethod'}}
+  let _ = c2.fooRename()  // expected-error {{value of type 'C2' has no member 'fooRename'}}
+  let _ = c2.swiftFooRename()
+  let _ = c2.C2FooRename()  // expected-error {{value of type 'C2' has no member 'C2FooRename'}}
+  let _ = c2.barRename()  // expected-error {{value of type 'C2' has no member 'barRename'}}
+  let _ = c2.swiftBarRename()
+  let _ = c2.B1BarRename()  // expected-error {{value of type 'C2' has no member 'B1BarRename'}}
+  let _ = c2.paramsRename(42)  // expected-error {{value of type 'C2' has no member 'paramsRename'}}
+  let _ = c2.swiftParamsRename(a1: 42)
+  let _ = c2.swiftParamsRename(b1: 42)  // expected-error {{incorrect argument label in call (have 'b1:', expected 'a1:')}}
 
-  d1.virtualMethod()
-  d1.swiftVirtualMethod()
-  d1.fooRename()  // expected-error {{value of type 'D1' has no member 'fooRename'}}
-  d1.swiftFooRename()  // expected-error {{ambiguous use of 'swiftFooRename()'}}
-  d1.barRename()  // expected-error {{value of type 'D1' has no member 'barRename'}}
-  d1.swiftBarRename()
-  d1.A2BarRename()
-  d1.swiftParamsRename(a1: 42)
-  d1.swiftParamsRename(a2: 42)
+  let _ = d1.virtualMethod()
+  let _ = d1.swiftVirtualMethod()
+  let _ = d1.fooRename()  // expected-error {{value of type 'D1' has no member 'fooRename'}}
+  let _ = d1.swiftFooRename()  // expected-error {{ambiguous use of 'swiftFooRename()'}}
+  let _ = d1.barRename()  // expected-error {{value of type 'D1' has no member 'barRename'}}
+  let _ = d1.swiftBarRename()
+  let _ = d1.A2BarRename()
+  let _ = d1.swiftParamsRename(a1: 42)
+  let _ = d1.swiftParamsRename(a2: 42)
 
-  d2.virtualMethod()  // expected-error {{'virtualMethod()' is unavailable: overrides multiple C++ methods with different Swift names}}
-  d2.swiftVirtualMethod()  // expected-error {{ambiguous use of 'swiftVirtualMethod()'}}
-  d2.fooRename()  // expected-error {{value of type 'D2' has no member 'fooRename'}}
-  d2.swiftFooRename()  // expected-error {{ambiguous use of 'swiftFooRename()'}}
-  d2.barRename()  // expected-error {{value of type 'D2' has no member 'barRename'}}
-  d2.swiftBarRename()  // expected-error {{'swiftBarRename()' is unavailable: overrides multiple C++ methods with different Swift names}}
-  d2.A2BarRename()  // expected-error {{'A2BarRename()' is unavailable: overrides multiple C++ methods with different Swift names}}
-  d2.swiftParamsRename(a1: 42)  // expected-error {{'swiftParamsRename(a1:)' is unavailable: overrides multiple C++ methods with different Swift names}}
-  d2.swiftParamsRename(a2: 42)  // expected-error {{'swiftParamsRename(a2:)' is unavailable: overrides multiple C++ methods with different Swift names}}
-  d2.swiftParamsRename(b1: 42)  // expected-error {{'swiftParamsRename(b1:)' is unavailable: ignoring swift_name 'swiftParamsRename(b1:)' in 'B1'; swift_name attributes have no effect on method overrides}}
+  let _ = d2.virtualMethod()  // expected-error {{'virtualMethod()' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.fooRename()  // expected-error {{value of type 'D2' has no member 'fooRename'}}
+  let _ = d2.swiftFooRename()
+  let _ = d2.barRename()  // expected-error {{value of type 'D2' has no member 'barRename'}}
+  let _ = d2.swiftBarRename()  // expected-error {{'swiftBarRename()' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.A2BarRename()  // expected-error {{'A2BarRename()' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.swiftParamsRename(a1: 42)  // expected-error {{'swiftParamsRename(a1:)' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.swiftParamsRename(a2: 42)  // expected-error {{'swiftParamsRename(a2:)' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d2.swiftParamsRename(b1: 42)  // expected-error {{no exact matches in call to instance method 'swiftParamsRename'}}
 
-  d3.virtualMethod()
-  d3.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: ignoring swift_name 'swiftVirtualMethod()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  d3.fooRename()  // expected-error {{value of type 'D3' has no member 'fooRename'}}
-  d3.swiftFooRename()
-  d3.barRename()  // expected-error {{value of type 'D3' has no member 'barRename'}}
-  d3.swiftBarRename()
-  d3.B1BarRename()  // expected-error {{'B1BarRename()' is unavailable: ignoring swift_name 'B1BarRename()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  d3.swiftParamsRename(a1: 42)
-  d3.swiftParamsRename(b1: 42)  // expected-error {{'swiftParamsRename(b1:)' is unavailable: ignoring swift_name 'swiftParamsRename(b1:)' in 'B1'; swift_name attributes have no effect on method overrides}}
+  let _ = d3.virtualMethod() // expected-error {{ambiguous use of 'virtualMethod()'}}
+  let _ = d3.swiftVirtualMethod()  // expected-error {{value of type 'D3' has no member 'swiftVirtualMethod'}}
+  let _ = d3.fooRename()  // expected-error {{value of type 'D3' has no member 'fooRename'}}
+  let _ = d3.swiftFooRename() // expected-error {{ambiguous use of 'swiftFooRename()'}}
+  let _ = d3.barRename()  // expected-error {{value of type 'D3' has no member 'barRename'}}
+  let _ = d3.swiftBarRename() // expected-error {{ambiguous use of 'swiftBarRename()'}}
+  let _ = d3.B1BarRename()  // expected-error {{value of type 'D3' has no member 'B1BarRename'}}
+  let _ = d3.swiftParamsRename(a1: 42) // expected-error {{ambiguous use of 'swiftParamsRename(a1:)'}}
+  let _ = d3.swiftParamsRename(b1: 42)  // expected-error {{no exact matches in call to instance method 'swiftParamsRename'}}
 
-  d4.virtualMethod()
-  d4.swiftVirtualMethod()  // expected-error {{'swiftVirtualMethod()' is unavailable: ignoring swift_name 'swiftVirtualMethod()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  d4.fooRename()  // expected-error {{value of type 'D4' has no member 'fooRename'}}
-  d4.swiftFooRename()  // expected-error {{ambiguous use of 'swiftFooRename()'}}
-  d4.barRename()  // expected-error {{value of type 'D4' has no member 'barRename'}}
-  d4.swiftBarRename()  // expected-error {{ambiguous use of 'swiftBarRename()'}}
-  d4.B1BarRename()  // expected-error {{'B1BarRename()' is unavailable: ignoring swift_name 'B1BarRename()' in 'B1'; swift_name attributes have no effect on method overrides}}
-  d4.paramsRename(42)  // expected-error {{value of type 'D4' has no member 'paramsRename'}}
-  d4.swiftParamsRename(42)  // expected-error {{missing argument label 'a1:' in call}}
-  d4.swiftParamsRename(a1: 42)
+  let _ = d4.virtualMethod() // expected-error {{ambiguous use of 'virtualMethod()'}}
+  let _ = d4.swiftVirtualMethod()  // expected-error {{value of type 'D4' has no member 'swiftVirtualMethod'}}
+  let _ = d4.fooRename()  // expected-error {{value of type 'D4' has no member 'fooRename'}}
+  let _ = d4.swiftFooRename()  // expected-error {{ambiguous use of 'swiftFooRename()'}}
+  let _ = d4.barRename()  // expected-error {{value of type 'D4' has no member 'barRename'}}
+  let _ = d4.swiftBarRename()  // expected-error {{ambiguous use of 'swiftBarRename()'}}
+  let _ = d4.B1BarRename()  // expected-error {{value of type 'D4' has no member 'B1BarRename'}}
+  let _ = d4.paramsRename(42)  // expected-error {{value of type 'D4' has no member 'paramsRename'}}
+  let _ = d4.swiftParamsRename(42) // expected-error {{no exact matches in call to instance method 'swiftParamsRename'}}
+  let _ = d4.swiftParamsRename(a1: 42) // expected-error {{ambiguous use of 'swiftParamsRename(a1:)'}}
 }
+
+@available(SwiftStdlib 5.8, *)
+func callsOverridesOfValueTypeMethods (_ frt: DerivedFRTValueType, _ empty_frt: EmptyDerivedFRTValueType, _ vt: DerivedValueType) {
+  let _ = frt.virtualMethod()
+  let _ = frt.renameMethodBase() // expected-error {{value of type 'DerivedFRTValueType' has no member 'renameMethodBase'}}
+  let _ = frt.swiftRenameMethodBase()
+  let _ = frt.renameMethodDerived()
+  let _ = frt.swiftRenameMethodDerived() // expected-error {{value of type 'DerivedFRTValueType' has no member 'swiftRenameMethodDerived'}}
+
+  let _ = frt.pureVirtualMethod()
+  let _ = frt.pureRenameBase() // expected-error {{value of type 'DerivedFRTValueType' has no member 'pureRenameBase'}}
+  let _ = frt.swiftPureRenameBase()
+  let _ = frt.pureRenameDerived()
+  let _ = frt.swiftPureRenameDerived() // expected-error {{value of type 'DerivedFRTValueType' has no member 'swiftPureRenameDerived'}}
+
+  let _ = empty_frt.virtualMethod()
+  let _ = empty_frt.renameMethodBase() // expected-error {{value of type 'EmptyDerivedFRTValueType' has no member 'renameMethodBase'}}
+  let _ = empty_frt.swiftRenameMethodBase()
+  let _ = empty_frt.renameMethodDerived()
+
+  let _ = empty_frt.pureVirtualMethod() // expected-error {{'pureVirtualMethod()' is unavailable: virtual function is not available in Swift because it is pure}}
+
+  let _ = vt.virtualMethod()
+  let _ = vt.renameMethodBase() // expected-error {{value of type 'DerivedValueType' has no member 'renameMethodBase'}}
+  let _ = vt.swiftRenameMethodBase()
+  let _ = vt.renameMethodDerived()
+  let _ = vt.swiftRenameMethodDerived() // expected-error {{value of type 'DerivedValueType' has no member 'swiftRenameMethodDerived'}}
+
+  let _ = vt.pureVirtualMethod()
+  let _ = vt.pureRenameBase() // expected-error {{value of type 'DerivedValueType' has no member 'pureRenameBase'}}
+  let _ = vt.swiftPureRenameBase()
+  let _ = vt.pureRenameDerived()
+  let _ = vt.swiftPureRenameDerived() // expected-error {{value of type 'DerivedValueType' has no member 'swiftPureRenameDerived'}}
+}
+
+@available(SwiftStdlib 5.8, *)
+func callsOverridesOfAbstractFRTMethods (_ frt: DerivedAbstractFRT, _ empty_frt: EmptyDerivedAbstractFRT) {
+  let _ = frt.pureVirtualMethod()
+  let _ = frt.pureRenameBase() // expected-error {{value of type 'DerivedAbstractFRT' has no member 'pureRenameBase'}}
+  let _ = frt.swiftPureRenameBase()
+  let _ = frt.pureRenameDerived()
+  let _ = frt.swiftPureRenameDerived() // expected-error {{value of type 'DerivedAbstractFRT' has no member 'swiftPureRenameDerived'}}
+
+  let _ = empty_frt.pureVirtualMethod()
+  let _ = empty_frt.pureRenameBase() // expected-error {{value of type 'EmptyDerivedAbstractFRT' has no member 'pureRenameBase'}}
+  let _ = empty_frt.swiftPureRenameBase()
+  let _ = empty_frt.pureRenameDerived()
+  let _ = empty_frt.swiftPureRenameDerived() // expected-error {{value of type 'EmptyDerivedAbstractFRT' has no member 'swiftPureRenameDerived'}}
+}
+

--- a/test/Interop/Cxx/foreign-reference/member-inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance.swift
@@ -158,4 +158,25 @@ if #available(SwiftStdlib 5.8, *) {
   } 
 }
 
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("renamed C++ virtual methods in FRT, which derives from value type") {
+    let frt = DerivedFRTValueType.create()
+    expectEqual(frt.virtualMethod(), 211)
+    expectEqual(frt.swiftRenameMethodBase(), 212)
+    expectEqual(frt.renameMethodDerived(), 213)
+    expectEqual(frt.pureVirtualMethod(), 214)
+    expectEqual(frt.swiftPureRenameBase(), 215)
+    expectEqual(frt.pureRenameDerived(), 216)
+  }
+}
+
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("renamed C++ pure virtual methods in FRT") {
+    let frt = DerivedAbstractFRT.create()      
+    expectEqual(frt.pureVirtualMethod(), 211)
+    expectEqual(frt.swiftPureRenameBase(), 212)
+    expectEqual(frt.pureRenameDerived(), 213)
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/83067, we overlooked the case where the base of a FRT is a value type. This caused the compiler to clone the pure virtual method to all derived FRTs, which meant we couldn't call the method in derived classes even if the method was implemented in them. 

Now we make sure to always import the virtual method, if defined in that C++ record, and only rely on the lazy clone from the base class when that record doesn't explicitly override the method. 

rdar://157331592
