### PR TITLE
Update swift compiler after clang gmodule CAS build update

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -143,11 +143,12 @@ public:
         auto &dep = cache.findKnownDependency(bridgingDep);
         auto *clangDep = dep.getAsClangModule();
         assert(clangDep && "wrong module dependency kind");
+        auto pcmPath = llvm::sys::path::filename(clangDep->mappedPCMPath).str();
         if (!clangDep->moduleCacheKey.empty()) {
           bridgingHeaderBuildCmd.push_back("-Xcc");
           bridgingHeaderBuildCmd.push_back("-fmodule-file-cache-key");
           bridgingHeaderBuildCmd.push_back("-Xcc");
-          bridgingHeaderBuildCmd.push_back(clangDep->mappedPCMPath);
+          bridgingHeaderBuildCmd.push_back(pcmPath);
           bridgingHeaderBuildCmd.push_back("-Xcc");
           bridgingHeaderBuildCmd.push_back(clangDep->moduleCacheKey);
         }
@@ -277,17 +278,21 @@ private:
   bool handleClangModuleDependency(
       ModuleDependencyID depModuleID,
       const ClangModuleDependencyStorage &clangDepDetails) {
+    auto pcmPath =
+        clangDepDetails.moduleCacheKey.empty()
+            ? clangDepDetails.mappedPCMPath
+            : llvm::sys::path::filename(clangDepDetails.mappedPCMPath).str();
     if (!resolvingDepInfo.isSwiftSourceModule()) {
       if (!resolvingDepInfo.isClangModule()) {
         commandline.push_back("-Xcc");
         commandline.push_back("-fmodule-file=" + depModuleID.ModuleName + "=" +
-                              clangDepDetails.mappedPCMPath);
+                              pcmPath);
       }
       if (!clangDepDetails.moduleCacheKey.empty()) {
         commandline.push_back("-Xcc");
         commandline.push_back("-fmodule-file-cache-key");
         commandline.push_back("-Xcc");
-        commandline.push_back(clangDepDetails.mappedPCMPath);
+        commandline.push_back(pcmPath);
         commandline.push_back("-Xcc");
         commandline.push_back(clangDepDetails.moduleCacheKey);
       }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -929,10 +929,10 @@ private:
         // Note: The implementation here assumes that all clang submodules
         //       belong to the same PCM file.
         ASTSourceDescriptor ParentDescriptor(*ClangModule->Parent);
-        Parent = getOrCreateModule({ParentDescriptor.getModuleName(),
-                                    ParentDescriptor.getPath(),
-                                    Desc.getASTFile(), Desc.getSignature()},
-                                   ClangModule->Parent);
+        Parent = getOrCreateModule(
+            {ParentDescriptor.getModuleName(), ParentDescriptor.getPath(),
+             Desc.getASTFile(), Desc.getSignature(), /*CASID=*/""},
+            ClangModule->Parent);
       }
       return getOrCreateModule(ClangModule, Parent, Desc.getModuleName(),
                                IncludePath, Signature, Desc.getASTFile());
@@ -2594,11 +2594,11 @@ private:
           // Describe the submodule, but substitute the cached ASTFile from
           // the toplevel module. The ASTFile pointer in SubModule may be
           // dangling and cant be trusted.
-          Scope = getOrCreateModule({SubModuleDesc->getModuleName(),
-                                     SubModuleDesc->getPath(),
-                                     TopLevelModuleDesc->getASTFile(),
-                                     TopLevelModuleDesc->getSignature()},
-                                    SubModuleDesc->getModuleOrNull());
+          Scope = getOrCreateModule(
+              {SubModuleDesc->getModuleName(), SubModuleDesc->getPath(),
+               TopLevelModuleDesc->getASTFile(),
+               TopLevelModuleDesc->getSignature(), /*CASID=*/""},
+              SubModuleDesc->getModuleOrNull());
         else if (SubModuleDesc->getModuleOrNull() == nullptr)
           // This is (bridging header) PCH.
           Scope = getOrCreateModule(*SubModuleDesc, nullptr);

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -18,13 +18,13 @@
 // CHECK:         "-dwarf-ext-refs"
 // CHECK:         "-fmodule-file-cache-key",
 // CHECK-NEXT:    "-Xcc",
-// CHECK-NEXT:    "{{.*}}{{/|\\}}A-{{.*}}.pcm",
+// CHECK-NEXT:    "A-{{.*}}.pcm",
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "llvmcas://{{.*}}",
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "-fmodule-file-cache-key",
 // CHECK-NEXT:    "-Xcc",
-// CHECK-NEXT:    "{{.*}}{{/|\\}}B-{{.*}}.pcm",
+// CHECK-NEXT:    "B-{{.*}}.pcm",
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "llvmcas://{{.*}}"
 

--- a/test/CAS/debug_info_pcm.swift
+++ b/test/CAS/debug_info_pcm.swift
@@ -16,8 +16,7 @@
 
 // RUN: dwarfdump --debug-info @%t/A.path | %FileCheck %s
 
-// CHECK: DW_AT_GNU_dwo_name
-// CHECK-SAME: TMP_DIR
+// CHECK: DW_AT_GNU_dwo_name ("llvmcas://{{.*}}")
 
 //--- test.swift
 import A

--- a/test/CAS/module_path_remap.swift
+++ b/test/CAS/module_path_remap.swift
@@ -14,7 +14,7 @@
 // DEPS-FS: /^src/test/CAS/module_path_remap.swift
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps bridgingHeader | %FileCheck %s -check-prefix DEPS-BRIDGING
-// DEPS-BRIDGING: -fmodule-file=F=/^tmp/clang-module-cache/F-{{.*}}.pcm
+// DEPS-BRIDGING: -fmodule-file=F=F-{{.*}}.pcm
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json F casFSRootID > %t/F.fs.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/F.fs.casid | %FileCheck %s -check-prefix F-FS
@@ -22,7 +22,7 @@
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json F commandLine | %FileCheck %s -check-prefix F-CMD
 // F-CMD: /^src/test/CAS/../ScanDependencies/Inputs/Swift/F.swiftinterface
-// F-CMD: -fmodule-file=SwiftShims=/^tmp/clang-module-cache/SwiftShims-{{.*}}.pcm
+// F-CMD: -fmodule-file=SwiftShims=SwiftShims-{{.*}}.pcm
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/tree.casid
 // RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/tree.casid | %FileCheck %s -check-prefix TREE

--- a/test/ScanDependencies/clang_module_output_symlink.swift
+++ b/test/ScanDependencies/clang_module_output_symlink.swift
@@ -12,7 +12,7 @@
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
-// CHECK:      "-fmodule-file=C=[[PCM_PATH:.*symlink.*C-.*.pcm]]"
+// CHECK:      "-fmodule-file=C=[[PCM_PATH:C-.*.pcm]]"
 // CHECK:      "-fmodule-file-cache-key"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "[[PCM_PATH]]"


### PR DESCRIPTION
Fix swift compiler build and test to work with new clang gmodule build with CAS, which encodes references to clang PCMs as CASIDs in https://github.com/swiftlang/llvm-project/pull/11026.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
