### PR TITLE
lit.cfg: copy compatibility span dylib when appropriate on Darwin

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2303,6 +2303,40 @@ if run_vendor == 'apple':
         if not os.path.isdir(concurrency_back_deploy_path):
             lit_config.fatal(f"Concurrency back deploy libraries not found at {concurrency_back_deploy_path}")
 
+compatibility_span_back_deploy_path = ''
+if run_vendor == 'apple':
+    COMPATIBILITY_SPAN_BACK_DEPLOY_EARLIEST_VERSIONS = {
+        'macosx': '10.14.4',
+        'ios': '12.2',
+        'maccatalyst': '13.1',
+        'tvos': '12.2',
+        'watchos': '5.2',
+        'xros': '1.0',
+    }
+
+    compatibility_span_back_deploy_version = tuple(
+        int(component) for component
+        in COMPATIBILITY_SPAN_BACK_DEPLOY_EARLIEST_VERSIONS.get(run_os, '').split('.'))
+
+    tuple_run_vers=tuple(int(component) for component in run_vers.split('.'))
+
+    if tuple_run_vers >= compatibility_span_back_deploy_version and tuple_run_vers < (26,):
+        config.available_features.add('back_deploy_compatibility_span')
+        toolchain_swiftc_path = subprocess.check_output(['xcrun', '--find', 'swiftc']).rstrip().decode('utf-8')
+        compatibility_span_back_deploy_path = os.path.join(
+            os.path.dirname(toolchain_swiftc_path), '..',
+            'lib', 'swift-6.2', xcrun_sdk_name)
+        if not os.path.isdir(compatibility_span_back_deploy_path):
+            lit_config.warning(
+                "Compatibility span back deploy libraries not found at "
+                f"{compatibility_span_back_deploy_path}. Falling back to local build...")
+            compatibility_span_back_deploy_path = os.path.join(
+                swift_obj_root, 'lib', 'swift-6.2', xcrun_sdk_name)
+            if not os.path.isdir(compatibility_span_back_deploy_path):
+                lit_config.fatal(
+                  "Compatibility span back deploy libraries "
+                  f"not found at {compatibility_span_back_deploy_path}")
+
 backtracer_path = make_path(config.swift_libexec_dir, 'swift',
                             config.target_sdk_name, 'swift-backtrace')
 config.substitutions.append(('%backtracer', backtracer_path))
@@ -2390,6 +2424,9 @@ def configure_remote_run():
         # Only copy when we have use_os_stdlib, otherwise we want to rely on the just-build concurrency
         if concurrency_back_deploy_path and 'use_os_stdlib' in lit_config.params:
             upload_dylibs(concurrency_back_deploy_path)
+
+        if compatibility_span_back_deploy_path and 'use_os_stdlib' in lit_config.params:
+            upload_dylibs(compatibility_span_back_deploy_path)
 
         # FIXME: Uploading specific files in bin/ is not very scalable.
         local_swift_reflection_test = lit.util.which(


### PR DESCRIPTION
This supports back deployment bots.

Addresses rdar://155841483