### PR TITLE
Add brotli support to FoundationNetworking (release 6.2)

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -619,6 +619,7 @@ enum Project {
   SourceKitLSP
   SymbolKit
   DocC
+  brotli
 
   LLVM
   Runtime
@@ -1996,6 +1997,26 @@ function Build-Sanitizers([Hashtable] $Platform) {
     })
 }
 
+function Build-Brotli([Hashtable] $Platform) {
+  $ArchName = $Platform.Architecture.LLVMName
+
+  Build-CMakeProject `
+    -Src $SourceCache\brotli `
+    -Bin "$(Get-ProjectBinaryCache $Platform brotli)" `
+    -InstallTo "$LibraryRoot\brotli\usr" `
+    -Platform $Platform `
+    -UseMSVCCompilers C `
+    -BuildTargets default `
+    -Defines @{
+      BUILD_SHARED_LIBS = "NO";
+      CMAKE_POSITION_INDEPENDENT_CODE = "YES";
+      CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
+      CMAKE_INSTALL_BINDIR = "$LibraryRoot\brotli\usr\bin\$($Platform.OS.ToString())\$ArchName";
+      CMAKE_INSTALL_LIBDIR = "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$ArchName";
+    }
+}
+
+
 function Build-ZLib([Hashtable] $Platform) {
   $ArchName = $Platform.Architecture.LLVMName
 
@@ -2095,7 +2116,7 @@ function Build-CURL([Hashtable] $Platform) {
       CURL_CA_BUNDLE = "none";
       CURL_CA_FALLBACK = "NO";
       CURL_CA_PATH = "none";
-      CURL_BROTLI = "NO";
+      CURL_BROTLI = "YES";
       CURL_DISABLE_ALTSVC = "NO";
       CURL_DISABLE_AWS = "YES";
       CURL_DISABLE_BASIC_AUTH = "NO";
@@ -2173,6 +2194,17 @@ function Build-CURL([Hashtable] $Platform) {
       USE_WIN32_LDAP = "NO";
       ZLIB_ROOT = "$LibraryRoot\zlib-1.3.1\usr";
       ZLIB_LIBRARY = "$LibraryRoot\zlib-1.3.1\usr\lib\$($Platform.OS.ToString())\$ArchName\zlibstatic.lib";
+      BROTLI_INCLUDE_DIR = "$LibraryRoot\brotli\usr\include";
+      BROTLIDEC_LIBRARY = if ($Platform.OS -eq [OS]::Windows) {
+        "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$ArchName\brotlidec.lib"
+      } else {
+        "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$ArchName\brotlidec.a"
+      };
+      BROTLICOMMON_LIBRARY = if ($Platform.OS -eq [OS]::Windows) {
+        "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$ArchName\brotlicommon.lib"
+      } else {
+        "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$ArchName\brotlicommon.a"
+      };
     })
 }
 
@@ -2404,6 +2436,17 @@ function Build-Foundation {
         "$LibraryRoot\zlib-1.3.1\usr\lib\$($Platform.OS.ToString())\$($Platform.Architecture.LLVMName)\libz.a"
       };
       ZLIB_INCLUDE_DIR = "$LibraryRoot\zlib-1.3.1\usr\include";
+      BROTLIDEC_LIBRARY = if ($Platform.OS -eq [OS]::Windows) {
+         "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$($Platform.Architecture.LLVMName)\brotlidec.lib"
+      } else {
+        "$LibraryRoot\brotli\usr\lib64\$($Platform.OS.ToString())\$($Platform.Architecture.LLVMName)\brotlidec.a"
+      };
+      BROTLICOMMON_LIBRARY = if ($Platform.OS -eq [OS]::Windows) {
+        "$LibraryRoot\brotli\usr\lib\$($Platform.OS.ToString())\$($Platform.Architecture.LLVMName)\brotlicommon.lib"
+      } else {
+        "$LibraryRoot\brotli\usr\lib64\$($Platform.OS.ToString())\$($Platform.Architecture.LLVMName)\brotlicommon.a"
+      };
+      BROTLI_INCLUDE_DIR = "$LibraryRoot\brotli\usr\include";
       dispatch_DIR = (Get-ProjectCMakeModules $Platform Dispatch);
       SwiftSyntax_DIR = (Get-ProjectBinaryCache $HostPlatform Compilers);
       _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
@@ -2426,6 +2469,7 @@ function Test-Foundation {
     $env:LIBXML_LIBRARY_PATH="$LibraryRoot/libxml2-2.11.5/usr/lib/windows/$($BuildPlatform.Architecture.LLVMName)"
     $env:LIBXML_INCLUDE_PATH="$LibraryRoot/libxml2-2.11.5/usr/include/libxml2"
     $env:ZLIB_LIBRARY_PATH="$LibraryRoot/zlib-1.3.1/usr/lib/windows/$($BuildPlatform.Architecture.LLVMName)"
+    $env:BROTLI_LIBRARY_PATH="$LibraryRoot/brotli/usr/lib/windows/$($BuildPlatform.Architecture.LLVMName)"
     $env:CURL_LIBRARY_PATH="$LibraryRoot/curl-8.9.1/usr/lib/windows/$($BuildPlatform.Architecture.LLVMName)"
     $env:CURL_INCLUDE_PATH="$LibraryRoot/curl-8.9.1/usr/include"
     Build-SPMProject `
@@ -2566,6 +2610,7 @@ function Build-SDK([Hashtable] $Platform, [switch] $IncludeMacros = $false) {
 
   # Third Party Dependencies
   Invoke-BuildStep Build-ZLib $Platform
+  Invoke-BuildStep Build-Brotli $Platform
   Invoke-BuildStep Build-XML2 $Platform
   Invoke-BuildStep Build-CURL $Platform
   Invoke-BuildStep Build-LLVM $Platform

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -118,6 +118,9 @@
         "zlib": {
           "remote": { "id": "madler/zlib" }
         },
+        "brotli": {
+          "remote": { "id": "google/brotli" }
+        },
         "mimalloc": {
           "remote": { "id": "microsoft/mimalloc" },
           "platforms": [ "Windows" ]
@@ -177,7 +180,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         },
         "release/6.2": {
@@ -232,6 +236,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.1"
             }
         },
@@ -441,7 +446,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         },
         "next" : {
@@ -491,7 +497,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         }
     }


### PR DESCRIPTION
(this is the 6.2 back port of https://github.com/swiftlang/swift/pull/83441)

Add brotli as a dependency to enable brotli decoding for curl.

brotli is a general purpose compression algorithm used extensively on web. (https://datatracker.ietf.org/doc/html/rfc7932) 

brotli support for curl is enabled by integrating the brotli compression library (https://github.com/google/brotli). I've also added some tests for FoundationNetworking in https://github.com/swiftlang/swift-corelibs-foundation/pull/5251 which exercises this feature by 
- looking at the accept-encoding http header 
- decoding a brotli encoded payload


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
