### PR TITLE
[Dependency Scanning] Fix optional import statement serialization logic

### DIFF
--- a/include/swift/DependencyScan/DependencyScanImpl.h
+++ b/include/swift/DependencyScan/DependencyScanImpl.h
@@ -65,6 +65,9 @@ struct swiftscan_dependency_info_s {
   /// The list of source import infos.
   swiftscan_import_info_set_t *imports;
 
+  /// The list of source optional import infos.
+  swiftscan_import_info_set_t *optional_imports;
+
   /// Specific details of a particular kind of module.
   swiftscan_module_details_t details;
 };

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -41,7 +41,7 @@ using llvm::BCVBR;
 const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 10;
 /// Increment this on every change.
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 3;
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 4;
 
 /// Various identifiers in this format will rely on having their strings mapped
 /// using this ID.

--- a/lib/DependencyScan/DependencyScanJSON.cpp
+++ b/lib/DependencyScan/DependencyScanJSON.cpp
@@ -228,9 +228,13 @@ void writeLinkLibraries(llvm::raw_ostream &out,
 
 void writeImportInfos(llvm::raw_ostream &out,
                       const swiftscan_import_info_set_t *imports,
-                      unsigned indentLevel, bool trailingComma) {
+                      bool optional, unsigned indentLevel,
+                      bool trailingComma) {
   out.indent(indentLevel * 2);
-  out << "\"imports\": ";
+  if (optional)
+    out << "\"optionalImports\": ";
+  else
+    out << "\"imports\": ";
   out << "[\n";
 
   for (size_t i = 0; i < imports->count; ++i) {
@@ -441,7 +445,9 @@ void writeJSON(llvm::raw_ostream &out,
                         /*trailingComma=*/true);
       writeLinkLibraries(out, moduleInfo.link_libraries,
                          3, /*trailingComma=*/true);
-      writeImportInfos(out, moduleInfo.imports,
+      writeImportInfos(out, moduleInfo.imports, /*optional*/ false,
+                       3, /*trailingComma=*/true);
+      writeImportInfos(out, moduleInfo.optional_imports, /*optional*/ true,
                        3, /*trailingComma=*/true);
     }
     // Swift and Clang-specific details.

--- a/test/ScanDependencies/serialized_imports.swift
+++ b/test/ScanDependencies/serialized_imports.swift
@@ -40,10 +40,16 @@
 // CHECK-IMPORTS-NEXT:          "importLocations": [
 // CHECK-IMPORTS-NEXT:            {
 // CHECK-IMPORTS-NEXT:              "bufferIdentifier": "{{.*}}serialized_imports.swift",
-// CHECK-IMPORTS-NEXT:              "linuNumber": 49,
+// CHECK-IMPORTS-NEXT:              "linuNumber": 54,
 // CHECK-IMPORTS-NEXT:              "columnNumber": 8
 // CHECK-IMPORTS-NEXT:            }
-// CHECK-IMPORTS-NEXT:          ]
+
+// CHECK-IMPORTS:          "optionalImports": [
+// CHECK-IMPORTS-NEXT:        {
+// CHECK-IMPORTS-NEXT:          "identifier": "E_Private",
+// CHECK-IMPORTS-NEXT:          "accessLevel": "public"
 // CHECK-IMPORTS-NEXT:        }
+// CHECK-IMPORTS-NEXT:      ],
 
 import E
+import E.Private

--- a/test/ScanDependencies/serialized_imports.swift
+++ b/test/ScanDependencies/serialized_imports.swift
@@ -3,12 +3,14 @@
 // RUN: %empty-directory(%t/module-cache)
 
 // Run the scanner once, emitting the serialized scanner cache
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -enable-cross-import-overlays 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-SAVE
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -enable-cross-import-overlays -module-name deps 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-SAVE
 // RUN: llvm-bcanalyzer --dump %t/cache.moddepcache > %t/cache.moddepcache.initial.dump.txt
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix CHECK-IMPORTS
 
 // Run the scanner again, but now re-using previously-serialized cache
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -enable-cross-import-overlays 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-LOAD
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps_incremental.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -enable-cross-import-overlays -module-name deps 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-LOAD
 // RUN: llvm-bcanalyzer --dump %t/cache.moddepcache > %t/cache.moddepcache.dump.txt
+// RUN: %validate-json %t/deps_incremental.json | %FileCheck %s -check-prefix CHECK-IMPORTS
 
 // Ensure that the initial scan, and the secondary scan which just re-used the initial scan's results report
 // the same number of import statement nodes, ensuring that serialization-deserialization did not affect
@@ -22,8 +24,26 @@
 // CHECK-REMARK-SAVE: remark: Incremental module scan: Serializing module scanning dependency cache to:
 // CHECK-REMARK-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
 
+// CHECK-IMPORTS:      "modulePath": "deps.swiftmodule",
+// CHECK-IMPORTS:      "imports": [
+// CHECK-IMPORTS-NEXT:        {
+// CHECK-IMPORTS-NEXT:          "identifier": "Swift",
+// CHECK-IMPORTS-NEXT:          "accessLevel": "public"
+// CHECK-IMPORTS-NEXT:        },
+// CHECK-IMPORTS-NEXT:        {
+// CHECK-IMPORTS-NEXT:          "identifier": "SwiftOnoneSupport",
+// CHECK-IMPORTS-NEXT:          "accessLevel": "public"
+// CHECK-IMPORTS-NEXT:        },
+// CHECK-IMPORTS-NEXT:        {
+// CHECK-IMPORTS-NEXT:          "identifier": "E",
+// CHECK-IMPORTS-NEXT:          "accessLevel": "public",
+// CHECK-IMPORTS-NEXT:          "importLocations": [
+// CHECK-IMPORTS-NEXT:            {
+// CHECK-IMPORTS-NEXT:              "bufferIdentifier": "{{.*}}serialized_imports.swift",
+// CHECK-IMPORTS-NEXT:              "linuNumber": 49,
+// CHECK-IMPORTS-NEXT:              "columnNumber": 8
+// CHECK-IMPORTS-NEXT:            }
+// CHECK-IMPORTS-NEXT:          ]
+// CHECK-IMPORTS-NEXT:        }
+
 import E
-
-
-
-


### PR DESCRIPTION
Previously, serialization of optional import statement node arrays erroneously used the node layout of a non-optional import node array while maintaining a separate index for these arrays which got serialized into each module's info node. This meant it got serialized out in a sequence of non-optional import arrays, and as a result, the consumer deserialized them as such, which broke ordering of which arrays of import nodes belong which module, causing mismatches between a module's actual import set and the import which got deserialized for it.

This change fixes the optional import serialization routine to use the purpose-made separate layout which gets read out according to the separate optional import array index.