### PR TITLE
runtime: Silence a `-Wglobal-constructors` error than appears with upstream clang on Windows

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -37,6 +37,9 @@
 #include "ImageInspection.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Runtime/Atomic.h"
+#if defined(_WIN32)
+#include "swift/Runtime/Config.h"
+#endif
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Runtime/Win32.h"
@@ -544,6 +547,7 @@ void swift::swift_abortDisabledUnicodeSupport() {
 }
 
 #if defined(_WIN32)
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 // On Windows, exceptions may be swallowed in some cases and the
 // process may not terminate as expected on crashes. For example,
 // illegal instructions used by llvm.trap. Disable the exception
@@ -555,5 +559,5 @@ static void ConfigureExceptionPolicy() {
                             UOI_TIMERPROC_EXCEPTION_SUPPRESSION,
                             &Suppress, sizeof(Suppress));
 }
-
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 #endif

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -25,15 +25,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if defined(_WIN32)
+#include "swift/Runtime/Config.h"
+#endif
 #include "swift/shims/LibcShims.h"
 
 #if defined(_WIN32)
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 static void __attribute__((__constructor__))
 _swift_stdlib_configure_console_mode(void) {
   static UINT uiPrevConsoleCP = GetConsoleOutputCP();
   atexit([]() { SetConsoleOutputCP(uiPrevConsoleCP); });
   SetConsoleOutputCP(CP_UTF8);
 }
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 #endif
 
 SWIFT_RUNTIME_STDLIB_INTERNAL


### PR DESCRIPTION
Missed these in https://github.com/swiftlang/swift/pull/81904.