### PR TITLE
[TypeCHecker] Tests/NFC: Restrict SIMD performance test to macOS only

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/simd_scalar_multiple.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/simd_scalar_multiple.swift.gyb
@@ -2,8 +2,9 @@
 
 // REQUIRES: asserts,no_asan
 
-// Flaky is some simulator configurations
+// Flaky is some configurations including simulators
 // REQUIRES: OS=macosx
+// REQUIRES: CPU=arm64 || CPU=arm64e
 
 func f(c: Float, a: SIMD2<Float>) -> SIMD2<Float> {
   return (c * a)


### PR DESCRIPTION
The test is flaky in some simulator and x86_64 configurations, let's try to restrict it even further to minimize CI impact.

Resolves: rdar://157636003

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
