### PR TITLE
[6.2] tests: increase the timeout for `large_nested_array.swift.gyb`

### DIFF
--- a/validation-test/SILOptimizer/large_nested_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_nested_array.swift.gyb
@@ -2,15 +2,15 @@
 // RUN: %gyb %s > %t/main.swift
 
 // The compiler should finish in less than 2 minutes. To give some slack,
-// specify a timeout of 12 minutes.
+// specify a timeout of 20 minutes.
 
 // TODO: 75% of compile time is spent in ARCSequenceOpts: rdar://144863155
 // The timeout should be decreased once we can get rid of ARCSequenceOpts
 
-// If the compiler needs more than 12 minutes, there is probably a real problem.
+// If the compiler needs more than 20 minutes, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 720 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
+// RUN: %{python} %S/../../test/Inputs/timeout.py 1200 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test


### PR DESCRIPTION
* **Explanation**: This fixes a timeout failure in CI. It looks like that some CI machines are slower than expected. I could not reproduce this locally. There doesn't seem to be a compile time regression.
* **Risk**: Zero. It's a test-only change
* **Testing**: Tested by lit tests.
* **Issue**: rdar://157535184
* **Reviewer**:  @ktoso
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/81067


