### PR TITLE
[Sema] Fix bad diagnostic for `nil + nil`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -237,9 +237,17 @@ ERROR(cannot_apply_binop_to_same_args,none,
       "binary operator '%0' cannot be applied to two %1 operands",
       (StringRef, Type))
 
+ERROR(cannot_apply_binop_to_args_with_no_exact_match,none,
+      "binary operator '%0' cannot be applied to two operands with no exact type matches",
+      (StringRef))
+
 ERROR(cannot_apply_unop_to_arg,none,
       "unary operator '%0' cannot be applied to an operand of type %1",
       (StringRef, Type))
+
+ERROR(cannot_apply_unop_to_arg_with_no_exact_match,none,
+      "unary operator '%0' cannot be applied to one operand with no exact type matches",
+      (StringRef))
 
 ERROR(cannot_apply_lvalue_unop_to_subelement,none,
       "cannot pass immutable value to mutating operator: %0",

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2169,44 +2169,82 @@ static void diagnoseOperatorAmbiguity(ConstraintSystem &cs,
     return false;
   };
 
-  const auto &solution = solutions.front();
   if (auto *binaryOp = dyn_cast<BinaryExpr>(applyExpr)) {
     auto *lhs = binaryOp->getLHS();
     auto *rhs = binaryOp->getRHS();
 
-    auto lhsType =
-        solution.simplifyType(solution.getType(lhs))->getRValueType();
-    auto rhsType =
-        solution.simplifyType(solution.getType(rhs))->getRValueType();
-
-    if (lhsType->isEqual(rhsType)) {
-      DE.diagnose(anchor->getLoc(), diag::cannot_apply_binop_to_same_args,
-                  operatorName.str(), lhsType)
-          .highlight(lhs->getSourceRange())
-          .highlight(rhs->getSourceRange());
-
-      if (isStandardComparisonOperator(binaryOp->getFn()) &&
-          isEnumWithAssociatedValues(lhsType)) {
-        DE.diagnose(applyExpr->getLoc(),
-                    diag::no_binary_op_overload_for_enum_with_payload,
-                    operatorName.str());
-        return;
+    const auto &first_solution = solutions.front();
+    auto first_lhsType =
+        first_solution.simplifyType(first_solution.getType(lhs))->getRValueType();
+    auto first_rhsType =
+        first_solution.simplifyType(first_solution.getType(rhs))->getRValueType();
+    
+    bool no_exact_match = false;
+    for (const auto& solution : solutions) {
+      auto lhsType =
+          solution.simplifyType(solution.getType(lhs))->getRValueType();
+      auto rhsType =
+          solution.simplifyType(solution.getType(rhs))->getRValueType();
+      
+      if (!lhsType->isEqual(first_lhsType) ||
+          !rhsType->isEqual(first_rhsType)) {
+        no_exact_match = true;
+        break;
       }
-    } else if (operatorName == ctx.Id_MatchOperator) {
-      DE.diagnose(anchor->getLoc(), diag::cannot_match_expr_pattern_with_value,
-                  lhsType, rhsType);
+    }
+
+    if (!no_exact_match) {
+      if (first_lhsType->isEqual(first_rhsType)) {
+        DE.diagnose(anchor->getLoc(), diag::cannot_apply_binop_to_same_args,
+                    operatorName.str(), first_lhsType)
+            .highlight(lhs->getSourceRange())
+            .highlight(rhs->getSourceRange());
+
+        if (isStandardComparisonOperator(binaryOp->getFn()) &&
+            isEnumWithAssociatedValues(first_lhsType)) {
+          DE.diagnose(applyExpr->getLoc(),
+                      diag::no_binary_op_overload_for_enum_with_payload,
+                      operatorName.str());
+          return;
+        }
+      } else if (operatorName == ctx.Id_MatchOperator) {
+        DE.diagnose(anchor->getLoc(), diag::cannot_match_expr_pattern_with_value,
+                    first_lhsType, first_rhsType);
+      } else {
+        DE.diagnose(anchor->getLoc(), diag::cannot_apply_binop_to_args,
+                    operatorName.str(), first_lhsType, first_rhsType)
+            .highlight(lhs->getSourceRange())
+            .highlight(rhs->getSourceRange());
+      }
     } else {
-      DE.diagnose(anchor->getLoc(), diag::cannot_apply_binop_to_args,
-                  operatorName.str(), lhsType, rhsType)
+      DE.diagnose(anchor->getLoc(), diag::cannot_apply_binop_to_args_with_no_exact_match,
+                  operatorName.str())
           .highlight(lhs->getSourceRange())
           .highlight(rhs->getSourceRange());
     }
   } else {
     auto *arg = applyExpr->getArgs()->getUnlabeledUnaryExpr();
     assert(arg && "Expected a unary arg");
-    auto argType = solution.simplifyType(solution.getType(arg));
-    DE.diagnose(anchor->getLoc(), diag::cannot_apply_unop_to_arg,
-                operatorName.str(), argType->getRValueType());
+    
+    const auto &first_solution = solutions.front();
+    auto first_argType = first_solution.simplifyType(first_solution.getType(arg));
+    
+    bool no_exact_match = false;
+    for (const auto& solution : solutions) {
+      auto argType = solution.simplifyType(solution.getType(arg));
+      if (!argType->isEqual(first_argType)) {
+        no_exact_match = true;
+        break;
+      }
+    }
+    
+    if (!no_exact_match) {
+      DE.diagnose(anchor->getLoc(), diag::cannot_apply_unop_to_arg,
+                  operatorName.str(), first_argType->getRValueType());
+    } else {
+      DE.diagnose(anchor->getLoc(), diag::cannot_apply_unop_to_arg_with_no_exact_match,
+                  operatorName.str());
+    }
   }
 
   std::set<std::string> parameters;

--- a/test/Constraints/add_with_nil.swift
+++ b/test/Constraints/add_with_nil.swift
@@ -1,6 +1,11 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift
 
-func test(_ x: Int) -> Int {
+func test_int_plus_nil(_ x: Int) -> Int {
   return x + nil
   // expected-error@-1 {{'nil' is not compatible with expected argument type 'Int'}}
+}
+
+func test_nil_plus_nil() -> Any? {
+  return nil + nil
+  // expected-error@-1 {{binary operator '+' cannot be applied to two operands with no exact type matches}}
 }

--- a/test/Constraints/add_with_non_additive_class.swift
+++ b/test/Constraints/add_with_non_additive_class.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+class NonAdditiveClass {}
+
+func test_non_additive_class_addition() -> NonAdditiveClass {
+  let a = NonAdditiveClass()
+  let b = NonAdditiveClass()
+  return a + b
+  // expected-error@-1 {{binary operator '+' cannot be applied to two 'NonAdditiveClass' operands}}
+}


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/83661

Compare all type binding results in `solutions`. When different type bindings are found, it indicates that type binding is unreliable, so use a more general error message.

@hamishknight 