### PR TITLE
[CSOptimizer] Add support for opened existential arguments

### DIFF
--- a/lib/Sema/OpenedExistentials.h
+++ b/lib/Sema/OpenedExistentials.h
@@ -150,6 +150,13 @@ std::optional<std::pair<TypeVariableType *, Type>>
 canOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
                                Type paramTy, Type argTy);
 
+/// A limited form of the check performed by \c canOpenExistentialCallArgument
+/// that assumes that a declaration where parameter came from, the parameter
+/// itself, and the types involved have been validated already.
+bool canOpenExistentialAt(ValueDecl *callee, unsigned paramIdx,
+                          GenericTypeParamType *genericParam,
+                          Type existentialTy);
+
 /// Given a type that includes an existential type that has been opened to
 /// the given type variable, replace the opened type variable and its member
 /// types with their upper bounds.

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -591,3 +591,18 @@ protocol PP3 {
     associatedtype A
 }
 
+protocol PP4 {
+}
+
+do {
+  func test<T>(env: T) where T: PP4 {}
+
+  func test(env: PP4? = nil) {
+    guard let env else {
+      return
+    }
+
+    // CHECK: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
+    test(env: env)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/cad1ff6235b5b3d.swift
+++ b/validation-test/compiler_crashers_2_fixed/cad1ff6235b5b3d.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::isArgumentGenericFunction(swift::Type, swift::Expr*)","signatureAssert":"Assertion failed: (!getFixedType(tyvar)), function getUnboundBindOverloadDisjunction"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   print($0) $00 + 0. / 1


### PR DESCRIPTION
Check whether it would be possible to match a parameter type
by opening an existential type of the candidate argument.

Resolves: rdar://158159462

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
