### PR TITLE
macOS smoketest: enable Distributed and Synchronization in runtimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1711,7 +1711,7 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
         # To ensure incremental builds work as expected
         BUILD_ALWAYS 1
         CMAKE_ARGS
-          -DSwift_ENABLE_RUNTIMES=StringProcessing
+          -DSwift_ENABLE_RUNTIMES=StringProcessing|Synchronization|Distributed
           -DBUILD_SHARED_LIBS=YES
           -DCMAKE_Swift_COMPILER_WORKS:BOOLEAN=YES
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -336,7 +336,9 @@ target_link_libraries(swiftCore
     swiftThreading
     $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt$<$<PLATFORM_ID:Windows>:T>>
   PUBLIC
-    swiftShims)
+    swiftShims
+  INTERFACE
+    swiftRuntimeCMakeConfig)
 
 string(TOLOWER "${SwiftCore_OBJECT_FORMAT}" SwiftCore_OBJECT_FORMAT_lc)
 if("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "elf")

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -2,6 +2,10 @@ configure_file("CMakeConfig.h.in"
   "${PROJECT_BINARY_DIR}/include/swift/Runtime/CMakeConfig.h"
   ESCAPE_QUOTES @ONLY)
 
+add_library(swiftRuntimeCMakeConfig INTERFACE)
+target_include_directories(swiftRuntimeCMakeConfig INTERFACE
+  $<$<COMPILE_LANGUAGE:C,CXX,Swift>:$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>>)
+
 add_library(swiftRuntime OBJECT
     "${PROJECT_SOURCE_DIR}/CompatibilityOverride/CompatibilityOverride.cpp"
     AnyHashableSupport.cpp
@@ -131,6 +135,14 @@ if(SwiftCore_ENABLE_OBJC_INTEROP)
     ReflectionMirrorObjC.mm
     ObjCRuntimeGetImageNameFromClass.mm)
 endif()
+
+install(FILES
+  "${PROJECT_BINARY_DIR}/include/swift/Runtime/CMakeConfig.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/swift/Runtime"
+  COMPONENT SwiftCore_development)
+install(TARGETS swiftRuntimeCMakeConfig
+  EXPORT SwiftCoreTargets
+  COMPONENT SwiftCore_development)
 
 if(NOT BUILD_SHARED_LIBS)
   install(TARGETS swiftRuntime

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -143,8 +143,8 @@ target_link_libraries(swiftDistributed PRIVATE
   swift_Concurrency
   swift_Builtin_float
   $<$<PLATFORM_ID:Android>:swiftAndroid>
-  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
-  # swiftDarwin/Libc/Platform
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>
+  $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
 
 install(TARGETS swiftDistributed
   EXPORT SwiftDistributedTargets

--- a/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
+++ b/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
@@ -287,8 +287,15 @@ endif()
 find_path(SwiftShims_INCLUDE_DIR "shims/module.modulemap" HINTS
   ${SwiftShims_INCLUDE_DIR_HINTS})
 add_library(swiftShims INTERFACE IMPORTED GLOBAL)
-set_target_properties(swiftShims PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${SwiftShims_INCLUDE_DIR}/shims")
+target_include_directories(swiftShims INTERFACE
+# This is needed for targets that import headers from
+# include/swift (e.g. include/swift/ABI/HeapObject.h)
+# that assumes the shims are located in `swift/shims`
+# relative path
+  "${SwiftShims_INCLUDE_DIR}/.."
+  "${SwiftShims_INCLUDE_DIR}/shims")
+target_compile_options(swiftShims INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=\"${SwiftShims_INCLUDE_DIR}/shims/module.modulemap\">")
 
 find_package_handle_standard_args(SwiftCore DEFAULT_MSG
   SwiftCore_LIBRARY SwiftCore_INCLUDE_DIR


### PR DESCRIPTION
To make this work:
* expose SwiftCMakeConfig.h from the Core build system, to support scenarios in which the downstream Distributed build is leveraging the config files generated by CMake itself.
* adjust how SwiftShims is defined in `FindSwiftCore.cmake`, so that the shims are found from C++ and that we don't get redefinition errors when multiple module maps are in the search paths.

Fixes #83449
Addresses rdar://149241603, rdar://157165530