### PR TITLE
PrintAsClang: Use proper types and look through typealiases in PrimitiveTypeMapping

### DIFF
--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -83,10 +83,13 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   MAP(CBool, "bool", false);
 
   MAP(CChar, "char", false);
-  MAP(CWideChar, "wchar_t", false);
   MAP(CChar8, "char8_t", false);
   MAP(CChar16, "char16_t", false);
   MAP(CChar32, "char32_t", false);
+
+  // Set after CChar32 to prefer char32_t for the shared underlying
+  // Unicode.Scalar. char32_t is stable across platforms.
+  MAP(CWideChar, "wchar_t", false);
 
   MAP(CSignedChar, "signed char", false);
   MAP(CShort, "short", false);
@@ -116,6 +119,8 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   MAP(Double, "double", false);
   MAP(Float32, "float", false);
   MAP(Float64, "double", false);
+
+  MAP(Float16, "_Float16", false);
 
   MAP_CXX(Int, "NSInteger", "ptrdiff_t", "swift::Int", false);
   MAP_CXX(UInt, "NSUInteger", "size_t", "swift::UInt", false);

--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -19,20 +19,66 @@
 
 using namespace swift;
 
+/// Find the implementation of the named type in the named module if loaded.
+static TypeDecl *findTypeInModuleByName(ASTContext &ctx,
+                                        Identifier moduleName,
+                                        Identifier typeName) {
+  auto module = ctx.getLoadedModule(moduleName);
+  if (!module)
+    return nullptr;
+
+  // Find all of the declarations with this name in the Swift module.
+  SmallVector<ValueDecl *, 1> results;
+  module->lookupValue(typeName, NLKind::UnqualifiedLookup, results);
+  for (auto result : results) {
+    if (auto nominal = dyn_cast<NominalTypeDecl>(result))
+      return nominal;
+
+    if (auto typealias = dyn_cast<TypeAliasDecl>(result))
+      return typealias;
+  }
+
+  return nullptr;
+}
+
 void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   assert(mappedTypeNames.empty() && "expected empty type map");
+
+  auto addMappedType = [&](Identifier moduleName, Identifier typeName,
+                           FullClangTypeInfo info) {
+    auto decl = findTypeInModuleByName(ctx, moduleName, typeName);
+    if (!decl)
+      return;
+
+    // Always map a direct definition match. Either the nominal decl or the
+    // typealias itself.
+    mappedTypeNames[decl] = info;
+
+    // If the underlying type of a typealias doesn't have a type, set it here.
+    // This aims to reproduce the typealias behavior from BuiltinMappedTypes.
+    if (auto typealias = dyn_cast<TypeAliasDecl>(decl)) {
+      auto underlying = typealias->getDeclaredInterfaceType()->getAnyNominal();
+      if (underlying && !mappedTypeNames.contains(underlying))
+        mappedTypeNames[underlying] = info;
+    }
+  };
+
+  // Map stdlib types.
 #define MAP(SWIFT_NAME, CLANG_REPR, NEEDS_NULLABILITY)                         \
-  mappedTypeNames[{ctx.StdlibModuleName, ctx.getIdentifier(#SWIFT_NAME)}] = {  \
-      CLANG_REPR, std::optional<StringRef>(CLANG_REPR),                        \
-      std::optional<StringRef>(CLANG_REPR), NEEDS_NULLABILITY}
+  addMappedType(ctx.StdlibModuleName,                                          \
+                ctx.getIdentifier(#SWIFT_NAME),                                \
+                {CLANG_REPR, std::optional<StringRef>(CLANG_REPR),             \
+                 std::optional<StringRef>(CLANG_REPR), NEEDS_NULLABILITY})
 #define MAP_C(SWIFT_NAME, OBJC_REPR, C_REPR, NEEDS_NULLABILITY)                \
-  mappedTypeNames[{ctx.StdlibModuleName, ctx.getIdentifier(#SWIFT_NAME)}] = {  \
-      OBJC_REPR, std::optional<StringRef>(C_REPR),                             \
-      std::optional<StringRef>(C_REPR), NEEDS_NULLABILITY}
+  addMappedType(ctx.StdlibModuleName,                                          \
+                ctx.getIdentifier(#SWIFT_NAME),                                \
+                {OBJC_REPR, std::optional<StringRef>(C_REPR),                  \
+                 std::optional<StringRef>(C_REPR), NEEDS_NULLABILITY})
 #define MAP_CXX(SWIFT_NAME, OBJC_REPR, C_REPR, CXX_REPR, NEEDS_NULLABILITY)    \
-  mappedTypeNames[{ctx.StdlibModuleName, ctx.getIdentifier(#SWIFT_NAME)}] = {  \
-      OBJC_REPR, std::optional<StringRef>(C_REPR),                             \
-      std::optional<StringRef>(CXX_REPR), NEEDS_NULLABILITY}
+  addMappedType(ctx.StdlibModuleName,                                          \
+                ctx.getIdentifier(#SWIFT_NAME),                                \
+                {OBJC_REPR, std::optional<StringRef>(C_REPR),                  \
+                 std::optional<StringRef>(CXX_REPR), NEEDS_NULLABILITY})
 
   MAP(CBool, "bool", false);
 
@@ -79,35 +125,37 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   MAP(UnsafeRawPointer, "void const *", true);
   MAP(UnsafeMutableRawPointer, "void *", true);
 
-  Identifier ID_ObjectiveC = ctx.Id_ObjectiveC;
-  mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}] = {
-      "BOOL", std::nullopt, std::nullopt, false};
-  mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}] = {
-      "SEL", std::nullopt, std::nullopt, true};
-  mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier(swift::getSwiftName(
-                                      KnownFoundationEntity::NSZone))}] = {
-      "struct _NSZone *", std::nullopt, std::nullopt, true};
+  // Map other module types.
 
-  mappedTypeNames[{ctx.Id_Darwin, ctx.getIdentifier("DarwinBoolean")}] = {
-      "Boolean", std::nullopt, std::nullopt, false};
+  addMappedType(ctx.Id_ObjectiveC, ctx.getIdentifier("ObjCBool"),
+                {"BOOL", std::nullopt, std::nullopt, false});
+  addMappedType(ctx.Id_ObjectiveC, ctx.getIdentifier("Selector"),
+                {"SEL", std::nullopt, std::nullopt, true});
+  addMappedType(ctx.Id_ObjectiveC,
+                ctx.getIdentifier(swift::getSwiftName(
+                                      KnownFoundationEntity::NSZone)),
+                {"struct _NSZone *", std::nullopt, std::nullopt, true});
 
-  mappedTypeNames[{ctx.Id_CoreGraphics, ctx.Id_CGFloat}] = {
-      "CGFloat", std::nullopt, std::nullopt, false};
+  addMappedType(ctx.Id_Darwin, ctx.getIdentifier("DarwinBoolean"),
+                {"Boolean", std::nullopt, std::nullopt, false});
 
-  mappedTypeNames[{ctx.Id_CoreFoundation, ctx.Id_CGFloat}] = {
-      "CGFloat", std::nullopt, std::nullopt, false};
+  addMappedType(ctx.Id_CoreGraphics, ctx.Id_CGFloat,
+                {"CGFloat", std::nullopt, std::nullopt, false});
+
+  addMappedType(ctx.Id_CoreFoundation, ctx.Id_CGFloat,
+                {"CGFloat", std::nullopt, std::nullopt, false});
 
   // Use typedefs we set up for SIMD vector types.
 #define MAP_SIMD_TYPE(BASENAME, _, __)                                         \
   StringRef simd2##BASENAME = "swift_" #BASENAME "2";                          \
-  mappedTypeNames[{ctx.Id_simd, ctx.getIdentifier(#BASENAME "2")}] = {         \
-      simd2##BASENAME, simd2##BASENAME, simd2##BASENAME, false};               \
+  addMappedType(ctx.Id_simd, ctx.getIdentifier(#BASENAME "2"),                 \
+      {simd2##BASENAME, simd2##BASENAME, simd2##BASENAME, false});             \
   StringRef simd3##BASENAME = "swift_" #BASENAME "3";                          \
-  mappedTypeNames[{ctx.Id_simd, ctx.getIdentifier(#BASENAME "3")}] = {         \
-      simd3##BASENAME, simd3##BASENAME, simd3##BASENAME, false};               \
+  addMappedType(ctx.Id_simd, ctx.getIdentifier(#BASENAME "3"),                 \
+      {simd3##BASENAME, simd3##BASENAME, simd3##BASENAME, false});             \
   StringRef simd4##BASENAME = "swift_" #BASENAME "4";                          \
-  mappedTypeNames[{ctx.Id_simd, ctx.getIdentifier(#BASENAME "4")}] = {         \
-      simd4##BASENAME, simd4##BASENAME, simd4##BASENAME, false};
+  addMappedType(ctx.Id_simd, ctx.getIdentifier(#BASENAME "4"),                 \
+      {simd4##BASENAME, simd4##BASENAME, simd4##BASENAME, false});
 #include "swift/ClangImporter/SIMDMappedTypes.def"
   static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,
                 "must add or remove special name mappings if max number of "
@@ -119,9 +167,11 @@ PrimitiveTypeMapping::getMappedTypeInfoOrNull(const TypeDecl *typeDecl) {
   if (mappedTypeNames.empty())
     initialize(typeDecl->getASTContext());
 
-  Identifier moduleName = typeDecl->getModuleContext()->getName();
-  Identifier name = typeDecl->getName();
-  auto iter = mappedTypeNames.find({moduleName, name});
+  auto nominal = dyn_cast<TypeDecl>(typeDecl);
+  if (!nominal)
+    return nullptr;
+
+  auto iter = mappedTypeNames.find(nominal);
   if (iter == mappedTypeNames.end())
     return nullptr;
   return &iter->second;

--- a/lib/PrintAsClang/PrimitiveTypeMapping.h
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.h
@@ -13,7 +13,7 @@
 #ifndef SWIFT_PRINTASCLANG_PRIMITIVETYPEMAPPING_H
 #define SWIFT_PRINTASCLANG_PRIMITIVETYPEMAPPING_H
 
-#include "swift/AST/Identifier.h"
+#include "swift/AST/Decl.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 
@@ -62,14 +62,14 @@ private:
 
   FullClangTypeInfo *getMappedTypeInfoOrNull(const TypeDecl *typeDecl);
 
-  /// A map from {Module, TypeName} pairs to {C name, C nullability} pairs.
+  /// Associate Swift types to their {name, nullability} in foreign languages.
   ///
   /// This is populated on first use with a list of known Swift types that are
   /// translated directly by the ObjC printer instead of structurally, allowing
   /// it to do things like map 'Int' to 'NSInteger' and 'Float' to 'float'.
   /// In some sense it's the reverse of the ClangImporter's MappedTypes.def.
-  llvm::DenseMap<std::pair<Identifier, Identifier>, FullClangTypeInfo>
-      mappedTypeNames;
+  /// Must be kept aligned with BuiltinMappedTypes.def.
+  llvm::DenseMap<TypeDecl*, FullClangTypeInfo> mappedTypeNames;
 };
 
 } // end namespace swift

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -11,8 +11,12 @@
 
 @_cdecl("referencesScalar")
 func referencesScalar() -> Unicode.Scalar { fatalError() }
-// CHECK: SWIFT_EXTERN wchar_t referencesScalar(void)
+// CHECK: SWIFT_EXTERN char32_t referencesScalar(void)
 
 @_cdecl("referencesRelated")
 func x_referencesRelated(a: CChar32, b: CWideChar) { }
 // CHECK: SWIFT_EXTERN void referencesRelated(char32_t a, wchar_t b)
+
+@_cdecl("referencesFloat16")
+func y_referencesFloat16(a: Float16, b: CFloat16) { }
+// CHECK: SWIFT_EXTERN void referencesFloat16(_Float16 a, _Float16 b)

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -11,4 +11,8 @@
 
 @_cdecl("referencesScalar")
 func referencesScalar() -> Unicode.Scalar { fatalError() }
-// CHECK: SWIFT_EXTERN Scalar referencesScalar(void)
+// CHECK: SWIFT_EXTERN wchar_t referencesScalar(void)
+
+@_cdecl("referencesRelated")
+func x_referencesRelated(a: CChar32, b: CWideChar) { }
+// CHECK: SWIFT_EXTERN void referencesRelated(char32_t a, wchar_t b)

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -5,7 +5,7 @@
 // or actually be printed using a C / Objective-C compatible type.
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
-// RUN:   %s -emit-module -verify -o %t \
+// RUN:   %s -emit-module -verify -o %t -emit-module-doc \
 // RUN:   -emit-clang-header-path %t/compat.h
 // RUN: %FileCheck %s --input-file %t/compat.h
 
@@ -17,6 +17,15 @@ func referencesScalar() -> Unicode.Scalar { fatalError() }
 func x_referencesRelated(a: CChar32, b: CWideChar) { }
 // CHECK: SWIFT_EXTERN void referencesRelated(char32_t a, wchar_t b)
 
-@_cdecl("referencesFloat16")
-func y_referencesFloat16(a: Float16, b: CFloat16) { }
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+    // Actual test of Float16, on supported platforms.
+    @_cdecl("referencesFloat16")
+    func y_referencesFloat16(a: Float16, b: CFloat16) { }
+#else
+    // Just print the expected string on macOS&x86_64 where there's no Float16.
+    // This disables this one check on unsupported platforms.
+    /// SWIFT_EXTERN void referencesFloat16(_Float16 a, _Float16 b)
+    @_cdecl("printTheDoc")
+    public func y_printTheDoc() { }
+#endif
 // CHECK: SWIFT_EXTERN void referencesFloat16(_Float16 a, _Float16 b)


### PR DESCRIPTION
There was a hard to see misalignment between types accepted as representable in C languages defined in `BuiltinMappedTypes` and those with an associated C type name defined in `PrimitiveTypeMapping`. While `BuiltinMappedTypes` looked through typealiases, `PrimitiveTypeMapping` didn't and instead referred only to types by their identifier. So even when both files defined the same types by name, their underlying type were only partially handled. An affected type was `Unicode.Scalar` which is the underlying type of `CWideChar` and `CChar32`. `Unicode.Scalar` was accepted as a C representable type but was not printed using a corresponding C type name, breaking the generated compatibility header.

Another issue with the use of identifiers in the `PrimitiveTypeMapping` logic was a limited support for nested types. It would track `Unicode.Scalar` only as `Scalar` opening the door to matching a different nested type.

This change updates `PrimitiveTypeMapping` to keep track of TypeDecls instead of identifiers and look through typealiases at definition. This realigns the behavior with `BuiltinMappedTypes` and addresses the issue with `Unicode.Scalar`, allowing it to be printed using the type defined by an alias and avoid matching an unrelated Scalar. This still allows a type alias to be associated to a more specific C type than the underlying type's. It should also prevent future types behind typealiases to trigger this same kind of misalignment.

As an additional improvement, use `char32_t` for `Unicode.Scalar` and associated Swift's `Float16` to clang's `_Float16`. `Float16` was another type that was accepted but would break the compatibility header.

rdar://157332446