### PR TITLE
[DebugInfo] Fix infinite recursion when opaque return type is defined inside function returning it

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -979,7 +979,10 @@ private:
       if (Scope)
         return MainFile;
     }
-    return cast<llvm::DIFile>(Scope);
+    if (Scope)
+      return cast<llvm::DIFile>(Scope);
+
+    return MainFile;
   }
 
   static unsigned getStorageSizeInBits(const llvm::DataLayout &DL,
@@ -3222,6 +3225,11 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
     Name = LinkageName;
   }
 
+  llvm::DISubprogram *ReplaceableType = DBuilder.createTempFunctionFwdDecl(
+      Scope, Name, LinkageName, File, Line, /*Type=*/nullptr, ScopeLine);
+  auto FwdDecl = llvm::TempDISubprogram(ReplaceableType);
+  ScopeCache[DS] = llvm::TrackingMDNodeRef(FwdDecl.get());
+
   CanSILFunctionType FnTy = getFunctionType(SILTy);
   auto Params = Opts.DebugInfoLevel > IRGenDebugInfoLevel::LineTables
                     ? createParameterTypes(SILTy)
@@ -3321,6 +3329,7 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   if (!DS)
     return nullptr;
 
+  DBuilder.replaceTemporary(std::move(FwdDecl), SP);
   ScopeCache[DS] = llvm::TrackingMDNodeRef(SP);
   return SP;
 }

--- a/test/DebugInfo/nested_opaque.swift
+++ b/test/DebugInfo/nested_opaque.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+
+protocol TheProtocol {
+}
+
+// CHECK: ![[FUNC_ID:[0-9]+]] = distinct !DISubprogram(name: "theFunction", 
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "TheType", scope: ![[FUNC_ID]]
+func theFunction() -> some TheProtocol {
+    struct TheType: TheProtocol {
+    }
+    return TheType()
+}
+
+theFunction()


### PR DESCRIPTION
**Explanation**: Fixes an infinite recursion when generating debug info for functions where the return type is an opaque defined inside the function itself.

**Scope**: debug info generation of opaque types.

**Issues**: rdar://150313956

**Original PRs**: https://github.com/swiftlang/swift/pull/81794

**Risk**: Low.  The patch only affects debug info generation, and is a very straightforward, obvious change.

**Testing**: one new unit test added.

**Reviewers**: @adrian-prantl 
