### PR TITLE
[cmake] APIDigester, IDE: Specify Clang link dependencies

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -17,11 +17,6 @@
 #ifndef __SWIFT_ABI_DIGESTER_MODULE_NODES_H__
 #define __SWIFT_ABI_DIGESTER_MODULE_NODES_H__
 
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/DeclObjC.h"
-#include "clang/Lex/Preprocessor.h"
-#include "clang/Sema/Lookup.h"
-#include "clang/Sema/Sema.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"

--- a/lib/APIDigester/CMakeLists.txt
+++ b/lib/APIDigester/CMakeLists.txt
@@ -7,4 +7,10 @@ add_swift_host_library(swiftAPIDigester STATIC
 target_link_libraries(swiftAPIDigester PRIVATE
   swiftIDE)
 
+# Clang dependencies. These are private because APIDigester's public
+# interface does not use Clang symbols.
+target_link_libraries(swiftAPIDigester PRIVATE
+  clangAST
+  clangLex)
+
 set_swift_llvm_is_available(swiftAPIDigester)

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -3,6 +3,8 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/STLExtras.h"
 #include <algorithm>
 #include <swift/APIDigester/ModuleAnalyzerNodes.h>

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -46,6 +46,14 @@ target_link_libraries(swiftIDE PRIVATE
   swiftParse
   swiftSema)
 
+# Clang dependencies. These are private because IDE's public
+# interface does not use Clang symbols.
+target_link_libraries(swiftIDE PRIVATE
+  clangAST
+  clangBasic
+  clangIndex
+  clangLex)
+
 if (SWIFT_BUILD_SWIFT_SYNTAX)
   target_link_libraries(swiftIDE PRIVATE
     swiftIDEUtilsBridging


### PR DESCRIPTION
This way, CMake will propagate the interface compile definitions of the Clang dependencies, which is important on Windows because Clang visibility macro expansions, controlled by compile definitions, must match between the Swift and Clang library.

See https://github.com/llvm/llvm-project/pull/108276/files#diff-4dd645a8b76bb3886a505258a8c2e598aeddea770e7b0a2b51689124a5ea6e9a.
