### PR TITLE
wasmswiftsdk.py: build the generator with the freshly built toolchain

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -279,9 +279,7 @@ class WasmSwiftSDK(product.Product):
             if build_sdk:
                 target_packages.append((swift_host_triple, wasi_sysroot, package_path))
 
-        swiftc_path = os.path.abspath(self.toolchain.swiftc)
-        toolchain_path = os.path.dirname(os.path.dirname(swiftc_path))
-        swift_run = os.path.join(toolchain_path, 'bin', 'swift-run')
+        swift_run = os.path.join(self.install_toolchain_path(host_target), "bin", "swift-run")
 
         swift_version = os.environ.get('TOOLCHAIN_VERSION',
                                        'swift-DEVELOPMENT-SNAPSHOT')

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -279,7 +279,13 @@ class WasmSwiftSDK(product.Product):
             if build_sdk:
                 target_packages.append((swift_host_triple, wasi_sysroot, package_path))
 
-        swift_run = os.path.join(self.install_toolchain_path(host_target), "bin", "swift-run")
+
+        if self.args.build_swift and self.args.build_swiftpm and self.args.install_swiftpm:
+            swift_run = os.path.join(self.install_toolchain_path(host_target), "bin", "swift-run")
+        else:
+            swiftc_path = os.path.abspath(self.toolchain.swiftc)
+            toolchain_path = os.path.dirname(os.path.dirname(swiftc_path))
+            swift_run = os.path.join(toolchain_path, 'bin', 'swift-run')
 
         swift_version = os.environ.get('TOOLCHAIN_VERSION',
                                        'swift-DEVELOPMENT-SNAPSHOT')


### PR DESCRIPTION
As Swift CI nodes use Swift 5.9 and Swift 5.10, and as of https://github.com/swiftlang/swift-sdk-generator/pull/227 Swift SDK Generator is no longer tested with Swift 5.9 and 5.10, we should build it with the freshly built toolchain. This will also unblock bump of `swift-tools-version` to 6.0 in the generator's package https://github.com/swiftlang/swift-sdk-generator/pull/237.