### PR TITLE
[cxx-interop] Do not import partial specializations of variables

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4638,6 +4638,11 @@ namespace {
       return result;
     }
 
+    Decl *VisitVarTemplatePartialSpecializationDecl(
+        const clang::VarTemplatePartialSpecializationDecl *decl) {
+      return nullptr;
+    }
+
     Decl *VisitImplicitParamDecl(const clang::ImplicitParamDecl *decl) {
       // Parameters are never directly imported.
       return nullptr;

--- a/test/ClangImporter/const_values_cxx.swift
+++ b/test/ClangImporter/const_values_cxx.swift
@@ -55,9 +55,6 @@ func foo() {
 
   print(MyClass().class_const_int)
   print(MyClass.class_static_const_int)
-
-  // TODO: This seems to be incorrectly imported, this test here is just to check that the compiler doesn't crash.
-  print(template_gcd)
 }
 
 // Only imported as external declarations:

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -177,3 +177,8 @@ module UninstantiatableSpecialMembers {
   header "uninstantiatable-special-members.h"
   requires cplusplus
 }
+
+module VariableTemplate {
+  header "variable-template.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/Inputs/variable-template.h
+++ b/test/Interop/Cxx/templates/Inputs/variable-template.h
@@ -1,0 +1,5 @@
+template <int N, int M>
+inline const int template_gcd = template_gcd<M, N % M>;
+
+template <int N>
+inline const int template_gcd<N, 0> = N;

--- a/test/Interop/Cxx/templates/variable-template-typechecker.swift
+++ b/test/Interop/Cxx/templates/variable-template-typechecker.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -I %S/Inputs
+
+import VariableTemplate
+
+let _: CInt = template_gcd // expected-error {{cannot find 'template_gcd' in scope}}


### PR DESCRIPTION
They do not get imported correctly and trigger linker errors.

rdar://149232900 / resolves https://github.com/swiftlang/swift/issues/80802

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
