### PR TITLE
[Cmake] Use correct magic symbols file for Concurrency

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(swift_Concurrency
   ThreadingError.cpp
   TracingSignpost.cpp
   "${PROJECT_SOURCE_DIR}/CompatibilityOverride/CompatibilityOverride.cpp"
-  "${PROJECT_SOURCE_DIR}/linker-support/magic-symbols-for-install-name.c"
+  "./linker-support/magic-symbols-for-install-name.c"
   Actor.swift
   AsyncCompactMapSequence.swift
   AsyncDropFirstSequence.swift


### PR DESCRIPTION
We want to use [this magic symbols file](https://github.com/swiftlang/swift/blob/main/stdlib/public/Concurrency/linker-support/magic-symbols-for-install-name.c), not [this one](https://github.com/swiftlang/swift/blob/main/stdlib/linker-support/magic-symbols-for-install-name.c).

Outstanding question: Do we need both?