### PR TITLE
[cxx-interop] Copy lazily bridged Cocoa strings correctly without hanging

### DIFF
--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -70,13 +70,14 @@ static_assert(sizeof(_impl::_impl_String) >= 0,
 SWIFT_INLINE_THUNK String::operator std::string() const {
   auto u = getUtf8();
   std::string result;
-  result.reserve(u.getCount() + 1);
-  using IndexType = decltype(u.getStartIndex());
-  for (auto s = u.getStartIndex().getEncodedOffset(),
-            e = u.getEndIndex().getEncodedOffset();
-       s != e; s = u.indexOffsetBy(IndexType::init(s), 1).getEncodedOffset()) {
-    result.push_back(u[IndexType::init(s)]);
+  result.reserve(u.getCount());
+
+  auto end_offset = u.getEndIndex().getEncodedOffset();
+  for (auto idx = u.getStartIndex(); idx.getEncodedOffset() < end_offset;
+       idx = u.indexAfter(idx)) {
+    result.push_back(static_cast<char>(u[idx]));
   }
+
   return result;
 }
 

--- a/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
@@ -69,5 +69,12 @@ int main() {
     assert(std::string(nsStr.UTF8String) == "nsstr");
     assert([nsStr2 isEqualToString:nsStr]);
   }
+
+  NSString *nsStrContainingUnicode = @"👨‍💻👩‍💻åäö";
+  {
+    swift::String swiftStr = swift::String::init(nsStrContainingUnicode);
+    assert(std::string(swiftStr) == "👨‍💻👩‍💻åäö");
+  }
+
   return 0;
 }


### PR DESCRIPTION
Fixes #69870