### PR TITLE
Demangling: correct build for the runtime

### DIFF
--- a/Runtimes/Core/Demangling/CMakeLists.txt
+++ b/Runtimes/Core/Demangling/CMakeLists.txt
@@ -21,7 +21,8 @@ target_compile_definitions(swiftDemangling PRIVATE
 # compiler, in order to avoid possible ODR violations if both are statically
 # linked into the same binary. (see also commit message for 5b1daa9055c99904c84862ecc313641fd9b26e63)
 target_compile_definitions(swiftDemangling PUBLIC
-    $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_INLINE_NAMESPACE=__runtime>)
+  -DSWIFT_RUNTIME
+  $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_INLINE_NAMESPACE=__runtime>)
 
 target_include_directories(swiftDemangling
   PRIVATE


### PR DESCRIPTION
Fix up some whitespace in the CMakeLists.txt to match the rest of the build system. Most importantly, define `SWIFT_RUNTIME` to avoid ODR violations in the runtime build.