### PR TITLE
utils/build-script: add`--test-with-wasm-runtime` option

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,6 +178,8 @@ set(SWIFT_LIT_ENVIRONMENT "" CACHE STRING "Environment to use for lit invocation
 
 option(SWIFT_TEST_USE_LEAKS "Run Swift stdlib tests under leaks" FALSE)
 
+option(SWIFT_TEST_WASM_RUNTIME "Wasm runtime used for running Wasm tests" "wasmkit")
+
 function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_override)
   set(swift_lit_args_result)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2093,7 +2093,8 @@ elif kIsWASI:
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = os.path.join(config.swift_utils, 'wasm-run.py')
+    config.target_run = f"{os.path.join(config.swift_utils, 'wasm-run.py')} " \
+      f"-r {config.wasm_runtime}"
     config.target_env_prefix = 'WASM_RUN_CHILD_'
 
     if 'interpret' in lit_config.params:

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -55,9 +55,16 @@ config.exe_linker_flags = r'''@CMAKE_EXE_LINKER_FLAGS@'''
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
 
-# --- android ---
+config.darwin_enable_maccatalyst = "@SWIFT_ENABLE_MACCATALYST@" == "TRUE"
+config.darwin_maccatalyst_build_flavor = "@BUILD_FLAVOR@"
+config.darwin_osx_variant_suffix = "@DEFAULT_OSX_VARIANT_SUFFIX@"
+
+# --- Android ---
 config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_api_level = "@SWIFT_ANDROID_API_LEVEL@"
+
+# --- Wasm ---
+config.wasm_runtime = "@SWIFT_TEST_WASM_RUNTIME@"
 
 # --- Windows ---
 msvc_runtime_flags = {
@@ -68,10 +75,6 @@ msvc_runtime_flags = {
 }
 config.swift_stdlib_msvc_runtime = \
     msvc_runtime_flags["@SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY@"]
-
-config.darwin_enable_maccatalyst = "@SWIFT_ENABLE_MACCATALYST@" == "TRUE"
-config.darwin_maccatalyst_build_flavor = "@BUILD_FLAVOR@"
-config.darwin_osx_variant_suffix = "@DEFAULT_OSX_VARIANT_SUFFIX@"
 
 # If we are not testing against the host compiler, we are testing against the
 # just built compiler. Add that as a feature so we can conditionally mark tests

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1183,6 +1183,11 @@ def create_argument_parser():
                 'Then re-builds the TSan runtime (compiler-rt) using this '
                 'freshly-built Clang and runs the TSan libdispatch tests.')
 
+    option('--test-with-wasm-runtime', store, metavar='WASM_RUNTIME',
+           choices=['wasmkit', 'nodejs'], default='wasmkit',
+           help='Wasm runtime to use when running tests. Available choices: '
+           '`wasmkit` or `nodejs`')
+
     option('--skip-test-osx', toggle_false('test_osx'),
            help='skip testing Swift stdlibs for Mac OS X')
     option('--skip-test-linux', toggle_false('test_linux'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -339,6 +339,7 @@ EXPECTED_DEFAULTS = {
     'test_swiftdocc': False,
     'test_toolchainbenchmarks': False,
     'test_wasmstdlib': False,
+    'test_with_wasm_runtime': 'wasmkit',
     'tvos': False,
     'tvos_all': False,
     'validation_test': None,
@@ -806,6 +807,7 @@ EXPECTED_OPTIONS = [
                   choices=['armv7', 'aarch64', 'x86_64']),
     ChoicesOption('--foundation-tests-build-type',
                   dest='foundation_tests_build_variant', choices=['Debug', 'Release']),
+    ChoicesOption('--test-with-wasm-runtime', choices=['wasmkit', 'nodejs']),
 
     StrOption('--android-api-level'),
     StrOption('--build-args'),

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -68,7 +68,7 @@ class WasmKit(product.Product):
         shutil.copy(bin_path, dest_bin_path)
 
     @classmethod
-    def cli_file_path(cls, build_dir):
+    def cli_file_path(cls, build_dir) -> str:
         return os.path.join(build_dir, 'bin', 'wasmkit')
 
 

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -220,10 +220,11 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
 
     def _wasm_runtime_lookup_failed(self) -> NoReturn:
-            print("wasmstdlib testing: Wasm runtime not found")
-            sys.exit(1)
+        print("wasmstdlib testing: Wasm runtime not found")
+        sys.exit(1)
 
     def infer_wasm_runtime(self, host_target) -> str:
+        '''Return absolute path to the Wasm runtime used'''
         build_root = os.path.dirname(self.build_dir)
         if self.args.test_with_wasm_runtime == 'wasmkit':
             wasmkit_build_path = os.path.join(
@@ -250,7 +251,6 @@ class WasmStdlib(cmake_product.CMakeProduct):
         ]
 
         wasm_runtime_bin_path = self.infer_wasm_runtime(host_target)
-        print(f"wasm_runtime_bin_path is {wasm_runtime_bin_path}")
         if not os.path.exists(wasm_runtime_bin_path) or not self.should_test_executable():
             test_target = "check-swift-only_non_executable-wasi-wasm32-custom"
         else:

--- a/utils/wasm-run.py
+++ b/utils/wasm-run.py
@@ -24,12 +24,16 @@ class WASIRunner(object):
             subprocess.check_call(command)
 
     def invocation(self, args):
-        command = ["wasmkit", "run"]
-        envs = collect_wasm_env()
-        for key in envs:
-            command.append("--env")
-            command.append(f"{key}={envs[key]}")
-        command.append("--")
+        if args.runtime == 'nodejs':
+            command = [os.path.join(os.path.dirname(__file__), 'wasm', 'node-wasi-runner')]
+        else:
+            command = ["wasmkit", "run"]
+            envs = collect_wasm_env()
+            for key in envs:
+                command.append("--env")
+                command.append(f"{key}={envs[key]}")
+            command.append("--")
+
         command.extend(args.command)
         return command
 
@@ -42,6 +46,11 @@ def main():
     parser.add_argument('-n', '--dry-run', action='store_true', dest='dry_run',
                         help="print the commands that would have been run, but"
                              " don't actually run them")
+    parser.add_argument('-r', '--runtime', metavar='WASM_RUNTIME',
+           choices=['wasmkit', 'nodejs'], default='wasmkit',
+           help='Wasm runtime to use when running tests. Available choices: '
+           '`wasmkit` or `nodejs`')
+
     parser.add_argument('command', nargs=argparse.REMAINDER,
                         help='the command to run', metavar='command...')
 


### PR DESCRIPTION
With this change, passing `--test-with-wasm-runtime=nodejs`/`--test-with-wasm-runtime=wasmkit` to `build-script` allows switching between WasmKit and Node.js for running Wasm tests locally. Existing presets keep using WasmKit, so CI behavior is not impacted. Potentially, availability of a JS runtime allows writing tests that exercise JS interop for custom concurrency executors.

Differences between the runtimes:

* with WasmKit on M4 `check-swift-wasi-wasm32-custom` target completes in 115 seconds with `stdlib/PrintFloat16.swift` the slowest test (115 seconds):
  ```
  Slowest Tests:
  --------------------------------------------------------------------------
  114.80s: Swift(wasi-wasm32) :: stdlib/PrintFloat16.swift
  [...]

  Testing Time: 114.95s

  Total Discovered Tests: 1642
    Excluded         :   2 (0.12%)
    Unsupported      : 953 (58.04%)
    Passed           : 683 (41.60%)
    Expectedly Failed:   4 (0.24%)
  ```

* with Node.js on M4 there's ~5x speedup in `check-swift-wasi-wasm32-custom` target at a cost of one failing test (reason TBC):
  ```
  Slowest Tests:
  --------------------------------------------------------------------------
  11.57s: Swift(wasi-wasm32) :: stdlib/PrintFloat16.swift
  [...]

  Failed Tests (1):
    Swift(wasi-wasm32) :: stdlib/StringIndex_bincompat.swift

  Testing Time: 26.13s

  Total Discovered Tests: 1642
    Unsupported      : 953 (58.04%)
    Passed           : 684 (41.66%)
    Expectedly Failed:   4 (0.24%)
    Failed           :   1 (0.06%)
  ```