### PR TITLE
[IRGen] Do not set HasLayoutString flag for non-copyable types requir…

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5808,8 +5808,12 @@ namespace {
         return false;
       }
 
-      if (IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnessesInstantiation) &&
-          IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation) {
+      auto &TI = IGM.getTypeInfo(getLoweredType());
+
+      if (IGM.Context.LangOpts.hasFeature(
+              Feature::LayoutStringValueWitnessesInstantiation) &&
+          IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation &&
+          TI.isCopyable(ResilienceExpansion::Maximal)) {
         return !!getLayoutString() || needsSingletonMetadataInitialization(IGM, Target);
       }
 
@@ -6285,9 +6289,11 @@ namespace {
     }
 
     bool hasInstantiatedLayoutString() {
+      auto &TI = IGM.getTypeInfo(getLoweredType());
       if (IGM.Context.LangOpts.hasFeature(
               Feature::LayoutStringValueWitnessesInstantiation) &&
-          IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation) {
+          IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation &&
+          TI.isCopyable(ResilienceExpansion::Maximal)) {
         return needsSingletonMetadataInitialization(IGM, Target);
       }
 

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -341,10 +341,12 @@ public struct NestedWrapper<T> {
     }
 }
 
-struct InternalGeneric<T> {
+struct InternalGeneric<T: ~Copyable>: ~Copyable {
     let y: Int
     let x: T
 }
+
+extension InternalGeneric: Copyable where T: Copyable {}
 
 public enum SinglePayloadSimpleClassEnum {
     case empty0
@@ -711,7 +713,7 @@ public func preSpec() {
 }
 
 @inline(never)
-public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: T) {
+public func testAssign<T: ~Copyable>(_ ptr: UnsafeMutablePointer<T>, from x: consuming T) {
     ptr.pointee = x
 }
 
@@ -721,7 +723,7 @@ public func testAssignCopy<T>(_ ptr: UnsafeMutablePointer<T>, from x: inout T) {
 }
 
 @inline(never)
-public func testInit<T>(_ ptr: UnsafeMutablePointer<T>, to x: T) {
+public func testInit<T: ~Copyable>(_ ptr: UnsafeMutablePointer<T>, to x: consuming T) {
     ptr.initialize(to: x)
 }
 
@@ -731,32 +733,32 @@ public func testInitTake<T>(_ ptr: UnsafeMutablePointer<T>, to x: consuming T) {
 }
 
 @inline(never)
-public func testDestroy<T>(_ ptr: UnsafeMutablePointer<T>) {
+public func testDestroy<T: ~Copyable>(_ ptr: UnsafeMutablePointer<T>) {
     _ = ptr.move()
 }
 
 @inline(never)
-public func allocateInternalGenericPtr<T>(of tpe: T.Type) -> UnsafeMutableRawPointer {
+public func allocateInternalGenericPtr<T: ~Copyable>(of tpe: T.Type) -> UnsafeMutableRawPointer {
     return UnsafeMutableRawPointer(
         UnsafeMutablePointer<InternalGeneric<T>>.allocate(capacity: 1))
 }
 
 @inline(never)
-public func testGenericAssign<T>(_ ptr: __owned UnsafeMutableRawPointer, from x: T) {
+public func testGenericAssign<T: ~Copyable>(_ ptr: __owned UnsafeMutableRawPointer, from x: consuming T) {
     let ptr = ptr.assumingMemoryBound(to: InternalGeneric<T>.self)
     let x = InternalGeneric(y: 23, x: x)
     testAssign(ptr, from: x)
 }
 
 @inline(never)
-public func testGenericInit<T>(_ ptr: __owned UnsafeMutableRawPointer, to x: T) {
+public func testGenericInit<T: ~Copyable>(_ ptr: __owned UnsafeMutableRawPointer, to x: consuming T) {
     let ptr = ptr.assumingMemoryBound(to: InternalGeneric<T>.self)
     let x = InternalGeneric(y: 23, x: x)
     testInit(ptr, to: x)
 }
 
 @inline(never)
-public func testGenericDestroy<T>(_ ptr: __owned UnsafeMutableRawPointer, of tpe: T.Type) {
+public func testGenericDestroy<T: ~Copyable>(_ ptr: __owned UnsafeMutableRawPointer, of tpe: T.Type) {
     let ptr = ptr.assumingMemoryBound(to: InternalGeneric<T>.self)
     testDestroy(ptr)
 }


### PR DESCRIPTION
…ing metadata instantiation

rdar://157795547

When types contain stored properties of resilient types, we instantiate their metadata at runtime. If those types are non-copyable, they won't have layout strings, so we must not set the flag.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
