### PR TITLE
[cxx-interop] Support SIMD types in reverse interop

### DIFF
--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -38,6 +38,7 @@
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
+#include <optional>
 
 using namespace swift;
 using namespace irgen;
@@ -59,14 +60,25 @@ getPrimitiveTypeFromLLVMType(ASTContext &ctx, const llvm::Type *type) {
     default:
       return std::nullopt;
     }
-  } else if (type->isFloatTy()) {
+  }
+  if (type->isFloatTy()) {
     return ctx.getFloatType();
-  } else if (type->isDoubleTy()) {
+  }
+  if (type->isDoubleTy()) {
     return ctx.getDoubleType();
-  } else if (type->isPointerTy()) {
+  }
+  if (type->isPointerTy()) {
     return ctx.getOpaquePointerType();
   }
-  // FIXME: Handle vector type.
+  if (const auto *vecTy = dyn_cast<llvm::VectorType>(type)) {
+    auto elemTy = getPrimitiveTypeFromLLVMType(ctx, vecTy->getElementType());
+    if (!elemTy)
+      return std::nullopt;
+    auto elemCount = vecTy->getElementCount();
+    if (!elemCount.isFixed())
+      return std::nullopt;
+    return BuiltinVectorType::get(ctx, *elemTy, elemCount.getFixedValue());
+  }
   return std::nullopt;
 }
 

--- a/lib/PrintAsClang/PrimitiveTypeMapping.h
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.h
@@ -21,18 +21,21 @@ namespace swift {
 
 class ASTContext;
 class TypeDecl;
+class Type;
 
 /// Provides a mapping from Swift's primitive types to C / Objective-C / C++
 /// primitive types.
 ///
 /// Certain types have mappings that differ in different language modes.
-/// For example, Swift's `Int` maps to `NSInteger` for Objective-C declarations,
-/// but to something like `intptr_t` or `swift::Int` for C and C++ declarations.
+/// For example, Swift's `Int` maps to `NSInteger` for Objective-C
+/// declarations, but to something like `intptr_t` or `swift::Int` for C and
+/// C++ declarations.
 class PrimitiveTypeMapping {
 public:
   struct ClangTypeInfo {
     StringRef name;
     bool canBeNullable;
+    bool simd;
   };
 
   /// Returns the Objective-C type name and nullability for the given Swift
@@ -47,6 +50,8 @@ public:
   /// primitive type declaration, or \c None if no such type name exists.
   std::optional<ClangTypeInfo> getKnownCxxTypeInfo(const TypeDecl *typeDecl);
 
+  std::optional<ClangTypeInfo> getKnownSIMDTypeInfo(Type t, ASTContext &ctx);
+
 private:
   void initialize(ASTContext &ctx);
 
@@ -58,6 +63,7 @@ private:
     // The C++ name of the Swift type.
     std::optional<StringRef> cxxName;
     bool canBeNullable;
+    bool simd = false;
   };
 
   FullClangTypeInfo *getMappedTypeInfoOrNull(const TypeDecl *typeDecl);

--- a/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
@@ -43,5 +43,14 @@ public func passStruct(_ x : Struct) {
 }
 
 // CHECK: class SWIFT_SYMBOL("s:8UseCxxTy6StructV") Struct final {
-// CHECK-NOT: init(
-// CHECK:  // Unavailable in C++: Swift global function 'passStruct(_:)'
+
+// CHECK: SWIFT_INLINE_THUNK void passStruct(const Struct& x) noexcept SWIFT_SYMBOL("s:8UseCxxTy10passStructyyAA0E0VF") {
+// CHECK-NEXT:   UseCxxTy::_impl::$s8UseCxxTy10passStructyyAA0E0VF(UseCxxTy::_impl::swift_interop_passDirect_UseCxxTy_swift_float4_0_16_swift_float4_16_32_swift_float4_32_48_swift_float4_48_64(UseCxxTy::_impl::_impl_Struct::getOpaquePointer(x)));
+// CHECK-NEXT:}
+
+// CHECK:  SWIFT_INLINE_THUNK Struct Struct::init() {
+// CHECK-NEXT:  return UseCxxTy::_impl::_impl_Struct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    UseCxxTy::_impl::swift_interop_returnDirect_UseCxxTy_swift_float4_0_16_swift_float4_16_32_swift_float4_32_48_swift_float4_48_64(result, UseCxxTy::_impl::$s8UseCxxTy6StructVACycfC());
+// CHECK-NEXT:  });
+// CHECK-NEXT:  }
+

--- a/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx-execution.cpp
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-simd-in-cxx.swift -module-name SIMD -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/simd.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-simd-execution.o
+// RUN: %target-interop-build-swift %S/swift-simd-in-cxx.swift -o %t/swift-simd-execution -Xlinker %t/swift-simd-execution.o -module-name SIMD -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-simd-execution
+// RUN: %target-run %t/swift-simd-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: rdar157848231
+
+#include "simd.h"
+#include <assert.h>
+#include <iostream>
+
+int main() {
+  swift_float3 vec{1.0, 2.0, 3.0};
+  SIMD::swiftThingSIMD(vec);
+  // CHECK: SIMD3<Float>(1.0, 2.0, 3.0)
+  SIMD::swiftThingSIMD2(vec);
+  // CHECK: SIMD3<Float>(1.0, 2.0, 3.0)
+  swift_float3 vec2 = SIMD::swiftThingSIMD3();
+  std::cout << vec2.x << " " << vec2.y << " " << vec2.z << "\n";
+  // CHECK: 4 5 6
+  vec2 = SIMD::swiftThingSIMD4();
+  std::cout << vec2.x << " " << vec2.y << " " << vec2.z << "\n";
+  // CHECK: 4 5 6
+  return 0;
+}
+

--- a/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-simd-in-cxx.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -module-name UseSIMD -cxx-interoperability-mode=default -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseSIMD.h
+// RUN: %FileCheck %s < %t/UseSIMD.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/UseSIMD.h -o %t/o.o
+
+// REQUIRES: objc_interop
+// REQUIRES: rdar157848231
+
+import simd
+
+public func swiftThingScalar(a: Float) {}
+
+public func swiftThingSIMD(a: float3) {
+    print(a)
+}
+
+public func swiftThingSIMD2(a: simd_float3) {
+    print(a)
+}
+
+public func swiftThingSIMD3() -> float3 {
+    float3(4, 5, 6)
+}
+
+public func swiftThingSIMD4() -> simd_float3 {
+    simd_float3(4, 5, 6)
+}
+
+// CHECK: SWIFT_EXTERN void $s7UseSIMD010swiftThingB01ays5SIMD3VySfG_tF(struct swift_interop_passStub_UseSIMD_swift_float4_0_16 a) SWIFT_NOEXCEPT SWIFT_CALL; // swiftThingSIMD(a:)
+// CHECK: SWIFT_EXTERN void $s7UseSIMD15swiftThingSIMD21ays5SIMD3VySfG_tF(struct swift_interop_passStub_UseSIMD_swift_float4_0_16 a) SWIFT_NOEXCEPT SWIFT_CALL; // swiftThingSIMD2(a:)
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseSIMD_swift_float4_0_16 $s7UseSIMD15swiftThingSIMD3s0E0VySfGyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // swiftThingSIMD3()
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseSIMD_swift_float4_0_16 $s7UseSIMD15swiftThingSIMD4s5SIMD3VySfGyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // swiftThingSIMD4()
+// CHECK: SWIFT_EXTERN void $s7UseSIMD16swiftThingScalar1aySf_tF(float a) SWIFT_NOEXCEPT SWIFT_CALL; // swiftThingScalar(a:)
+
+// CHECK:      SWIFT_INLINE_THUNK void swiftThingSIMD(swift_float3 a) noexcept SWIFT_SYMBOL("s:7UseSIMD010swiftThingB01ays5SIMD3VySfG_tF") {
+// CHECK-NEXT:   UseSIMD::_impl::$s7UseSIMD010swiftThingB01ays5SIMD3VySfG_tF(UseSIMD::_impl::swift_interop_passDirect_UseSIMD_swift_float4_0_16(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(a))));
+// CHECK-NEXT: }
+
+// CHECK:      WIFT_INLINE_THUNK void swiftThingSIMD2(swift_float3 a) noexcept SWIFT_SYMBOL("s:7UseSIMD15swiftThingSIMD21ays5SIMD3VySfG_tF") {
+// CHECK-NEXT:   UseSIMD::_impl::$s7UseSIMD15swiftThingSIMD21ays5SIMD3VySfG_tF(UseSIMD::_impl::swift_interop_passDirect_UseSIMD_swift_float4_0_16(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(a))));
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK swift_float3 swiftThingSIMD3() noexcept SWIFT_SYMBOL("s:7UseSIMD15swiftThingSIMD3s0E0VySfGyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(swift_float3)) char storage[sizeof(swift_float3)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<swift_float3 *>(storage);
+// CHECK-NEXT: UseSIMD::_impl::swift_interop_returnDirect_UseSIMD_swift_float4_0_16(storage, UseSIMD::_impl::$s7UseSIMD15swiftThingSIMD3s0E0VySfGyF());
+// CHECK-NEXT: return *storageObjectPtr;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK swift_float3 swiftThingSIMD4() noexcept SWIFT_SYMBOL("s:7UseSIMD15swiftThingSIMD4s5SIMD3VySfGyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(swift_float3)) char storage[sizeof(swift_float3)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<swift_float3 *>(storage);
+// CHECK-NEXT: UseSIMD::_impl::swift_interop_returnDirect_UseSIMD_swift_float4_0_16(storage, UseSIMD::_impl::$s7UseSIMD15swiftThingSIMD4s5SIMD3VySfGyF());
+// CHECK-NEXT: return *storageObjectPtr;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK void swiftThingScalar(float a) noexcept SWIFT_SYMBOL("s:7UseSIMD16swiftThingScalar1aySf_tF") {
+// CHECK-NEXT:   UseSIMD::_impl::$s7UseSIMD16swiftThingScalar1aySf_tF(a);
+// CHECK-NEXT: }


### PR DESCRIPTION
This supports both built-in vector types and the SIMDX<T> Swift types
that are used through type aliases like float3. These SIMD types are
passed via compatibility structs (with their valued memcpy-d into the
ABI compatible struct) as they have special ABI rules. E.g., a float3 is
not passed as float3, but as float4 on the ABI level.

Previously, we did not expose simd types from Swift to C++ (unless the
SIMD types were impoted from clang).

rdar://153218744
