### PR TITLE
Tests: Add a test for rdar://158172056

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1243,3 +1243,11 @@ void takeNullableId(_Nullable id);
 @interface PaletteDescriptor : NSObject <NSCopying>
 @property (readonly, nonnull) ColorArray *colors;
 @end
+
+@protocol NSIndexable <NSObject>
+- (id)objectAtIndex:(NSInteger)index;
+@end
+
+@interface NSCouldConformToIndexable : NSObject
+- (id)objectAtIndex:(NSInteger)index;
+@end

--- a/test/decl/protocol/conforms/objc_renamed.swift
+++ b/test/decl/protocol/conforms/objc_renamed.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+extension NSCouldConformToIndexable: @retroactive NSIndexable {
+}
+
+extension NSCouldConformToIndexable {
+  func testIndex(_ i: Int) {
+    _ = objectAtIndex(i) // expected-error {{'objectAtIndex' has been renamed to 'object(at:)'}}
+    _ = object(at: i)
+  }
+}


### PR DESCRIPTION
The bug tracked by rdar://158172056 was already fixed by https://github.com/swiftlang/swift/pull/83607 but this additional test case is needed to ensure that conformances to Obj-C protocols with obsolete requirements imported under legacy spellings not regress again.