### PR TITLE
[Windows] Stop using multiroot data file

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2854,7 +2854,7 @@ function Test-Foundation {
       -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
       -Platform $BuildPlatform `
       -Configuration $FoundationTestConfiguration `
-      -j 1
+      -j 1 # Running parallel causes a non-deterministic crash in CI only, see https://github.com/swiftlang/swift/issues/83606
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2834,17 +2834,12 @@ function Build-Foundation {
 }
 
 function Test-Foundation {
-  $ScratchPath = "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests"
-
   # Foundation tests build via swiftpm rather than CMake
   Build-SPMProject `
     -Action Test `
     -Src $SourceCache\swift-foundation `
-    -Bin "$ScratchPath" `
-    -Platform $BuildPlatform `
-    -Configuration $FoundationTestConfiguration `
-    --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
-    --test-product swift-foundationPackageTests
+    -Bin "$BinaryCache\$($BuildPlatform.Triple)\CoreFoundationTests" `
+    -Platform $BuildPlatform
 
   Invoke-IsolatingEnvVars {
     $env:DISPATCH_INCLUDE_PATH="$(Get-SwiftSDK $BuildPlatform.OS)/usr/include"
@@ -2856,12 +2851,10 @@ function Test-Foundation {
     Build-SPMProject `
       -Action Test `
       -Src $SourceCache\swift-corelibs-foundation `
-      -Bin "$ScratchPath" `
+      -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
       -Platform $BuildPlatform `
       -Configuration $FoundationTestConfiguration `
-      --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
-      --test-product swift-corelibs-foundationPackageTests `
-      -j 1 # Running parallel causes a non-deterministic crash in CI only, see https://github.com/swiftlang/swift/issues/83606
+      -j 1
   }
 }
 

--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -6,13 +6,10 @@
    <FileRef location = "group:../../../../sourcekit-lsp"></FileRef>
    <FileRef location = "group:../../../../swift-argument-parser"></FileRef>
    <FileRef location = "group:../../../../swift-collections"></FileRef>
-   <FileRef location = "group:../../../../swift-corelibs-foundation"></FileRef>
    <FileRef location = "group:../../../../swift-crypto"></FileRef>
    <FileRef location = "group:../../../../swift-docc"></FileRef>
    <FileRef location = "group:../../../../swift-driver"></FileRef>
    <FileRef location = "group:../../../../swift-format"></FileRef>
-   <FileRef location = "group:../../../../swift-foundation"></FileRef>
-   <FileRef location = "group:../../../../swift-foundation-icu"></FileRef>
    <FileRef location = "group:../../../../swift-stress-tester/SourceKitStressTester"></FileRef>
    <FileRef location = "group:../../../../swift-syntax"></FileRef>
    <FileRef location = "group:../../../../swift-syntax/CodeGeneration"></FileRef>


### PR DESCRIPTION
I have seen testing of swift-foundation fail without an error message (eg. https://ci-external.swift.org/job/sourcekit-lsp-PR-windows/3152/, build log attached to this PR), which likely started occurring after https://github.com/swiftlang/swift/pull/80122. Revert that change to unbreak CI.

[sourcekit-lsp-PR-windows-3152.txt](https://github.com/user-attachments/files/21753045/sourcekit-lsp-PR-windows-3152.txt)

