### PR TITLE
[6.2][cxx-interop] Fix name mangling for reference types

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -14,6 +14,7 @@
 #include "ImporterImpl.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "clang/AST/TemplateArgumentVisitor.h"
+#include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
 
 using namespace swift;
@@ -92,6 +93,18 @@ struct TemplateInstantiationNamePrinter
       return buffer.str().str();
     }
     return "_";
+  }
+
+  std::string VisitReferenceType(const clang::ReferenceType *type) {
+    llvm::SmallString<128> storage;
+    llvm::raw_svector_ostream buffer(storage);
+    if (type->isLValueReferenceType()) {
+      buffer << "__cxxLRef<";
+    } else {
+      buffer << "__cxxRRef<";
+    }
+    buffer << Visit(type->getPointeeType().getTypePtr()) << ">";
+    return buffer.str().str();
   }
 
   std::string VisitPointerType(const clang::PointerType *type) {

--- a/test/Interop/CxxToSwiftToCxx/references-correctly-mangled-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/references-correctly-mangled-execution.cpp
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+
+// RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
+// RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -g
+
+// RUN: %target-codesign %t/swift-cxx-execution
+// RUN: %target-run %t/swift-cxx-execution
+
+// REQUIRES: executable_test
+
+//--- header.h
+#include <functional>
+namespace my_cpp {
+struct First {
+  double value;
+};
+struct Second {
+  bool value;
+};
+
+using First_cb = std::function<void(const First &)>;
+using Second_cb = std::function<void(const Second &)>;
+} // namespace my_cpp
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxStdlib
+import CxxTest
+
+public func
+hello(first : my_cpp.First_cb /* std::function */,
+      second : my_cpp.Second_cb /* std::function */) {
+  first.callAsFunction(my_cpp.First(value : 3.14))
+      second.callAsFunction(my_cpp.Second(value : true))
+}
+
+//--- use-swift-cxx-types.cpp
+
+#include "header.h"
+#include "UseCxx.h"
+#include <assert.h>
+
+int main() {
+  UseCxx::hello([](const my_cpp::First &) {}, [](const my_cpp::Second &) {});
+}


### PR DESCRIPTION
Explanation: When generating type names for template instantiations for name mangling we did not generate correct names for reference types resulting in collisions in the mangled names.
Issues: rdar://155973210
Original PRs: #83176
Risk: Low, the generated string is only used for name mangling.
Testing: Added a compiler test.
Reviewers: @egorzhdan
