### PR TITLE
[CS] Open generic requirements for types with unbound + placeholder types

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5796,6 +5796,23 @@ public:
   }
 };
 
+/// A function object suitable for use as an \c OpenRequirementFn that "opens"
+/// the requirements for a given type's generic signature given a set of
+/// argument substitutions.
+class OpenGenericTypeRequirements {
+  ConstraintSystem &cs;
+  const ConstraintLocatorBuilder &locator;
+  PreparedOverloadBuilder *preparedOverload;
+
+public:
+  explicit OpenGenericTypeRequirements(
+      ConstraintSystem &cs, const ConstraintLocatorBuilder &locator,
+      PreparedOverloadBuilder *preparedOverload)
+      : cs(cs), locator(locator), preparedOverload(preparedOverload) {}
+
+  void operator()(GenericTypeDecl *decl, TypeSubstitutionFn subst) const;
+};
+
 class HandlePlaceholderType {
   ConstraintSystem &cs;
   ConstraintLocator *locator;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1697,6 +1697,9 @@ namespace {
       // Introduce type variables for unbound generics.
       const auto genericOpener = OpenUnboundGenericType(CS, locator);
       const auto placeholderHandler = HandlePlaceholderType(CS, locator);
+      const auto requirementOpener =
+          OpenGenericTypeRequirements(CS, locator,
+                                      /*preparedOverload*/ nullptr);
 
       // Add a PackElementOf constraint for 'each T' type reprs.
       PackExpansionExpr *elementEnv = nullptr;
@@ -1708,7 +1711,7 @@ namespace {
 
       const auto result = TypeResolution::resolveContextualType(
           repr, CS.DC, options, genericOpener, placeholderHandler,
-          packElementOpener);
+          packElementOpener, requirementOpener);
       if (result->hasError()) {
         CS.recordFix(
             IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(locator)));
@@ -1973,7 +1976,9 @@ namespace {
             // Introduce type variables for unbound generics.
             OpenUnboundGenericType(CS, argLocator),
             HandlePlaceholderType(CS, argLocator),
-            OpenPackElementType(CS, argLocator, elementEnv));
+            OpenPackElementType(CS, argLocator, elementEnv),
+            OpenGenericTypeRequirements(CS, locator,
+                                        /*preparedOverload*/ nullptr));
         if (result->hasError()) {
           auto &ctxt = CS.getASTContext();
           result = PlaceholderType::get(ctxt, specializationArg);

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -452,6 +452,7 @@ class GenericClass<A> {}
 func genericFunc<T>(t: T) {
   _ = [T: GenericClass] // expected-error {{generic parameter 'A' could not be inferred}}
   // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+  // expected-error@-2 {{generic struct 'Dictionary' requires that 'T' conform to 'Hashable'}}
 }
 
 // https://github.com/apple/swift/issues/46113

--- a/test/Constraints/requirement_opening.swift
+++ b/test/Constraints/requirement_opening.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift
+
+struct K<U> {} // expected-note 6{{'U' declared as parameter to type 'K'}}
+protocol Q {}
+
+struct S1<T: Q>: ExpressibleByArrayLiteral { // expected-note 2{{where 'T' = 'K<Int>'}}
+  init(_ x: T) {}
+  init(arrayLiteral: T...) {}
+}
+
+typealias R1<T: Q> = S1<T> // expected-note {{where 'T' = 'K<Int>'}} expected-note 2{{where 'T' = 'K<U>'}}
+
+func foo(_ x: K<Int>) {
+  let _ = [x] as S1<K> // expected-error {{generic struct 'S1' requires that 'K<Int>' conform to 'Q'}}
+  let _ = [x] as R1<K> // expected-error {{generic type alias 'R1' requires that 'K<Int>' conform to 'Q'}}
+
+  let _: S1<K> = [x]   // expected-error {{generic struct 'S1' requires that 'K<Int>' conform to 'Q'}}
+  // FIXME: We ought to be able to infer 'U' here.
+  let _: R1<K> = [x] // expected-error 2 {{generic type alias 'R1' requires that 'K<U>' conform to 'Q'}}
+  // expected-error@-1 2 {{generic parameter 'U' could not be inferred}}
+}
+
+protocol P2 {
+  associatedtype A
+}
+
+struct S2<A: Q>: P2 {} // expected-note 3{{where 'A' = 'K<Int>'}}
+typealias R2<A: Q> = S2<A> // expected-note 2{{where 'A' = 'K<Int>'}} expected-note 2{{where 'A' = 'K<U>'}}
+
+// Same as S2, but without the Q requirement.
+struct S3<A>: P2 {}
+typealias R3<A: Q> = S3<A> // expected-note {{where 'A' = 'K<Int>'}} expected-note {{where 'A' = 'K<U>'}}
+
+func foo<T: P2>(_ y: T.A.Type) -> T {}
+let _ = foo(K<Int>.self) as S2<K> // expected-error {{generic struct 'S2' requires that 'K<Int>' conform to 'Q'}}
+let _ = foo(K<Int>.self) as R2<K> // expected-error {{generic type alias 'R2' requires that 'K<Int>' conform to 'Q'}}
+let _ = foo(K<Int>.self) as R3<K> // expected-error {{generic type alias 'R3' requires that 'K<Int>' conform to 'Q'}}
+
+let _: S2<K> = foo(K<Int>.self)   // expected-error {{generic struct 'S2' requires that 'K<Int>' conform to 'Q'}}
+// FIXME: We ought to be able to infer 'U' here.
+let _: R2<K> = foo(K<Int>.self)   // expected-error 2{{generic type alias 'R2' requires that 'K<U>' conform to 'Q'}}
+// expected-error@-1 2 {{generic parameter 'U' could not be inferred}}
+let _: R3<K> = foo(K<Int>.self)   // expected-error {{generic type alias 'R3' requires that 'K<U>' conform to 'Q'}}
+// expected-error@-1 2 {{generic parameter 'U' could not be inferred}}
+
+func foo<T: P2>(_ x: T.Type, _ y: T.A.Type) {}
+foo(S2<_>.self, K<Int>.self) // expected-error {{generic struct 'S2' requires that 'K<Int>' conform to 'Q'}}
+foo(R2<_>.self, K<Int>.self) // expected-error {{generic type alias 'R2' requires that 'K<Int>' conform to 'Q'}}
+
+struct S4<T: Q> { // expected-note {{where 'T' = 'Int'}}
+  init(_ x: T) {}
+}
+
+_ = S4<_>(0) // expected-error {{generic struct 'S4' requires that 'Int' conform to 'Q'}}

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -383,7 +383,7 @@ struct Kitten : ExpressibleByCatLiteral {}
 struct Puppy : ExpressibleByDogLiteral {}
 
 struct Claws<A: ExpressibleByCatLiteral> { // expected-note 3 {{'A' declared as parameter to type 'Claws'}}
-  struct Fangs<B: ExpressibleByDogLiteral> { } // expected-note {{where 'B' = 'NotADog'}}
+  struct Fangs<B: ExpressibleByDogLiteral> { } // expected-note 3 {{where 'B' = 'NotADog'}}
 }
 
 struct NotADog {}
@@ -407,9 +407,14 @@ do {
   // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{36-36=<<#A: ExpressibleByCatLiteral#>>}}
   let _: Claws.Fangs<NotADog> = something()
   // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-error@-2 {{generic struct 'Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
+
+  // FIXME: We get a duplicate diagnostic here because we don't differentiate
+  // constraint locators when opening generic requirements, we just use a
+  // locator for the top-level TypeRepr.
   _ = Claws.Fangs<NotADog>()
   // expected-error@-1 {{generic parameter 'A' could not be inferred}}
-  // expected-error@-2 {{generic struct 'Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
+  // expected-error@-2 2{{generic struct 'Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
   // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}} {{12-12=<<#A: ExpressibleByCatLiteral#>>}}
 }
 

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -427,3 +427,17 @@ extension OuterGeneric.MidNonGeneric {
 
   }
 }
+
+protocol P {}
+
+struct A<T> {}
+extension A where T: P { // expected-note {{where 'T' = 'T'}}
+  struct B<U> {
+    init(_ u: U) {}
+  }
+}
+extension A {
+  func bar() {
+    B(0) // expected-error {{referencing generic struct 'B' on 'A' requires that 'T' conform to 'P'}}
+  }
+}


### PR DESCRIPTION
- Introduce a generic requirements opening function for type resolution, which is used by the constraint system in cases where we need to impose requirements on opened type variables.
- Refactor `replaceInferableTypesWithTypeVars` to use this function when opening generic types that contain either placeholder or unbound generic types.

Together these changes ensure that we don't drop generic requirements when an unbound generic or placeholder type is used as a generic argument.

rdar://154857586
Resolves #82722