### PR TITLE
Tests: Use a local cache in tests importing AppKit from the SDK

### DIFF
--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-typecheck-verify-swift -module-cache-path %t/cache
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/test/Interpreter/SDK/GLKit.swift
+++ b/test/Interpreter/SDK/GLKit.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-run-simple-swift(-module-cache-path %t/cache) | %FileCheck %s
 // REQUIRES: executable_test
 
 // NOTE: Clang used to miscompile GLKit functions on i386. rdar://problem/19184403

--- a/test/Interpreter/SDK/cf_extensions.swift
+++ b/test/Interpreter/SDK/cf_extensions.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-run-simple-swift(-module-cache-path %t/cache)
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/Interpreter/SDK/cf_type_bridging.swift
+++ b/test/Interpreter/SDK/cf_type_bridging.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-run-simple-swift(-module-cache-path %t/cache)
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/Interpreter/SDK/mapkit_header_static.swift
+++ b/test/Interpreter/SDK/mapkit_header_static.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-run-simple-swift(-module-cache-path %t/cache) | %FileCheck %s
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/Interpreter/SDK/objc_ns_enum.swift
+++ b/test/Interpreter/SDK/objc_ns_enum.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-run-simple-swift(-module-cache-path %t/cache)
 // REQUIRES: executable_test
 
 // NSButtonType (from AppKit) and UIViewAnimationCurve (from UIKit) both have


### PR DESCRIPTION
Tests importing AppKit have a tendency to be flaky when they share a module cache with other builds using a different set of framework search flags. Make sure they use a local cache, otherwise the compiler can reuse incompatible cached modules.

Alternatively, we could align all builds using the same cache to have exactly the same framework search paths or enable explicit module builds. For now a local module cache is likely the most reliable and compatible.

rdar://142949965

Followup to #78530 which updated another set of AppKit clients.