### PR TITLE
Runtimes: add support for Builtin_float in FindSwiftOverlay

### DIFF
--- a/Runtimes/Supplemental/cmake/modules/FindSwiftOverlay.cmake
+++ b/Runtimes/Supplemental/cmake/modules/FindSwiftOverlay.cmake
@@ -65,6 +65,12 @@ if(APPLE)
   # SDK as a tbd for a shared library in the shared cache.
   list(APPEND swiftDarwin_NAMES libswiftDarwin.tbd)
   set(swiftDarwin_MODULE_NAME "Darwin.swiftmodule")
+
+  list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+    "${CMAKE_OSX_SYSROOT}/usr/lib/swift")
+  list(APPEND swift_Builtin_float_LIBRARY_HINTS
+    "${CMAKE_OSX_SYSROOT}/usr/lib/swift")
+  list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.tbd)
 elseif(LINUX)
   #ToDo(swiftlang/swift/issues/83014): Handle the static MUSL SDK case
   list(APPEND OVERLAY_TARGET_NAMES "swiftGlibc")
@@ -76,12 +82,24 @@ elseif(LINUX)
     list(APPEND swiftGlibc_LIBRARY_HINTS
       "${Swift_SDKROOT}/usr/lib/swift_static/linux")
     list(APPEND swiftGlibc_NAMES libswiftGlibc.a)
+
+    list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift_static/linux")
+    list(APPEND swift_Builtin_float_LIBRARY_HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift_static/linux")
+    list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.a)
   else()
     list(APPEND swiftGlibc_INCLUDE_DIR_HINTS
       "${Swift_SDKROOT}/usr/lib/swift/linux/")
     list(APPEND swiftGlibc_LIBRARY_HINTS
       "${Swift_SDKROOT}/usr/lib/swift/linux")
     list(APPEND swiftGlibc_NAMES libswiftGlibc.so)
+
+    list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift/linux")
+    list(APPEND swift_Builtin_float_LIBRARY_HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift/linux")
+    list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.so)
   endif()
   set(swiftGlibc_MODULE_NAME "Glibc.swiftmodule")
 elseif(WIN32)
@@ -119,6 +137,21 @@ elseif(WIN32)
     list(APPEND swiftCRT_NAMES swiftCRT.lib)
   endif()
   set(swiftCRT_MODULE_NAME "CRT.swiftmodule")
+
+  list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+    "${Swift_SDKROOT}/usr/lib/swift/windows"
+    "$ENV{SDKROOT}/usr/lib/swift/windows")
+  list(APPEND swift_Builtin_float_LIBRARY_HINTS
+    "${Swift_SDKROOT}/usr/lib/swift/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}"
+    "${Swift_SDKROOT}/usr/lib/swift"
+    "$ENV{SDKROOT}/usr/lib/swift/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}"
+    "$ENV{SDKROOT}/usr/lib/swift")
+
+ if(SwiftOverlay_USE_STATIC_LIBS)
+    list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.lib)
+  else()
+    list(APPEND swift_Builtin_float_NAMES swift_Builtin_float.lib)
+  endif()
 elseif(ANDROID)
   list(APPEND OVERLAY_TARGET_NAMES "swiftAndroid")
 
@@ -132,6 +165,16 @@ elseif(ANDROID)
       "$ENV{SDKROOT}/usr/lib/swift_static/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
       "$ENV{SDKROOT}/usr/lib/swift_static")
     list(APPEND swiftAndroid_NAMES libswiftAndroid.a)
+
+    list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+      "${Swift_SDKROOT}/usr/lib/swift_static/android"
+      "$ENV{SDKROOT}/usr/lib/swift_static/android")
+    list(APPEND swift_Builtin_float_LIBRARY_HINTS
+      "${Swift_SDKROOT}/usr/lib/swift_static/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
+      "${Swift_SDKROOT}/usr/lib/swift_static"
+      "$ENV{SDKROOT}/usr/lib/swift_static/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
+      "$ENV{SDKROOT}/usr/lib/swift_static")
+    list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.a)
   else()
     list(APPEND swiftAndroid_INCLUDE_DIR_HINTS
       "${Swift_SDKROOT}/usr/lib/swift/android"
@@ -142,6 +185,16 @@ elseif(ANDROID)
       "$ENV{SDKROOT}/usr/lib/swift/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
       "$ENV{SDKROOT}/usr/lib/swift")
     list(APPEND swiftAndroid_NAMES libswiftAndroid.so)
+
+    list(APPEND swift_Builtin_float_INCLUDE_DIR_HINTS
+      "${Swift_SDKROOT}/usr/lib/swift/android"
+      "$ENV{SDKROOT}/usr/lib/swift/android")
+    list(APPEND swift_Builtin_float_LIBRARY_HINTS
+      "${Swift_SDKROOT}/usr/lib/swift/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
+      "${Swift_SDKROOT}/usr/lib/swift"
+      "$ENV{SDKROOT}/usr/lib/swift/android/${${PROJECT_NAME}_ARCH_SUBDIR}"
+      "$ENV{SDKROOT}/usr/lib/swift")
+    list(APPEND swift_Builtin_float_NAMES libswift_Builtin_float.so)
   endif()
   set(swiftAndroid_MODULE_NAME "Android.swiftmodule")
 else()
@@ -188,9 +241,39 @@ foreach(OVERLAY_TARGET ${OVERLAY_TARGET_NAMES})
       ${OVERLAY_TARGET})
 endforeach()
 
+find_path(swift_Builtin_float_INCLUDE_DIR
+  "_Builtin_float.swiftmodule"
+  NO_CMAKE_FIND_ROOT_PATH
+  HINTS
+    ${swift_Builtin_float_INCLUDE_DIR_HINTS})
+find_library(swift_Builtin_float_LIBRARY
+  NAMES
+    ${swift_Builtin_float_NAMES}
+  NO_CMAKE_FIND_ROOT_PATH
+  HINTS
+    ${swift_Builtin_float_LIBRARY_HINTS})
+
+if(SwiftOverlay_USE_STATIC_LIBS)
+  add_library(swift_Builtin_float STATIC IMPORTED GLOBAL)
+else()
+  add_library(swift_Builtin_float SHARED IMPORTED GLOBAL)
+endif()
+
+target_include_directories(swift_Builtin_float INTERFACE
+  "${swift_Builtin_float_INCLUDE_DIR}")
+
+if(LINUX OR ANDROID)
+  set_target_properties(swift_Builtin_float PROPERTIES
+    IMPORTED_LOCATION "${swift_Builtin_float_LIBRARY}")
+else()
+  set_target_properties(swift_Builtin_float PROPERTIES
+    IMPORTED_IMPLIB "${swift_Builtin_float_LIBRARY}")
+endif()
+
 foreach(OVERLAY_TARGET ${OVERLAY_TARGET_NAMES})
   list(APPEND vars_to_check "${OVERLAY_TARGET}_LIBRARY" "${OVERLAY_TARGET}_INCLUDE_DIR")
 endforeach()
+list(APPEND vars_to_check "swift_Builtin_float_LIBRARY" "swift_Builtin_float_INCLUDE_DIR")
 
 find_package_handle_standard_args(SwiftOverlay DEFAULT_MSG
   ${vars_to_check})


### PR DESCRIPTION
This is needed to build Distributed and Cxx overlays in Apple vendor
configurations.

Addresses rdar://158046291