### PR TITLE
[Sema] Resolve interface type in `ExtendedTypeRequest`

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3028,7 +3028,7 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   TypeResolutionOptions options(TypeResolverContext::ExtensionBinding);
   if (ext->isInSpecializeExtensionContext())
     options |= TypeResolutionFlags::AllowUsableFromInline;
-  const auto resolution = TypeResolution::forStructural(
+  const auto resolution = TypeResolution::forInterface(
       ext->getDeclContext(), options, nullptr,
       // FIXME: Don't let placeholder types escape type resolution.
       // For now, just return the placeholder type.

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -592,16 +592,16 @@ func f60503() {
 }
 
 // rdar://105089074
-enum EWithIdent<Id> where Id: P { // expected-note 2 {{where 'Id' = 'Int'}}
+enum EWithIdent<Id> where Id: P {
 case test(Id)
 }
 
-extension [EWithIdent<Int>] {
+extension [EWithIdent<Int>] { // expected-error {{type 'Int' does not conform to protocol 'P'}}
   func test() {
     sorted { lhs, rhs in
       switch (rhs, rhs) {
       case let (.test(x), .test(y)): break
-        // expected-error@-1 2 {{generic enum 'EWithIdent' requires that 'Int' conform to 'P'}}
+        // expected-error@-1 2 {{type 'Element' has no member 'test'}}
       case (_, _): break
       }
     }

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -230,3 +230,24 @@ extension (NewGeneric) {
     return NewGeneric()
   }
 }
+
+protocol P7 {}
+extension Float: P7 {}
+
+protocol Q1 {
+  associatedtype X
+  func foo(_ x: X)
+}
+struct S7<T: P7>: Q1 {
+  func foo(_ x: T) {}
+}
+
+// Make sure we reject these extensions.
+extension S7<Int> {} // expected-error {{type 'Int' does not conform to protocol 'P7'}}
+extension [S7<Int>] {} // expected-error {{type 'Int' does not conform to protocol 'P7'}}
+extension Array<S7<Int>> {} // expected-error {{type 'Int' does not conform to protocol 'P7'}}
+extension S7<Int>? {} // expected-error {{type 'Int' does not conform to protocol 'P7'}}
+extension S7<Int>.X {} // expected-error {{type 'Int' does not conform to protocol 'P7'}}
+extension S7<Float>.X {} // expected-error {{extension of type 'S7<Float>.X' (aka 'Float') must be declared as an extension of 'Float'}}
+// expected-note@-1 {{did you mean to extend 'Float' instead?}}
+extension S7<T> {} // expected-error {{cannot find type 'T' in scope}}

--- a/validation-test/compiler_crashers_2_fixed/28db756e678d736.swift
+++ b/validation-test/compiler_crashers_2_fixed/28db756e678d736.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","signature":"swift::Lowering::SILGenModule::useConformance(swift::ProtocolConformanceRef)"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: not %target-swift-frontend -emit-silgen %s
 protocol a {
 }
 struct b<c: a> {


### PR DESCRIPTION
Resolving only a structural type meant we weren't checking generic constraints, allowing invalid extensions to get past the type-checker. Change to resolve an interface type.
