### PR TITLE
[6.2][cxx-interop] Fix crash when using bridging headers in reverse interop

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -272,6 +272,10 @@ bool swift::cxx_translation::isObjCxxOnly(const clang::Decl *D,
   // requirements and the language options to check if we should actually
   // consider the module to have ObjC constructs.
   const auto &langOpts = D->getASTContext().getLangOpts();
+  // TODO: have a reasonable guess for headers specified via
+  // `-import-objc-header`.
+  if (!D->hasOwningModule())
+    return false;
   auto clangModule = D->getOwningModule()->getTopLevelModule();
   bool requiresObjC = false;
   for (auto req : clangModule->Requirements)

--- a/test/Interop/CxxToSwiftToCxx/bridge-bridging-header-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-bridging-header-to-cxx.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -import-objc-header %t/header.h
+
+// RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
+// RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -g -import-objc-header %t/header.h
+
+//--- header.h
+struct CxxTy {
+    int field;
+};
+
+//--- use-cxx-types.swift
+public func foo() -> CxxTy {
+    CxxTy()
+}
+
+//--- use-swift-cxx-types.cpp
+
+#include "header.h"
+#include "UseCxx.h"
+
+int main() {
+    auto obj = UseCxx::foo();
+}


### PR DESCRIPTION
Explanation: The original code had the assumption we only import modules. However, there is a flag to import an umbrella header in which case the clang nodes have no owning module. This PR prevents a null dereference in that case. The problem affects the users of C++ interop who also use the umbrella header feature (`-import-objc-header` flag). 
Issues: rdar://157489426
Original PRs: #83540
Risk: Low, added a check to avoid null dereference.
Testing: Added a compiler test.
Reviewers: @egorzhdan
