### PR TITLE
[embedded] When loading (sub-)modules, propagate the Embedded flag and use it for hash computation

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2083,6 +2083,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // Inherit Embedded Swift
   if (langOpts.hasFeature(Feature::Embedded)) {
     genericSubInvocation.getLangOptions().enableFeature(Feature::Embedded);
+    GenericArgs.push_back("-enable-experimental-feature");
+    GenericArgs.push_back("Embedded");
   }
 }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2079,6 +2079,11 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
       GenericArgs.push_back("-stdlib=libc++");
     }
   }
+
+  // Inherit Embedded Swift
+  if (langOpts.hasFeature(Feature::Embedded)) {
+    genericSubInvocation.getLangOptions().enableFeature(Feature::Embedded);
+  }
 }
 
 /// Calculate an output filename in \p genericSubInvocation's cache path that
@@ -2912,7 +2917,10 @@ static std::string getContextHash(const CompilerInvocation &CI,
       unsigned(CI.getSILOptions().EnableOSSAModules),
 
       // Is the C++ interop enabled?
-      unsigned(CI.getLangOptions().EnableCXXInterop)
+      unsigned(CI.getLangOptions().EnableCXXInterop),
+
+      // Is Embedded Swift enabled?
+      unsigned(CI.getLangOptions().hasFeature(Feature::Embedded))
   );
 
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);


### PR DESCRIPTION
Addresses this module-clash problem:

```
$ rm -r /tmp/mc                                                                                                                                                            
$ echo "import Darwin" | swiftly run swiftc - -o /dev/null -wmo -sdk $(xcrun --show-sdk-path --sdk macosx) -module-cache-path /tmp/mc
... OK
$ echo "import Darwin" | swiftly run swiftc - -o /dev/null -wmo -sdk $(xcrun --show-sdk-path --sdk macosx) -module-cache-path /tmp/mc -enable-experimental-feature Embedded
... FAIL!
```

rdar://151311600