### PR TITLE
build: Install dispatch libraries in arch subdir

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2737,6 +2737,7 @@ function Build-Dispatch([Hashtable] $Platform) {
     -SwiftSDK (Get-SwiftSDK $Platform.OS) `
     -Defines @{
       ENABLE_SWIFT = "YES";
+      dispatch_INSTALL_ARCH_SUBDIR = "YES";
     }
 }
 


### PR DESCRIPTION
This is the proper installation scheme for the Windows platform.