### PR TITLE
[stdlib, 6.2.x] guard against deinitializing empty OutputSpan instances

### DIFF
--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -315,6 +315,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func removeAll() {
+    guard count > 0 else { return }
     _ = unsafe _start().withMemoryRebound(to: Element.self, capacity: _count) {
       unsafe $0.deinitialize(count: _count)
     }


### PR DESCRIPTION
- Explanation: Before adding this guard, we could unwrap a nil pointer.

- Resolves: rdar://158440246

- Risk: Low. This is a targeted bug fix.

- Main branch PR: https://github.com/swiftlang/swift/pull/83771

- Reviewed by: @stephentyrone 

- Testing: added coverage for a nil-based `OutputSpan`