### PR TITLE
Revert "AST: Re-enable TypeSubstituter::transformSubstitutionMap() again"

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -358,7 +358,7 @@ public:
   std::optional<Type> transformLocalArchetypeType(LocalArchetypeType *local,
                                                   TypePosition pos);
 
-  SubstitutionMap transformSubstitutionMap(SubstitutionMap subs);
+  // SubstitutionMap transformSubstitutionMap(SubstitutionMap subs);
 
   CanType transformSILField(CanType fieldTy, TypePosition pos);
 };
@@ -474,10 +474,13 @@ Type TypeSubstituter::transformDependentMemberType(DependentMemberType *dependen
   return result;
 }
 
+// FIXME: This exposes a scalability issue; see test/SILGen/opaque_result_type_slow.swift.
+/*
 SubstitutionMap TypeSubstituter::transformSubstitutionMap(SubstitutionMap subs) {
   // FIXME: Take level into account? Move level down into IFS?
   return subs.subst(IFS);
 }
+*/
 
 CanType TypeSubstituter::transformSILField(CanType fieldTy, TypePosition pos) {
   // Type substitution does not walk into the SILBoxType's field types, because

--- a/test/Generics/rdar158774099.swift
+++ b/test/Generics/rdar158774099.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify \
+// RUN:     %t/View.swift %t/Modifier.swift %t/MyStorage.swift %t/Storage.swift %t/WrappedStorage.swift
+
+//--- Storage.swift
+
+protocol Representable {
+  associatedtype Outputs
+  typealias Context = RepresentableContext<Self>
+}
+
+struct RepresentableContext<R: Representable> {}
+
+struct Inputs<Outputs> {
+}
+
+protocol Storage<Value> {
+  associatedtype Value
+  associatedtype R: Representable
+
+  func body(content: Content) -> Value
+
+  typealias Content = Inputs<R.Outputs>
+}
+
+//--- WrappedStorage.swift
+private struct WrappedStorage<Base: Storage>: Storage where Base.Value == MyStorage.Value {
+  typealias R = Base.R
+
+  init(base: Base, body: @escaping (Base.Value) -> Void) {
+  }
+
+  func body(content: Content) -> Base.Value { fatalError() }
+}
+
+extension Storage where Value == MyStorage.Value {
+  func withStorage(body: @escaping (Value) -> Void) -> some Storage<Value> {
+    WrappedStorage(base: self, body: body)
+  }
+}
+
+//--- MyStorage.swift
+struct MyRepresentable: Representable {
+  struct Outputs {}
+}
+
+struct MyStorage: Storage {
+  typealias R = MyRepresentable
+
+  struct Value: Equatable {}
+
+  func body(content: Content) -> Value {
+    fatalError()
+  }
+}
+
+//--- Modifier.swift
+extension P {
+  func storage(_: some Storage) -> some P { Test() }
+}
+
+//--- View.swift
+protocol P {
+}
+
+struct Test: P {
+}
+
+func test() -> some P {
+  let storage = MyStorage().withStorage { value in }
+  return Test().storage(storage)
+}


### PR DESCRIPTION
This reverts commit 81bf4490aebecb976ea792405385a7268fc6e710 and adds a regression test-case.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
