### PR TITLE
Mark a UTF8Span test unavailable on watchOS.

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -329,6 +329,9 @@ func testWrite(_ w: inout ArrayWrapper) {
 }
 
 // Test store_borrow extension which is required when the addressable UTF8View is extended over the Span's uses.
+//
+// UTF8Span is unavailable on watchOS as of the introduction of this test.
+@available(watchOS, unavailable)
 @available(SwiftStdlib 6.2, *)
 func testSpanOfBorrowByAddress(_ i: Int) -> Int {
     let span = String(i).utf8.span


### PR DESCRIPTION
Fixes rdar://158517336 - Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable
