### PR TITLE
[Sema] Remove `isInvalid` checks from `checkAndContextualizePatternBindingInit`

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -591,17 +591,12 @@ static void checkAndContextualizePatternBindingInit(PatternBindingDecl *binding,
                                                     unsigned i) {
   // Force the entry to be checked.
   (void)binding->getCheckedPatternBindingEntry(i);
-  if (binding->isInvalid())
-    return;
 
   if (!binding->isInitialized(i))
     return;
 
   if (!binding->isInitializerChecked(i))
     TypeChecker::typeCheckPatternBinding(binding, i);
-
-  if (binding->isInvalid())
-    return;
 
   // If we entered an initializer context, contextualize any auto-closures we
   // might have created. Note that we don't contextualize the initializer for a

--- a/validation-test/compiler_crashers_2_fixed/f7546097c158a148.swift
+++ b/validation-test/compiler_crashers_2_fixed/f7546097c158a148.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ActorIsolationChecker::checkLocalCaptures(swift::AnyFunctionRef)","signatureAssert":"Assertion failed: (Captures.hasBeenComputed()), function getCaptureInfo"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a {
   b : c =, d = {} protocol c


### PR DESCRIPTION
The invalid bit on PatternBindingDecl is very coarse grained, it means any of the possible binding entries could be invalid. Contextualization can handle invalid code anyway (e.g this is what we do for `typeCheckBody`), so let's just avoid checking.