### PR TITLE
Observation: do not import all of Darwin to implement locking facilities

### DIFF
--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -102,7 +102,6 @@ target_link_libraries(swiftObservation PRIVATE
   swiftCore
   swift_Concurrency
   $<$<PLATFORM_ID:Android>:swiftAndroid>
-  $<$<PLATFORM_ID:Darwin>:swiftDarwin>
   $<$<PLATFORM_ID:Linux>:swiftGlibc>
   $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
 

--- a/stdlib/public/Observation/Sources/Observation/Locking.swift
+++ b/stdlib/public/Observation/Sources/Observation/Locking.swift
@@ -15,8 +15,8 @@
 // symbols that are not provided by this library - so instead it has to re-implement 
 // all of this on its own... 
 
-#if canImport(Darwin)
-import Darwin
+#if canImport(Darwin.os.lock)
+import Darwin.os.lock
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -31,7 +31,7 @@ import Bionic
 #endif
 
 internal struct Lock {
-  #if canImport(Darwin)
+  #if canImport(Darwin.os.lock)
   typealias Primitive = os_unfair_lock
   #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
   #if os(FreeBSD) || os(OpenBSD)
@@ -59,7 +59,7 @@ internal struct Lock {
   }
 
   fileprivate static func initialize(_ platformLock: PlatformLock) {
-    #if canImport(Darwin)
+    #if canImport(Darwin.os.lock)
     platformLock.initialize(to: os_unfair_lock())
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_init(platformLock, nil)
@@ -82,7 +82,7 @@ internal struct Lock {
   }
 
   fileprivate static func lock(_ platformLock: PlatformLock) {
-    #if canImport(Darwin)
+    #if canImport(Darwin.os.lock)
     os_unfair_lock_lock(platformLock)
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     pthread_mutex_lock(platformLock)
@@ -95,7 +95,7 @@ internal struct Lock {
   }
 
   fileprivate static func unlock(_ platformLock: PlatformLock) {
-    #if canImport(Darwin)
+    #if canImport(Darwin.os.lock)
     os_unfair_lock_unlock(platformLock)
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_unlock(platformLock)


### PR DESCRIPTION
At the same time, drop that dependency in the new build system, so that we don't add an additional linkage for Darwin platforms compared to what we are doing in the current build system.

Addresses rdar://158313871