### PR TITLE
[CSDiagnostics] Prevent nested type references in KeyPath components

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -681,6 +681,9 @@ ERROR(expr_keypath_nonescapable_type,none,
 ERROR(expr_keypath_not_property,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %kind0",
       (const ValueDecl *, bool))
+ERROR(expr_keypath_type_ref,none,
+      "%select{key path|dynamic key path member lookup}1 cannot refer to type %0",
+      (const ValueDecl *, bool))
 ERROR(expr_keypath_mutating_getter,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %0, "
       "which has a mutating getter",

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2024,6 +2024,8 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
     AsyncOrThrowsMethod,
     // Allow a reference to an enum case as a key path component.
     EnumCase,
+    // Allow a reference to a type as a key path component.
+    TypeReference,
   } Kind;
 
   ValueDecl *Member;
@@ -2056,6 +2058,8 @@ public:
     case RefKind::AsyncOrThrowsMethod:
       return "allow reference to async or throwing method as a key path "
              "component";
+    case RefKind::TypeReference:
+      return "allow reference to a type as a key path component";
     }
     llvm_unreachable("covered switch");
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6485,6 +6485,12 @@ bool InvalidAsyncOrThrowsMethodRefInKeyPath::diagnoseAsError() {
   return true;
 }
 
+bool InvalidTypeRefInKeyPath::diagnoseAsError() {
+  emitDiagnostic(diag::expr_keypath_type_ref, getMember(),
+                 isForKeyPathDynamicMemberLookup());
+  return true;
+}
+
 SourceLoc InvalidUseOfAddressOf::getLoc() const {
   auto anchor = getAnchor();
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1889,6 +1889,27 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to reference a type as a key path component
+/// e.g.
+///
+/// ```swift
+/// struct S {
+///   enum Q {}
+/// }
+///
+/// _ = \S.Type.Q
+/// ```
+class InvalidTypeRefInKeyPath final : public InvalidMemberRefInKeyPath {
+public:
+  InvalidTypeRefInKeyPath(const Solution &solution, ValueDecl *member,
+                          ConstraintLocator *locator)
+      : InvalidMemberRefInKeyPath(solution, member, locator) {
+    assert(isa<TypeDecl>(member));
+  }
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose an attempt to reference a member which has a mutating getter as a
 /// key path component e.g.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1288,6 +1288,10 @@ bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
                                                    getLocator());
     return failure.diagnose(asNote);
   }
+  case RefKind::TypeReference: {
+    InvalidTypeRefInKeyPath failure(solution, Member, getLocator());
+    return failure.diagnose(asNote);
+  }
   }
   llvm_unreachable("covered switch");
 }
@@ -1384,6 +1388,11 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, Type baseType,
   // Referencing initializers in key path is not currently allowed.
   if (isa<ConstructorDecl>(member))
     return AllowInvalidRefInKeyPath::create(cs, baseType, RefKind::Initializer,
+                                            member, locator);
+
+  // Referencing types in key path is not currently allowed.
+  if (isa<TypeDecl>(member))
+    return AllowInvalidRefInKeyPath::create(cs, baseType, RefKind::TypeReference,
                                             member, locator);
 
   return nullptr;

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1429,3 +1429,14 @@ func testKeyPathInout() {
   takesInoutOpt(\.count)
   takesInoutOpt(\String.count)
 }
+
+func testKeypathWithTypeReference() {
+  struct S {
+    enum Q {
+          static let i = 1
+    }
+  }
+  _ = \S.Q.Type.i // okay
+
+  _ = \S.Type.Q // expected-error {{key path cannot refer to type 'Q'}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1433,7 +1433,7 @@ func testKeyPathInout() {
 func testKeypathWithTypeReference() {
   struct S {
     enum Q {
-          static let i = 1
+      static let i = 1
     }
   }
   _ = \S.Q.Type.i // okay


### PR DESCRIPTION
This change adds detection for nested type references in KeyPath components and applies the appropriate fix to generate meaningful error messages, following the same pattern already established for method references.

The fix ensures that invalid KeyPath references fail gracefully in normal mode and provide helpful diagnostics in diagnostic mode, improving the developer experience when working with KeyPaths.

Resolves: https://github.com/swiftlang/swift/issues/83197