### PR TITLE
[6.2.1][cherrypick] Plumb native-clang-tools-path to build support.

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -150,13 +150,15 @@ class CMake(object):
             define("CMAKE_CXX_COMPILER_LAUNCHER:PATH", args.cmake_cxx_launcher)
 
         if self.prefer_native_toolchain and product:
+            clang_tools_path = product.native_clang_tools_path(args.host_target)
+            define("CMAKE_C_COMPILER:PATH", os.path.join(clang_tools_path,
+                                                         'bin', 'clang'))
+            define("CMAKE_CXX_COMPILER:PATH", os.path.join(clang_tools_path,
+                                                           'bin', 'clang++'))
+
             toolchain_path = product.native_toolchain_path(args.host_target)
             cmake_swiftc_path = os.getenv('CMAKE_Swift_COMPILER',
                                           os.path.join(toolchain_path, 'bin', 'swiftc'))
-            define("CMAKE_C_COMPILER:PATH", os.path.join(toolchain_path,
-                                                         'bin', 'clang'))
-            define("CMAKE_CXX_COMPILER:PATH", os.path.join(toolchain_path,
-                                                           'bin', 'clang++'))
             define("CMAKE_Swift_COMPILER:PATH", cmake_swiftc_path)
         else:
             cmake_swiftc_path = os.getenv('CMAKE_Swift_COMPILER', toolchain.swiftc)

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -217,6 +217,12 @@ class Product(object):
         return targets.toolchain_path(install_destdir,
                                       self.args.install_prefix)
 
+    def native_clang_tools_path(self, host_target):
+        if self.args.native_clang_tools_path is not None:
+            return os.path.split(self.args.native_clang_tools_path)[0]
+        else:
+            return self.install_toolchain_path(host_target)
+
     def native_toolchain_path(self, host_target):
         if self.args.native_swift_tools_path is not None:
             return os.path.split(self.args.native_swift_tools_path)[0]

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -54,8 +54,9 @@ class SwiftPM(product.Product):
             self.source_dir, 'Utilities', 'bootstrap')
 
         toolchain_path = self.native_toolchain_path(host_target)
+        clang_tools_path = self.native_clang_tools_path(host_target)
         swiftc = os.path.join(toolchain_path, "bin", "swiftc")
-        clang = os.path.join(toolchain_path, "bin", "clang")
+        clang = os.path.join(clang_tools_path, "bin", "clang")
 
         # FIXME: We require llbuild build directory in order to build. Is
         # there a better way to get this?


### PR DESCRIPTION
- **Explanation**:

Ensures the native-clang-tools-path option works correctly with the build support modules.

The build support Python libraries assume by default that if we do not supply a Swift toolchain path, we can find clang in the installed toolchain path: i.e., the clang that we just built. However, possibly during bootstrap, we may not have a preexisting Swift compiler but still want to use the clang on the platform that is already installed.

build-script already gives us native-clang-tools-path. Here, we plumb this through to the relevant Python modules. If the native-clang-tools-path is not specified, we use the install_toolchain_path, just like native_toolchain_path, and the existing behavior is effectively unchanged. If we do specify a native-clang-tools-path, then we return it to ensure that we properly refer to the clang that lives there instead of always defaulting to the just-built clang.

(This is the same as #82768, applied to `release/6.2.1`.)

- **Scope**:

Changes are limited to the build system only, and as mentioned, if native-clang-tools-path is not specified, the behavior is unchanged. 

- **Issues**:

Of relevance to the OpenBSD port in #78437, since we likely do not want to use the just-built LLVM tools like clang as part of the installation.

- **Original PRs**:

#81587

- **Risk**:

Minimal, only potentially affects seldom-used flag.

- **Testing**:

Has passed CI.

- **Reviewers**:

@justice-adams-apple 