### PR TITLE
[cxx-interop] Avoid ambiguous C++ overloads for functions from Swift extensions

### DIFF
--- a/test/Interop/SwiftToCxx/initializers/init-in-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-extension-in-cxx.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/inits.h
+// RUN: %FileCheck %s < %t/inits.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/inits.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public struct OverloadedInitInExtension {
+    let x: Int
+
+    public init(_ x: Int) {
+        self.x = x
+    }
+}
+extension OverloadedInitInExtension {
+    public init(viaExtension x: Int) {
+        self.x = x
+    }
+}
+
+// Make sure we don't emit ambiguous overloads:
+// CHECK: static SWIFT_INLINE_THUNK OverloadedInitInExtension init(swift::Int x)
+// CHECK-NOT: static SWIFT_INLINE_THUNK OverloadedInitInExtension init(swift::Int x)

--- a/test/Interop/SwiftToCxx/methods/method-in-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-extension-in-cxx.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Method -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
+// RUN: %FileCheck %s < %t/methods.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public struct OverloadedMethodInExtension {
+    var x: Int
+
+    public mutating func add(_ x: Int) {
+        self.x += x
+    }
+}
+extension OverloadedMethodInExtension {
+    public mutating func add(viaExtension x: Int) {
+        self.x += x
+    }
+}
+
+// Make sure we don't emit ambiguous overloads:
+// CHECK: SWIFT_INLINE_THUNK void OverloadedMethodInExtension::add(swift::Int x)
+// CHECK-NOT: SWIFT_INLINE_THUNK void OverloadedMethodInExtension::add(swift::Int x)


### PR DESCRIPTION
Reverse interop has logic that avoids emitting ambiguous overloads into the generated header. That logic did not apply for functions declared within Swift extensions. This meant that the generated C++ header would sometimes not compile.

rdar://158252800

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
