### PR TITLE
Basic: Fix `-print-supported-features`

### DIFF
--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -91,7 +91,7 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
 
   // Include only experimental features that are available in production.
   llvm::erase_if(experimental, [](auto &feature) {
-    return feature.isAvailableInProduction();
+    return !feature.isAvailableInProduction();
   });
 
   out << "{\n";

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -8,6 +8,6 @@
 // CHECK:     { "name": "InferIsolatedConformances", "migratable": true, "categories": ["IsolatedConformances"], "enabled_in": "7" },
 // CHECK:   ],
 // CHECK:   "experimental": [
-// CHECK:     { "name": "{{.*}}" }
+// CHECK:     { "name": "BuiltinModule" }
 // CHECK:   ]
 // CHECK: }


### PR DESCRIPTION
The check to only include experimental features that are available in production was inverted.

Resolves rdar://158273047.