### PR TITLE
[Sema] Clean up extension binding a little

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2053,6 +2053,7 @@ class ExtensionDecl final : public GenericContext, public Decl,
   std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoaderSlow();
 
   friend class ExtendedNominalRequest;
+  friend class BindExtensionsRequest;
   friend class Decl;
 public:
   using Decl::getASTContext;
@@ -2090,13 +2091,14 @@ public:
   Type getExtendedType() const;
 
   /// Retrieve the nominal type declaration that is being extended.
-  /// Will  trip an assertion if the declaration has not already been computed.
+  /// Will trip an assertion if the declaration has not already been computed.
   /// In order to fail fast when type checking work is attempted
   /// before extension binding has taken place.
-
   NominalTypeDecl *getExtendedNominal() const;
 
-  /// Compute the nominal type declaration that is being extended.
+  /// Compute the nominal type declaration that is being extended. The result
+  /// is not cached, this should only be invoked by extension binding itself.
+  /// FIXME: Make this private once lldb has been migrated off it.
   NominalTypeDecl *computeExtendedNominal(
       bool excludeMacroExpansions=false) const;
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -267,7 +267,7 @@ public:
 /// Request the nominal declaration extended by a given extension declaration.
 class ExtendedNominalRequest
     : public SimpleRequest<
-          ExtendedNominalRequest, NominalTypeDecl *(ExtensionDecl *, bool),
+          ExtendedNominalRequest, NominalTypeDecl *(const ExtensionDecl *),
           RequestFlags::SeparatelyCached | RequestFlags::DependencySink> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -276,8 +276,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  NominalTypeDecl * evaluate(Evaluator &evaluator, ExtensionDecl *ext,
-                             bool excludeMacroExpansions) const;
+  NominalTypeDecl * evaluate(Evaluator &evaluator, const ExtensionDecl *ext) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -32,7 +32,7 @@ SWIFT_REQUEST(NameLookup, DirectPrecedenceGroupLookupRequest,
               TinyPtrVector<PrecedenceGroupDecl *>(OperatorLookupDescriptor),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
-              NominalTypeDecl *(ExtensionDecl *), SeparatelyCached,
+              NominalTypeDecl *(const ExtensionDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, GenericParamListRequest,
               GenericParamList *(GenericContext *), SeparatelyCached,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5437,11 +5437,9 @@ public:
   bool isCached() const { return true; }
 };
 
-/// A request that allows IDE inspection to lazily kick extension binding after
-/// it has finished mutating the AST. This will eventually be subsumed when we
-/// properly requestify extension binding.
-class BindExtensionsForIDEInspectionRequest
-    : public SimpleRequest<BindExtensionsForIDEInspectionRequest,
+/// Performs extension binding for all of the extensions in a module.
+class BindExtensionsRequest
+    : public SimpleRequest<BindExtensionsRequest,
                            evaluator::SideEffect(ModuleDecl *),
                            RequestFlags::Cached> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -647,7 +647,7 @@ SWIFT_REQUEST(TypeChecker, DefaultIsolationInSourceFileRequest,
               std::optional<DefaultIsolation>(const SourceFile *),
               Cached, NoLocationInfo)
 
-SWIFT_REQUEST(TypeChecker, BindExtensionsForIDEInspectionRequest,
+SWIFT_REQUEST(TypeChecker, BindExtensionsRequest,
               evaluator::SideEffect(ModuleDecl *),
               Cached, NoLocationInfo)
 

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -24,6 +24,7 @@ class ModuleDecl;
 class SourceLoader : public ModuleLoader {
 private:
   ASTContext &Ctx;
+  std::vector<ModuleDecl *> ModulesToBindExtensions;
   bool EnableLibraryEvolution;
 
   explicit SourceLoader(ASTContext &ctx,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2097,24 +2097,8 @@ ExtensionDecl::takeConformanceLoaderSlow() {
 }
 
 NominalTypeDecl *ExtensionDecl::getExtendedNominal() const {
-  if (hasBeenBound()) {
-    return ExtendedNominal.getPointer();
-  } else if (canNeverBeBound()) {
-    return computeExtendedNominal();
-  }
-
-  llvm_unreachable(
-      "Extension must have already been bound (by bindExtensions)");
-}
-
-NominalTypeDecl *ExtensionDecl::computeExtendedNominal(
-    bool excludeMacroExpansions) const {
-  ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-                           ExtendedNominalRequest{
-                               const_cast<ExtensionDecl *>(this),
-                               excludeMacroExpansions},
-                           nullptr);
+  auto &eval = getASTContext().evaluator;
+  return evaluateOrDefault(eval, ExtendedNominalRequest{this}, nullptr);
 }
 
 bool ExtensionDecl::canNeverBeBound() const {

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -205,22 +205,15 @@ HasMissingDesignatedInitializersRequest::evaluate(Evaluator &evaluator,
 
 std::optional<NominalTypeDecl *>
 ExtendedNominalRequest::getCachedResult() const {
-  // Note: if we fail to compute any nominal declaration, it's considered
-  // a cache miss. This allows us to recompute the extended nominal types
-  // during extension binding.
-  // This recomputation is also what allows you to extend types defined inside
-  // other extensions, regardless of source file order. See \c bindExtensions(),
-  // which uses a worklist algorithm that attempts to bind everything until
-  // fixed point.
   auto ext = std::get<0>(getStorage());
-  if (!ext->hasBeenBound() || !ext->getExtendedNominal())
+  if (!ext->hasBeenBound())
     return std::nullopt;
-  return ext->getExtendedNominal();
+  return ext->ExtendedNominal.getPointer();
 }
 
 void ExtendedNominalRequest::cacheResult(NominalTypeDecl *value) const {
   auto ext = std::get<0>(getStorage());
-  ext->setExtendedNominal(value);
+  const_cast<ExtensionDecl *>(ext)->setExtendedNominal(value);
 }
 
 void ExtendedNominalRequest::writeDependencySink(

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -14,6 +14,7 @@
 #include "CodeCompletionDiagnostics.h"
 #include "CodeCompletionResultBuilder.h"
 #include "ExprContextAnalysis.h"
+#include "ReadyForTypeCheckingCallback.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Comment.h"
@@ -105,7 +106,7 @@ std::string swift::ide::removeCodeCompletionTokens(
 namespace {
 
 class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks,
-                                    public DoneParsingCallback {
+                                    public ReadyForTypeCheckingCallback {
   CodeCompletionContext &CompletionContext;
   CodeCompletionConsumer &Consumer;
   CodeCompletionExpr *CodeCompleteTokenExpr = nullptr;
@@ -214,8 +215,8 @@ public:
   CodeCompletionCallbacksImpl(Parser &P,
                               CodeCompletionContext &CompletionContext,
                               CodeCompletionConsumer &Consumer)
-      : CodeCompletionCallbacks(P), DoneParsingCallback(),
-        CompletionContext(CompletionContext), Consumer(Consumer) {}
+      : CodeCompletionCallbacks(P), CompletionContext(CompletionContext),
+        Consumer(Consumer) {}
 
   void setAttrTargetDeclKind(std::optional<DeclKind> DK) override {
     if (DK == DeclKind::PatternBinding)
@@ -290,7 +291,7 @@ public:
   void completeTypeAttrInheritanceBeginning() override;
   void completeOptionalBinding() override;
 
-  void doneParsing(SourceFile *SrcFile) override;
+  void readyForTypeChecking(SourceFile *SrcFile) override;
 
 private:
   void addKeywords(CodeCompletionResultSink &Sink, bool MaybeFuncBody);
@@ -1622,7 +1623,7 @@ void CodeCompletionCallbacksImpl::afterPoundCompletion(SourceLoc CompletionLoc,
   Consumer.handleResults(CompletionContext);
 }
 
-void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
+void CodeCompletionCallbacksImpl::readyForTypeChecking(SourceFile *SrcFile) {
   CompletionContext.CodeCompletionKind = Kind;
 
   if (Kind == CompletionKind::None) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -175,25 +175,6 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks,
 
   /// \returns true on success, false on failure.
   bool typecheckParsedType() {
-    // If the type appeared inside an extension, make sure that extension has
-    // been bound.
-    auto SF = CurDeclContext->getParentSourceFile();
-    auto visitTopLevelDecl = [&](Decl *D) {
-      if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-        if (ED->getSourceRange().contains(ParsedTypeLoc.getLoc())) {
-          ED->computeExtendedNominal();
-        }
-      }
-    };
-    for (auto item : SF->getTopLevelItems()) {
-      if (auto D = item.dyn_cast<Decl *>()) {
-        visitTopLevelDecl(D);
-      }
-    }
-    for (auto *D : SF->getHoistedDecls()) {
-      visitTopLevelDecl(D);
-    }
-
     assert(ParsedTypeLoc.getTypeRepr() && "should have a TypeRepr");
     if (ParsedTypeLoc.wasValidated() && !ParsedTypeLoc.isError()) {
       return true;

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/IDE/CursorInfo.h"
 #include "ExprContextAnalysis.h"
+#include "ReadyForTypeCheckingCallback.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
@@ -374,14 +375,14 @@ public:
 
 // MARK: - CursorInfoDoneParsingCallback
 
-class CursorInfoDoneParsingCallback : public DoneParsingCallback {
+class CursorInfoDoneParsingCallback : public ReadyForTypeCheckingCallback {
   CursorInfoConsumer &Consumer;
   SourceLoc RequestedLoc;
 
 public:
   CursorInfoDoneParsingCallback(Parser &P, CursorInfoConsumer &Consumer,
                                 SourceLoc RequestedLoc)
-      : DoneParsingCallback(), Consumer(Consumer), RequestedLoc(RequestedLoc) {}
+      : Consumer(Consumer), RequestedLoc(RequestedLoc) {}
 
 private:
   /// Shared core of `getExprResult` and `getDeclResult`.
@@ -489,7 +490,7 @@ public:
                      SrcFile, Finder);
   }
 
-  void doneParsing(SourceFile *SrcFile) override {
+  void readyForTypeChecking(SourceFile *SrcFile) override {
     if (!SrcFile) {
       return;
     }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Sema/IDETypeChecking.h"
+#include "ReadyForTypeCheckingCallback.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTPrinter.h"
@@ -32,9 +33,11 @@
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Sema/IDETypeCheckingRequests.h"
+#include "swift/Subsystems.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace swift;
+using namespace ide;
 
 void swift::getTopLevelDeclsForDisplay(ModuleDecl *M,
                                        SmallVectorImpl<Decl *> &Results,
@@ -1027,4 +1030,12 @@ swift::getShorthandShadows(LabeledConditionalStmt *CondStmt, DeclContext *DC) {
     });
   }
   return Result;
+}
+
+void ReadyForTypeCheckingCallback::doneParsing(SourceFile *SrcFile) {
+  // Import resolution will have already been done by IDEInspectionInstance,
+  // we need to bind extensions here though since IDEInspectionSecondPassRequest
+  // can mutate the AST.
+  bindExtensions(*SrcFile->getParentModule());
+  readyForTypeChecking(SrcFile);
 }

--- a/lib/IDE/ReadyForTypeCheckingCallback.h
+++ b/lib/IDE/ReadyForTypeCheckingCallback.h
@@ -1,0 +1,37 @@
+//===--- ReadyForTypeCheckingCallback.h -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_READYFORTYPECHECKINGCALLBACK_H
+#define SWIFT_IDE_READYFORTYPECHECKINGCALLBACK_H
+
+#include "swift/Parse/IDEInspectionCallbacks.h"
+
+namespace swift {
+namespace ide {
+
+/// IDE inspection callback that is invoked once the resulting AST is ready
+/// for type-checking work.
+class ReadyForTypeCheckingCallback : public DoneParsingCallback {
+public:
+  virtual ~ReadyForTypeCheckingCallback() {}
+
+  virtual void doneParsing(SourceFile *SrcFile) override;
+
+  /// Called when the AST has been parsed and had its imports resolved and
+  /// extensions bound.
+  virtual void readyForTypeChecking(SourceFile *SrcFile) = 0;
+};
+
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_READYFORTYPECHECKINGCALLBACK_H

--- a/lib/IDE/SignatureHelp.cpp
+++ b/lib/IDE/SignatureHelp.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/IDE/SignatureHelp.h"
+#include "ReadyForTypeCheckingCallback.h"
 #include "swift/IDE/ArgumentCompletion.h"
 #include "swift/Sema/IDETypeChecking.h"
 
@@ -20,7 +21,7 @@ using namespace swift::constraints;
 
 namespace {
 class SignatureHelpCallbacks : public CodeCompletionCallbacks,
-                               public DoneParsingCallback {
+                               public ReadyForTypeCheckingCallback {
   SignatureHelpConsumer &Consumer;
   SourceLoc Loc;
   CodeCompletionExpr *CCExpr = nullptr;
@@ -28,14 +29,14 @@ class SignatureHelpCallbacks : public CodeCompletionCallbacks,
 
 public:
   SignatureHelpCallbacks(Parser &P, SignatureHelpConsumer &Consumer)
-      : CodeCompletionCallbacks(P), DoneParsingCallback(), Consumer(Consumer) {}
+      : CodeCompletionCallbacks(P), Consumer(Consumer) {}
 
   // Only handle callbacks for argument completions.
   // {
   void completeCallArg(CodeCompletionExpr *E) override;
   // }
 
-  void doneParsing(SourceFile *SrcFile) override;
+  void readyForTypeChecking(SourceFile *SrcFile) override;
 };
 
 void SignatureHelpCallbacks::completeCallArg(CodeCompletionExpr *E) {
@@ -43,7 +44,7 @@ void SignatureHelpCallbacks::completeCallArg(CodeCompletionExpr *E) {
   CCExpr = E;
 }
 
-void SignatureHelpCallbacks::doneParsing(SourceFile *SrcFile) {
+void SignatureHelpCallbacks::readyForTypeChecking(SourceFile *SrcFile) {
   if (!CCExpr)
     return;
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/IDE/TypeContextInfo.h"
 #include "ExprContextAnalysis.h"
+#include "ReadyForTypeCheckingCallback.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/USRGeneration.h"
@@ -27,7 +28,7 @@ using namespace swift;
 using namespace ide;
 
 class ContextInfoCallbacks : public CodeCompletionCallbacks,
-                             public DoneParsingCallback {
+                             public ReadyForTypeCheckingCallback {
   TypeContextInfoConsumer &Consumer;
   SourceLoc Loc;
   Expr *ParsedExpr = nullptr;
@@ -37,7 +38,7 @@ class ContextInfoCallbacks : public CodeCompletionCallbacks,
 
 public:
   ContextInfoCallbacks(Parser &P, TypeContextInfoConsumer &Consumer)
-      : CodeCompletionCallbacks(P), DoneParsingCallback(), Consumer(Consumer) {}
+      : CodeCompletionCallbacks(P), Consumer(Consumer) {}
 
   void completePostfixExprBeginning(CodeCompletionExpr *E) override;
   void completeForEachSequenceBeginning(CodeCompletionExpr *E) override;
@@ -52,7 +53,7 @@ public:
   void completeUnresolvedMember(CodeCompletionExpr *E,
                                 SourceLoc DotLoc) override;
 
-  void doneParsing(SourceFile *SrcFile) override;
+  void readyForTypeChecking(SourceFile *SrcFile) override;
 };
 
 void ContextInfoCallbacks::completePostfixExprBeginning(CodeCompletionExpr *E) {
@@ -111,7 +112,7 @@ public:
   ArrayRef<Type> getTypes() const { return Types; }
 };
 
-void ContextInfoCallbacks::doneParsing(SourceFile *SrcFile) {
+void ContextInfoCallbacks::readyForTypeChecking(SourceFile *SrcFile) {
   if (!ParsedExpr)
     return;
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -210,13 +210,7 @@ void Parser::performIDEInspectionSecondPassImpl(
   assert(!State->hasIDEInspectionDelayedDeclState() &&
          "Second pass should not set any code completion info");
 
-  auto *SF = DC->getParentSourceFile();
-
-  // Bind extensions if needed. This needs to be done here since we may have
-  // mutated the AST above.
-  bindExtensions(*SF->getParentModule());
-
-  DoneParsingCallback->doneParsing(SF);
+  DoneParsingCallback->doneParsing(DC->getParentSourceFile());
 
   State->restoreIDEInspectionDelayedDeclState(info);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -214,11 +214,7 @@ void Parser::performIDEInspectionSecondPassImpl(
 
   // Bind extensions if needed. This needs to be done here since we may have
   // mutated the AST above.
-  {
-    auto *M = SF->getParentModule();
-    BindExtensionsForIDEInspectionRequest req(M);
-    evaluateOrDefault(Context.evaluator, req, {});
-  }
+  bindExtensions(*SF->getParentModule());
 
   DoneParsingCallback->doneParsing(SF);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4002,11 +4002,6 @@ public:
       return;
     }
 
-    // Record a dependency from TypeCheckPrimaryFileRequest to
-    // ExtendedNominalRequest, since the call to getExtendedNominal()
-    // above doesn't record a dependency when reading a cached value.
-    ED->computeExtendedNominal();
-
     if (!extType->hasError()) {
       // The first condition catches syntactic forms like
       //     protocol A & B { ... } // may be protocols or typealiases


### PR DESCRIPTION
- Turn `BindExtensionsForIDEInspectionRequest` into the main extension binding request.
- Change `ExtendedNominalRequest` such that it's no longer what extension binding calls into to do the name lookup, instead it calls directly into `computeExtendedNominal`. `getExtendedNominal` can then be the entrypoint for `ExtendedNominalRequest` and assumes that extension binding has already run. This avoids needing to fake the dependency relationship in the DeclChecker.