### PR TITLE
Mem2Reg: Fix lifetime completion for enum case values.

### DIFF
--- a/include/swift/SIL/OSSACompleteLifetime.h
+++ b/include/swift/SIL/OSSACompleteLifetime.h
@@ -62,15 +62,22 @@ private:
   /// TODO: Remove this option.
   bool ForceLivenessVerification;
 
+  /// If true, lifetimes are completed with `end_lifetime` instead of `destroy_value`.
+  /// This can be used e.g. for enum values of non-trivial enum types, which are
+  /// known to be a trivial case.
+  bool nonDestroyingEnd;
+
 public:
   OSSACompleteLifetime(
       SILFunction *function, const DominanceInfo *domInfo,
       DeadEndBlocks &deadEndBlocks,
       HandleTrivialVariable_t handleTrivialVariable = IgnoreTrivialVariable,
-      bool forceLivenessVerification = false)
+      bool forceLivenessVerification = false,
+      bool nonDestroyingEnd = false)
       : domInfo(domInfo), deadEndBlocks(deadEndBlocks),
         completedValues(function), handleTrivialVariable(handleTrivialVariable),
-        ForceLivenessVerification(forceLivenessVerification) {}
+        ForceLivenessVerification(forceLivenessVerification),
+        nonDestroyingEnd(nonDestroyingEnd) {}
 
   /// The kind of boundary at which to complete the lifetime.
   ///

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1823,8 +1823,15 @@ void StackAllocationPromoter::run(BasicBlockSetVector &livePhiBlocks) {
   deleter.forceDeleteWithUsers(asi);
 
   // Now, complete lifetimes!
+  // We know that the incomplete values are trivial enum cases. Therefore we
+  // complete their lifetimes with `end_lifetime` instead of `destroy_value`.
+  // This is especially important for embedded swift where we are not allowed
+  // to insert destroys which were not there before.
   OSSACompleteLifetime completion(function, domInfo,
-                                  *deadEndBlocksAnalysis->get(function));
+                                  *deadEndBlocksAnalysis->get(function),
+                                  OSSACompleteLifetime::IgnoreTrivialVariable,
+                                  /*forceLivenessVerification=*/false,
+                                  /*nonDestroyingEnd=*/true);
 
   // We may have incomplete lifetimes for enum locations on trivial paths.
   // After promoting them, complete lifetime here.

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -58,6 +58,11 @@ enum KlassOptional {
   case none
 }
 
+enum Result<S, F> {
+  case success(S)
+  case failure(F)
+}
+
 sil [ossa] @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
 sil [ossa] @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
 sil [ossa] @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
@@ -1549,3 +1554,40 @@ bb9:
   dealloc_stack %5
   br bb3
 }
+
+// CHECK-LABEL: sil [ossa] @test_end_lifetime_of_trivial_enum_case :
+// CHECK-NOT:     alloc_stack
+// CHECK:       bb2(%{{[0-9]+}} : $Int): 
+// CHECK:         fix_lifetime
+// CHECK:         end_borrow
+// CHECK:         end_lifetime %1
+// CHECK:       bb3:
+// CHECK-LABEL: } // end sil function 'test_end_lifetime_of_trivial_enum_case'
+sil [ossa] @test_end_lifetime_of_trivial_enum_case : $@convention(thin) (@inout X, @owned Result<X, Int>) -> () {
+bb0(%0 : $*X, %1 : @owned $Result<X, Int>):
+  %2 = alloc_stack $Result<X, Int>
+  store %1 to [init] %2
+  %3 = load_borrow %2
+  switch_enum %3, case #Result.success!enumelt: bb1, case #Result.failure!enumelt: bb2
+
+bb1(%10 : @guaranteed $X):
+  end_borrow %3
+  %12 = load [take] %2
+  %13 = unchecked_enum_data %12 : $Result<X, Int>, #Result.success!enumelt
+  store %13 to [assign] %0
+  br bb3
+
+bb2(%20 : $Int):
+  end_borrow %3
+  %22 = load_borrow %2
+  %23 = unchecked_enum_data %22, #Result.failure!enumelt
+  fix_lifetime %23
+  end_borrow %22
+  br bb3
+
+bb3:
+  dealloc_stack %2
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -17,6 +17,12 @@ public enum FakeOptional<T> {
   case some(T)
 }
 
+public enum E<T> {
+  case a(T)
+  case b(T)
+  case c
+}
+
 sil @swift_asyncLet_finish : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
 sil @swift_asyncLet_get : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
 sil @getC : $@convention(thin) () -> (@owned C)
@@ -119,6 +125,38 @@ bb2:
   br bb3
 
 bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @enumTest_no_destroy : $@convention(method) (@guaranteed E<C>) -> () {
+// CHECK:       bb2(%{{[0-9]+}} : @guaranteed $C):
+// CHECK:         destroy_value [dead_end]
+// CHECK-NEXT:    unreachable
+// CHECK:       bb3:
+// CHECK:         end_lifetime
+// CHECK-NEXT:    br bb4
+// CHECK-LABEL: } // end sil function 'enumTest_no_destroy'
+sil [ossa] @enumTest_no_destroy : $@convention(method) (@guaranteed E<C>) -> () {
+bb0(%0 : @guaranteed $E<C>):
+  specify_test "ossa_complete_lifetime @instruction[0] liveness_no_destroy"
+  %copy = copy_value %0 : $E<C>
+  %borrow = begin_borrow %copy : $E<C>
+  switch_enum %borrow : $E<C>, case #E.a!enumelt: bb1, case #E.b!enumelt: bb2, case #E.c!enumelt: bb3
+
+bb1(%10 : @guaranteed $C):
+  end_borrow %borrow : $E<C>
+  destroy_value %copy : $E<C>
+  br bb4
+
+bb2(%15 : @guaranteed $C):
+  unreachable
+
+bb3:
+  end_borrow %borrow : $E<C>
+  br bb4
+
+bb4:
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
Enum types may have incomplete lifetimes in address form for trivial case values. When promoted to value form, they will end up with incomplete ossa lifetimes. Because we know that the incomplete enum values are trivial enum cases we complete their lifetimes with `end_lifetime` instead of `destroy_value`. This is especially important for Embedded Swift where we are not allowed to insert destroys which were not there before.

Fixes a compiler crash in Embedded Swift caused by de-virtualizing such an inserted destroy and ending up with a non-specialized generic function.

rdar://158807801
