### PR TITLE
IRGen: Use C compatible representation for `@cdecl` enums

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4874,6 +4874,16 @@ public:
     return getAttrs().hasAttribute<IndirectAttr>();
   }
 
+  /// True if the enum is marked with `@cdecl`.
+  bool isCDeclEnum() const {
+    return getAttrs().hasAttribute<CDeclAttr>();
+  }
+
+  /// True if the enum is marked with `@cdecl` or `@objc`.
+  bool isCCompatibleEnum() const {
+    return isCDeclEnum() || isObjC();
+  }
+
   /// True if the enum can be exhaustively switched within \p useDC.
   ///
   /// Note that this property is \e not necessarily true for all children of

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -654,7 +654,7 @@ clang::QualType ClangTypeConverter::visitEnumType(EnumType *type) {
     return convert(Context.TheEmptyTupleType);
 
   auto ED = type->getDecl();
-  if (!ED->isObjC() && !ED->getAttrs().hasAttribute<CDeclAttr>())
+  if (!ED->isCCompatibleEnum())
     // Can't translate something not marked with @objc or @cdecl.
     return clang::QualType();
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6536,8 +6536,9 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
         std::move(elementsWithPayload), std::move(elementsWithNoPayload)));
   }
 
-  // Enums imported from Clang or marked with @objc use C-compatible layout.
-  if (theEnum->hasClangNode() || theEnum->isObjC()) {
+  // Enums imported from Clang or marked with @objc or @cdecl use a
+  // C-compatible layout.
+  if (theEnum->hasClangNode() || theEnum->isCCompatibleEnum()) {
     assert(elementsWithPayload.empty() && "C enum with payload?!");
     assert(alwaysFixedSize == IsFixedSize && "C enum with resilient payload?!");
     return std::unique_ptr<EnumImplStrategy>(
@@ -6982,7 +6983,7 @@ CCompatibleEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                     llvm::StructType *enumTy){
   // The type should have come from Clang or be @objc,
   // and should have a raw type.
-  assert((theEnum->hasClangNode() || theEnum->isObjC())
+  assert((theEnum->hasClangNode() || theEnum->isCCompatibleEnum())
          && "c-compatible enum didn't come from clang!");
   assert(theEnum->hasRawType()
          && "c-compatible enum doesn't have raw type!");

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2408,7 +2408,7 @@ private:
   void maybePrintTagKeyword(const TypeDecl *NTD) {
     auto *ED = dyn_cast<EnumDecl>(NTD);
     if (ED && !NTD->hasClangNode()) {
-      if (ED->getAttrs().hasAttribute<CDeclAttr>()) {
+      if (ED->isCDeclEnum()) {
         // We should be able to use the tag macro for all printed enums but
         // for now restrict it to @cdecl to guard it behind the feature flag.
         os << "SWIFT_ENUM_TAG ";

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -538,8 +538,7 @@ public:
   }
 
   void forwardDeclare(const EnumDecl *ED) {
-    assert(ED->isObjC() || ED->getAttrs().getAttribute<CDeclAttr>() ||
-           ED->hasClangNode());
+    assert(ED->isCCompatibleEnum() || ED->hasClangNode());
     
     forwardDeclare(ED, [&]{
       if (ED->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {

--- a/test/Interpreter/cdecl_enum_run.swift
+++ b/test/Interpreter/cdecl_enum_run.swift
@@ -1,0 +1,45 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature CDecl) > %t.out
+// RUN: %FileCheck --input-file %t.out %s
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: executable_test
+
+@cdecl
+enum CDecl8: UInt8 {
+case a
+case b
+}
+
+@cdecl
+enum CDecl16: UInt16 {
+case a
+case b
+}
+
+@cdecl(SomeName)
+enum CDecl32: UInt32 {
+case a
+case b
+}
+
+@objc
+enum ObjCEnum: UInt32 {
+case a
+case b
+}
+
+enum SwiftEnum: Int32 {
+case a
+case b
+}
+
+print("@cdecl enum 8 is \(MemoryLayout<CDecl8>.size) bytes")
+// CHECK: @cdecl enum 8 is 1 bytes
+print("@cdecl enum 16 is \(MemoryLayout<CDecl16>.size) bytes")
+// CHECK: @cdecl enum 16 is 2 bytes
+print("@cdecl enum 32 is \(MemoryLayout<CDecl32>.size) bytes")
+// CHECK: @cdecl enum 32 is 4 bytes
+print("@objc enum is \(MemoryLayout<ObjCEnum>.size) bytes")
+// CHECK: @objc enum is 4 bytes
+print("Swift enum is \(MemoryLayout<SwiftEnum>.size) bytes")
+// CHECK: Swift enum is 1 bytes

--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -39,6 +39,7 @@
 
 @cdecl func useEnum(e: CEnum) -> CEnum {
     print(e)
+    print(e.rawValue)
     return e
 }
 
@@ -59,8 +60,15 @@ int main() {
     primitiveTypes(1, 2, 3, 'a', 1.0f, 2.0, true);
     // CHECK-NEXT: 1 2 3 97 1.0 2.0 true
 
-    CEnum e = useEnum(CEnumB);
-    // CHECK-NEXT: B
-    printf("%d\n", e);
+    CEnum a = useEnum(CEnumA);
+    // CHECK-NEXT: CEnum
+    // CHECK-NEXT: 0
+    printf("%d\n", a);
+    // CHECK-NEXT: 0
+
+    CEnum b = useEnum(CEnumB);
+    // CHECK-NEXT: CEnum
+    // CHECK-NEXT: 1
+    printf("%d\n", b);
     // CHECK-NEXT: 1
 }


### PR DESCRIPTION
Enforce using the raw type of `@cdecl` enums for their memory layout. This brings the same behavior to `@cdecl` enum as what we have for `@objc` enums.

Resolves https://github.com/swiftlang/swift/issues/83738