### PR TITLE
[cxx-interop] Export empty enums as namespaces

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -354,8 +354,6 @@ swift::cxx_translation::getDeclRepresentation(
         return {Unsupported, UnrepresentableGeneric};
       genericSignature = typeDecl->getGenericSignature();
     }
-    if (!isa<ClassDecl>(typeDecl) && isZeroSized && (*isZeroSized)(typeDecl))
-      return {Unsupported, UnrepresentableZeroSizedValueType};
   }
   if (const auto *varDecl = dyn_cast<VarDecl>(VD)) {
     // Check if any property accessor throws, do not expose it in that case.
@@ -390,6 +388,17 @@ swift::cxx_translation::getDeclRepresentation(
         }
       }
     }
+  }
+  // The zero-sized check runs after enum-specific checks so that the more
+  // specific reason wins (e.g., a single-case enum with an unrepresentable
+  // associated-value tuple keeps its specific diagnostic instead of being
+  // labeled "zero sized value type").
+  if (const auto *typeDecl = dyn_cast<NominalTypeDecl>(VD)) {
+    if (!isa<ClassDecl>(typeDecl) && isZeroSized && (*isZeroSized)(typeDecl) &&
+        // Non-generic empty enums are exported as namespaces.
+        !(isa<EnumDecl>(typeDecl) && !cast<EnumDecl>(typeDecl)->hasCases() &&
+          !cast<EnumDecl>(typeDecl)->hasGenericParamList()))
+      return {Unsupported, UnrepresentableZeroSizedValueType};
   }
 
   // Generic requirements are not yet supported in C++.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -245,6 +245,9 @@ private:
                                const ModuleDecl *moduleContext) {
     if (TD->isImplicit() || TD->isSynthesized())
       return;
+    // Empty enums are exported as namespaces.
+    if (owningPrinter.isEmptyEnum(TD))
+      return;
     os << "  using ";
     ClangSyntaxPrinter(getASTContext(), os).printBaseName(TD);
     os << "=";
@@ -495,12 +498,61 @@ private:
     return false;
   }
 
+  bool isNestedInNonNamespaceType(EnumDecl *ED) {
+    Decl *D = ED;
+    while (auto parent = D->getDeclContext()->getAsDecl()) {
+      const auto *parentNTD = dyn_cast<NominalTypeDecl>(parent);
+      if (!parentNTD)
+        if (const auto *extDecl = dyn_cast<ExtensionDecl>(parent))
+          parentNTD = extDecl->getExtendedNominal();
+      if (!parentNTD) {
+        D = parent;
+        continue;
+      }
+      // Anything that isn't itself an empty enum will be emitted as a C++
+      // class — we cannot put a namespace inside it.
+      if (!owningPrinter.isEmptyEnum(parentNTD))
+        return true;
+      D = parent;
+    }
+    return false;
+  }
+
   void visitEnumDeclCxx(EnumDecl *ED) {
     assert(owningPrinter.outputLang == OutputLanguageMode::Cxx);
+    ClangSyntaxPrinter syntaxPrinter(ED->getASTContext(), os);
+
+    if (owningPrinter.isEmptyEnum(ED)) {
+      if (isNestedInNonNamespaceType(ED)) {
+        owningPrinter.getCxxDeclEmissionScope()
+            .additionalUnrepresentableDeclarations.insert(
+                {ED, "empty enum cannot be represented as a namespace"});
+        return;
+      }
+      syntaxPrinter.printParentNamespaceForNestedTypes(
+          ED, [&](raw_ostream &os) {
+            syntaxPrinter.printNamespace(
+                cxx_translation::getNameForCxx(ED),
+                [ED, this](llvm::raw_ostream &) {
+                  CxxEmissionScopeRAII cxxScopeRAII(owningPrinter);
+                  printMembers(ED->getAllMembers());
+                  for (const auto *ext :
+                       owningPrinter.interopContext.getExtensionsForNominalType(
+                           ED)) {
+                    if (!cxx_translation::isExposableToCxx(
+                            ext->getGenericSignature()))
+                      continue;
+
+                    printMembers(ext->getAllMembers());
+                  }
+                });
+          });
+      recordEmittedDeclInCurrentCxxLexicalScope(ED);
+      return;
+    }
 
     ClangValueTypePrinter valueTypePrinter(os, owningPrinter.prologueOS,
                                            owningPrinter.interopContext);
-    ClangSyntaxPrinter syntaxPrinter(ED->getASTContext(), os);
     DeclAndTypeClangFunctionPrinter clangFuncPrinter(
         os, owningPrinter.prologueOS, owningPrinter.typeMapping,
         owningPrinter.interopContext, owningPrinter);
@@ -1991,8 +2043,19 @@ private:
 
   void visitFuncDecl(FuncDecl *FD) {
     if (outputLang == OutputLanguageMode::Cxx) {
-      if (FD->getDeclContext()->isTypeContext())
+      if (FD->getDeclContext()->isTypeContext()) {
+        // Instance members of an empty enum cannot be represented — there
+        // is no instance to call them on (empty enums are namespaces in
+        // C++).
+        if (owningPrinter.isMemberOfEmptyEnum(FD) && !FD->isStatic()) {
+          owningPrinter.getCxxDeclEmissionScope()
+              .additionalUnrepresentableDeclarations.insert(
+                  {FD, "cannot be represented because empty enums (as C++ "
+                       "namespaces) have no instances"});
+          return;
+        }
         return printAbstractFunctionAsMethod(FD, FD->isStatic());
+      }
 
       // Emit the underlying C signature that matches the Swift ABI
       // in the generated C++ implementation prologue for the module.
@@ -2020,6 +2083,16 @@ private:
   }
 
   void visitConstructorDecl(ConstructorDecl *CD) {
+    // An empty enum is emitted as a C++ namespace and cannot be
+    // constructed — there is no C++ type to construct.
+    if (outputLang == OutputLanguageMode::Cxx &&
+        owningPrinter.isMemberOfEmptyEnum(CD)) {
+      owningPrinter.getCxxDeclEmissionScope()
+          .additionalUnrepresentableDeclarations.insert(
+              {CD, "cannot be constructed because empty enums map to C++ "
+                   "namespaces"});
+      return;
+    }
     printAbstractFunctionAsMethod(CD, false);
   }
 
@@ -2086,6 +2159,17 @@ private:
   void visitVarDecl(VarDecl *VD) {
     assert(VD->getDeclContext()->isTypeContext() &&
            "cannot handle global variables right now");
+
+    if (owningPrinter.isEmptyEnum(
+            VD->getInterfaceType()->getNominalOrBoundGenericNominal()))
+      return;
+
+    // Properties of an empty enum cannot be emitted as C++ methods — the
+    // containing type is a namespace, and instance properties have no
+    // instance to live on.
+    if (outputLang == OutputLanguageMode::Cxx &&
+        owningPrinter.isMemberOfEmptyEnum(VD) && !VD->isStatic())
+      return;
 
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Documentation.
@@ -3195,6 +3279,17 @@ bool DeclAndTypePrinter::isZeroSized(const NominalTypeDecl *decl) {
   if (sizeAndAlignment)
     return sizeAndAlignment->size == 0;
   return false;
+}
+
+bool DeclAndTypePrinter::isEmptyEnum(const Decl *decl) {
+  // Generic empty enums cannot be C++ namespaces (a namespace cannot have
+  // template parameters); fall back to the unrepresentable-stub path.
+  const auto *ED = dyn_cast_or_null<EnumDecl>(decl);
+  return ED && !ED->hasCases() && !ED->hasGenericParamList();
+}
+
+bool DeclAndTypePrinter::isMemberOfEmptyEnum(const Decl *member) {
+  return isEmptyEnum(member->getDeclContext()->getAsDecl());
 }
 
 bool DeclAndTypePrinter::isVisible(const ValueDecl *vd) const {

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -134,6 +134,11 @@ public:
   bool shouldInclude(const ValueDecl *VD);
 
   bool isZeroSized(const NominalTypeDecl *decl);
+  bool isEmptyEnum(const Decl *decl);
+
+  /// True if \p member's enclosing type context is an empty enum
+  /// (i.e., \p member lives inside what we emit as a C++ namespace).
+  bool isMemberOfEmptyEnum(const Decl *member);
 
   /// Returns true if \p vd is visible given the current access level and thus
   /// can be included in the generated header.

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -582,6 +582,9 @@ public:
   }
 
   void forwardDeclareCxxValueTypeIfNeeded(const NominalTypeDecl *NTD) {
+    // Empty enums are exported as namespaces; no class forward declaration.
+    if (printer.isEmptyEnum(NTD))
+      return;
     forwardDeclare(NTD, [&]() {
       ClangValueTypePrinter::forwardDeclType(os, NTD, printer);
     });
@@ -1120,10 +1123,12 @@ public:
           emitStubComment();
           continue;
         }
-        auto representation = cxx_translation::getDeclRepresentation(
-            vd, [this](const NominalTypeDecl *decl) {
-              return printer.isZeroSized(decl);
-            });
+        auto customReasonIt =
+            emissionScope.additionalUnrepresentableDeclarations.find(vd);
+        bool hasCustomReason =
+            customReasonIt !=
+                emissionScope.additionalUnrepresentableDeclarations.end() &&
+            !customReasonIt->second.empty();
         if (nmtd->hasGenericParamList()) {
           auto genericSignature =
               nmtd->getGenericSignature().getCanonicalSignature();
@@ -1133,20 +1138,28 @@ public:
         ClangSyntaxPrinter(nmtd->getASTContext(), os).printBaseName(vd);
         os << " { } SWIFT_UNAVAILABLE_MSG(\"";
 
-        auto diag =
-            representation.isUnsupported() && representation.error.has_value()
-                ? cxx_translation::diagnoseRepresenationError(
-                      *representation.error, const_cast<ValueDecl *>(vd))
-                : Diagnostic(
-                      vd->isStdlibDecl() ? diag::unexposed_other_decl_in_cxx
-                                         : diag::unsupported_other_decl_in_cxx,
-                      const_cast<ValueDecl *>(vd));
-        // Emit a specific unavailable message when we know why a decl can't be
-        // exposed, or a generic message otherwise.
-        auto diagString =
-            M.getASTContext().Diags.getFormatStringForDiagnostic(diag.getID());
-        DiagnosticEngine::formatDiagnosticText(os, diagString, diag.getArgs(),
-                                               DiagnosticFormatOptions());
+        if (hasCustomReason) {
+          os << customReasonIt->second;
+        } else {
+          auto representation = cxx_translation::getDeclRepresentation(
+              vd, [this](const NominalTypeDecl *decl) {
+                return printer.isZeroSized(decl);
+              });
+          auto diag =
+              representation.isUnsupported() && representation.error.has_value()
+                  ? cxx_translation::diagnoseRepresenationError(
+                        *representation.error, const_cast<ValueDecl *>(vd))
+                  : Diagnostic(vd->isStdlibDecl()
+                                   ? diag::unexposed_other_decl_in_cxx
+                                   : diag::unsupported_other_decl_in_cxx,
+                               const_cast<ValueDecl *>(vd));
+          // Emit a specific unavailable message when we know why a decl can't
+          // be exposed, or a generic message otherwise.
+          auto diagString =
+              M.getASTContext().Diags.getFormatStringForDiagnostic(diag.getID());
+          DiagnosticEngine::formatDiagnosticText(os, diagString, diag.getArgs(),
+                                                 DiagnosticFormatOptions());
+        }
         os << "\");\n";
         continue;
       }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -424,6 +424,10 @@ public:
     // Handle known type names.
     if (printIfKnownSimpleType(decl, optionalKind, isInOutParam))
       return ClangRepresentation::representable;
+    // Empty enums are exported as C++ namespaces, when possible and we do not
+    // support exposing zero sized types in other contexts.
+    if (declPrinter.isEmptyEnum(decl))
+      return ClangRepresentation::unsupported;
     if (!declPrinter.shouldInclude(decl))
       return ClangRepresentation::unsupported; // FIXME: propagate why it's not
                                                // exposed.
@@ -1672,12 +1676,18 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   FunctionSignatureModifiers modifiers;
   if (isDefinition)
     modifiers.qualifierContext = typeDeclContext;
-  modifiers.isStatic = (isStatic || isConstructor) && !isDefinition;
+  // An empty enum is emitted as a C++ namespace; `static` in namespace scope
+  // would give the function internal linkage instead of being a "static
+  // member". Skip it for empty enums.
+  bool inEmptyEnumNamespace = declAndTypePrinter.isEmptyEnum(typeDeclContext);
+  modifiers.isStatic = (isStatic || isConstructor) && !isDefinition &&
+                       !inEmptyEnumNamespace;
   modifiers.isInline = true;
   bool isMutating =
       isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false;
   modifiers.isConst = !isa<ClassDecl>(typeDeclContext) && !isMutating &&
-                      !isConstructor && !isStatic;
+                      !isConstructor && !isStatic &&
+                      !inEmptyEnumNamespace;
   modifiers.hasSymbolUSR = !isDefinition;
   auto result = printFunctionSignature(
       FD, signature, cxx_translation::getNameForCxx(FD), resultTy,
@@ -1749,7 +1759,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
   FunctionSignatureModifiers modifiers;
   if (isDefinition)
     modifiers.qualifierContext = typeDeclContext;
-  modifiers.isStatic = isStatic && !isDefinition;
+  // `static` at namespace scope means internal linkage; suppress it for
+  // empty enums (which are emitted as namespaces).
+  bool inEmptyEnumNamespace = declAndTypePrinter.isEmptyEnum(typeDeclContext);
+  modifiers.isStatic = isStatic && !isDefinition && !inEmptyEnumNamespace;
   modifiers.isInline = true;
   modifiers.isConst =
       !isStatic && accessor->isGetter() && !isa<ClassDecl>(typeDeclContext);

--- a/test/Interop/SwiftToCxx/enums/empty-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/empty-enum-in-cxx.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// Top-level empty enums become C++ namespaces that expose static members
+// and nested types.
+public enum Utils {
+    public static func getAnswer() -> Int { 42 }
+
+    public struct Helper {
+        public var x: Int
+    }
+}
+
+// A nested empty enum inside a struct cannot be a namespace (C++ does not
+// allow namespaces inside classes). It should become an unavailable stub.
+public struct Container {
+    public enum Nested {}
+
+    public var x: Int = 1
+}
+
+// A nested empty enum inside a class has the same restriction.
+public class HolderClass {
+    public enum NestedInClass {}
+}
+
+// An empty enum as a struct member is allowed (the struct is still exposed;
+// the field's C++ accessor is skipped because the type is a namespace).
+public enum Padding {
+    public init() { fatalError("uninhabited") }
+}
+public struct WithPadding {
+    public let p: Padding
+    public let value: Int
+    public init() {
+        self.value = 99
+        self.p = Padding()
+    }
+}
+
+// An empty enum as a function parameter makes the function uncallable
+// (no value of the parameter type can ever exist), so the function is
+// emitted as an unavailable comment. An empty enum as a return type, on
+// the other hand, simply means the function never returns — the C++
+// thunk is emitted with a `void` return type and `SWIFT_NORETURN`.
+public func takesEmpty(_ e: Padding) {}
+public func returnsEmpty() -> Padding { fatalError() }
+
+// `@frozen` makes no difference — empty is empty, with or without the
+// attribute. The C++ binding is the same.
+@frozen
+public enum FrozenEmpty {
+    public static func id() -> Int { 1 }
+}
+
+// A static var on an empty enum: must NOT have the C++ `static` keyword
+// at namespace scope (that would mean internal linkage).
+public enum WithStaticVar {
+    public static var answer: Int { 42 }
+}
+
+// `extension Empty { ... }` of an empty enum: the extension's static
+// members are emitted into the same namespace as the enum.
+public enum Extended {}
+extension Extended {
+    public static func extFunc() -> Int { 7 }
+}
+
+// A generic empty enum cannot become a C++ namespace (namespaces have no
+// template parameters). It must be emitted as an unavailable stub.
+public enum GenericEmpty<T> {
+    public static func tag() -> Int { 1 }
+}
+
+// Empty enums wrapped in Optional / Array / Tuple in a function signature
+// also bail (each via the common ClangRepresentation::unsupported path
+// for the inner type).
+public func takesOptional(_ x: Padding?) {}
+public func takesArray(_ x: [Padding]) {}
+public func takesTuple(_ x: (Int, Padding)) {}
+
+// Top-level type declarations are emitted in alphabetic order, with
+// classes/structs interleaved with namespaces.
+// CHECK: namespace Extended {
+// CHECK:   SWIFT_INLINE_THUNK swift::Int extFunc() SWIFT_SYMBOL(
+// CHECK: } // namespace Extended
+
+// CHECK: namespace FrozenEmpty {
+// CHECK:   SWIFT_INLINE_THUNK swift::Int id() SWIFT_SYMBOL(
+// CHECK: } // namespace FrozenEmpty
+
+// CHECK: namespace Padding {
+// CHECK: } // namespace Padding
+
+// CHECK: namespace Utils {
+// CHECK:   using Helper=__UtilsNested::Helper;
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getAnswer() SWIFT_SYMBOL(
+// CHECK: } // namespace Utils
+
+// CHECK: class SWIFT_SYMBOL({{.*}}) WithPadding final {
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getValue()
+
+// `static` must NOT appear here — at namespace scope it would mean internal
+// linkage. The accessor is a normal inline function in the namespace.
+// CHECK: namespace WithStaticVar {
+// CHECK-NOT: static
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getAnswer() SWIFT_SYMBOL(
+// CHECK: } // namespace WithStaticVar
+
+// CHECK: SWIFT_INLINE_THUNK void returnsEmpty() {{.*}}SWIFT_NORETURN
+
+// Generic empty enum becomes an unavailable stub.
+// CHECK: class GenericEmpty { } SWIFT_UNAVAILABLE_MSG(
+
+// CHECK: class Nested { } SWIFT_UNAVAILABLE_MSG("empty enum cannot be represented as a namespace");
+// CHECK: class NestedInClass { } SWIFT_UNAVAILABLE_MSG("empty enum cannot be represented as a namespace");
+
+// CHECK: // Unavailable in C++: Swift global function 'takesArray
+// CHECK: // Unavailable in C++: Swift global function 'takesEmpty
+// CHECK: // Unavailable in C++: Swift global function 'takesOptional
+// CHECK: // Unavailable in C++: Swift global function 'takesTuple

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -36,25 +36,8 @@ public enum Empty {
 
 }
 
-// CHECK:         // Tags for resilient enum Empty
-// CHECK-NEXT:    extern "C" {
-// CHECK-NEXT:    }
-// CHECK-EMPTY:
-// CHECK-NEXT:    } // namespace _impl
-// CHECK-EMPTY:
-// CHECK-NEXT:    class SWIFT_SYMBOL("s:5Enums5EmptyO") Empty final {
-// CHECK:         enum class cases {
-// CHECK-NEXT:      unknownDefault
-// CHECK-NEXT:    };
-// CHECK:         inline const static struct _impl_unknownDefault {  // impl struct for case unknownDefault
-// CHECK-NEXT:      SWIFT_INLINE_THUNK constexpr operator cases() const {
-// CHECK-NEXT:        return cases::unknownDefault;
-// CHECK-NEXT:      }
-// CHECK-NEXT:    } unknownDefault;
-// CHECK-NEXT:    SWIFT_INLINE_THUNK bool isUnknownDefault() const;
-// CHECK:         SWIFT_INLINE_THUNK operator cases() const {
-// CHECK-NEXT:      return cases::unknownDefault;
-// CHECK-NEXT:    }
+// CHECK:         namespace Empty {
+// CHECK:         } // namespace Empty
 // CHECK:         // Tags for resilient enum Foo
 // CHECK-NEXT:    extern "C" {
 // CHECK-NEXT:    extern unsigned $s5Enums3FooO1ayACSdcACmFWC;

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
@@ -12,6 +12,7 @@
 // REQUIRES: executable_test
 
 #include "structs.h"
+#include <iostream>
 
 int main() {
   using namespace Structs;
@@ -21,4 +22,6 @@ int main() {
 
   auto xx = makeAudioFileType();
   AudioFileType::SubType yy = xx.getCAF();
+  auto xxx = Empty::getInt();
+  Empty::NestedInEmpty *ptr = nullptr;
 }

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -53,6 +53,10 @@ public class AuxConfig {
     }
 
     public var directory = AuxDirectory()
+
+    public enum Empty {
+        public static func getInt() -> Int { 55 }
+    }
 }
 
 public func makeRecordConfig() -> RecordConfig {
@@ -85,6 +89,26 @@ extension AudioFileType {
     }
 }
 
+public enum Empty {
+    public static func getInt() -> Int { 42 }
+
+    public struct NestedInEmpty {
+        public var x : Int
+    }
+}
+
+public enum Padding {
+    // Swift requires enum inits to never return; Padding is uninhabited.
+    public init() { fatalError("Padding is uninhabited") }
+}
+public struct MyStruct {
+    public let p1: Padding
+    public let someField: Int
+    public init() {
+        self.someField = 42
+        self.p1 = Padding()
+    }
+}
 
 public func getFiles() -> [RecordConfig.File] {
     []

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -35,11 +35,11 @@ public func f() -> ZeroSizedStruct {
 public func g(x: ZeroSizedStruct) {
 }
 
-// CHECK: class ZeroSizedEnum { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum' is a zero sized value type, it cannot be exposed to C++ yet");
+// CHECK: namespace ZeroSizedEnum
 
 // CHECK: class ZeroSizedEnum2 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum2' is a zero sized value type, it cannot be exposed to C++ yet");
 
-// CHECK: class ZeroSizedEnum3 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum3' is a zero sized value type, it cannot be exposed to C++ yet");
+// CHECK: class ZeroSizedEnum3 { } SWIFT_UNAVAILABLE_MSG("enum 'ZeroSizedEnum3' can not yet be represented in C++ as one of its cases has multiple associated values");
 
 // CHECK: class ZeroSizedStruct { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedStruct' is a zero sized value type, it cannot be exposed to C++ yet");
 


### PR DESCRIPTION
It is a common idiom in Swift to use empty enums as namespaces. Previously, we just exported all zero sized types as unavailable declarations so users had no way to access anything in these "namespaces". This PR changes reverse interop to treat empty enums as namespaces.

rdar://147499583