### PR TITLE
[ClangImporter] Skip importing values for ObjCBool declarations

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1094,6 +1094,9 @@ public:
   /// on macOS or Foundation on Linux.
   bool isCGFloat();
 
+  /// Check if this is a ObjCBool type from the Objective-C module.
+  bool isObjCBool();
+
   /// Check if this is a std.string type from C++.
   bool isCxxString();
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1281,6 +1281,19 @@ bool TypeBase::isCGFloat() {
          NTD->getName().is("CGFloat");
 }
 
+bool TypeBase::isObjCBool() {
+  auto *NTD = getAnyNominal();
+  if (!NTD)
+    return false;
+
+  auto *DC = NTD->getDeclContext();
+  if (!DC->isModuleScopeContext())
+    return false;
+
+  auto *module = DC->getParentModule();
+  return module->getName().is("ObjectiveC") && NTD->getName().is("ObjCBool");
+}
+
 bool TypeBase::isCxxString() {
   auto *nominal = getAnyNominal();
   if (!nominal)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4572,8 +4572,11 @@ namespace {
           // CGFloats is special cased in the importer, and needs more handling.
           bool isCGFloat = (type && type->isCGFloat()) ||
                            (type && synthesizer.isCGFloat(type));
+          // Do not attempts to import ObjCBool values, for similar reasons.
+          bool isObjCBool = (type && type->isObjCBool()) ||
+                            (type && synthesizer.isObjCBool(type));
 
-          if (type && !isCGFloat) {
+          if (type && !isCGFloat && !isObjCBool) {
             auto convertKind = ConstantConvertKind::None;
             // Request conversions on enums, and swift_wrapper((enum/struct))
             // types

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -195,6 +195,8 @@ Type SwiftDeclSynthesizer::getConstantLiteralType(
   }
 }
 
+// This method is exposed on SwiftDeclSynthesizer to keep code that accesses
+// RawTypes together.
 bool SwiftDeclSynthesizer::isCGFloat(Type type) {
   auto found = ImporterImpl.RawTypes.find(type->getAnyNominal());
   if (found == ImporterImpl.RawTypes.end()) {
@@ -203,6 +205,18 @@ bool SwiftDeclSynthesizer::isCGFloat(Type type) {
   
   Type importTy = found->second;
   return importTy->isCGFloat();
+}
+
+// This method is exposed on SwiftDeclSynthesizer to keep code that accesses
+// RawTypes together.
+bool SwiftDeclSynthesizer::isObjCBool(Type type) {
+  auto found = ImporterImpl.RawTypes.find(type->getAnyNominal());
+  if (found == ImporterImpl.RawTypes.end()) {
+    return false;
+  }
+  
+  Type importTy = found->second;
+  return importTy->isObjCBool();
 }
 
 ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -354,6 +354,8 @@ public:
 
   bool isCGFloat(Type type);
 
+  bool isObjCBool(Type type);
+
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 

--- a/test/ClangImporter/const_values_objc.swift
+++ b/test/ClangImporter/const_values_objc.swift
@@ -31,6 +31,9 @@ static const MyFloatType MyFloatTypeValue1 = 10;
 static const MyFloatType MyFloatTypeValue2 = 20;
 static const MyFloatType MyFloatTypeValue3 = 30;
 
+static const BOOL MyBoolConstantValue1 = YES;
+static const BOOL MyBoolConstantValue2 = NO;
+
 //--- main.swift
 func foo() {
   print(MyClass.value)
@@ -38,6 +41,8 @@ func foo() {
   print(MyFloatType.value1)
   print(MyFloatType.value2)
   print(MyFloatType.value3)
+  print(MyBoolConstantValue1)
+  print(MyBoolConstantValue2)
 }
 
 // CHECK:      // static MyClass.value.getter
@@ -57,3 +62,8 @@ func foo() {
 // CHECK-NOT: // static MyFloatType.value1.getter
 // CHECK-NOT: // static MyFloatType.value2.getter
 // CHECK-NOT: // static MyFloatType.value3.getter
+
+// ObjCBools are not imported:
+
+// CHECK-NOT: // MyBoolConstantValue1.getter
+// CHECK-NOT: // MyBoolConstantValue2.getter

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
@@ -13,6 +13,8 @@ typedef int NSInteger;
 #endif
 
 typedef __typeof__(__objc_yes) BOOL;
+#define YES __objc_yes
+#define NO  __objc_no
 
 typedef struct objc_selector    *SEL;
 SEL sel_registerName(const char *str);


### PR DESCRIPTION
Same story as in <https://github.com/swiftlang/swift/pull/83238>, but for ObjCBool, see the rationale for the previous change:

> This solves a compiler crasher, for which a reproducer is in the attached lit test. The existing logic tries to skip CGFloat from getting their constant values imported -- this is because importing CGFloats is special cased and needs more work to work correctly. However, we were failing to skip importing a CGFloat if it was used under a typedef with a different name. In this case, the code in VisitVarDecl attempted to recognize a CGFloat through type->isCGFloat() which is not enough (the type is not a CGFloat directly, it's a typedef instead). Let's instead ask the SwiftDeclSynthesizer directly if it's going to import the type as a CGFloat.

rdar://158245295