### PR TITLE
[CS] Handle holes in `mergeEquivalenceClasses`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -454,11 +454,11 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+28,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 8+26,
     /// Type variable options.
-    Options : 7,
+    Options : 8,
     /// The unique number assigned to this type variable.
-    ID : 27
+    ID : 26
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ErrorUnionType, TypeBase, 32,

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -229,6 +229,13 @@ public:
   /// e.g. `foo[0]` or `\Foo.[0]`
   bool isSubscriptMemberRef() const;
 
+  /// Determine whether this locator represents one of the parameter types
+  /// associated with a closure.
+  bool isClosureParameterType() const;
+
+  /// Determine whether this locator represents a closure result type.
+  bool isClosureResultType() const;
+
   /// Determine whether give locator points to the type of the
   /// key path expression.
   bool isKeyPathType() const;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1952,6 +1952,14 @@ public:
   ConstraintLocator *
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
+  /// Retrieve the type variable that represents the originating hole in the
+  /// equivalence class for a given type variable.
+  TypeVariableType *getHoleTypeVar(TypeVariableType *tv);
+
+  /// Retrieve the locator for the hole that represents the originating hole in
+  /// the equivalence class for a given type variable.
+  ConstraintLocator *getHoleLocator(TypeVariableType *tv);
+
   /// Lookup and return parent associated with given expression.
   Expr *getParentExpr(Expr *expr) {
     if (auto result = getExprDepthAndParent(expr))

--- a/include/swift/Sema/TypeVariableType.h
+++ b/include/swift/Sema/TypeVariableType.h
@@ -49,6 +49,14 @@ enum TypeVariableOptions {
 
   /// Whether the type variable can be bound only to a pack expansion type.
   TVO_PackExpansion = 0x40,
+
+  /// Whether the hole for this type variable origates from a different
+  /// type variable in its equivalence class.
+  /// FIXME: This is an unfortunate hack due to the fact that choosing a
+  /// different representative changes binding order and regresses a bunch of
+  /// test cases. Once binding order is made more resilient we ought to be able
+  /// to remove this.
+  TVO_NonRepresentativeHole = 0x80,
 };
 
 /// The implementation object for a type variable used within the
@@ -119,6 +127,12 @@ public:
 
   /// Whether this type variable can bind only to PackExpansionType.
   bool isPackExpansion() const { return getRawOptions() & TVO_PackExpansion; }
+
+  /// Whether the hole for this type variable origates from a different
+  /// type variable in its equivalence class.
+  bool isNonRepresentativeHole() const {
+    return getRawOptions() & TVO_NonRepresentativeHole;
+  }
 
   /// Whether this type variable prefers a subtype binding over a supertype
   /// binding.
@@ -285,28 +299,40 @@ public:
       otherRep->getImpl().recordBinding(*trail);
     otherRep->getImpl().ParentOrFixed = getTypeVariable();
 
+    auto &bits = getTypeVariable()->Bits.TypeVariableType;
+
     if (canBindToLValue() && !otherRep->getImpl().canBindToLValue()) {
       if (trail)
         recordBinding(*trail);
-      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToLValue;
+      bits.Options &= ~TVO_CanBindToLValue;
     }
 
     if (canBindToInOut() && !otherRep->getImpl().canBindToInOut()) {
       if (trail)
         recordBinding(*trail);
-      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToInOut;
+      bits.Options &= ~TVO_CanBindToInOut;
     }
 
     if (canBindToNoEscape() && !otherRep->getImpl().canBindToNoEscape()) {
       if (trail)
         recordBinding(*trail);
-      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToNoEscape;
+      bits.Options &= ~TVO_CanBindToNoEscape;
     }
 
     if (canBindToPack() && !otherRep->getImpl().canBindToPack()) {
       if (trail)
         recordBinding(*trail);
-      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToPack;
+      bits.Options &= ~TVO_CanBindToPack;
+    }
+
+    // If we're merging a non-hole with a hole, add the flag to allow binding
+    // to a hole. This type variable then becomes a "non-representative" hole,
+    // which is an unfortunate hack necessary to preserve binding order. See
+    // the comment on `TVO_NonRepresentativeHole` for more info.
+    if (!canBindToHole() && otherRep->getImpl().canBindToHole()) {
+      if (trail)
+        recordBinding(*trail);
+      bits.Options |= (TVO_CanBindToHole | TVO_NonRepresentativeHole);
     }
   }
 
@@ -421,6 +447,7 @@ private:
     ENTRY(TVO_PrefersSubtypeBinding, "prefer subtype");
     ENTRY(TVO_CanBindToPack, "pack");
     ENTRY(TVO_PackExpansion, "pack expansion");
+    ENTRY(TVO_NonRepresentativeHole, "non-rep hole");
     }
   #undef ENTRY
   }

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -111,7 +111,9 @@ TypeVarBindingProducer::TypeVarBindingProducer(
     : BindingProducer(cs, typeVar->getImpl().getLocator()),
       TypeVar(typeVar), CanBeNil(bindings.canBeNil()) {
   if (bindings.isDirectHole()) {
-    auto *locator = getLocator();
+    auto *holeTV = CS.getHoleTypeVar(TypeVar);
+    auto *locator = holeTV->getImpl().getLocator();
+
     // If this type variable is associated with a code completion token
     // and it failed to infer any bindings let's adjust holes's locator
     // to point to a code completion token to avoid attempting to "fix"
@@ -122,7 +124,7 @@ TypeVarBindingProducer::TypeVarBindingProducer(
           CS.getConstraintLocator(bindings.getAssociatedCodeCompletionToken());
     }
 
-    Bindings.push_back(Binding::forHole(TypeVar, locator));
+    Bindings.push_back(Binding::forHole(holeTV, locator));
     return;
   }
 
@@ -439,7 +441,7 @@ bool TypeVarBindingProducer::computeNext() {
 
 std::optional<std::pair<ConstraintFix *, FixImpact>>
 TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
-  auto *dstLocator = TypeVar->getImpl().getLocator();
+  auto *dstLocator = cs.getHoleLocator(TypeVar);
   auto *srcLocator = Binding.getLocator();
 
   // FIXME: This check could be turned into an assert once
@@ -460,7 +462,7 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
 
   auto defaultImpact = FixImpact::Mismatch;
 
-  if (auto *GP = TypeVar->getImpl().getGenericParameter()) {
+  if (auto *GP = dstLocator->getGenericParameter()) {
     // If it is representative for a key path root, let's emit a more
     // specific diagnostic.
     auto *keyPathRoot =
@@ -490,12 +492,12 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     }
   }
 
-  if (TypeVar->getImpl().isClosureParameterType()) {
+  if (dstLocator->isClosureParameterType()) {
     ConstraintFix *fix = SpecifyClosureParameterType::create(cs, dstLocator);
     return std::make_pair(fix, defaultImpact);
   }
 
-  if (TypeVar->getImpl().isClosureResultType()) {
+  if (dstLocator->isClosureResultType()) {
     auto *closure = castToExpr<ClosureExpr>(dstLocator->getAnchor());
     // If the whole body is being ignored due to a pre-check failure,
     // let's not record a fix about result type since there is
@@ -614,15 +616,17 @@ static bool shouldIgnoreHoleForCodeCompletion(ConstraintSystem &cs,
                                               ConstraintLocator *srcLocator) {
   if (!cs.isForCodeCompletion())
     return false;
-  
+
+  auto *holeLoc = cs.getHoleLocator(typeVar);
+
   // Don't penalize solutions with unresolved generics.
-  if (typeVar->getImpl().getGenericParameter())
+  if (holeLoc->getGenericParameter())
     return true;
 
   // Don't penalize solutions if we couldn't determine the type of the code
   // completion token. We still want to examine the surrounding types in
   // that case.
-  if (typeVar->getImpl().isCodeCompletionToken())
+  if (holeLoc->directlyAt<CodeCompletionExpr>())
     return true;
 
   // When doing completion in a result builder, we avoid solving unrelated
@@ -650,7 +654,7 @@ static bool shouldIgnoreHoleForCodeCompletion(ConstraintSystem &cs,
   if (cs.hasArgumentsIgnoredForCodeCompletion()) {
     // Avoid simplifying the locator if the constraint system didn't ignore
     // any arguments.
-    auto argExpr = simplifyLocatorToAnchor(typeVar->getImpl().getLocator());
+    auto argExpr = simplifyLocatorToAnchor(holeLoc);
     if (cs.isArgumentIgnoredForCodeCompletion(argExpr.dyn_cast<Expr *>())) {
       return true;
     }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -461,7 +461,7 @@ bool BindingSet::isDelayed() const {
     return true;
 
   if (isHole()) {
-    auto *locator = TypeVar->getImpl().getLocator();
+    auto *locator = CS.getHoleLocator(TypeVar);
     assert(locator && "a hole without locator?");
 
     // Delay resolution of the code completion expression until

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13345,15 +13345,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
   // a fix, let's propagate holes to the "input" type. Doing so
   // provides more information to upcoming argument and result matching.
   if (shouldAttemptFixes()) {
-    if (auto *typeVar = type2->getAs<TypeVariableType>()) {
+    Type underlyingType = desugar2->getMetatypeInstanceType();
+    if (auto *typeVar = underlyingType->getAs<TypeVariableType>()) {
       auto *locator = typeVar->getImpl().getLocator();
       if (hasFixFor(locator)) {
         recordAnyTypeVarAsPotentialHole(func1);
       }
-    }
-    Type underlyingType = desugar2;
-    while (auto *MT = underlyingType->getAs<AnyMetatypeType>()) {
-      underlyingType = MT->getInstanceType();
     }
     underlyingType =
         getFixedTypeRecursive(underlyingType, flags, /*wantRValue=*/true);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -558,6 +558,22 @@ bool ConstraintLocator::isSubscriptMemberRef() const {
   return path.back().getKind() == ConstraintLocator::SubscriptMember;
 }
 
+bool ConstraintLocator::isClosureParameterType() const {
+  if (!getAnchor())
+    return false;
+
+  return isExpr<ClosureExpr>(getAnchor()) &&
+         isLastElement<LocatorPathElt::TupleElement>();
+}
+
+bool ConstraintLocator::isClosureResultType() const {
+  if (!getAnchor())
+    return false;
+
+  return isExpr<ClosureExpr>(getAnchor()) &&
+         isLastElement<LocatorPathElt::ClosureResult>();
+}
+
 bool ConstraintLocator::isKeyPathType() const {
   auto anchor = getAnchor();
   auto path = getPath();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -900,6 +900,31 @@ void ConstraintSystem::restoreType(const KeyPathExpr *KP, unsigned I, Type T) {
   }
 }
 
+TypeVariableType *ConstraintSystem::getHoleTypeVar(TypeVariableType *tv) {
+  if (!tv->getImpl().isNonRepresentativeHole())
+    return tv;
+
+  // If we have a non-representative hole, the hole type var is given by
+  // a member of its equivalence class. Pick the the one with the lowest ID to
+  // ensure consistency.
+  TypeVariableType *candidate = nullptr;
+  for (auto equiv : CG[tv].getEquivalenceClass()) {
+    auto &impl = equiv->getImpl();
+    if (equiv == tv || !impl.canBindToHole() || impl.isNonRepresentativeHole())
+      continue;
+
+    if (!candidate || candidate->getID() > equiv->getID())
+      candidate = equiv;
+  }
+  ASSERT(candidate &&
+         "Non-representative hole ought to have hole in its equivalence class");
+  return candidate;
+}
+
+ConstraintLocator *ConstraintSystem::getHoleLocator(TypeVariableType *tv) {
+  return getHoleTypeVar(tv)->getImpl().getLocator();
+}
+
 std::pair<Type, ExistentialArchetypeType *>
 ConstraintSystem::openAnyExistentialType(Type type,
                                          ConstraintLocator *locator) {

--- a/lib/Sema/TypeVariableType.cpp
+++ b/lib/Sema/TypeVariableType.cpp
@@ -90,19 +90,11 @@ bool TypeVariableType::Implementation::isTapType() const {
 }
 
 bool TypeVariableType::Implementation::isClosureParameterType() const {
-  if (!(locator && locator->getAnchor()))
-    return false;
-
-  return isExpr<ClosureExpr>(locator->getAnchor()) &&
-         locator->isLastElement<LocatorPathElt::TupleElement>();
+  return locator && locator->isClosureParameterType();
 }
 
 bool TypeVariableType::Implementation::isClosureResultType() const {
-  if (!(locator && locator->getAnchor()))
-    return false;
-
-  return isExpr<ClosureExpr>(locator->getAnchor()) &&
-         locator->isLastElement<LocatorPathElt::ClosureResult>();
+  return locator && locator->isClosureResultType();
 }
 
 bool TypeVariableType::Implementation::isKeyPathType() const {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1592,3 +1592,13 @@ do {
     let x: String = 0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
   }. // expected-error {{expected member name following '.'}}
 }
+
+func testArrayLiteralMetatypeMismatch() {
+  // Make sure we can correctly turn 'T' into a hole here.
+  func foo<T>(_ xs: T.Type, _: Int) -> T {} // expected-note {{in call to function 'foo'}}
+  func foo(_ i: Int) {
+    let x = foo([], i)
+    // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+    // expected-error@-2 {{cannot convert value of type '[Any]' to expected argument type 'T.Type'}}
+  }
+}

--- a/test/Constraints/rdar45511837.swift
+++ b/test/Constraints/rdar45511837.swift
@@ -18,8 +18,6 @@ class Foo<Bar: NSObject> {
 
   lazy var foo: () -> Void = {
     // TODO: improve diagnostic message
-    _ = self.foobar + nil // expected-error {{'Bar' is not convertible to 'String'}}
-    // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
-    // expected-error@-2 {{'nil' is not compatible with expected argument type 'String'}}
+    _ = self.foobar + nil // expected-error {{generic parameter 'Self' could not be inferred}}
   }
 }

--- a/validation-test/Sema/SwiftUI/rdar88256059.swift
+++ b/validation-test/Sema/SwiftUI/rdar88256059.swift
@@ -9,7 +9,8 @@ struct MyView: View {
 
   var body: some View {
     Table(self.data) {
-      // expected-error@-1 {{expected expression of type 'Columns' in result builder 'TableColumnBuilder'}} {{23-23=<#T##Columns#>}}
+      // expected-error@-1 {{expected expression of type 'Column' in result builder 'TableColumnBuilder'}} {{23-23=<#T##Column#>}}
+      // expected-error@-2 {{generic parameter 'Column' could not be inferred}}
     }
   }
 }


### PR DESCRIPTION
Make sure we preserve `TVO_CanBindToHole`. This unfortunately requires introducing the concept of a "non representative" hole for representatives where the actual hole is given by another type variable in the equivalence class. This avoids disturbing binding order and regressing diagnostics. Once binding is less sensitive to ordering we ought to be able to always choose the hole as the representative.