### PR TITLE
cmake: add support for bootstrapping with swiftly

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -195,6 +195,18 @@ function(add_swift_compiler_modules_library name)
 
     # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
     list(APPEND swift_compile_options "-Xcc" "-Xclang" "-Xcc" "-fmodule-format=raw")
+
+  elseif(swift_exec_bin_dir MATCHES ".*/swiftly/bin")
+    # Detect and handle swiftly-managed hosts.
+    execute_process(COMMAND swiftly use --print-location
+      OUTPUT_VARIABLE swiftly_dir
+      ERROR_VARIABLE err)
+    if(err)
+      message(SEND_ERROR "Failed to find swiftly Swift compiler")
+    endif()
+    string(STRIP "${swiftly_dir}" swiftly_dir)
+
+    list(APPEND sdk_option "-I" "${swiftly_dir}/usr/lib" "-I" "${swiftly_dir}/usr/lib")
   else()
     list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
   endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -550,6 +550,19 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
         else()
           get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
           get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+
+          # Detect and handle swiftly-managed hosts.
+          if(swift_bin_dir MATCHES ".*/swiftly/bin")
+            execute_process(COMMAND swiftly use --print-location
+              OUTPUT_VARIABLE swiftly_dir
+              ERROR_VARIABLE err)
+            if(err)
+              message(SEND_ERROR "Failed to find swiftly Swift compiler")
+            endif()
+            string(STRIP "${swiftly_dir}" swiftly_dir)
+            set(swift_dir "${swiftly_dir}/usr")
+          endif()
+
         endif()
         set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       else()
@@ -611,6 +624,19 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
         else()
           get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
           get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+
+          # Detect and handle swiftly-managed hosts.
+          if(swift_bin_dir MATCHES ".*/swiftly/bin")
+            execute_process(COMMAND swiftly use --print-location
+              OUTPUT_VARIABLE swiftly_dir
+              ERROR_VARIABLE err)
+            if(err)
+              message(SEND_ERROR "Failed to find swiftly Swift compiler")
+            endif()
+            string(STRIP "${swiftly_dir}" swiftly_dir)
+            set(swift_dir "${swiftly_dir}/usr")
+          endif()
+
           set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
           target_link_directories(${target} PRIVATE ${host_lib_dir})
 

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -115,6 +115,19 @@ function(get_bootstrapping_swift_lib_dir bs_lib_dir bootstrapping)
       # FIXME: This assumes the ABI hasn't changed since the builder.
       get_filename_component(swift_bin_dir ${CMAKE_Swift_COMPILER} DIRECTORY)
       get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+
+      # Detect and handle swiftly-managed hosts.
+      if(swift_bin_dir MATCHES ".*/swiftly/bin")
+        execute_process(COMMAND swiftly use --print-location
+          OUTPUT_VARIABLE swiftly_dir
+          ERROR_VARIABLE err)
+        if(err)
+          message(SEND_ERROR "Failed to find swiftly Swift compiler")
+        endif()
+        string(STRIP "${swiftly_dir}" swiftly_dir)
+        set(swift_dir "${swiftly_dir}/usr")
+      endif()
+
       set(bs_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
     endif()
   endif()

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -111,6 +111,19 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
         # installed host toolchain.
         get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
         get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+
+        # Detect and handle swiftly-managed hosts.
+        if(swift_bin_dir MATCHES ".*/swiftly/bin")
+          execute_process(COMMAND swiftly use --print-location
+            OUTPUT_VARIABLE swiftly_dir
+            ERROR_VARIABLE err)
+          if(err)
+            message(SEND_ERROR "Failed to find swiftly Swift compiler")
+          endif()
+          string(STRIP "${swiftly_dir}" swiftly_dir)
+          set(swift_dir "${swiftly_dir}/usr")
+        endif()
+
         set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       else()
         set(host_lib_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")


### PR DESCRIPTION
For hosts that have a swiftly-managed Swift compiler, we could not bootstrap using those tools, because of some hardcoded assumptions about where the `/lib` directory lives, relative to the `/bin` directory that contains the detected `swiftc`.

This patch adds specific support for detecting when the `swiftc` is coming from a swiftly install and uses the correct paths.

I've tested this patch on my Linux machine that has swiftly 1.0.1, with the Swift 6.1.2 toolchain.

Based on a patch by @etcwilde 