### PR TITLE
[cxx-interop] Make reverse interop header compile in embedded mode

### DIFF
--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -38,7 +38,11 @@ SWIFT_INLINE_THUNK T_0_0 get() const
 /// Constructs a Swift string from a C string.
 SWIFT_INLINE_THUNK String(const char *cString) noexcept {
   if (!cString) {
+#ifdef __EmbeddedSwift__
+    auto res = _impl::$eS2SycfC();
+#else
     auto res = _impl::$sS2SycfC();
+#endif
     memcpy(_getOpaquePointer(), &res, sizeof(res));
     return;
   }

--- a/test/Interop/SwiftToCxx/core/embedded-swift-execution.cpp
+++ b/test/Interop/SwiftToCxx/core/embedded-swift-execution.cpp
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/embedded-swift.swift -target arm64-apple-macosx15.0 -module-name Core -swift-version 6 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-embedded-execution.o -fno-exceptions -fno-rtti
+// RUN: %target-interop-build-swift -target arm64-apple-macosx15.0 -wmo %S/embedded-swift.swift -o %t/swift-embedded-execution -Xlinker %t/swift-embedded-execution.o -module-name Core -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature Embedded -Xcc -fno-rtti -Xcc -fno-exceptions -Xlinker %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a
+
+// RUN: %target-codesign %t/swift-embedded-execution
+// RUN: %target-run %t/swift-embedded-execution
+
+// REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: executable_test
+// REQUIRES: CPU=arm64e || CPU=arm64
+
+#include <assert.h>
+#include "core.h"
+
+int main() {
+  assert(Core::id(5) == 5);
+  return 0;
+}


### PR DESCRIPTION
These are the minimal changes to make the reverse interop header compile when embedded Swift is used. Previously, the _SwiftStdlibCxxOverlay.h and the generated interop header disagreed on the mangling of a symbol.

This is not sufficient yet to use the embedded Swift standard library from reverse interop, there are some missing symbols while linking. But this PR enables doing reverse interop without using the stdlib types like swift::String in C++. Follow-up PRs will fix the rest of the issues.

rdar://154740225
