### PR TITLE
SIL: fix printing of dependent existential archetypes

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7221,6 +7221,9 @@ public:
     if (Options.PrintForSIL) {
       auto *env = T->getGenericEnvironment();
 
+      if (!T->isRoot())
+        Printer << '(';
+
       Printer << "@opened(\"" << env->getOpenedExistentialUUID() << "\", ";
       auto existentialTy = env->maybeApplyOuterContextSubstitutions(
           env->getOpenedExistentialType());
@@ -7232,7 +7235,8 @@ public:
       auto interfaceTy = T->getInterfaceType();
       auto selfTy = interfaceTy->getRootGenericParam();
       auto &ctx = selfTy->getASTContext();
-      newAlternativeTypeNames[selfTy->getCanonicalType()] = ctx.Id_Self;
+      Identifier selfId = (T->isRoot() ? ctx.Id_Self : ctx.getIdentifier("Self)"));
+      newAlternativeTypeNames[selfTy->getCanonicalType()] = selfId;
 
       PrintOptions::OverrideScope scope(Options);
       OVERRIDE_PRINT_OPTION(scope, AlternativeTypeNames, &newAlternativeTypeNames);

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1744,6 +1744,22 @@ bb0:
   return %1 : $()
 }
 
+protocol P2 {
+  associatedtype A
+}
+
+// CHECK-LABEL: sil [ossa] @test_dependent_existential_archetype :
+// CHECK:         %2 = alloc_stack $(@opened("0B7C132E-8010-11F0-8526-0EA13E3AABB4", any P2) Self).A
+// CHECK-LABEL: } // end sil function 'test_dependent_existential_archetype'
+sil [ossa] @test_dependent_existential_archetype : $@convention(thin) (@thick any P2.Type) -> () {
+bb0(%0 : $@thick any P2.Type):
+  %1 = open_existential_metatype %0 to $@thick (@opened("0B7C132E-8010-11F0-8526-0EA13E3AABB4", any P2) Self).Type
+  %2 = alloc_stack $(@opened("0B7C132E-8010-11F0-8526-0EA13E3AABB4", any P2) Self).A
+  dealloc_stack %2
+  %r = tuple ()
+  return %r
+}
+
 class Foo2: Foo {}
 
 // CHECK-LABEL: sil_vtable Foo {

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -320,7 +320,7 @@ func testCovariantSelfSubscript8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] [var_decl] $Any, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod1 : <Self where Self : P> (Self) -> () -> Self.A
-// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
 func testCovariantAssocMethod1(p: any P) {
   let x = p.covariantAssocMethod1()
@@ -330,7 +330,7 @@ func testCovariantAssocMethod1(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod2 : <Self where Self : P> (Self) -> () -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocMethod2(p: any P) {
   let x = p.covariantAssocMethod2()
 }
@@ -338,7 +338,7 @@ func testCovariantAssocMethod2(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod3 : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
-// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
+// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick ((@opened([[OPENED_ID]], any P) Self).A).Type, $@thick any Any.Type
 // CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
 // CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocMethod3(p: any P) {
@@ -349,8 +349,8 @@ func testCovariantAssocMethod3(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod4 : <Self where Self : P> (Self) -> () -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocMethod4(p: any P) {
   let x = p.covariantAssocMethod4()
 }
@@ -359,7 +359,7 @@ func testCovariantAssocMethod4(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod5 : <Self where Self : P> (Self) -> () -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<@opened([[OPENED_ID]], any P) Self.A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<(@opened([[OPENED_ID]], any P) Self).A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
 // CHECK: debug_value %{{[0-9]+}} : $Array<Any>, let, name "x"
 func testCovariantAssocMethod5(p: any P) {
   let x = p.covariantAssocMethod5()
@@ -369,7 +369,7 @@ func testCovariantAssocMethod5(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod6 : <Self where Self : P> (Self) -> () -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, @opened([[OPENED_ID]], any P) Self.A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, (@opened([[OPENED_ID]], any P) Self).A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
 // CHECK: debug_value %{{[0-9]+}} : $Dictionary<String, Any>, let, name "x"
 func testCovariantAssocMethod6(p: any P) {
   let x = p.covariantAssocMethod6()
@@ -379,7 +379,7 @@ func testCovariantAssocMethod6(p: any P) {
 // CHECK: function_ref thunk for @callee_guaranteed (@in_guaranteed Any) -> ()
 // CHECK-NEXT: function_ref @$sypIgn_1A42existential_member_accesses_self_assoctype1PPQzIegn_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@in_guaranteed Any) -> ()) -> ()
 // CHECK: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]<@opened([[OPENED_ID]], any P) Self>
-// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self.A>
+// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed (@opened([[OPENED_ID]], any P) Self).A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <(@opened([[OPENED_ID]], any P) Self).A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod7 : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
@@ -390,7 +390,7 @@ func testCovariantAssocMethod7(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*[[OPENED_TY:@opened\("[0-9A-F-]+", any P\) Self]]
 // CHECK: [[THUNK:%[0-9]+]] = function_ref @[[ASSOCTYPE_ARRAY_THUNK_NAME:\$[0-9a-zA-Z_]+]] : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@guaranteed Array<τ_0_0.A>, @guaranteed @noescape @callee_guaranteed (@guaranteed Array<Any>) -> ()) -> ()
 // CHECK: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]<[[OPENED_TY]]>
-// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<[[OPENED_TY]].A>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]].A>
+// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<([[OPENED_TY]]).A>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <([[OPENED_TY]]).A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.covariantAssocMethod8 : <Self where Self : P> (Self) -> ((Self.A...) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
@@ -407,7 +407,7 @@ func testCovariantAssocMethod8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] [var_decl] $Any, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty1!getter : <Self where Self : P> (Self) -> () -> Self.A
-// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
 func testCovariantAssocProperty1(p: any P) {
   let x = p.covariantAssocProperty1
@@ -417,7 +417,7 @@ func testCovariantAssocProperty1(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty2!getter : <Self where Self : P> (Self) -> () -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocProperty2(p: any P) {
   let x = p.covariantAssocProperty2
 }
@@ -425,7 +425,7 @@ func testCovariantAssocProperty2(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty3!getter : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
-// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
+// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick ((@opened([[OPENED_ID]], any P) Self).A).Type, $@thick any Any.Type
 // CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
 // CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocProperty3(p: any P) {
@@ -436,8 +436,8 @@ func testCovariantAssocProperty3(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty4!getter : <Self where Self : P> (Self) -> () -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocProperty4(p: any P) {
   let x = p.covariantAssocProperty4
 }
@@ -446,7 +446,7 @@ func testCovariantAssocProperty4(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty5!getter : <Self where Self : P> (Self) -> () -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<@opened([[OPENED_ID]], any P) Self.A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<(@opened([[OPENED_ID]], any P) Self).A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
 // CHECK: debug_value %{{[0-9]+}} : $Array<Any>, let, name "x"
 func testCovariantAssocProperty5(p: any P) {
   let x = p.covariantAssocProperty5
@@ -456,7 +456,7 @@ func testCovariantAssocProperty5(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty6!getter : <Self where Self : P> (Self) -> () -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, @opened([[OPENED_ID]], any P) Self.A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, (@opened([[OPENED_ID]], any P) Self).A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
 // CHECK: debug_value %{{[0-9]+}} : $Dictionary<String, Any>, let, name "x"
 func testCovariantAssocProperty6(p: any P) {
   let x = p.covariantAssocProperty6
@@ -465,7 +465,7 @@ func testCovariantAssocProperty6(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self,  #P.covariantAssocProperty7!getter : <Self where Self : P> (Self) -> () -> ((Self.A) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <τ_0_0.A>
-// CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <@opened([[OPENED_ID]], any P) Self.A> to $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self.A>) -> ()
+// CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <(@opened([[OPENED_ID]], any P) Self).A> to $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <(@opened([[OPENED_ID]], any P) Self).A>) -> ()
 // CHECK: [[THUNK:%[0-9]+]] = function_ref @$sxRi_zRi0_zly1A42existential_member_accesses_self_assoctype1PPQzIsgn_Iegg_ypIgn_Iegg_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed (@in_guaranteed Any) -> (), @guaranteed @callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>) -> ()) -> ()
 // CHECK: partial_apply [callee_guaranteed] [[THUNK]]<@opened([[OPENED_ID]], any P) Self>([[STEP1]]) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed (@in_guaranteed Any) -> (), @guaranteed @callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>) -> ()) -> ()
 // CHECK: debug_value %{{[0-9]+}} : $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@in_guaranteed Any) -> ()) -> (), let, name "x"
@@ -476,7 +476,7 @@ func testCovariantAssocProperty7(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*[[OPENED_TY:@opened\("[0-9A-F-]+", any P\) Self]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]],  #P.covariantAssocProperty8!getter : <Self where Self : P> (Self) -> () -> ((Self.A...) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<[[OPENED_TY]]>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0>) -> () for <τ_0_0.A>
-// CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0>) -> () for <[[OPENED_TY]].A> to $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]].A>) -> ()
+// CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0>) -> () for <([[OPENED_TY]]).A> to $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <([[OPENED_TY]]).A>) -> ()
 // CHECK: [[THUNK:%[0-9]+]] = function_ref @[[THUNK_NAME:\$[0-9a-zA-Z_]+]] : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed (@guaranteed Array<Any>) -> (), @guaranteed @callee_guaranteed (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0.A>) -> ()) -> ()
 // CHECK: partial_apply [callee_guaranteed] [[THUNK]]<[[OPENED_TY]]>([[STEP1]])
 // CHECK: debug_value %{{[0-9]+}} : $@callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed Array<Any>) -> ()) -> (), let, name "x"
@@ -493,7 +493,7 @@ func testCovariantAssocProperty8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] [var_decl] $Any, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A
-// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
 func testCovariantAssocSubscript1(p: any P) {
   let x = p[covariantAssocSubscript1: ()]
@@ -503,7 +503,7 @@ func testCovariantAssocSubscript1(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocSubscript2(p: any P) {
   let x = p[covariantAssocSubscript2: ()]
 }
@@ -511,7 +511,7 @@ func testCovariantAssocSubscript2(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
-// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
+// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick ((@opened([[OPENED_ID]], any P) Self).A).Type, $@thick any Any.Type
 // CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
 // CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocSubscript3(p: any P) {
@@ -522,8 +522,8 @@ func testCovariantAssocSubscript3(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
-// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
+// CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $(@opened([[OPENED_ID]], any P) Self).A
 func testCovariantAssocSubscript4(p: any P) {
   let x = p[covariantAssocSubscript4: ()]
 }
@@ -532,7 +532,7 @@ func testCovariantAssocSubscript4(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<@opened([[OPENED_ID]], any P) Self.A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<(@opened([[OPENED_ID]], any P) Self).A, Any>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
 // CHECK: debug_value %{{[0-9]+}} : $Array<Any>, let, name "x"
 func testCovariantAssocSubscript5(p: any P) {
   let x = p[covariantAssocSubscript5: ()]
@@ -542,7 +542,7 @@ func testCovariantAssocSubscript5(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, @opened([[OPENED_ID]], any P) Self.A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, (@opened([[OPENED_ID]], any P) Self).A, String, Any>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
 // CHECK: debug_value %{{[0-9]+}} : $Dictionary<String, Any>, let, name "x"
 func testCovariantAssocSubscript6(p: any P) {
   let x = p[covariantAssocSubscript6: ()]
@@ -551,7 +551,7 @@ func testCovariantAssocSubscript6(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[THUNK:%[0-9]+]] = function_ref @$sypIgn_1A42existential_member_accesses_self_assoctype1PPQzIegn_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@in_guaranteed Any) -> ()) -> ()
 // CHECK: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]<@opened([[OPENED_ID]], any P) Self>
-// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self.A>
+// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed (@opened([[OPENED_ID]], any P) Self).A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <(@opened([[OPENED_ID]], any P) Self).A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
@@ -562,7 +562,7 @@ func testCovariantAssocSubscript7(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*[[OPENED_TY:@opened\("[0-9A-F-]+", any P\) Self]]
 // CHECK: [[THUNK:%[0-9]+]] = function_ref @[[ASSOCTYPE_ARRAY_THUNK_NAME]] : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@guaranteed Array<τ_0_0.A>, @guaranteed @noescape @callee_guaranteed (@guaranteed Array<Any>) -> ()) -> ()
 // CHECK: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]<[[OPENED_TY]]>
-// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<[[OPENED_TY]].A>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]].A>
+// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<([[OPENED_TY]]).A>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <([[OPENED_TY]]).A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.subscript!getter : <Self where Self : P> (Self) -> ((Self.A...) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
@@ -581,7 +581,7 @@ protocol P2: P where A: Class & P {}
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P2 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P2) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod1 : <Self where Self : P> (Self) -> () -> Self.A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
-// CHECK: init_existential_ref %{{[0-9]+}} : $@opened([[OPENED_ID]], any P2) Self.A : $@opened([[OPENED_ID]], any P2) Self.A, $any Class & P
+// CHECK: init_existential_ref %{{[0-9]+}} : $(@opened([[OPENED_ID]], any P2) Self).A : $(@opened([[OPENED_ID]], any P2) Self).A, $any Class & P
 // CHECK: debug_value %{{[0-9]+}} : $any Class & P, let, name "x"
 func testCovariantAssocMethod1Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod1()
@@ -590,7 +590,7 @@ func testCovariantAssocMethod1Constrained(p2: any P2) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P2 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P2) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod2 : <Self where Self : P> (Self) -> () -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
-// CHECK: init_existential_ref %{{[0-9]+}} : $@opened([[OPENED_ID]], any P2) Self.A : $@opened([[OPENED_ID]], any P2) Self.A, $any Class & P
+// CHECK: init_existential_ref %{{[0-9]+}} : $(@opened([[OPENED_ID]], any P2) Self).A : $(@opened([[OPENED_ID]], any P2) Self).A, $any Class & P
 // CHECK: debug_value %{{[0-9]+}} : $Optional<any Class & P>, let, name "x"
 func testCovariantAssocMethod2Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod2()
@@ -599,7 +599,7 @@ func testCovariantAssocMethod2Constrained(p2: any P2) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P2 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P2) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod3 : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
-// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P2) Self.A).Type, $@thick any (Class & P).Type
+// CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick ((@opened([[OPENED_ID]], any P2) Self).A).Type, $@thick any (Class & P).Type
 // CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]]
 // CHECK: debug_value [[MV]] : $@thick any (Class & P).Type, let, name "x"
 func testCovariantAssocMethod3Constrained(p2: any P2) {
@@ -609,8 +609,8 @@ func testCovariantAssocMethod3Constrained(p2: any P2) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P2 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P2) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod4 : <Self where Self : P> (Self) -> () -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
-// CHECK: init_existential_ref %{{[0-9]+}} : $@opened([[OPENED_ID]], any P2) Self.A : $@opened([[OPENED_ID]], any P2) Self.A, $any Class & P
-// CHECK: init_existential_ref %{{[0-9]+}} : $@opened([[OPENED_ID]], any P2) Self.A : $@opened([[OPENED_ID]], any P2) Self.A, $any Class & P
+// CHECK: init_existential_ref %{{[0-9]+}} : $(@opened([[OPENED_ID]], any P2) Self).A : $(@opened([[OPENED_ID]], any P2) Self).A, $any Class & P
+// CHECK: init_existential_ref %{{[0-9]+}} : $(@opened([[OPENED_ID]], any P2) Self).A : $(@opened([[OPENED_ID]], any P2) Self).A, $any Class & P
 // CHECK: debug_value %{{[0-9]+}} : $(any Class & P, any Class & P), let, name "x"
 func testCovariantAssocMethod4Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod4()
@@ -620,7 +620,7 @@ func testCovariantAssocMethod4Constrained(p2: any P2) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod5 : <Self where Self : P> (Self) -> () -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<@opened([[OPENED_ID]], any P2) Self.A, any Class & P>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[ARRAY_UPCAST_FN]]<(@opened([[OPENED_ID]], any P2) Self).A, any Class & P>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
 // CHECK: debug_value %{{[0-9]+}} : $Array<any Class & P>, let, name "x"
 func testCovariantAssocMethod5Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod5()
@@ -630,7 +630,7 @@ func testCovariantAssocMethod5Constrained(p2: any P2) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod6 : <Self where Self : P> (Self) -> () -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, @opened([[OPENED_ID]], any P2) Self.A, String, any Class & P>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK: [[RESULT:%[0-9]+]] = apply [[DICT_UPCAST_FN]]<String, (@opened([[OPENED_ID]], any P2) Self).A, String, any Class & P>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
 // CHECK: debug_value %{{[0-9]+}} : $Dictionary<String, any Class & P>, let, name "x"
 func testCovariantAssocMethod6Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod6()
@@ -640,7 +640,7 @@ func testCovariantAssocMethod6Constrained(p2: any P2) {
 // CHECK: function_ref thunk for @callee_guaranteed (@guaranteed Class & P) -> ()
 // CHECK-NEXT: [[THUNK1:%[0-9]+]] = function_ref @$s42existential_member_accesses_self_assoctype1P_AA5ClassCXcIgg_1AAaBPQzIegn_AA2P2RzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@guaranteed any Class & P) -> ()) -> ()
 // CHECK-NEXT: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK1]]<@opened([[OPENED_ID]], any P2) Self>
-// CHECK-NEXT: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] :  $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P2) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P2) Self.A>
+// CHECK-NEXT: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] :  $@callee_guaranteed (@in_guaranteed (@opened([[OPENED_ID]], any P2) Self).A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <(@opened([[OPENED_ID]], any P2) Self).A>
 // CHECK-NEXT: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK-NEXT: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod7 : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
 // CHECK-NEXT: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
@@ -708,7 +708,7 @@ protocol P5<A>{
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype30testCovariantAssocGenericClass2p5AA0iJ0CySiGAA2P5_pSi1AAaGPRts_XP_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P5<Int> to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P5<Int>) Self
 // CHECK: [[APPLY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P5<Int>) Self>([[OPENED]]) : $@convention(witness_method: P5) <τ_0_0 where τ_0_0 : P5> (@in_guaranteed τ_0_0) -> @owned τ_0_0.B
-// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY]] : $@opened([[OPENED_ID]], any P5<Int>) Self.B to $GenericClass<Int>
+// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY]] : $(@opened([[OPENED_ID]], any P5<Int>) Self).B to $GenericClass<Int>
 // CHECK: return %{{[0-9]+}} : $GenericClass<Int>
 // CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype30testCovariantAssocGenericClass2p5AA0iJ0CySiGAA2P5_pSi1AAaGPRts_XP_tF'
 func testCovariantAssocGenericClass(p5: any P5<Int>) -> GenericClass<Int> {
@@ -719,7 +719,7 @@ func testCovariantAssocGenericClass(p5: any P5<Int>) -> GenericClass<Int> {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype33testCovariantAssocGenericSubClass2p5AA0ijK0CySbGAA2P5_pSb1AAaGPRts_XP_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P5<Bool> to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P5<Bool>) Self
 // CHECK: apply %3<@opened([[OPENED_ID]], any P5<Bool>) Self>([[OPENED]]) : $@convention(witness_method: P5) <τ_0_0 where τ_0_0 : P5> (@in_guaranteed τ_0_0) -> @owned τ_0_0.C
-// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY:%[0-9]+]] : $@opened([[OPENED_ID]], any P5<Bool>) Self.C to $GenericSubClass<Bool>
+// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY:%[0-9]+]] : $(@opened([[OPENED_ID]], any P5<Bool>) Self).C to $GenericSubClass<Bool>
 // CHECK: return %{{[0-9]+}} : $GenericSubClass<Bool>
 // CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype33testCovariantAssocGenericSubClass2p5AA0ijK0CySbGAA2P5_pSb1AAaGPRts_XP_tF'
 func testCovariantAssocGenericSubClass(p5: any P5<Bool>) -> GenericSubClass<Bool> {
@@ -740,8 +740,8 @@ protocol P4: P where A == (B, B) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P4 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P4) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P4) Self, #P.covariantAssocMethod1 : <Self where Self : P> (Self) -> () -> Self.A
 // CHECK: apply %4<@opened([[OPENED_ID]], any P4) Self>(%{{[0-9]+}}, [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
-// CHECK: init_existential_addr %{{[0-9]+}} : $*any P4, $@opened([[OPENED_ID]], any P4) Self.B
-// CHECK: init_existential_addr %{{[0-9]+}} : $*any P4, $@opened([[OPENED_ID]], any P4) Self.B
+// CHECK: init_existential_addr %{{[0-9]+}} : $*any P4, $(@opened([[OPENED_ID]], any P4) Self).B
+// CHECK: init_existential_addr %{{[0-9]+}} : $*any P4, $(@opened([[OPENED_ID]], any P4) Self).B
 func testCovariantAssocMethod1PartiallyConcrete(p4: any P4) {
   let x = p4.covariantAssocMethod1()
 }

--- a/test/SILOptimizer/mandatory_inlining_open_existential.swift
+++ b/test/SILOptimizer/mandatory_inlining_open_existential.swift
@@ -12,7 +12,7 @@ protocol P {
 // CHECK-LABEL: sil hidden [always_inline] @$s35mandatory_inlining_open_existential6callee1pAA1P_pAaD_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access {{%[0-9]+}} : $*any P to $*[[OPENED_TY:@opened\("[-A-F0-9]+", any P\) Self]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.f : <Self where Self : P> (Self) -> () -> Self.Assoc
-// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*any P, $[[OPENED_TY]].Assoc
+// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*any P, $([[OPENED_TY]]).Assoc
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[RESULT]], [[OPENED]])
 // CHECK: }
 @inline(__always)
@@ -23,7 +23,7 @@ func callee(p: any P) -> any P {
 // CHECK-LABEL: sil hidden @$s35mandatory_inlining_open_existential6caller1pAA1P_pAaD_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access {{%[0-9]+}} : $*any P to $*[[OPENED_TY:@opened\("[-A-F0-9]+", any P\) Self]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.f : <Self where Self : P> (Self) -> () -> Self.Assoc
-// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*any P, $[[OPENED_TY]].Assoc
+// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*any P, $([[OPENED_TY]]).Assoc
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[RESULT]], [[OPENED]])
 // CHECK: }
 func caller(p: any P) -> any P {


### PR DESCRIPTION
We were missing parentheses:
```
  $@opened("...", any P2) Self.A
```
->
```
  $(@opened("...", any P2) Self).A
```
