### PR TITLE
[6.2][StrictMemorySafety] Check the safety of return types of calls

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8505,7 +8505,7 @@ static bool hasUnsafeType(Evaluator &evaluator, clang::QualType clangType) {
     // All other pointers are considered unsafe.
     return true;
   }
-  
+
   // Handle records recursively.
   if (auto recordDecl = clangType->getAsTagDecl()) {
     // If we reached this point the types is not imported as a shared reference,
@@ -8582,7 +8582,7 @@ ClangDeclExplicitSafety::evaluate(Evaluator &evaluator,
     if (hasUnsafeType(evaluator, field->getType()))
       return ExplicitSafety::Unsafe;
   }
-  
+
   // Okay, call it safe.
   return ExplicitSafety::Safe;
 }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -21,11 +21,12 @@
 #include "TypeCheckUnsafe.h"
 
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/Effects.h"
-#include "swift/AST/UnsafeUse.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/Effects.h"
 #include "swift/AST/PackConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/Types.h"
+#include "swift/AST/UnsafeUse.h"
 
 using namespace swift;
 
@@ -243,19 +244,29 @@ bool swift::enumerateUnsafeUses(ConcreteDeclRef declRef,
   // If the type of this declaration involves unsafe types, diagnose that.
   ASTContext &ctx = decl->getASTContext();
   auto subs = declRef.getSubstitutions();
-  if (!skipTypeCheck) {
-    auto type = decl->getInterfaceType();
-    if (subs) {
-      if (auto *genericFnType = type->getAs<GenericFunctionType>())
-        type = genericFnType->substGenericArgs(subs);
-      else
-        type = type.subst(subs);
-    }
+  auto type = decl->getInterfaceType();
+  if (subs) {
+    if (auto *genericFnType = type->getAs<GenericFunctionType>())
+      type = genericFnType->substGenericArgs(subs);
+    else
+      type = type.subst(subs);
+  }
 
+  if (skipTypeCheck) {
+    // We check the arguements instead of the funcion type for function calls.
+    // On the other hand, we still need to check the return type as we might not
+    // have a declRef with the type of the return type. E.g. in
+    // `return funcionCall()`.
+    if (auto *fnTy = type->getAs<AnyFunctionType>())
+      type = fnTy->getResult();
+    else
+      type = Type();
+  }
+  if (type) {
     bool shouldReturnTrue = false;
     diagnoseUnsafeType(ctx, loc, type, [&](Type unsafeType) {
       if (fn(UnsafeUse::forReferenceToUnsafe(
-               decl, isCall && !isa<ParamDecl>(decl), unsafeType, loc)))
+              decl, isCall && !isa<ParamDecl>(decl), unsafeType, loc)))
         shouldReturnTrue = true;
     });
 

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -162,7 +162,7 @@ public struct CheckedContinuation<T, E: Error>: Sendable {
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(returning value: sending T) {
-    if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
+    if let c: UnsafeContinuation<T, E> = unsafe canary.takeContinuation() {
       unsafe c.resume(returning: value)
     } else {
       #if !$Embedded
@@ -186,7 +186,7 @@ public struct CheckedContinuation<T, E: Error>: Sendable {
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(throwing error: __owned E) {
-    if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
+    if let c: UnsafeContinuation<T, E> = unsafe canary.takeContinuation() {
       unsafe c.resume(throwing: error)
     } else {
       #if !$Embedded

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -888,7 +888,7 @@ internal func _task_serialExecutor_getExecutorRef<E>(_ executor: E) -> Builtin.E
 @_silgen_name("_task_taskExecutor_getTaskExecutorRef")
 internal func _task_taskExecutor_getTaskExecutorRef<E>(_ taskExecutor: E) -> Builtin.Executor
     where E: TaskExecutor {
-  return taskExecutor.asUnownedTaskExecutor().executor
+  return unsafe taskExecutor.asUnownedTaskExecutor().executor
 }
 
 // Used by the concurrency runtime

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -318,7 +318,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   /// Returns the result of executing the closure.
   @available(StdlibDeploymentTarget 6.2, *)
   public func withUnsafeExecutorPrivateData<R, E>(body: (UnsafeMutableRawBufferPointer) throws(E) -> R) throws(E) -> R {
-    let base = _jobGetExecutorPrivateData(self.context)
+    let base = unsafe _jobGetExecutorPrivateData(self.context)
     let size = unsafe 2 * MemoryLayout<OpaquePointer>.stride
     return unsafe try body(UnsafeMutableRawBufferPointer(start: base,
                                                          count: size))
@@ -470,13 +470,13 @@ extension ExecutorJob {
 
     /// Allocate a specified number of bytes of uninitialized memory.
     public func allocate(capacity: Int) -> UnsafeMutableRawBufferPointer {
-      let base = _jobAllocate(context, capacity)
+      let base = unsafe _jobAllocate(context, capacity)
       return unsafe UnsafeMutableRawBufferPointer(start: base, count: capacity)
     }
 
     /// Allocate uninitialized memory for a single instance of type `T`.
     public func allocate<T>(as type: T.Type) -> UnsafeMutablePointer<T> {
-      let base = _jobAllocate(context, MemoryLayout<T>.size)
+      let base = unsafe _jobAllocate(context, MemoryLayout<T>.size)
       return unsafe base.bindMemory(to: type, capacity: 1)
     }
 
@@ -484,7 +484,7 @@ extension ExecutorJob {
     /// instances of type `T`.
     public func allocate<T>(capacity: Int, as type: T.Type)
       -> UnsafeMutableBufferPointer<T> {
-      let base = _jobAllocate(context, MemoryLayout<T>.stride * capacity)
+      let base = unsafe _jobAllocate(context, MemoryLayout<T>.stride * capacity)
       let typedBase = unsafe base.bindMemory(to: T.self, capacity: capacity)
       return unsafe UnsafeMutableBufferPointer<T>(start: typedBase, count: capacity)
     }

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -125,7 +125,7 @@ func __withTaskPriorityEscalationHandler0<T, E>(
   onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void,
   isolation: isolated (any Actor)? = #isolation
 ) async throws(E) -> T {
-  let record = _taskAddPriorityEscalationHandler(handler: handler0)
+  let record = unsafe _taskAddPriorityEscalationHandler(handler: handler0)
   defer { unsafe _taskRemovePriorityEscalationHandler(record: record) }
 
   return try await operation()

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -146,9 +146,9 @@ public func withTaskExecutorPreference<T, Failure>(
   }
 
   let taskExecutorBuiltin: Builtin.Executor =
-    taskExecutor.asUnownedTaskExecutor().executor
+    unsafe taskExecutor.asUnownedTaskExecutor().executor
 
-  let record = _pushTaskExecutorPreference(taskExecutorBuiltin)
+  let record = unsafe _pushTaskExecutorPreference(taskExecutorBuiltin)
   defer {
     unsafe _popTaskExecutorPreference(record: record)
   }
@@ -177,9 +177,9 @@ public func _unsafeInheritExecutor_withTaskExecutorPreference<T: Sendable>(
   }
 
   let taskExecutorBuiltin: Builtin.Executor =
-    taskExecutor.asUnownedTaskExecutor().executor
+    unsafe taskExecutor.asUnownedTaskExecutor().executor
 
-  let record = _pushTaskExecutorPreference(taskExecutorBuiltin)
+  let record = unsafe _pushTaskExecutorPreference(taskExecutorBuiltin)
   defer {
     unsafe _popTaskExecutorPreference(record: record)
   }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -984,7 +984,7 @@ internal func _getCurrentTaskName() -> UnsafePointer<UInt8>?
 
 @available(SwiftStdlib 6.2, *)
 internal func _getCurrentTaskNameString() -> String? {
-  if let stringPtr = _getCurrentTaskName() {
+  if let stringPtr = unsafe _getCurrentTaskName() {
     unsafe String(cString: stringPtr)
   } else {
     nil

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -77,7 +77,7 @@ public func withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = _taskAddCancellationHandler(handler: handler)
+  let record = unsafe _taskAddCancellationHandler(handler: handler)
   defer { unsafe _taskRemoveCancellationHandler(record: record) }
 
   return try await operation()
@@ -98,7 +98,7 @@ public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = _taskAddCancellationHandler(handler: handler)
+  let record = unsafe _taskAddCancellationHandler(handler: handler)
   defer { unsafe _taskRemoveCancellationHandler(record: record) }
 
   return try await operation()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -178,7 +178,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// or if the task-local has no value bound, this will return the `defaultValue`
   /// of the task local.
   public func get() -> Value {
-    guard let rawValue = _taskLocalValueGet(key: key) else {
+    guard let rawValue = unsafe _taskLocalValueGet(key: key) else {
       return self.defaultValue
     }
 

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -21,7 +21,7 @@ extension std.string {
   ///   Swift string.
   @_alwaysEmitIntoClient
   public init(_ string: String) {
-    unsafe self = unsafe string.withCString(encodedAs: UTF8.self) { buffer in
+    self = unsafe string.withCString(encodedAs: UTF8.self) { buffer in
 #if os(Windows)
       // Use the 2 parameter constructor.
       // The MSVC standard library has a enable_if template guard

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -549,7 +549,7 @@ extension DistributedActorSystem {
         errorCode: .typeDeserializationFailure)
     }
 
-    guard let resultBuffer = _openExistential(returnTypeFromTypeInfo, do: doAllocateReturnTypeBuffer) else {
+    guard let resultBuffer = unsafe _openExistential(returnTypeFromTypeInfo, do: doAllocateReturnTypeBuffer) else {
       throw ExecuteDistributedTargetError(
         message: "Failed to allocate buffer for distributed target return type",
         errorCode: .typeDeserializationFailure)

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -73,7 +73,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     }
 
     // Look for contiguous storage in the NSArray
-    let cocoaStorageBaseAddress = self.contiguousStorage(self.indices)
+    let cocoaStorageBaseAddress = unsafe self.contiguousStorage(self.indices)
 
     if let cocoaStorageBaseAddress = unsafe cocoaStorageBaseAddress {
       return unsafe _SliceBuffer(
@@ -113,7 +113,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
   ) -> UnsafeMutablePointer<AnyObject>?
   {
     _internalInvariant(!subRange.isEmpty)
-    var enumerationState = _makeSwiftNSFastEnumerationState()
+    var enumerationState = unsafe _makeSwiftNSFastEnumerationState()
 
     // This function currently returns nil unless the first
     // subRange.upperBound items are stored contiguously.  This is an

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -190,13 +190,13 @@ internal final class _ContiguousArrayStorage<
   @objc(objectAtIndexedSubscript:)
   @_effects(readonly)
   final override internal func objectAtSubscript(_ index: Int) -> Unmanaged<AnyObject> {
-    return _objectAt(index)
+    return unsafe _objectAt(index)
   }
   
   @objc(objectAtIndex:)
   @_effects(readonly)
   final override internal func objectAt(_ index: Int) -> Unmanaged<AnyObject> {
-    return _objectAt(index)
+    return unsafe _objectAt(index)
   }
   
   @objc internal override final var count: Int {

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -315,8 +315,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   ) {
     _precondition(count >= 0, "Invalid count")
     guard count > 0 else { return }
-    let bridgedKeys = bridgeKeys()
-    let bridgedValues = bridgeValues()
+    let bridgedKeys = unsafe bridgeKeys()
+    let bridgedValues = unsafe bridgeValues()
     var i = 0 // Current position in the output buffers
 
     defer { _fixLifetime(self) }
@@ -355,8 +355,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
       Unmanaged<AnyObject>,
       UnsafeMutablePointer<UInt8>
     ) -> Void) {
-    let bridgedKeys = bridgeKeys()
-    let bridgedValues = bridgeValues()
+    let bridgedKeys = unsafe bridgeKeys()
+    let bridgedValues = unsafe bridgeValues()
 
     defer { _fixLifetime(self) }
 
@@ -409,7 +409,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     var stored = 0
 
     // Only need to bridge once, so we can hoist it out of the loop.
-    let bridgedKeys = bridgeKeys()
+    let bridgedKeys = unsafe bridgeKeys()
     for i in 0..<count {
       if bucket == endBucket { break }
 
@@ -700,7 +700,7 @@ extension __CocoaDictionary: Sequence {
     // This stored property should be stored at offset zero.  There's code below
     // relying on this.
     internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
-      _makeSwiftNSFastEnumerationState()
+      unsafe _makeSwiftNSFastEnumerationState()
 
     // This stored property should be stored right after
     // `_fastEnumerationState`.  There's code below relying on this.

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -157,7 +157,7 @@ public func swift_slowAlloc(_ size: Int, _ alignMask: Int) -> UnsafeMutableRawPo
   } else {
     alignment = alignMask + 1
   }
-  return alignedAlloc(size: size, alignment: alignment)
+  return unsafe alignedAlloc(size: size, alignment: alignment)
 }
 
 @_cdecl("swift_slowDealloc")
@@ -171,7 +171,7 @@ public func swift_allocObject(metadata: Builtin.RawPointer, requiredSize: Int, r
 }
 
 func swift_allocObject(metadata: UnsafeMutablePointer<ClassMetadata>, requiredSize: Int, requiredAlignmentMask: Int) -> UnsafeMutablePointer<HeapObject> {
-  let p = swift_slowAlloc(requiredSize, requiredAlignmentMask)!
+  let p = unsafe swift_slowAlloc(requiredSize, requiredAlignmentMask)!
   let object = unsafe p.assumingMemoryBound(to: HeapObject.self)
   unsafe _swift_embedded_set_heap_object_metadata_pointer(object, metadata)
   unsafe object.pointee.refcount = 1

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -629,7 +629,7 @@ public class ReferenceWritableKeyPath<
           return unsafe UnsafeMutablePointer(mutating: typedPointer)
         }
       }
-      return _openExistential(base, do: formalMutation(_:))
+      return _openExistential(base, do: unsafe formalMutation(_:))
     }
     
     return unsafe (address, keepAlive)
@@ -1825,7 +1825,7 @@ internal struct RawKeyPathComponent {
     case .get(id: _, accessors: let accessors, argument: let argument),
          .mutatingGetSet(id: _, accessors: let accessors, argument: let argument),
          .nonmutatingGetSet(id: _, accessors: let accessors, argument: let argument):
-      let getter: ComputedAccessorsPtr.Getter<CurValue, NewValue> = accessors.getter()
+      let getter: ComputedAccessorsPtr.Getter<CurValue, NewValue> = unsafe accessors.getter()
 
       unsafe pointer.initialize(
         to: getter(
@@ -2263,7 +2263,7 @@ func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
   root: Root,
   keyPath: ReferenceWritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return keyPath._projectMutableAddress(from: root)
+  return unsafe keyPath._projectMutableAddress(from: root)
 }
 
 @_silgen_name("swift_setAtWritableKeyPath")
@@ -2299,7 +2299,7 @@ func _setAtReferenceWritableKeyPath<Root, Value>(
   value: __owned Value
 ) {
   // TODO: we should be able to do this more efficiently than projecting.
-  let (addr, owner) = keyPath._projectMutableAddress(from: root)
+  let (addr, owner) = unsafe keyPath._projectMutableAddress(from: root)
   unsafe addr.pointee = value
   _fixLifetime(owner)
   // FIXME: this needs a deallocation barrier to ensure that the
@@ -4353,7 +4353,7 @@ fileprivate func dynamicLibraryAddress<Base, Leaf>(
   _: Base.Type,
   _ leaf: Leaf.Type
 ) -> String {
-  let getter: ComputedAccessorsPtr.Getter<Base, Leaf> = pointer.getter()
+  let getter: ComputedAccessorsPtr.Getter<Base, Leaf> = unsafe pointer.getter()
   let pointer = unsafe unsafeBitCast(getter, to: UnsafeRawPointer.self)
   if let cString = unsafe keyPath_copySymbolName(UnsafeRawPointer(pointer)) {
     defer {

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -90,7 +90,7 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
 @_unavailableInEmbedded
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
-  let (stringPtr, count) = _getTypeName(type, qualified: qualified)
+  let (stringPtr, count) = unsafe _getTypeName(type, qualified: qualified)
   return unsafe String._fromUTF8Repairing(
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
@@ -107,7 +107,7 @@ public func _getMangledTypeName(_ type: any (~Copyable & ~Escapable).Type)
 @_preInverseGenerics
 public // SPI
 func _mangledTypeName(_ type: any (~Copyable & ~Escapable).Type) -> String? {
-  let (stringPtr, count) = _getMangledTypeName(type)
+  let (stringPtr, count) = unsafe _getMangledTypeName(type)
   guard count > 0 else {
     return nil
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -354,7 +354,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
         }
         target.write(")")
       case .enum:
-        if let cString = _getEnumCaseName(value),
+        if let cString = unsafe _getEnumCaseName(value),
             let caseName = unsafe String(validatingCString: cString) {
           // Write the qualified type name in debugPrint.
           if isDebugPrint {
@@ -393,7 +393,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
     printTypeName(metatypeValue)
   } else {
     // Fall back to the type or an opaque summary of the kind
-    if let cString = _opaqueSummary(mirror.subjectType),
+    if let cString = unsafe _opaqueSummary(mirror.subjectType),
         let opaqueSummary = unsafe String(validatingCString: cString) {
       target.write(opaqueSummary)
     } else {
@@ -537,7 +537,7 @@ internal func _dumpPrint_unlocked<T, TargetStream: TextOutputStream>(
       return
     case .`enum`:
       target.write(_typeName(mirror.subjectType, qualified: true))
-      if let cString = _getEnumCaseName(value),
+      if let cString = unsafe _getEnumCaseName(value),
           let caseName = unsafe String(validatingCString: cString) {
         target.write(".")
         target.write(caseName)

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -434,7 +434,7 @@ func _convertConstArrayToPointerArgument<
   FromElement,
   ToPointer: _Pointer
 >(_ arr: [FromElement]) -> (AnyObject?, ToPointer) {
-  let (owner, opaquePointer) = arr._cPointerArgs()
+  let (owner, opaquePointer) = unsafe arr._cPointerArgs()
 
   let validPointer: ToPointer
   if let addr = unsafe opaquePointer {
@@ -453,7 +453,7 @@ func _convertConstArrayToPointerArgument<
   FromElement,
   ToPointer: _Pointer
 >(_ arr: [FromElement]) -> (Builtin.NativeObject?, ToPointer) {
-  let (owner, opaquePointer) = arr._cPointerArgs()
+  let (owner, opaquePointer) = unsafe arr._cPointerArgs()
 
   let validPointer: ToPointer
   if let addr = unsafe opaquePointer {

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -106,7 +106,7 @@ struct _RuntimeFunctionCounters {
   public static let runtimeFunctionNames =
     getRuntimeFunctionNames()
   public static let runtimeFunctionCountersOffsets =
-    _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
+    unsafe _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
   public static let numRuntimeFunctionCounters =
     Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
   public static let runtimeFunctionNameToIndex: [String: Int] =
@@ -119,7 +119,7 @@ struct _RuntimeFunctionCounters {
     UnsafePointer<UnsafePointer<CChar>>
 
   public static func getRuntimeFunctionNames() -> [String] {
-    let names = _RuntimeFunctionCounters._getRuntimeFunctionNames()
+    let names = unsafe _RuntimeFunctionCounters._getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
       Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
     var functionNames: [String] = []
@@ -504,7 +504,7 @@ public // @testable
 func _collectReferencesInsideObject(_ value: Any) -> [UnsafeRawPointer] {
   let savedMode = _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
   // Collect all references inside the object
-  let refs = _RuntimeFunctionCounters.collectAllReferencesInsideObject(value)
+  let refs = unsafe _RuntimeFunctionCounters.collectAllReferencesInsideObject(value)
   _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
   return unsafe refs
 }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -227,7 +227,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
 
     let (bucket, found) = native.find(element)
     guard found else { return nil }
-    let bridged = bridgeElements()
+    let bridged = unsafe bridgeElements()
     return unsafe bridged[bucket]
   }
 
@@ -272,7 +272,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       "Invalid fast enumeration state")
 
     // Only need to bridge once, so we can hoist it out of the loop.
-    let bridgedElements = bridgeElements()
+    let bridgedElements = unsafe bridgeElements()
 
     var stored = 0
     for i in 0..<count {
@@ -526,7 +526,7 @@ extension __CocoaSet: Sequence {
     // This stored property should be stored at offset zero.  There's code below
     // relying on this.
     internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
-      _makeSwiftNSFastEnumerationState()
+      unsafe _makeSwiftNSFastEnumerationState()
 
     // This stored property should be stored right after
     // `_fastEnumerationState`.  There's code below relying on this.

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -81,7 +81,7 @@ private func _objc(_ str: _CocoaString) -> _StringSelectorHolder {
 
 @_effects(releasenone)
 private func _copyNSString(_ str: _StringSelectorHolder) -> _CocoaString {
-  return str.copy(with: nil)
+  return unsafe str.copy(with: nil)
 }
 
 @usableFromInline // @testable
@@ -127,7 +127,7 @@ private func _stdlib_binary_createIndirectTaggedPointerNSString(
 internal func _stdlib_binary_CFStringGetCharactersPtr(
   _ source: _CocoaString
 ) -> UnsafeMutablePointer<UTF16.CodeUnit>? {
-  return _NSStringCharactersPtr(_objc(source))
+  return unsafe _NSStringCharactersPtr(_objc(source))
 }
 
 @_effects(releasenone)
@@ -284,7 +284,7 @@ internal func _cocoaHashASCIIBytes(
 internal func _cocoaCStringUsingEncodingTrampoline(
   _ string: _CocoaString, _ encoding: UInt
 ) -> UnsafePointer<UInt8>? {
-  return _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
+  return unsafe _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
 }
 
 @_effects(readonly)
@@ -380,7 +380,7 @@ private func _NSStringASCIIPointer(_ str: _StringSelectorHolder) -> UnsafePointe
 @_effects(readonly)
 private func _NSStringUTF8Pointer(_ str: _StringSelectorHolder) -> UnsafePointer<UInt8>? {
   //We don't have a way to ask for UTF8 here currently
-  return _NSStringASCIIPointer(str)
+  return unsafe _NSStringASCIIPointer(str)
 }
 
 @_effects(readonly)
@@ -412,7 +412,7 @@ private func _withCocoaASCIIPointer<R>(
   }
   #endif
   defer { _fixLifetime(str) }
-  if let ptr = _NSStringASCIIPointer(_objc(str)) {
+  if let ptr = unsafe _NSStringASCIIPointer(_objc(str)) {
     return unsafe work(ptr)
   }
   return nil
@@ -437,7 +437,7 @@ private func _withCocoaUTF8Pointer<R>(
   }
   #endif
   defer { _fixLifetime(str) }
-  if let ptr = _NSStringUTF8Pointer(_objc(str)) {
+  if let ptr = unsafe _NSStringUTF8Pointer(_objc(str)) {
     return unsafe work(ptr)
   }
   return nil
@@ -483,7 +483,7 @@ private enum CocoaStringPointer {
 private func _getCocoaStringPointer(
   _ cfImmutableValue: _CocoaString
 ) -> CocoaStringPointer {
-  if let ascii = stableCocoaASCIIPointer(cfImmutableValue) {
+  if let ascii = unsafe stableCocoaASCIIPointer(cfImmutableValue) {
     return unsafe .ascii(ascii)
   }
   // We could ask for UTF16 here via _stdlib_binary_CFStringGetCharactersPtr,
@@ -534,7 +534,7 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
 #endif
 
     let (fastUTF8, isASCII): (Bool, Bool)
-    switch _getCocoaStringPointer(immutableCopy) {
+    switch unsafe _getCocoaStringPointer(immutableCopy) {
     case .ascii(_): (fastUTF8, isASCII) = (true, true)
     case .utf8(_): (fastUTF8, isASCII) = (true, false)
     default:  (fastUTF8, isASCII) = (false, false)

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -973,7 +973,7 @@ extension _StringObject {
 #if _runtime(_ObjC)
     if largeFastIsConstantCocoa {
       return unsafe withCocoaObject {
-        _getNSCFConstantStringContentsPointer($0)
+        unsafe _getNSCFConstantStringContentsPointer($0)
       }
     }
     if largeIsCocoa {
@@ -989,7 +989,7 @@ extension _StringObject {
   internal var sharedUTF8: UnsafeBufferPointer<UInt8> {
     @_effects(releasenone) @inline(never) get {
       _internalInvariant(largeFastIsShared)
-      let start = self.getSharedUTF8Start()
+      let start = unsafe self.getSharedUTF8Start()
       return unsafe UnsafeBufferPointer(start: start, count: largeCount)
     }
   }

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -91,7 +91,7 @@ extension _AbstractStringStorage {
          (_cocoaUTF8Encoding, _):
       return unsafe start
     default:
-      return _cocoaCStringUsingEncodingTrampoline(self, encoding)
+      return unsafe _cocoaCStringUsingEncodingTrampoline(self, encoding)
     }
   }
   
@@ -238,7 +238,7 @@ extension __StringStorage {
   @objc(cStringUsingEncoding:)
   @_effects(readonly)
   final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return _cString(encoding: encoding)
+    return unsafe _cString(encoding: encoding)
   }
 
   @objc(getCString:maxLength:encoding:)
@@ -356,7 +356,7 @@ extension __SharedStringStorage {
   @objc(cStringUsingEncoding:)
   @_effects(readonly)
   final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return _cString(encoding: encoding)
+    return unsafe _cString(encoding: encoding)
   }
 
   @objc(getCString:maxLength:encoding:)

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -178,7 +178,7 @@ extension _StringGuts {
         usesScratch: false, allocatedMemory: false)
     }
 
-    let (object, ptr, len) = self._allocateForDeconstruct()
+    let (object, ptr, len) = unsafe self._allocateForDeconstruct()
     return unsafe (
       owner: object,
       _convertPointerToPointerArgument(ptr),

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -852,7 +852,7 @@ extension String.UTF16View {
       return _utf16Distance(from: startIndex, to: idx)
     }
 
-    let breadcrumbs = _guts.loadUnmanagedBreadcrumbs()
+    let breadcrumbs = unsafe _guts.loadUnmanagedBreadcrumbs()
 
     // Simple and common: endIndex aka `length`.
     if idx == endIndex {
@@ -896,7 +896,7 @@ extension String.UTF16View {
     }
 
     // Simple and common: endIndex aka `length`.
-    let breadcrumbs = _guts.loadUnmanagedBreadcrumbs()
+    let breadcrumbs = unsafe _guts.loadUnmanagedBreadcrumbs()
     let utf16Count = unsafe breadcrumbs._withUnsafeGuaranteedRef { $0.utf16Length }
     if offset == utf16Count { return endIndex }
 

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -84,13 +84,13 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   @objc(objectAtIndexedSubscript:)
   @_effects(readonly)
   dynamic internal func objectAtSubscript(_ index: Int) -> Unmanaged<AnyObject> {
-    return _objectAt(index)
+    return unsafe _objectAt(index)
   }
   
   @objc(objectAtIndex:)
   @_effects(readonly)
   dynamic internal func objectAt(_ index: Int) -> Unmanaged<AnyObject> {
-    return _objectAt(index)
+    return unsafe _objectAt(index)
   }
 
   @objc internal func getObjects(

--- a/stdlib/public/core/UTF8SpanIterators.swift
+++ b/stdlib/public/core/UTF8SpanIterators.swift
@@ -28,7 +28,7 @@ extension UTF8Span {
     }
 
     private var _start: UnsafeRawPointer {
-      codeUnits._start()
+      unsafe codeUnits._start()
     }
 
     /// Decode and return the scalar starting at `currentCodeUnitOffset`.
@@ -247,7 +247,7 @@ extension UTF8Span {
     }
 
     private var _start: UnsafeRawPointer {
-      codeUnits._start()
+      unsafe codeUnits._start()
     }
 
     /// Return the `Character` starting at `currentCodeUnitOffset`. After the

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -1277,7 +1277,7 @@ extension Unicode.Scalar.Properties {
   /// This property corresponds to the "Name_Alias" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var nameAlias: String? {
-    guard let nameAliasPtr = _swift_stdlib_getNameAlias(_scalar.value) else {
+    guard let nameAliasPtr = unsafe _swift_stdlib_getNameAlias(_scalar.value) else {
       return nil
     }
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -156,8 +156,8 @@ public func callReturnLifetimeBound(_ p: inout MutableSpan<CInt>) {
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callReturnPointer() {
-  let _: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
-  let _: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableBufferPointer<CInt>? = unsafe returnPointer(4) // call wrapper
+  let _: UnsafeMutablePointer<CInt>? = unsafe returnPointer(4) // call unsafe interop
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -207,7 +207,7 @@ public func callFunc(_ p: inout MutableSpan<CInt>?) {
 @_lifetime(p: copy p)
 @inlinable
 public func callFuncRenameKeyword(_ p: inout MutableSpan<CInt>?) {
-  let _ = funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
+  let _ = unsafe funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -125,8 +125,8 @@ public func callOffBySome(_ p: UnsafeMutableBufferPointer<CInt>) {
 
 @inlinable
 public func callReturnPointer() {
-  let _: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
-  let _: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableBufferPointer<CInt>? = unsafe returnPointer(4) // call wrapper
+  let _: UnsafeMutablePointer<CInt>? = unsafe returnPointer(4) // call unsafe interop
 }
 
 @inlinable

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -82,8 +82,8 @@ public func callNullable(_ p: RawSpan?) {
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callReturnPointer() {
-  let _: UnsafeRawBufferPointer? = returnPointer(4) // call wrapper
-  let _: UnsafeRawPointer? = returnPointer(4) // call unsafe interop
+  let _: UnsafeRawBufferPointer? = unsafe returnPointer(4) // call wrapper
+  let _: UnsafeRawPointer? = unsafe returnPointer(4) // call unsafe interop
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -80,8 +80,8 @@ public func callOpaqueptr(_ p: UnsafeRawBufferPointer) {
 
 @inlinable
 public func callReturnPointer() {
-  let _: UnsafeMutableRawBufferPointer? = returnPointer(4) // call wrapper
-  let _: UnsafeMutableRawPointer? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableRawBufferPointer? = unsafe returnPointer(4) // call wrapper
+  let _: UnsafeMutableRawPointer? = unsafe returnPointer(4) // call unsafe interop
 }
 
 @inlinable
@@ -106,7 +106,7 @@ public func callCharsized(_ p: UnsafeMutableRawBufferPointer) {
 
 @inlinable
 public func callBytesized() {
-  let _: UnsafeMutableRawBufferPointer = bytesized(37)
+  let _: UnsafeMutableRawBufferPointer = unsafe bytesized(37)
 }
 
 @inlinable

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -166,7 +166,7 @@ func callMixedFuncWithMutableSafeWrapper1(_ span: inout MutableSpan<CInt>, ) {
 
 func MixedFuncWithMutableSafeWrapper2(_ v: VecOfInt) {
     var v2 = v
-    let _ = MixedFuncWithMutableSafeWrapper2(&v2, 37)
+    let _ : MutableSpan<Int32> = MixedFuncWithMutableSafeWrapper2(&v2, 37)
 }
 
 @_lifetime(span: copy span)

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -373,6 +373,7 @@ func testInterpolation(ptr: UnsafePointer<Int>) {
   _ = "Hello \(unsafe ptr)" // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
   // expected-note@-1{{reference to unsafe type 'UnsafePointer<Int>'}}
   // expected-note@-2{{argument #0 in call to instance method 'appendInterpolation' has unsafe type 'UnsafePointer<Int>'}}
+  // expected-note@-3{{reference to instance method 'appendInterpolation' involves unsafe type 'UnsafePointer<Int>'}}
 }
 
 func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -11,7 +11,8 @@ func iAmImpliedUnsafe() -> UnsafeType? { nil }
 @unsafe
 func labeledUnsafe(_: UnsafeType) {
   unsafe iAmUnsafe()
-  let _ = iAmImpliedUnsafe() // okay, since the unsafety is captured in the result type
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let _ = iAmImpliedUnsafe() // expected-note{{reference to global function 'iAmImpliedUnsafe()' involves unsafe type 'UnsafeType'}}
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   let _ = iAmImpliedUnsafe // expected-note{{reference to global function 'iAmImpliedUnsafe()' involves unsafe type 'UnsafeType'}}
 }

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -50,6 +50,7 @@ extension ConformsToMultiP: MultiP {
   @unsafe func f() -> UnsafeSuper {
     .init() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
     // expected-note@-1{{argument 'self' in call to initializer 'init' has unsafe type 'UnsafeSuper.Type'}}
+    // expected-note@-2{{reference to initializer 'init()' involves unsafe type 'UnsafeSuper'}}
   }
 }
 
@@ -202,7 +203,8 @@ func testMe(
   unsafeSuper.f() // expected-note{{argument 'self' in call to instance method 'f' has unsafe type 'UnsafeSuper'}}
   // expected-note@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
 
-  _ = getPointers() // unsafe return is fine
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
+  _ = getPointers() // expected-note{{reference to global function 'getPointers()' involves unsafe type 'PointerType'}}
 
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
   _ = getPointers // expected-note{{reference to global function 'getPointers()' involves unsafe type 'PointerType'}}

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -8,8 +8,9 @@ func test(
   other: UnsafeMutablePointer<Int>
 ) {
   var array = [1, 2, 3]
-  // expected-warning@+2{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
-  // expected-note@+1{{argument #0 in call to instance method 'withUnsafeBufferPointer' has unsafe type '(UnsafeBufferPointer<Int>) -> ()'}}
+  // expected-warning@+3{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
+  // expected-note@+2{{argument #0 in call to instance method 'withUnsafeBufferPointer' has unsafe type '(UnsafeBufferPointer<Int>) -> ()'}}
+  // expected-note@+1{{reference to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
   array.withUnsafeBufferPointer{ buffer in
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{5-5=unsafe }}
     print(buffer) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}


### PR DESCRIPTION
Explanation: There were some scenarios where we could call an unsafe function without marking the expression as unsafe. These affect mostly cases where the function's result is passed to another function or returned. This PR makes sure we always flag functions with unsafe return types, even if their result is not stored anywhere for later use.
Issues: rdar://157237301
Original PRs: #83520
Risk: Low, worst case scenario the user has to add redundant unsafe keywords in strict memory safe mode.
Testing: Added a compiler test.
Reviewers: @DougGregor
