### PR TITLE
Tests: Use variant module triple

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -382,6 +382,7 @@ foreach(SDK ${SWIFT_SDKS})
       get_swift_test_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}" "${BUILD_FLAVOR}")
       get_swift_test_variant_suffix(DEFAULT_OSX_VARIANT_SUFFIX "${SDK}" "${ARCH}" "default")
       get_swift_test_versioned_target_triple(VARIANT_TRIPLE "${SDK}" "${ARCH}" "${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}" "${BUILD_FLAVOR}")
+      set(VARIANT_MODULE_TRIPLE "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_MODULE}")
 
       # A directory where to put the xUnit-style XML test results.
       set(SWIFT_TEST_RESULTS_DIR

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1274,7 +1274,7 @@ def use_interpreter_for_simple_runs():
     config.target_run_simple_swiftgyb_parameterized = make_simple_target_run(gyb=True, parameterized=True)
     config.available_features.add('interpret')
 
-target_specific_module_triple = config.variant_triple
+target_specific_module_triple = config.variant_module_triple
 target_future = target_specific_module_triple
 
 config.target_run = ''
@@ -1291,10 +1291,6 @@ config.target_clang_resource_dir_opt = ''
 config.target_swift_default_executor_opt = '-lswift_ConcurrencyDefaultExecutor'
 
 if run_vendor == 'apple':
-    target_specific_module_triple = '{}-apple-{}'.format(
-        { 'aarch64': 'arm64', 'amd64': 'x86_64' }.get(run_cpu, run_cpu),
-        { 'macosx': 'macos', 'darwin': 'macos' }.get(run_os, run_os)
-    )
 
     config.target_object_format = "macho"
     config.target_shared_library_prefix = 'lib'
@@ -1492,8 +1488,6 @@ if run_vendor == 'apple':
             lit_config.note("Testing AppleTV simulator " + config.variant_triple)
             xcrun_sdk_name = "appletvsimulator"
             target_future_version = "99.99.0"
-
-        target_specific_module_triple += "-simulator"
 
         config.target_env_prefix = 'SIMCTL_CHILD_'
 
@@ -3242,6 +3236,8 @@ config.substitutions.append( ('%IRGenFileCheck', IRGenFileCheck) )
 visual_studio_version = os.environ.get('VisualStudioVersion')
 if kIsWindows and visual_studio_version:
   config.available_features.add('MSVC_VER=%s' % visual_studio_version)
+
+lit_config.note(f"Target Triple: {config.target_triple}, Variant Triple: {config.variant_triple}, Module Triple: {config.variant_module_triple}")
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))
 config.substitutions.append( ('%use_no_opaque_pointers', '-Xcc -Xclang -Xcc -no-opaque-pointers' ) )

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -28,6 +28,7 @@ config.swift_src_root = lit_config.params.get("swift_src_root", "@SWIFT_SOURCE_D
 config.swift_obj_root = "@SWIFT_BINARY_DIR@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.variant_triple = "@VARIANT_TRIPLE@"
+config.variant_module_triple = "@VARIANT_MODULE_TRIPLE@"
 config.variant_sdk = "@VARIANT_SDK@"
 config.variant_suffix = "@VARIANT_SUFFIX@"
 config.external_embedded_platform = "@VARIANT_EXTERNAL_EMBEDDED_PLATFORM@" == "TRUE"

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -25,6 +25,7 @@ config.swift_src_root = "@SWIFT_SOURCE_DIR@"
 config.swift_obj_root = "@SWIFT_BINARY_DIR@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.variant_triple = "@VARIANT_TRIPLE@"
+config.variant_module_triple = "@VARIANT_MODULE_TRIPLE@"
 config.variant_suffix = "@VARIANT_SUFFIX@"
 config.variant_sdk = "@VARIANT_SDK@"
 config.swift_test_results_dir = \


### PR DESCRIPTION
This switches from using lit.cfg to attempt to recompute the module triple to using the triple computed in CMake to ensure consistency. This is a better source of truth than having many sources everywhere.

In case anyone sees this and is wondering, the "target triple" refers to the triple that the compiler is built for, while the "variant triple" refers to the platform that the tests and runtimes are built for.