### PR TITLE
build.ps1: add a workaround for Android build break

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1678,6 +1678,11 @@ function Build-CMakeProject {
             "-Xclang-linker", "-resource-dir", "-Xclang-linker", "${AndroidPrebuiltRoot}\lib\clang\$($(Get-AndroidNDK).ClangVersion)"
           )
 
+          # FIXME(compnerd) remove this once we have the early swift-driver
+          if ($SwiftSDK) {
+            $SwiftFlags += @("-Xclang-linker", "-L", "-Xclang-linker", [IO.Path]::Combine($SwiftSDK, "usr", "lib", "swift", "android", $Platform.Architecture.LLVMName))
+          }
+
           $SwiftFlags += if ($DebugInfo) { @("-g") } else { @("-gnone") }
 
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags


### PR DESCRIPTION
The C++ driver will not add in the architecture to the library search path when building for Android on Windows. Workaround this by explicitly adding in the addition library search path. Once the early swift-driver is enabled, this should be possible to remove.