### PR TITLE
Tests: Update the `nsmanaged-attr.swift` test for the Xcode 26 SDKs

### DIFF
--- a/test/ModuleInterface/nsmanaged-attr.swift
+++ b/test/ModuleInterface/nsmanaged-attr.swift
@@ -16,24 +16,24 @@
 import CoreData
 import Foundation
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class MyObject : CoreData.NSManagedObject {
+// CHECK: @objc @_inheritsConvenienceInitializers{{ nonisolated | }}public class MyObject : CoreData.NSManagedObject {
 public class MyObject: NSManagedObject {
-  // CHECK: @objc @NSManaged dynamic public var myVar: Swift.String {
+  // CHECK: @objc @NSManaged{{ nonisolated | }}dynamic public var myVar: Swift.String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged public var myVar: String
-  // CHECK: @NSManaged @objc dynamic public var myVar2: Swift.String {
+  // CHECK: @NSManaged @objc{{ nonisolated | }}dynamic public var myVar2: Swift.String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged @objc public var myVar2: String
-  // CHECK: @NSManaged @objc dynamic public var myVar3: Swift.String {
+  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar3: Swift.String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged @objc dynamic public var myVar3: String
-  // CHECK: @NSManaged @objc dynamic public var myVar4: Swift.String {
+  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar4: Swift.String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: }
   @NSManaged @objc dynamic public private(set) var myVar4: String


### PR DESCRIPTION
Something has changed about the CoreData module and caused the declarations in this test interface to now be printed with `nonisolated` modifiers.

Resolves rdar://158783868.
