### PR TITLE
AST: Request-ify getting the AvailabilityDomain from a ValueDecl

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -153,8 +153,7 @@ public:
 
   /// If `decl` represents an availability domain, returns the corresponding
   /// `AvailabilityDomain` value. Otherwise, returns `std::nullopt`.
-  static std::optional<AvailabilityDomain> forCustom(ValueDecl *decl,
-                                                     const ASTContext &ctx);
+  static std::optional<AvailabilityDomain> forCustom(ValueDecl *decl);
 
   static AvailabilityDomain forCustom(const CustomAvailabilityDomain *domain) {
     return AvailabilityDomain(domain);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2925,6 +2925,10 @@ private:
 
     /// Whether we've evaluated the ApplyAccessNoteRequest.
     unsigned accessNoteApplied : 1;
+
+    /// Whether the AvailabilityDomainForDeclRequest request was evaluated and
+    /// yielded no availability domain.
+    unsigned noAvailabilityDomain : 1;
   } LazySemanticInfo = { };
 
   friend class DynamicallyReplacedDeclRequest;
@@ -2938,6 +2942,7 @@ private:
   friend class ActorIsolationRequest;
   friend class OpaqueResultTypeRequest;
   friend class ApplyAccessNoteRequest;
+  friend class AvailabilityDomainForDeclRequest;
 
   friend class Decl;
   SourceLoc getLocFromSource() const { return NameLoc; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5424,6 +5424,26 @@ public:
   bool isCached() const { return true; }
 };
 
+class AvailabilityDomainForDeclRequest
+    : public SimpleRequest<AvailabilityDomainForDeclRequest,
+                           std::optional<AvailabilityDomain>(ValueDecl *),
+                           RequestFlags::Cached | RequestFlags::SplitCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  std::optional<AvailabilityDomain> evaluate(Evaluator &evaluator,
+                                             ValueDecl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+  std::optional<std::optional<AvailabilityDomain>> getCachedResult() const;
+  void cacheResult(std::optional<AvailabilityDomain> domain) const;
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -648,3 +648,7 @@ SWIFT_REQUEST(TypeChecker, BindExtensionsForIDEInspectionRequest,
 SWIFT_REQUEST(TypeChecker, ModuleHasTypeCheckerPerformanceHacksEnabledRequest,
               bool(const ModuleDecl *),
               Cached, NoLocationInfo)
+
+SWIFT_REQUEST(TypeChecker, AvailabilityDomainForDeclRequest,
+              std::optional<AvailabilityDomain>(ValueDecl *),
+              Cached | SplitCached, NoLocationInfo)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2837,3 +2837,28 @@ void SemanticAvailableAttrRequest::cacheResult(
   if (!value)
     attr->setInvalid();
 }
+
+//----------------------------------------------------------------------------//
+// AvailabilityDomainForDeclRequest computation.
+//----------------------------------------------------------------------------//
+
+std::optional<std::optional<AvailabilityDomain>>
+AvailabilityDomainForDeclRequest::getCachedResult() const {
+  auto decl = std::get<0>(getStorage());
+
+  if (decl->LazySemanticInfo.noAvailabilityDomain)
+    return std::optional<AvailabilityDomain>();
+  return decl->getASTContext().evaluator.getCachedNonEmptyOutput(*this);
+}
+
+void AvailabilityDomainForDeclRequest::cacheResult(
+    std::optional<AvailabilityDomain> domain) const {
+  auto decl = std::get<0>(getStorage());
+
+  if (!domain) {
+    decl->LazySemanticInfo.noAvailabilityDomain = 1;
+    return;
+  }
+
+  decl->getASTContext().evaluator.cacheNonEmptyOutput(*this, std::move(domain));
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4103,7 +4103,7 @@ void ClangModuleUnit::lookupAvailabilityDomains(
   if (!imported)
     return;
 
-  auto customDomain = AvailabilityDomain::forCustom(imported, ctx);
+  auto customDomain = AvailabilityDomain::forCustom(imported);
   ASSERT(customDomain);
   results.push_back(*customDomain);
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5824,8 +5824,7 @@ decodeDomainKind(uint8_t kind) {
 
 static std::optional<AvailabilityDomain>
 decodeAvailabilityDomain(AvailabilityDomainKind domainKind,
-                         PlatformKind platformKind, ValueDecl *decl,
-                         const ASTContext &ctx) {
+                         PlatformKind platformKind, ValueDecl *decl) {
   switch (domainKind) {
   case AvailabilityDomainKind::Universal:
     return AvailabilityDomain::forUniversal();
@@ -5838,7 +5837,7 @@ decodeAvailabilityDomain(AvailabilityDomainKind domainKind,
   case AvailabilityDomainKind::Platform:
     return AvailabilityDomain::forPlatform(platformKind);
   case AvailabilityDomainKind::Custom:
-    return AvailabilityDomain::forCustom(decl, ctx);
+    return AvailabilityDomain::forCustom(decl);
   }
 }
 
@@ -5905,7 +5904,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
     }
   }
 
-  auto domain = decodeAvailabilityDomain(domainKind, platform, domainDecl, ctx);
+  auto domain = decodeAvailabilityDomain(domainKind, platform, domainDecl);
   if (!domain)
     return llvm::make_error<InavalidAvailabilityDomainError>();
 


### PR DESCRIPTION
Cache the result of turning a `ValueDecl` into an `AvailabilityDomain`. Use split caching to make the common case of the decl not representing an availability domain efficient.

NFC.