### PR TITLE
[frontend] Expose via a LangOption whether or not the compiler is compiling for a triple that supports AArch64 TBI.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -671,6 +671,9 @@ namespace swift {
     bool RestrictNonProductionExperimentalFeatures = false;
 #endif
 
+    /// Set to true if we support AArch64TBI.
+    bool HasAArch64TBI = false;
+
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -274,6 +274,9 @@ public:
   /// C++ stdlib is the default for the specified target.
   void computeCXXStdlibOptions();
 
+  /// Compute whether or not we support aarch64TBI
+  void computeAArch64TBIOptions();
+
   /// Computes the runtime resource path relative to the given Swift
   /// executable.
   static void computeRuntimeResourcePathFromExecutablePath(

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -814,6 +814,8 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   Invocation.getLangOptions().UnavailableDeclOptimizationMode =
       options.UnavailableDeclOptimization;
 
+  Invocation.computeAArch64TBIOptions();
+
   // Enable strict concurrency if we have the feature specified or if it was
   // specified via a command line option to sil-opt.
   if (Invocation.getLangOptions().hasFeature(Feature::StrictConcurrency)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -371,6 +371,13 @@ setBridgingHeaderFromFrontendOptions(ClangImporterOptions &ImporterOpts,
       FrontendOpts.InputsAndOutputs.getFilenameOfFirstInput();
 }
 
+void CompilerInvocation::computeAArch64TBIOptions() {
+  auto &LLVMArgs = getFrontendOptions().LLVMArgs;
+  auto aarch64_use_tbi =
+      std::find(LLVMArgs.begin(), LLVMArgs.end(), "-aarch64-use-tbi");
+  LangOpts.HasAArch64TBI = aarch64_use_tbi != LLVMArgs.end();
+}
+
 void CompilerInvocation::computeCXXStdlibOptions() {
   // The MSVC driver in Clang is not aware of the C++ stdlib, and currently
   // always assumes libstdc++, which is incorrect: the Microsoft stdlib is
@@ -4099,6 +4106,8 @@ bool CompilerInvocation::parseArgs(
   setIRGenOutputOptsFromFrontendOptions(IRGenOpts, FrontendOpts);
   setBridgingHeaderFromFrontendOptions(ClangImporterOpts, FrontendOpts);
   computeCXXStdlibOptions();
+  computeAArch64TBIOptions();
+
   if (LangOpts.hasFeature(Feature::Embedded)) {
     IRGenOpts.InternalizeAtLink = true;
     IRGenOpts.DisableLegacyTypeInfo = true;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4614,6 +4614,8 @@ int main(int argc, char *argv[]) {
     InitInvok.computeCXXStdlibOptions();
   }
 
+  InitInvok.computeAArch64TBIOptions();
+
   if (!options::InProcessPluginServerPath.empty()) {
     InitInvok.getSearchPathOptions().InProcessPluginServerPath =
         options::InProcessPluginServerPath;


### PR DESCRIPTION
Just breaking down layers of a larger patch to make it easier to review.

----

Split out of https://github.com/swiftlang/swift/pull/83346