### PR TITLE
6.2: [SIL] Fix visitAccessedAddress @ end_borrow

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2795,6 +2795,23 @@ void swift::visitAccessedAddress(SILInstruction *I,
       visitor(singleOperand);
     return;
   }
+  case SILInstructionKind::EndBorrowInst: {
+    auto *ebi = cast<EndBorrowInst>(I);
+    SmallVector<SILValue, 4> roots;
+    findGuaranteedReferenceRoots(ebi->getOperand(),
+                                 /*lookThroughNestedBorrows=*/true, roots);
+    for (auto root : roots) {
+      if (auto *lbi = dyn_cast<LoadBorrowInst>(root)) {
+        visitor(&lbi->getOperandRef());
+        return;
+      }
+      if (auto *sbi = dyn_cast<StoreBorrowInst>(root)) {
+        visitor(&sbi->getOperandRef(StoreInst::Dest));
+        return;
+      }
+    }
+    break;
+  }
   // Non-access cases: these are marked with memory side effects, but, by
   // themselves, do not access formal memory.
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
@@ -2827,7 +2844,6 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::EndAccessInst:
   case SILInstructionKind::EndApplyInst:
-  case SILInstructionKind::EndBorrowInst:
   case SILInstructionKind::EndUnpairedAccessInst:
   case SILInstructionKind::EndLifetimeInst:
   case SILInstructionKind::ExistentialMetatypeInst:

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -84,6 +84,10 @@ struct STXXITXXII {
 struct MoS: ~Copyable {}
 struct MoE: ~Copyable {}
 
+struct UnsafeMutablePointer<T> {
+  var _rawValue: Builtin.RawPointer
+}
+
 sil @unknown : $@convention(thin) () -> ()
 sil @use_S : $@convention(thin) (@in_guaranteed S) -> ()
 
@@ -1344,5 +1348,25 @@ entry(%c_addr : $*X):
   apply undef(%stack) : $@convention(thin) (@in X) -> ()
   dealloc_stack %stack
   %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @no_hoist_into_load_borrow_scope : {{.*}} {
+// CHECK:         end_borrow
+// CHECK-NEXT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'no_hoist_into_load_borrow_scope'
+sil [ossa] @no_hoist_into_load_borrow_scope : $@convention(thin) (@in X) -> () {
+entry(%c_addr_in : $*X):
+  %c_ptr = address_to_pointer [stack_protection] %c_addr_in to $Builtin.RawPointer
+  %c_up = struct $UnsafeMutablePointer<X> (%c_ptr)
+  %c_ptr_2 = struct_extract %c_up, #UnsafeMutablePointer._rawValue // user: %45
+  %c_addr = pointer_to_address %c_ptr_2 to [strict] $*X
+  %c_borrow = load_borrow %c_addr
+  apply undef(%c_borrow) : $@convention(thin) (@guaranteed X) -> ()
+  %c_copy = load [copy] %c_addr_in
+  end_borrow %c_borrow
+  %retval = tuple ()
+  destroy_addr %c_addr_in
+  destroy_value %c_copy
   return %retval
 }


### PR DESCRIPTION
**Explanation**: Fix a compiler crash involving unsafe pointers.

The `visitAccessedAddress` utility reports what addresses may be read or written by an instruction.  That information is used to make determinations such as "is this instruction a deinit barrier".  

Previously, `end_borrow` instructions were never considered to access addresses.  This was incorrect:  The `load_borrow` and `store_borrow` instructions do their work within a scope and the address is effectively accessed for the duration of those scopes.  And those scopes are marked by `end_borrow` instructions.  That means those `end_borrow` instructions effectively access the loaded-from an stored-to addresses and must be regarded as such.  The result was that a `destroy_addr %a` could be hoisted into a `load_borrow %a` scope, releasing the stored object before the end of the scope within which it was guaranteed to remain live.

Here, this is fixed by teaching the utility to handle `end_borrow` instructions correctly: if the scope ended by the `end_borrow` comes from `load_borrow`s or `store_borrow`s, then the loaded-from and stored-to addresses are visited.  This results in such `end_borrow`s being regarded as deinit barriers which in turn prevents invalid hoisting of `destroy_addr`s into such scopes.
**Scope**: Affects optimized code involving unsafe pointers.
**Issue**: rdar://157772187
**Original PR**: https://github.com/swiftlang/swift/pull/83639
**Risk**: Low.  Previously, _all_ addresses accessed by an end_borrow were skipped.  Now, some addresses are visited.  A bug would either be visiting too many or too few.  If too few are visited, the patch still decreases the bugginess.  If too many are visited, the effect is to make optimizations (those that consider the isDeinitBarrier predicate) unnecessarily conservative and potentially to introduce spurious static exclusivity diagnostics (the utility is called from DiagnoseStaticExclusivity).
**Testing**: Added test.
**Reviewer**: Meghana Gupta ( @meg-gupta )
