### PR TITLE
[cxx-interop] Import constexpr globals in a namespace

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4599,7 +4599,7 @@ namespace {
         isStatic = true;
 
       // For now we don't import static constexpr. TODO: Lift this restriction.
-      if (isStatic && decl->isConstexpr())
+      if (isStatic && !isClangNamespace(dc) && decl->isConstexpr())
         return nullptr;
 
       auto introducer = Impl.shouldImportGlobalAsLet(decl->getType())

--- a/test/Interop/Cxx/namespace/Inputs/constexpr-in-namespace.h
+++ b/test/Interop/Cxx/namespace/Inputs/constexpr-in-namespace.h
@@ -1,0 +1,4 @@
+namespace NS1 {
+constexpr int myConstexprInt = 123;
+static constexpr int myStaticConstexprInt = 456;
+} // namespace NS1

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -12,6 +12,11 @@ module ClassesSecondHeader {
   requires cplusplus
 }
 
+module ConstexprInNamespace {
+  header "constexpr-in-namespace.h"
+  requires cplusplus
+}
+
 module ExternWithinNamespace {
   header "extern-within-namespace.h"
   export *

--- a/test/Interop/Cxx/namespace/constexpr-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/namespace/constexpr-in-namespace-module-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprInNamespace -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: enum NS1 {
+// CHECK:   static var myConstexprInt: Int32
+// CHECK:   static var myStaticConstexprInt: Int32
+// CHECK: }

--- a/test/Interop/Cxx/namespace/constexpr-in-namespace.swift
+++ b/test/Interop/Cxx/namespace/constexpr-in-namespace.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import ConstexprInNamespace
+
+var NamespacesTestSuite = TestSuite("Constexpr in namespace")
+
+NamespacesTestSuite.test("constexpr int") {
+  expectEqual(NS1.myConstexprInt, 123)
+}
+
+NamespacesTestSuite.test("static constexpr int") {
+  expectEqual(NS1.myStaticConstexprInt, 456)
+}
+
+runAllTests()


### PR DESCRIPTION
rdar://150756970 / resolves https://github.com/swiftlang/swift/issues/81327

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
