### PR TITLE
[CSOptimizer] All the candidates should match `Any` parameter type

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1388,6 +1388,12 @@ static void determineBestChoicesInContext(
         }
       }
 
+      // If the parameter is `Any` we assume that all candidates are
+      // convertible to it, which makes it a perfect match. The solver
+      // would then decide whether erasing to an existential is preferable.
+      if (paramType->isAny())
+        return 1;
+
       // Check protocol requirement(s) if this parameter is a
       // generic parameter type.
       if (genericSig && paramType->isTypeParameter()) {

--- a/test/Constraints/disfavored.swift
+++ b/test/Constraints/disfavored.swift
@@ -35,3 +35,15 @@ func test(s: String, answer: Int) {
   let r2c = f2(s)
   let _: A = r2c
 }
+
+do {
+  @available(*, deprecated)
+  @_disfavoredOverload
+  func test(v: Int) {}
+
+  func test(v: Any) {}
+
+  func call(v: Int) {
+    test(v: v) // Ok (the overload that takes `Int` is disfavored)
+  }
+}


### PR DESCRIPTION
If the parameter is `Any` we assume that all candidates are convertible to it, which makes it a perfect match. The solver would then decide whether erasing to an existential is preferable.

Resolves: rdar://157644867

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
