### PR TITLE
[cxx-interop] Allow many specializations of a class template

### DIFF
--- a/test/Interop/Cxx/templates/many-specializations.swift
+++ b/test/Interop/Cxx/templates/many-specializations.swift
@@ -5,4 +5,4 @@
 // CHECK-NEXT: struct TemplateStruct<T> {
 // CHECK-NEXT: }
 
-// CHECK-NOT: typealias
+// CHECK: typealias T1000


### PR DESCRIPTION
An old piece of logic in ClangImporter was trying to limit the number of instantiations for each C++ class template to prevent long compile times. Unfortunately this started causing hard-to-reproduce deserialization errors on large projects which use many different instantiations of `std::vector` and `std::allocator`.

The instantiation limit was arbitrary, it serves no real purpose and causes issues. This change removes it.

rdar://158397914

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
