### PR TITLE
[rebranch] Temporarily disable debug info generation for async functions

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3741,6 +3741,11 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
     llvm::DIExpression *Expr, unsigned Line, unsigned Col,
     llvm::DILocalScope *Scope, const SILDebugScope *DS, bool InCoroContext,
     AddrDbgInstrKind AddrDInstKind) {
+  // Workaround for debug info assertion in Verifier.cpp where the #dbg_declares
+  // have references to non ints and ptrs.
+  if (InCoroContext)
+    return;
+
   Storage = Storage->stripPointerCasts();
   // Set the location/scope of the intrinsic.
   auto *InlinedAt = createInlinedAt(DS);

--- a/test/DebugInfo/DynamicSelfLocation.swift
+++ b/test/DebugInfo/DynamicSelfLocation.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-irgen -g -o - | %FileCheck %s
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 func some_func(_: () -> Void) async {}
 

--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 func use<T>(_ t: T) {}
 func forceSplit() async {

--- a/test/DebugInfo/async-await-no-debug-info-after-split-point.swift
+++ b/test/DebugInfo/async-await-no-debug-info-after-split-point.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 
 func ASYNC___1___() async -> Int {

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - -parse-as-library \
 // RUN:    -module-name M  -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 @available(SwiftStdlib 5.1, *)
 extension Collection where Element: Sendable {

--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: rdar157299589
 
 
 // Test that x is described as a direct dbg.declare of the incoming function

--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: rdar157299589
 
 public func getVegetables() async -> [String] {
   return ["leek", "carrot"]  

--- a/test/DebugInfo/async-let.swift
+++ b/test/DebugInfo/async-let.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: rdar157299589
 
 public actor Alice {
   let bob = Bob()

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 // Test that lifetime extension preserves a dbg.declare for "n" in the resume
 // funclet.

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -3,6 +3,7 @@
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: rdar157299589
 
 func getString() async -> String {
   return ""

--- a/test/DebugInfo/async-task-alloc.swift
+++ b/test/DebugInfo/async-task-alloc.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: rdar157299589
 
 // Test dynamically allocated local variables in async functions.
 

--- a/test/DebugInfo/debug_fragment_merge.swift
+++ b/test/DebugInfo/debug_fragment_merge.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -primary-file %s -Xllvm -sil-disable-pass=temp-lvalue-elimination -emit-irgen -O -g | %FileCheck %s
 
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
+// REQUIRES: rdar157299589
 
 protocol External {
   func use(str: String);

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -14,6 +14,7 @@
 // slightly differently on other platforms.
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: rdar157299589
 
 //////////////////
 // Declarations //

--- a/test/DebugInfo/nonisolated_nonsending.swift
+++ b/test/DebugInfo/nonisolated_nonsending.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir -g %s -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+// REQUIRES: rdar157299589
 
 public protocol P: Sendable {
   func f(_: Int) async

--- a/test/DebugInfo/sending_params_and_results.swift
+++ b/test/DebugInfo/sending_params_and_results.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir -g -o - -module-name test -strict-concurrency=complete -swift-version 5 -enable-upcoming-feature SendingArgsAndResults -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 // REQUIRES: swift_feature_SendingArgsAndResults
+// REQUIRES: rdar157299589
 
 // Test that we can properly reconstruct sending from various tests when
 // emitting debug info. Only place examples in here that have already failed.


### PR DESCRIPTION
Temporary workaround for a compiler crash in rebranch:
```
location of #dbg_declare must be a pointer or int
```