### PR TITLE
FreeBSD: No availability OS version

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/Feature.h"
 #include "swift/Basic/FunctionBodySkipping.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Platform.h"
 #include "swift/Basic/PlaygroundOption.h"
 #include "swift/Basic/Version.h"
 #include "swift/Config.h"
@@ -693,18 +694,7 @@ namespace swift {
     /// This is only implemented on certain OSs. If no target has been
     /// configured, returns v0.0.0.
     llvm::VersionTuple getMinPlatformVersion() const {
-      if (Target.isMacOSX()) {
-        llvm::VersionTuple OSVersion;
-        Target.getMacOSXVersion(OSVersion);
-        return OSVersion;
-      } else if (Target.isiOS()) {
-        return Target.getiOSVersion();
-      } else if (Target.isWatchOS()) {
-        return Target.getOSVersion();
-      } else if (Target.isXROS()) {
-        return Target.getOSVersion();
-      }
-      return llvm::VersionTuple(/*Major=*/0, /*Minor=*/0, /*Subminor=*/0);
+      return getVersionForTriple(Target);
     }
 
     /// Sets an implicit platform condition.

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -85,6 +85,9 @@ namespace swift {
   /// returned.
   StringRef getPlatformNameForTriple(const llvm::Triple &triple);
 
+  /// Returns the version tuple for a given target triple
+  llvm::VersionTuple getVersionForTriple(const llvm::Triple &triple);
+
   /// Returns the platform Kind for Darwin triples.
   DarwinPlatformKind getDarwinPlatformKind(const llvm::Triple &triple);
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -278,6 +278,23 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   llvm_unreachable("unsupported OS");
 }
 
+llvm::VersionTuple swift::getVersionForTriple(const llvm::Triple &triple) {
+  if (triple.isMacOSX()) {
+    llvm::VersionTuple OSVersion;
+    triple.getMacOSXVersion(OSVersion);
+    return OSVersion;
+  } else if (triple.isiOS()) {
+    return triple.getiOSVersion();
+  } else if (triple.isWatchOS()) {
+    return triple.getOSVersion();
+  } else if (triple.isXROS()) {
+    return triple.getOSVersion();
+  } else if (triple.isOSWindows()) {
+    return triple.getOSVersion();
+  }
+  return llvm::VersionTuple(/*Major=*/0, /*Minor=*/0, /*Subminor=*/0);
+}
+
 StringRef swift::getMajorArchitectureName(const llvm::Triple &Triple) {
   if (Triple.isOSLinux()) {
     switch (Triple.getSubArch()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -56,17 +56,6 @@ swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
 }
 
-/// Converts a llvm::Triple to a llvm::VersionTuple.
-static llvm::VersionTuple
-getVersionTuple(const llvm::Triple &triple) {
-  if (triple.isMacOSX()) {
-    llvm::VersionTuple OSVersion;
-    triple.getMacOSXVersion(OSVersion);
-    return OSVersion;
-  }
-  return triple.getOSVersion();
-}
-
 void CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
     StringRef mainExecutablePath, bool shared,
     llvm::SmallVectorImpl<char> &runtimeResourcePath) {
@@ -1623,7 +1612,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // First, set up default minimum inlining target versions.
   auto getDefaultMinimumInliningTargetVersion =
       [&](const llvm::Triple &triple) -> llvm::VersionTuple {
-    const auto targetVersion = getVersionTuple(triple);
+    const auto targetVersion = getVersionForTriple(triple);
 
     // In API modules, default to the version when Swift first became available.
     if (Opts.LibraryLevel == LibraryLevel::API) {


### PR DESCRIPTION
Transparent and inlinable declarations had the OS version availability applied to them. This broke some declarations coming from the standard library, specifically `_checkExpectedExecutor`. Rather than crashing, SILGen silently omits the check, resulting in failing tests, and unchecked code. FreeBSD is not one of the platforms where availability is set up, so clear the availability version number like what is done for all non-Apple platforms.