### PR TITLE
[OSSA] Fix borrowCopyOverGuaranteedUsers at dead-ends.

### DIFF
--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -79,11 +79,6 @@ void extendLocalBorrow(BeginBorrowInst *beginBorrow,
 /// newly created phis do not yet have a borrow scope.
 bool createBorrowScopeForPhiOperands(SILPhiArgument *newPhi);
 
-SILValue
-makeGuaranteedValueAvailable(SILValue value, SILInstruction *user,
-                             DeadEndBlocks &deBlocks,
-                             InstModCallbacks callbacks = InstModCallbacks());
-
 /// Compute the liveness boundary for a guaranteed value. Returns true if no
 /// uses are pointer escapes. If pointer escapes are present, the liveness
 /// boundary is still valid for all known uses.

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -969,7 +969,14 @@ BeginBorrowInst *OwnershipLifetimeExtender::borrowCopyOverGuaranteedUsers(
   // Create destroys at the end of copy's lifetime. This only needs to consider
   // uses that end the borrow scope.
   {
-    ValueLifetimeAnalysis lifetimeAnalysis(copy, borrow->getEndBorrows());
+    SmallVector<SILInstruction *, 16> users;
+    for (auto *user : guaranteedUsers) {
+      users.push_back(user);
+    }
+    for (auto *user : borrow->getEndBorrows()) {
+      users.push_back(user);
+    }
+    ValueLifetimeAnalysis lifetimeAnalysis(copy, users);
     ValueLifetimeBoundary copyBoundary;
     lifetimeAnalysis.computeLifetimeBoundary(copyBoundary);
 

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -1164,3 +1164,38 @@ bb0:
   %13 = tuple ()
   return %13
 }
+
+/// A scenario where a borrow of a copy is introduced but the cfg is such that
+/// no end_borrows are inserted for the borrow.  The copy must still be
+/// destroyed.
+// CHECK-LABEL: sil [ossa] @no_boundary_for_end_borrows : {{.*}} {
+// TODO: There shouldn't actually be a copy_value here, but lifetime transfer
+//       APIs are written and OSSARAUWHelper is in use, there will be.
+//       Even then, this test case shouldn't crash.
+// CHECK:         copy_value
+// CHECK:         destroy_value
+// CHECK-LABEL: } // end sil function 'no_boundary_for_end_borrows'
+sil [ossa] @no_boundary_for_end_borrows : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+entry(%s : @guaranteed $NonTrivialStruct):
+  %c1 = struct_extract %s : $NonTrivialStruct, #NonTrivialStruct.val
+  cond_br undef, loop_entry, exit
+
+exit:
+  apply undef(%c1) : $@convention(thin) (@guaranteed Klass) -> ()
+  return undef : $()
+
+loop_entry:
+  %c2 = struct_extract %s : $NonTrivialStruct, #NonTrivialStruct.val
+  apply undef(%c2) : $@convention(thin) (@guaranteed Klass) -> ()
+  br loop_header
+
+loop_header:
+  apply undef(%c2) : $@convention(thin) (@guaranteed Klass) -> ()
+  cond_br undef, die, loop_backedge
+
+loop_backedge:
+  br loop_header
+
+die:
+  unreachable
+}


### PR DESCRIPTION
The utility was computing the boundary of the `copy_value` with the `end_borrow`s as users.  But there may not be any `end_borrow`s thanks to dead-ends.  Instead, consider both guaranteed users and any `end_borrow`s.

Fixes a miscompile in CSE.

rdar://158353230
