### PR TITLE
Sema: Don't apply access level fix-it to `@dynamicMemberLookup` subscript

### DIFF
--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -53,10 +53,10 @@ namespace swift {
 
   /// Emit a fix-it to set the access of \p VD to \p desiredAccess.
   ///
-  /// This actually updates \p VD as well.
+  /// This actually updates \p VD as well if \p updateAttr is true.
   void fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
                    AccessLevel desiredAccess, bool isForSetter = false,
-                   bool shouldUseDefaultAccess = false);
+                   bool shouldUseDefaultAccess = false, bool updateAttr = true);
 
   /// Compute the location of the 'var' keyword for a 'var'-to-'let' Fix-It.
   SourceLoc getFixItLocForVarToLet(VarDecl *var);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2171,7 +2171,9 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
                             diag::dynamic_member_lookup_candidate_inaccessible,
                             inaccessibleCandidate);
       fixItAccess(diag, inaccessibleCandidate,
-                  requiredAccessScope.requiredAccessForDiagnostics());
+                  requiredAccessScope.requiredAccessForDiagnostics(),
+                  /*isForSetter=*/false, /*useDefaultAccess=*/false,
+                  /*updateAttr=*/false);
       diag.warnUntilSwiftVersionIf(!shouldError, futureVersion);
 
       if (shouldError) {

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -253,9 +253,8 @@ public struct Inaccessible1 {
 
 @dynamicMemberLookup
 public struct Inaccessible2 {
-  // expected-non-resilient-warning @+3 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{21-29=public}}
-  // expected-resilient-error @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{21-29=public}}
-  // expected-error @+1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but subscript 'subscript(dynamicMember:)' is public}}
+  // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{21-29=public}}
+  // expected-resilient-error @+1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{21-29=public}}
   @usableFromInline internal subscript(dynamicMember member: String) -> Int {
     return 42
   }
@@ -276,6 +275,18 @@ private struct Inaccessible4 {
   // expected-resilient-error @+1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{3-10=fileprivate}}
   private subscript(dynamicMember member: String) -> Int {
     return 42
+  }
+}
+
+@dynamicMemberLookup
+public struct Inaccessible5 {
+  internal struct Nested { }
+  var nested: Nested
+
+  // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-11=public}}
+  // expected-resilient-error @+1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{3-11=public}}
+  internal subscript<Value>(dynamicMember keyPath: KeyPath<Nested, Value>) -> Value {
+    nested[keyPath: keyPath]
   }
 }
 

--- a/test/attr/attr_dynamic_member_lookup_swift7.swift
+++ b/test/attr/attr_dynamic_member_lookup_swift7.swift
@@ -50,8 +50,7 @@ public struct Inaccessible1 {
 
 @dynamicMemberLookup
 public struct Inaccessible2 {
-  // expected-error @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{21-29=public}}
-  // expected-error @+1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but subscript 'subscript(dynamicMember:)' is public}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}{{21-29=public}}
   @usableFromInline internal subscript(dynamicMember member: String) -> Int {
     return 42
   }


### PR DESCRIPTION
The adjusted access level for the subscript shouldn't be fixed automatically since sometimes the diagnostic is a warning and other times automatically applying the fix-it immediately causes other errors, which can be confusing.

Resolves rdar://158261884.
