### PR TITLE
[Sema] Sink Pattern invalidation into `SyntacticElementTarget::markInvalid`

### DIFF
--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -493,7 +493,7 @@ Type DoCatchStmt::getCaughtErrorType() const {
     ->getCaseLabelItems()
     .front()
     .getPattern();
-  if (firstPattern->hasType())
+  if (firstPattern->hasType() && !firstPattern->getType()->hasError())
     return firstPattern->getType();
 
   return Type();

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -302,9 +302,7 @@ void SyntacticElementTarget::markInvalid() const {
     InvalidationWalker(ASTContext &ctx) : Ctx(ctx) {}
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-      if (!E->getType())
-        E->setType(ErrorType::get(Ctx));
-
+      E->setType(ErrorType::get(Ctx));
       return Action::Continue(E);
     }
 

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -308,6 +308,11 @@ void SyntacticElementTarget::markInvalid() const {
       return Action::Continue(E);
     }
 
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+      P->setType(ErrorType::get(Ctx));
+      return Action::Continue(P);
+    }
+
     PreWalkAction walkToDeclPre(Decl *D) override {
       // Mark any VarDecls and PatternBindingDecls as invalid.
       if (auto *VD = dyn_cast<VarDecl>(D)) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -854,6 +854,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
   auto &Context = DC->getASTContext();
   initializer = target.getAsExpr();
+  pattern = target.getInitializationPattern();
 
   if (!initializer->getType())
     initializer->setType(ErrorType::get(Context));


### PR DESCRIPTION
Rather than handling this in the callers of `typeCheckExpression`, handle it in the constraint system's invalidation logic. This also ensures we set a type for sub-pattern nodes.