### PR TITLE
[CS] Use apply component locator for `verifyThatArgumentIsHashable`

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -260,6 +260,10 @@ public:
   /// of the key path at some index.
   bool isKeyPathMemberComponent() const;
 
+  /// Determine whether this locator points to an apply component of the key
+  /// path at some index.
+  bool isKeyPathApplyComponent() const;
+
   /// Determine whether this locator points to the member found
   /// via key path dynamic member lookup.
   bool isForKeyPathDynamicMemberLookup() const;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6405,7 +6405,8 @@ SourceLoc KeyPathSubscriptIndexHashableFailure::getLoc() const {
   auto *locator = getLocator();
 
   if (locator->isKeyPathSubscriptComponent() ||
-      locator->isKeyPathMemberComponent()) {
+      locator->isKeyPathMemberComponent() ||
+      locator->isKeyPathApplyComponent()) {
     auto *KPE = castToExpr<KeyPathExpr>(getAnchor());
     if (auto kpElt = locator->findFirst<LocatorPathElt::KeyPathComponent>())
       return KPE->getComponents()[kpElt->getIndex()].getLoc();
@@ -6417,7 +6418,7 @@ SourceLoc KeyPathSubscriptIndexHashableFailure::getLoc() const {
 bool KeyPathSubscriptIndexHashableFailure::diagnoseAsError() {
   auto *locator = getLocator();
   emitDiagnostic(diag::expr_keypath_arg_or_index_not_hashable,
-                 !locator->isKeyPathMemberComponent(),
+                 !locator->isKeyPathApplyComponent(),
                  resolveType(NonConformingType));
   return true;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1707,9 +1707,10 @@ public:
   KeyPathSubscriptIndexHashableFailure(const Solution &solution, Type type,
                                        ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator), NonConformingType(type) {
-    assert((locator->isResultOfKeyPathDynamicMemberLookup() ||
-            locator->isKeyPathSubscriptComponent()) ||
-           locator->isKeyPathMemberComponent());
+    assert(locator->isResultOfKeyPathDynamicMemberLookup() ||
+           locator->isKeyPathSubscriptComponent() ||
+           locator->isKeyPathMemberComponent() ||
+           locator->isKeyPathApplyComponent());
   }
 
   SourceLoc getLoc() const override;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1198,7 +1198,6 @@ namespace {
     /// component kind.
     Type addApplyConstraints(
         Expr *anchor, Type memberTy, ArgumentList *argList,
-        ConstraintLocator *memberComponentLoc,
         ConstraintLocator *applyComponentLoc,
         SmallVectorImpl<TypeVariableType *> *addedTypeVars = nullptr) {
       // Locators used in this expression.
@@ -1225,7 +1224,7 @@ namespace {
       for (auto index : indices(params)) {
         const auto &param = params[index];
         CS.verifyThatArgumentIsHashable(index, param.getParameterType(),
-                                        memberComponentLoc, loc);
+                                        applyComponentLoc, loc);
       }
 
       // Add the constraint that the index expression's type be convertible
@@ -3895,11 +3894,8 @@ namespace {
 
         case KeyPathExpr::Component::Kind::UnresolvedApply:
         case KeyPathExpr::Component::Kind::Apply: {
-          auto prevMemberLocator = CS.getConstraintLocator(
-              locator, LocatorPathElt::KeyPathComponent(i - 1));
           base = addApplyConstraints(E, base, component.getArgs(),
-                                     prevMemberLocator, memberLocator,
-                                     &componentTypeVars);
+                                     memberLocator, &componentTypeVars);
           break;
         }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9221,9 +9221,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // If this is an implicit Hashable conformance check generated for each
     // index argument of the keypath subscript component, we could just treat
     // it as though it conforms.
-    if ((loc->isResultOfKeyPathDynamicMemberLookup() ||
-         loc->isKeyPathSubscriptComponent()) ||
-        loc->isKeyPathMemberComponent()) {
+    if (loc->isResultOfKeyPathDynamicMemberLookup() ||
+        loc->isKeyPathSubscriptComponent() ||
+        loc->isKeyPathMemberComponent() ||
+        loc->isKeyPathApplyComponent()) {
       if (protocol ==
           getASTContext().getProtocol(KnownProtocolKind::Hashable)) {
         auto *fix =

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -627,6 +627,13 @@ bool ConstraintLocator::isKeyPathMemberComponent() const {
   });
 }
 
+bool ConstraintLocator::isKeyPathApplyComponent() const {
+  return hasKeyPathComponent(this, [](auto kind) {
+    return kind == KeyPathExpr::Component::Kind::Apply ||
+           kind == KeyPathExpr::Component::Kind::UnresolvedApply;
+  });
+}
+
 bool ConstraintLocator::isForKeyPathDynamicMemberLookup() const {
   auto path = getPath();
   return !path.empty() && path.back().isKeyPathDynamicMember();

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -596,41 +596,34 @@ bool ConstraintLocator::isResultOfKeyPathDynamicMemberLookup() const {
   });
 }
 
-bool ConstraintLocator::isKeyPathSubscriptComponent() const {
-  auto *anchor = getAsExpr(getAnchor());
-  auto *KPE = dyn_cast_or_null<KeyPathExpr>(anchor);
+static bool hasKeyPathComponent(
+    const ConstraintLocator *loc,
+    llvm::function_ref<bool(KeyPathExpr::Component::Kind)> predicate) {
+  auto *KPE = getAsExpr<KeyPathExpr>(loc->getAnchor());
   if (!KPE)
     return false;
 
-  using ComponentKind = KeyPathExpr::Component::Kind;
-  return llvm::any_of(getPath(), [&](const LocatorPathElt &elt) {
+  return llvm::any_of(loc->getPath(), [&](const LocatorPathElt &elt) {
     auto keyPathElt = elt.getAs<LocatorPathElt::KeyPathComponent>();
     if (!keyPathElt)
       return false;
 
-    auto index = keyPathElt->getIndex();
-    auto &component = KPE->getComponents()[index];
-    return component.getKind() == ComponentKind::Subscript ||
-           component.getKind() == ComponentKind::UnresolvedSubscript;
+    auto &component = KPE->getComponents()[keyPathElt->getIndex()];
+    return predicate(component.getKind());
+  });
+}
+
+bool ConstraintLocator::isKeyPathSubscriptComponent() const {
+  return hasKeyPathComponent(this, [](auto kind) {
+    return kind == KeyPathExpr::Component::Kind::Subscript ||
+           kind == KeyPathExpr::Component::Kind::UnresolvedSubscript;
   });
 }
 
 bool ConstraintLocator::isKeyPathMemberComponent() const {
-  auto *anchor = getAsExpr(getAnchor());
-  auto *KPE = dyn_cast_or_null<KeyPathExpr>(anchor);
-  if (!KPE)
-    return false;
-
-  using ComponentKind = KeyPathExpr::Component::Kind;
-  return llvm::any_of(getPath(), [&](const LocatorPathElt &elt) {
-    auto keyPathElt = elt.getAs<LocatorPathElt::KeyPathComponent>();
-    if (!keyPathElt)
-      return false;
-
-    auto index = keyPathElt->getIndex();
-    auto &component = KPE->getComponents()[index];
-    return component.getKind() == ComponentKind::Member ||
-           component.getKind() == ComponentKind::UnresolvedMember;
+  return hasKeyPathComponent(this, [](auto kind) {
+    return kind == KeyPathExpr::Component::Kind::Member ||
+           kind == KeyPathExpr::Component::Kind::UnresolvedMember;
   });
 }
 

--- a/validation-test/compiler_crashers_2_fixed/3c95e32711989555.swift
+++ b/validation-test/compiler_crashers_2_fixed/3c95e32711989555.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::ProtocolDecl*, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 \_(error)

--- a/validation-test/compiler_crashers_2_fixed/5f26ba86c56cc88.swift
+++ b/validation-test/compiler_crashers_2_fixed/5f26ba86c56cc88.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::getCalleeLocator(swift::constraints::ConstraintLocator*, bool, llvm::function_ref<swift::Type (swift::Expr*)>, llvm::function_ref<swift::Type (swift::Type)>, llvm::function_ref<std::__1::optional<swift::constraints::SelectedOverload> (swift::constraints::ConstraintLocator*)>)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a func b(c : [Int]) {
   \ a(c.map{})


### PR DESCRIPTION
For a method key path use the locator for the apply itself rather than the member, ensuring we handle invalid cases where the apply is the first component, and providing more accurate location info.

rdar://157720159