### PR TITLE
[SILGen] Fix the type of closure thunks that are passed const reference structs #3

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3368,8 +3368,8 @@ public:
 class FunctionConversionExpr : public ImplicitConversionExpr {
 public:
   FunctionConversionExpr(Expr *subExpr, Type type)
-    : ImplicitConversionExpr(ExprKind::FunctionConversion, subExpr, type) {}
-  
+      : ImplicitConversionExpr(ExprKind::FunctionConversion, subExpr, type) {}
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::FunctionConversion;
   }
@@ -4301,19 +4301,19 @@ private:
   }
 
 public:
-  ClosureExpr(const DeclAttributes &attributes,
-              SourceRange bracketRange, VarDecl *capturedSelfDecl,
-              ParameterList *params, SourceLoc asyncLoc, SourceLoc throwsLoc,
-              TypeExpr *thrownType, SourceLoc arrowLoc, SourceLoc inLoc,
-              TypeExpr *explicitResultType, DeclContext *parent)
-    : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
-                          parent),
-      Attributes(attributes), BracketRange(bracketRange),
-      CapturedSelfDecl(capturedSelfDecl),
-      AsyncLoc(asyncLoc), ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc),
-      InLoc(inLoc), ThrownType(thrownType),
-      ExplicitResultTypeAndBodyState(explicitResultType, BodyState::Parsed),
-      Body(nullptr) {
+  ClosureExpr(const DeclAttributes &attributes, SourceRange bracketRange,
+              VarDecl *capturedSelfDecl, ParameterList *params,
+              SourceLoc asyncLoc, SourceLoc throwsLoc, TypeExpr *thrownType,
+              SourceLoc arrowLoc, SourceLoc inLoc, TypeExpr *explicitResultType,
+              DeclContext *parent)
+      : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
+                            parent),
+        Attributes(attributes), BracketRange(bracketRange),
+        CapturedSelfDecl(capturedSelfDecl), AsyncLoc(asyncLoc),
+        ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc), InLoc(inLoc),
+        ThrownType(thrownType),
+        ExplicitResultTypeAndBodyState(explicitResultType, BodyState::Parsed),
+        Body(nullptr) {
     setParameterList(params);
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
     Bits.ClosureExpr.ImplicitSelfCapture = false;

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -261,11 +261,9 @@ struct SILDeclRef {
   ///   for the containing ClassDecl.
   /// - If 'loc' is a global VarDecl, this returns its GlobalAccessor
   ///   SILDeclRef.
-  explicit SILDeclRef(
-      Loc loc,
-      bool isForeign = false,
-      bool isDistributed = false,
-      bool isDistributedLocal = false);
+  explicit SILDeclRef(Loc loc, bool isForeign = false,
+                      bool isDistributed = false,
+                      bool isDistributedLocal = false);
 
   /// See above put produces a prespecialization according to the signature.
   explicit SILDeclRef(Loc loc, GenericSignature prespecializationSig);

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -87,7 +87,8 @@ class SILFunctionBuilder {
       llvm::function_ref<SILFunction *(SILLocation loc, SILDeclRef constant)>
           getOrCreateDeclaration = [](SILLocation loc, SILDeclRef constant)
           -> SILFunction * { return nullptr; },
-      ProfileCounter entryCount = ProfileCounter());
+      ProfileCounter entryCount = ProfileCounter(),
+      const clang::Type *foreignType = nullptr);
 
   /// Create a function declaration.
   ///

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -875,8 +875,9 @@ public:
 
   /// Returns the formal type, lowered AST type, and SILFunctionType
   /// for a constant reference.
-  const SILConstantInfo &getConstantInfo(TypeExpansionContext context,
-                                         SILDeclRef constant);
+  const SILConstantInfo &
+  getConstantInfo(TypeExpansionContext context, SILDeclRef constant,
+                  const clang::Type *foreignType = nullptr);
 
   /// Get the generic signature for a constant.
   GenericSignatureWithCapturedEnvironments
@@ -904,11 +905,12 @@ public:
   }
 
   /// Returns the SILFunctionType for the given declaration.
-  CanSILFunctionType getConstantFunctionType(TypeExpansionContext context,
-                                             SILDeclRef constant) {
-    return getConstantInfo(context, constant).SILFnType;
+  CanSILFunctionType
+  getConstantFunctionType(TypeExpansionContext context, SILDeclRef constant,
+                          const clang::Type *foreignType = nullptr) {
+    return getConstantInfo(context, constant, foreignType).SILFnType;
   }
-  
+
   /// Returns the SILParameterInfo for the given declaration's `self` parameter.
   /// `constant` must refer to a method.
   SILParameterInfo getConstantSelfParameter(TypeExpansionContext context,
@@ -977,8 +979,9 @@ public:
   };
 
   /// Derive the lowered formal type of the given constant.
-  LoweredFormalTypes getLoweredFormalTypes(SILDeclRef constant,
-                                           CanAnyFunctionType formalType);
+  LoweredFormalTypes
+  getLoweredFormalTypes(SILDeclRef constant, CanAnyFunctionType formalType,
+                        const clang::Type *foreignType = nullptr);
 
   /// Given a function type, yield its bridged formal type.
   CanAnyFunctionType getBridgedFunctionType(AbstractionPattern fnPattern,

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -290,10 +290,10 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     SILLocation loc, SILDeclRef constant, ForDefinition_t forDefinition,
     llvm::function_ref<SILFunction *(SILLocation loc, SILDeclRef constant)>
         getOrCreateDeclaration,
-    ProfileCounter entryCount) {
+    ProfileCounter entryCount, const clang::Type *foreignType) {
   auto nameTmp = constant.mangle();
   auto constantType = mod.Types.getConstantFunctionType(
-      TypeExpansionContext::minimal(), constant);
+      TypeExpansionContext::minimal(), constant, foreignType);
   SILLinkage linkage = constant.getLinkage(forDefinition);
 
   if (auto fn = mod.lookUpFunction(nameTmp)) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -799,7 +799,8 @@ static ActorIsolation getActorIsolationForFunction(SILFunction &fn) {
 }
 
 SILFunction *SILGenModule::getFunction(SILDeclRef constant,
-                                       ForDefinition_t forDefinition) {
+                                       ForDefinition_t forDefinition,
+                                       const clang::Type *foreignType) {
   // If we already emitted the function, return it.
   if (auto emitted = getEmittedFunction(constant, forDefinition))
     return emitted;
@@ -819,9 +820,11 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
   auto &IGM = *this;
   auto *F = builder.getOrCreateFunction(
       getBestLocation(constant), constant, forDefinition,
-      [&IGM](SILLocation loc, SILDeclRef constant) -> SILFunction * {
-        return IGM.getFunction(constant, NotForDefinition);
-      });
+      [&IGM, foreignType](SILLocation loc,
+                          SILDeclRef constant) -> SILFunction * {
+        return IGM.getFunction(constant, NotForDefinition, foreignType);
+      },
+      ProfileCounter(), foreignType);
 
   F->setDeclRef(constant);
   F->setActorIsolation(getActorIsolationForFunction(*F));

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -145,8 +145,8 @@ public:
                                   ForDefinition_t forDefinition);
 
   /// Get the function for a SILDeclRef, creating it if necessary.
-  SILFunction *getFunction(SILDeclRef constant,
-                           ForDefinition_t forDefinition);
+  SILFunction *getFunction(SILDeclRef constant, ForDefinition_t forDefinition,
+                           const clang::Type *foreignType = nullptr);
 
   /// Get the dynamic dispatch thunk for a SILDeclRef.
   SILFunction *getDynamicThunk(SILDeclRef constant,
@@ -348,7 +348,8 @@ public:
   void emitForeignToNativeThunk(SILDeclRef thunk);
 
   /// Emits a thunk from a Swift function to the native Swift convention.
-  void emitNativeToForeignThunk(SILDeclRef thunk);
+  void emitNativeToForeignThunk(SILDeclRef thunk,
+                                const clang::Type *foreignType = nullptr);
 
   /// Emits the distributed actor thunk for the decl if there is one associated
   /// with it.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4258,10 +4258,10 @@ private:
                                             loweredSubstArgType,
                                             param.getSILStorageInterfaceType());
         case SILFunctionLanguage::C:
-          return Conversion::getBridging(Conversion::BridgeToObjC,
-             arg.getSubstRValueType(),
-             origParamType.getType(),
-             param.getSILStorageInterfaceType());
+          return Conversion::getBridging(
+              Conversion::BridgeToObjC, arg.getSubstRValueType(),
+              origParamType.getType(), param.getSILStorageInterfaceType(),
+              origParamType);
         }
         llvm_unreachable("bad language");
       }();

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1348,10 +1348,9 @@ Conversion::adjustForInitialOptionalInjection() const {
   case BridgeFromObjC:
   case BridgeResultFromObjC:
     return OptionalInjectionConversion::forInjection(
-      getBridging(getKind(), getSourceType().getOptionalObjectType(),
-                  getResultType(), getLoweredResultType(),
-                  isBridgingExplicit())
-    );
+        getBridging(getKind(), getSourceType().getOptionalObjectType(),
+                    getResultType(), getLoweredResultType(),
+                    getBridgingOriginalInputType(), isBridgingExplicit()));
   }
   llvm_unreachable("bad kind");
 }
@@ -1373,9 +1372,9 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   case BridgeToObjC:
   case BridgeFromObjC:
   case BridgeResultFromObjC:
-    return Conversion::getBridging(getKind(), newSourceType,
-                                   getResultType(), getLoweredResultType(),
-                                   isBridgingExplicit());
+    return Conversion::getBridging(
+        getKind(), newSourceType, getResultType(), getLoweredResultType(),
+        getBridgingOriginalInputType(), isBridgingExplicit());
   }
   llvm_unreachable("bad kind");
 }
@@ -1394,9 +1393,9 @@ std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
 
   case BridgeToObjC: {
     auto sourceOptType = getSourceType().wrapInOptionalType();
-    return Conversion::getBridging(ForceAndBridgeToObjC,
-                                   sourceOptType, getResultType(),
-                                   getLoweredResultType(),
+    return Conversion::getBridging(ForceAndBridgeToObjC, sourceOptType,
+                                   getResultType(), getLoweredResultType(),
+                                   getBridgingOriginalInputType(),
                                    isBridgingExplicit());
   }
   }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -919,9 +919,10 @@ public:
     return getTypeLowering(t).getLoweredType().getCategoryType(t.getCategory());
   }
 
-  const SILConstantInfo &getConstantInfo(TypeExpansionContext context,
-                                         SILDeclRef constant) {
-    return SGM.Types.getConstantInfo(context, constant);
+  const SILConstantInfo &
+  getConstantInfo(TypeExpansionContext context, SILDeclRef constant,
+                  const clang::Type *foreignType = nullptr) {
+    return SGM.Types.getConstantInfo(context, constant, foreignType);
   }
 
   /// Return the normal local type-lowering information for the given
@@ -1952,7 +1953,8 @@ public:
   SILValue
   emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
                         SILConstantInfo constantInfo,
-                        bool callPreviousDynamicReplaceableImpl = false);
+                        bool callPreviousDynamicReplaceableImpl = false,
+                        const clang::Type *foreignType = nullptr);
 
   /// Returns a reference to a function value that dynamically dispatches
   /// the function in a runtime-modifiable way.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8508,9 +8508,6 @@ public:
 
 llvm::Expected<const clang::Type *>
 ModuleFile::getClangType(ClangTypeID TID) {
-  if (!getContext().LangOpts.UseClangFunctionTypes)
-    return nullptr;
-
   if (TID == 0)
     return nullptr;
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -116,6 +116,8 @@ class Serializer : public SerializerBase {
   /// an error in the AST.
   bool hadError = false;
 
+  bool hadImplementationOnlyImport = false;
+
   /// Helper for serializing entities in the AST block object graph.
   ///
   /// Keeps track of assigning IDs to newly-seen entities, and collecting

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -10,6 +10,10 @@ struct NonTrivial {
   int *p;
 };
 
+struct Trivial {
+  int i;
+};
+
 void cfunc(void (^ _Nonnull block)(NonTrivial)) noexcept {
   block(NonTrivial());
 }
@@ -74,5 +78,14 @@ inline void releaseSharedRef(SharedRef *_Nonnull x) {
     delete x;
   }
 }
+
+void cfuncConstRefNonTrivial(void (*_Nonnull)(const NonTrivial &));
+void cfuncConstRefTrivial(void (*_Nonnull)(const Trivial &));
+void blockConstRefNonTrivial(void (^_Nonnull)(const NonTrivial &));
+void blockConstRefTrivial(void (^_Nonnull)(const Trivial &));
+#if __OBJC__
+void cfuncConstRefStrong(void (*_Nonnull)(const ARCStrong &));
+void blockConstRefStrong(void (^_Nonnull)(const ARCStrong &));
+#endif
 
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -35,3 +35,101 @@ public func testClosureToFuncPtr() {
 public func testClosureToBlockReturnNonTrivial() {
   cfuncReturnNonTrivial({() -> NonTrivial in return NonTrivial() })
 }
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial
+// CHECK: %[[V3:.*]] = function_ref @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = apply %[[V3]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_addr %[[V1]] : $*NonTrivial
+// CHECK: dealloc_stack %[[V1]] : $*NonTrivial
+// CHECK: return %[[V4]] : $()
+
+public func testConstRefNonTrivial() {
+  cfuncConstRefNonTrivial({S in });
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial
+// CHECK: %[[V3:.*]] = function_ref @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = apply %[[V3]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_addr %[[V1]] : $*NonTrivial
+// CHECK: dealloc_stack %[[V1]] : $*NonTrivial
+// CHECK: return %[[V4]] : $()
+public func testConstRefNonTrivial2() {
+  cfuncConstRefNonTrivial(({S in }));
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main19testConstRefTrivialyyFySo0E0VcfU_To : $@convention(c) (@in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*Trivial):
+// CHECK: %[[V1:.*]] = load [trivial] %[[V0]] : $*Trivial
+// CHECK: %[[V2:.*]] = function_ref @$s4main19testConstRefTrivialyyFySo0E0VcfU_ : $@convention(thin) (Trivial) -> ()
+// CHECK: %[[V3:.*]] = apply %[[V2]](%[[V1]]) : $@convention(thin) (Trivial) -> ()
+// CHECK: return %[[V3]] : $()
+
+public func testConstRefTrivial() {
+  cfuncConstRefTrivial({S in });
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main18testConstRefStrongyyFySo9ARCStrongVcfU_To : $@convention(c) (@in_guaranteed ARCStrong) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*ARCStrong):
+// CHECK: %[[V1:.*]] = alloc_stack $ARCStrong
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*ARCStrong
+// CHECK: %[[V3:.*]] = load [copy] %[[V1]] : $*ARCStrong
+// CHECK: %[[V4:.*]] = begin_borrow %[[V3]] : $ARCStrong
+// CHECK: %[[V5:.*]] = function_ref @$s4main18testConstRefStrongyyFySo9ARCStrongVcfU_ : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V6:.*]] = apply %[[V5]](%[[V4]]) : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V4]] : $ARCStrong
+// CHECK: destroy_value %[[V3]] : $ARCStrong
+// CHECK: destroy_addr %[[V1]] : $*ARCStrong
+// CHECK: dealloc_stack %[[V1]] : $*ARCStrong
+// CHECK: return %[[V6]] : $()
+
+public func testConstRefStrong() {
+  cfuncConstRefStrong({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo10NonTrivialVIegn_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> (), @in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> (), %[[V1:.*]] : $*NonTrivial):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: apply %[[V4]](%[[V1]]) : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: end_borrow %[[V4]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+
+public func testBlockConstRefNonTrivial() {
+  blockConstRefNonTrivial({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo7TrivialVIegy_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (Trivial) -> (), @in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (Trivial) -> (), %[[V1:.*]] : $*Trivial):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (Trivial) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (Trivial) -> ()
+// CHECK: %[[V4:.*]] = load [trivial] %[[V1]] : $*Trivial
+// CHECK: %[[V5:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (Trivial) -> ()
+// CHECK: apply %[[V5]](%[[V4]]) : $@callee_guaranteed (Trivial) -> ()
+// CHECK: end_borrow %[[V5]] : $@callee_guaranteed (Trivial) -> ()
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (Trivial) -> ()
+
+public func testBlockConstRefTrivial() {
+  blockConstRefTrivial({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo9ARCStrongVIegg_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@guaranteed ARCStrong) -> (), @in_guaranteed ARCStrong) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (@guaranteed ARCStrong) -> (), %[[V1:.*]] : $*ARCStrong):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V4:.*]] = load_borrow %[[V1]] : $*ARCStrong
+// CHECK: %[[V5:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: apply %[[V5]](%[[V4]]) : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V5]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V4]] : $ARCStrong
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+
+public func testBlockConstRefStrong() {
+  blockConstRefStrong({S in });
+}

--- a/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
+++ b/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
@@ -1,0 +1,60 @@
+// Crash reproducer from https://github.com/swiftlang/swift/issues/77047#issuecomment-2440103712
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir %t/artifacts
+
+// RUN: %target-swift-frontend -c %t/ChibiStdlib.swift -parse-stdlib -emit-module -emit-module-path %t/sdk/usr/lib/swift/Swift.swiftmodule/%module-target-triple.swiftmodule -module-name Swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -o %t/artifacts
+// RUN: %target-swift-frontend -c %t/XMLParser.swift -parse-as-library -emit-module -emit-module-path %t/sdk/usr/lib/swift/MyFoundationXML.swiftmodule/%module-target-triple.swiftmodule -module-name MyFoundationXML -module-link-name MyFoundationXML -resource-dir %t/sdk -O -I %t/include -o %t/artifacts  -sdk %t/sdk
+// RUN: %target-swift-frontend -c %t/Check.swift -o %t/artifacts -index-store-path %t/index-store -index-system-modules -resource-dir %t/sdk -parse-stdlib -sdk %t/sdk
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir %t/artifacts
+
+// RUN: %target-swift-frontend -c %t/ChibiStdlib.swift -parse-stdlib -emit-module -emit-module-path %t/sdk/usr/lib/swift/Swift.swiftmodule/%module-target-triple.swiftmodule -module-name Swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -o %t/artifacts
+// RUN: %target-swift-frontend -c %t/XMLParser.swift -enable-library-evolution -parse-as-library -emit-module -emit-module-path %t/sdk/usr/lib/swift/MyFoundationXML.swiftmodule/%module-target-triple.swiftmodule -module-name MyFoundationXML -module-link-name MyFoundationXML -resource-dir %t/sdk -O -I %t/include -o %t/artifacts  -sdk %t/sdk
+// RUN: %target-swift-frontend -c %t/Check.swift -o %t/artifacts -index-store-path %t/index-store -index-system-modules -resource-dir %t/sdk -parse-stdlib -sdk %t/sdk
+
+
+//--- Check.swift
+import MyFoundationXML
+
+//--- XMLParser.swift
+@_implementationOnly import _MyCFXMLInterface
+
+func _NSXMLParserExternalEntityWithURL(originalLoaderFunction: _CFXMLInterfaceExternalEntityLoader) {}
+
+//--- include/module.modulemap
+module _MyCFXMLInterface {
+  header "MyCFXMLInterface.h"
+}
+
+//--- include/MyCFXMLInterface.h
+#if !defined(__COREFOUNDATION_CFXMLINTERFACE__)
+#define __COREFOUNDATION_CFXMLINTERFACE__ 1
+
+typedef struct _xmlParserCtxt *_CFXMLInterfaceParserContext;
+typedef void (*_CFXMLInterfaceExternalEntityLoader)(_CFXMLInterfaceParserContext);
+
+#endif
+
+//--- ChibiStdlib.swift
+precedencegroup AssignmentPrecedence {
+  assignment: true
+  associativity: right
+}
+
+public typealias Void = ()
+
+@frozen
+public struct OpaquePointer {
+  @usableFromInline
+  internal var _rawValue: Builtin.RawPointer
+
+  @usableFromInline @_transparent
+  internal init(_ v: Builtin.RawPointer) {
+    self._rawValue = v
+  }
+}

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -69,12 +69,11 @@ StdFunctionTestSuite.test("FunctionStringToString init from closure and pass as 
   expectEqual(std.string("prefixabcabc"), res)
 }
 
-// FIXME: assertion for address-only closure params (rdar://124501345)
-//StdFunctionTestSuite.test("FunctionStringToStringConstRef init from closure and pass as parameter") {
-//  let res = invokeFunctionTwiceConstRef(.init({ $0 + std.string("abc") }),
-//                                        std.string("prefix"))
-//  expectEqual(std.string("prefixabcabc"), res)
-//}
+StdFunctionTestSuite.test("FunctionStringToStringConstRef init from closure and pass as parameter") {
+  let res = invokeFunctionTwiceConstRef(.init({ $0 + std.string("abc") }),
+                                        std.string("prefix"))
+  expectEqual(std.string("prefixabcabc"), res)
+}
 #endif
 
 runAllTests()

--- a/test/Serialization/Inputs/convention_c_function.swift
+++ b/test/Serialization/Inputs/convention_c_function.swift
@@ -1,0 +1,3 @@
+public func foo(fn: @convention(c) () -> ()) -> () {
+  fn()
+}

--- a/test/Serialization/clang-function-types-convention-c.swift
+++ b/test/Serialization/clang-function-types-convention-c.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/convention_c_function.swift
+// RUN: llvm-bcanalyzer %t/convention_c_function.swiftmodule | %FileCheck -check-prefix=CHECK-BCANALYZER %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %t %s | %FileCheck %s
+
+import convention_c_function
+
+// CHECK-BCANALYZER-LABEL: (INDEX_BLOCK):
+// CHECK-BCANALYZER: CLANG_TYPE_OFFSETS
+
+// Test that the assertion in SILDeclRef doesn't fail.
+
+// CHECK-LABEL: sil [ossa] @$s4main3baryyF : $@convention(thin) () -> () {
+// CHECK: %[[V0:.*]] = function_ref @$s4main3baryyFyycfU_To : $@convention(c) () -> ()
+// CHECK: %[[V1:.*]] = function_ref @$s21convention_c_function3foo2fnyyyXC_tF : $@convention(thin) (@convention(c) () -> ()) -> ()
+// CHECK: apply %[[V1]](%[[V0]]) : $@convention(thin) (@convention(c) () -> ()) -> ()
+
+public func bar() {
+  foo(fn : {})
+}
+


### PR DESCRIPTION
This PR is another attempt at landing #76903. The changes compared to the original PR:
* Instead of increasing the size of SILDeclRef, store the necessary type information in the conversion AST nodes.
* The PR above introduced a crash during indexing system modules that references foreign types coming from modules imported as implementation only. These entities are implementation details so they do not need to be included during serialization. This PR adds a test and adds logic to exclude such clang types in the serialization process.

rdar://131321096&141786724
