### PR TITLE
[xcodegen] Allow absolute path for output in compile commands

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
@@ -42,7 +42,7 @@ struct ClangBuildArgsProvider {
       else {
         continue
       }
-      let output = command.output.map { command.directory.appending($0) }
+      let output = command.output.map { $0.absolute(in: command.directory) }
       if let existing = commandsToAdd[relFilePath],
          let existingOutput = existing.output,
           output == nil || existingOutput.exists || !output!.exists {

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CompileCommands.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CompileCommands.swift
@@ -27,7 +27,7 @@ extension CompileCommands {
   struct Element: Decodable {
     var directory: AbsolutePath
     var file: AbsolutePath
-    var output: RelativePath?
+    var output: AnyPath?
     var command: Command
   }
 }


### PR DESCRIPTION
Looks like in newer versions of CMake this can be an absolute path.