### PR TITLE
stdlib: Mark UnsafeRawBufferPointer's withContiguousStorageIfAvailable as @inline(__always)

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1163,6 +1163,7 @@ extension Unsafe${Mutable}RawBufferPointer {
 
 %  if Mutable:
   @_alwaysEmitIntoClient
+  @inline(__always)
   public func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
@@ -1180,6 +1181,7 @@ extension Unsafe${Mutable}RawBufferPointer {
 
 %  end
   @_alwaysEmitIntoClient
+  @inline(__always)
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {


### PR DESCRIPTION
The body seems to only reinterpret pointer types (`withMemoryRebound`). Inlining it should not lead to code size gains and has shown to reduce code size.
