### PR TITLE
[cxx-interop] Properly support OS objects in reverse interop

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ClangSyntaxPrinter.h"
+#include "DeclAndTypePrinter.h"
 #include "PrimitiveTypeMapping.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
@@ -100,6 +101,12 @@ bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclInnerStaticAssert(
 }
 
 void ClangSyntaxPrinter::printClangTypeReference(const clang::Decl *typeDecl) {
+  StringRef osObjectName = DeclAndTypePrinter::maybeGetOSObjectBaseName(
+      dyn_cast<clang::NamedDecl>(cast<clang::NamedDecl>(typeDecl)));
+  if (!osObjectName.empty()) {
+    os << osObjectName << "_t";
+    return;
+  }
   if (cast<clang::NamedDecl>(typeDecl)->getDeclName().isEmpty() &&
       isa<clang::TagDecl>(typeDecl)) {
     if (auto *tnd =

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3127,6 +3127,8 @@ const TypeDecl *DeclAndTypePrinter::getObjCTypeDecl(const TypeDecl* TD) {
 
 StringRef
 DeclAndTypePrinter::maybeGetOSObjectBaseName(const clang::NamedDecl *decl) {
+  if (!decl)
+    return StringRef();
   StringRef name = decl->getName();
   if (!name.consume_front("OS_"))
     return StringRef();

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -320,11 +320,16 @@ public:
     auto *cd = CT->getDecl();
     if (cd->hasClangNode()) {
       const auto *clangDecl = cd->getClangDecl();
-      ClangSyntaxPrinter(cd->getASTContext(), os).printClangTypeReference(clangDecl);
+      ClangSyntaxPrinter(cd->getASTContext(), os)
+          .printClangTypeReference(clangDecl);
       bool alreadyPointer = false;
       if (const auto *typedefDecl = dyn_cast<clang::TypedefNameDecl>(clangDecl))
         if (importer::isCFTypeDecl(typedefDecl))
           alreadyPointer = true;
+      if (!DeclAndTypePrinter::maybeGetOSObjectBaseName(
+               dyn_cast<clang::NamedDecl>(clangDecl))
+               .empty())
+        alreadyPointer = true;
       os << (alreadyPointer ? " " : " *")
          << (!optionalKind || *optionalKind == OTK_None ? "_Nonnull"
                                                         : "_Nullable");

--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -4,6 +4,7 @@
 // RUN: %FileCheck %s < %t/UseCoreFoundation.h
 
 // RUN: echo "#include <netinet/in.h>" > %t/full-header.h
+// RUN: echo "#include <dispatch/dispatch.h>" >> %t/full-header.h
 // RUN: cat %t/UseCoreFoundation.h >> %t/full-header.h
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/full-header.h -o %t/o.o
 
@@ -11,6 +12,9 @@
 
 import CoreFoundation
 import Foundation
+import Dispatch
+
+public func testDispatch(x: DispatchSemaphore) {}
 
 public func foobar(_ a: CFData) -> Bool {
     true
@@ -33,7 +37,9 @@ public enum MyEnum {
 // CHECK: SWIFT_EXTERN bool $s17UseCoreFoundation6foobarySbSo9CFDataRefaF(CFDataRef _Nonnull a) SWIFT_NOEXCEPT SWIFT_CALL; // foobar(_:)
 // CHECK: SWIFT_EXTERN CFDateRef _Nullable $s17UseCoreFoundation13returnsCFDateSo0E3RefaSgyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // returnsCFDate()
 // CHECK: SWIFT_EXTERN void $s17UseCoreFoundation11takesCFDate1xySo0E3RefaSg_tF(CFDateRef _Nullable x) SWIFT_NOEXCEPT SWIFT_CALL; // takesCFDate(x:)
+// CHECK: SWIFT_EXTERN void $s17UseCoreFoundation12testDispatch1xySo21OS_dispatch_semaphoreC_tF(dispatch_semaphore_t _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // testDispatch(x:)
 
 // CHECK: SWIFT_INLINE_THUNK swift::Optional<in_addr> networkThing() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation12networkThingSo7in_addrVSgyF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: SWIFT_INLINE_THUNK CFDateRef _Nullable returnsCFDate() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation13returnsCFDateSo0E3RefaSgyF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: SWIFT_INLINE_THUNK void takesCFDate(CFDateRef _Nullable x) noexcept SWIFT_SYMBOL("s:17UseCoreFoundation11takesCFDate1xySo0E3RefaSg_tF") {
+// CHECK: SWIFT_INLINE_THUNK void testDispatch(dispatch_semaphore_t _Nonnull x) noexcept SWIFT_SYMBOL("s:17UseCoreFoundation12testDispatch1xySo21OS_dispatch_semaphoreC_tF") {


### PR DESCRIPTION
These objects are behind typedefs and user code supposed to use the typedef names. We already have some logic in place for Obj-C interop. Reuse the same logic for C++ to use the correct names.

rdar://150453489
