### PR TITLE
[Windows] Test swift-foundation in debug configuration when `$FoundationTestConfiguration` is set to `debug`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2850,7 +2850,8 @@ function Test-Foundation {
     -Action Test `
     -Src $SourceCache\swift-foundation `
     -Bin "$BinaryCache\$($BuildPlatform.Triple)\CoreFoundationTests" `
-    -Platform $BuildPlatform
+    -Platform $BuildPlatform `
+    -Configuration $FoundationTestConfiguration
 
   Invoke-IsolatingEnvVars {
     $env:DISPATCH_INCLUDE_PATH="$(Get-SwiftSDK $BuildPlatform.OS)/usr/include"


### PR DESCRIPTION
This was discussed in https://github.com/swiftlang/swift/pull/80122#discussion_r2253881915 but got reverted by https://github.com/swiftlang/swift/pull/83693. Re-apply the fix.