### PR TITLE
Frontend: Allow `-dump-availability-scopes` to be used with any action

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -710,6 +710,12 @@ public:
     }
   }
 
+  SourceFile &getPrimaryOrMainSourceFile() const {
+    if (SourceFile *SF = getPrimarySourceFile())
+      return *SF;
+    return getMainModule()->getMainSourceFile();
+  }
+
   /// Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation, std::string &Error,
              ArrayRef<const char *> Args = {});

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -798,6 +798,9 @@ public:
   /// \returns true if any errors occurred.
   bool performSILProcessing(SILModule *silModule);
 
+  /// Dumps any debugging output for the compilation, if requested.
+  void emitEndOfPipelineDebuggingOutput();
+
 private:
   /// Creates a new source file for the main module.
   SourceFile *createSourceFileForMainModule(ModuleDecl *mod,

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -167,9 +167,6 @@ public:
     /// Parse and dump scope map.
     DumpScopeMaps,
 
-    /// Parse, type-check, and dump availability scopes
-    DumpAvailabilityScopes,
-
     EmitImportedModules, ///< Emit the modules that this one imports
     EmitPCH,             ///< Emit PCH of imported bridging header
 
@@ -312,6 +309,10 @@ public:
   /// Indicates whether or not the Clang importer should dump lookup tables
   /// upon termination.
   bool DumpClangLookupTables = false;
+
+  /// Indicates whether or not availability scopes should be dumped upon
+  /// termination.
+  bool DumpAvailabilityScopes = false;
 
   /// Indicates whether standard help should be shown.
   bool PrintHelp = false;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -35,6 +35,21 @@ namespace llvm {
 namespace swift {
 enum class IntermoduleDepTrackingMode;
 
+/// Options for debugging the behavior of the frontend.
+struct CompilerDebuggingOptions {
+  /// Indicates whether or not the Clang importer should print statistics upon
+  /// termination.
+  bool PrintClangStats = false;
+
+  /// Indicates whether or not the availability scope trees built during
+  /// compilation should be dumped upon termination.
+  bool DumpAvailabilityScopes = false;
+
+  /// Indicates whether or not the Clang importer should dump lookup tables
+  /// upon termination.
+  bool DumpClangLookupTables = false;
+};
+
 /// Options for controlling the behavior of the frontend.
 class FrontendOptions {
   friend class ArgsToFrontendOptionsConverter;
@@ -123,6 +138,9 @@ public:
 
   /// A set of modules allowed to import this module.
   std::set<std::string> AllowableClients;
+
+  /// Options for debugging the compiler.
+  CompilerDebuggingOptions CompilerDebuggingOpts;
 
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
@@ -301,18 +319,6 @@ public:
   /// Indicates whether or not the frontend should print statistics upon
   /// termination.
   bool PrintStats = false;
-
-  /// Indicates whether or not the Clang importer should print statistics upon
-  /// termination.
-  bool PrintClangStats = false;
-
-  /// Indicates whether or not the Clang importer should dump lookup tables
-  /// upon termination.
-  bool DumpClangLookupTables = false;
-
-  /// Indicates whether or not availability scopes should be dumped upon
-  /// termination.
-  bool DumpAvailabilityScopes = false;
 
   /// Indicates whether standard help should be shown.
   bool PrintHelp = false;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -455,7 +455,8 @@ private:
   llvm::StringSaver Saver;
 };
 
-struct ModuleInterfaceLoaderOptions {
+class ModuleInterfaceLoaderOptions {
+public:
   FrontendOptions::ActionType requestedAction =
       FrontendOptions::ActionType::EmitModuleOnly;
   bool remarkOnRebuildFromInterface = false;
@@ -464,28 +465,11 @@ struct ModuleInterfaceLoaderOptions {
   bool disableBuildingInterface = false;
   bool downgradeInterfaceVerificationError = false;
   bool strictImplicitModuleContext = false;
+  CompilerDebuggingOptions compilerDebuggingOptions;
   std::string mainExecutablePath;
-  ModuleInterfaceLoaderOptions(const FrontendOptions &Opts):
-    remarkOnRebuildFromInterface(Opts.RemarkOnRebuildFromModuleInterface),
-    disableInterfaceLock(Opts.DisableInterfaceFileLock),
-    disableImplicitSwiftModule(Opts.DisableImplicitModules),
-    disableBuildingInterface(Opts.DisableBuildingInterface),
-    downgradeInterfaceVerificationError(Opts.DowngradeInterfaceVerificationError),
-    strictImplicitModuleContext(Opts.StrictImplicitModuleContext),
-    mainExecutablePath(Opts.MainExecutablePath)
-  {
-    switch (Opts.RequestedAction) {
-    case FrontendOptions::ActionType::TypecheckModuleFromInterface:
-      requestedAction = FrontendOptions::ActionType::Typecheck;
-      break;
-    case FrontendOptions::ActionType::ScanDependencies:
-      requestedAction = Opts.RequestedAction;
-      break;
-    default:
-      requestedAction = FrontendOptions::ActionType::EmitModuleOnly;
-      break;
-    }
-  }
+
+  ModuleInterfaceLoaderOptions(const FrontendOptions &Opts,
+                               bool inheritDebuggingOpts = false);
   ModuleInterfaceLoaderOptions() = default;
 };
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -673,6 +673,9 @@ def dump_clang_lookup_tables : Flag<["-"], "dump-clang-lookup-tables">,
   HelpText<"Dump the importer's Swift-name-to-Clang-name lookup tables to "
            "stderr">;
 
+def dump_availability_scopes : Flag<["-"], "dump-availability-scopes">,
+                               HelpText<"Dump availability scopes to stderr">;
+
 def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-validate-system-headers">,
   HelpText<"Disable validating system headers in the Clang importer">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1435,11 +1435,7 @@ def dump_scope_maps : Separate<["-"], "dump-scope-maps">,
   MetaVarName<"<expanded-or-list-of-line:column>">,
   ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def dump_availability_scopes :
-  Flag<["-"], "dump-availability-scopes">,
-  HelpText<"Type-check input file(s) and dump availability scopes">,
-  ModeOpt,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+
 def dump_type_info : Flag<["-"], "dump-type-info">,
   HelpText<"Output YAML dump of fixed-size types from all imported modules">,
   ModeOpt,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -198,6 +198,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   computeTBDOptions();
 
   Opts.DumpClangLookupTables |= Args.hasArg(OPT_dump_clang_lookup_tables);
+  Opts.DumpAvailabilityScopes |= Args.hasArg(OPT_dump_availability_scopes);
 
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
@@ -665,8 +666,6 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::MergeModules;
   if (Opt.matches(OPT_dump_scope_maps))
     return FrontendOptions::ActionType::DumpScopeMaps;
-  if (Opt.matches(OPT_dump_availability_scopes))
-    return FrontendOptions::ActionType::DumpAvailabilityScopes;
   if (Opt.matches(OPT_dump_interface_hash))
     return FrontendOptions::ActionType::DumpInterfaceHash;
   if (Opt.matches(OPT_dump_type_info))

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -197,8 +197,11 @@ bool ArgsToFrontendOptionsConverter::convert(
   computeDebugTimeOptions();
   computeTBDOptions();
 
-  Opts.DumpClangLookupTables |= Args.hasArg(OPT_dump_clang_lookup_tables);
-  Opts.DumpAvailabilityScopes |= Args.hasArg(OPT_dump_availability_scopes);
+  Opts.CompilerDebuggingOpts.DumpAvailabilityScopes |=
+      Args.hasArg(OPT_dump_availability_scopes);
+
+  Opts.CompilerDebuggingOpts.DumpClangLookupTables |=
+      Args.hasArg(OPT_dump_clang_lookup_tables);
 
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
@@ -472,7 +475,8 @@ void ArgsToFrontendOptionsConverter::handleDebugCrashGroupArguments() {
 void ArgsToFrontendOptionsConverter::computePrintStatsOptions() {
   using namespace options;
   Opts.PrintStats |= Args.hasArg(OPT_print_stats);
-  Opts.PrintClangStats |= Args.hasArg(OPT_print_clang_stats);
+  Opts.CompilerDebuggingOpts.PrintClangStats |=
+      Args.hasArg(OPT_print_clang_stats);
   Opts.PrintZeroStats |= Args.hasArg(OPT_print_zero_stats);
 #if defined(NDEBUG) && !LLVM_ENABLE_STATS
   if (Opts.PrintStats || Opts.PrintClangStats)

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -473,7 +473,6 @@ static bool shouldEmitFineModuleTrace(FrontendOptions::ActionType action) {
   case swift::FrontendOptions::ActionType::PrintAST:
   case swift::FrontendOptions::ActionType::PrintASTDecl:
   case swift::FrontendOptions::ActionType::DumpScopeMaps:
-  case swift::FrontendOptions::ActionType::DumpAvailabilityScopes:
   case swift::FrontendOptions::ActionType::EmitImportedModules:
   case swift::FrontendOptions::ActionType::EmitPCH:
   case swift::FrontendOptions::ActionType::EmitModuleOnly:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -41,7 +41,6 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpPCM:
   case ActionType::EmitPCH:
     return false;
@@ -111,7 +110,6 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -157,7 +155,6 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -200,7 +197,6 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -239,7 +235,6 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::MergeModules:
   case ActionType::Immediate:
   case ActionType::DumpTypeInfo:
@@ -305,7 +300,6 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::DumpPCM:
   case ActionType::PrintVersion:
@@ -378,7 +372,6 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -422,7 +415,6 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -467,7 +459,6 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -509,7 +500,6 @@ bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -550,7 +540,6 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -600,7 +589,6 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::TypecheckModuleFromInterface:
@@ -643,7 +631,6 @@ bool FrontendOptions::canActionEmitConstValues(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -687,7 +674,6 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::CompileModuleFromInterface:
@@ -733,7 +719,6 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -776,7 +761,6 @@ bool FrontendOptions::canActionEmitAPIDescriptor(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -818,7 +802,6 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitPCH:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
@@ -877,7 +860,6 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitImportedModules:
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
@@ -907,7 +889,6 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::CompileModuleFromInterface:
@@ -948,7 +929,6 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
@@ -994,7 +974,6 @@ bool FrontendOptions::doesActionBuildModuleFromInterface(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
-  case ActionType::DumpAvailabilityScopes:
   case ActionType::DumpTypeInfo:
   case ActionType::Typecheck:
   case ActionType::ResolveImports:

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -203,6 +203,7 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
     ArrayRef<std::string> CompiledCandidates,
     StringRef CompilerVersion) {
   auto Invocation = Instance.getInvocation();
+
   // Try building forwarding module first. If succeed, return.
   if (Instance.getASTContext()
           .getModuleInterfaceChecker()
@@ -254,6 +255,9 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
                  builtByCompiler);
       }
     }
+
+    // If requested, dump debugging output before exiting.
+    Instance.emitEndOfPipelineDebuggingOutput();
   };
 
   Instance.performSema();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1040,6 +1040,10 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   if (opts.DumpClangLookupTables && ctx.getClangModuleLoader())
     ctx.getClangModuleLoader()->dumpSwiftLookupTables();
 
+  if (opts.DumpAvailabilityScopes)
+    getPrimaryOrMainSourceFile(Instance).getAvailabilityScope()->dump(
+        llvm::errs(), Instance.getASTContext().SourceMgr);
+
   // Report mangling stats if there was no error.
   if (!ctx.hadError())
     Mangle::printManglingStats();
@@ -1295,17 +1299,12 @@ static bool performAction(CompilerInstance &Instance,
         });
   case FrontendOptions::ActionType::DumpScopeMaps:
     return withSemanticAnalysis(
-        Instance, observer, [](CompilerInstance &Instance) {
+        Instance, observer,
+        [](CompilerInstance &Instance) {
           return dumpAndPrintScopeMap(Instance,
                                       getPrimaryOrMainSourceFile(Instance));
-        }, /*runDespiteErrors=*/true);
-  case FrontendOptions::ActionType::DumpAvailabilityScopes:
-    return withSemanticAnalysis(
-        Instance, observer, [](CompilerInstance &Instance) {
-          getPrimaryOrMainSourceFile(Instance).getAvailabilityScope()->dump(
-              llvm::errs(), Instance.getASTContext().SourceMgr);
-          return Instance.getASTContext().hadError();
-        }, /*runDespiteErrors=*/true);
+        },
+        /*runDespiteErrors=*/true);
   case FrontendOptions::ActionType::DumpInterfaceHash:
     getPrimaryOrMainSourceFile(Instance).dumpInterfaceHash(llvm::errs());
     return Instance.getASTContext().hadError();

--- a/test/ModuleInterface/availability-scopes.swift
+++ b/test/ModuleInterface/availability-scopes.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -dump-availability-scopes 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Test.swiftinterface -o /dev/null -module-name Test -dump-availability-scopes 2>&1 | %FileCheck --strict-whitespace %s
+
+// CHECK: {{^}}(root {{.*}} file={{.*}}{{/|\\}}availability-scopes.swift.tmp{{/|\\}}Test.swiftinterface
+// CHECK: {{^}}  (decl {{.*}}unavailable=* decl=unavailable()
+@available(*, unavailable)
+public func unavailable() { }


### PR DESCRIPTION
Instead of treating `-dump-availability-scopes` as a distinct frontend action, make it a debugging option that causes extra debugging output to be emitted at the end of compilation for any action type. This allows the flag to be composed with the `-typecheck-module-from-interface` and `-compile-module-from-interface` actions, which can be useful for debugging compiler behavior when building `.swiftinterface` files.

The `-dump-clang-lookup-tables` and `-print-clang-stats` flags have also been updated to work with module interface builds as well.