### PR TITLE
Cxx: do not tie libstdc++ to Linux

### DIFF
--- a/Runtimes/Overlay/Cxx/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/CMakeLists.txt
@@ -1,8 +1,12 @@
 
+include(CheckSymbolExists)
+check_symbol_exists(_LIBCPP_VERSION "version" HAVE_LIBCPP_VERSION)
+check_symbol_exists(__GLIBCXX__ "version" HAVE___GLIBCXX__)
+
 if(NOT APPLE)
   add_subdirectory(cxxshim)
 endif()
-if(LINUX)
+if(HAVE___GLIBCXX__)
   add_subdirectory(libstdcxx)
 endif()
 add_subdirectory(std)

--- a/Runtimes/Overlay/Cxx/std/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/std/CMakeLists.txt
@@ -22,7 +22,7 @@ target_compile_options(swiftCxxStdlib PRIVATE
 target_compile_options(swiftCxxStdlib PRIVATE
   "$<$<PLATFORM_ID:Android>:SHELL:-Xcc --sysroot -Xcc ${CMAKE_ANDROID_NDK_TOOLCHAIN_UNIFIED}/sysroot>")
 target_link_libraries(swiftCxxStdlib PRIVATE
-  $<$<PLATFORM_ID:Linux>:libstdcxx>
+  $<$<BOOL:${HAVE___GLIBCXX__}>:libstdcxx>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:cxxshim>
   swiftCxx
   swiftCore


### PR DESCRIPTION
This extracts the C++ runtime detection as recommended by Ben Boeckel. Detect if `__GLIBCXX__` is defined in `<version>` indicating that libstdc++ is being used. This allows for building the overlay for alternative C++ runtimes (e.g. libc++) on Linux.