### PR TITLE
[cxx-interop] Validate C foreign reference types

### DIFF
--- a/test/Interop/C/struct/Inputs/foreign-reference-invalid.h
+++ b/test/Interop/C/struct/Inputs/foreign-reference-invalid.h
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:nonexistent")))
+__attribute__((swift_attr("release:nonexistent"))) NonExistent {
+  int value;
+};
+
+struct __attribute__((swift_attr("import_reference"))) NoRetainRelease {
+  int value;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:badRetain")))
+__attribute__((swift_attr("release:badRelease"))) BadRetainRelease {
+  int value;
+};
+
+float badRetain(struct BadRetainRelease *v);
+void badRelease(struct BadRetainRelease *v, int i);

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -7,6 +7,10 @@ module ForeignReference {
   header "foreign-reference.h"
 }
 
+module ForeignReferenceInvalid {
+  header "foreign-reference-invalid.h"
+}
+
 module StructAsOptionSet {
   header "struct-as-option-set.h"
 }

--- a/test/Interop/C/struct/foreign-reference-invalid-typechecker.swift
+++ b/test/Interop/C/struct/foreign-reference-invalid-typechecker.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs -disable-availability-checking -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import ForeignReferenceInvalid
+
+// CHECK: error: cannot find retain function 'nonexistent' for reference type 'NonExistent'
+// CHECK: error: cannot find release function 'nonexistent' for reference type 'NonExistent'
+public func test(x: NonExistent) { }
+
+// CHECK: error: reference type 'NoRetainRelease' must have 'retain:' Swift attribute
+// CHECK: error: reference type 'NoRetainRelease' must have 'release:' Swift attribute
+public func test(x: NoRetainRelease) { }
+
+// CHECK: error: specified retain function 'badRetain' is invalid; retain function must either return have 'void', the reference count as an integer, or the parameter type
+// CHECK: error: specified release function 'badRelease' is invalid; release function must have exactly one argument of type 'BadRetainRelease'
+public func test(x: BadRetainRelease) { }


### PR DESCRIPTION
Swift validates the retain/release operations for foreign reference types to check for obvious errors, e.g. a wrong parameter type or return type.

That logic was only running for C++ foreign reference types. This patch enables it for C foreign reference types as well.

rdar://158609723

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
