### PR TITLE
[stdlib] Make non-frozen types BitwiseCopyable

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -22,9 +22,9 @@ import Swift
 /// This clock is suitable for high resolution measurements of execution.
 @available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
-public struct ContinuousClock: Sendable {
+public struct ContinuousClock: BitwiseCopyable, Sendable {
   /// A continuous point in time used for `ContinuousClock`.
-  public struct Instant: Sendable {
+  public struct Instant: BitwiseCopyable, Sendable {
     internal var _value: Swift.Duration
 
     internal init(_value: Swift.Duration) {

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -22,8 +22,8 @@ import Swift
 /// This clock is suitable for high resolution measurements of execution.
 @available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
-public struct SuspendingClock: Sendable {
-  public struct Instant: Sendable {
+public struct SuspendingClock: BitwiseCopyable, Sendable {
+  public struct Instant: BitwiseCopyable, Sendable {
     internal var _value: Swift.Duration
 
     internal init(_value: Swift.Duration) {

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2015 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@
 #if os(Linux) || os(Android)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode: Int32, Sendable {
+public enum POSIXErrorCode: Int32, BitwiseCopyable, Sendable {
   /// Operation not permitted.
   case EPERM           = 1
   /// No such file or directory.
@@ -308,7 +308,7 @@ public enum POSIXErrorCode: Int32, Sendable {
 // Matches WASI-libc declarations at https://github.com/WebAssembly/wasi-libc/blob/ad513341/libc-bottom-half/headers/public/wasi/api.h#L106
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode: Int32, Sendable {
+public enum POSIXErrorCode: Int32, BitwiseCopyable, Sendable {
   /// Argument list too long.
   case E2BIG           = 1
   /// Permission denied.
@@ -474,7 +474,7 @@ public enum POSIXErrorCode: Int32, Sendable {
 #elseif os(Windows)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode: Int32, Sendable {
+public enum POSIXErrorCode: Int32, BitwiseCopyable, Sendable {
     
     /// Operation not permitted
     case EPERM          = 1
@@ -600,7 +600,7 @@ public enum POSIXErrorCode: Int32, Sendable {
 #elseif os(OpenBSD) || os(FreeBSD)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode: Int32, Sendable {
+public enum POSIXErrorCode: Int32, BitwiseCopyable, Sendable {
     /// Operation not permitted
     case EPERM			= 1
     /// No such file or directory

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2013 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1323,7 +1323,7 @@ public enum FloatingPointClassification: Sendable {
 }
 
 /// A rule for rounding a floating-point number.
-public enum FloatingPointRoundingRule: Sendable {
+public enum FloatingPointRoundingRule: BitwiseCopyable, Sendable {
   /// Round to the closest allowed value; if two values are equally close, the
   /// one with greater magnitude is chosen.
   ///

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ extension Unicode.Scalar {
 
   /// A value that provides access to properties of a Unicode scalar that are
   /// defined by the Unicode standard.
-  public struct Properties: Sendable {
+  public struct Properties: BitwiseCopyable, Sendable {
     @usableFromInline
     internal var _scalar: Unicode.Scalar
 
@@ -869,7 +869,7 @@ extension Unicode {
   /// The general category of a scalar is its "first-order, most usual
   /// categorization". It does not attempt to cover multiple uses of some
   /// scalars, such as the use of letters to represent Roman numerals.
-  public enum GeneralCategory: Sendable {
+  public enum GeneralCategory: BitwiseCopyable, Sendable {
 
     /// An uppercase letter.
     ///
@@ -1324,7 +1324,7 @@ extension Unicode {
   ///     let overlayClassIsOverlay = overlayClass == .overlay
   ///     // overlayClassIsOverlay == true
   public struct CanonicalCombiningClass:
-    Comparable, Hashable, RawRepresentable, Sendable
+    BitwiseCopyable, Comparable, Hashable, RawRepresentable, Sendable
   {
     /// Base glyphs that occupy their own space and do not combine with others.
     public static let notReordered = CanonicalCombiningClass(rawValue: 0)
@@ -1447,7 +1447,7 @@ extension Unicode {
   /// Some letterlike scalars used in numeric systems, such as Greek or Latin
   /// letters, do not have a non-nil numeric type, in order to prevent programs
   /// from incorrectly interpreting them as numbers in non-numeric contexts.
-  public enum NumericType: Sendable {
+  public enum NumericType: BitwiseCopyable, Sendable {
 
     /// A digit that is commonly understood to form base-10 numbers.
     ///


### PR DESCRIPTION
Resolves part of #79470.

> [!NOTE]
> `MachErrorCode` and `POSIXErrorCode` (for Apple platforms) were removed by #81726.