### PR TITLE
build.ps1: add `CMAKE_NINJA_FORCE_RESPONSE_FILE`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3159,6 +3159,7 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
+      CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
       ENABLE_TESTING = "NO";
 
@@ -3189,6 +3190,7 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
+      CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
       CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
       ENABLE_TESTING = "NO";


### PR DESCRIPTION
Add the flag to force a response file usage with Ninja to avoid exhausing the Windows command line limits.
