### PR TITLE
Re-apply "[Build] Temporarily add -j 1 to swift-corelibs-foundation Windows build"

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2841,7 +2841,8 @@ function Test-Foundation {
       -Src $SourceCache\swift-corelibs-foundation `
       -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
       -Platform $BuildPlatform `
-      -Configuration $FoundationTestConfiguration
+      -Configuration $FoundationTestConfiguration `
+      -j 1
   }
 }
 


### PR DESCRIPTION
Reverts swiftlang/swift#83010. This is unfortunately still happening, despite every PR test I ran being green :(. From a brief look it's about a 1 in 5 failure rate.