### PR TITLE
[Windows] Use a multiroot data file to test (corelibs-)foundation on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2842,12 +2842,16 @@ function Build-Foundation {
 }
 
 function Test-Foundation {
+  $ScratchPath = "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests"
+
   # Foundation tests build via swiftpm rather than CMake
   Build-SPMProject `
     -Action Test `
     -Src $SourceCache\swift-foundation `
-    -Bin "$BinaryCache\$($BuildPlatform.Triple)\CoreFoundationTests" `
-    -Platform $BuildPlatform
+    -Bin "$ScratchPath" `
+    -Platform $BuildPlatform `
+    --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+    --test-product swift-foundationPackageTests
 
   Invoke-IsolatingEnvVars {
     $env:DISPATCH_INCLUDE_PATH="$(Get-SwiftSDK $BuildPlatform.OS)/usr/include"
@@ -2859,10 +2863,10 @@ function Test-Foundation {
     Build-SPMProject `
       -Action Test `
       -Src $SourceCache\swift-corelibs-foundation `
-      -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
+      -Bin "$ScratchPath" `
       -Platform $BuildPlatform `
-      -Configuration $FoundationTestConfiguration `
-      -j 1 # Running parallel causes a non-deterministic crash in CI only, see https://github.com/swiftlang/swift/issues/83606
+      --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+      --test-product swift-corelibs-foundationPackageTests
   }
 }
 

--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -6,10 +6,13 @@
    <FileRef location = "group:../../../../sourcekit-lsp"></FileRef>
    <FileRef location = "group:../../../../swift-argument-parser"></FileRef>
    <FileRef location = "group:../../../../swift-collections"></FileRef>
+   <FileRef location = "group:../../../../swift-corelibs-foundation"></FileRef>
    <FileRef location = "group:../../../../swift-crypto"></FileRef>
    <FileRef location = "group:../../../../swift-docc"></FileRef>
    <FileRef location = "group:../../../../swift-driver"></FileRef>
    <FileRef location = "group:../../../../swift-format"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation-icu"></FileRef>
    <FileRef location = "group:../../../../swift-stress-tester/SourceKitStressTester"></FileRef>
    <FileRef location = "group:../../../../swift-syntax"></FileRef>
    <FileRef location = "group:../../../../swift-syntax/CodeGeneration"></FileRef>


### PR DESCRIPTION
Re-lands https://github.com/swiftlang/swift/pull/80122 but with release instead of debug for now because of the fatalError issue we're seeing. This still saves us 5-10 minutes on top of what we have today.