### PR TITLE
[SIL] Fix visitAccessedAddress at end_borrow.

### DIFF
--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -84,6 +84,10 @@ struct STXXITXXII {
 struct MoS: ~Copyable {}
 struct MoE: ~Copyable {}
 
+struct UnsafeMutablePointer<T> {
+  var _rawValue: Builtin.RawPointer
+}
+
 sil @unknown : $@convention(thin) () -> ()
 sil @use_S : $@convention(thin) (@in_guaranteed S) -> ()
 
@@ -1344,5 +1348,25 @@ entry(%c_addr : $*X):
   apply undef(%stack) : $@convention(thin) (@in X) -> ()
   dealloc_stack %stack
   %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @no_hoist_into_load_borrow_scope : {{.*}} {
+// CHECK:         end_borrow
+// CHECK-NEXT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'no_hoist_into_load_borrow_scope'
+sil [ossa] @no_hoist_into_load_borrow_scope : $@convention(thin) (@in X) -> () {
+entry(%c_addr_in : $*X):
+  %c_ptr = address_to_pointer [stack_protection] %c_addr_in to $Builtin.RawPointer
+  %c_up = struct $UnsafeMutablePointer<X> (%c_ptr)
+  %c_ptr_2 = struct_extract %c_up, #UnsafeMutablePointer._rawValue // user: %45
+  %c_addr = pointer_to_address %c_ptr_2 to [strict] $*X
+  %c_borrow = load_borrow %c_addr
+  apply undef(%c_borrow) : $@convention(thin) (@guaranteed X) -> ()
+  %c_copy = load [copy] %c_addr_in
+  end_borrow %c_borrow
+  %retval = tuple ()
+  destroy_addr %c_addr_in
+  destroy_value %c_copy
   return %retval
 }


### PR DESCRIPTION
`end_borrow` instructions may end the scopes introduced by `load_borrow` or `store_borrow` instructions, or those introduced by `begin_borrow`s whose operands' guaranteed roots includes a `load_borrow`.

Previously, such scope ending instructions which end the scope associated with a borrowing load or store were not regarded as accessing the loaded-from or stored-to address.  One consequence of this is that they were not regarded as accessing pointers and thus not as deinit barriers; that in turn resulted in `destroy_addr`s being hoisted into such borrow scopes.

Here this is fixed by regarding such `end_borrow`s to access the loaded-from or stored-to address of the scope-introducing `load_borrow` or `store_borrow` respectively.

rdar://157772187

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
