### PR TITLE
[6.2][CSSimplify] SE-0324: Use correct conversion when converting array types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8070,7 +8070,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                 // for imported declarations.
                 if (isArgumentOfImportedDecl(locator)) {
                   conversionsOrFixes.push_back(
-                      ConversionRestrictionKind::InoutToCPointer);
+                      baseIsArray ? ConversionRestrictionKind::ArrayToCPointer
+                                  : ConversionRestrictionKind::InoutToCPointer);
                 }
               }
             }

--- a/test/SILGen/diagnose_implicit_raw_conversion.swift
+++ b/test/SILGen/diagnose_implicit_raw_conversion.swift
@@ -45,10 +45,10 @@ func test_errors<T>(arg: T, sarg: String, anyBCArg: BitwiseCopyable) {
     readBytes(&array)     // expected-warning {{forming 'UnsafeRawPointer' to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
     writeBytes(&array)  // expected-warning {{forming 'UnsafeMutableRawPointer' to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
 
-    read_char(&array)   // expected-warning {{forming 'UnsafePointer<Int8>' to a variable of type 'Array<T>'; this is likely incorrect because 'T' may contain an object reference.}}
-    write_char(&array)  // expected-warning {{forming 'UnsafeMutablePointer<Int8>' to a variable of type 'Array<T>'; this is likely incorrect because 'T' may contain an object reference.}}
-    read_uchar(&array)  // expected-warning {{forming 'UnsafePointer<UInt8>' to a variable of type 'Array<T>'; this is likely incorrect because 'T' may contain an object reference.}}
-    write_uchar(&array) // expected-warning {{forming 'UnsafeMutablePointer<UInt8>' to a variable of type 'Array<T>'; this is likely incorrect because 'T' may contain an object reference.}}
+    read_char(&array)   // expected-warning {{forming 'UnsafePointer<CChar>' (aka 'UnsafePointer<Int8>') to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
+    write_char(&array)  // expected-warning {{forming 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
+    read_uchar(&array)  // expected-warning {{forming 'UnsafePointer<UInt8>' to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
+    write_uchar(&array) // expected-warning {{forming 'UnsafeMutablePointer<UInt8>' to a variable of type '[T]'; this is likely incorrect because 'T' may contain an object reference.}}
 
     var anyBC: BitwiseCopyable = anyBCArg
     readBytes(&anyBC)   // expected-warning {{forming 'UnsafeRawPointer' to a variable of type 'any BitwiseCopyable'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
@@ -67,10 +67,10 @@ func test_errors<T>(arg: T, sarg: String, anyBCArg: BitwiseCopyable) {
     readBytes(&bcArray)     // expected-warning {{forming 'UnsafeRawPointer' to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
     writeBytes(&bcArray)  // expected-warning {{forming 'UnsafeMutableRawPointer' to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
 
-    read_char(&bcArray)   // expected-warning {{forming 'UnsafePointer<Int8>' to a variable of type 'Array<any BitwiseCopyable>'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
-    write_char(&bcArray)  // expected-warning {{forming 'UnsafeMutablePointer<Int8>' to a variable of type 'Array<any BitwiseCopyable>'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
-    read_uchar(&bcArray)  // expected-warning {{forming 'UnsafePointer<UInt8>' to a variable of type 'Array<any BitwiseCopyable>'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
-    write_uchar(&bcArray) // expected-warning {{forming 'UnsafeMutablePointer<UInt8>' to a variable of type 'Array<any BitwiseCopyable>'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
+    read_char(&bcArray)   // expected-warning {{forming 'UnsafePointer<CChar>' (aka 'UnsafePointer<Int8>') to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
+    write_char(&bcArray)  // expected-warning {{forming 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
+    read_uchar(&bcArray)  // expected-warning {{forming 'UnsafePointer<UInt8>' to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
+    write_uchar(&bcArray) // expected-warning {{forming 'UnsafeMutablePointer<UInt8>' to a variable of type '[any BitwiseCopyable]'; this is likely incorrect because 'any BitwiseCopyable' may contain an object reference.}}
 
     var string: String = sarg
     readBytes(&string)   // expected-warning {{forming 'UnsafeRawPointer' to an inout variable of type String exposes the internal representation rather than the string contents.}}


### PR DESCRIPTION
- Explanation:

  If the argument type is an array and it's passed to an imported declaration that accepts a raw pointer, the solver should use an "array-to-c-pointer" conversion instead of the one for pointers.

- Resolves: rdar://158629300

- Main Branch PR: https://github.com/swiftlang/swift/pull/83862

- Risk: Very Low. This is a narrow fix only for array typed arguments to imported declarations references that expect a raw pointer argument.

- Reviewed By: @atrick  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 29b04f4a6303c1d7d0577a2e37003dfab9ece459)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
