### PR TITLE
NFC: refactor source-line sensitive tests, remove unused build-presets configuration

### DIFF
--- a/test/Backtracing/Crash.test
+++ b/test/Backtracing/Crash.test
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Crash
-// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/CrashNoDebug
-// RUN: %target-build-swift %s -parse-as-library -O -g -o %t/CrashOpt
-// RUN: %target-build-swift %s -parse-as-library -O -o %t/CrashOptNoDebug
+// RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -Onone -g -o %t/Crash
+// RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -Onone -o %t/CrashNoDebug
+// RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -O -g -o %t/CrashOpt
+// RUN: %target-build-swift %S/Inputs/Crash.swift -parse-as-library -O -o %t/CrashOptNoDebug
 // RUN: %target-codesign %t/Crash
 // RUN: %target-codesign %t/CrashNoDebug
 // RUN: %target-codesign %t/CrashOpt
@@ -20,45 +20,17 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-func level1() {
-  level2()
-}
-
-func level2() {
-  level3()
-}
-
-func level3() {
-  level4()
-}
-
-func level4() {
-  level5()
-}
-
-func level5() {
-  print("About to crash")
-  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-  ptr.pointee = 42
-}
-
-@main
-struct Crash {
-  static func main() {
-    level1()
-  }
-}
 
 // CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
 
 // CHECK: Thread 0 {{(".*" )?}}crashed:
 
-// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:42:15
-// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:36:3
-// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:32:3
-// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:28:3
-// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:24:3
-// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:48:5
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:20:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:14:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:10:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:6:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:2:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:26:5
 // CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static Crash.$main() + {{[0-9]+}} in Crash at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in Crash at {{.*}}/Crash.swift
 
@@ -72,59 +44,57 @@ struct Crash {
 
 // FRIENDLY: Thread 0 {{(".*" )?}}crashed:
 
-// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:42:15
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:20:15
 
-// FRIENDLY: 40|   print("About to crash")
-// FRIENDLY-NEXT: 41|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT: 42|   ptr.pointee = 42
+// FRIENDLY: 18|   print("About to crash")
+// FRIENDLY-NEXT: 19|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 20|   ptr.pointee = 42
 // FRIENDLY-NEXT:   |               ^
-// FRIENDLY-NEXT: 43| }
-// FRIENDLY-NEXT: 44|
+// FRIENDLY-NEXT: 21| }
+// FRIENDLY-NEXT: 22|
 
-// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:36:3
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:14:3
 
-// FRIENDLY: 34|
-// FRIENDLY-NEXT: 35| func level4() {
-// FRIENDLY-NEXT: 36|   level5()
+// FRIENDLY: 12|
+// FRIENDLY-NEXT: 13| func level4() {
+// FRIENDLY-NEXT: 14|   level5()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 37| }
-// FRIENDLY-NEXT: 38|
+// FRIENDLY-NEXT: 15| }
+// FRIENDLY-NEXT: 16|
 
-// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:32:3
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:10:3
 
-// FRIENDLY: 30|
-// FRIENDLY-NEXT: 31| func level3() {
-// FRIENDLY-NEXT: 32|   level4()
+// FRIENDLY: 8|
+// FRIENDLY-NEXT: 9| func level3() {
+// FRIENDLY-NEXT: 10|   level4()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 33| }
-// FRIENDLY-NEXT: 34|
+// FRIENDLY-NEXT: 11| }
+// FRIENDLY-NEXT: 12|
 
-// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:28:3
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:6:3
 
-// FRIENDLY: 26|
-// FRIENDLY-NEXT: 27| func level2() {
-// FRIENDLY-NEXT: 28|   level3()
+// FRIENDLY: 4|
+// FRIENDLY-NEXT: 5| func level2() {
+// FRIENDLY-NEXT: 6|   level3()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 29| }
-// FRIENDLY-NEXT: 30|
+// FRIENDLY-NEXT: 7| }
+// FRIENDLY-NEXT: 8|
 
-// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:24:3
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:2:3
 
-// FRIENDLY:  22|
-// FRIENDLY-NEXT: 23| func level1() {
-// FRIENDLY-NEXT: 24|   level2()
+// FRIENDLY:      1| func level1() {
+// FRIENDLY-NEXT: 2|   level2()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 25| }
-// FRIENDLY-NEXT: 26|
+// FRIENDLY-NEXT: 3| }
 
-// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:48:5
+// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:26:5
 
-// FRIENDLY: 46| struct Crash {
-// FRIENDLY-NEXT: 47|   static func main() {
-// FRIENDLY-NEXT: 48|     level1()
+// FRIENDLY: 24| struct Crash {
+// FRIENDLY-NEXT: 25|   static func main() {
+// FRIENDLY-NEXT: 26|     level1()
 // FRIENDLY-NEXT:   |     ^
-// FRIENDLY-NEXT: 49|   }
-// FRIENDLY-NEXT: 50| }
+// FRIENDLY-NEXT: 27|   }
+// FRIENDLY-NEXT: 28| }
 
 // NODEBUG: *** Program crashed: Bad pointer dereference at 0x{{0*}}4 ***
 
@@ -149,12 +119,12 @@ struct Crash {
 
 // OPTIMIZED: Thread 0 {{(".*" )?}}crashed:
 
-// OPTIMIZED: 0 [inlined]          0x{{[0-9a-f]+}} level5() in CrashOpt at {{.*}}/Crash.swift:42:15
-// OPTIMIZED-NEXT: 1 [inlined]          0x{{[0-9a-f]+}} level4() in CrashOpt at {{.*}}/Crash.swift:36:3
-// OPTIMIZED-NEXT: 2 [inlined]          0x{{[0-9a-f]+}} level3() in CrashOpt at {{.*}}/Crash.swift:32:3
-// OPTIMIZED-NEXT: 3 [inlined]          0x{{[0-9a-f]+}} level2() in CrashOpt at {{.*}}/Crash.swift:28:3
-// OPTIMIZED-NEXT: 4 [inlined]          0x{{[0-9a-f]+}} level1() in CrashOpt at {{.*}}/Crash.swift:24:3
-// OPTIMIZED-NEXT: 5 [inlined]          0x{{[0-9a-f]+}} static Crash.main() in CrashOpt at {{.*}}/Crash.swift:48:5
+// OPTIMIZED: 0 [inlined]          0x{{[0-9a-f]+}} level5() in CrashOpt at {{.*}}/Crash.swift:20:15
+// OPTIMIZED-NEXT: 1 [inlined]          0x{{[0-9a-f]+}} level4() in CrashOpt at {{.*}}/Crash.swift:14:3
+// OPTIMIZED-NEXT: 2 [inlined]          0x{{[0-9a-f]+}} level3() in CrashOpt at {{.*}}/Crash.swift:10:3
+// OPTIMIZED-NEXT: 3 [inlined]          0x{{[0-9a-f]+}} level2() in CrashOpt at {{.*}}/Crash.swift:6:3
+// OPTIMIZED-NEXT: 4 [inlined]          0x{{[0-9a-f]+}} level1() in CrashOpt at {{.*}}/Crash.swift:2:3
+// OPTIMIZED-NEXT: 5 [inlined]          0x{{[0-9a-f]+}} static Crash.main() in CrashOpt at {{.*}}/Crash.swift:26:5
 // OPTIMIZED: {{6|7}} [system]           0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashOpt at {{.*}}
 
 // OPTIMIZED: Registers:

--- a/test/Backtracing/Inputs/Crash.swift
+++ b/test/Backtracing/Inputs/Crash.swift
@@ -1,0 +1,28 @@
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to crash")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct Crash {
+  static func main() {
+    level1()
+  }
+}

--- a/test/IRGen/prespecialized-metadata/class-inmodule-1argument-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-1argument-run.swift
@@ -44,29 +44,29 @@ func consume<T>(clazzType: MyGenericClazz<T>.Type) {
 
 
 public func doit() {
-  // CHECK: [[FLOAT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Float> @ 48
+  // CHECK: [[FLOAT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Float> @ [[@LINE+1]]
   consume(MyGenericClazz<Float>())
-  // CHECK: [[FLOAT_METADATA_ADDRESS]] MyGenericClazz<Float> @ 50
+  // CHECK: [[FLOAT_METADATA_ADDRESS]] MyGenericClazz<Float> @ [[@LINE+1]]
   consume(clazz: MyGenericClazz<Float>())
 
-  // CHECK: [[DOUBLE_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Double> @ 53
+  // CHECK: [[DOUBLE_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Double> @ [[@LINE+1]]
   consume(MyGenericClazz<Double>())
-  // CHECK: [[DOUBLE_METADATA_ADDRESS]] MyGenericClazz<Double> @ 55
+  // CHECK: [[DOUBLE_METADATA_ADDRESS]] MyGenericClazz<Double> @ [[@LINE+1]]
   consume(clazz: MyGenericClazz<Double>())
 
-  // CHECK: [[INT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Int> @ 58
+  // CHECK: [[INT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Int> @ [[@LINE+1]]
   consume(MyGenericClazz<Int>())
-  // CHECK: [[INT_METADATA_ADDRESS]] MyGenericClazz<Int> @ 60
+  // CHECK: [[INT_METADATA_ADDRESS]] MyGenericClazz<Int> @ [[@LINE+1]]
   consume(clazz: MyGenericClazz<Int>())
 
-  // CHECK: [[STRING_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<String> @ 63
+  // CHECK: [[STRING_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<String> @ [[@LINE+1]]
   consume(MyGenericClazz<String>())
-  // CHECK: [[STRING_METADATA_ADDRESS]] MyGenericClazz<String> @ 65
+  // CHECK: [[STRING_METADATA_ADDRESS]] MyGenericClazz<String> @ [[@LINE+1]]
   consume(clazz: MyGenericClazz<String>())
 
-  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ 68
+  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ [[@LINE+1]]
   consume(MyGenericClazz<MyGenericClazz<String>>())
-  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ 70
+  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ [[@LINE+1]]
   consume(clazz: MyGenericClazz<MyGenericClazz<String>>())
 
   // CHECK: [[FLOAT_METADATA_METATYPE_ADDRESS:[0-9a-f]+]] MyGenericClazz<Float>

--- a/test/IRGen/prespecialized-metadata/class-inmodule-2argument-1super-2argument-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-2argument-1super-2argument-run.swift
@@ -61,20 +61,20 @@ func consume<Input, Output>(derived: MyWeakMutableInstanceMethodBox<Input,  Outp
 }
 
 func doit() {
-    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Int, Bool> @ 65
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Int, Bool> @ [[@LINE+1]]
     consume(WeakMutableInstanceMethodBox<Int, Bool>())
-    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] WeakMutableInstanceMethodBox<Int, Bool> @ 67
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] WeakMutableInstanceMethodBox<Int, Bool> @ [[@LINE+1]]
     consume(base: WeakMutableInstanceMethodBox<Int, Bool>())
-    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Double, Float> @ 69
+    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Double, Float> @ [[@LINE+1]]
     consume(WeakMutableInstanceMethodBox<Double, Float>())
-    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS]] WeakMutableInstanceMethodBox<Double, Float> @ 71
+    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS]] WeakMutableInstanceMethodBox<Double, Float> @ [[@LINE+1]]
     consume(base: WeakMutableInstanceMethodBox<Double, Float>())
 
-    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 74
+    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] MyWeakMutableInstanceMethodBox<Int, Bool> @ [[@LINE+1]]
     consume(MyWeakMutableInstanceMethodBox<Int, Bool>())
-    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 76
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ [[@LINE+1]]
     consume(base: MyWeakMutableInstanceMethodBox<Int, Bool>())
-    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 78
+    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ [[@LINE+1]]
     consume(derived: MyWeakMutableInstanceMethodBox<Int, Bool>())
 
     // CHECK: [[SUBCLASS_METADATA_DOUBLE_FLOAT_ADDRESS:[0-9a-f]+]] MyWeakMutableInstanceMethodBox<Double, Float>

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-otherfile-1argument-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-otherfile-1argument-run.swift
@@ -17,8 +17,8 @@ func consume<First>(oneArgument: OneArgument<First>) {
 }
 
 func doit() {
-  // CHECK: [[METADATA_ADDRESS:[0-9a-f]+]] 3 @ 21
+  // CHECK: [[METADATA_ADDRESS:[0-9a-f]+]] 3 @ [[@LINE+1]]
   consume(OneArgument(3))
-  // CHECK: [[METADATA_ADDRESS]] 3 @ 23
+  // CHECK: [[METADATA_ADDRESS]] 3 @ [[@LINE+1]]
   consume(oneArgument: OneArgument(3))
 }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-run.swift
@@ -51,27 +51,27 @@ func consumeType_OneArgumentAtFirstUsageDynamic_Dynamic(line: UInt = #line) {
 
 @inline(never)
 func doit() {
-  // CHECK: [[STATIC_METADATA_ADDRESS:[0-9a-f]+]] @ 55
+  // CHECK: [[STATIC_METADATA_ADDRESS:[0-9a-f]+]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageStatic_Static()
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 57
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageStatic_Dynamic()
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 59
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageStatic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 61
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageDynamic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 63
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageDynamic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 65
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ [[@LINE+1]]
   consumeType_OneArgumentAtFirstUsageDynamic_Static()
 
   let staticMetadata = ptr(to: OneArgument<FirstUsageStatic>.self)
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 69
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ [[@LINE+1]]
   print(staticMetadata, "@", #line)
   assert(isStaticallySpecializedGenericMetadata(staticMetadata))
   assert(!isCanonicalStaticallySpecializedGenericMetadata(staticMetadata))
 
   let dynamicMetadata = ptr(to: OneArgument<FirstUsageDynamic>.self)
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 75
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ [[@LINE+1]]
   print(dynamicMetadata, "@", #line)
   assert(!isStaticallySpecializedGenericMetadata(dynamicMetadata))
   assert(!isCanonicalStaticallySpecializedGenericMetadata(dynamicMetadata))

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -689,9 +689,6 @@ build-subdir=buildbot_incremental
 
 lto
 
-[preset: ncgenerics,smoketest=macosx]
-mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
-build-subdir=buildbot_incremental
 
 [preset: buildbot_incremental,tools=RA,llvm-only]
 build-subdir=buildbot_incremental_llvmonly


### PR DESCRIPTION
I've developed and split out these clean-ups / refactorings while working on https://github.com/swiftlang/swift/pull/83622