### PR TITLE
[SemanticARCOpts] Fix miscompile at dead-ends.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -630,6 +630,21 @@ struct BorrowedValue {
   /// necessarilly dominated by the borrow scope.
   void computeTransitiveLiveness(MultiDefPrunedLiveness &liveness) const;
 
+  /// Whether \p insts are completely within this borrow introducer's local
+  /// scope.
+  ///
+  /// Precondition: \p insts are dominated by the local borrow introducer.
+  ///
+  /// This ignores reborrows. The assumption is that, since \p insts are
+  /// dominated by this local scope, checking the extended borrow scope should
+  /// not be necessary to determine they are within the scope.
+  ///
+  /// \p deadEndBlocks is optional during transition. It will be completely
+  /// removed in an upcoming commit.
+  template <typename Instructions>
+  bool areWithinExtendedScope(Instructions insts,
+                              DeadEndBlocks *deadEndBlocks) const;
+
   /// Returns true if \p uses are completely within this borrow introducer's
   /// local scope.
   ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1441,6 +1441,43 @@ bool isRedundantMoveValue(MoveValueInst *mvi);
 /// `forEndBorrowValue`, which is the operand value of an `end_borrow`.
 void updateReborrowFlags(SILValue forEndBorrowValue);
 
+/// A location at which a value is used.  Abstracts over explicit uses
+/// (operands) and implicit uses (instructions).
+struct UsePoint {
+  using Value = llvm::PointerUnion<SILInstruction *, Operand *>;
+  Value value;
+
+  UsePoint(Operand *op) : value(op) {}
+  UsePoint(SILInstruction *inst) : value(inst) {}
+  UsePoint(Value value) : value(value) {}
+
+  SILInstruction *getInstruction() const {
+    if (auto *op = dyn_cast<Operand *>(value)) {
+      return op->getUser();
+    }
+    return cast<SILInstruction *>(value);
+  }
+
+  Operand *getOperandOrNull() const { return dyn_cast<Operand *>(value); }
+
+  Operand *getOperand() const { return cast<Operand *>(value); }
+};
+
+struct UsePointToInstruction {
+  SILInstruction *operator()(const UsePoint point) const {
+    return point.getInstruction();
+  }
+};
+
+using UsePointInstructionRange =
+    TransformRange<ArrayRef<UsePoint>, UsePointToInstruction>;
+
+struct PointToOperand {
+  Operand *operator()(const UsePoint point) const { return point.getOperand(); }
+};
+
+using PointOperandRange = TransformRange<ArrayRef<UsePoint>, PointToOperand>;
+
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -729,6 +729,20 @@ public:
   bool isWithinBoundary(SILInstruction *inst,
                         DeadEndBlocks *deadEndBlocks) const;
 
+  /// Whether all \p insts are between this def and the liveness boundary;
+  /// \p deadEndBlocks is optional.
+  template <typename Instructions>
+  bool areWithinBoundary(Instructions insts,
+                         DeadEndBlocks *deadEndBlocks) const {
+    assert(asImpl().isInitialized());
+
+    for (auto *inst : insts) {
+      if (!isWithinBoundary(inst, deadEndBlocks))
+        return false;
+    }
+    return true;
+  };
+
   /// Returns true when all \p uses are between this def and the liveness
   /// boundary \p deadEndBlocks is optional.
   bool areUsesWithinBoundary(ArrayRef<Operand *> uses,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -670,6 +670,10 @@ public:
   using TransformedOperandValueRange =
     OptionalTransformRange<ArrayRef<Operand>, OperandToTransformedValue>;
 
+  /// Functor for Operand::getUser()
+  struct OperandToUser;
+  using OperandUserRange = TransformRange<ArrayRef<Operand *>, OperandToUser>;
+
   static OperandValueRange getOperandValues(ArrayRef<Operand*> operands);
 
   OperandRefValueRange getOperandValues() const;
@@ -1018,6 +1022,12 @@ struct SILInstruction::OperandToValue {
 struct SILInstruction::OperandRefToValue {
   SILValue operator()(const Operand &use) const {
     return use.get();
+  }
+};
+
+struct SILInstruction::OperandToUser {
+  SILInstruction *operator()(const Operand *use) const {
+    return const_cast<Operand *>(use)->getUser();
   }
 };
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -992,6 +992,9 @@ bool BorrowedValue::areWithinExtendedScope(Instructions insts,
   return liveness.areWithinBoundary(insts, deadEndBlocks);
 }
 
+template bool BorrowedValue::areWithinExtendedScope<UsePointInstructionRange>(
+    UsePointInstructionRange insts, DeadEndBlocks *deadEndBlocks) const;
+
 template bool
 BorrowedValue::areWithinExtendedScope<SILInstruction::OperandUserRange>(
     SILInstruction::OperandUserRange insts, DeadEndBlocks *deadEndBlocks) const;

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -975,8 +975,9 @@ computeTransitiveLiveness(MultiDefPrunedLiveness &liveness) const {
   });
 }
 
-bool BorrowedValue::areUsesWithinExtendedScope(
-    ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
+template <typename Instructions>
+bool BorrowedValue::areWithinExtendedScope(Instructions insts,
+                                           DeadEndBlocks *deadEndBlocks) const {
   // First make sure that we actually have a local scope. If we have a non-local
   // scope, then we have something (like a SILFunctionArgument) where a larger
   // semantic construct (in the case of SILFunctionArgument, the function
@@ -988,7 +989,17 @@ bool BorrowedValue::areUsesWithinExtendedScope(
   // Compute the local scope's liveness.
   MultiDefPrunedLiveness liveness(value->getFunction());
   computeTransitiveLiveness(liveness);
-  return liveness.areUsesWithinBoundary(uses, deadEndBlocks);
+  return liveness.areWithinBoundary(insts, deadEndBlocks);
+}
+
+template bool
+BorrowedValue::areWithinExtendedScope<SILInstruction::OperandUserRange>(
+    SILInstruction::OperandUserRange insts, DeadEndBlocks *deadEndBlocks) const;
+
+bool BorrowedValue::areUsesWithinExtendedScope(
+    ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
+  SILInstruction::OperandUserRange users(uses, SILInstruction::OperandToUser());
+  return areWithinExtendedScope(users, deadEndBlocks);
 }
 
 // The visitor \p func is only called on final scope-ending uses, not reborrows.

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -796,14 +796,8 @@ static FunctionTest SSAPrunedLiveness__areUsesWithinBoundary(
 template <typename LivenessWithDefs>
 bool PrunedLiveRange<LivenessWithDefs>::areUsesWithinBoundary(
     ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
-  assert(asImpl().isInitialized());
-
-  for (auto *use : uses) {
-    auto *user = use->getUser();
-    if (!isWithinBoundary(user, deadEndBlocks))
-      return false;
-  }
-  return true;
+  SILInstruction::OperandUserRange users(uses, SILInstruction::OperandToUser());
+  return areWithinBoundary(users, deadEndBlocks);
 }
 
 template <typename LivenessWithDefs>

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -27,6 +27,7 @@
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/Projection.h"
+#include "swift/SIL/Test.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
@@ -827,6 +828,20 @@ bool SemanticARCOptVisitor::tryPerformOwnedCopyValueOptimization(
   eraseAndRAUWSingleValueInstruction(cvi, cvi->getOperand());
   return true;
 }
+
+namespace swift::test {
+static FunctionTest SemanticARCOptsCopyValueOptsGuaranteedValueOptTest(
+    "semantic_arc_opts__copy_value_opts__guaranteed_value_opt",
+    [](auto &function, auto &arguments, auto &test) {
+      SemanticARCOptVisitor visitor(function, test.getPassManager(),
+                                    *test.getDeadEndBlocks(),
+                                    /*onlyMandatoryOpts=*/false);
+
+      visitor.performGuaranteedCopyValueOptimization(
+          cast<CopyValueInst>(arguments.takeInstruction()));
+      function.print(llvm::errs());
+    });
+} // end namespace swift::test
 
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -170,7 +170,7 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
         return borrowScope.isLocalScope();
       });
 
-  auto destroys = lr.getDestroyingUses();
+  auto destroys = lr.getDestroyingInsts();
   if (destroys.empty() && haveAnyLocalScopes) {
     return false;
   }
@@ -196,8 +196,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
   // block.
   {
     if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
-          return !borrowScope.areUsesWithinExtendedScope(
-              lr.getAllConsumingUses(), nullptr);
+          return !borrowScope.areWithinExtendedScope(lr.getAllConsumingInsts(),
+                                                     nullptr);
         })) {
       LLVM_DEBUG(llvm::dbgs() << "copy_value is extending borrow introducer "
                                  "lifetime, bailing out\n");
@@ -238,8 +238,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
       }
 
       if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
-            return !borrowScope.areUsesWithinExtendedScope(
-                phiArgLR.getAllConsumingUses(), nullptr);
+            return !borrowScope.areWithinExtendedScope(
+                phiArgLR.getAllConsumingInsts(), nullptr);
           })) {
         return false;
       }

--- a/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
@@ -212,7 +212,11 @@ bool swift::semanticarc::tryConvertOwnedPhisToGuaranteedPhis(Context &ctx) {
     SmallVector<std::pair<SILValue, unsigned>, 8> incomingValueUpdates;
     for (auto introducer : ownedValueIntroducers) {
       SILValue v = introducer.value;
-      OwnershipLiveRange lr(v);
+      SmallVector<std::pair<Operand *, SILValue>, 4> extraConsumes;
+      for (auto op : incomingValueOperandList) {
+        extraConsumes.push_back({op.getOperand(), op.getOriginal()});
+      }
+      OwnershipLiveRange lr(v, extraConsumes);
 
       // For now, we only handle copy_value for simplicity.
       //

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -363,12 +363,14 @@ OwnershipLiveRange::hasUnknownConsumingUse(bool assumingAtFixPoint) const {
   return HasConsumingUse_t::YesButAllPhiArgs;
 }
 
-OwnershipLiveRange::DestroyingInstsRange
+SILInstruction::OperandUserRange
 OwnershipLiveRange::getDestroyingInsts() const {
-  return DestroyingInstsRange(getDestroyingUses(), OperandToUser());
+  return SILInstruction::OperandUserRange(getDestroyingUses(),
+                                          SILInstruction::OperandToUser());
 }
 
-OwnershipLiveRange::ConsumingInstsRange
+SILInstruction::OperandUserRange
 OwnershipLiveRange::getAllConsumingInsts() const {
-  return ConsumingInstsRange(consumingUses, OperandToUser());
+  return SILInstruction::OperandUserRange(consumingUses,
+                                          SILInstruction::OperandToUser());
 }

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
@@ -94,7 +94,8 @@ class LLVM_LIBRARY_VISIBILITY OwnershipLiveRange {
   ArrayRef<UsePoint> unknownConsumingUses;
 
 public:
-  OwnershipLiveRange(SILValue value);
+  OwnershipLiveRange(SILValue value,
+                     ArrayRef<std::pair<Operand *, SILValue>> extraUses = {});
   OwnershipLiveRange(const OwnershipLiveRange &) = delete;
   OwnershipLiveRange &operator=(const OwnershipLiveRange &) = delete;
 

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
@@ -113,17 +113,9 @@ public:
     return unknownConsumingUses;
   }
 
-private:
-  struct OperandToUser;
+  SILInstruction::OperandUserRange getDestroyingInsts() const;
 
-public:
-  using DestroyingInstsRange =
-      TransformRange<ArrayRef<Operand *>, OperandToUser>;
-  DestroyingInstsRange getDestroyingInsts() const;
-
-  using ConsumingInstsRange =
-      TransformRange<ArrayRef<Operand *>, OperandToUser>;
-  ConsumingInstsRange getAllConsumingInsts() const;
+  SILInstruction::OperandUserRange getAllConsumingInsts() const;
 
   /// If this LiveRange has a single destroying use, return that use. Otherwise,
   /// return nullptr.
@@ -198,16 +190,6 @@ public:
                                   DeadEndBlocks &deadEndBlocks,
                                   ValueLifetimeAnalysis::Frontier &scratch);
 };
-
-struct OwnershipLiveRange::OperandToUser {
-  OperandToUser() {}
-
-  SILInstruction *operator()(const Operand *use) const {
-    auto *nonConstUse = const_cast<Operand *>(use);
-    return nonConstUse->getUser();
-  }
-};
-
 } // namespace semanticarc
 } // namespace swift
 

--- a/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
@@ -36,6 +36,7 @@ public:
 
 private:
   Operand *op;
+  SILValue original;
 
   OwnershipPhiOperand(Operand *op) : op(op) {}
 
@@ -70,10 +71,14 @@ public:
   Operand *getOperand() const { return op; }
   SILValue getValue() const { return op->get(); }
   SILType getType() const { return op->get()->getType(); }
+  SILValue getOriginal() const { return original; }
 
   unsigned getOperandNumber() const { return op->getOperandNumber(); }
 
-  void markUndef() & { op->set(SILUndef::get(getValue())); }
+  void markUndef() & {
+    original = op->get();
+    op->set(SILUndef::get(getValue()));
+  }
 
   SILInstruction *getInst() const { return op->getUser(); }
 

--- a/test/SILOptimizer/semantic-arc-opts-unit.sil
+++ b/test/SILOptimizer/semantic-arc-opts-unit.sil
@@ -1,0 +1,41 @@
+// RUN: not --crash %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct Inner {
+  var o: Builtin.NativeObject
+}
+struct Outer {
+  var inner: Inner
+}
+
+// CHECK-LABEL: sil [ossa] @check_keep_copy_required_to_destroy_at_unreachable : {{.*}} {
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'check_keep_copy_required_to_destroy_at_unreachable'
+sil [ossa] @check_keep_copy_required_to_destroy_at_unreachable : $@convention(thin) (@in_guaranteed Outer) -> () {
+entry(%o_addr : $*Outer):
+  %o_copy = load [copy] %o_addr : $*Outer
+  %o_borrow = begin_borrow %o_copy : $Outer
+  %i = struct_extract %o_borrow : $Outer, #Outer.inner
+  %i_copy = copy_value %i : $Inner
+  specify_test "semantic_arc_opts__copy_value_opts__guaranteed_value_opt %i_copy"
+  (%o2_addr, %token) = begin_apply undef(%i_copy) : $@yield_once @convention(thin) (@guaranteed Inner) -> @yields @inout Outer
+  try_apply undef(%o2_addr) : $@convention(thin) (@inout Outer) -> @error any Error, normal success, error failure
+
+success(%empty : $()):
+  end_apply %token as $()
+  destroy_value %i_copy : $Inner
+  end_borrow %o_borrow : $Outer
+  destroy_value %o_copy : $Outer
+  return undef : $()
+
+failure(%error : @owned $any Error):
+  end_borrow %o_borrow : $Outer
+  destroy_value %error : $any Error
+  end_apply %token as $()
+  destroy_value [dead_end] %o_copy : $Outer
+  unreachable
+}

--- a/test/SILOptimizer/semantic-arc-opts-unit.sil
+++ b/test/SILOptimizer/semantic-arc-opts-unit.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
Without complete OSSA lifetimes, a value may have an "incomplete lifetime"--it may not be destroyed on paths into dead-end regions.  When a value lacks a destroy on a path into a dead-end region, it is effectively destroyed at its availability boundary (e.g. an `unreachable` instruction). Indeed, lifetime completion amounts to making such implicit destroys explicit (with correct nesting).

`SemanticARCOpts`' `performGuaranteedCopyValueOptimization` attempts to eliminate a `copy_value` of a guaranteed value.  To do so, it computes the live range (`OwnershipLiveRange`) of the `copy_value`.  Among other things, it checks that all destroys of the `copy_value` are within the scope of all guaranteed bases of the copied value.  If any destroys are _not_ within any of those scopes, the copy cannot be eliminated (because the copy would have been originally live beyond the range which it would be live in after copy elimination).

A value with an incomplete lifetime is implicitly destroyed at its availability boundary.  So those implicit destroys along the availability boundary must _also_ be within the scopes of those guaranteed bases.

Previously, implicit destroys along availability boundaries were not considered.  This resulted in invalid shortening of lifetimes--before the transformation a value would be unconsumed up to its availability boundary; after the transformation it would be consumed somewhere before that.  For example:

```
sil [ossa] @f : $@convention(thin) (@owned Outer) -> () {
entry(%o : $*Outer):
  %o_borrow = begin_borrow %o : $Outer
  %i = struct_extract %o_borrow : $Outer, #Outer.inner
  %i_copy = copy_value %i : $Inner
  end_borrow %o_borrow : $Outer
  destroy_value %o : $Outer
  apply @g(%i_copy) : $@convention(thin) (@guaranteed Inner) -> ()
  unreachable // %i_copy implicitly destroyed
}
```

Here, `%i_copy` is implicitly destroyed at `unreachable` but `%i` is consumed at the scope end of `%o_borrow`.  That means that an attempt to RAUW `%i_copy` with `%i` would be invalid because uses of `%i_copy` may be outside the live range of `%i`.

(Note that this happens not to occur in the above example because there's a bailout in the case that there are no destroys, but perturbing the example to include a `cond_br` on one branch of which the value is destroyed results in the miscompile described above.)

Here, this is fixed by adding the instructions on the availability boundary at which the value is implicitly destroyed to the live range. Do this by adding the instructions on the availability boundary of each def from which the live range is generated to the live range.

One wrinkle is that the OwnershipLiveRange utility is used in one place by a utility when SIL is in an invalid state (phi uses have been replaced with undef so values leaks on those paths).  Account for this by manually fixing up the liveness instance passed to the lifetime completion utility.

rdar://157291161
