### PR TITLE
CMake: readd StringProcessing dependency to StdlibUnittest

### DIFF
--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -37,6 +37,9 @@ if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
   list(APPEND swift_stdlib_unittest_link_libraries "swift_Concurrency")
   list(APPEND swift_stdlib_unittest_modules "_Concurrency")
 endif()
+if (SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+  list(APPEND swift_stdlib_unittest_modules "_StringProcessing")
+endif()
 
 add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the


### PR DESCRIPTION
This reverts commit 4a95275bdedcaaff54875eca71286147758078d2.

I remove the dependency looking at the modules that StdlibUnittest directly imports -- but it turns out we import StringProcessing indirectly as a result of importing Foundation from e.g. the underlying Apple SDKs.

Addresses rdar://158797152