### PR TITLE
[ConstraintSystem] Adjust `isArgumentOfImportedDecl` to handle synthesized declarations

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -522,6 +522,8 @@ SwiftDeclSynthesizer::createDefaultConstructor(NominalTypeDecl *structDecl) {
   // Mark the constructor transparent so that we inline it away completely.
   constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
 
+  constructor->setSynthesized();
+
   constructor->setBodySynthesizer(synthesizeStructDefaultConstructorBody,
                                   structDecl);
 
@@ -651,6 +653,8 @@ ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
 
   // Make the constructor transparent so we inline it away completely.
   constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
+
+  constructor->setSynthesized();
 
   if (wantBody) {
     auto memberMemory =
@@ -1294,6 +1298,7 @@ SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
                               /*ThrownType=*/TypeLoc(), paramPL,
                               /*GenericParams=*/nullptr, enumDecl);
   ctorDecl->setImplicit();
+  ctorDecl->setSynthesized();
   ctorDecl->copyFormalAccessFrom(enumDecl);
   ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
   return ctorDecl;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4437,7 +4437,22 @@ bool ConstraintSystem::isArgumentOfImportedDecl(
     return false;
 
   auto *choice = overload->choice.getDecl();
-  return choice->hasClangNode();
+
+  // Imported declaration.
+  if (choice->hasClangNode())
+    return true;
+
+  // Implicit declaration synthesized by the compiler.
+  // Such declarations don't have clang nodes backing
+  // them but for the purposes of this check we consider
+  // them imported if the parent is.
+  if (choice->isSynthesized()) {
+    auto *dc = choice->getDeclContext();
+    if (auto *parent = dc->getAsDecl())
+      return parent->hasClangNode();
+  }
+
+  return false;
 }
 
 ConversionEphemeralness

--- a/test/Constraints/swift_to_c_pointer_conversions_in_synthesized.swift
+++ b/test/Constraints/swift_to_c_pointer_conversions_in_synthesized.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+
+//--- Test.h
+#include <stdint.h>
+
+typedef struct {
+    uint8_t* buffer;
+} frame_t __attribute__((swift_name("Frame")));
+
+//--- main.swift
+func test(rawPointer: UnsafeMutableRawPointer) {
+  _ = Frame(buffer: rawPointer) // Ok (even though init is synthesized the type is imported)
+}


### PR DESCRIPTION
If the declaration was synthesized for an imported type,
let's consider it imported as well even though there is
no direct clang declaration backing it.

This allows us to support features like pointer conversions
that are gated on the declarations being imported from C.

Resolves: https://github.com/swiftlang/swift/issues/83221
Resolves: rdar://156356307

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
