### PR TITLE
Lifetime inference: implicit subscript getter depenency + implicit _modify

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1393,7 +1393,7 @@ protected:
       return std::nullopt;
     }
     if (wrappedAccessorKind) {
-      auto *var = cast<VarDecl>(accessor->getStorage());
+      auto *var = cast<AbstractStorageDecl>(accessor->getStorage());
       for (auto *wrappedAccessor : var->getAllAccessors()) {
         if (wrappedAccessor->isImplicit())
           continue;

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1021,7 +1021,8 @@ protected:
     }
 
     bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
-    if (auto accessor = dyn_cast<AccessorDecl>(afd)) {
+    auto accessor = dyn_cast<AccessorDecl>(afd);
+    if (accessor) {
       if (isImplicitOrSIL() || useLazyInference()) {
         if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
           // Implicit accessors that return or yield a non-Escapable value may
@@ -1038,14 +1039,18 @@ protected:
       }
       // Explicit accessors are inferred the same way as regular methods.
     }
-    // Do infer the result of a mutating method when 'self' is
-    // non-Escapable. The missing dependence on inout 'self' will be diagnosed
-    // later anyway, so an explicit annotation will still be needed.
+    // Do not infer the result's dependence when the method is mutating and
+    // 'self' is non-Escapable. Independently, a missing dependence on inout
+    // 'self' will be diagnosed. Since an explicit annotation will be needed for
+    // 'self', we also require the method's result to have an explicit
+    // annotation.
     if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
       return;
     }
-    // Methods with parameters only apply to lazy inference.
-    if (!useLazyInference() && afd->getParameters()->size() > 0) {
+    // Methods with parameters only apply to lazy inference. This does not
+    // include accessors because a subscript's index is assumed not to be the
+    // source of the result's dependency.
+    if (!accessor && !useLazyInference() && afd->getParameters()->size() > 0) {
       return;
     }
     if (!useLazyInference() && !isImplicitOrSIL()) {

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -318,6 +318,16 @@ struct Accessors {
       yield &ne
     }
   }
+
+  // Synthesized _modify...
+  subscript(_ index: Int) -> NEImmortal {
+    get { // OK
+      NEImmortal()
+    }
+
+    set { // OK (no dependency)
+    }
+  }
 }
 
 struct TrivialAccessors {


### PR DESCRIPTION
- **Lifetime inference: give subscripts an implicit dependency on 'self'**
  Allow a subscript getter to return a non-Escapable type without an explicit
  '@'lifetime annotation.
  
      subscript(_ index: Int) -> Span {
        get {} // OK
      }
  

- **Lifetime inference: fix a crash on implicit _modify for subscripts.**
  Fixes rdar://155976839 (Compiler crash when _modify is not specified for
  ~Escapable type)
  

- **Lifetime test: implicit subscript getter depenency, implicit _modify**
  