### PR TITLE
[FrontendOptions] Default `IndexStoreCompress` to `false`

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -137,7 +137,7 @@ public:
   bool IndexIncludeLocals = false;
   
   /// Whether to compress the record and unit files in the index store.
-  bool IndexStoreCompress;
+  bool IndexStoreCompress = false;
 
   bool SerializeDebugInfoSIL = false;
   /// If building a module from interface, ignore compiler flags


### PR DESCRIPTION
As discussed in https://github.com/swiftlang/swift/pull/82947#discussion_r2261126925.