### PR TITLE
Sema: Simplify recording required import access levels

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -76,15 +76,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   }
 
   // Remember that the module defining the decl must be imported publicly.
-  recordRequiredImportAccessLevelForDecl(
-      D, DC, AccessLevel::Public,
-      [&](AttributedImport<ImportedModule> attributedImport) {
-        ModuleDecl *importedVia = attributedImport.module.importedModule,
-                   *sourceModule = D->getModuleContext();
-        Context.Diags.diagnose(loc, diag::module_api_import, D, importedVia,
-                               sourceModule, importedVia == sourceModule,
-                               /*isImplicit*/ false);
-      });
+  recordRequiredImportAccessLevelForDecl(D, DC, AccessLevel::Public, loc);
 
   // General check on access-level of the decl.
   auto declAccessScope =

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -711,15 +711,8 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
 
   auto &C = nominal->getASTContext();
   auto loc = nominal->getLoc();
-  recordRequiredImportAccessLevelForDecl(
-    C.getDistributedActorDecl(), nominal, nominal->getEffectiveAccess(),
-    [&](AttributedImport<ImportedModule> attributedImport) {
-  ModuleDecl *importedVia = attributedImport.module.importedModule,
-             *sourceModule = nominal->getModuleContext();
-  C.Diags.diagnose(loc, diag::module_api_import, nominal, importedVia,
-                         sourceModule, importedVia == sourceModule,
-                         /*isImplicit*/ false);
-});
+  recordRequiredImportAccessLevelForDecl(C.getDistributedActorDecl(), nominal,
+                                         nominal->getEffectiveAccess(), loc);
 
   // ==== Constructors
   // --- Get the default initializer

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1509,11 +1509,19 @@ using RequiredImportAccessLevelCallback =
     std::function<void(AttributedImport<ImportedModule>)>;
 
 /// Make a note that uses of \p decl in \p dc require that the decl's defining
-/// module be imported with an access level that is at least as permissive as \p
-/// accessLevel.
+/// module be imported with an access level that is at least as permissive as
+/// \p accessLevel.
 void recordRequiredImportAccessLevelForDecl(
     const Decl *decl, const DeclContext *dc, AccessLevel accessLevel,
     RequiredImportAccessLevelCallback remark);
+
+/// Make a note that uses of \p decl in \p dc require that the decl's defining
+/// module be imported with an access level that is at least as permissive as
+/// \p accessLevel. If `-Rmodule-api-import` is specified, a remark is emitted.
+void recordRequiredImportAccessLevelForDecl(const ValueDecl *decl,
+                                            const DeclContext *dc,
+                                            AccessLevel accessLevel,
+                                            SourceLoc loc);
 
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);


### PR DESCRIPTION
To reduce code duplication, implement a convenience version of `swift::recordRequiredImportAccessLevelForDecl()` that handles the common case of recording required import access for a reference to a `ValueDecl`.

NFC.
