### PR TITLE
🍒[cxx-interop] Enable reference-counted types on Windows

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6881,7 +6881,7 @@ namespace {
 
     void emitInitializeMetadata(IRGenFunction &IGF, llvm::Value *metadata,
                                 MetadataDependencyCollector *collector) {
-      llvm_unreachable("Not implemented for foreign reference types.");
+      // Foreign reference types do not currently require extra metadata.
     }
 
     // Visitor methods.

--- a/test/Interop/C/struct/foreign-reference.swift
+++ b/test/Interop/C/struct/foreign-reference.swift
@@ -3,9 +3,6 @@
 //
 // REQUIRES: executable_test
 
-// XFAIL: OS=windows-msvc
-// FIXME: Runtime support for C++ foreign reference types is missing on Windows (https://github.com/swiftlang/swift/issues/82643)
-
 import StdlibUnittest
 import ForeignReference
 

--- a/test/Interop/Cxx/foreign-reference/extensions.swift
+++ b/test/Interop/Cxx/foreign-reference/extensions.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
 // REQUIRES: executable_test
 
-// Metadata for foreign reference types is not supported on Windows.
-// UNSUPPORTED: OS=windows-msvc
-
 import ReferenceCounted
 
 protocol MyProto {

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -1,9 +1,6 @@
 // REQUIRES: executable_test
 // RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs)
 
-// TODO: Fix this lit test failure on windows rdar://145218056
-// XFAIL: OS=windows-msvc
-
 import Inheritance
 import StdlibUnittest
 

--- a/test/Interop/Cxx/foreign-reference/multiple-protocol-conformances.swift
+++ b/test/Interop/Cxx/foreign-reference/multiple-protocol-conformances.swift
@@ -2,8 +2,6 @@
 // RUN: split-file %s %t
 // RUN: %target-build-swift -I %S/Inputs %t/main.swift %t/second.swift -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking
 
-// XFAIL: OS=windows-msvc
-
 //--- main.swift
 import ReferenceCounted
 

--- a/test/Interop/Cxx/foreign-reference/print-reference.swift
+++ b/test/Interop/Cxx/foreign-reference/print-reference.swift
@@ -2,9 +2,6 @@
 
 // REQUIRES: executable_test
 
-// Metadata for foreign reference types is not supported on Windows.
-// UNSUPPORTED: OS=windows-msvc
-
 // Temporarily disable when running with an older runtime (rdar://153205860)
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
-// XFAIL: OS=windows-msvc
 
 import ReferenceCounted
 

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -2,7 +2,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking -O)
 //
 // REQUIRES: executable_test
-// XFAIL: OS=windows-msvc
 
 // Temporarily disable when running with an older runtime (rdar://128681137)
 // UNSUPPORTED: use_os_stdlib

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
 //
 // REQUIRES: executable_test
-// XFAIL: OS=windows-msvc
 
 // Temporarily disable when running with an older runtime (rdar://128681577)
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
  - **Explanation**: This enables the use of reference-counted foreign reference types on Windows. As it turns out, the assertion that was failing on Windows previously was unnecessary. This also enabled many of the tests on Windows.
  - **Scope**: This only changes IRGen for foreign reference types.
  - **Issues**: rdar://154694125 / https://github.com/swiftlang/swift/issues/82643
  - **Original PRs**: https://github.com/swiftlang/swift/pull/83802
  - **Risk**: Low, this only removes an assertion.
  - **Testing**: Added a compiler test.
  - **Reviewers**: @Xazax-hun
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
