### PR TITLE
ComputeSideEffects: compute properties even if function has an effect attribute

### DIFF
--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1281,3 +1281,119 @@ bb0(%0: $any Error):
   %r = tuple ()
   return %r : $()
 }
+
+// Base case: @destroy_not_escaped_closure_test. It has every global and argument effect, so we can see which are removed.
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_readnone
+// CHECK-NEXT:  [global: copy,deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readnone'
+sil [readnone] @test_effect_attribute_readnone : $@convention(thin)(@owned @callee_guaranteed () -> ()) -> Builtin.Int1 {
+bb0(%0 : $@callee_guaranteed () -> ()):
+  %1 = destroy_not_escaped_closure %0: $@callee_guaranteed () -> ()
+  return %1 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil [readonly] @test_effect_attribute_readonly
+// CHECK-NEXT:  [%0: read v**.c*.v**, copy v**.c*.v**]
+// CHECK-NEXT:  [global: read,copy,deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readonly'
+sil [readonly] @test_effect_attribute_readonly : $@convention(thin)(@owned @callee_guaranteed () -> ()) -> Builtin.Int1 {
+bb0(%0 : $@callee_guaranteed () -> ()):
+  %1 = destroy_not_escaped_closure %0: $@callee_guaranteed () -> ()
+  return %1 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil [releasenone] @test_effect_attribute_releasenone
+// CHECK-NEXT:  [%0: read v**.c*.v**, write v**.c*.v**, copy v**.c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,allocate,deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_releasenone'
+sil [releasenone] @test_effect_attribute_releasenone : $@convention(thin)(@owned @callee_guaranteed () -> ()) -> Builtin.Int1 {
+bb0(%0 : $@callee_guaranteed () -> ()):
+  %1 = destroy_not_escaped_closure %0: $@callee_guaranteed () -> ()
+  return %1 : $Builtin.Int1
+}
+
+// These tests are adapted from the test case in rdar://155870190
+sil @test_effect_attribute_no_barrier : $@convention(thin) () -> () {
+  [global: ]
+}
+
+sil @test_effect_attribute_barrier : $@convention(thin) () -> () {
+  [global: deinit_barrier]
+}
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_call_no_barrier
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_call_no_barrier'
+sil [readnone] @test_effect_attribute_call_no_barrier : $@convention(thin) () -> @out Any {
+bb0(%0 : $*Any):
+  %2 = function_ref @test_effect_attribute_no_barrier : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_call_barrier
+// CHECK-NEXT:  [global: deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_call_barrier'
+sil [readnone] @test_effect_attribute_call_barrier : $@convention(thin) () -> @out Any {
+bb0(%0 : $*Any):
+  %2 = function_ref @test_effect_attribute_barrier : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  %4 = tuple ()
+  return %4
+}
+
+// The readnone attribute can not rule out reads from indirect arguments.
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_readnone_direct_argument
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readnone_direct_argument'
+sil [readnone] @test_effect_attribute_readnone_direct_argument : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  return %0
+}
+
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_readnone_indirect_argument
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readnone_indirect_argument'
+sil [readnone] @test_effect_attribute_readnone_indirect_argument : $@convention(thin) (@in Int) -> Int {
+bb0(%0 : $*Int):
+  %1 = load %0
+  return %1
+}
+
+// Base case: @retain_and_store. The indirect result has a write effect, which readnone & readonly can't rule out.
+// CHECK-LABEL: sil [readnone] @test_effect_attribute_readnone_indirect_result
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readnone_indirect_result'
+sil [readnone] @test_effect_attribute_readnone_indirect_result : $@convention(thin) (@guaranteed X) -> @out X {
+bb0(%0 : $*X, %1 : $X):
+  strong_retain %1 : $X
+  store %1 to %0  : $*X
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [readonly] @test_effect_attribute_readonly_indirect_result
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: copy v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+// CHECK-LABEL: } // end sil function 'test_effect_attribute_readonly_indirect_result'
+sil [readonly] @test_effect_attribute_readonly_indirect_result : $@convention(thin) (@guaranteed X) -> @out X {
+bb0(%0 : $*X, %1 : $X):
+  strong_retain %1 : $X
+  store %1 to %0  : $*X
+
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -336,6 +336,39 @@ bb0(%0 : @guaranteed $Any, %1 : $*Any):
   return %11 : $()
 }
 
+sil [readnone] @createAny_effects : $@convention(thin) () -> @out Any
+sil [readnone] @createAny_no_barrier_effects : $@convention(thin) () -> @out Any {
+ [global:]
+}
+
+// CHECK-LABEL: sil [ossa] @test_deinit_barrier_effects :
+// CHECK:         copy_addr [take]
+// CHECK-LABEL: } // end sil function 'test_deinit_barrier_effects'
+sil [ossa] @test_deinit_barrier_effects : $@convention(thin) (@guaranteed Any, @inout Any) -> () {
+bb0(%0 : @guaranteed $Any, %1 : $*Any):
+  %2 = alloc_stack $Any
+  %4 = function_ref @createAny_effects : $@convention(thin) () -> @out Any
+  %5 = apply %4(%2) : $@convention(thin) () -> @out Any
+  copy_addr [take] %2 to %1 : $*Any
+  dealloc_stack %2 : $*Any
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_no_deinit_barrier_effects :
+// CHECK-NOT:     copy_addr
+// CHECK-LABEL: } // end sil function 'test_no_deinit_barrier_effects'
+sil [ossa] @test_no_deinit_barrier_effects : $@convention(thin) (@guaranteed Any, @inout Any) -> () {
+bb0(%0 : @guaranteed $Any, %1 : $*Any):
+  %2 = alloc_stack $Any
+  %4 = function_ref @createAny_no_barrier_effects : $@convention(thin) () -> @out Any
+  %5 = apply %4(%2) : $@convention(thin) () -> @out Any
+  copy_addr [take] %2 to %1 : $*Any
+  dealloc_stack %2 : $*Any
+  %11 = tuple ()
+  return %11 : $()
+}
+
 struct TwoFields {
   var a: Child
   var b: Child


### PR DESCRIPTION
Currently, the compute-side-effects pass does nothing if a function has an effect attribute. This prevents certain optimisations, such as temporary lvalue elimination, from working for callers of such functions.

This is a naive fix, which will worsen the performance of the compute-side-effects pass by making it run of functions it wouldn't have otherwise.

For the test case this patch aims to fix, we only need to compute the isDeinitBarrier property. We could attempt to only store that property, but there is no benefit to this over storing all the computed side effect properties. The benefit of the previous behaviour was avoiding the overhead of computing any properties in the first place.

rdar://155870190

This aims to resolve the same problem as #38324.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
