### PR TITLE
🍒 [demangling] make printGenericSignature virtual

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -949,7 +949,7 @@ protected:
 
   void printImplFunctionType(NodePointer fn, unsigned depth);
 
-  void printGenericSignature(NodePointer Node, unsigned depth);
+  virtual void printGenericSignature(NodePointer Node, unsigned depth);
 
   void printFunctionSigSpecializationParams(NodePointer Node, unsigned depth);
 


### PR DESCRIPTION
- **Explanation**:
https://github.com/swiftlang/llvm-project/pull/11068 requires the `printGenericSignature` to be virtual. This patch makes the method virtual.
- **Scope**:
This patch affects the swift demangler (the `NodePrinter` class).
- **Issues**:

- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/83375
- **Risk**:
Low, this only makes a method virtual.
- **Testing**:
Built at desk with https://github.com/swiftlang/llvm-project/pull/11068 and ran the tests locally.
- **Reviewers**:
  - @Michael137 
  - @adrian-prantl 