### PR TITLE
AST: Update Swift 6.2 runtime OS versions

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -160,7 +160,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 2),
-  FUTURE
+  PLATFORM(macOS,   (26, 0, 0))
+  PLATFORM(iOS,     (26, 0, 0))
+  PLATFORM(watchOS, (26, 0, 0))
+  PLATFORM(visionOS,(26, 0, 0))
 )
 
 RUNTIME_VERSION(

--- a/test/Availability/value_generics_availability.swift
+++ b/test/Availability/value_generics_availability.swift
@@ -2,13 +2,13 @@
 
 // REQUIRES: OS=macosx
 
-struct A<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+struct A<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                         // expected-note@-1 {{add '@available' attribute to enclosing generic struct}}
 
-class B<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+class B<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                        // expected-note@-1 {{add '@available' attribute to enclosing generic class}}
 
-enum C<let N: Int> {} // expected-error {{values in generic types are only available in macOS 99.99.0 or newer}}
+enum C<let N: Int> {} // expected-error {{values in generic types are only available in macOS 26.0.0 or newer}}
                       // expected-note@-1 {{add '@available' attribute to enclosing generic enum}}
 
 func something<let N: Int>(_: A<N>) {} // OK, because A can't reference value generics.


### PR DESCRIPTION
Swift 6.2 is aligned with the version 26 of each of Apple's operating systems and the runtime availability metadata should reflect this.
