### PR TITLE
utils: Make build.ps1 work with PowerShell Core

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1678,8 +1678,10 @@ function Build-CMakeProject {
 
           $ArgWithForwardSlashes = $Arg.Replace("\", "/")
           if ($ArgWithForwardSlashes.Contains(" ")) {
-            # Quote and escape the quote so it makes it through
-            $Value += "\""$ArgWithForwardSlashes\"""
+            # Escape the quote so it makes it through. PowerShell 5 and Core
+            # handle quotes differently, so we need to check the version.
+            $quote = if ($PSEdition  -eq "Core") { '"' } else { '\"' }
+            $Value += "$quote$ArgWithForwardSlashes$quote"
           } else {
             $Value += $ArgWithForwardSlashes
           }
@@ -3692,6 +3694,9 @@ if (-not $SkipBuild) {
   }
 
   Remove-Item -Force -Recurse ([IO.Path]::Combine((Get-InstallDir $HostPlatform), "Platforms")) -ErrorAction Ignore
+
+  # Clear the progress bar from the output or it keeps ghosting.
+  1..10 | ForEach-Object { Write-Progress -Id $_ -Activity "Removing previous Platforms directory" -Completed }
 
   Invoke-BuildStep Build-CMark $BuildPlatform
   Invoke-BuildStep Build-BuildTools $BuildPlatform

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3695,9 +3695,6 @@ if (-not $SkipBuild) {
 
   Remove-Item -Force -Recurse ([IO.Path]::Combine((Get-InstallDir $HostPlatform), "Platforms")) -ErrorAction Ignore
 
-  # Clear the progress bar from the output or it keeps ghosting.
-  1..10 | ForEach-Object { Write-Progress -Id $_ -Activity "Removing previous Platforms directory" -Completed }
-
   Invoke-BuildStep Build-CMark $BuildPlatform
   Invoke-BuildStep Build-BuildTools $BuildPlatform
   if ($IsCrossCompiling) {


### PR DESCRIPTION
Windows PowerShell (version 5) and PowerShell Core (versions 6+) do not handle escaping parameters for external programs invocation in the same manner. In order to keep the script compatible with both editions of PowerShell, these changes use the appropriate quote escaping style depending on the PowerShell edition.