### PR TITLE
Avoid dropping ExtInfo in `replaceParamErrorTypeByPlaceholder`

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -989,7 +989,8 @@ static Type replaceParamErrorTypeByPlaceholder(Type type, ValueDecl *value, bool
     }
   }
   assert(newParams.size() == declParams.size());
-  return FunctionType::get(newParams, funcType->getResult());
+  return FunctionType::get(newParams, funcType->getResult(),
+                           funcType->getExtInfo());
 }
 
 DeclReferenceType

--- a/validation-test/IDE/crashers_fixed/23da5344b07b939.swift
+++ b/validation-test/IDE/crashers_fixed/23da5344b07b939.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","signature":"swift::AnyFunctionType::getExtInfo() const","signatureAssert":"Assertion failed: (hasExtInfo()), function getExtInfo"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 func a(b) a#^COMPLETE^#


### PR DESCRIPTION
Make sure we preserve the info to avoid hitting an assert.