### PR TITLE
6.2: [InlineArray] Fix outlining metadata collection.

### DIFF
--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -180,6 +180,14 @@ public:
                           Element.destroy(IGF, elt[0], eltTy, isOutlined);
                         }, {address});
   }
+
+  void collectMetadataForOutlining(OutliningMetadataCollector &collector,
+                                   SILType T) const override {
+    auto &IGM = collector.IGF.IGM;
+    auto elementTy = getElementSILType(IGM, T);
+    IGM.getTypeInfo(elementTy).collectMetadataForOutlining(collector,
+                                                           elementTy);
+  }
 };
 
 template<typename BaseTypeInfo>

--- a/validation-test/IRGen/rdar158083136.swift
+++ b/validation-test/IRGen/rdar158083136.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend %s -disable-availability-checking -emit-ir
+
+func f<let i: Int, T>(
+    _: consuming InlineArray<i, (String, T)>
+) {
+}


### PR DESCRIPTION
**Explanation**: Fix a compiler crash when emitting outlined value functions for `InlineArray<_, Tuple>`.

When an `InlineArray` is handled indirectly (e.g. it has a dynamic layout--via generics, resilient types, or an integer generic size--or it's passed as an argument and is "large") and is copied, destroyed, or released, an outlined value function is emitted for that operation.  That function needs access to the types used in the element type of the `InlineArray` to perform its work.  The metadata for such types that can't be discovered within the function (e.g. `T`) are passed as arguments.

Previously, it happened to get access to them some of the time, but not always, which resulted in compiler crashes when performing value operations on indirect `InlineArray<_, Tuple>`s.  Here, this is fixed by ensuring the metadata required for the element type is passed to the outlined value functions.
**Scope**: Affects `InlineArray`.
**Issue**: rdar://155668963
**Original PR**: https://github.com/swiftlang/swift/pull/83683
**Risk**: Low, just adds a missing override in IRGen's representation of `InlineArray`.  The implementation results in more types being passed to the outline value functions.  If the implementation is wrong, it will either be because 1. not all the types required for the function are passed in which case the same style of crash as already happens will occur or 2. more types than are necessary are passed to the function in which case there will be a small code-size cost.
**Testing**: Added a test.
**Reviewer**: Dario Rexin ( @drexin )
