### PR TITLE
Build WasmKit with host SwiftPM when SwiftPM is not built

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -76,6 +76,7 @@ def run_swift_build(host_target, product, swiftpm_package_product_name, set_inst
     swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
 
     if not os.path.exists(swift_build) or product.args.build_runtime_with_host_compiler:
+        print("WARNING: build-script's `wasmkit.py` is running local development code path, don't use for deployment!")
         swift_build = product.toolchain.swift_build
 
     if host_target.startswith('macos'):

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -76,7 +76,10 @@ def run_swift_build(host_target, product, swiftpm_package_product_name, set_inst
     swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
 
     if not os.path.exists(swift_build) or product.args.build_runtime_with_host_compiler:
-        print("WARNING: build-script's `wasmkit.py` is running local development code path, don't use for deployment!")
+        print(
+            f"WARNING: build-script's {os.path.basename(__file__)} is running local development code path, "
+            "don't use these build artifacts for deployment!"
+        )
         swift_build = product.toolchain.swift_build
 
     if host_target.startswith('macos'):

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -73,11 +73,10 @@ class WasmKit(product.Product):
 
 
 def run_swift_build(host_target, product, swiftpm_package_product_name, set_installation_rpath=False):
-    if product.args.build_runtime_with_host_compiler:
-      swift_build = product.toolchain.swift_build
-    else:
-      # Building with the freshly-built SwiftPM
-      swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
+    swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
+
+    if not os.path.exists(swift_build) or product.args.build_runtime_with_host_compiler:
+        swift_build = product.toolchain.swift_build
 
     if host_target.startswith('macos'):
         # Universal binary on macOS


### PR DESCRIPTION
Currently, passing `--wasmkit` to `build-script` also requires `--swiftpm --install-swiftpm` and all of their dependencies (at the very least Dispatch, Foundation, XCTest, Testing, llbuild, swift-build). We can conditionally switch to host SwiftPM when new SwiftPM is not built or installed.