### PR TITLE
Cache SILFunction::getLoweredTypeInContext()

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -60,16 +60,19 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var hasLoweredAddresses: Bool { bridged.hasLoweredAddresses() }
 
-  /// The lowered function type in the expansion context of self.
+  public var loweredFunctionType: CanonicalType {
+    CanonicalType(bridged: bridged.getLoweredFunctionType())
+  }
+
+  /// The lowered function type, with opaque archetypes erased.
   ///
-  /// Always expanding a function type means that the opaque result types
-  /// have the correct generic signature. For example:
+  /// For example:
   ///    @substituted <τ_0_0> () -> @out τ_0_0 for <some P>
   /// is lowered to this inside its module:
   ///    @substituted <τ_0_0> () -> @out τ_0_0 for <ActualResultType>
   /// and this outside its module
   ///    @substituted <τ_0_0> () -> @out τ_0_0 for <some P>
-  public var loweredFunctionType: CanonicalType {
+  public var loweredFunctionTypeInContext: CanonicalType {
     CanonicalType(bridged: bridged.getLoweredFunctionTypeInContext())
   }
 
@@ -354,7 +357,7 @@ public func != (lhs: Function, rhs: Function) -> Bool { lhs !== rhs }
 // Function conventions.
 extension Function {
   public var convention: FunctionConvention {
-    FunctionConvention(for: loweredFunctionType, in: self)
+    FunctionConvention(for: loweredFunctionTypeInContext, in: self)
   }
 
   public var argumentConventions: ArgumentConventions {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -486,6 +486,7 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getAccessorName() const;
   BRIDGED_INLINE bool hasOwnership() const;
   BRIDGED_INLINE bool hasLoweredAddresses() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getLoweredFunctionType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getLoweredFunctionTypeInContext() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getGenericSignature() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getForwardingSubstitutionMap() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -706,8 +706,7 @@ bool BridgedFunction::hasOwnership() const { return getFunction()->hasOwnership(
 bool BridgedFunction::hasLoweredAddresses() const { return getFunction()->getModule().useLoweredAddresses(); }
 
 BridgedCanType BridgedFunction::getLoweredFunctionTypeInContext() const {
-  auto expansion = getFunction()->getTypeExpansionContext();
-  return getFunction()->getLoweredFunctionTypeInContext(expansion);
+  return getFunction()->getLoweredFunctionTypeInContext();
 }
 
 BridgedGenericSignature BridgedFunction::getGenericSignature() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -705,6 +705,10 @@ bool BridgedFunction::hasOwnership() const { return getFunction()->hasOwnership(
 
 bool BridgedFunction::hasLoweredAddresses() const { return getFunction()->getModule().useLoweredAddresses(); }
 
+BridgedCanType BridgedFunction::getLoweredFunctionType() const {
+  return getFunction()->getLoweredFunctionType();
+}
+
 BridgedCanType BridgedFunction::getLoweredFunctionTypeInContext() const {
   return getFunction()->getLoweredFunctionTypeInContext();
 }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -236,6 +236,8 @@ private:
   /// The lowered type of the function.
   CanSILFunctionType LoweredType;
 
+  CanSILFunctionType LoweredTypeInContext;
+
   /// The context archetypes of the function.
   GenericEnvironment *GenericEnv = nullptr;
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -572,6 +572,9 @@ public:
   CanSILFunctionType getLoweredFunctionType() const {
     return LoweredType;
   }
+
+  CanSILFunctionType getLoweredFunctionTypeInContext() const;
+
   CanSILFunctionType
   getLoweredFunctionTypeInContext(TypeExpansionContext context) const;
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -5291,11 +5291,15 @@ TypeExpansionContext::TypeExpansionContext(const SILFunction &f)
       inContext(f.getModule().getAssociatedContext()),
       isContextWholeModule(f.getModule().isWholeModule()) {}
 
+CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext() const {
+  return getLoweredFunctionTypeInContext(getTypeExpansionContext());
+}
+
 CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext(
     TypeExpansionContext context) const {
   auto origFunTy = getLoweredFunctionType();
   auto &M = getModule();
-  auto funTy = M.Types.getLoweredType(origFunTy , context);
+  auto funTy = M.Types.getLoweredType(origFunTy, context);
   return cast<SILFunctionType>(funTy.getASTType());
 }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -5292,7 +5292,12 @@ TypeExpansionContext::TypeExpansionContext(const SILFunction &f)
       isContextWholeModule(f.getModule().isWholeModule()) {}
 
 CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext() const {
-  return getLoweredFunctionTypeInContext(getTypeExpansionContext());
+  if (!LoweredTypeInContext) {
+    const_cast<SILFunction *>(this)->LoweredTypeInContext
+      = getLoweredFunctionTypeInContext(
+        getTypeExpansionContext());
+  }
+  return LoweredTypeInContext;
 }
 
 CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext(

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6499,8 +6499,7 @@ void SILGenFunction::emitYield(SILLocation loc,
   SmallVector<ManagedValue, 4> yieldArgs;
   SmallVector<DelayedArgument, 2> delayedArgs;
 
-  auto fnType = F.getLoweredFunctionTypeInContext(getTypeExpansionContext())
-    ->getUnsubstitutedType(SGM.M);
+  auto fnType = F.getLoweredFunctionTypeInContext()->getUnsubstitutedType(SGM.M);
   SmallVector<SILParameterInfo, 4> substYieldTys;
   for (auto origYield : fnType->getYields()) {
     substYieldTys.push_back(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3734,8 +3734,7 @@ static SILFunction *getOrCreateKeyPathGetter(
     thunk->setGenericEnvironment(genericEnv);
   }
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
-  signature = subSGF.F.getLoweredFunctionTypeInContext(
-      subSGF.F.getTypeExpansionContext());
+  signature = subSGF.F.getLoweredFunctionTypeInContext();
   auto resultArgTy =
       subSGF.silConv.getSILType(signature->getSingleResult(), signature,
                                 subSGF.F.getTypeExpansionContext());
@@ -3832,8 +3831,7 @@ static SILFunction *getOrCreateKeyPathSetter(
     thunk->setGenericEnvironment(genericEnv);
   }
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
-  signature = subSGF.F.getLoweredFunctionTypeInContext(
-      subSGF.F.getTypeExpansionContext());
+  signature = subSGF.F.getLoweredFunctionTypeInContext();
   auto valueArgTy =
       subSGF.silConv.getSILType(signature->getParameters()[0], signature,
                                 subSGF.getTypeExpansionContext());
@@ -3968,8 +3966,7 @@ static SILFunction *getOrCreateKeyPathAppliedMethod(
     thunk->setGenericEnvironment(genericEnv);
   }
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
-  signature = subSGF.F.getLoweredFunctionTypeInContext(
-      subSGF.F.getTypeExpansionContext());
+  signature = subSGF.F.getLoweredFunctionTypeInContext();
   auto resultArgTy =
       subSGF.silConv.getSILType(signature->getSingleResult(), signature,
                                 subSGF.F.getTypeExpansionContext());
@@ -4058,8 +4055,7 @@ static SILFunction *getOrCreateUnappliedKeypathMethod(
     thunk->setGenericEnvironment(genericEnv);
   }
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
-  signature = subSGF.F.getLoweredFunctionTypeInContext(
-      subSGF.F.getTypeExpansionContext());
+  signature = subSGF.F.getLoweredFunctionTypeInContext();
   auto resultArgTy =
       subSGF.silConv.getSILType(signature->getSingleResult(), signature,
                                 subSGF.F.getTypeExpansionContext());

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -92,7 +92,7 @@ struct LoweredParamGenerator {
                         unsigned numIgnoredTrailingParameters)
     : SGF(SGF), fnTy(SGF.F.getLoweredFunctionType()),
       parameterTypes(
-          SGF.F.getLoweredFunctionTypeInContext(SGF.B.getTypeExpansionContext())
+          SGF.F.getLoweredFunctionTypeInContext()
               ->getParameters().drop_back(numIgnoredTrailingParameters)) {}
 
   ParamDecl *paramDecl = nullptr;


### PR DESCRIPTION
This can be called frequently, and in pathological cases, it costs a lot of CPU time to repeatedly erase opaque archetypes appearing in the lowered type. Cache the result in the SILFunction instead. This saved 15 seconds of compile time on a real project.