### PR TITLE
test: `@_inlineable` -> `@inlinable`

### DIFF
--- a/test/Interop/C/implementation-only-imports/check-function-visibility-inversed.swift
+++ b/test/Interop/C/implementation-only-imports/check-function-visibility-inversed.swift
@@ -11,7 +11,7 @@
 import UserA
 @_implementationOnly import UserB
 
-@_inlineable
+@inlinable
 public func callFortyTwo() -> CInt {
   return getFortyTwo()
 }

--- a/test/Interop/C/implementation-only-imports/check-function-visibility.swift
+++ b/test/Interop/C/implementation-only-imports/check-function-visibility.swift
@@ -11,7 +11,7 @@
 @_implementationOnly import UserA
 import UserB
 
-@_inlineable
+@inlinable
 public func callFortyTwo() -> CInt {
   return getFortyTwo()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
@@ -11,7 +11,7 @@
 @_implementationOnly import UserA
 import UserB
 
-@_inlineable
+@inlinable
 public func createAWrapper() {
   let _ = MagicWrapper()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
@@ -11,7 +11,7 @@
 import UserA
 @_implementationOnly import UserB
 
-@_inlineable
+@inlinable
 public func createAWrapper() {
   let _ = MagicWrapper()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
@@ -7,7 +7,7 @@
 @_implementationOnly import DeclA
 import DeclB
 
-@_inlineable
+@inlinable
 public func callFortySomething() -> CInt {
   return getFortySomething()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
@@ -11,7 +11,7 @@
 import UserA
 @_implementationOnly import UserB
 
-@_inlineable
+@inlinable
 public func callFortyTwo() -> CInt {
   return getFortyTwo()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
@@ -11,7 +11,7 @@
 @_implementationOnly import UserA
 import UserB
 
-@_inlineable
+@inlinable
 public func callFortyTwo() -> CInt {
   return getFortyTwo()
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
@@ -12,7 +12,7 @@ import UserA
 @_implementationOnly import UserB
 
 // Operator `+` is a non-member function.
-@_inlineable
+@inlinable
 public func addWrappers() {
   let wrapperA = MagicWrapper()
   let wrapperB = MagicWrapper()
@@ -20,7 +20,7 @@ public func addWrappers() {
 }
 
 // Operator `-` is a member function.
-@_inlineable
+@inlinable
 public func subtractWrappers() {
   var wrapperA = MagicWrapper()
   let wrapperB = MagicWrapper()

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
@@ -12,7 +12,7 @@
 import UserB
 
 // Operator `+` is a non-member function.
-@_inlineable
+@inlinable
 public func addWrappers() {
   let wrapperA = MagicWrapper()
   let wrapperB = MagicWrapper()
@@ -20,7 +20,7 @@ public func addWrappers() {
 }
 
 // Operator `-` is a member function.
-@_inlineable
+@inlinable
 public func subtractWrappers() {
   var wrapperA = MagicWrapper()
   let wrapperB = MagicWrapper()

--- a/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
+++ b/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
@@ -7,7 +7,7 @@
 @_implementationOnly import UserA
 import UserC
 
-@_inlineable
+@inlinable
 public func createAWrapper() {
   let _ = MagicWrapper()
 }

--- a/test/NameLookup/Inputs/NIOFoundationCompat.swift
+++ b/test/NameLookup/Inputs/NIOFoundationCompat.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Data {
-  @_inlineable
+  @inlinable
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
     let r: R? = nil
     return r!


### PR DESCRIPTION
The Swift 4 spelling only should remain in specific tests that ensure it's still accepted in that mode. Those tests that remain intact are:

- `test/attr/attr_inlinable_old_spelling.swift`
- `test/Compatibility/attr_inlinable_old_spelling_4.swift`
- `test/Compatibility/attr_inlinable_old_spelling_42.swift`
