### PR TITLE
[6.2][TypeCheckEffects] AbstractFunction: Parameter types should be mapped…

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -395,7 +395,10 @@ public:
     }
     case Kind::Closure: return getClosure()->getType();
     case Kind::Parameter:
-      return getParameter()->getInterfaceType()->lookThroughAllOptionalTypes();
+      auto *param = getParameter();
+      auto *dc = param->getDeclContext();
+      return dc->mapTypeIntoContext(param->getInterfaceType())
+          ->lookThroughAllOptionalTypes();
     }
     llvm_unreachable("bad kind");
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar156955193.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar156955193.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Definition {
+  associatedtype Delegate
+}
+
+enum Kind {
+  case normal
+  case other
+}
+
+struct Payload {
+}
+
+extension Definition where Delegate == ((Kind, Payload) -> Void) {
+  static func invokeDelegate(_ delegate: Delegate, kind: Kind, payload: Payload) {
+    delegate(kind, payload)
+  }
+}
+
+extension Definition where Delegate == ((Kind, Payload) -> Void)? {
+  static func invokeOptionalDelegate(_ delegate: Delegate, kind: Kind, payload: Payload) {
+    delegate?(kind, payload)
+  }
+}


### PR DESCRIPTION
… into context

- Explanation:

  Parameter type could be represented by an associated type which is bound to a concrete type by an extension, `AbstractFunction::getType()` should map it into context before returning because the construct is that it always produces a function type.

- Resolves: rdar://156955193

- Main Branch PR: https://github.com/swiftlang/swift/pull/83687

- Risk: Low. This is a very narrow fix that only affects situations when parameter type, represented by an associated type, is bound by an extension.

- Reviewed By: @DougGregor 

- Testing: Added new test-cases to the suite.

(cherry picked from commit 32b97d0e2ad67f66cadc77373d39a2f841b5c637)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
