### PR TITLE
[concurrency] Cleanup verify-additional-prefix usage in tests.

### DIFF
--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete
 
 // REQUIRES: concurrency
 
@@ -14,7 +14,7 @@ actor SomeGlobalActor {
 
 // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 @SomeGlobalActor(unsafe) func globalSome() { } // expected-note 2{{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-tns-note @-1 {{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-note @-1 {{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
 
 // ----------------------------------------------------------------------
 // Witnessing and unsafe global actor
@@ -56,15 +56,15 @@ struct S4_P1: P1 {
 @MainActor(unsafe)
 protocol P2 {
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func g()
 }
 
 struct S5_P2: P2 {
   func f() { } // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   // expected-note@-1 {{main actor isolation inferred from conformance to protocol 'P2'}}
-  // expected-complete-tns-note @-2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-tns-note @-3 {{main actor isolation inferred from conformance to protocol 'P2'}}}
+  // expected-complete-note @-2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note @-3 {{main actor isolation inferred from conformance to protocol 'P2'}}}
   func g() { }
 }
 
@@ -76,12 +76,12 @@ nonisolated func testP2(x: S5_P2, p2: P2) {
 }
 
 func testP2_noconcurrency(x: S5_P2, p2: P2) {
-  // expected-complete-tns-note @-1 2{{add '@MainActor' to make global function 'testP2_noconcurrency(x:p2:)' part of global actor 'MainActor'}}
+  // expected-complete-note @-1 2{{add '@MainActor' to make global function 'testP2_noconcurrency(x:p2:)' part of global actor 'MainActor'}}
   p2.f() // okay without complete. with targeted/minimal not concurrency-related code.
-  // expected-complete-tns-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  // expected-complete-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // okay
   x.f() // okay without complete. with targeted/minimal not concurrency-related code
-  // expected-complete-tns-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  // expected-complete-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   x.g() // OKAY
 }
 
@@ -96,7 +96,7 @@ class C1 {
 class C2: C1 {
   override func method() { // expected-note 2{{overridden declaration is here}}
     globalSome() // okay when not in complete
-    // expected-complete-tns-warning @-1 {{call to global actor 'SomeGlobalActor'-isolated global function 'globalSome()' in a synchronous main actor-isolated context}}
+    // expected-complete-warning @-1 {{call to global actor 'SomeGlobalActor'-isolated global function 'globalSome()' in a synchronous main actor-isolated context}}
   }
 }
 

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-concurrency -target %target-swift-5.1-abi-triple -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -enable-experimental-concurrency -target %target-swift-5.1-abi-triple -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
-// RUN: %target-swift-frontend -enable-experimental-concurrency -target %target-swift-5.1-abi-triple -emit-sil -o /dev/null -verify -strict-concurrency=complete %s -verify-additional-prefix complete-and-tns-
+// RUN: %target-swift-frontend -enable-experimental-concurrency -target %target-swift-5.1-abi-triple -emit-sil -o /dev/null -verify -strict-concurrency=complete %s -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 
@@ -115,11 +115,11 @@ struct SomeStruct {
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
 
   // expected-warning@+2 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
-  // expected-complete-and-tns-note@+1 {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note@+1 {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
   @MainActor(unsafe) init(mainActorUnsafe: Int) {}
 }
 
-// expected-complete-and-tns-note @+3 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
+// expected-complete-note @+3 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
 // expected-note @+2 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
 // expected-note @+1 2 {{add 'async' to function 'globActorTest1()' to make it asynchronous}}
 func globActorTest1() {
@@ -129,7 +129,7 @@ func globActorTest1() {
 
   _ = SomeStruct(asyncMainActorUnsafe: 0) // expected-error {{'async' call in a function that does not support concurrency}}
 
-  _ = SomeStruct(mainActorUnsafe: 0) // expected-complete-and-tns-warning {{call to main actor-isolated initializer 'init(mainActorUnsafe:)' in a synchronous nonisolated context}}
+  _ = SomeStruct(mainActorUnsafe: 0) // expected-complete-warning {{call to main actor-isolated initializer 'init(mainActorUnsafe:)' in a synchronous nonisolated context}}
 }
 
 func globActorTestAsyncEdition() async {

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix without-transferring-
 
 // Then strict-concurrency with everything.
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -target %target-swift-5.1-abi-triple %s -o /dev/null -verify -emit-sil  -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
 // RUN: %target-swift-frontend -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o /dev/null -verify -emit-sil -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
-// RUN: %target-swift-frontend -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o /dev/null -verify -emit-sil -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o /dev/null -verify -emit-sil -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -140,9 +140,9 @@ func test_detached_throwing() async -> String {
 
 // ==== Detached Tasks with inout Params---------------------------------------
 @available(SwiftStdlib 5.1, *)
-func printOrderNumber(n: inout Int) async { // expected-tns-note {{parameter 'n' is declared 'inout'}}
-  Task.detached { // expected-tns-error {{escaping closure captures 'inout' parameter 'n'}}
-      n+=1 // expected-tns-note {{captured here}}
-      print(n) // expected-tns-note {{captured here}}
+func printOrderNumber(n: inout Int) async { // expected-complete-note {{parameter 'n' is declared 'inout'}}
+  Task.detached { // expected-complete-error {{escaping closure captures 'inout' parameter 'n'}}
+      n+=1 // expected-complete-note {{captured here}}
+      print(n) // expected-complete-note {{captured here}}
   }
 }

--- a/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
+++ b/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
+
+// This file contains tests that test specific type checker functionality that
+// used to be in concurrent_value_checking.swift. This prevented other region
+// isolation errors from being emitted. We used to use multiple prefix tests to
+// validate aboth at the same time. Better to just split it.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+class NotConcurrent { } // expected-note 3{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
+
+@MainActor var booleanValue: Bool { false }
+
+actor TestActor {}
+
+@globalActor
+struct SomeGlobalActor {
+  static var shared: TestActor { TestActor() }
+}
+
+@SomeGlobalActor
+let globalValue: NotConcurrent? = nil
+
+@SomeGlobalActor
+func globalSync(_: NotConcurrent?) {
+}
+
+@SomeGlobalActor
+func globalAsync(_: NotConcurrent?) async {
+  if await booleanValue {
+    return
+  }
+  await globalAsync(globalValue) // both okay because we're in the actor
+  globalSync(nil)
+}
+
+enum E {
+  @SomeGlobalActor static let notSafe: NotConcurrent? = nil
+}
+
+func globalTest() async {
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot be accessed from outside of the actor}} {{11-11=await }}
+  let a = globalValue // expected-warning{{non-Sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  await globalAsync(a)
+  await globalSync(a)
+
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot be accessed from outside of the actor}} {{11-11=await }}
+  let _ = E.notSafe // expected-warning{{non-Sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+
+  // expected-error@+3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+2 {{call is 'async'}}
+  // expected-note@+1 {{property access is 'async'}}
+  globalAsync(E.notSafe)
+
+  // expected-warning@-2 {{non-Sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+}
+
+class C11 { }
+
+class C12: @unchecked C11 { } // expected-error {{'@unchecked' cannot apply to non-protocol type 'C11'}}
+
+protocol P { }
+
+protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' only applies in inheritance clauses}}
+
+typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' only applies in inheritance clauses}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify-additional-prefix complete- -verify -strict-concurrency=complete
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -131,7 +131,7 @@ func fromAsync() async {
 }
 
 // expected-minimal-and-targeted-note @+2 {{mutation of this var is only permitted within the actor}}
-// expected-complete-and-tns-error @+1 {{top-level code variables cannot have a global actor}}
+// expected-complete-error @+1 {{top-level code variables cannot have a global actor}}
 @SomeGlobalActor var value: Int = 42
 
 func topLevelSyncFunction(_ number: inout Int) { }

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -8,7 +8,7 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix without-transferring-
 
 // Emit SIL with strict concurrency + region-based isolation + transferring
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -38,7 +38,7 @@ func testConversions(f: @escaping @SomeGlobalActor (Int) -> Void, g: @escaping (
 
 @OtherGlobalActor func onOtherGlobalActor() -> Int { 5 } // expected-note{{calls to global function 'onOtherGlobalActor()' from outside of its actor context are implicitly asynchronous}}
 @preconcurrency @OtherGlobalActor func onOtherGlobalActorUnsafe() -> Int { 5 }  // expected-note 2{{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-tns-note @-1 {{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-note @-1 {{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
 
 func someSlowOperation() async -> Int { 5 }
 
@@ -99,7 +99,7 @@ func testClosuresOld() {
   }
 
   acceptOnSomeGlobalActor { () -> Int in
-    let i = onOtherGlobalActorUnsafe() // expected-complete-tns-warning {{call to global actor 'OtherGlobalActor'-isolated global function 'onOtherGlobalActorUnsafe()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+    let i = onOtherGlobalActorUnsafe() // expected-complete-warning {{call to global actor 'OtherGlobalActor'-isolated global function 'onOtherGlobalActorUnsafe()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
     return i
   }
 
@@ -129,16 +129,16 @@ func g2(_ x: X<() -> Void>) {
 
 
 func testTypesNonConcurrencyContext() { // expected-note{{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
-  // expected-complete-tns-note @-1 {{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
+  // expected-complete-note @-1 {{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
   let f1 = onSomeGlobalActor // expected-note{{calls to let 'f1' from outside of its actor context are implicitly asynchronous}}
-  let f2 = onSomeGlobalActorUnsafe // expected-complete-tns-note {{calls to let 'f2' from outside of its actor context are implicitly asynchronous}}
+  let f2 = onSomeGlobalActorUnsafe // expected-complete-note {{calls to let 'f2' from outside of its actor context are implicitly asynchronous}}
 
   let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-  let _: () -> Int = f2 // expected-complete-tns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f2 // expected-complete-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
 
   _ = {
     let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-    let _: () -> Int = f2 // expected-complete-tns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2 // expected-complete-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
   }
 
   @SomeGlobalActor func isolated() {
@@ -147,7 +147,7 @@ func testTypesNonConcurrencyContext() { // expected-note{{add '@SomeGlobalActor'
   }
 
   _ = f1() // expected-error{{call to global actor 'SomeGlobalActor'-isolated let 'f1' in a synchronous nonisolated context}}
-  _ = f2() // expected-complete-tns-error {{call to global actor 'SomeGlobalActor'-isolated let 'f2' in a synchronous nonisolated context}}
+  _ = f2() // expected-complete-error {{call to global actor 'SomeGlobalActor'-isolated let 'f2' in a synchronous nonisolated context}}
 }
 
 func testTypesConcurrencyContext() async {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
@@ -455,7 +455,7 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in the Swift 6 language mode}}
+  // expected-complete-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in the Swift 6 language mode}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -572,18 +572,18 @@ struct WrapperOnUnsafeActor<Wrapped> {
 // HasWrapperOnUnsafeActor does not have an inferred global actor attribute,
 // because synced and $synced have different global actors.
 struct HasWrapperOnUnsafeActor {
-// expected-complete-tns-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
-// expected-complete-tns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
+// expected-complete-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
+// expected-complete-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
 
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
   // expected-note @-1 2{{property declared here}}
-  // expected-complete-tns-note @-2 2{{property declared here}}
+  // expected-complete-note @-2 2{{property declared here}}
 
   func testUnsafeOkay() {
-    // expected-complete-tns-note @-1 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
-    // expected-complete-tns-note @-2 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
-    _ = synced // expected-complete-tns-warning {{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
-    _ = $synced // expected-complete-tns-warning {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
+    // expected-complete-note @-1 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
+    // expected-complete-note @-2 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
+    _ = synced // expected-complete-warning {{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
+    _ = $synced // expected-complete-warning {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
     _ = _synced // okay
   }
 
@@ -663,7 +663,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 // defer bodies inherit global actor-ness
 @MainActor
 var statefulThingy: Bool = false // expected-minimal-targeted-note {{var declared here}}
-// expected-complete-tns-error @-1 {{top-level code variables cannot have a global actor}}
+// expected-complete-error @-1 {{top-level code variables cannot have a global actor}}
 
 @MainActor
 func useFooInADefer() -> String { // expected-minimal-targeted-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}
@@ -686,9 +686,9 @@ func replacesDynamicOnMainActor() {
 // Global-actor isolation of stored property initializer expressions
 // ----------------------------------------------------------------------
 
-// expected-complete-tns-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
+// expected-complete-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 class Cutter {
-  // expected-complete-tns-note@+1 {{initializer for property 'x' is main actor-isolated}}
+  // expected-complete-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = useFooInADefer()
   @MainActor var y = { () -> Bool in
       var z = statefulThingy
@@ -699,10 +699,10 @@ class Cutter {
 @SomeGlobalActor
 class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in the Swift 6 language mode}}
+  // expected-complete-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in the Swift 6 language mode}}
 
   nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a nonisolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+  // expected-complete-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -verify -target %target-swift-5.1-abi-triple -strict-concurrency=complete -verify-additional-prefix region-isolation- -emit-sil -o /dev/null %s
+// RUN: %target-swift-frontend -verify -target %target-swift-5.1-abi-triple -strict-concurrency=complete -emit-sil -o /dev/null %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -39,8 +39,8 @@ class NotSendable {
   MyActor.ns = ns
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
-    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
+    // expected-warning @+3 {{sending 'ns' risks causing data races}}
+    // expected-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -61,8 +61,8 @@ class NotSendable {
   ns.stash()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
-    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
+    // expected-warning @+3 {{sending 'ns' risks causing data races}}
+    // expected-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -82,8 +82,8 @@ class NotSendable {
   let ns = NotSendable()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
-    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
+    // expected-warning @+3 {{sending 'ns' risks causing data races}}
+    // expected-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
-
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -8,7 +6,7 @@
 
 @available(SwiftStdlib 5.1, *)
 actor A {
-  func f() { } // expected-typechecker-note 3{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  func f() { }
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -16,22 +14,7 @@ extension Actor {
   func g() { }
 }
 
-@MainActor func mainActorFn() {} // expected-typechecker-note {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
-
-#if ALLOW_TYPECHECKER_ERRORS
-
-@available(SwiftStdlib 5.1, *)
-func testA<T: Actor>(
-  a: isolated A,  // expected-typechecker-note {{previous 'isolated' parameter 'a'}}
-  b: isolated T,  // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  c: isolated Int // expected-typechecker-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
-) {
-  a.f()
-  a.g()
-  b.g()
-}
-
-#endif
+@MainActor func mainActorFn() {}
 
 actor Other {
   func inc() {}
@@ -42,98 +25,31 @@ actor Counter {
   func pass(_ f: @Sendable  (Self) async -> Void) {}
 }
 
-#if ALLOW_TYPECHECKER_ERRORS
-
-// This is illegal at the SIL level so even though we could ignore this
-// note/warning, we will get a crash otherwise.
-@available(SwiftStdlib 5.1, *)
-// expected-typechecker-note@+2 {{previous 'isolated' parameter 'a'}}
-// expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async {
-  a.inc()
-  b.inc()
-}
-
-func taaaa() async {
-  await Counter().pass { isoC in
-    await Other().pass { isoO in
-      await testDoubleIsolatedParams(a: isoC, b: isoO)
-    }
-  }
-}
-
-#endif
-
 @available(SwiftStdlib 5.1, *)
 typealias Fn = (isolated A) -> Void
 
 @available(SwiftStdlib 5.1, *)
 func globalFunc(_ a: A) { }
 
-#if ALLOW_TYPECHECKER_ERRORS
-
-@available(SwiftStdlib 5.1, *)
-func globalFuncIsolated(_: isolated A) { // expected-typechecker-note{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
-  let _: Int = globalFuncIsolated // expected-typechecker-error{{cannot convert value of type '(isolated A) -> ()' to specified type 'Int'}}
-  let _: (A) -> Void = globalFuncIsolated // expected-typechecker-error{{cannot convert value of type '(isolated A) -> ()' to specified type '(A) -> Void'}}
-  let _: Fn = globalFunc // okay
-}
-
-@available(SwiftStdlib 5.1, *)
-// expected-typechecker-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
-@MainActor func testIsolatedParamCalls(a: isolated A, b: A) {
-  globalFunc(a)
-  globalFunc(b)
-
-  globalFuncIsolated(a)
-  globalFuncIsolated(b) // expected-typechecker-error{{call to actor-isolated global function 'globalFuncIsolated' in a synchronous actor-isolated context}}
-}
-
-#endif
-
 @available(SwiftStdlib 5.1, *)
 func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
   globalFunc(a)
   globalFunc(b)
 
-  #if ALLOW_TYPECHECKER_ERRORS
-  globalFuncIsolated(a)
-  globalFuncIsolated(b) // expected-typechecker-error{{actor-isolated global function 'globalFuncIsolated' cannot be called from outside of the actor}} {{3-3=await }}
-  await globalFuncIsolated(b)
-  #endif
 }
 
 @available(SwiftStdlib 5.1, *)
 func testIsolatedParamCaptures(a: isolated A) async {
-#if ALLOW_TYPECHECKER_ERRORS
-  let _ = { @MainActor in
-    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
-  }
-
-  let _: @MainActor () -> () = {
-    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
-  }
-#endif
-
   let _ = {
     a.f()
   }
-
-#if ALLOW_TYPECHECKER_ERRORS
-  let _ = { @Sendable in
-    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
-  }
-#endif
 }
 
 actor MyActor {
-  func hello() {} // expected-typechecker-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
+  func hello() {}
 }
 
 // Compiler >= 5.3 is ended to suppress the parser error
-#if compiler(>=5.3) && ALLOW_TYPECHECKER_ERRORS
-typealias MyFn = (isolated: Int) -> Void // expected-typechecker-error {{function types cannot have argument labels; use '_' before 'isolated'}}
-#endif
 typealias MyFnFixed = (_: isolated MyActor) -> Void
 
 func standalone(_: isolated MyActor) {}
@@ -165,53 +81,23 @@ struct S: P {
   func j(isolated: Int) -> Int { return isolated }
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
-  #if ALLOW_TYPECHECKER_ERRORS
-  func m(thing: MyActor) { thing.hello() } // expected-typechecker-error {{call to actor-isolated instance method 'hello()' in a synchronous nonisolated context}}
-  #else
   func m(thing: MyActor) { }
-  #endif
 }
 
 func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
   s.m(thing: ma)
   await p.m(thing: ma)
-  // expected-complete-warning@-1 {{passing argument of non-Sendable type 'any P' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'p' risks causing data races}}
-  // expected-tns-note @-3 {{sending task-isolated 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'p' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
 
 // Redeclaration checking
 actor TestActor {
-  func test() { // expected-typechecker-note{{'test()' previously declared here}}
+  func test() {
   }
-#if ALLOW_TYPECHECKER_ERRORS
-  nonisolated func test() { // expected-typechecker-error{{invalid redeclaration of 'test()'}}
-  }
-#endif
 }
 
-#if ALLOW_TYPECHECKER_ERRORS
-
-func redecl(_: TestActor) { } // expected-typechecker-note{{'redecl' previously declared here}}
-func redecl(_: isolated TestActor) { } // expected-typechecker-error{{invalid redeclaration of 'redecl'}}
-
-#endif
-
-func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-typechecker-note {{in call to function 'tuplify'}}
-
-#if ALLOW_TYPECHECKER_ERRORS
-
-@available(SwiftStdlib 5.1, *)
-func testTuplingIsolated(
-                         _ a: isolated A, // expected-typechecker-note {{previous 'isolated' parameter 'a'}}
-                         _ b: isolated A  // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-                        ) {
-  tuplify(testTuplingIsolated)
-  // expected-typechecker-error@-1 {{generic parameter 'Ts' could not be inferred}}
-  // expected-typechecker-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
-}
-
-#endif
+func tuplify<Ts>(_ fn: (Ts) -> Void) {}
 
 // Inference of "isolated" on closure parameters.
 @available(SwiftStdlib 5.1, *)
@@ -231,54 +117,13 @@ func testIsolatedClosureInference(one: A, two: A) async {
   let _: (isolated A) -> Void = { (a2: isolated A) in
     a2.f()
   }
-
-#if ALLOW_TYPECHECKER_ERRORS
-  let f: (isolated A, isolated A) -> Void = // expected-typechecker-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      // expected-typechecker-note@+2 {{previous 'isolated' parameter 'a1'}}
-      // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      { (a1, a2) in
-        a1.f()
-        a2.f()
-      }
-
-  await f(one, two)
-
-  let g: (isolated A, isolated A) -> Void = // expected-typechecker-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      // expected-typechecker-note@+2 {{previous 'isolated' parameter '$0'}}
-      // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      {
-        $0.f()
-        $1.f()
-      }
-
-  await g(one, two)
-  #endif
 }
-
-#if ALLOW_TYPECHECKER_ERRORS
-
-struct CheckIsolatedFunctionTypes {
-  // expected-typechecker-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  // expected-typechecker-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  func a(_ f: @MainActor @Sendable (isolated A, isolated A) -> ()) {}
-
-  // expected-typechecker-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
-  // expected-typechecker-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  @MainActor func update<R>(_ callback: @Sendable @escaping @MainActor (isolated A) -> R) -> R {
-    callback(A()) // expected-typechecker-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
-  }
-}
-
-#endif
 
 @available(SwiftStdlib 5.1, *)
 func checkIsolatedAndGlobalClosures(_ a: A) {
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
       = {
     $0.f()
-    #if ALLOW_TYPECHECKER_ERRORS
-    mainActorFn() // expected-typechecker-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
-    #endif
   }
 
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
@@ -286,16 +131,6 @@ func checkIsolatedAndGlobalClosures(_ a: A) {
     $0.f()
     mainActorFn()
   }
-
-#if ALLOW_TYPECHECKER_ERRORS
-  let _ = { @MainActor (a: isolated A, // expected-typechecker-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in the Swift 6 language mode}}{{13-24=}}
-                                       // expected-typechecker-note@-1 {{previous 'isolated' parameter 'a'}}
-                        b: isolated A, // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-                        c: isolated A) async in
-    a.f()
-    mainActorFn()
-  }
-#endif
 }
 
 // "isolated" existential parameters.
@@ -307,23 +142,15 @@ protocol P2: Actor {
 func testExistentialIsolated(a: isolated P2, b: P2) async {
   a.m()
   await b.m()
-  #if ALLOW_TYPECHECKER_ERRORS
-  b.m() // expected-typechecker-error{{actor-isolated instance method 'm()' cannot be called from outside of the actor}} {{3-3=await }}
-  #endif
 }
 
 // "isolated" parameters of closures make the closure itself isolated.
 extension TestActor {
   func isolatedMethod() { }
-  // expected-typechecker-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
+ 
 
   // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated func isolatedToParameter(_ other: isolated TestActor) {
-    #if ALLOW_TYPECHECKER_ERRORS
-    isolatedMethod()
-    // expected-typechecker-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
-    #endif
-
     other.isolatedMethod()
   }
 }
@@ -338,42 +165,6 @@ func isolatedClosures() {
     }
   }
 }
-
-#if ALLOW_TYPECHECKER_ERRORS
-
-// expected-typechecker-error@+3 {{global function 'allOfEm' has multiple actor-isolation attributes (@MainActor and 'nonisolated')}}
-// expected-typechecker-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{12-24=}}
-// expected-typechecker-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
-@MainActor nonisolated func allOfEm(_ a: isolated A) {
-  a.f()
-}
-
-@MainActor class MAClass {
-
-  // expected-typechecker-note@+2 {{previous 'isolated' parameter 'a'}}
-  // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  init(_ a: isolated A, _ b: isolated A) {
-    // FIXME: wrong isolation. should be isolated to `a` only!
-    a.f()
-    b.f()
-  }
-
-  // expected-typechecker-note@+3 {{previous 'isolated' parameter 'a'}}
-  // expected-typechecker-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  // expected-typechecker-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
-  nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
-    a.f()
-    b.f()
-    return 0
-  }
-
-  // expected-typechecker-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
-  nonisolated func millionDollars(_ a: isolated A) {
-    a.f()
-  }
-}
-
-#endif
 
 // Test case for https://github.com/apple/swift/issues/62568
 func execute<ActorType: Actor>(
@@ -404,25 +195,10 @@ func getValues(
   }
 }
 
-#if ALLOW_TYPECHECKER_ERRORS
-
-func isolated_generic_bad_1<T>(_ t: isolated T) {}
-// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
-func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
-// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
-func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
-// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
-// expected-typechecker-warning@-2 {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-
-func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
-// expected-typechecker-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
-
-#endif
-
 func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
 
 
-class NotSendable {} // expected-complete-note 5 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+class NotSendable {}
 
 func optionalIsolated(_ ns: NotSendable, to actor: isolated (any Actor)?) async {}
 func optionalIsolatedSync(_ ns: NotSendable, to actor: isolated (any Actor)?) {}
@@ -435,37 +211,23 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-3 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
-
-#if ALLOW_TYPECHECKER_ERRORS
-  optionalIsolatedSync(ns, to: myActor)
-  // expected-typechecker-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
-  // expected-complete-warning@-2 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  #endif
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
 
 @MainActor func callFromMainActor(ns: NotSendable) async {
   await optionalIsolated(ns, to: nil)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
 
   optionalIsolatedSync(ns, to: nil)
 
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning@-1 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and main actor-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending main actor-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and main actor-isolated uses}}
 
-#if ALLOW_TYPECHECKER_ERRORS
-  optionalIsolatedSync(ns, to: myActor)
-  // expected-typechecker-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
-  // expected-complete-warning@-2 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-#endif
 }
 
 // TODO: Consider making an actor's Self behave like in a struct, removing this special casing.
@@ -473,12 +235,6 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 //       See: https://github.com/apple/swift/issues/70954 and rdar://121091417
 actor A2 {
   nonisolated func f1() async {
-#if ALLOW_TYPECHECKER_ERRORS
-    await { (self: isolated Self) in }(self)
-    // expected-typechecker-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
-    await { (self: isolated Self?) in }(self)
-    // expected-typechecker-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
-#endif
   }
   nonisolated func f2() async -> Self {
     await { (self: isolated Self) in }(self)
@@ -495,9 +251,9 @@ func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
 
   // FIXME: The `a` in the capture list and `isolated a` are the same,
   // but the actor isolation checker doesn't know that.
-  Task { [a] in // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between 'a'-isolated code and concurrent execution of the closure}}
+  Task { [a] in // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'a'-isolated code and concurrent execution of the closure}}
     _ = a
-    _ = ns // expected-tns-note {{closure captures 'a'-isolated 'ns'}}
+    _ = ns // expected-note {{closure captures 'a'-isolated 'ns'}}
   }
 }
 
@@ -547,14 +303,6 @@ func testLValueIsolated() async {
 nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
   await pass(value: ns, isolation: nil)
 }
-
-#if ALLOW_TYPECHECKER_ERRORS
-
-func invalidIsolatedClosureParam<A: AnyActor> ( // expected-typechecker-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-  _: (isolated A) async throws -> Void // expected-typechecker-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
-) {}
-
-#endif
 
 public func useDefaultIsolation(
   _ isolation: isolated (any Actor)? = #isolation

--- a/test/Concurrency/isolated_parameters_typechecker_errors.swift
+++ b/test/Concurrency/isolated_parameters_typechecker_errors.swift
@@ -1,0 +1,517 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+// REQUIRES: swift_swift_parser
+
+@available(SwiftStdlib 5.1, *)
+actor A {
+  func f() { } // expected-note 3{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+}
+
+@available(SwiftStdlib 5.1, *)
+extension Actor {
+  func g() { }
+}
+
+@MainActor func mainActorFn() {} // expected-note {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
+
+@available(SwiftStdlib 5.1, *)
+func testA<T: Actor>(
+  a: isolated A,  // expected-note {{previous 'isolated' parameter 'a'}}
+  b: isolated T,  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  c: isolated Int // expected-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
+) {
+  a.f()
+  a.g()
+  b.g()
+}
+
+actor Other {
+  func inc() {}
+  func pass(_ f: @Sendable  (Self) async -> Void) {}
+}
+actor Counter {
+  func inc() {}
+  func pass(_ f: @Sendable  (Self) async -> Void) {}
+}
+
+// This is illegal at the SIL level so even though we could ignore this
+// note/warning, we will get a crash otherwise.
+@available(SwiftStdlib 5.1, *)
+// expected-note@+2 {{previous 'isolated' parameter 'a'}}
+// expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async {
+  a.inc()
+  b.inc()
+}
+
+func taaaa() async {
+  await Counter().pass { isoC in
+    await Other().pass { isoO in
+      await testDoubleIsolatedParams(a: isoC, b: isoO)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+typealias Fn = (isolated A) -> Void
+
+@available(SwiftStdlib 5.1, *)
+func globalFunc(_ a: A) { }
+
+@available(SwiftStdlib 5.1, *)
+func globalFuncIsolated(_: isolated A) { // expected-note{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
+  let _: Int = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type 'Int'}}
+  let _: (A) -> Void = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type '(A) -> Void'}}
+  let _: Fn = globalFunc // okay
+}
+
+@available(SwiftStdlib 5.1, *)
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
+@MainActor func testIsolatedParamCalls(a: isolated A, b: A) {
+  globalFunc(a)
+  globalFunc(b)
+
+  globalFuncIsolated(a)
+  globalFuncIsolated(b) // expected-error{{call to actor-isolated global function 'globalFuncIsolated' in a synchronous actor-isolated context}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
+  globalFunc(a)
+  globalFunc(b)
+
+  globalFuncIsolated(a)
+  globalFuncIsolated(b) // expected-error{{actor-isolated global function 'globalFuncIsolated' cannot be called from outside of the actor}} {{3-3=await }}
+  await globalFuncIsolated(b)
+}
+
+@available(SwiftStdlib 5.1, *)
+func testIsolatedParamCaptures(a: isolated A) async {
+  let _ = { @MainActor in
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
+  }
+
+  let _: @MainActor () -> () = {
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
+  }
+
+  let _ = {
+    a.f()
+  }
+
+  let _ = { @Sendable in
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  }
+}
+
+actor MyActor {
+  func hello() {} // expected-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
+}
+
+// Compiler >= 5.3 is ended to suppress the parser error
+#if compiler(>=5.3)
+typealias MyFn = (isolated: Int) -> Void // expected-error {{function types cannot have argument labels; use '_' before 'isolated'}}
+#endif
+typealias MyFnFixed = (_: isolated MyActor) -> Void
+
+func standalone(_: isolated MyActor) {}
+
+func check() {
+  let _: MyFnFixed = standalone
+  let _: MyFnFixed = { (_: isolated MyActor) in () }
+}
+
+
+@available(SwiftStdlib 5.1, *)
+protocol P {
+  func f(isolated: MyActor) async
+  func g(isolated x: MyActor) async
+  func h(isolated MyActor: isolated MyActor)
+  func i(isolated: isolated MyActor)
+  func j(isolated: Int) -> Int
+  func k(isolated y: Int) -> Int
+  func l(isolated _: Int) -> Int
+  func m(thing: isolated MyActor)
+}
+
+@available(SwiftStdlib 5.1, *)
+struct S: P {
+  func f(isolated: MyActor) async { await isolated.hello() }
+  func g(isolated x: MyActor) async { await x.hello() }
+  func h(isolated MyActor: isolated MyActor) { i(isolated: MyActor) }
+  func i(isolated: isolated MyActor) { isolated.hello() }
+  func j(isolated: Int) -> Int { return isolated }
+  func k(isolated y: Int) -> Int { return j(isolated: y) }
+  func l(isolated _: Int) -> Int { return k(isolated: 0) }
+  func m(thing: MyActor) { thing.hello() } // expected-error {{call to actor-isolated instance method 'hello()' in a synchronous nonisolated context}}
+}
+
+func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
+  s.m(thing: ma)
+  await p.m(thing: ma)
+}
+
+// Redeclaration checking
+actor TestActor {
+  func test() { // expected-note{{'test()' previously declared here}}
+  }
+  nonisolated func test() { // expected-error{{invalid redeclaration of 'test()'}}
+  }
+}
+
+func redecl(_: TestActor) { } // expected-note{{'redecl' previously declared here}}
+func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration of 'redecl'}}
+
+func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
+
+@available(SwiftStdlib 5.1, *)
+func testTuplingIsolated(
+                         _ a: isolated A, // expected-note {{previous 'isolated' parameter 'a'}}
+                         _ b: isolated A  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+                        ) {
+  tuplify(testTuplingIsolated)
+  // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
+}
+
+// Inference of "isolated" on closure parameters.
+@available(SwiftStdlib 5.1, *)
+func testIsolatedClosureInference(one: A, two: A) async {
+  let _: (isolated A) -> Void = {
+    $0.f()
+  }
+
+  let _: (isolated A) -> Void = {
+    $0.f()
+  }
+
+  let _: (isolated A) -> Void = { a2 in
+    a2.f()
+  }
+
+  let _: (isolated A) -> Void = { (a2: isolated A) in
+    a2.f()
+  }
+
+  let f: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      // expected-note@+2 {{previous 'isolated' parameter 'a1'}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      { (a1, a2) in
+        a1.f()
+        a2.f()
+      }
+
+  await f(one, two)
+
+  let g: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      // expected-note@+2 {{previous 'isolated' parameter '$0'}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      {
+        $0.f()
+        $1.f()
+      }
+
+  await g(one, two)
+}
+
+struct CheckIsolatedFunctionTypes {
+  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  func a(_ f: @MainActor @Sendable (isolated A, isolated A) -> ()) {}
+
+  // expected-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
+  // expected-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  @MainActor func update<R>(_ callback: @Sendable @escaping @MainActor (isolated A) -> R) -> R {
+    callback(A()) // expected-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func checkIsolatedAndGlobalClosures(_ a: A) {
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      = {
+    $0.f()
+    mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
+  }
+
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      = { @MainActor in // expected-warning {{closure with 'isolated' parameter '$0' cannot have a global actor; this is an error in the Swift 6 language mode}}{{11-22=}}
+    $0.f()
+    mainActorFn()
+  }
+
+  let _ = { @MainActor (a: isolated A, // expected-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in the Swift 6 language mode}}{{13-24=}}
+                                       // expected-note@-1 {{previous 'isolated' parameter 'a'}}
+                        b: isolated A, // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+                        c: isolated A) async in
+    a.f()
+    mainActorFn()
+  }
+}
+
+// "isolated" existential parameters.
+protocol P2: Actor {
+  func m()
+}
+
+@available(SwiftStdlib 5.1, *)
+func testExistentialIsolated(a: isolated P2, b: P2) async {
+  a.m()
+  await b.m()
+  b.m() // expected-error{{actor-isolated instance method 'm()' cannot be called from outside of the actor}} {{3-3=await }}
+}
+
+// "isolated" parameters of closures make the closure itself isolated.
+extension TestActor {
+  func isolatedMethod() { }
+  // expected-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
+
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
+  nonisolated func isolatedToParameter(_ other: isolated TestActor) {
+    isolatedMethod()
+    // expected-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
+
+    other.isolatedMethod()
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func isolatedClosures() {
+  let _: (isolated TestActor) -> Void = { (ta: isolated TestActor) in
+    ta.isolatedMethod() // okay, isolated to ta
+
+    _ = {
+      ta.isolatedMethod() // okay, isolated to ta
+    }
+  }
+}
+
+// expected-error@+3 {{global function 'allOfEm' has multiple actor-isolation attributes (@MainActor and 'nonisolated')}}
+// expected-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{12-24=}}
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
+@MainActor nonisolated func allOfEm(_ a: isolated A) {
+  a.f()
+}
+
+@MainActor class MAClass {
+
+  // expected-note@+2 {{previous 'isolated' parameter 'a'}}
+  // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  init(_ a: isolated A, _ b: isolated A) {
+    // FIXME: wrong isolation. should be isolated to `a` only!
+    a.f()
+    b.f()
+  }
+
+  // expected-note@+3 {{previous 'isolated' parameter 'a'}}
+  // expected-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
+  nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
+    a.f()
+    b.f()
+    return 0
+  }
+
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
+  nonisolated func millionDollars(_ a: isolated A) {
+    a.f()
+  }
+}
+
+// Test case for https://github.com/apple/swift/issues/62568
+func execute<ActorType: Actor>(
+  on isolatedActor: isolated ActorType,
+  task: @escaping @Sendable (isolated ActorType) -> Void)
+{
+  // Compiler correctly allows this task to execute synchronously.
+  task(isolatedActor)
+  // Start a task that inherits the current execution context (i.e. that of the isolatedActor)
+  Task {
+    // 'await' is not not necessary because 'task' is synchronous.
+    task(isolatedActor)
+  }
+}
+
+actor ProtectsDictionary {
+  var dictionary: [String: String] = ["A": "B"]
+}
+
+func getValues(
+  forKeys keys: [String],
+  from actor: isolated ProtectsDictionary
+) -> [String?] {
+  // A non-escaping, synchronous closure cannot cross isolation
+  // boundaries; it should be isolated to 'actor'.
+  keys.map { key in
+    actor.dictionary[key]
+  }
+}
+
+func isolated_generic_bad_1<T>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-warning@-2 {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+
+func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
+// expected-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
+
+func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
+
+
+class NotSendable {} // expected-complete-note 5 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+func optionalIsolated(_ ns: NotSendable, to actor: isolated (any Actor)?) async {}
+func optionalIsolatedSync(_ ns: NotSendable, to actor: isolated (any Actor)?) {}
+
+nonisolated func callFromNonisolated(ns: NotSendable) async {
+  await optionalIsolated(ns, to: nil)
+
+  optionalIsolatedSync(ns, to: nil)
+
+  let myActor = A()
+
+  await optionalIsolated(ns, to: myActor)
+
+  optionalIsolatedSync(ns, to: myActor)
+  // expected-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
+}
+
+@MainActor func callFromMainActor(ns: NotSendable) async {
+  await optionalIsolated(ns, to: nil)
+
+  optionalIsolatedSync(ns, to: nil)
+
+  let myActor = A()
+
+  await optionalIsolated(ns, to: myActor)
+
+  optionalIsolatedSync(ns, to: myActor)
+  // expected-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
+}
+
+// TODO: Consider making an actor's Self behave like in a struct, removing this special casing.
+//       We could consider changing this, so that self is always Self because we don't allow inheritance of actors.
+//       See: https://github.com/apple/swift/issues/70954 and rdar://121091417
+actor A2 {
+  nonisolated func f1() async {
+    await { (self: isolated Self) in }(self)
+    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
+    await { (self: isolated Self?) in }(self)
+    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
+  }
+  nonisolated func f2() async -> Self {
+    await { (self: isolated Self) in }(self)
+    await { (self: isolated Self?) in }(self)
+    return self
+  }
+}
+
+func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
+  Task {
+    _ = a
+    _ = ns
+  }
+
+  // FIXME: The `a` in the capture list and `isolated a` are the same,
+  // but the actor isolation checker doesn't know that.
+  Task { [a] in
+    _ = a
+    _ = ns
+  }
+}
+
+
+@globalActor actor MyGlobal {
+  static let shared = MyGlobal()
+}
+
+func sync(isolatedTo actor: isolated (any Actor)?) {}
+
+func pass(value: NotSendable, isolation: isolated (any Actor)?) async -> NotSendable {
+  value
+}
+
+func preciseIsolated(a: isolated MyActor) async {
+  sync(isolatedTo: a)
+  sync(isolatedTo: nil) // okay from anywhere
+  sync(isolatedTo: #isolation)
+
+  Task { @MainActor in
+    sync(isolatedTo: MainActor.shared)
+    sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
+  }
+
+  Task { @MyGlobal in
+    sync(isolatedTo: MyGlobal.shared)
+    sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
+  }
+
+  Task.detached {
+    sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
+  }
+}
+
+func testLValueIsolated() async {
+  var a = A() // expected-warning {{variable 'a' was never mutated}}
+  await sync(isolatedTo: a)
+}
+
+@MainActor func fromMain(ns: NotSendable) async -> NotSendable {
+  await pass(value: ns, isolation: MainActor.shared)
+}
+
+nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
+  await pass(value: ns, isolation: nil)
+}
+
+func invalidIsolatedClosureParam<A: AnyActor> ( // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+  _: (isolated A) async throws -> Void // expected-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
+) {}
+
+public func useDefaultIsolation(
+  _ isolation: isolated (any Actor)? = #isolation
+) {}
+
+public func useDefaultIsolationWithoutIsolatedParam(
+  _ isolation: (any Actor)? = #isolation
+) {}
+
+@MainActor func callUseDefaultIsolation() async {
+  useDefaultIsolation()
+  useDefaultIsolationWithoutIsolatedParam()
+}
+
+public actor MyActorIsolatedParameterMerge {
+  private var inProgressIndexTasks: [Int: Int] = [:]
+
+  public func test() async {
+    await withTaskGroup(of: Void.self) { taskGroup in
+      for (_, _) in inProgressIndexTasks {}
+      await taskGroup.waitForAll()
+    }
+  }
+}
+
+// rdar://138394497
+class ClassWithIsolatedAsyncInitializer {
+    init(isolation: isolated (any Actor)? = #isolation) async {}
+}
+
+// https://github.com/swiftlang/swift/issues/80992
+struct WritableActorKeyPath<Root: Actor, Value>: Sendable {
+    var getter: @Sendable (isolated Root) -> Value
+    var setter: @Sendable (isolated Root, Value) -> Void
+
+    subscript(_ root: isolated Root) -> Value {
+        get { getter(root) }
+        nonmutating set { setter(root, newValue) }
+    }
+}

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete- -strict-concurrency=complete
 
 // REQUIRES: concurrency
 
@@ -22,15 +22,15 @@ extension Future {
 extension Future {
   @available(*, deprecated, message: "")
   func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
-    // expected-complete-and-tns-note @-1 {{parameter 'callback' is implicitly non-Sendable}}
+    // expected-complete-note @-1 {{parameter 'callback' is implicitly non-Sendable}}
     return self.flatMap(callback)
-    // expected-complete-and-tns-warning @-1 {{passing non-Sendable parameter 'callback' to function expecting a '@Sendable' closure}}
+    // expected-complete-warning @-1 {{passing non-Sendable parameter 'callback' to function expecting a '@Sendable' closure}}
   }
 
   @inlinable
   @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
   public func flatMapErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> T) -> Future<T> {
     return self.flatMapErrorThrowing(callback)
-    // expected-complete-and-tns-warning @-1 {{function call causes an infinite recursion}}
+    // expected-complete-warning @-1 {{function call causes an infinite recursion}}
   }
 }

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=minimal
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted -verify-additional-prefix targeted-complete-
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 
 @preconcurrency @MainActor func f() { }
 // expected-note @-1 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-tns-note @-2 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-note @-2 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
 
 @preconcurrency typealias FN = @Sendable () -> Void
 
@@ -18,18 +18,18 @@ struct Outer {
 
 func test() {
   var _: Outer.FN = {
-    f() // expected-complete-tns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
   }
 
   var _: FN = {
-    f() // expected-complete-tns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
     print("Hello")
   }
 
   var mutableVariable = 0
   preconcurrencyFunc {
     mutableVariable += 1 // no sendable warning unless we have complete
-    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code}}
+    // expected-complete-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code}}
   }
   mutableVariable += 1
 }
@@ -57,10 +57,10 @@ func testAsync() async {
 @preconcurrency typealias Handler = (@Sendable () -> OtherHandler?)?
 @preconcurrency func f(arg: Int, withFn: Handler?) {}
 
-class C { // expected-complete-tns-note {{class 'C' does not conform to the 'Sendable' protocol}}
+class C { // expected-complete-note {{class 'C' does not conform to the 'Sendable' protocol}}
   func test() {
     f(arg: 5, withFn: { [weak self] () -> OtherHandler? in
-        _ = self // expected-complete-tns-warning {{capture of 'self' with non-Sendable type 'C?' in a '@Sendable' closure}}
+        _ = self // expected-complete-warning {{capture of 'self' with non-Sendable type 'C?' in a '@Sendable' closure}}
         return nil
       })
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 
@@ -46,40 +46,40 @@ func testInAsync(x: X, plainClosure: () -> Void) async { // expected-note 2{{par
 
 func testElsewhere(x: X) {
   let _: Int = unsafelySendableClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(@Sendable () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(@Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyMainActorClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(@MainActor () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-minimal-targeted-error{{type '(() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-minimal-targeted-error{{type '(X) -> (() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(X) -> (@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(X) -> (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-minimal-targeted-error{{type '(() -> Void) -> ()'}}
-  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.sendableVar // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-error @-1 {{type '@Sendable () -> Void'}}
   let _: Int = x.mainActorVar // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-tns-error @-1 {{type '@MainActor () -> Void'}}
+  // expected-complete-error @-1 {{type '@MainActor () -> Void'}}
   let _: Int = x[{ onMainActor() }] // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-error @-1 {{type '@Sendable () -> Void'}}
   let _: Int = X[statically: { onMainActor() }] // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-error @-1 {{type '@Sendable () -> Void'}}
 }
 
 @MainActor @preconcurrency func onMainActorAlways() { }
-// expected-complete-tns-note @-1 {{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-note @-1 {{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
 @preconcurrency @MainActor class MyModelClass {
 
   // default init() is 'nonisolated' in '-strict-concurrency=complete'
 
   func f() { }
-  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 
 func testCalls(x: X) {
-  // expected-complete-tns-note @-1 2{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
+  // expected-complete-note @-1 2{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
   unsafelyMainActorClosure {
     onMainActor()
   }
@@ -97,15 +97,15 @@ func testCalls(x: X) {
     })
 
   onMainActorAlways() // okay with minimal/targeted concurrency. Not ok with complete.
-  // expected-complete-tns-warning @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
+  // expected-complete-warning @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   // Ok with minimal/targeted concurrency, Not ok with complete.
-  let _: () -> Void = onMainActorAlways // expected-complete-tns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-complete-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   let c = MyModelClass()
 
   // okay with minimal/targeted... an error with complete.
-  c.f() // expected-complete-tns-warning {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  c.f() // expected-complete-warning {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
 }
 
 func testCallsWithAsync() async {
@@ -125,14 +125,14 @@ func testCallsWithAsync() async {
 protocol Q: P { }
 
 class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
-// expected-complete-tns-note @-1 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+// expected-complete-note @-1 2{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct S1: P {
-  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'NS'}}
+  var ns: NS // expected-complete-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'NS'}}
 }
 
 struct S2: Q {
-  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-Sendable type 'NS'}}
+  var ns: NS // expected-complete-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-Sendable type 'NS'}}
 }
 
 struct S3: Q, Sendable {
@@ -169,11 +169,11 @@ public enum StringPlacement : Sendable {
 func testStringPlacement() {
   let fn1 = StringPlacement.position(before: "Test")
   let _: Int = fn1   // expected-minimal-targeted-error{{cannot convert value of type '([String]) -> Int' to specified type 'Int'}}
-  // expected-complete-tns-error @-1 {{type 'StringPlacement.StringPosition' (aka '@Sendable (Array<String>) -> Int')}}
+  // expected-complete-error @-1 {{type 'StringPlacement.StringPosition' (aka '@Sendable (Array<String>) -> Int')}}
 
   let fn2 = StringPlacement.position(before:)
   let _: Int = fn2 // expected-minimal-targeted-error{{cannot convert value of type '(String) -> ([String]) -> Int' to specified type 'Int'}}
-  // expected-complete-tns-error @-1 {{type '(String) -> StringPlacement.StringPosition' (aka '(String) -> @Sendable (Array<String>) -> Int')}}
+  // expected-complete-error @-1 {{type '(String) -> StringPlacement.StringPosition' (aka '(String) -> @Sendable (Array<String>) -> Int')}}
 }
 
 // @preconcurrency in an outer closure
@@ -189,17 +189,17 @@ class EventLoop {
   func scheduleTask<T>(deadline: Int, _ task: @escaping @Sendable () throws -> T) -> Scheduled<T> { fatalError("") }
 }
 
-class C { // expected-complete-tns-note {{'C' does not conform to the 'Sendable' protocol}}
+class C { // expected-complete-note {{'C' does not conform to the 'Sendable' protocol}}
   var ev: EventLoop? = nil
 
   func test(i: Int) {
-    func doNext() { // expected-complete-tns-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
+    func doNext() { // expected-complete-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
       doPreconcurrency {
         self.ev?.scheduleTask(deadline: i, doNext)
-        // expected-complete-tns-warning @-1 {{capture of 'self' with non-Sendable type 'C' in a '@Sendable' closure}}
-        // expected-complete-tns-warning @-2 {{converting non-Sendable function value to '@Sendable () throws -> ()' may introduce data races}}
-        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
-        // expected-complete-tns-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+        // expected-complete-warning @-1 {{capture of 'self' with non-Sendable type 'C' in a '@Sendable' closure}}
+        // expected-complete-warning @-2 {{converting non-Sendable function value to '@Sendable () throws -> ()' may introduce data races}}
+        // expected-complete-warning @-3 {{capture of 'doNext()' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
+        // expected-complete-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         return
       }
     }
@@ -224,26 +224,25 @@ protocol NotIsolated {
   func requirement()
 }
 
-// expected-complete-tns-warning@+1{{conformance of 'MainActorPreconcurrency' to protocol 'NotIsolated' crosses into main actor-isolated code and can cause data races}}
+// expected-complete-warning@+1{{conformance of 'MainActorPreconcurrency' to protocol 'NotIsolated' crosses into main actor-isolated code and can cause data races}}
 extension MainActorPreconcurrency: NotIsolated {
-  // expected-complete-note@-1{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
-  // expected-complete-tns-note@-2{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
-  // expected-complete-tns-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-complete-tns-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-complete-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
+  // expected-complete-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-complete-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
   func requirement() {}
-  // expected-complete-tns-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
-  // expected-complete-tns-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
+  // expected-complete-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
 
 
   class Nested {
     weak var c: MainActorPreconcurrency?
 
     func test() {
-    // expected-complete-tns-note@-1 {{add '@MainActor' to make instance method 'test()' part of global actor 'MainActor'}}
+    // expected-complete-note@-1 {{add '@MainActor' to make instance method 'test()' part of global actor 'MainActor'}}
 
       if let c {
         c.requirement()
-        // expected-complete-tns-warning@-1 {{call to main actor-isolated instance method 'requirement()' in a synchronous nonisolated context}}
+        // expected-complete-warning@-1 {{call to main actor-isolated instance method 'requirement()' in a synchronous nonisolated context}}
       }
     }
   }
@@ -361,11 +360,11 @@ func testSendableMetatypeDowngrades() {
   func acceptsSendableMetatype<T: SendableMetatype>(_: T.Type) {}
   func acceptsSendableMetatypeStrict<T: SendableMetatype>(_: T.Type) {}
 
-  func test<T>(t: T.Type) { // expected-complete-tns-note 2 {{consider making generic parameter 'T' conform to the 'SendableMetatype' protocol}} {{14-14=: SendableMetatype}}
+  func test<T>(t: T.Type) { // expected-complete-note 2 {{consider making generic parameter 'T' conform to the 'SendableMetatype' protocol}} {{14-14=: SendableMetatype}}
     acceptsSendableMetatype(t)
-    // expected-complete-tns-warning@-1 {{type 'T' does not conform to the 'SendableMetatype' protocol}}
+    // expected-complete-warning@-1 {{type 'T' does not conform to the 'SendableMetatype' protocol}}
     acceptsSendableMetatypeStrict(t)
-    // expected-complete-tns-warning@-1 {{type 'T' does not conform to the 'SendableMetatype' protocol}}
+    // expected-complete-warning@-1 {{type 'T' does not conform to the 'SendableMetatype' protocol}}
   }
 }
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete
 
 // REQUIRES: concurrency
 
@@ -158,9 +158,9 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
 // rdar://86653457 - Crash due to missing Sendable conformances.
 // expected-warning @+1 {{non-final class 'Klass' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
 class Klass<Output: Sendable>: Sendable {}
-// expected-complete-and-tns-warning @+1 {{type 'S' does not conform to the 'Sendable' protocol}}
+// expected-complete-warning @+1 {{type 'S' does not conform to the 'Sendable' protocol}}
 final class SubKlass: Klass<[S]> {}
-// expected-complete-and-tns-note @+1 {{consider making struct 'S' conform to the 'Sendable' protocol}}
+// expected-complete-note @+1 {{consider making struct 'S' conform to the 'Sendable' protocol}}
 public struct S {}
 
 // rdar://88700507 - redundant conformance of @MainActor-isolated subclass to 'Sendable'
@@ -205,14 +205,14 @@ public struct TestSendableWitnesses2 : NoSendableReqs {
 
 // @preconcurrency attributes to make it akin to an imported Obj-C API
 @preconcurrency @MainActor public protocol EscapingSendableProtocol {
-  // expected-complete-and-tns-note @+1 {{protocol requires function 'f(handler:)' with type '(@escaping @MainActor @Sendable (Int) -> Void) -> ()'}}
+  // expected-complete-note @+1 {{protocol requires function 'f(handler:)' with type '(@escaping @MainActor @Sendable (Int) -> Void) -> ()'}}
   @preconcurrency func f(handler: @escaping @MainActor @Sendable (Int) -> Void)
 }
 
 // TODO: The following error should actually be a warning.
-// expected-complete-and-tns-error @+2 {{type 'TestEscapingOnly' does not conform to protocol 'EscapingSendableProtocol'}}
-// expected-complete-and-tns-note @+1 {{add stubs for conformance}}
+// expected-complete-error @+2 {{type 'TestEscapingOnly' does not conform to protocol 'EscapingSendableProtocol'}}
+// expected-complete-note @+1 {{add stubs for conformance}}
 class TestEscapingOnly: EscapingSendableProtocol {
-    // expected-complete-and-tns-note @+1 {{candidate has non-matching type '(@escaping (Int) -> Void) -> ()'}}
+    // expected-complete-note @+1 {{candidate has non-matching type '(@escaping (Int) -> Void) -> ()'}}
     func f(handler: @escaping (Int) -> Void) {}
 }

--- a/test/Concurrency/sendable_existentials.swift
+++ b/test/Concurrency/sendable_existentials.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -emit-sil -o /dev/null %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
@@ -35,22 +35,22 @@ func testE(a: Any, aOpt: Any?) async {
 }
 
 func testESilently(a: Any, aOpt: Any?) {
-  send(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  sendOpt(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  sendOpt(aOpt) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  send(a) // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(a) // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(aOpt) // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
-  let _: E = .something(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  _ = E.something(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  let _: E = .something(a) // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  _ = E.something(a) // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
   var sendable: Sendable
-  sendable = a // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendable = a // expected-complete-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
   var arrayOfSendable: [Sendable]
-  arrayOfSendable = [a, a] // expected-complete-and-tns-warning 2{{'Any' does not conform to the 'Sendable' protocol}}
+  arrayOfSendable = [a, a] // expected-complete-warning 2{{'Any' does not conform to the 'Sendable' protocol}}
 
   func localFunc() { }
-  sendable = localFunc // expected-complete-and-tns-warning {{'() -> ()' does not conform to the 'Sendable' protocol}}
-  // expected-complete-and-tns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  sendable = localFunc // expected-complete-warning {{'() -> ()' does not conform to the 'Sendable' protocol}}
+  // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   _ = sendable
   _ = arrayOfSendable
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1,11 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-ni- -verify-additional-prefix tns- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-ni-ns- -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
-
-// This run validates that for specific test cases around closures, we properly
-// emit errors in the type checker before we run sns. This ensures that we know that
-// these cases can't happen when SNS is enabled.
-//
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix ni- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix ni-ns- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
@@ -18,7 +12,7 @@
 /// Classes are always non-Sendable, so this is non-Sendable
 class NonSendableKlass { // expected-complete-note 53{{}}
   // expected-typechecker-only-note @-1 3{{}}
-  // expected-tns-note @-2 {{}}
+  // expected-note @-2 {{}}
   var field: NonSendableKlass? = nil
   var boolean: Bool = false
 
@@ -109,15 +103,15 @@ enum MyEnum<T> {
 extension MyActor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
-    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
+    // expected-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-ni-warning @-1 {{sending 'self.finalKlass' risks causing data races}}
-    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-ni-warning @-1 {{sending 'self.finalKlass' risks causing data races}}
+    // expected-ni-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 
   // We do not warn on this since we warn in the caller of our getter instead.
@@ -130,8 +124,8 @@ extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
-    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
+    // expected-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 }
 
@@ -160,13 +154,13 @@ func closureInOut(_ a: MyActor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-warning @-2 {{sending 'ns0' risks causing data races}}
+  // expected-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
   if await booleanFlag {
-    await a.useKlass(ns1) // expected-tns-note {{access can happen concurrently}}
+    await a.useKlass(ns1) // expected-note {{access can happen concurrently}}
   } else {
-    closure() // expected-tns-note {{access can happen concurrently}}
+    closure() // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -183,16 +177,16 @@ func closureInOutDifferentActor(_ a: MyActor, _ a2: MyActor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-warning @-2 {{sending 'ns0' risks causing data races}}
+  // expected-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
   // We only emit a warning on the first use we see, so make sure we do both
   // the use and the closure.
   if await booleanFlag {
-    await a2.useKlass(ns1) // expected-tns-note {{access can happen concurrently}}
+    await a2.useKlass(ns1) // expected-note {{access can happen concurrently}}
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
   } else {
-    closure() // expected-tns-note {{access can happen concurrently}}
+    closure() // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -207,17 +201,17 @@ func closureInOut2(_ a: MyActor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns0) // expected-warning {{sending 'ns0' risks causing data races}}
+  // expected-note @-1 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
-  closure = { useInOut(&contents) } // expected-tns-note {{access can happen concurrently}}
+  closure = { useInOut(&contents) } // expected-note {{access can happen concurrently}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns1) // expected-warning {{sending 'ns1' risks causing data races}}
+  // expected-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
-  closure() // expected-tns-note {{access can happen concurrently}}
+  closure() // expected-note {{access can happen concurrently}}
 }
 
 func closureNonInOut(_ a: MyActor) async {
@@ -235,11 +229,11 @@ func closureNonInOut(_ a: MyActor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns1) // expected-warning {{sending 'ns1' risks causing data races}}
+  // expected-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
-  closure() // expected-tns-note {{access can happen concurrently}}
+  closure() // expected-note {{access can happen concurrently}}
 }
 
 // TODO: Rework the nonisolated closure so we only treat nonisolated closures
@@ -267,8 +261,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTuple() async {
@@ -278,8 +272,8 @@ extension MyActor {
     let x = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending value of non-Sendable type '(Int, () -> ())' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated value of non-Sendable type '(Int, () -> ())' to main actor-isolated global function 'transferToMain' risks causing races in between 'self'-isolated and main actor-isolated uses}}
+    // expected-warning @-2 {{sending value of non-Sendable type '(Int, () -> ())' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated value of non-Sendable type '(Int, () -> ())' to main actor-isolated global function 'transferToMain' risks causing races in between 'self'-isolated and main actor-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTupleBackwards() async {
@@ -288,8 +282,8 @@ extension MyActor {
     }
 
     let x = (closure, 1)
-    await transferToMain(x) // expected-tns-warning {{sending value of non-Sendable type '(() -> (), Int)' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated value of non-Sendable type '(() -> (), Int)' to main actor-isolated global function 'transferToMain' risks causing races in between 'self'-isolated and main actor-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending value of non-Sendable type '(() -> (), Int)' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '(() -> (), Int)' to main actor-isolated global function 'transferToMain' risks causing races in between 'self'-isolated and main actor-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughOptional() async {
@@ -298,8 +292,8 @@ extension MyActor {
     }
     let x: Any? = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughOptionalBackwards() async {
@@ -311,8 +305,8 @@ extension MyActor {
     // store it all as once.
     let x: Any? = (closure, 1)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit() async {
@@ -323,8 +317,8 @@ extension MyActor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
 
     closure = {}
 
@@ -349,8 +343,8 @@ extension MyActor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit3() async {
@@ -359,8 +353,8 @@ extension MyActor {
     // We get a transfer after use error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
 
     if await booleanFlag {
       closure = {
@@ -370,9 +364,9 @@ extension MyActor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-note @-2 {{access can happen concurrently}}
-    // expected-tns-warning @-3 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-4 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-note @-2 {{access can happen concurrently}}
+    // expected-warning @-3 {{sending 'closure' risks causing data races}}
+    // expected-note @-4 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // In this case, we reinit along both paths, but only one has an actor derived
@@ -394,27 +388,9 @@ extension MyActor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
-
-  #if TYPECHECKER_ONLY
-
-  func simpleClosureCaptureSelfThroughTupleWithFieldAccess() async {
-    // In this case, we erase that we accessed self so we hit a type checker
-    // error. We could make this a SNS error, but since in the other cases where
-    // we have a nonisolated non-async we are probably going to change it to be
-    // async as well making these errors go away.
-    let x = (self, 1)
-    let closure: () -> () = {
-      print(x.0.klass) // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-    }
-    await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  }
-
-  #endif
 
   func simpleClosureCaptureSelfThroughTuple() async {
     let x = (self, self.klass)
@@ -423,8 +399,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughTuple2() async {
@@ -434,8 +410,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughOptional() async {
@@ -445,8 +421,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -457,34 +433,6 @@ func testSimpleLetClosureCaptureActor() async {
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
-#if TYPECHECKER_ONLY
-
-func testSimpleLetClosureCaptureActorField() async {
-  let a = MyActor()
-  let closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
-  let a = (MyActor(), 0)
-  let closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-func testSimpleLetClosureCaptureActorFieldThroughOptional() async {
-  let a: MyActor? = MyActor()
-  let closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-#endif
-
 func testSimpleVarClosureCaptureActor() async {
   let a = MyActor()
   var closure = {}
@@ -493,36 +441,6 @@ func testSimpleVarClosureCaptureActor() async {
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
-#if TYPECHECKER_ONLY
-
-func testSimpleVarClosureCaptureActorField() async {
-  let a = MyActor()
-  var closure = {}
-  closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
-  let a = (MyActor(), 0)
-  var closure = {}
-  closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-func testSimpleVarClosureCaptureActorFieldThroughOptional() async {
-  let a: MyActor? = MyActor()
-  var closure = {}
-  closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
-  await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
-  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-}
-
-#endif
 
 extension MyActor {
   // Make sure that we properly propagate actor derived from klass into field's
@@ -534,8 +452,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // Make sure that we properly propagate actor derived from klass into field's
@@ -547,8 +465,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -561,8 +479,8 @@ extension MyActor {
     // This should error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
 
     // This doesnt since we re-assign
     closure = {}
@@ -575,11 +493,11 @@ extension MyActor {
     // But this transfer should.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
-    // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-warning @-2 {{sending 'closure' risks causing data races}}
+    // expected-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
 
     // But this will error since we race.
-    closure() // expected-tns-note {{access can happen concurrently}}
+    closure() // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -599,8 +517,8 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
   // Show that we error if we are not sendable.
   await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-Sendable type '() -> Void' into actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{sending 'f2' risks causing data races}}
-  // expected-tns-note @-3 {{sending task-isolated 'f2' to actor-isolated instance method 'useNonSendableFunction' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-warning @-2 {{sending 'f2' risks causing data races}}
+  // expected-note @-3 {{sending task-isolated 'f2' to actor-isolated instance method 'useNonSendableFunction' risks causing data races between actor-isolated and task-isolated uses}}
 }
 
 func testSendableClosureCapturesNonSendable(a: MyActor) {
@@ -644,14 +562,14 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{sending 'box' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(box) // expected-warning {{sending 'box' risks causing data races}}
+  // expected-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
 
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
   // all.
-  useValue(box.k) // expected-tns-note {{access can happen concurrently}}
+  useValue(box.k) // expected-note {{access can happen concurrently}}
 }
 
 func multipleFieldVarMergeTest1() async {
@@ -659,13 +577,13 @@ func multipleFieldVarMergeTest1() async {
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
-  await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(box.k1) // expected-warning {{sending 'box.k1' risks causing data races}}
+  // expected-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
 
   // So even if we reassign over k1, since we did a merge, this should error.
-  box.k1 = NonSendableKlass() // expected-tns-note {{access can happen concurrently}}
+  box.k1 = NonSendableKlass() // expected-note {{access can happen concurrently}}
   useValue(box)
 }
 
@@ -700,12 +618,12 @@ func multipleFieldTupleMergeTest1() async {
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{sending 'box.0' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'box.0' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(box.0) // expected-warning {{sending 'box.0' risks causing data races}}
+  // expected-note @-1 {{sending 'box.0' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
-  box.0 = NonSendableKlass() // expected-tns-note {{access can happen concurrently}}
+  box.0 = NonSendableKlass() // expected-note {{access can happen concurrently}}
   useValue(box)
 }
 
@@ -753,56 +671,56 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.letNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial  // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableNonTrivial  // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -821,55 +739,55 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.letNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial  // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableNonTrivial  // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -888,28 +806,28 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letSendableTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.letSendableTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.letSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.letNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -917,30 +835,30 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.letNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -957,10 +875,10 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
     print(test)
   }
   _ = cls2
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.letSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   let z2 = test.varSendableNonTrivial
   _ = z2
@@ -969,28 +887,28 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  _ = test.varSendableNonTrivial // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.varNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -998,30 +916,30 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.varNonSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -1034,10 +952,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.letSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -1049,10 +967,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.varSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -1064,10 +982,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1080,10 +998,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.letSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -1096,10 +1014,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
+  let z = test.varSendableNonTrivial // expected-note {{access can happen concurrently}}
   _ = z
   useValue(test)
 }
@@ -1112,10 +1030,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1127,10 +1045,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1142,10 +1060,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1157,10 +1075,10 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1175,14 +1093,14 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+    // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
   }
 
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
@@ -1196,12 +1114,12 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+    // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
   useValue(test)
 }
 
@@ -1218,13 +1136,13 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+    // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass()
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
@@ -1238,9 +1156,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // loop carry use and an error due to multiple params. Then we could emit
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access can happen concurrently}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+    // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-note @-2 {{access can happen concurrently}}
 
     // This is treated as a use since test is in box form and is mutable. So we
     // treat assignment as a merge.
@@ -1267,9 +1185,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access can happen concurrently}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-note @-2 {{access can happen concurrently}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
   }
@@ -1291,17 +1209,17 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
-  useValue(test)  // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
+  useValue(test)  // expected-note {{access can happen concurrently}}
 }
 
 // In this case since we are tracking the transfer from the else statement, we
@@ -1312,21 +1230,21 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  test.varSendableNonTrivial = SendableKlass() // expected-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 ////////////////////////////
@@ -1335,30 +1253,30 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
   useValue(z)
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.2 // expected-tns-note {{access can happen concurrently}}
+  let z = test.2 // expected-note {{access can happen concurrently}}
   useValue(z)
   useValue(test)
 }
@@ -1366,40 +1284,40 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varSendableTrivialVarTupleFieldTest2() async {
   var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test.2) // expected-warning {{sending 'test.2' risks causing data races}}
+  // expected-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
-  useValue(test) // expected-tns-note {{access can happen concurrently}}
+  useValue(test) // expected-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-warning {{sending 'test' risks causing data races}}
+  // expected-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.2 // expected-tns-note {{access can happen concurrently}}
+  let z = test.2 // expected-note {{access can happen concurrently}}
   useValue(z)
   useValue(test)
 }
@@ -1412,16 +1330,16 @@ func controlFlowTest1() async {
   let x = NonSendableKlass()
 
   if await booleanFlag {
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
-  useValue(x) // expected-tns-note 2{{access can happen concurrently}}
+  useValue(x) // expected-note 2{{access can happen concurrently}}
 }
 
 // This test seems like something that we should not error upon. What is
@@ -1436,9 +1354,9 @@ func controlFlowTest2() async {
   var x = NonSendableKlass()
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access can happen concurrently}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-note @-2 {{access can happen concurrently}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     x = NonSendableKlass()
@@ -1461,45 +1379,32 @@ actor ActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
-
-  // This triggers a crash in SILGen with tns enabled.
-  #if TYPECHECKER_ONLY
-  func recursive() async {
-    let x = NonSendableKlass()
-    await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-    // expected-typechecker-only-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-
-    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  }
-  #endif
 
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
@@ -1514,53 +1419,40 @@ final actor FinalActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
-
-  // This triggers a crash in SILGen with tns enabled.
-  #if TYPECHECKER_ONLY
-  func recursive() async {
-    let x = NonSendableKlass()
-    await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-    // expected-typechecker-only-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-
-    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  }
-  #endif
 
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
-    let _ = x // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    let _ = x // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     // expected-complete-warning @-2 {{capture of 'x' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -1579,8 +1471,8 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
     // loop we are disconnected... meaning that we are ok. The second time
     // through the loop, we are now main actor isolated, but again b/c we
     // inherit isolation, we are ok.
-    await useValueAsync(c) // expected-tns-ni-warning {{sending 'c' risks causing data races}}
-    // expected-tns-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+    await useValueAsync(c) // expected-ni-warning {{sending 'c' risks causing data races}}
+    // expected-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klass
   }
@@ -1590,8 +1482,8 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let a = MainActorIsolatedKlass()
   var c = NonSendableKlass()
   for _ in 0..<1024 {
-    await useValueAsync(c) // expected-tns-ni-warning {{sending 'c' risks causing data races}}
-    // expected-tns-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+    await useValueAsync(c) // expected-ni-warning {{sending 'c' risks causing data races}}
+    // expected-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klassLet
   }
@@ -1600,24 +1492,24 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
 func testGetActorName() async {
   let a = MyActor()
   let x = NonSendableKlass()
-  await a.useKlass(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  await a.useKlass(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 extension MyActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
-    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
+    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-warning {{sending 'self.klass' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
 extension FinalActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
-    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
+    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-warning {{sending 'self.klass' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
@@ -1629,16 +1521,16 @@ extension NonSendableKlass {
 
 extension MyActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
-    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
+    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-warning {{sending 'self.klass' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
 extension FinalActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
-    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
+    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-warning {{sending 'self.klass' risks causing data races}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
@@ -1667,8 +1559,8 @@ extension MyActor {
       let x = NonSendableKlass()
       self.useKlass(x)
       await transferToMain(x)
-      // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-      // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+      // expected-warning @-1 {{sending 'x' risks causing data races}}
+      // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
       // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     }
   }
@@ -1728,10 +1620,10 @@ func initAccessorTests() {
 func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
   let x = NonSendableKlass()
   await a.useKlass(x)
-  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
-  await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
+  await b.useKlass(x) // expected-note {{access can happen concurrently}}
   // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
 }
 
@@ -1743,19 +1635,19 @@ func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.
 }
 
 func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
-  await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 func sendableGlobalActorIsolated() {
   let x = NonSendableKlass()
   let _ = { @Sendable @MainActor in
-    print(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-    // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    print(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     // expected-complete-warning @-2 {{capture of 'x' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
-  print(x) // expected-tns-note {{access can happen concurrently}}
+  print(x) // expected-note {{access can happen concurrently}}
 }
 
 // We do not get an error here since we are transferring x both times to a
@@ -1764,9 +1656,9 @@ func sendableGlobalActorIsolated() {
 // value.
 func testIndirectParameterSameIsolationNoError() async {
   let x = NonSendableKlass()
-  await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  await transferToMain(x) // expected-tns-note {{access can happen concurrently}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-note {{access can happen concurrently}}
 }
 
 extension MyActor {
@@ -1779,12 +1671,12 @@ extension MyActor {
         _ = self
         _ = sc
 
-        Task { // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+        Task { // expected-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+          // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 
-        Task { // expected-tns-note {{access can happen concurrently}}
+        Task { // expected-note {{access can happen concurrently}}
           _ = sc
         }
       }
@@ -1839,8 +1731,8 @@ actor FunctionWithSendableResultAndIsolationActor {
 @MainActor
 func previouslyBrokenTestCase(ns: NonSendableKlass) async -> SendableGenericStruct? {
   return await { () -> SendableGenericStruct? in
-    return await ns.getSendableGenericStructAsync() // expected-tns-ni-warning {{sending 'ns' risks causing data races}}
-    // expected-tns-ni-note @-1 {{sending main actor-isolated 'ns' to nonisolated instance method 'getSendableGenericStructAsync()' risks causing data races between nonisolated and main actor-isolated uses}}
+    return await ns.getSendableGenericStructAsync() // expected-ni-warning {{sending 'ns' risks causing data races}}
+    // expected-ni-note @-1 {{sending main actor-isolated 'ns' to nonisolated instance method 'getSendableGenericStructAsync()' risks causing data races between nonisolated and main actor-isolated uses}}
   }()
 }
 
@@ -1878,15 +1770,15 @@ public class Context {
 
 extension MyActor {
   public func withContext<T>(_ block: sending (NonSendableKlass) throws -> T) async throws -> sending T {
-    return try block(klass) // expected-tns-warning {{returning 'self'-isolated 'self.klass' as a 'sending' result risks causing data races}}
-    // expected-tns-note @-1 {{returning 'self'-isolated 'self.klass' risks causing data races since the caller assumes that 'self.klass' can be safely sent to other isolation domains}}
+    return try block(klass) // expected-warning {{returning 'self'-isolated 'self.klass' as a 'sending' result risks causing data races}}
+    // expected-note @-1 {{returning 'self'-isolated 'self.klass' risks causing data races since the caller assumes that 'self.klass' can be safely sent to other isolation domains}}
   }
 }
 
 func nonSendableAllocBoxConsumingParameter(x: consuming SendableKlass) async throws {
   try await withThrowingTaskGroup(of: Void.self) { group in
-    group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-tns-note {{closure captures reference to mutable parameter 'x' which is accessible to code in the current task}}
+    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      useValue(x) // expected-note {{closure captures reference to mutable parameter 'x' which is accessible to code in the current task}}
     }
 
     try await group.waitForAll()
@@ -1898,8 +1790,8 @@ func nonSendableAllocBoxConsumingVar() async throws {
   x = SendableKlass()
 
   try await withThrowingTaskGroup(of: Void.self) { group in
-    group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-tns-note {{closure captures reference to mutable var 'x' which is accessible to code in the current task}}
+    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      useValue(x) // expected-note {{closure captures reference to mutable var 'x' which is accessible to code in the current task}}
     }
 
     try await group.waitForAll()
@@ -1917,8 +1809,8 @@ func offByOneWithImplicitPartialApply() {
       func b() {
           let asdf = ""
           Task { @MainActor in
-            a.description = asdf // expected-tns-warning {{sending 'self' risks causing data races}}
-            // expected-tns-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+            a.description = asdf // expected-warning {{sending 'self' risks causing data races}}
+            // expected-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
           }
       }
   }
@@ -1956,8 +1848,8 @@ func testIndirectAndDirectSendingResultsWithGlobalActor() async {
 func testFunctionIsNotEmpty(input: SendableKlass) async throws {
   var result: [SendableKlass] = []
   try await withThrowingTaskGroup(of: Void.self) { taskGroup in // expected-warning {{no calls to throwing functions occur within 'try' expression}}
-    taskGroup.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      result.append(input) // expected-tns-note {{closure captures reference to mutable var 'result' which is accessible to code in the current task}}
+    taskGroup.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      result.append(input) // expected-note {{closure captures reference to mutable var 'result' which is accessible to code in the current task}}
     }
   }
 }
@@ -1977,8 +1869,8 @@ extension NonIsolatedFinalKlass {
   // We used to crash while computing the isolation of the ref_element_addr
   // here. Make sure we do not crash.
   func testGetIsolationInfoOfField() async {
-    await transferToMain(ns) // expected-tns-warning {{sending 'self.ns' risks causing data races}}
-    // expected-tns-note @-1 {{sending task-isolated 'self.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+    await transferToMain(ns) // expected-warning {{sending 'self.ns' risks causing data races}}
+    // expected-note @-1 {{sending task-isolated 'self.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   }
 }
 
@@ -1987,20 +1879,20 @@ func mutableLocalCaptureDataRace() async {
   x = 0
   _ = x
 
-  Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
+  Task.detached { x = 1 } // expected-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+  // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
 
-  x = 2 // expected-tns-note {{access can happen concurrently}}
+  x = 2 // expected-note {{access can happen concurrently}}
 }
 
 func mutableLocalCaptureDataRace2() async {
   var x = 0
   x = 0
 
-  Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
+  Task.detached { x = 1 } // expected-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+  // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
 
-  print(x) // expected-tns-note {{access can happen concurrently}}
+  print(x) // expected-note {{access can happen concurrently}}
 }
 
 func localCaptureDataRace3() async {
@@ -2015,10 +1907,10 @@ nonisolated func localCaptureDataRace4() {
   var x = 0
   _ = x
 
-  Task.detached { @MainActor in x = 1 } // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  Task.detached { @MainActor in x = 1 } // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
 
-  x = 2 // expected-tns-note {{access can happen concurrently}}
+  x = 2 // expected-note {{access can happen concurrently}}
 }
 
 // We shouldn't error here since every time around, we are using the same
@@ -2091,10 +1983,10 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
 
     func d() {
       a.block = c // expected-warning {{converting non-Sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
-      // expected-tns-warning @-1 {{non-Sendable '@MainActor () -> ()'-typed result can not be returned from main actor-isolated function to nonisolated context}}
-      // expected-tns-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-      // expected-tns-warning @-3 {{sending 'self' risks causing data races}}
-      // expected-tns-note @-4 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-warning @-1 {{non-Sendable '@MainActor () -> ()'-typed result can not be returned from main actor-isolated function to nonisolated context}}
+      // expected-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+      // expected-warning @-3 {{sending 'self' risks causing data races}}
+      // expected-note @-4 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
     @MainActor
@@ -2103,9 +1995,9 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
 }
 
 nonisolated(nonsending) func testCallNonisolatedNonsending(_ x: NonSendableKlass) async {
-  await useValueAsync(x) // expected-tns-ni-warning {{sending 'x' risks causing data races}}
-  // expected-tns-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
-  await useValueAsyncConcurrent(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsyncConcurrent' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
-  // expected-tns-ni-ns-note @-2 {{sending task-isolated 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent and task-isolated uses}}
+  await useValueAsync(x) // expected-ni-warning {{sending 'x' risks causing data races}}
+  // expected-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  await useValueAsyncConcurrent(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsyncConcurrent' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  // expected-ni-ns-note @-2 {{sending task-isolated 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent and task-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // READ THIS: This test is intended to centralize all tests that use
 // nonisolated(unsafe).
@@ -54,37 +54,37 @@ func transferLetNonTransferrableSquelched(_ ns: NonSendableKlass) async {
   let ns4 = ns
 
   await transferToMainDirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -95,25 +95,25 @@ func useAfterTransferLetSquelchedDirect() async {
   let ns4 = ns
 
   await transferToMainDirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns) // expected-tns-note {{access can happen concurrently}}
+  print(ns) // expected-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns2)
   print(ns2)
 
   await transferToMainDirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns3) // expected-tns-note {{access can happen concurrently}}
+  print(ns3) // expected-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns4) // expected-tns-note {{access can happen concurrently}}
+  print(ns4) // expected-note {{access can happen concurrently}}
 }
 
 func useAfterTransferSquelchedIndirect() async {
@@ -123,25 +123,25 @@ func useAfterTransferSquelchedIndirect() async {
   let ns4 = ns
 
   await transferToMainIndirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns) // expected-tns-note {{access can happen concurrently}}
+  print(ns) // expected-note {{access can happen concurrently}}
 
   await transferToMainIndirect(ns2)
   print(ns2)
 
   await transferToMainIndirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns3) // expected-tns-note {{access can happen concurrently}}
+  print(ns3) // expected-note {{access can happen concurrently}}
 
   await transferToMainIndirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns4) // expected-tns-note {{access can happen concurrently}}
+  print(ns4) // expected-note {{access can happen concurrently}}
 }
 
 // We consider the klass field separate from the klass, so we get an error.
@@ -149,12 +149,12 @@ func transferNonTransferrableClassField(_ ns: NonSendableKlass) async {
   nonisolated(unsafe) let ns2 = ns
 
   await transferToMainDirect(ns2.field!)
-  // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainIndirect(ns2.field!)
-  // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -166,18 +166,18 @@ func transferNonTransferrableStructField(_ ns: NonSendableStruct) async {
   await transferToMainIndirect(ns2)
 
   await transferToMainDirect(ns2.field!)
-  // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field!)
-  // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field)
-  // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
 }
 
@@ -186,13 +186,13 @@ func testConsumingTransfer(_ ns: NonSendableKlass) async {
   nonisolated(unsafe) let ns2 = ns
 
   await transferToMainDirectConsuming(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirectConsuming(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirectConsuming(ns2)
@@ -209,37 +209,37 @@ func transferVarNonTransferrableSquelched(_ ns: NonSendableKlass) async {
   let ns4 = ns
 
   await transferToMainDirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -251,25 +251,25 @@ func useAfterTransferVarSquelchedDirect() async {
   let ns4 = ns
 
   await transferToMainDirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns) // expected-tns-note {{access can happen concurrently}}
+  print(ns) // expected-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns2)
   print(ns2)
 
   await transferToMainDirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns3) // expected-tns-note {{access can happen concurrently}}
+  print(ns3) // expected-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  print(ns4) // expected-tns-note {{access can happen concurrently}}
+  print(ns4) // expected-note {{access can happen concurrently}}
 }
 
 //////////////////////////////
@@ -284,20 +284,20 @@ func transferLetNonTransferrableSquelchedAddressOnly<T>(_ ns: T) async { // expe
   let ns4 = ns
 
   await transferToMainIndirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 }
 
@@ -308,8 +308,8 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
   let ns4 = ns
 
   await transferToMainIndirect(ns)
-  // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns)
 
@@ -317,14 +317,14 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
   print(ns2)
 
   await transferToMainIndirect(ns3)
-  // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns3' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns3)
 
   await transferToMainIndirect(ns4)
-  // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-warning @-1 {{sending 'ns4' risks causing data races}}
+  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns4)
 }
@@ -394,8 +394,8 @@ actor MyActor {
 
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
@@ -416,8 +416,8 @@ final actor MyFinalActor {
 
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
@@ -443,10 +443,10 @@ final class FinalNonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
     // TODO: Is this correct?
     let x = nonIsolatedLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    print(x) // expected-tns-note {{access can happen concurrently}}
+    print(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -470,10 +470,10 @@ class NonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
     // TODO: Is this correct?
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    print(x) // expected-tns-note {{access can happen concurrently}}
+    print(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -497,10 +497,10 @@ struct NonIsolatedUnsafeFieldStruct: Sendable {
     // TODO: Is this correct?
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    print(x) // expected-tns-note {{access can happen concurrently}}
+    print(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -523,10 +523,10 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // TODO: Is this correct?
     let x = nonIsolatedUnsafeVarObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    print(x) // expected-tns-note {{access can happen concurrently}}
+    print(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -548,8 +548,8 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // 'x' is treated as global actor 'CustomActor' isolated.
     let x = nonIsolatedLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
@@ -573,8 +573,8 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // nonisolated(unsafe) only applies to nonIsolatedUnsafeLetObject.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
@@ -597,8 +597,8 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
@@ -625,20 +625,20 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x2 = nonIsolatedUnsafeVarObject
     await transferToMainDirect(x2)
-    // expected-tns-warning @-1 {{sending 'x2' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x2' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x2' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x2' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x3 = nonIsolatedUnsafeVarComputedObject
     await transferToMainDirect(x3)
-    // expected-tns-warning @-1 {{sending 'x3' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x3' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     print(x)
@@ -662,8 +662,8 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // nonIsolatedUnsafeVarObject is not.
     let x = nonIsolatedUnsafeVarObject
     await transferToMainDirect(x)
-    // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+    // expected-warning @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
@@ -686,12 +686,12 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
-    // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
-    // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -719,12 +719,12 @@ final class FinalNonIsolatedUnsafeFieldKlass {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
-    // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
-    // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -752,12 +752,12 @@ class NonIsolatedUnsafeFieldKlass {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
-    // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
-    // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -787,15 +787,15 @@ class NonIsolatedUnsafeFieldGenericKlass<T> { // expected-complete-note 4{{}}
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     await transferToMainIndirect(letAddressOnly)
-    // expected-tns-warning @-1 {{sending 'self.letAddressOnly' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self.letAddressOnly' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-warning @-1 {{sending 'self.letAddressOnly' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated 'self.letAddressOnly' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     // TODO: This diagnostic is unfortunate since we are erroring on the
     // temporary created by the class_method call.
     await transferToMainIndirect(varAddressOnly)
-    // expected-tns-warning @-1 {{sending value of non-Sendable type 'T?' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated value of non-Sendable type 'T?' to main actor-isolated global function 'transferToMainIndirect' risks causing races in between task-isolated and main actor-isolated uses}}
+    // expected-warning @-1 {{sending value of non-Sendable type 'T?' risks causing data races}}
+    // expected-note @-2 {{sending task-isolated value of non-Sendable type 'T?' to main actor-isolated global function 'transferToMainIndirect' risks causing races in between task-isolated and main actor-isolated uses}}
   }
 
   // This is safe since self will become MainActor isolated as a result of

--- a/test/Concurrency/transfernonsendable_typechecker_errors.swift
+++ b/test/Concurrency/transfernonsendable_typechecker_errors.swift
@@ -1,0 +1,174 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+
+// This test validates that for specific test cases around closures, we properly
+// emit errors in the type checker before we run sns. This ensures that we know that
+// these cases can't happen when SNS is enabled.
+
+class NonSendableKlass { // expected-note 2{{}}
+  var field: NonSendableKlass? = nil
+  var boolean: Bool = false
+
+  init() {}
+  init(_ x: NonSendableKlass) {
+  }
+
+  func asyncCall() async {}
+  func asyncCallWithIsolatedParameter(isolation: isolated (any Actor)? = #isolation) async {
+  }
+}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+var booleanFlag: Bool { false }
+
+class SendableKlass : @unchecked Sendable {}
+
+actor MyActor {
+  var klass = NonSendableKlass()
+  // expected-note @-1 7{{property declared here}}
+  final var finalKlass = NonSendableKlass()
+
+  func useKlass(_ x: NonSendableKlass) {}
+
+  func useSendableFunction(_: @Sendable () -> Void) {}
+  func useNonSendableFunction(_: () -> Void) {}
+  func doSomething() {}
+  @MainActor func useKlassMainActor(_ x: NonSendableKlass) {}
+}
+
+struct SingleFieldKlassBox { // expected-complete-note 2{{consider making struct 'SingleFieldKlassBox' conform to the 'Sendable' protocol}}
+  var k = NonSendableKlass()
+}
+
+struct TwoFieldKlassBox { // expected-note 2{{}}
+  var k1 = NonSendableKlass()
+  var k2 = NonSendableKlass()
+}
+
+class TwoFieldKlassClassBox {
+  var k1 = NonSendableKlass()
+  var k2 = NonSendableKlass()
+  var recursive: TwoFieldKlassClassBox? = nil
+}
+
+struct SendableGenericStruct : Sendable {
+  var x = SendableKlass()
+}
+
+enum MyEnum<T> {
+    case none
+    indirect case some(NonSendableKlass)
+    case more(T)
+}
+
+///////////
+// Tests //
+///////////
+
+extension MyActor {
+  func simpleClosureCaptureSelfThroughTupleWithFieldAccess() async {
+    // In this case, we erase that we accessed self so we hit a type checker
+    // error. We could make this a SNS error, but since in the other cases where
+    // we have a nonisolated non-async we are probably going to change it to be
+    // async as well making these errors go away.
+    let x = (self, 1)
+    let closure: () -> () = {
+      print(x.0.klass) // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+    }
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+}
+
+func testSimpleLetClosureCaptureActorField() async {
+  let a = MyActor()
+  let closure = { print(a.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
+  let a = (MyActor(), 0)
+  let closure = { print(a.0.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleLetClosureCaptureActorFieldThroughOptional() async {
+  let a: MyActor? = MyActor()
+  let closure = { print(a!.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleVarClosureCaptureActorField() async {
+  let a = MyActor()
+  var closure = {}
+  closure = { print(a.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
+  let a = (MyActor(), 0)
+  var closure = {}
+  closure = { print(a.0.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleVarClosureCaptureActorFieldThroughOptional() async {
+  let a: MyActor? = MyActor()
+  var closure = {}
+  closure = { print(a!.klass) } // expected-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+actor ActorWithSetter {
+  var field = NonSendableKlass()
+  var twoFieldBox = TwoFieldKlassBox()
+  var twoFieldBoxInTuple = (NonSendableKlass(), TwoFieldKlassBox())
+  var recursive: ActorWithSetter? = nil
+  var classBox = TwoFieldKlassClassBox()
+
+  // This triggers a crash in SILGen with tns enabled.
+  func recursive() async {
+    let x = NonSendableKlass()
+    await self.recursive!.twoFieldBoxInTuple.1.k2 = x
+    // expected-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+
+    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  }
+}
+
+final actor FinalActorWithSetter {
+  var field = NonSendableKlass()
+  var twoFieldBox = TwoFieldKlassBox()
+  var twoFieldBoxInTuple = (NonSendableKlass(), TwoFieldKlassBox())
+  var recursive: ActorWithSetter? = nil
+  var classBox = TwoFieldKlassClassBox()
+
+  // This triggers a crash in SILGen with tns enabled.
+  func recursive() async {
+    let x = NonSendableKlass()
+    await self.recursive!.twoFieldBoxInTuple.1.k2 = x
+    // expected-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+
+    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  }
+}


### PR DESCRIPTION
This includes a bunch of fixes. It is not exhaustive but fit my time boxed time period I set aside to look at this today.

A quick non-exhaustive list:

1. I removed unnecessary verify-additional-prefix lines.
2. Split tests with typechecker error and non-typechecker error components.
3. Removed complete- lines that we used when testing w/without send non sednable.
4. Translated complete-and-tns- lines to be just complete- since they are just testing strict-concurrency=complete and we are not testing complete without send non sendable anymore.
