### PR TITLE
SwiftOnoneSupport, Concurrency: embed plist/manifest

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -156,3 +156,7 @@ install(TARGETS swift_Concurrency
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 emit_swift_interface(swift_Concurrency)
 install_swift_interface(swift_Concurrency)
+
+# Configure plist creation for Darwin platforms.
+generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swift_Concurrency)
+embed_manifest(swift_Concurrency)

--- a/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
+++ b/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
@@ -42,3 +42,4 @@ install_swift_interface(swiftSwiftOnoneSupport)
 
 # Configure plist creation for Darwin platforms.
 generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftSwiftOnoneSupport)
+embed_manifest(swiftSwiftOnoneSupport)


### PR DESCRIPTION
Ensure that we install the runtime manifest into the Concurrency runtime. This is required for the Win32 SxS mechanism to function.