### PR TITLE
[IDE] Erase archetypes without declaration generic signature

### DIFF
--- a/lib/IDE/CodeCompletionStringBuilder.cpp
+++ b/lib/IDE/CodeCompletionStringBuilder.cpp
@@ -26,9 +26,6 @@ using namespace swift;
 using namespace swift::ide;
 
 Type ide::eraseArchetypes(Type type, GenericSignature genericSig) {
-  if (!genericSig)
-    return type;
-
   if (auto *genericFuncType = type->getAs<GenericFunctionType>()) {
     assert(genericFuncType->getGenericSignature()->isEqual(genericSig) &&
            "if not, just use the GFT's signature instead below");
@@ -64,7 +61,7 @@ Type ide::eraseArchetypes(Type type, GenericSignature genericSig) {
         return upperBound;
     }
 
-    if (t->isTypeParameter()) {
+    if (t->isTypeParameter() && genericSig) {
       auto upperBound =
           genericSig->getUpperBound(t,
                                     /*forExistentialSelf=*/false,

--- a/test/IDE/complete_after_sself.swift
+++ b/test/IDE/complete_after_sself.swift
@@ -73,8 +73,8 @@ extension MyProto {
     Self.#^SSELF_DOT_IN_STATICMETHOD_MyProto^#
   }
 // CHECK-MyProto: Begin completions, 5 items
-// CHECK-MyProto-DAG: Keyword[self]/CurrNominal:          self[#Self.Type#];
-// CHECK-MyProto-DAG: Keyword/CurrNominal:                Type[#Self.Type#];
+// CHECK-MyProto-DAG: Keyword[self]/CurrNominal:          self[#MyProto.Type#];
+// CHECK-MyProto-DAG: Keyword/CurrNominal:                Type[#MyProto.Type#];
 // CHECK-MyProto-DAG: Decl[Constructor]/CurrNominal:      init()[#MyProto#];
 // CHECK-MyProto-DAG: Decl[InstanceMethod]/CurrNominal:   instanceMethod({#(self): MyProto#})[#() -> Void#];
 // CHECK-MyProto-DAG: Decl[StaticMethod]/CurrNominal:     staticMethod()[#Void#];

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -125,12 +125,16 @@ func testGenericUnderconstrained1<G: P>(r: G) {
   r.#^testGenericUnderconstrained1^#
 }
 // testGenericUnderconstrained1-NOT: CurrNominal
-// testGenericUnderconstrained1: Keyword[self]/CurrNominal:          self[#{{any P|G}}#];
+// testGenericUnderconstrained1: Keyword[self]/CurrNominal:          self[#P#];
 // testGenericUnderconstrained1-NOT: CurrNominal
 
 func testExistential1(r: P) {
-  r.#^testExistential1?check=testGenericUnderconstrained1^#
+  r.#^testExistential1^#
 }
+
+// testExistential1-NOT: CurrNominal
+// testExistential1: Keyword[self]/CurrNominal:          self[#any P#];
+// testExistential1-NOT: CurrNominal
 
 @dynamicMemberLookup
 protocol E {

--- a/test/IDE/complete_members_optional.swift
+++ b/test/IDE/complete_members_optional.swift
@@ -40,5 +40,5 @@ func optionalMembers2<T : HasOptionalMembers1>(_ a: T) {
 // OPTIONAL_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal: optionalInstanceFunc?({#(self): HasOptionalMembers1#})[#() -> Int#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_2-DAG: Decl[StaticMethod]/CurrNominal: optionalClassFunc?()[#Int#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_2-DAG: Decl[StaticVar]/CurrNominal: optionalClassProperty[#Int?#]{{; name=.+$}}
-// OPTIONAL_MEMBERS_2-DAG: Keyword[self]/CurrNominal: self[#T.Type#]; name=self
-// OPTIONAL_MEMBERS_2-DAG: Keyword/CurrNominal: Type[#T.Type#]; name=Type
+// OPTIONAL_MEMBERS_2-DAG: Keyword[self]/CurrNominal: self[#HasOptionalMembers1.Type#]; name=self
+// OPTIONAL_MEMBERS_2-DAG: Keyword/CurrNominal: Type[#HasOptionalMembers1.Type#]; name=Type

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -72,7 +72,7 @@ func testPostfix9<G: P where G.T == Int>(x: G) {
 func testPostfix10<G: P where G.T : Fooable>(x: G) {
   x.foo()#^POSTFIX_10^#
 }
-// POSTFIX_10: Decl[PostfixOperatorFunction]/CurrModule: ***[#G.T#]
+// POSTFIX_10: Decl[PostfixOperatorFunction]/CurrModule: ***[#Fooable#]
 
 func testPostfixSpace(x: inout S) {
   x #^S_POSTFIX_SPACE^#
@@ -172,7 +172,7 @@ func ****<T: Fooable>(x: T, y: T) -> T { return x }
 func testInfix9<T: P where T.T: Fooable>(x: T) {
   x.foo()#^INFIX_9?check=FOOABLE_INFIX^#
 }
-// FOOABLE_INFIX: Decl[InfixOperatorFunction]/CurrModule:   **** {#T.T#}[#T.T#]
+// FOOABLE_INFIX: Decl[InfixOperatorFunction]/CurrModule:   **** {#T.T#}[#Fooable#]
 
 func testInfix10<T: P where T.T: Fooable>(x: T) {
   (x.foo() **** x.foo())#^INFIX_10?check=FOOABLE_INFIX^#
@@ -210,8 +210,8 @@ func testInfix15<T: P where T.T == S2>() {
 // INFIX_15: Begin completions, 6 items
 // INFIX_15-DAG: Decl[AssociatedType]/CurrNominal:   .T; name=T
 // INFIX_15-DAG: Decl[InstanceMethod]/CurrNominal:   .foo({#(self): P#})[#() -> S2#]; name=foo(:)
-// INFIX_15-DAG: Keyword[self]/CurrNominal:          .self[#T.Type#]; name=self
-// INFIX_15-DAG: Keyword/CurrNominal:                .Type[#T.Type#]; name=Type
+// INFIX_15-DAG: Keyword[self]/CurrNominal:          .self[#P.Type#]; name=self
+// INFIX_15-DAG: Keyword/CurrNominal:                .Type[#P.Type#]; name=Type
 // INFIX_15-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem:  != {#(any (~Copyable & ~Escapable).Type)?#}[#Bool#];
 // INFIX_15-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem:  == {#(any (~Copyable & ~Escapable).Type)?#}[#Bool#];
 
@@ -221,7 +221,7 @@ func testInfix16<T: P where T.T == S2>() {
 
 // INFIX_16: Begin completions, 2 items
 // INFIX_16-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(self): P#})[#() -> S2#]; name=(:)
-// INFIX_16-DAG: Keyword[self]/CurrNominal:        .self[#(T) -> () -> S2#]; name=self
+// INFIX_16-DAG: Keyword[self]/CurrNominal:        .self[#(P) -> () -> S2#]; name=self
 
 func testInfix17(x: Void) {
   x#^INFIX_17?check=VOID_OPERATORS^#

--- a/test/IDE/complete_protocol_static_member.swift
+++ b/test/IDE/complete_protocol_static_member.swift
@@ -21,7 +21,7 @@ func test<T: FontStyle>(x: T) {
 }
 
 // EXTENSION_NOT_APPLIED: Begin completions, 1 item
-// EXTENSION_NOT_APPLIED-DAG: Keyword[self]/CurrNominal:          self[#T#];
+// EXTENSION_NOT_APPLIED-DAG: Keyword[self]/CurrNominal:          self[#FontStyle#];
 // EXTENSION_NOT_APPLIED-NOT: variableDeclaredInConstraintExtension
 
 struct WrapperStruct<T: FontStyle> {

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -110,7 +110,7 @@ func testSubscriptCallSig<T>(val: MyStruct1<T>) {
   val[#^LABELED_SUBSCRIPT^#
 // LABELED_SUBSCRIPT: Begin completions, 2 items
 // LABELED_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#idx1: Int#}, {#idx2: Comparable#}[']'][#Int!#];
-// LABELED_SUBSCRIPT-DAG: Pattern/CurrNominal/Flair[ArgLabels]:                ['[']{#keyPath: KeyPath<MyStruct1<T>, Value>#}[']'][#Value#];
+// LABELED_SUBSCRIPT-DAG: Pattern/CurrNominal/Flair[ArgLabels]:                ['[']{#keyPath: KeyPath<MyStruct1<Comparable>, Value>#}[']'][#Value#];
 }
 
 func testSubcscriptTuple(val: (x: Int, String)) {

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -622,7 +622,7 @@ func testTypeIdentifierGeneric1<
 
 // TYPE_IDENTIFIER_GENERIC_1: Begin completions, 2 items
 // TYPE_IDENTIFIER_GENERIC_1-DAG: Decl[AssociatedType]/CurrNominal: FooTypeAlias1{{; name=.+$}}
-// TYPE_IDENTIFIER_GENERIC_1-DAG: Keyword/None:          Type[#GenericFoo.Type#]
+// TYPE_IDENTIFIER_GENERIC_1-DAG: Keyword/None:          Type[#FooProtocol.Type#]
 
 func testTypeIdentifierGeneric2<
     GenericFoo : FooProtocol & BarProtocol
@@ -631,7 +631,7 @@ func testTypeIdentifierGeneric2<
 // TYPE_IDENTIFIER_GENERIC_2: Begin completions, 3 items
 // TYPE_IDENTIFIER_GENERIC_2-DAG: Decl[AssociatedType]/CurrNominal: BarTypeAlias1{{; name=.+$}}
 // TYPE_IDENTIFIER_GENERIC_2-DAG: Decl[AssociatedType]/CurrNominal: FooTypeAlias1{{; name=.+$}}
-// TYPE_IDENTIFIER_GENERIC_2-DAG: Keyword/None:          Type[#GenericFoo.Type#]
+// TYPE_IDENTIFIER_GENERIC_2-DAG: Keyword/None:          Type[#(BarProtocol & FooProtocol).Type#]
 
 func testTypeIdentifierGeneric3<
     GenericFoo>(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_3^#

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -101,7 +101,7 @@ extension G6 {
   subscript(b x: Int) -> T.#^GEN_EXT_RETURN_6^# { return 0 }
 }
 // GEN_PARAM_6-DAG: Decl[AssociatedType]/CurrNominal:   Assoc;
-// GEN_PARAM_6-DAG: Keyword/None:                       Type[#T.Type#];
+// GEN_PARAM_6-DAG: Keyword/None:                       Type[#It.Type#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_PARAM_1 | %FileCheck %s -check-prefix=GENPROTO_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_RETURN_1 | %FileCheck %s -check-prefix=GENPROTO_1
@@ -117,4 +117,4 @@ extension GP1 {
   subscript(b x: Int) -> I.#^GENPROTO_EXT_RETURN_1^# { return 1 }
 }
 // GENPROTO_1-DAG: Decl[AssociatedType]/CurrNominal:   Assoc;
-// GENPROTO_1-DAG: Keyword/None:                       Type[#Self.I.Type#];
+// GENPROTO_1-DAG: Keyword/None:                       Type[#It.Type#];

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -775,7 +775,7 @@ class TestResolveFuncParam2 {
 
 func testResolveFuncParam3<Foo : FooProtocol>(_ foo: Foo) {
   foo.#^RESOLVE_FUNC_PARAM_3^#
-// RESOLVE_FUNC_PARAM_3-DAG: Keyword[self]/CurrNominal: self[#Foo#]; name=self
+// RESOLVE_FUNC_PARAM_3-DAG: Keyword[self]/CurrNominal: self[#FooProtocol#]; name=self
 // RESOLVE_FUNC_PARAM_3-DAG: Decl[InstanceVar]/CurrNominal: fooInstanceVar1[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-DAG: Decl[InstanceVar]/CurrNominal: fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-DAG: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
@@ -784,7 +784,7 @@ func testResolveFuncParam3<Foo : FooProtocol>(_ foo: Foo) {
 
 func testResolveFuncParam4<FooBar : FooProtocol & BarProtocol>(_ fooBar: FooBar) {
   fooBar.#^RESOLVE_FUNC_PARAM_4^#
-// RESOLVE_FUNC_PARAM_4-DAG: Keyword[self]/CurrNominal: self[#FooBar#]; name=self
+// RESOLVE_FUNC_PARAM_4-DAG: Keyword[self]/CurrNominal: self[#BarProtocol & FooProtocol#]; name=self
 // RESOLVE_FUNC_PARAM_4-DAG: Decl[InstanceVar]/CurrNominal:    barInstanceVar[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-DAG: Decl[InstanceMethod]/CurrNominal: barInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-DAG: Decl[InstanceMethod]/CurrNominal: barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
@@ -796,7 +796,7 @@ func testResolveFuncParam4<FooBar : FooProtocol & BarProtocol>(_ fooBar: FooBar)
 
 func testResolveFuncParam5<FooExBarEx : FooExProtocol & BarExProtocol>(_ a: FooExBarEx) {
   a.#^RESOLVE_FUNC_PARAM_5^#
-// RESOLVE_FUNC_PARAM_5-DAG: Keyword[self]/CurrNominal: self[#FooExBarEx#]; name=self
+// RESOLVE_FUNC_PARAM_5-DAG: Keyword[self]/CurrNominal: self[#BarExProtocol & FooExProtocol#]; name=self
 // RESOLVE_FUNC_PARAM_5-DAG: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-DAG: Decl[InstanceVar]/Super: barInstanceVar[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-DAG: Decl[InstanceMethod]/Super: barInstanceFunc0()[#Double#]{{; name=.+$}}
@@ -810,7 +810,7 @@ func testResolveFuncParam5<FooExBarEx : FooExProtocol & BarExProtocol>(_ a: FooE
 
 func testResolveFuncParam6<Foo : FooProtocol where Foo : FooClass>(_ foo: Foo) {
   foo.#^RESOLVE_FUNC_PARAM_6^#
-// RESOLVE_FUNC_PARAM_6-DAG: Keyword[self]/CurrNominal: self[#Foo#]; name=self
+// RESOLVE_FUNC_PARAM_6-DAG: Keyword[self]/CurrNominal: self[#FooClass & FooProtocol#]; name=self
 // RESOLVE_FUNC_PARAM_6-DAG: Decl[InstanceVar]/CurrNominal: fooInstanceVar1[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-DAG: Decl[InstanceVar]/CurrNominal: fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-DAG: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
@@ -829,7 +829,7 @@ class TestResolveConstructorParam1 {
 class TestResolveConstructorParam2 {
   init<Foo : FooProtocol>(foo: Foo) {
     foo.#^RESOLVE_CONSTRUCTOR_PARAM_2^#
-// RESOLVE_CONSTRUCTOR_PARAM_2-DAG: Keyword[self]/CurrNominal: self[#Foo#]; name=self
+// RESOLVE_CONSTRUCTOR_PARAM_2-DAG: Keyword[self]/CurrNominal: self[#FooProtocol#]; name=self
 // RESOLVE_CONSTRUCTOR_PARAM_2-DAG: Decl[InstanceVar]/CurrNominal:  fooInstanceVar1[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-DAG: Decl[InstanceVar]/CurrNominal:  fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-DAG: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
@@ -840,7 +840,7 @@ class TestResolveConstructorParam2 {
 class TestResolveConstructorParam3<Foo : FooProtocol> {
   init(foo: Foo) {
     foo.#^RESOLVE_CONSTRUCTOR_PARAM_3^#
-// RESOLVE_CONSTRUCTOR_PARAM_3-DAG: Keyword[self]/CurrNominal: self[#Foo#]; name=self
+// RESOLVE_CONSTRUCTOR_PARAM_3-DAG: Keyword[self]/CurrNominal: self[#FooProtocol#]; name=self
 // RESOLVE_CONSTRUCTOR_PARAM_3-DAG: Decl[InstanceVar]/CurrNominal:  fooInstanceVar1[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-DAG: Decl[InstanceVar]/CurrNominal:  fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-DAG: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
@@ -953,7 +953,7 @@ func testResolveGenericParams2<Foo : FooProtocol>(_ foo: Foo) {
 // RESOLVE_GENERIC_PARAMS_2-DAG: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(a): FooProtocol#})[#Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2-DAG: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(a): FooProtocol#})[#FooProtocol#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2-DAG: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(a): U#})[#U#]{{; name=.+$}}
-// RESOLVE_GENERIC_PARAMS_2-DAG: Keyword[self]/CurrNominal:        .self[#FooGenericStruct<Foo>#]; name=self
+// RESOLVE_GENERIC_PARAMS_2-DAG: Keyword[self]/CurrNominal:        .self[#FooGenericStruct<FooProtocol>#]; name=self
 
   FooGenericStruct<Foo>#^RESOLVE_GENERIC_PARAMS_2_STATIC^#
 // RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<FooProtocol>#]; name=()
@@ -966,8 +966,8 @@ func testResolveGenericParams2<Foo : FooProtocol>(_ foo: Foo) {
 // RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Decl[StaticMethod]/CurrNominal:   .fooVoidStaticFunc1({#(a): FooProtocol#})[#Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Decl[StaticMethod]/CurrNominal:   .fooTStaticFunc1({#(a): FooProtocol#})[#FooProtocol#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Decl[StaticMethod]/CurrNominal:   .fooUInstanceFunc1({#(a): U#})[#U#]{{; name=.+$}}
-// RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Keyword[self]/CurrNominal:        .self[#FooGenericStruct<Foo>.Type#]; name=self
-// RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Keyword/CurrNominal:              .Type[#FooGenericStruct<Foo>.Type#]; name=Type
+// RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Keyword[self]/CurrNominal:        .self[#FooGenericStruct<FooProtocol>.Type#]; name=self
+// RESOLVE_GENERIC_PARAMS_2_STATIC-DAG: Keyword/CurrNominal:              .Type[#FooGenericStruct<FooProtocol>.Type#]; name=Type
 
 }
 
@@ -1571,7 +1571,7 @@ func testDeDuped3<T : dedupP where T.T == Int>(_ x: T) {
 // PROTOCOL_EXT_DEDUP_3-DAG: Decl[InstanceMethod]/CurrNominal:   .foo()[#Int#]; name=foo()
 // PROTOCOL_EXT_DEDUP_3-DAG: Decl[InstanceVar]/CurrNominal:      .bar[#Int#]; name=bar
 // PROTOCOL_EXT_DEDUP_3-DAG: Decl[Subscript]/CurrNominal:        [{#(x): Int#}][#Int#]; name=[:]
-// PROTOCOL_EXT_DEDUP_3-DAG: Keyword[self]/CurrNominal:          .self[#T#]; name=self
+// PROTOCOL_EXT_DEDUP_3-DAG: Keyword[self]/CurrNominal:          .self[#dedupP#]; name=self
 }
 
 //===--- Check calls that may throw

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -4,8 +4,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP4 | %FileCheck %s -check-prefix=TYPE1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP5 | %FileCheck %s -check-prefix=TYPE1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP6 | %FileCheck %s -check-prefix=EMPTY
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_1 | %FileCheck %s -check-prefix=GEN_T_ASSOC_E
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_2 | %FileCheck %s -check-prefix=GEN_T_ASSOC_E
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_1 | %FileCheck %s -check-prefix=FUNC_ASSOC_NODUP_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_2 | %FileCheck %s -check-prefix=FUNC_ASSOC_NODUP_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_1 | %FileCheck %s -check-prefix=GEN_T
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_2 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_2_ASSOC | %FileCheck %s -check-prefix=GEN_T_ASSOC_DOT
@@ -90,11 +90,15 @@ protocol D: C {associatedtype E}
 
 func ab<T: A & B>(_ arg: T) where T.#^FUNC_ASSOC_NODUP_1^#
 
+// FUNC_ASSOC_NODUP_1: Begin completions, 2 items
+// FUNC_ASSOC_NODUP_1-NEXT: Decl[AssociatedType]/{{Super|CurrNominal}}: E; name=E
+// FUNC_ASSOC_NODUP_1-NEXT: Keyword/None:               Type[#(A & B).Type#];
+
 func ab<T: D>(_ arg: T) where T.#^FUNC_ASSOC_NODUP_2^#
 
-// GEN_T_ASSOC_E: Begin completions, 2 items
-// GEN_T_ASSOC_E-NEXT: Decl[AssociatedType]/{{Super|CurrNominal}}: E; name=E
-// GEN_T_ASSOC_E-NEXT: Keyword/None:               Type[#T.Type#];
+// FUNC_ASSOC_NODUP_2: Begin completions, 2 items
+// FUNC_ASSOC_NODUP_2-NEXT: Decl[AssociatedType]/{{Super|CurrNominal}}: E; name=E
+// FUNC_ASSOC_NODUP_2-NEXT: Keyword/None:               Type[#D.Type#];
 
 protocol Assoc {
   associatedtype Q
@@ -107,7 +111,7 @@ func f2<T>(_: T) where T.#^FUNC_2^# {}
 // GEN_T_DOT-NOT: Keyword/CurrNominal:                self[#T#];
 func f2b<T: Assoc>(_: T) where T.#^FUNC_2_ASSOC^# {}
 // GEN_T_ASSOC_DOT-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}: Q;
-// GEN_T_ASSOC_DOT-DAG: Keyword/None:                       Type[#T.Type#];
+// GEN_T_ASSOC_DOT-DAG: Keyword/None:                       Type[#Assoc.Type#];
 // GEN_T_ASSOC_DOT-NOT: Keyword/CurrNominal:                self[#T#];
 func f3<T>(_: T) where T == #^FUNC_3^# {}
 func f3<T>(_: T) where T == T.#^FUNC_4^# {}
@@ -153,7 +157,7 @@ protocol P2 {
 // P2-DAG: Decl[Protocol]/Local:                       P2[#P2#]
 
 // U_DOT: Begin completions, 2 items
-// U_DOT-DAG: Keyword/None:                       Type[#Self.U.Type#];
+// U_DOT-DAG: Keyword/None:                       Type[#Assoc.Type#];
 // U_DOT-DAG: Decl[AssociatedType]/CurrNominal:   Q;
 
 protocol P3 where #^PROTOCOL^# {
@@ -179,7 +183,7 @@ protocol P4 where Self.#^PROTOCOL_SELF^# {
 // PROTOCOL_SELF-DAG: Decl[AssociatedType]/CurrNominal:   T;
 // PROTOCOL_SELF-DAG: Decl[TypeAlias]/CurrNominal:        U[#Self.T.Q#];
 // PROTOCOL_SELF-DAG: Decl[TypeAlias]/CurrNominal:        IntAlias[#Int#];
-// PROTOCOL_SELF-DAG: Keyword/None:                       Type[#Self.Type#];
+// PROTOCOL_SELF-DAG: Keyword/None:                       Type[#P4.Type#];
 
 struct TA1<T: Assoc> where #^NOMINAL_TYPEALIAS^# {
   typealias U = T.Q
@@ -191,7 +195,7 @@ extension TA1 where #^NOMINAL_TYPEALIAS_EXT^# { }
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[TypeAlias]/CurrNominal:        U[#T.Q#];
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[Struct]/Local:                 TA1[#TA1<T>#];
-// NOMINAL_TYPEALIAS_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA1<T>#];
+// NOMINAL_TYPEALIAS_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA1<Assoc>#];
 
 struct TA2<T: Assoc> {
   struct Inner1<U> where #^NOMINAL_TYPEALIAS_NESTED1^# {
@@ -212,15 +216,15 @@ extension TA2.Inner1 where #^NOMINAL_TYPEALIAS_NESTED1_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED1_EXT: Begin completions, 5 items
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       U[#U#];
-// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#Assoc#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
-// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner1<U>#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<Assoc>.Inner1<U>#];
 extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED2_EXT: Begin completions, 4 items
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
-// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#Assoc#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
-// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner2#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<Assoc>.Inner2#];
 
 protocol WithAssoc {
   associatedtype T: Assoc
@@ -228,7 +232,7 @@ protocol WithAssoc {
 extension WithAssoc where T.#^EXT_ASSOC_MEMBER_1^# 
 // EXT_ASSOC_MEMBER: Begin completions, 2 items
 // EXT_ASSOC_MEMBER-DAG: Decl[AssociatedType]/CurrNominal:   Q;
-// EXT_ASSOC_MEMBER-DAG: Keyword/None:                       Type[#Self.T.Type#];
+// EXT_ASSOC_MEMBER-DAG: Keyword/None:                       Type[#Assoc.Type#];
 
 extension WithAssoc where Int == T.#^EXT_ASSOC_MEMBER_2^# 
 // Same as EXT_ASSOC_MEMBER
@@ -240,4 +244,4 @@ func foo<K: WithAssoc>(_ key: K.Type) where K.#^WHERE_CLAUSE_WITH_EQUAL^# == S1 
 
 // WHERE_CLAUSE_WITH_EQUAL: Begin completions, 2 items
 // WHERE_CLAUSE_WITH_EQUAL-DAG: Decl[AssociatedType]/CurrNominal:   T;
-// WHERE_CLAUSE_WITH_EQUAL-DAG: Keyword/None:                       Type[#K.Type#];
+// WHERE_CLAUSE_WITH_EQUAL-DAG: Keyword/None:                       Type[#WithAssoc.Type#];

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -16,7 +16,7 @@
       key.kind: source.lang.swift.keyword,
       key.name: "self",
       key.description: "self",
-      key.typename: "T",
+      key.typename: "Proto",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,


### PR DESCRIPTION
> [!NOTE]
> This PR depends on #83646 and it should be set as this PR's base but GitHub doesn't allow this.
> Commit 5376af0c67aaacf104b54c42575ed03513fe3b92 is the only change added in this PR.

The `swift::ide::eraseArchetypes` function is used in code completion to replace archetypes with their upper bound for completion string printing.

Currently, it checks for a provided generic signature before doing anything and returns immediately if no generic signature is provided. This shouldn't be necessary for archetypes though since they carry their generic signature.

This PR enables more helpful code completion results for things like `.self` and `.Type` and more generally for types without an explicit generic signature attached.