### PR TITLE
AST: Refactor `ConditionallyAvailableSubstitutions` to use `AvailabilityQuery`

### DIFF
--- a/include/swift/AST/AvailabilityQuery.h
+++ b/include/swift/AST/AvailabilityQuery.h
@@ -62,6 +62,15 @@ public:
         isUnavailable, std::nullopt, std::nullopt);
   }
 
+  /// Returns an `AvailabilityQuery` for a query that evaluates to true or
+  /// false at compile-time in the universal availability domain.
+  static AvailabilityQuery universallyConstant(bool isUnavailable, bool value) {
+    return AvailabilityQuery(AvailabilityDomain::forUniversal(),
+                             value ? ResultKind::ConstTrue
+                                   : ResultKind::ConstFalse,
+                             isUnavailable, std::nullopt, std::nullopt);
+  }
+
   /// Returns an `AvailabilityQuery` for a query that must be evaluated at
   /// runtime with the given arguments, which may be zero, one, or two version
   /// tuples that should be passed to the query function.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilityQuery.h"
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ClangNode.h"
@@ -3697,40 +3698,37 @@ public:
     return false;
   }
 
-  using AvailabilityCondition = std::pair<VersionRange, bool>;
-
   class ConditionallyAvailableSubstitutions final
-      : private llvm::TrailingObjects<
-            ConditionallyAvailableSubstitutions,
-            AvailabilityCondition> {
+      : private llvm::TrailingObjects<ConditionallyAvailableSubstitutions,
+                                      AvailabilityQuery> {
     friend TrailingObjects;
 
-    unsigned NumAvailabilityConditions;
+    unsigned NumAvailabilityQueries;
 
     SubstitutionMap Substitutions;
 
     /// A type with limited availability described by the provided set
     /// of availability conditions (with `and` relationship).
     ConditionallyAvailableSubstitutions(
-        ArrayRef<AvailabilityCondition> availabilityContext,
+        ArrayRef<AvailabilityQuery> availabilityQueries,
         SubstitutionMap substitutions)
-        : NumAvailabilityConditions(availabilityContext.size()),
+        : NumAvailabilityQueries(availabilityQueries.size()),
           Substitutions(substitutions) {
-      assert(!availabilityContext.empty());
-      std::uninitialized_copy(availabilityContext.begin(),
-                              availabilityContext.end(),
-                              getTrailingObjects<AvailabilityCondition>());
+      assert(!availabilityQueries.empty());
+      std::uninitialized_copy(availabilityQueries.begin(),
+                              availabilityQueries.end(),
+                              getTrailingObjects<AvailabilityQuery>());
     }
 
   public:
-    ArrayRef<AvailabilityCondition> getAvailability() const {
-      return {getTrailingObjects<AvailabilityCondition>(), NumAvailabilityConditions};
+    ArrayRef<AvailabilityQuery> getAvailabilityQueries() const {
+      return {getTrailingObjects<AvailabilityQuery>(), NumAvailabilityQueries};
     }
 
     SubstitutionMap getSubstitutions() const { return Substitutions; }
 
     static ConditionallyAvailableSubstitutions *
-    get(ASTContext &ctx, ArrayRef<AvailabilityCondition> availabilityContext,
+    get(ASTContext &ctx, ArrayRef<AvailabilityQuery> availabilityContext,
         SubstitutionMap substitutions);
   };
 };

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10881,14 +10881,12 @@ void OpaqueTypeDecl::setConditionallyAvailableSubstitutions(
 
 OpaqueTypeDecl::ConditionallyAvailableSubstitutions *
 OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-    ASTContext &ctx,
-    ArrayRef<AvailabilityCondition> availabilityContext,
+    ASTContext &ctx, ArrayRef<AvailabilityQuery> availabilityQueries,
     SubstitutionMap substitutions) {
-  auto size =
-      totalSizeToAlloc<AvailabilityCondition>(availabilityContext.size());
+  auto size = totalSizeToAlloc<AvailabilityQuery>(availabilityQueries.size());
   auto mem = ctx.Allocate(size, alignof(ConditionallyAvailableSubstitutions));
   return new (mem)
-      ConditionallyAvailableSubstitutions(availabilityContext, substitutions);
+      ConditionallyAvailableSubstitutions(availabilityQueries, substitutions);
 }
 
 bool AbstractFunctionDecl::hasInlinableBodyText() const {

--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -131,14 +131,13 @@ getAvailabilityQueryForBackDeployment(AbstractFunctionDecl *AFD) {
       variantRange = variantAttrAndRange->second;
 
     return AvailabilityQuery::dynamic(attr->getAvailabilityDomain(),
-                                      /*isUnavailable=*/false, primaryRange,
-                                      variantRange);
+                                      primaryRange, variantRange);
   }
 
   if (auto primaryAttrAndRange = AFD->getBackDeployedAttrAndRange(ctx))
     return AvailabilityQuery::dynamic(
         primaryAttrAndRange->first->getAvailabilityDomain(),
-        /*isUnavailable=*/false, primaryAttrAndRange->second, std::nullopt);
+        primaryAttrAndRange->second, std::nullopt);
 
   return std::nullopt;
 }

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -218,8 +218,7 @@ struct RuntimeVersionCheck {
     // This won't be filled in by TypeCheckAvailability because we have
     // invalid SourceLocs in this area of the AST.
     availableInfo->setAvailabilityQuery(AvailabilityQuery::dynamic(
-        domain, /*isUnavailable=*/false, AvailabilityRange(getVersionRange()),
-        std::nullopt));
+        domain, AvailabilityRange(getVersionRange()), std::nullopt));
 
     // earlyReturnBody = "{ return nil }"
     auto earlyReturn = new (C) FailStmt(SourceLoc(), SourceLoc());

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3721,8 +3721,6 @@ public:
   // There is no clear winner here since there are candidates within
   // limited availability contexts.
   void finalizeOpaque(const Candidate &universallyAvailable) {
-    using AvailabilityCondition = OpaqueTypeDecl::AvailabilityCondition;
-
     SmallVector<OpaqueTypeDecl::ConditionallyAvailableSubstitutions *, 4>
         conditionalSubstitutions;
     SubstitutionMap universalSubstMap = std::get<1>(universallyAvailable);
@@ -3735,7 +3733,7 @@ public:
         continue;
 
       unsigned neverAvailableCount = 0, alwaysAvailableCount = 0;
-      SmallVector<AvailabilityCondition, 4> conditions;
+      SmallVector<AvailabilityQuery, 4> queries;
 
       for (const auto &elt : stmt->getCond()) {
         auto availabilityQuery = elt.getAvailability()->getAvailabilityQuery();
@@ -3762,11 +3760,7 @@ public:
         auto domain = availabilityQuery->getDomain();
         ASSERT(domain.isPlatform());
 
-        auto availabilityRange = availabilityQuery->getPrimaryRange();
-        ASSERT(availabilityRange);
-
-        conditions.push_back({availabilityRange->getRawVersionRange(),
-                              availabilityQuery->isUnavailability()});
+        queries.push_back(*availabilityQuery);
       }
 
       // If there were any conditions that were always false, then this
@@ -3782,18 +3776,20 @@ public:
         break;
       }
 
-      ASSERT(conditions.size() > 0);
+      ASSERT(queries.size() > 0);
 
       conditionalSubstitutions.push_back(
           OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-              Ctx, conditions,
+              Ctx, queries,
               std::get<1>(candidate).mapReplacementTypesOutOfContext()));
     }
 
     // Add universally available choice as the last one.
     conditionalSubstitutions.push_back(
         OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-            Ctx, {{VersionRange::all(), /*unavailable=*/false}},
+            Ctx,
+            {AvailabilityQuery::universallyConstant(/*isUnavailable=*/false,
+                                                    /*value=*/true)},
             universalSubstMap.mapReplacementTypesOutOfContext()));
 
     OpaqueDecl->setConditionallyAvailableSubstitutions(

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3787,9 +3787,7 @@ public:
     // Add universally available choice as the last one.
     conditionalSubstitutions.push_back(
         OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-            Ctx,
-            {AvailabilityQuery::universallyConstant(/*isUnavailable=*/false,
-                                                    /*value=*/true)},
+            Ctx, {AvailabilityQuery::universallyConstant(true)},
             universalSubstMap.mapReplacementTypesOutOfContext()));
 
     OpaqueDecl->setConditionallyAvailableSubstitutions(

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4592,7 +4592,8 @@ public:
       DECODE_VER_TUPLE(version);
 
       queries.push_back(AvailabilityQuery::dynamic(
-          domain, isUnavailability, AvailabilityRange(version), std::nullopt));
+                            domain, AvailabilityRange(version), std::nullopt)
+                            .asUnavailable(isUnavailability));
     }
   }
 
@@ -4731,7 +4732,7 @@ public:
               OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
                   ctx,
                   {AvailabilityQuery::universallyConstant(
-                      /*isUnavailable=*/false, /*value=*/true)},
+                      /*value=*/true)},
                   subMapOrError.get()));
 
           opaqueDecl->setConditionallyAvailableSubstitutions(limitedAvailability);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4905,12 +4905,18 @@ public:
 
         unsigned condAbbrCode =
             S.DeclTypeAbbrCodes[ConditionalSubstitutionConditionLayout::Code];
-        for (const auto &condition : subs->getAvailability()) {
-          ENCODE_VER_TUPLE(osVersion, std::optional<llvm::VersionTuple>(
-                                          condition.first.getLowerEndpoint()));
+        for (const auto &query : subs->getAvailabilityQueries()) {
+          // FIXME: [availability] Support arbitrary domains (rdar://156513787).
+          DEBUG_ASSERT(query.getDomain().isPlatform());
+
+          auto availableRange = query.getPrimaryRange().value_or(
+              AvailabilityRange::alwaysAvailable());
+
+          ENCODE_VER_TUPLE(osVersion,
+                           std::optional<llvm::VersionTuple>(
+                               availableRange.getRawMinimumVersion()));
           ConditionalSubstitutionConditionLayout::emitRecord(
-              S.Out, S.ScratchRecord, condAbbrCode,
-              /*isUnavailable=*/condition.second,
+              S.Out, S.ScratchRecord, condAbbrCode, query.isUnavailability(),
               LIST_VER_TUPLE_PIECES(osVersion));
         }
       }


### PR DESCRIPTION
Conditionally available opaque return types should support availability conditions that are evaluated in any availability domain. Update `ConditionallyAvailableSubstitutions` to model its conditions with `AvailabilityQuery` instead of assuming that conditions are always a single version query for the current platform.

This PR builds toward resolving rdar://156513787, which still requires serializing arbitrary availability queries in Swift modules and generating opaque type accessors during IRGen that can evaluate arbitrary availability queries. 