### PR TITLE
[OSSACompleteLifetime] Promote assertion.

### DIFF
--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -333,7 +333,34 @@ void AvailabilityBoundaryVisitor::computeRegion(
       // Thus finding a value available at the end of such a block means that
       // the block does _not_ must not exits the function normally; in other
       // words its terminator must be an UnreachableInst.
-      assert(isa<UnreachableInst>(block->getTerminator()));
+      if (!isa<UnreachableInst>(block->getTerminator())) {
+        llvm::errs() << "Invalid SIL provided to OSSALifetimeCompletion?! {{\n";
+        llvm::errs() << "OSSALifetimeCompletion is visiting the availability "
+                        "boundary of ";
+        value->print(llvm::errs());
+        llvm::errs()
+            << "When walking forward from the def to the availability boundary "
+               "a non-dead-end successor-less block was encountered: bb"
+            << block->getDebugID()
+            << "\nIts terminator must be an unreachable but is actually "
+               "instead "
+            << *block->getTerminator()
+            << "The walk stops at consumes, so reaching such a block means the "
+               "value was leaked.  The function with the leak is as follows:\n";
+        block->getFunction()->print(llvm::errs());
+        llvm::errs()
+            << "Invalid SIL provided to OSSALifetimeCompletion?! }}\n"
+            << "Something that ran before OSSALifetimeCompletion (the current "
+               "pass, an earlier pass, SILGen) has introduced a leak of this "
+               "value.\n"
+            << "Please rerun the crashing swift-frontend command with the "
+               "following flags added and file a bug with the output:\n"
+            << "-sil-ownership-verify-all -Xllvm '-sil-print-function="
+            << block->getFunction()->getName()
+            << "' -Xllvm -sil-print-types -Xllvm -sil-print-module-on-error\n";
+        llvm::report_fatal_error("Invalid lifetime of value whose availability "
+                                 "boundary is being visited.");
+      }
     }
     for (auto *successor : block->getSuccessorBlocks()) {
       regionWorklist.pushIfNotVisited(successor);

--- a/validation-test/SILOptimizer/ossa_lifetime_completion_crash.sil
+++ b/validation-test/SILOptimizer/ossa_lifetime_completion_crash.sil
@@ -24,6 +24,7 @@ class C {}
 // CHECK: Something that ran before OSSALifetimeCompletion (the current pass, an earlier pass, SILGen) has introduced a leak of this value.
 // CHECK: Please rerun the crashing swift-frontend command with the following flags added and file a bug with the output:
 // CHECK: -sil-ownership-verify-all -Xllvm '-sil-print-function=leak_c' -Xllvm -sil-print-types -Xllvm -sil-print-module-on-error
+// CHECK: Use the -disable-sil-ownership-verifier to disable this check.
 // CHECK: Invalid lifetime of value whose availability boundary is being visited.
 sil [ossa] @leak_c : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):

--- a/validation-test/SILOptimizer/ossa_lifetime_completion_crash.sil
+++ b/validation-test/SILOptimizer/ossa_lifetime_completion_crash.sil
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -sil-print-types \
+// RUN:     -test-runner                             \
+// RUN:     %s                                       \
+// RUN:     -sil-disable-input-verify                \
+// RUN:     -o /dev/null                             \
+// RUN: 2>&1 | tee %t/out
+// RUN: %FileCheck %s < %t/out
+
+
+
+class C {}
+
+// CHECK: Invalid SIL provided to OSSALifetimeCompletion?!
+// CHECK: OSSALifetimeCompletion is visiting the availability boundary of %0 = argument of bb0 : $C
+// CHECK: When walking forward from the def to the availability boundary a non-dead-end successor-less block was encountered: bb0
+// CHECK: Its terminator must be an unreachable but is actually instead   return undef : $()                              // id: %1
+// CHECK: The walk stops at consumes, so reaching such a block means the value was leaked.  The function with the leak is as follows:
+// CHECK: sil [ossa] @leak_c : $@convention(thin) (@owned C) -> () {
+// CHECK: bb0(%0 : @owned $C):
+// CHECK:   return undef : $()
+// CHECK: } // end sil function 'leak_c'
+// CHECK: Invalid SIL provided to OSSALifetimeCompletion?!
+// CHECK: Something that ran before OSSALifetimeCompletion (the current pass, an earlier pass, SILGen) has introduced a leak of this value.
+// CHECK: Please rerun the crashing swift-frontend command with the following flags added and file a bug with the output:
+// CHECK: -sil-ownership-verify-all -Xllvm '-sil-print-function=leak_c' -Xllvm -sil-print-types -Xllvm -sil-print-module-on-error
+// CHECK: Invalid lifetime of value whose availability boundary is being visited.
+sil [ossa] @leak_c : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  specify_test "ossa_lifetime_completion @argument availability"
+  return undef : $()
+}

--- a/validation-test/SILOptimizer/ossa_lifetime_completion_no_crash.sil
+++ b/validation-test/SILOptimizer/ossa_lifetime_completion_no_crash.sil
@@ -1,0 +1,16 @@
+// RUN: %target-sil-opt -sil-print-types    \
+// RUN:     -test-runner                    \
+// RUN:     %s                              \
+// RUN:     -sil-disable-input-verify       \
+// RUN:     -disable-sil-ownership-verifier \
+// RUN:     -o /dev/null                    \
+// RUN: 2>&1 | %FileCheck %s
+
+class C {}
+
+// CHECK: end running test
+sil [ossa] @leak_c : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  specify_test "ossa_lifetime_completion @argument availability"
+  return undef : $()
+}


### PR DESCRIPTION
Use `llvm::report_fatal_error` instead.  Also, add logging to clarify that reaching this point is a bug in the incoming SIL.
