### PR TITLE
AST: Make the decl associated with an AvailabilityDomain a ValueDecl

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -33,10 +33,10 @@
 namespace swift {
 class ASTContext;
 class CustomAvailabilityDomain;
-class Decl;
 class DeclContext;
 class FuncDecl;
 class ModuleDecl;
+class ValueDecl;
 
 /// Represents a dimension of availability (e.g. macOS platform or Swift
 /// language mode).
@@ -153,7 +153,7 @@ public:
 
   /// If `decl` represents an availability domain, returns the corresponding
   /// `AvailabilityDomain` value. Otherwise, returns `std::nullopt`.
-  static std::optional<AvailabilityDomain> forCustom(Decl *decl,
+  static std::optional<AvailabilityDomain> forCustom(ValueDecl *decl,
                                                      const ASTContext &ctx);
 
   static AvailabilityDomain forCustom(const CustomAvailabilityDomain *domain) {
@@ -250,7 +250,7 @@ public:
 
   /// Returns the decl that represents the domain, or `nullptr` if the domain
   /// does not have a decl.
-  Decl *getDecl() const;
+  ValueDecl *getDecl() const;
 
   /// Returns the module that the domain belongs to, if it is a custom domain.
   ModuleDecl *getModule() const;
@@ -343,22 +343,22 @@ private:
   Identifier name;
   Kind kind;
   ModuleDecl *mod;
-  Decl *decl;
+  ValueDecl *decl;
   FuncDecl *predicateFunc;
 
   CustomAvailabilityDomain(Identifier name, Kind kind, ModuleDecl *mod,
-                           Decl *decl, FuncDecl *predicateFunc);
+                           ValueDecl *decl, FuncDecl *predicateFunc);
 
 public:
   static const CustomAvailabilityDomain *get(StringRef name, Kind kind,
-                                             ModuleDecl *mod, Decl *decl,
+                                             ModuleDecl *mod, ValueDecl *decl,
                                              FuncDecl *predicateFunc,
                                              const ASTContext &ctx);
 
   Identifier getName() const { return name; }
   Kind getKind() const { return kind; }
   ModuleDecl *getModule() const { return mod; }
-  Decl *getDecl() const { return decl; }
+  ValueDecl *getDecl() const { return decl; }
 
   /// Returns the function that should be called at runtime to determine whether
   /// the domain is available, or `nullptr` if the domain's availability is not

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5911,7 +5911,7 @@ const AvailabilityContext::Storage *AvailabilityContext::Storage::get(
 
 const CustomAvailabilityDomain *
 CustomAvailabilityDomain::get(StringRef name, Kind kind, ModuleDecl *mod,
-                              Decl *decl, FuncDecl *predicateFunc,
+                              ValueDecl *decl, FuncDecl *predicateFunc,
                               const ASTContext &ctx) {
   auto identifier = ctx.getIdentifier(name);
   llvm::FoldingSetNodeID id;

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -39,7 +39,7 @@ getCustomDomainKind(clang::FeatureAvailKind featureAvailKind) {
 }
 
 static const CustomAvailabilityDomain *
-customDomainForClangDecl(Decl *decl, const ASTContext &ctx) {
+customDomainForClangDecl(ValueDecl *decl, const ASTContext &ctx) {
   auto *clangDecl = decl->getClangDecl();
   ASSERT(clangDecl);
 
@@ -68,7 +68,7 @@ customDomainForClangDecl(Decl *decl, const ASTContext &ctx) {
 }
 
 std::optional<AvailabilityDomain>
-AvailabilityDomain::forCustom(Decl *decl, const ASTContext &ctx) {
+AvailabilityDomain::forCustom(ValueDecl *decl, const ASTContext &ctx) {
   if (!decl)
     return std::nullopt;
 
@@ -247,7 +247,7 @@ llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
   }
 }
 
-Decl *AvailabilityDomain::getDecl() const {
+ValueDecl *AvailabilityDomain::getDecl() const {
   if (auto *customDomain = getCustomDomain())
     return customDomain->getDecl();
 
@@ -369,7 +369,8 @@ bool StableAvailabilityDomainComparator::operator()(
 }
 
 CustomAvailabilityDomain::CustomAvailabilityDomain(Identifier name, Kind kind,
-                                                   ModuleDecl *mod, Decl *decl,
+                                                   ModuleDecl *mod,
+                                                   ValueDecl *decl,
                                                    FuncDecl *predicateFunc)
     : name(name), kind(kind), mod(mod), decl(decl),
       predicateFunc(predicateFunc) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4098,7 +4098,8 @@ void ClangModuleUnit::lookupAvailabilityDomains(
   if (varDecl->getOwningModule() != getClangModule())
     return;
 
-  auto *imported = ctx.getClangModuleLoader()->importDeclDirectly(varDecl);
+  auto *imported = dyn_cast_or_null<ValueDecl>(
+      ctx.getClangModuleLoader()->importDeclDirectly(varDecl));
   if (!imported)
     return;
 


### PR DESCRIPTION
A decl that represents an `AvailabilityDomain` should always be a `ValueDecl`.
