### PR TITLE
Runtimes: build Observation when running macOS smoketest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1711,7 +1711,7 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
         # To ensure incremental builds work as expected
         BUILD_ALWAYS 1
         CMAKE_ARGS
-          -DSwift_ENABLE_RUNTIMES=StringProcessing|Synchronization|Distributed
+          -DSwift_ENABLE_RUNTIMES=StringProcessing|Synchronization|Distributed|Observation
           -DBUILD_SHARED_LIBS=YES
           -DCMAKE_Swift_COMPILER_WORKS:BOOLEAN=YES
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -92,3 +92,14 @@ if(SwiftRuntime_ENABLE_differentiation)
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()
+
+# Observation
+if(SwiftRuntime_ENABLE_observation)
+  ExternalProject_Add(Observation
+    PREFIX "Observation"
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Observation"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -97,8 +97,12 @@ set_target_properties(swiftObservation PROPERTIES
 # FIXME: We should split out the parts that are needed by the runtime to avoid
 # pulling in headers from the compiler.
 target_include_directories(swiftObservation PRIVATE
-  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include")
+  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include"
+  # For `swift/runtime/CMakeConfig.h`, which should be generated
+  # by the Core build system.
+  "${${PROJECT_NAME}_PATH_TO_SWIFT_RUNTIME_HEADERS}")
 target_link_libraries(swiftObservation PRIVATE
+  swiftShims
   swiftCore
   swift_Concurrency
   $<$<PLATFORM_ID:Android>:swiftAndroid>


### PR DESCRIPTION
Piggyback the addition of a flag to specify the path of the CMakeConfig.h header needed to compile Observation (needed when consuming SwiftCore through the fine module), and the declaration of SwiftShims as a dependency.

Addresses rdar://149241712