### PR TITLE
Distributed: do not import all of Darwin to implement locking facilities

### DIFF
--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -143,8 +143,7 @@ target_link_libraries(swiftDistributed PRIVATE
   swift_Concurrency
   swift_Builtin_float
   $<$<PLATFORM_ID:Android>:swiftAndroid>
-  $<$<PLATFORM_ID:Windows>:swiftWinSDK>
-  $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
 
 install(TARGETS swiftDistributed
   EXPORT SwiftDistributedTargets

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -12,8 +12,8 @@
 
 import Swift
 
-#if canImport(Darwin)
-import Darwin
+#if canImport(Darwin.os.lock)
+import Darwin.os.lock
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)


### PR DESCRIPTION
At the same time, drop that dependency in the new build system, so that we don't add an additional linkage for Darwin platforms compared to what we are doing in the current build system.

Addresses rdar://158314427