### PR TITLE
[6.2] [AST] Visit TypeValueExpr's TypeRepr in ASTWalker

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1461,6 +1461,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitTypeValueExpr(TypeValueExpr *E) {
+    if (auto *TR = E->getRepr()) {
+      if (doIt(TR))
+        return nullptr;
+    }
     return E;
   }
 

--- a/test/Index/index_generic_params.swift
+++ b/test/Index/index_generic_params.swift
@@ -165,3 +165,16 @@ _ = C.Nested(value: 1)
 // CHECK-NEXT: [[@LINE+2]]:7 | struct/Swift | Nested | [[C_Nested_USR]] | Ref | rel: 0
 // CHECK-NEXT: [[@LINE+1]]:14 | constructor/Swift | init(value:) | [[C_Nested_init_USR]] | Ref,Call | rel: 0
 _ = C.Nested.init(value: 1)
+
+// MARK: - Test value generic parameters
+
+struct HasValueGenericParam<let Param: Int> {
+// CHECK:      [[@LINE-1]]:33 | type-alias/generic-type-param/Swift | Param | s:14swift_ide_test20HasValueGenericParamV0G0xmfp | Def,RelChild | rel: 1
+// CHECK-NEXT:   RelChild | struct/Swift | HasValueGenericParam
+  func foo() {
+    _ = Param
+    // CHECK:      [[@LINE-1]]:9 | type-alias/generic-type-param/Swift | Param | s:14swift_ide_test20HasValueGenericParamV0G0xmfp | Ref,RelCont | rel: 1
+    // CHECK-NEXT:   RelCont | instance-method/Swift | foo()
+  }
+}
+

--- a/test/SourceKit/CursorInfo/cursor_generics.swift
+++ b/test/SourceKit/CursorInfo/cursor_generics.swift
@@ -34,6 +34,12 @@ public protocol Proto<Assoc> {
   associatedtype Assoc
 }
 
+struct HasValueGenericParam<let Param: Int> {
+  func foo() {
+    _ = Param
+  }
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=1:10 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: <Declaration>func testGenerics&lt;T&gt;(x: <Type usr="s:15cursor_generics12testGenerics1xyx_tlF1TL_xmfp">T</Type>)</Declaration>
 
@@ -69,3 +75,7 @@ public protocol Proto<Assoc> {
 // CHECK_ASSOC_COMMON-NEXT: source.refactoring.kind.rename.global
 // CHECK_ASSOC_COMMON-NEXT: Global Rename
 // CHECK_ASSOC_COMMON-NEXT: ACTIONS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=39:9 %s -- %s | %FileCheck -check-prefix=CHECK_VALUE_GENERIC %s
+// CHECK_VALUE_GENERIC: source.lang.swift.ref.generic_type_param (37:33-37:38)
+// CHECK_VALUE_GENERIC: <Declaration>let Param : <Type usr="s:Si">Int</Type></Declaration>


### PR DESCRIPTION
*6.2 cherry-pick of #83113*

- Explanation: Fixes cursor info and indexing for references to value generic parameters
- Scope: Affects value generic parameter references
- Issue: rdar://145509737
- Risk: Low/Medium, while it does touch the ASTWalker, the new behavior matches what we already do for TypeExprs
- Testing: Added tests to test suite
- Reviewer: Rintaro Ishizaki, Ben Barham