### PR TITLE
build.ps1: enable the C++ interop on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2577,6 +2577,8 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
 
         SwiftCore_DIR = "${RuntimeBinaryCache}\cmake\SwiftCore";
+
+        SwiftOverlay_ENABLE_CXX_INTEROP = "YES";
       }
 
     Build-CMakeProject `


### PR DESCRIPTION
With the last changes to the C++ interop support in the new runtimes build, the default on Windows matches what it is on Apple platforms. Explicitly opt into the C++ overlay build on Windows.