### PR TITLE
[cxx-interop] Do not define inherited copy/move operations

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2985,7 +2985,9 @@ namespace {
                             usingShadowDecl)) {
                   auto baseCtorDecl = dyn_cast<clang::CXXConstructorDecl>(
                       ctorUsingShadowDecl->getTargetDecl());
-                  if (!baseCtorDecl || baseCtorDecl->isDeleted())
+                  if (!baseCtorDecl || baseCtorDecl->isDeleted() ||
+                      baseCtorDecl->isCopyConstructor() ||
+                      baseCtorDecl->isMoveConstructor())
                     continue;
                   auto loc = ctorUsingShadowDecl->getLocation();
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -48,8 +48,6 @@
 // CHECK-NEXT: }
 
 // CHECK:      public struct UsingBaseConstructorWithParam {
-// CHECK-NEXT:   public init(consuming _: consuming IntBox)
-// CHECK-NEXT:   public init(_: IntBox)
 // CHECK-NEXT:   public init(_: UInt32)
 // CHECK-NEXT:   public init(_: Int32)
 // CHECK-NEXT:   public var value: Int32
@@ -57,8 +55,6 @@
 
 // CHECK:      public struct UsingBaseConstructorEmpty {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public init(consuming _: consuming Empty)
-// CHECK-NEXT:   public init(_: Empty)
 // CHECK-NEXT:   public var value: Int32
 // CHECK-NEXT: }
 


### PR DESCRIPTION
When inheriting constructors, we define the inherited ctors in the derived class. We should not do that for copy and move operations as these operations can never be invoked (the implicit/defined/deleted ctor in the derived class always takes precedence). This fixes an issue where the lifetime parameters are not getting inferred for these spurious constructor definitions. This should also save us from doing some redundant work in the importer. Fixes #82183.

rdar://153081347
