### PR TITLE
Sema: Allow overrides to be unavailable in the current Swift language mode

### DIFF
--- a/test/Availability/availability_unavailable_overrides.swift
+++ b/test/Availability/availability_unavailable_overrides.swift
@@ -239,7 +239,6 @@ func testOverrideOfUnavailableDeclFromUnavailableDerivedType() {
   }
 }
 
-
 func testImplicitSuperInit() {
   // FIXME: The diagnostics for the implicit call to super.init() could be
   // relaxed since both initializers are unreachable and the developer cannot
@@ -254,5 +253,21 @@ func testImplicitSuperInit() {
     override init() {}
     // expected-error@-1 {{'init()' is unavailable}}
     // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'Base' occurs implicitly at the end of this initializer}}
+  }
+}
+
+func testUnavailableInSwiftOverrides() {
+  class Base {
+    func availableMethod() {}
+  }
+
+  class Derived1: Base {
+    @available(swift, introduced: 99)
+    override func availableMethod() {}
+  }
+
+  class Derived2: Base {
+    @available(swift, obsoleted: 1)
+    override func availableMethod() {}
   }
 }

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -83,6 +83,20 @@ class SomeCellSub5 : SomeCell {
   func otherIsEnabled() { } // should not conflict
 }
 
+class SomeCellSub6 : SomeCell {
+  @available(*, unavailable)
+  @objc override init(string: String) {
+    super.init(string: string)
+  }
+}
+
+class SomeCellSub7 : SomeCell {
+  @available(swift, obsoleted: 4)
+  @objc override init(string: String) {
+    super.init(string: string)
+  }
+}
+
 class FailSub : FailBase {
   override init(value: Int) { try! super.init(value: value) } // expected-error {{overriding a throwing '@objc' initializer with a non-throwing initializer is not supported}}
   override class func processValue() {} // expected-error {{overriding a throwing '@objc' method with a non-throwing method is not supported}}


### PR DESCRIPTION
Fixes a regression from https://github.com/swiftlang/swift/pull/83354.

Resolves rdar://158262522
