### PR TITLE
[Caching] Do not infer default on disk cas path when parsing options

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -778,8 +778,6 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
   if (const Arg *A = Args.getLastArg(OPT_cas_path))
     Opts.CASOpts.CASPath = A->getValue();
-  else if (Opts.CASOpts.CASPath.empty())
-    Opts.CASOpts.CASPath = llvm::cas::getDefaultOnDiskCASPath();
 
   if (const Arg *A = Args.getLastArg(OPT_cas_plugin_path))
     Opts.CASOpts.PluginPath = A->getValue();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -466,6 +466,11 @@ bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
     return false;
 
   const auto &Opts = getInvocation().getCASOptions();
+  if (Opts.CASOpts.CASPath.empty() && Opts.CASOpts.PluginPath.empty()) {
+    Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
+                         "no CAS options provided");
+    return true;
+  }
   auto MaybeDB = Opts.CASOpts.getOrCreateDatabases();
   if (!MaybeDB) {
     Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,

--- a/test/CAS/cas_output_backend.swift
+++ b/test/CAS/cas_output_backend.swift
@@ -13,6 +13,9 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
+// RUN: not %target-swift-frontend -c -cache-compile-job %s -o %t/test.o @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=NOT-CONFIG
+// NOT-CONFIG: error: CAS cannot be initialized from the specified '-cas-*' options: no CAS options provided
+
 // RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd > %t/cache_key.json


### PR DESCRIPTION
Currently, swift-frontend will always try to infer a default CASPath if no `-cas-path` is passed. The function `getDefaultOnDiskCASPath` called to infer the default path can fatal error in some environment where no caching directory and home directory, no matter if caching is used or not.

Remove the inferred path during parsing since that is not strictly necessary. If caching is enabled and no CASPath is passed, there will be error during CAS construction time.

rdar://158899187

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
