### PR TITLE
[Dependency Scanning] Revert Swift overlay lookup using "visible" Clang modules only

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -609,6 +609,25 @@ ModuleDependencyScanner::ModuleDependencyScanner(
         DependencyTracker, CAS, ActionCache, PrefixMapper.get(), Diagnostics));
 }
 
+/// Find all of the imported Clang modules starting with the given module name.
+static void findAllImportedClangModules(StringRef moduleName,
+                                        const ModuleDependenciesCache &cache,
+                                        std::vector<std::string> &allModules,
+                                        llvm::StringSet<> &knownModules) {
+  if (!knownModules.insert(moduleName).second)
+    return;
+  allModules.push_back(moduleName.str());
+  auto moduleID =
+      ModuleDependencyID{moduleName.str(), ModuleDependencyKind::Clang};
+  auto optionalDependencies = cache.findDependency(moduleID);
+  if (!optionalDependencies.has_value())
+    return;
+
+  for (const auto &dep : cache.getClangDependencies(moduleID))
+    findAllImportedClangModules(dep.ModuleName, cache, allModules,
+                                knownModules);
+}
+
 static std::set<ModuleDependencyID>
 collectBinarySwiftDeps(const ModuleDependenciesCache &cache) {
   std::set<ModuleDependencyID> binarySwiftModuleDepIDs;
@@ -1462,7 +1481,14 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
     ModuleDependencyIDSetVector &swiftOverlayDependencies) {
   PrettyStackTraceStringAction trace(
       "Resolving Swift Overlay dependencies of module", moduleID.ModuleName);
-  auto visibleClangDependencies = cache.getVisibleClangModules(moduleID);
+  std::vector<std::string> allClangDependencies;
+  llvm::StringSet<> knownModules;
+
+  // Find all of the discovered Clang modules that this module depends on.
+  for (const auto &dep : cache.getClangDependencies(moduleID))
+    findAllImportedClangModules(dep.ModuleName, cache, allClangDependencies,
+                                knownModules);
+
   llvm::StringMap<SwiftModuleScannerQueryResult> swiftOverlayLookupResult;
   std::mutex lookupResultLock;
 
@@ -1492,9 +1518,9 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
   };
 
   // Enque asynchronous lookup tasks
-  for (const auto &clangDep : visibleClangDependencies)
+  for (const auto &clangDep : allClangDependencies)
     ScanningThreadPool.async(scanForSwiftDependency,
-                             getModuleImportIdentifier(clangDep.getKey()));
+                             getModuleImportIdentifier(clangDep));
   ScanningThreadPool.wait();
 
   // Aggregate both previously-cached and freshly-scanned module results
@@ -1521,8 +1547,8 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
             lookupResult.incompatibleCandidates, cache, std::nullopt);
     }
   };
-  for (const auto &clangDep : visibleClangDependencies)
-    recordResult(clangDep.getKey().str());
+  for (const auto &clangDep : allClangDependencies)
+    recordResult(clangDep);
 
   // C++ Interop requires additional handling
   bool lookupCxxStdLibOverlay = ScanCompilerInvocation.getLangOptions().EnableCXXInterop;
@@ -1543,8 +1569,8 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
   }
 
   if (lookupCxxStdLibOverlay) {
-    for (const auto &clangDepNameEntry : visibleClangDependencies) {
-      auto clangDepName = clangDepNameEntry.getKey().str();
+    for (const auto &clangDepNameEntry : allClangDependencies) {
+      auto clangDepName = clangDepNameEntry;
       // If this Clang module is a part of the C++ stdlib, and we haven't
       // loaded the overlay for it so far, it is a split libc++ module (e.g.
       // std_vector). Load the CxxStdlib overlay explicitly.

--- a/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
+++ b/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar157603647
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/clang-module-cache)
 // RUN: %empty-directory(%t/swiftDeps)


### PR DESCRIPTION
We have identified scenarios where this is insufficient and compilation still relies on the presence of certain overlay modules this excludes. Reverting to prior lookup logic while we investigate.

This does not fully revert https://github.com/swiftlang/swift/pull/83050 which was inter-dependent with a Clang API change. Instead it only reverts the logic of `resolveSwiftOverlayDependenciesForModule` to its prior implementation. 

Resolves rdar://157519278