### PR TITLE
IRGen: Restore implicit truncation in some calls to `llvm::APInt` ctor

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2556,9 +2556,10 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
   llvm::Constant *One =
       llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
                                                       1));
-  llvm::Constant *NegativeOne =
-      llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
-                                                      -2));
+  // TODO: Avoid implicit truncation.
+  llvm::Constant *NegativeOne = llvm::Constant::getIntegerValue(
+      IntPtrTy, APInt(IntPtrTy->getBitWidth(), -2, /*isSigned*/ false,
+                      /*implicitTrunc*/ true));
   swift::irgen::Alignment PointerAlignment = IGF.IGM.getPointerAlignment();
 
   llvm::Value *PtrToInt = IGF.Builder.CreatePtrToInt(pointer, IntPtrTy);
@@ -2587,8 +2588,10 @@ llvm::Value *emitIndirectCoroFunctionPointer(IRGenFunction &IGF,
       IntPtrTy, APInt(IntPtrTy->getBitWidth(), 0));
   llvm::Constant *One = llvm::Constant::getIntegerValue(
       IntPtrTy, APInt(IntPtrTy->getBitWidth(), 1));
+  // TODO: Avoid implicit truncation.
   llvm::Constant *NegativeOne = llvm::Constant::getIntegerValue(
-      IntPtrTy, APInt(IntPtrTy->getBitWidth(), -2));
+      IntPtrTy, APInt(IntPtrTy->getBitWidth(), -2, /*isSigned*/ false,
+                      /*implicitTrunc*/ true));
   swift::irgen::Alignment PointerAlignment = IGF.IGM.getPointerAlignment();
 
   llvm::Value *PtrToInt = IGF.Builder.CreatePtrToInt(pointer, IntPtrTy);


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/81464. Fixes an assertion failure on 32-bit Windows.

The default value was flipped in https://github.com/llvm/llvm-project/pull/114539.