### PR TITLE
Fix build failure in `ArgsToFrontendOptionsConverter.cpp`

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -479,7 +479,7 @@ void ArgsToFrontendOptionsConverter::computePrintStatsOptions() {
       Args.hasArg(OPT_print_clang_stats);
   Opts.PrintZeroStats |= Args.hasArg(OPT_print_zero_stats);
 #if defined(NDEBUG) && !LLVM_ENABLE_STATS
-  if (Opts.PrintStats || Opts.PrintClangStats)
+  if (Opts.PrintStats || Opts.CompilerDebuggingOpts.PrintClangStats)
     Diags.diagnose(SourceLoc(), diag::stats_disabled);
 #endif
 }


### PR DESCRIPTION
```
error: no member named 'PrintClangStats' in 'swift::FrontendOptions'
```

Resolves rdar://158206551.
