### PR TITLE
[AST] NFC: Rename function type isolation `NonisolatedCaller` to `Non…

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1293,7 +1293,7 @@ class TargetExtendedFunctionTypeFlags {
 
     // Values for the enumerated isolation kinds
     IsolatedAny            = 0x00000002U,
-    NonIsolatedCaller      = 0x00000004U,
+    NonIsolatedNonsending  = 0x00000004U,
 
     // Values if we have a sending result.
     HasSendingResult  = 0x00000010U,
@@ -1328,7 +1328,7 @@ public:
   const TargetExtendedFunctionTypeFlags<int_type>
   withNonIsolatedCaller() const {
     return TargetExtendedFunctionTypeFlags<int_type>((Data & ~IsolationMask) |
-                                                     NonIsolatedCaller);
+                                                     NonIsolatedNonsending);
   }
 
   const TargetExtendedFunctionTypeFlags<int_type>
@@ -1352,7 +1352,7 @@ public:
   }
 
   bool isNonIsolatedCaller() const {
-    return (Data & IsolationMask) == NonIsolatedCaller;
+    return (Data & IsolationMask) == NonIsolatedNonsending;
   }
 
   bool hasSendingResult() const {

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -67,17 +67,17 @@ public:
     /// Inherits isolation from the caller. This is only applicable
     /// to asynchronous function types.
     ///
-    /// NOTE: The difference in between NonIsolatedCaller and
-    /// NonIsolated is that NonIsolatedCaller is a strictly
+    /// NOTE: The difference in between NonIsolatedNonsending and
+    /// NonIsolated is that NonIsolatedNonsending is a strictly
     /// weaker form of nonisolation. While both in their bodies cannot
-    /// access isolated state directly, NonIsolatedCaller functions
+    /// access isolated state directly, NonIsolatedNonsending functions
     /// /are/ allowed to access state isolated to their caller via
     /// function arguments since we know that the callee will stay
     /// in the caller's isolation domain. In contrast, NonIsolated
     /// is strongly nonisolated and is not allowed to access /any/
     /// isolated state (even via function parameters) since it is
     /// considered safe to run on /any/ actor.
-    NonIsolatedCaller,
+    NonIsolatedNonsending,
   };
 
   static constexpr size_t NumBits = 3; // future-proof this slightly
@@ -103,7 +103,7 @@ public:
     return { Kind::Erased };
   }
   static FunctionTypeIsolation forNonIsolatedCaller() {
-    return { Kind::NonIsolatedCaller };
+    return { Kind::NonIsolatedNonsending };
   }
 
   Kind getKind() const { return value.getInt(); }
@@ -124,7 +124,7 @@ public:
     return getKind() == Kind::Erased;
   }
   bool isNonIsolatedCaller() const {
-    return getKind() == Kind::NonIsolatedCaller;
+    return getKind() == Kind::NonIsolatedNonsending;
   }
 
   /// Two function type isolations are equal if they have the same kind and

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -6510,7 +6510,7 @@ namespace {
         case FunctionTypeIsolation::Kind::Erased:
           printFlag("@isolated(any)");
           break;
-        case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+        case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
           printFlag("nonisolated(nonsending)");
           break;
         }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3389,7 +3389,7 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
       appendOperator("YA");
     break;
 
-  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+  case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
     appendOperator("YC");
     break;
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6499,7 +6499,7 @@ public:
       Printer << "@isolated(any) ";
       break;
 
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       Printer << "nonisolated(nonsending) ";
       break;
     }

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -571,7 +571,7 @@ SILGenFunction::emitFunctionTypeIsolation(SILLocation loc,
 
   // Emit nonisolated by simply emitting Optional.none in the result type.
   case FunctionTypeIsolation::Kind::NonIsolated:
-  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+  case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
     return emitNonIsolatedIsolation(loc);
 
   // Emit global actor isolation by loading .shared from the global actor,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5459,10 +5459,10 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
   // isolated parameter preventing us from having to memcpy over the array.
   if (outputSubstType->isAsync()) {
     if (outputSubstType->getIsolation().getKind() ==
-        FunctionTypeIsolation::Kind::NonIsolatedCaller)
+        FunctionTypeIsolation::Kind::NonIsolatedNonsending)
       options |= ThunkGenFlag::ThunkHasImplicitIsolatedParam;
     if (inputSubstType->getIsolation().getKind() ==
-        FunctionTypeIsolation::Kind::NonIsolatedCaller)
+        FunctionTypeIsolation::Kind::NonIsolatedNonsending)
       options |= ThunkGenFlag::CalleeHasImplicitIsolatedParam;
   }
 
@@ -5526,7 +5526,7 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
     // For a function for caller isolation, we'll have to figure out what the
     // output function's formal isolation is. This is quite doable, but we don't
     // have to do it yet.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       llvm_unreachable("synchronous function has caller isolation?");
 
     // For a function with parameter isolation, we'll have to dig the
@@ -5628,7 +5628,7 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
             outputIsolation.getGlobalActorType()->getCanonicalType();
         return SGF.emitGlobalActorIsolation(loc, globalActor).getValue();
       }
-      case FunctionTypeIsolation::Kind::NonIsolatedCaller: {
+      case FunctionTypeIsolation::Kind::NonIsolatedNonsending: {
         return implicitIsolationParam.getValue();
       }
       case FunctionTypeIsolation::Kind::Parameter:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1323,7 +1323,7 @@ namespace {
       case FunctionTypeIsolation::Kind::GlobalActor:
         return ActorIsolation::forGlobalActor(
             thunkTy->getIsolation().getGlobalActorType());
-      case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
         return ActorIsolation::forCallerIsolationInheriting();
       }
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2975,7 +2975,7 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
       return true;
 
     // A thunk is going to pass `nil` to the isolated parameter.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       return matchIfConversion();
 
     // Erasing global-actor isolation to non-isolation can admit data
@@ -2999,10 +2999,10 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
     llvm_unreachable("bad kind");
 
   // Converting to a caller isolated async function type.
-  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+  case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
     switch (isolation1.getKind()) {
     // Exact match.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       return true;
 
     // Global actor: Thunk will hop to the global actor
@@ -3049,7 +3049,7 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
 
     // A thunk is going to pass in an instance of a global actor
     // to the isolated parameter.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       return matchIfConversion();
 
     // Parameter isolation cannot be altered in the same way.
@@ -3079,7 +3079,7 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
       return matchIfConversion();
 
     // A thunk is going to forward the isolation.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       return matchIfConversion();
 
     // Don't allow dynamically-isolated function types to convert to
@@ -3104,7 +3104,7 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
 
     // It's not possible to form a thunk for this case because
     // we don't know what to pass to the isolated parameter.
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       return false;
 
     // Parameter isolation is value-dependent and can't be erased in the

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2763,7 +2763,7 @@ namespace {
 
           switch (toIsolation.getKind()) {
           // Converting to `nonisolated(nonsending)` function type
-          case FunctionTypeIsolation::Kind::NonIsolatedCaller: {
+          case FunctionTypeIsolation::Kind::NonIsolatedNonsending: {
             switch (fromIsolation.getKind()) {
             case FunctionTypeIsolation::Kind::NonIsolated: {
               // nonisolated -> nonisolated(nonsending) doesn't cross
@@ -2783,7 +2783,7 @@ namespace {
             case FunctionTypeIsolation::Kind::Parameter:
               llvm_unreachable("invalid conversion");
 
-            case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+            case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
               // Non isolated caller is always async. This can only occur if we
               // are converting from an `@Sendable` representation to something
               // else. So we need to just check that we diagnose non sendable
@@ -2800,7 +2800,7 @@ namespace {
           case FunctionTypeIsolation::Kind::NonIsolated: {
             switch (fromIsolation.getKind()) {
             case FunctionTypeIsolation::Kind::Parameter:
-            case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+            case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
             case FunctionTypeIsolation::Kind::Erased:
               diagnoseNonSendableParametersAndResult(
                   toFnType, version::Version::getFutureMajorLanguageVersion());
@@ -2851,7 +2851,7 @@ namespace {
             }
 
             // Runs on the actor.
-            case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+            case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
               break;
 
             case FunctionTypeIsolation::Kind::GlobalActor:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4242,7 +4242,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
           attr->getAttrName());
       break;
 
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
       llvm_unreachable(
           "cannot happen because multiple execution behavior attributes "
           "aren't allowed.");
@@ -5352,7 +5352,7 @@ TypeResolver::resolveCallerIsolatedTypeRepr(CallerIsolatedTypeRepr *repr,
                     repr);
     break;
 
-  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+  case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
     llvm_unreachable(
         "cannot happen because multiple nonisolated(nonsending) attributes "
         "aren't allowed.");

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7383,7 +7383,7 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
   auto isolation = swift::FunctionTypeIsolation::forNonIsolated();
   if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolated)) {
     // do nothing
-  } else if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolatedCaller)) {
+  } else if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolatedNonsending)) {
     isolation = swift::FunctionTypeIsolation::forNonIsolatedCaller();
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::Parameter)) {
     isolation = swift::FunctionTypeIsolation::forParameter();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -707,7 +707,7 @@ enum class FunctionTypeIsolation : uint8_t {
   NonIsolated,
   Parameter,
   Erased,
-  NonIsolatedCaller,
+  NonIsolatedNonsending,
   // NOTE: All of the new kinds should be added above.
   GlobalActorOffset, // Add this to the global actor type ID
 };

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5889,8 +5889,8 @@ public:
     switch (isolation.getKind()) {
     case swift::FunctionTypeIsolation::Kind::NonIsolated:
       return unsigned(FunctionTypeIsolation::NonIsolated);
-    case swift::FunctionTypeIsolation::Kind::NonIsolatedCaller:
-      return unsigned(FunctionTypeIsolation::NonIsolatedCaller);
+    case swift::FunctionTypeIsolation::Kind::NonIsolatedNonsending:
+      return unsigned(FunctionTypeIsolation::NonIsolatedNonsending);
     case swift::FunctionTypeIsolation::Kind::Parameter:
       return unsigned(FunctionTypeIsolation::Parameter);
     case swift::FunctionTypeIsolation::Kind::Erased:


### PR DESCRIPTION
…isolatedNonsending`

This reduces the number of ways we refer to caller isolated async functions and matches the name to the attribute spelling.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
