### PR TITLE
[rbi] Teach RegionIsolation how to properly error when 'inout sending' params are returned.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1119,6 +1119,32 @@ ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
 NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
       "%1 %0 risks causing races in between %1 uses and caller uses since caller assumes value is not actor isolated",
       (Identifier, StringRef))
+ERROR(regionbasedisolation_inout_sending_cannot_be_returned_param, none,
+      "'inout sending' parameter %0 cannot be returned",
+      (Identifier))
+ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value, none,
+      "%0 cannot be returned",
+      (Identifier))
+ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value_result, none,
+      "result of %kind0 cannot be returned",
+      (const ValueDecl *))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_param, none,
+     "returning 'inout sending' parameter %0 risks concurrent access as caller assumes %0 and result can be sent to different isolation domains",
+     (Identifier))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_value, none,
+     "returning %0 risks concurrent access to 'inout sending' parameter %1 as caller assumes %1 and result can be sent to different isolation domains",
+     (Identifier, Identifier))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_return_value, none,
+     "returning result of %kind0 risks concurrent access to 'inout sending' parameter %1 as caller assumes %1 and result can be sent to different isolation domains",
+     (const ValueDecl *, Identifier))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_actor_param, none,
+     "returning %0 risks concurrent access as caller assumes %0 is not actor-isolated and result is %1", (Identifier, StringRef))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_actor_value, none,
+     "returning %0 risks concurrent access to 'inout sending' parameter %1 as caller assumes %1 is not actor-isolated and result is %2",
+     (Identifier, Identifier, StringRef))
+NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_actor_return_value, none,
+     "returning result of %kind0 risks concurrent access to 'inout sending' parameter %1 as caller assumes %1 is not actor-isolated and result is %2",
+     (const ValueDecl *, Identifier, StringRef))
 
 //===
 // Out Sending

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -544,6 +544,10 @@ public:
 
   bool isSupportedFunction() const { return supportedFunction; }
 
+  NullablePtr<BlockPartitionState> getBlockState(SILBasicBlock *block) const {
+    return blockStates->get(block);
+  }
+
   using iterator = BasicBlockData::iterator;
   using const_iterator = BasicBlockData::const_iterator;
   using reverse_iterator = BasicBlockData::reverse_iterator;

--- a/include/swift/SILOptimizer/Utils/PartitionOpError.def
+++ b/include/swift/SILOptimizer/Utils/PartitionOpError.def
@@ -52,6 +52,9 @@ PARTITION_OP_ERROR(InOutSendingNotInitializedAtExit)
 /// at end of function without being reinitialized with something disconnected.
 PARTITION_OP_ERROR(InOutSendingNotDisconnectedAtExit)
 
+/// This is emitted when a concrete inout sending parameter is returned.
+PARTITION_OP_ERROR(InOutSendingReturned)
+
 /// Used to signify an "unknown code pattern" has occured while performing
 /// dataflow.
 ///

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1126,6 +1126,40 @@ public:
     }
   };
 
+  struct InOutSendingReturnedError {
+    const PartitionOp *op;
+
+    /// The 'inout sending' parameter that caused the error to be emitted.
+    Element inoutSendingElement;
+
+    /// The actual returned value. If we return the 'inout sending' parameter
+    /// then this will equal inoutSendingElement.
+    Element returnedValue;
+
+    /// If we are actor isolated due to being in the same region as the out
+    /// parameter of a actor isolated method... this is that actor isolation.
+    SILDynamicMergedIsolationInfo isolationInfo;
+
+    InOutSendingReturnedError(const PartitionOp &op,
+                              Element inoutSendingElement,
+                              Element returnedValue,
+                              SILDynamicMergedIsolationInfo isolationInfo = {})
+        : op(&op), inoutSendingElement(inoutSendingElement),
+          returnedValue(returnedValue), isolationInfo(isolationInfo) {}
+
+    InOutSendingReturnedError(const PartitionOp &op,
+                              Element inoutSendingElement,
+                              SILDynamicMergedIsolationInfo isolationInfo = {})
+        : InOutSendingReturnedError(op, inoutSendingElement,
+                                    inoutSendingElement, isolationInfo) {}
+
+    void print(llvm::raw_ostream &os, RegionAnalysisValueMap &valueMap) const;
+
+    SWIFT_DEBUG_DUMPER(dump(RegionAnalysisValueMap &valueMap)) {
+      print(llvm::dbgs(), valueMap);
+    }
+  };
+
   struct NonSendableIsolationCrossingResultError {
     const PartitionOp *op;
 
@@ -1295,6 +1329,42 @@ public:
     if (auto opt = getIsolationRegionInfo(region, nullptr))
       return opt->first;
     return SILDynamicMergedIsolationInfo();
+  }
+
+  /// If \p region is not disconnected only because of an out parameter, return
+  /// that out parameter. We do not care about other non-disconnected parameters
+  /// since we always want to prefer the return error.
+  SILValue findNonDisconnectedOutParameterInRegion(Region region) const {
+    for (const auto &pair : p.range()) {
+      if (pair.second != region)
+        continue;
+      auto info = getIsolationRegionInfo(pair.first);
+
+      // If we do not have any isolation info, then something bad
+      // happened. Return SILValue().
+      if (!info)
+        return {};
+
+      // If we have something that is disconnected... continue. We do not care
+      // about this.
+      if (info.isDisconnected())
+        continue;
+
+      // See if we ahve an indirect out parameter...
+      if (auto value = asImpl().getIndirectOutParameter(pair.first)) {
+        return value;
+      }
+
+      // If this was not an out parameter, return {}.
+      return {};
+    }
+
+    // After going over our loop, if result is not SILValue(), then we found
+    // that our region is not disconnected due only to a single 'indirect out'
+    // parameter. If SILValue() then we had all disconnected values. If we found
+    // multiple non-disconnected things, we would have bailed earlier in the
+    // loop itself.
+    return SILValue();
   }
 
   bool isTaskIsolatedDerived(Element elt) const {
@@ -1534,7 +1604,9 @@ public:
              "Require PartitionOp's argument should already be tracked");
 
       // First check if the region of our 'inout sending' element has been
-      // sent. In that case, we emit a special use after free error.
+      // sent. In that case, we emit a special use after free error so that the
+      // user knows that they need to reinitialize the 'inout sending'
+      // parameter.
       if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArg1())) {
         for (auto sentOperand : sentOperandSet->data()) {
           handleError(InOutSendingNotInitializedAtExitError(op, op.getOpArg1(),
@@ -1543,7 +1615,7 @@ public:
         return;
       }
 
-      // If we were not sent, check if our region is actor isolated. If so,
+      // If we were not sent, check if our region is not disconnected. If so,
       // error since we need a disconnected value in the inout parameter.
       Region inoutSendingRegion = p.getRegion(op.getOpArg1());
       auto dynamicRegionIsolation = getIsolationRegionInfo(inoutSendingRegion);
@@ -1554,12 +1626,82 @@ public:
         return;
       }
 
-      // Otherwise, emit the error if the dynamic region isolation is not
-      // disconnected.
+      auto handleDirectReturn = [&]() -> bool {
+        bool emittedDiagnostic = false;
+
+        // For each value we are returning...
+        for (auto value : op.getSourceInst()->getOperandValues()) {
+          // Find its element and check if that element is in the same region as
+          // our inout sending param...
+          auto elt = asImpl().getElement(value);
+          if (!elt || inoutSendingRegion != p.getRegion(*elt))
+            continue;
+
+          emittedDiagnostic = true;
+          // Then check if our element is the same as our inoutSendingParam. In
+          // that case, we emit a special error that only refers to the
+          // inoutSendingParam as one entity.
+          //
+          // NOTE: This is taking advantage of us looking through loads when
+          // determining element identity. When that changes, this code will
+          // need to be updated to look through loads.
+          if (*elt == op.getOpArg1()) {
+            handleError(InOutSendingReturnedError(op, op.getOpArg1(),
+                                                  dynamicRegionIsolation));
+            continue;
+          }
+
+          // Otherwise, we need to refer to a different value in the same region
+          // as the 'inout sending' parameter. Emit a special error. For that.
+          handleError(InOutSendingReturnedError(op, op.getOpArg1(), *elt,
+                                                dynamicRegionIsolation));
+        }
+
+        return emittedDiagnostic;
+      };
+
+      // Then check if our region isolated value is not disconnected...
       if (!dynamicRegionIsolation.isDisconnected()) {
+        // Before we emit the more general "inout sending" not disconnected at
+        // exit error... check if our dynamic region isolation is not
+        // disconnected since it is in the same region an out parameter. In that
+        // case we want to emit a special 'cannot return value' error.
+        if (auto outParam =
+                findNonDisconnectedOutParameterInRegion(inoutSendingRegion)) {
+          handleError(InOutSendingReturnedError(op, op.getOpArg1(),
+                                                getElement(outParam).value(),
+                                                dynamicRegionIsolation));
+          return;
+        }
+
+        // If we did not have an out parameter, see if we are returning a
+        // value that is in the region as our 'inout sending' parameter.
+        if (handleDirectReturn())
+          return;
+
+        // Otherwise, we emit the normal not disconnected at exit error.
         handleError(InOutSendingNotDisconnectedAtExitError(
             op, op.getOpArg1(), dynamicRegionIsolation));
+        return;
       }
+
+      // Ok, we have a disconnected value. We could still be returning a
+      // disconnected value in the same region as an 'inout sending'
+      // parameter. We cannot allow that since the caller considers 'inout
+      // sending' values to be in their own region on function return. So it
+      // would assume that it could potentially send the value in the 'inout
+      // sending' parameter and the return value to different isolation
+      // domains... allowing for races.
+
+      // Even though we are disconnected, see if our SILFunction has an actor
+      // isolation. In that case, we want to use that since the direct return
+      // value will be inferred in the caller to have that isolation.
+      if (auto isolation = SILIsolationInfo::getFunctionIsolation(
+              op.getSourceInst()->getFunction())) {
+        dynamicRegionIsolation = {isolation};
+      }
+
+      handleDirectReturn();
       return;
     }
     case PartitionOpKind::UnknownPatternError:
@@ -1569,10 +1711,6 @@ public:
       // Then emit an unknown code pattern error.
       return handleError(UnknownCodePatternError(op));
     case PartitionOpKind::NonSendableIsolationCrossingResult: {
-      // Grab the dynamic dataflow isolation information for our element's
-      // region.
-      Region region = p.getRegion(op.getOpArg1());
-
       // Then emit the error.
       return handleError(
           NonSendableIsolationCrossingResultError(op, op.getOpArg1()));
@@ -1756,6 +1894,14 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   /// This is used to determine if an element is in the same region as a task
   /// isolated value.
   bool isTaskIsolatedDerived(Element elt) const { return false; }
+
+  /// If \p elt maps to a representative that is an indirect out parameter,
+  /// return that value.
+  SILValue getIndirectOutParameter(Element elt) const { return {}; }
+
+  /// If \p elt maps to a representative that is an 'inout sending' parameter
+  /// that returns that value.
+  SILValue getInOutSendingParameter(Element elt) const { return {}; }
 
   /// By default, do nothing upon error.
   void handleError(PartitionOpError error) {}

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -546,6 +546,11 @@ public:
   /// Infer isolation of conformances for the given instruction.
   static SILIsolationInfo getConformanceIsolation(SILInstruction *inst);
 
+  /// Return SILIsolationInfo based off of the attached ActorIsolation of \p
+  /// fn. If \p fn does not have an actor isolation set, returns an invalid
+  /// SILIsolationInfo.
+  static SILIsolationInfo getFunctionIsolation(SILFunction *fn);
+
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.
   ///

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4115,7 +4115,10 @@ bool BlockPartitionState::recomputeExitFromEntry(
     }
 
     std::optional<Element> getElement(SILValue value) const {
-      return translator.getValueMap().getTrackableValue(value).value.getID();
+      auto trackableValue = translator.getValueMap().getTrackableValue(value);
+      if (trackableValue.value.isSendable())
+        return {};
+      return trackableValue.value.getID();
     }
 
     SILValue getRepresentative(SILValue value) const {

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -12,6 +12,8 @@
 
 #define DEBUG_TYPE "send-non-sendable"
 
+#include "swift/SIL/PrunedLiveness.h"
+
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Concurrency.h"
 #include "swift/AST/DiagnosticsSIL.h"
@@ -2288,6 +2290,652 @@ bool SentNeverSendableDiagnosticInferrer::run() {
 }
 
 //===----------------------------------------------------------------------===//
+//               MARK: InOutSendingReturnedError Error Emitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class InOutSendingReturnedDiagnosticEmitter {
+  /// A region analysis function info that we use if we need to determine which
+  /// incoming block edge had an error upon it.
+  RegionAnalysisFunctionInfo *raFuncInfo;
+
+  /// The function exiting inst where the 'inout sending' parameter was actor
+  /// isolated.
+  TermInst *functionExitingInst;
+
+  /// The 'inout sending' param that we are emitting an error for.
+  SILValue inoutSendingParam;
+
+  /// The element number of the 'inout sending' param.
+  Element inoutSendingParamElement;
+
+  /// If we did not return the 'inout sending' param directly but instead
+  /// returned something else in the same region. This is that value.
+  ///
+  /// If we actually returned the inout sending parameter this is SILValue().
+  SILValue returnedValue;
+
+  /// If we had a failure due to returning a value that is actor isolated due to
+  /// it being in the same region as an out parameter. THis is the actor
+  /// isolation.
+  SILDynamicMergedIsolationInfo isolationInfo;
+
+  bool emittedErrorDiagnostic = false;
+
+public:
+  class LastValueEnum;
+
+  InOutSendingReturnedDiagnosticEmitter(
+      RegionAnalysisFunctionInfo *raFuncInfo, TermInst *functionExitingInst,
+      SILValue inoutSendingParam, Element inoutSendingParamElement,
+      SILValue erroringValue, SILDynamicMergedIsolationInfo isolationInfo)
+      : raFuncInfo(raFuncInfo), functionExitingInst(functionExitingInst),
+        inoutSendingParam(inoutSendingParam),
+        inoutSendingParamElement(inoutSendingParamElement),
+        returnedValue(erroringValue), isolationInfo(isolationInfo) {}
+
+  ~InOutSendingReturnedDiagnosticEmitter() {
+    // If we were supposed to emit a diagnostic and didn't emit an unknown
+    // pattern error.
+    if (!emittedErrorDiagnostic)
+      emitUnknownPatternError();
+  }
+
+  SILFunction *getFunction() const { return inoutSendingParam->getFunction(); }
+
+  std::optional<DiagnosticBehavior> getBehaviorLimit() const {
+    return inoutSendingParam->getType().getConcurrencyDiagnosticBehavior(
+        getFunction());
+  }
+
+  void emitUnknownPatternError() {
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(functionExitingInst,
+                  diag::regionbasedisolation_unknown_pattern)
+        .limitBehaviorIf(getBehaviorLimit());
+  }
+
+  void emit();
+
+  /// Called if we return the actual inout sending value.
+  void emitReturnInOutSendingError(SILDynamicMergedIsolationInfo isolationInfo,
+                                   SILLocation loc) {
+    // We should always be able to find a name for an inout sending param. If we
+    // do not, emit an unknown pattern error.
+    auto inoutSendingParamName = inferNameHelper(inoutSendingParam);
+    if (!inoutSendingParamName) {
+      return emitUnknownPatternError();
+    }
+
+    diagnoseError(
+        loc, diag::regionbasedisolation_inout_sending_cannot_be_returned_param,
+        *inoutSendingParamName)
+        .limitBehaviorIf(getBehaviorLimit());
+    if (isolationInfo->isActorIsolated()) {
+      diagnoseNote(
+          loc,
+          diag::
+              regionbasedisolation_inout_sending_cannot_be_returned_note_actor_param,
+          *inoutSendingParamName,
+          isolationInfo->printForDiagnostics(getFunction()));
+      return;
+    }
+    diagnoseNote(
+        loc,
+        diag::regionbasedisolation_inout_sending_cannot_be_returned_note_param,
+        *inoutSendingParamName);
+  }
+
+  void emitValueError(SILValue value,
+                      SILDynamicMergedIsolationInfo isolationInfo,
+                      SILLocation loc) {
+    // We should always be able to find a name for an inout sending param. If we
+    // do not, emit an unknown pattern error.
+    auto inoutSendingParamName = inferNameHelper(inoutSendingParam);
+    if (!inoutSendingParamName) {
+      return emitUnknownPatternError();
+    }
+
+    std::optional<Identifier> erroringEltName = inferNameHelper(value);
+    if (!erroringEltName) {
+      return emitUnknownPatternError();
+    }
+
+    diagnoseError(
+        loc, diag::regionbasedisolation_inout_sending_cannot_be_returned_value,
+        *erroringEltName)
+        .limitBehaviorIf(getBehaviorLimit());
+    if (isolationInfo->isActorIsolated()) {
+      diagnoseNote(
+          loc,
+          diag::
+              regionbasedisolation_inout_sending_cannot_be_returned_note_actor_value,
+          *erroringEltName, *inoutSendingParamName,
+          isolationInfo->printForDiagnostics(getFunction()));
+      return;
+    }
+    diagnoseNote(
+        loc,
+        diag::regionbasedisolation_inout_sending_cannot_be_returned_note_value,
+        *erroringEltName, *inoutSendingParamName);
+  }
+
+  /// Print \p value in a standard way. Allow for loc to override the specific
+  /// location used to emit the diagnostic fi non-standard.
+  void emitLastValueEnum(const LastValueEnum &value,
+                         SILDynamicMergedIsolationInfo isolationInfo,
+                         SILLocation loc = SILLocation::invalid());
+
+  /// Emit an error for use when we are processing the incoming value of a phi
+  /// argument or of the dynamic value of an indirect out parameter.
+  bool emitOutParamIncomingValueError(const LastValueEnum &value);
+
+  void emitDeclRefError(SILDeclRef declRef,
+                        SILDynamicMergedIsolationInfo isolationInfo,
+                        SILLocation loc) {
+    // We should always be able to find a name for an inout sending param. If we
+    // do not, emit an unknown pattern error.
+    auto inoutSendingParamName = inferNameHelper(inoutSendingParam);
+    if (!inoutSendingParamName) {
+      return emitUnknownPatternError();
+    }
+
+    diagnoseError(
+        loc,
+        diag::
+            regionbasedisolation_inout_sending_cannot_be_returned_value_result,
+        declRef.getAbstractFunctionDecl())
+        .limitBehaviorIf(getBehaviorLimit());
+
+    if (isolationInfo->isActorIsolated()) {
+      diagnoseNote(
+          loc,
+          diag::
+              regionbasedisolation_inout_sending_cannot_be_returned_note_actor_return_value,
+          declRef.getAbstractFunctionDecl(), *inoutSendingParamName,
+          isolationInfo.printForDiagnostics(getFunction()));
+      return;
+    }
+    diagnoseNote(
+        loc,
+        diag::
+            regionbasedisolation_inout_sending_cannot_be_returned_note_return_value,
+        declRef.getAbstractFunctionDecl(), *inoutSendingParamName);
+  }
+
+  ASTContext &getASTContext() const {
+    return functionExitingInst->getFunction()->getASTContext();
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SourceLoc loc, Diag<T...> diag,
+                                   U &&...args) {
+    emittedErrorDiagnostic = true;
+    return std::move(getASTContext()
+                         .Diags.diagnose(loc, diag, std::forward<U>(args)...)
+                         .warnUntilSwiftVersion(6));
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SILLocation loc, Diag<T...> diag,
+                                   U &&...args) {
+    return diagnoseError(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SILInstruction *inst, Diag<T...> diag,
+                                   U &&...args) {
+    return diagnoseError(inst->getLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SourceLoc loc, Diag<T...> diag, U &&...args) {
+    return getASTContext().Diags.diagnose(loc, diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SILLocation loc, Diag<T...> diag,
+                                  U &&...args) {
+    return diagnoseNote(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SILInstruction *inst, Diag<T...> diag,
+                                  U &&...args) {
+    return diagnoseNote(inst->getLoc(), diag, std::forward<U>(args)...);
+  }
+};
+
+} // namespace
+
+static SILValue lookThroughAccess(SILValue value) {
+  while (true) {
+    // We look through access, copies, and loads.
+    if (auto *bai = dyn_cast<BeginAccessInst>(value)) {
+      value = bai->getOperand();
+      continue;
+    }
+
+    if (auto *cvi = dyn_cast<CopyValueInst>(value)) {
+      value = cvi->getOperand();
+      continue;
+    }
+
+    if (auto *bbi = dyn_cast<BeginBorrowInst>(value);
+        bbi && !bbi->isFromVarDecl()) {
+      value = bbi->getOperand();
+      continue;
+    }
+
+    if (auto *mvi = dyn_cast<MoveValueInst>(value);
+        mvi && !mvi->isFromVarDecl()) {
+      value = mvi->getOperand();
+      continue;
+    }
+
+    if (auto *li = dyn_cast<LoadInst>(value)) {
+      value = li->getOperand();
+      continue;
+    }
+
+    if (auto *lbi = dyn_cast<LoadBorrowInst>(value)) {
+      value = lbi->getOperand();
+      continue;
+    }
+
+    return value;
+  }
+}
+
+class InOutSendingReturnedDiagnosticEmitter::LastValueEnum {
+public:
+  enum Kind {
+    None,
+    ApplySite,
+    CopyAddr,
+    Store,
+    Value,
+    ReturnTerm,
+  };
+
+private:
+  Kind kind;
+  std::variant<FullApplySite, SILValue, CopyAddrInst *, StoreInst *, Operand *>
+      value;
+
+  LastValueEnum() : kind(Kind::None), value() {}
+  LastValueEnum(FullApplySite inst) : kind(Kind::ApplySite), value(inst) {}
+  LastValueEnum(SILValue value) : kind(Kind::Value), value(value) {}
+  LastValueEnum(CopyAddrInst *inst) : kind(Kind::CopyAddr), value(inst) {}
+  LastValueEnum(StoreInst *inst) : kind(Kind::Store), value(inst) {}
+  LastValueEnum(Operand *branchUse) : kind(Kind::ReturnTerm), value(branchUse) {
+    assert(isa<TermInst>(branchUse->getUser()));
+    assert(branchUse->getUser()->getLoc().getKind() == SILLocation::ReturnKind);
+  }
+
+public:
+  static LastValueEnum get(SILValue value);
+  static LastValueEnum get(SILInstruction *inst);
+  static LastValueEnum get(Operand *use);
+  static bool isSupported(Operand *use);
+
+  operator bool() const { return getKind() != Kind::None; }
+
+  Kind getKind() const { return kind; }
+  bool isApplySite() const { return getKind() == Kind::ApplySite; }
+  bool isValue() const { return getKind() == Kind::Value; }
+  bool isStore() const { return getKind() == Kind::Store; }
+  bool isCopyAddr() const { return getKind() == Kind::CopyAddr; }
+
+  /// Is this a terminator instruction that is an incoming value to an epilogue
+  /// block and thus forms part of the return from a function.
+  bool isReturnTerm() const { return getKind() == Kind::ReturnTerm; }
+
+  FullApplySite getFullApplySite() const {
+    return std::get<FullApplySite>(value);
+  }
+  SILDeclRef getDeclRef() const {
+    return getFullApplySite().getCalleeFunction()->getDeclRef();
+  }
+  SILValue getValue() const {
+    switch (getKind()) {
+    case None:
+    case ApplySite:
+      return SILValue();
+    case CopyAddr:
+      return getCopyAddr()->getAllOperands()[CopyLikeInstruction::Src].get();
+    case Store:
+      return getStore()->getAllOperands()[CopyLikeInstruction::Src].get();
+    case Value:
+      return std::get<SILValue>(value);
+    case ReturnTerm:
+      return std::get<Operand *>(value)->get();
+    }
+  }
+  CopyAddrInst *getCopyAddr() const { return std::get<CopyAddrInst *>(value); }
+  StoreInst *getStore() const { return std::get<StoreInst *>(value); }
+  Operand *getReturnTerm() const { return std::get<Operand *>(value); }
+
+  SILBasicBlock *getParentBlock() const {
+    switch (getKind()) {
+    case None:
+      return nullptr;
+    case ApplySite:
+      return getFullApplySite()->getParent();
+    case Value:
+      return getValue()->getParentBlock();
+    case CopyAddr:
+      return getCopyAddr()->getParentBlock();
+    case Store:
+      return getStore()->getParentBlock();
+    case ReturnTerm:
+      return getReturnTerm()->getParentBlock();
+    }
+  }
+
+  SILInstruction *getDefiningInsertionPoint() const {
+    switch (getKind()) {
+    case None:
+      return nullptr;
+    case ApplySite:
+      return *getFullApplySite();
+    case Value:
+      return getValue()->getDefiningInsertionPoint();
+    case CopyAddr:
+      return getCopyAddr();
+    case Store:
+      return getStore();
+    case ReturnTerm:
+      return getReturnTerm()->getUser();
+    }
+  }
+
+  SILLocation getLoc() const {
+    switch (getKind()) {
+    case None:
+      return SILLocation::invalid();
+    case ApplySite:
+    case Value:
+    case CopyAddr:
+    case Store:
+    case ReturnTerm:
+      return getDefiningInsertionPoint()->getLoc();
+    }
+  }
+
+  bool operator==(SILValue otherValue) const {
+    switch (getKind()) {
+    case None:
+    case ApplySite:
+      return false;
+    case CopyAddr:
+    case Store:
+    case Value:
+    case ReturnTerm:
+      return lookThroughAccess(getValue()) == lookThroughAccess(otherValue);
+    }
+  }
+
+  static bool
+  findLastValuesForOutParam(SILFunctionArgument *fArg,
+                            SmallVectorImpl<LastValueEnum> &lastValues);
+
+  void print(llvm::raw_ostream &os) const {
+    switch (getKind()) {
+    case None:
+      os << "none\n";
+      return;
+    case ApplySite:
+      os << "apply site: " << *getFullApplySite();
+      return;
+    case CopyAddr:
+      os << "copy_addr: " << *getCopyAddr();
+      return;
+    case Store:
+      os << "store: " << *getStore();
+      return;
+    case Value:
+      os << "value: " << *getValue();
+      break;
+    case ReturnTerm:
+      os << "return term: " << *getReturnTerm()->getUser();
+    }
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+};
+
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum::get(
+    SILInstruction *user) {
+  if (auto *cai = dyn_cast<CopyAddrInst>(user)) {
+    return {cai};
+  }
+
+  if (auto *si = dyn_cast<StoreInst>(user)) {
+    return {si};
+  }
+
+  if (auto fas = FullApplySite::isa(user)) {
+    return {fas};
+  }
+
+  return {};
+}
+
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum::get(Operand *use) {
+  if (auto value = get(use->getUser()))
+    return value;
+
+  if (auto *ti = dyn_cast<TermInst>(use->getUser())) {
+    if (ti->getLoc().getKind() == SILLocation::ReturnKind) {
+      return {use};
+    }
+  }
+
+  return {};
+}
+
+bool InOutSendingReturnedDiagnosticEmitter::LastValueEnum::isSupported(
+    Operand *use) {
+  if (auto fas = FullApplySite::isa(use->getUser())) {
+    if (fas.isIndirectResultOperand(*use)) {
+      auto *fn = fas.getCalleeFunction();
+      return fn && fn->getDeclRef();
+    }
+  }
+
+  if (auto *ti = dyn_cast<TermInst>(use->getUser())) {
+    if (ti->getLoc().getKind() == SILLocation::ReturnKind) {
+      return true;
+    }
+  }
+
+  return isa<CopyAddrInst, StoreInst>(use->getUser());
+}
+
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum
+InOutSendingReturnedDiagnosticEmitter::LastValueEnum::get(SILValue value) {
+  if (auto *inst = value->getDefiningInstruction()) {
+    if (auto e = get(inst))
+      return e;
+  }
+
+  return {value};
+}
+
+void InOutSendingReturnedDiagnosticEmitter::emitLastValueEnum(
+    const LastValueEnum &value, SILDynamicMergedIsolationInfo isolationInfo,
+    SILLocation loc) {
+  switch (value.getKind()) {
+  case LastValueEnum::None:
+    llvm::report_fatal_error("Found .none enum elt");
+  case LastValueEnum::ApplySite:
+    emitDeclRefError(value.getDeclRef(), isolationInfo,
+                     loc ? loc : value.getLoc());
+    return;
+  case LastValueEnum::Store:
+  case LastValueEnum::CopyAddr:
+    emitValueError(value.getValue(), isolationInfo, loc ? loc : value.getLoc());
+    return;
+  case LastValueEnum::Value:
+    emitValueError(value.getValue(), isolationInfo,
+                   loc ? loc : functionExitingInst->getLoc());
+    return;
+  case LastValueEnum::ReturnTerm:
+    emitValueError(value.getValue(), isolationInfo, loc ? loc : value.getLoc());
+    return;
+  }
+  llvm::report_fatal_error("Should never hit this");
+}
+
+bool InOutSendingReturnedDiagnosticEmitter::emitOutParamIncomingValueError(
+    const LastValueEnum &finalValue) {
+  auto *block = finalValue.getParentBlock();
+  auto state = raFuncInfo->getBlockState(block);
+  assert(state.isNonNull());
+
+  // Grab the exit partition of the block. We make a copy here on purpose
+  // since it /is/ possible for DiagnosticEvaluator to modify
+  auto workingExitPartition = state.get()->getExitPartition();
+
+  // See if given the exit partition of the block if we would emit an error
+  // when we execute an InOutSendingAtFunctionExit partition op.
+  SmallFrozenMultiMap<Operand *, RequireInst, 8> sendingOpToRequireInstMultiMap;
+  SmallVector<PartitionOpError, 2> errors;
+  DiagnosticEvaluator evaluator(workingExitPartition, raFuncInfo,
+                                sendingOpToRequireInstMultiMap, errors,
+                                raFuncInfo->getSendingOperandToStateMap());
+  PartitionOp op = PartitionOp::InOutSendingAtFunctionExit(
+      inoutSendingParamElement, finalValue.getDefiningInsertionPoint());
+  evaluator.apply(op);
+
+  // Check if we got an error. If we did not, then this is not one of the
+  // guilty code paths. Continue.
+  if (errors.empty()) {
+    return false;
+  }
+
+  // Loop through the errors to find our InOutReturnedError. We emit one error
+  // per return... but we emit for multiple returns separate diagnostics.
+  for (auto err : errors) {
+    if (err.getKind() != PartitionOpError::InOutSendingReturned)
+      continue;
+    auto castError = err.getInOutSendingReturnedError();
+    if (castError.inoutSendingElement != inoutSendingParamElement)
+      continue;
+    // Ok, we found an error. Lets emit it and return early.
+    if (finalValue == inoutSendingParam) {
+      emitReturnInOutSendingError(isolationInfo, finalValue.getLoc());
+      return true;
+    }
+
+    // Force us to use the location of the finalValue. We do not want to use the
+    // function exiting inst.
+    emitLastValueEnum(finalValue, isolationInfo, finalValue.getLoc());
+    return true;
+  }
+
+  return false;
+}
+
+void InOutSendingReturnedDiagnosticEmitter::emit() {
+  // Check if we had a separate erroring value that is our returned value. If we
+  // do not then we just returned the 'inout sending' parameter. Emit a special
+  // message and return.
+  if (inoutSendingParam == returnedValue) {
+    return emitReturnInOutSendingError(isolationInfo,
+                                       functionExitingInst->getLoc());
+  }
+
+  // Before we do anything, see if we have a phi argument that is an epilogue
+  // phi. In such a case, we want to process the incoming values.
+  if (auto *phi = dyn_cast<SILPhiArgument>(returnedValue)) {
+    bool handledValue = false;
+    phi->visitIncomingPhiOperands([&](Operand *op) {
+      if (op->getUser()->getLoc().getKind() != SILLocation::ReturnKind)
+        return true;
+      handledValue |=
+          emitOutParamIncomingValueError(LastValueEnum::get(op->get()));
+      return true;
+    });
+    if (handledValue)
+      return;
+  }
+
+  // Check if we have an indirect out parameter as our erroring returned value.
+  auto *fArg = dyn_cast<SILFunctionArgument>(returnedValue);
+  if (!fArg || !fArg->isIndirectResult()) {
+    // If we do not have one... emit a normal error.
+    return emitLastValueEnum(LastValueEnum::get(returnedValue), isolationInfo);
+  }
+
+  SmallVector<LastValueEnum, 8> finalValues;
+  if (!LastValueEnum::findLastValuesForOutParam(fArg, finalValues))
+    return emitLastValueEnum(LastValueEnum::get(returnedValue), isolationInfo);
+
+  // If we have a single value, then we have found our value.
+  if (finalValues.size() == 1) {
+    if (finalValues[0] == inoutSendingParam) {
+      return emitReturnInOutSendingError(isolationInfo,
+                                         finalValues[0].getLoc());
+    }
+    emitLastValueEnum(finalValues[0], isolationInfo);
+    return;
+  }
+
+  // If we have multiple finalValues, then that means that we had multiple
+  // return values. In such a case, we must have a single epilog block
+  // that our finalValues jointly dominate. That means that we need to
+  // determine which block the error actually occured along and emit an
+  // error for the value in that block. We know we are going to emit an
+  // error, so we can spend more time finding the better diagnostic since
+  // we are going to fail.
+  for (auto finalValue : finalValues) {
+    emitOutParamIncomingValueError(finalValue);
+  }
+}
+
+bool InOutSendingReturnedDiagnosticEmitter::LastValueEnum::
+    findLastValuesForOutParam(SILFunctionArgument *fArg,
+                              SmallVectorImpl<LastValueEnum> &lastValues) {
+  assert(fArg->isIndirectResult());
+  SmallVector<SILBasicBlock *, 8> visitedBlocks;
+  SSAPrunedLiveness prunedLiveRange(fArg->getFunction(), &visitedBlocks);
+
+  // Look for copy_addr and store uses into fArg. They should all be complete
+  // stores.
+  prunedLiveRange.initializeDef(fArg);
+  for (auto *use : fArg->getUses()) {
+    if (LastValueEnum::isSupported(use)) {
+      prunedLiveRange.updateForUse(use->getUser(), false /*lifetime ending*/);
+      continue;
+    }
+    return false;
+  }
+
+  PrunedLivenessBoundary boundary;
+  prunedLiveRange.computeBoundary(boundary);
+
+  for (auto *user : boundary.lastUsers) {
+    if (auto e = LastValueEnum::get(user)) {
+      lastValues.emplace_back(e);
+      continue;
+    }
+
+    llvm::report_fatal_error("Out of sync with earlier check");
+  }
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //              MARK: InOutSendingNotDisconnected Error Emitter
 //===----------------------------------------------------------------------===//
 
@@ -2881,6 +3529,21 @@ void SendNonSendableImpl::emitVerbatimErrors() {
       InOutSendingNotDisconnectedDiagnosticEmitter emitter(
           cast<TermInst>(error.op->getSourceInst()), inoutSendingVal,
           isolationRegionInfo);
+      emitter.emit();
+      continue;
+    }
+    case PartitionOpError::InOutSendingReturned: {
+      auto error = erasedError.getInOutSendingReturnedError();
+      auto inoutSendingVal =
+          info->getValueMap().getRepresentative(error.inoutSendingElement);
+      auto returnedValue =
+          info->getValueMap().getRepresentative(error.returnedValue);
+
+      REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
+
+      InOutSendingReturnedDiagnosticEmitter emitter(
+          info, cast<TermInst>(error.op->getSourceInst()), inoutSendingVal,
+          error.inoutSendingElement, returnedValue, error.isolationInfo);
       emitter.emit();
       continue;
     }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -102,6 +102,15 @@ void PartitionOpError::NonSendableIsolationCrossingResultError::print(
      << '\n';
 }
 
+void PartitionOpError::InOutSendingReturnedError::print(
+    llvm::raw_ostream &os, RegionAnalysisValueMap &valueMap) const {
+  os << "    Emitting Error. Kind: InOutSendingReturnedError!\n"
+     << "        ID:  %%" << inoutSendingElement << '\n'
+     << "        Rep: " << valueMap.getRepresentativeValue(inoutSendingElement)
+     << "        Returned Value ID:  %%" << returnedValue << '\n'
+     << "        Rep: " << valueMap.getRepresentativeValue(returnedValue);
+}
+
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1629,6 +1629,24 @@ bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
   return *behavior != DiagnosticBehavior::Ignore;
 }
 
+SILIsolationInfo SILIsolationInfo::getFunctionIsolation(SILFunction *fn) {
+  auto isolation = fn->getActorIsolation();
+  if (!isolation)
+    return {};
+
+  if (isolation->isGlobalActor()) {
+    return SILIsolationInfo::getGlobalActorIsolated(
+        SILValue(), isolation->getGlobalActor());
+  }
+
+  if (isolation->isActorInstanceIsolated()) {
+    return SILIsolationInfo::getActorInstanceIsolated(
+        SILValue(), cast<SILFunctionArgument>(fn->maybeGetIsolatedArgument()));
+  }
+
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 //                            MARK: ActorInstance
 //===----------------------------------------------------------------------===//

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -39,6 +39,8 @@ final class FinalKlassWithNonSendableStructPair {
 }
 
 func useValue<T>(_ t: T) {}
+func useValueAndReturnGeneric<T>(_ t: T) -> T { t }
+func useNonSendableKlassAndReturn(_ t: NonSendableKlass) -> NonSendableKlass { t }
 func getAny() -> Any { fatalError() }
 
 actor Custom {
@@ -55,6 +57,8 @@ struct CustomActor {
 @CustomActor func transferToCustom<T>(_ t: T) {}
 
 func throwingFunction() throws { fatalError() }
+
+func getBool() -> Bool { false }
 
 func transferArg(_ x: sending NonSendableKlass) {
 }
@@ -111,7 +115,6 @@ func testSimpleTransferUseOfOtherParamNoError2() {
 }
 
 @MainActor func transferToMain2(_ x: sending NonSendableKlass, _ y: NonSendableKlass, _ z: NonSendableKlass) async {
-
 }
 
 // TODO: How to test this?
@@ -514,6 +517,2422 @@ func testWrongIsolationGlobalIsolation(_ x: inout sending NonSendableKlass) {
   x = globalKlass
 } // expected-warning {{'inout sending' parameter 'x' cannot be main actor-isolated at end of function}}
 // expected-note @-1 {{main actor-isolated 'x' risks causing races in between main actor-isolated uses and caller uses since caller assumes value is not actor isolated}}
+
+//////////////////////////////////////
+// MARK: Return Inout Sending Tests //
+//////////////////////////////////////
+
+func returnInOutSendingDirectly(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionLet(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+
+func returnInOutSendingViaHelper(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingHelperDirect(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingDirectlyIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  if getBool() {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  fatalError()
+}
+
+func returnInOutSendingRegionLetIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingRegionVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  if getBool() {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  fatalError()
+}
+
+func returnInOutSendingViaHelperIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  if getBool() {
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingHelperDirectIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  if getBool() {
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingViaHelperVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  if getBool() {
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingDirectlyElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  if getBool() {
+    print(x)
+    fatalError()
+  } else {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingRegionLetElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  if getBool() {
+    print(y)
+    fatalError()
+  } else {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingRegionVarElse(_ x: inout sending NonSendableKlass, z: NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingViaHelperElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingHelperDirectElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  if getBool() {
+    print(x)
+    return z
+  } else {
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingViaHelperVarElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnInOutSendingDirectlyFor(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  for _ in 0..<1 {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(x)
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingDirectlyFor2(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  for _ in 0..<1 {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(x)
+  return z
+}
+
+func returnInOutSendingRegionLetFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionLetFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionLetFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return z
+}
+
+func returnInOutSendingRegionVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionVarFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionVarFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return z
+}
+
+func returnInOutSendingViaHelperFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingViaHelperFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingHelperDirectFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  for _ in 0..<1 {
+    if getBool() {
+      return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingViaHelperVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingDirectlyGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  guard getBool() else {
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionLetGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingRegionVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  guard getBool() else {
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingViaHelperGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  let y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingHelperDirectGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  guard getBool() else {
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingViaHelperVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnInOutSendingViaHelperVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+  var y = x
+  y = x
+  return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingDirectly<T>(_ x: inout sending T) -> T {
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionLet<T>(_ x: inout sending T) -> T {
+  let y = x
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionVar<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelper<T>(_ x: inout sending T) -> T {
+  let y = x
+  return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingHelperDirect<T>(_ x: inout sending T) -> T {
+  return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelperVar<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingDirectlyIf<T>(_ x: inout sending T) -> T {
+  if getBool() {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  fatalError()
+}
+
+func returnGenericInOutSendingRegionLetIf<T>(_ x: inout sending T) -> T {
+  let y = x
+  if getBool() {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingRegionVarIf<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  if getBool() {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  fatalError()
+}
+
+func returnGenericInOutSendingViaHelperIf<T>(_ x: inout sending T) -> T {
+  let y = x
+  if getBool() {
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingHelperDirectIf<T>(_ x: inout sending T) -> T {
+  if getBool() {
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingViaHelperVarIf<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  if getBool() {
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  } else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingDirectlyElse<T>(_ x: inout sending T) -> T {
+  if getBool() {
+    print(x)
+    fatalError()
+  } else {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingRegionLetElse<T>(_ x: inout sending T) -> T {
+  let y = x
+  if getBool() {
+    print(y)
+    fatalError()
+  } else {
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingRegionVarElse<T>(_ x: inout sending T, z: T) -> T {
+  var y = x
+  y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+      return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingViaHelperElse<T>(_ x: inout sending T, _ z: T) -> T {
+  let y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingHelperDirectElse<T>(_ x: inout sending T, _ z: T) -> T {
+  if getBool() {
+    print(x)
+    return z
+  } else {
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingViaHelperVarElse<T>(_ x: inout sending T, _ z: T) -> T {
+  var y = x
+  y = x
+  if getBool() {
+    print(y)
+    return z
+  } else {
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+func returnGenericInOutSendingDirectlyFor<T>(_ x: inout sending T, _ z: T) -> T {
+  for _ in 0..<1 {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(x)
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingDirectlyFor2<T>(_ x: inout sending T, _ z: T) -> T {
+  for _ in 0..<1 {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(x)
+  return z
+}
+
+func returnGenericInOutSendingRegionLetFor<T>(_ x: inout sending T) -> T {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionLetFor2<T>(_ x: inout sending T) -> T {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionLetFor3<T>(_ x: inout sending T, _ z: T) -> T {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return z
+}
+
+func returnGenericInOutSendingRegionVarFor<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionVarFor2<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionVarFor3<T>(_ x: inout sending T, _ z: T) -> T {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return z
+}
+
+func returnGenericInOutSendingViaHelperFor<T>(_ x: inout sending T) -> T {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelperFor2<T>(_ x: inout sending T) -> T {
+  let y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingHelperDirectFor<T>(_ x: inout sending T) -> T {
+  for _ in 0..<1 {
+    if getBool() {
+      return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelperVarFor<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  for _ in 0..<1 {
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+    }
+  }
+  print(y)
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingDirectlyGuard<T>(_ x: inout sending T) -> T {
+  guard getBool() else {
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionLetGuard<T>(_ x: inout sending T) -> T {
+  let y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingRegionVarGuard<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  guard getBool() else {
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return y // expected-warning {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelperGuard<T>(_ x: inout sending T) -> T {
+  let y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingHelperDirectGuard<T>(_ x: inout sending T) -> T {
+  guard getBool() else {
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+func returnGenericInOutSendingViaHelperVarGuard<T>(_ x: inout sending T) -> T {
+  var y = x
+  y = x
+  guard getBool() else {
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+  return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+  // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+///////////////////////////////////////////////////
+// MARK: ReturnSendingInOutTestActor Actor Tests //
+///////////////////////////////////////////////////
+
+actor ReturnSendingInOutTestActor {
+
+  func testInOutSendingReinit(_ x: inout sending NonSendableKlass) async {
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+  } // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+  func testInOutSendingReinit2(_ x: inout sending NonSendableKlass) async {
+    await transferToMain(x)
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit3(_ x: inout sending NonSendableKlass) async throws {
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+
+
+    try throwingFunction() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit4(_ x: inout sending NonSendableKlass) async throws {
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+
+
+    do {
+      try throwingFunction()
+      x = NonSendableKlass()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit5(_ x: inout sending NonSendableKlass) async throws {
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+
+
+    do {
+      try throwingFunction()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit6(_ x: inout sending NonSendableKlass) async throws {
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+
+
+    do {
+      try throwingFunction()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+  } // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+  func returnInOutSendingDirectly(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionLet(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelper(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingHelperDirect(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingDirectlyIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnInOutSendingRegionLetIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnInOutSendingViaHelperIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingHelperDirectIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingDirectlyElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      print(x)
+      fatalError()
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionLetElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      print(y)
+      fatalError()
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionVarElse(_ x: inout sending NonSendableKlass, z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingHelperDirectElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      print(x)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperVarElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnInOutSendingDirectlyFor(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingDirectlyFor2(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(x)
+    return z
+  }
+
+  func returnInOutSendingRegionLetFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionLetFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionLetFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnInOutSendingRegionVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionVarFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionVarFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnInOutSendingViaHelperFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelperFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingHelperDirectFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingDirectlyGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionLetGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingRegionVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelperGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingHelperDirectGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectly<T>(_ x: inout sending T) -> T {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLet<T>(_ x: inout sending T) -> T {
+    let y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVar<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelper<T>(_ x: inout sending T) -> T {
+    let y = x
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirect<T>(_ x: inout sending T) -> T {
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVar<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyIf<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnGenericInOutSendingRegionLetIf<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionVarIf<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnGenericInOutSendingViaHelperIf<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingHelperDirectIf<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperVarIf<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    } else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingDirectlyElse<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      print(x)
+      fatalError()
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionLetElse<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      print(y)
+      fatalError()
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionVarElse<T>(_ x: inout sending T, z: T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperElse<T>(_ x: inout sending T, _ z: T) -> T {
+    let y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingHelperDirectElse<T>(_ x: inout sending T, _ z: T) -> T {
+    if getBool() {
+      print(x)
+      return z
+    } else {
+      return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperVarElse<T>(_ x: inout sending T, _ z: T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingDirectlyFor<T>(_ x: inout sending T, _ z: T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyFor2<T>(_ x: inout sending T, _ z: T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(x)
+    return z
+  }
+
+  func returnGenericInOutSendingRegionLetFor<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetFor2<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetFor3<T>(_ x: inout sending T, _ z: T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnGenericInOutSendingRegionVarFor<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarFor2<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarFor3<T>(_ x: inout sending T, _ z: T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnGenericInOutSendingViaHelperFor<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperFor2<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirectFor<T>(_ x: inout sending T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVarFor<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyGuard<T>(_ x: inout sending T) -> T {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetGuard<T>(_ x: inout sending T) -> T {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarGuard<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperGuard<T>(_ x: inout sending T) -> T {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirectGuard<T>(_ x: inout sending T) -> T {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVarGuard<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+    }
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is 'self'-isolated}}
+  }
+}
+
+////////////////////////////////////////////////////////////////
+// MARK: ReturnSendingInOutTestGlobalActorIsolatedClass Tests //
+////////////////////////////////////////////////////////////////
+
+@MainActor
+class ReturnSendingInOutTestGlobalActorIsolatedClass {
+
+  func testInOutSendingReinit(_ x: inout sending NonSendableKlass) async {
+    await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
+  } // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    // expected-note @-2 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+
+  func testInOutSendingReinit2(_ x: inout sending NonSendableKlass) async {
+    await transferToCustom(x)
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit3(_ x: inout sending NonSendableKlass) async throws {
+    await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+
+    try throwingFunction() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit4(_ x: inout sending NonSendableKlass) async throws {
+    await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+
+    do {
+      try throwingFunction()
+      x = NonSendableKlass()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit5(_ x: inout sending NonSendableKlass) async throws {
+    await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+
+    do {
+      try throwingFunction()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+
+    x = NonSendableKlass()
+  }
+
+  func testInOutSendingReinit6(_ x: inout sending NonSendableKlass) async throws {
+    await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+
+    do {
+      try throwingFunction()
+    } catch {
+      throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+    }
+  } // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+  func returnInOutSendingDirectly(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionLet(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelper(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingHelperDirect(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingDirectlyIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnInOutSendingRegionLetIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnInOutSendingViaHelperIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingHelperDirectIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperVarIf(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingDirectlyElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      print(x)
+      fatalError()
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionLetElse(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      print(y)
+      fatalError()
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingRegionVarElse(_ x: inout sending NonSendableKlass, z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingHelperDirectElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    if getBool() {
+      print(x)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingViaHelperVarElse(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnInOutSendingDirectlyFor(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingDirectlyFor2(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(x)
+    return z
+  }
+
+  func returnInOutSendingRegionLetFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionLetFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionLetFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnInOutSendingRegionVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionVarFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionVarFor3(_ x: inout sending NonSendableKlass, _ z: NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnInOutSendingViaHelperFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelperFor2(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingHelperDirectFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVarFor(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingDirectlyGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionLetGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingRegionVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelperGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingHelperDirectGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useNonSendableKlassAndReturn(x) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVarGuard(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnInOutSendingViaHelperVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
+    var y = x
+    y = x
+    return useNonSendableKlassAndReturn(y) // expected-warning {{result of global function 'useNonSendableKlassAndReturn' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectly<T>(_ x: inout sending T) -> T {
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLet<T>(_ x: inout sending T) -> T {
+    let y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVar<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelper<T>(_ x: inout sending T) -> T {
+    let y = x
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirect<T>(_ x: inout sending T) -> T {
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVar<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyIf<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnGenericInOutSendingRegionLetIf<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionVarIf<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    fatalError()
+  }
+
+  func returnGenericInOutSendingViaHelperIf<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingHelperDirectIf<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperVarIf<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    } else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingDirectlyElse<T>(_ x: inout sending T) -> T {
+    if getBool() {
+      print(x)
+      fatalError()
+    } else {
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionLetElse<T>(_ x: inout sending T) -> T {
+    let y = x
+    if getBool() {
+      print(y)
+      fatalError()
+    } else {
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingRegionVarElse<T>(_ x: inout sending T, z: T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperElse<T>(_ x: inout sending T, _ z: T) -> T {
+    let y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingHelperDirectElse<T>(_ x: inout sending T, _ z: T) -> T {
+    if getBool() {
+      print(x)
+      return z
+    } else {
+      return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingViaHelperVarElse<T>(_ x: inout sending T, _ z: T) -> T {
+    var y = x
+    y = x
+    if getBool() {
+      print(y)
+      return z
+    } else {
+      return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+      // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+  }
+
+  func returnGenericInOutSendingDirectlyFor<T>(_ x: inout sending T, _ z: T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(x)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyFor2<T>(_ x: inout sending T, _ z: T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+        // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(x)
+    return z
+  }
+
+  func returnGenericInOutSendingRegionLetFor<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetFor2<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetFor3<T>(_ x: inout sending T, _ z: T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnGenericInOutSendingRegionVarFor<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarFor2<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarFor3<T>(_ x: inout sending T, _ z: T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return y // expected-warning {{'y' cannot be returned}}
+        // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return z
+  }
+
+  func returnGenericInOutSendingViaHelperFor<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperFor2<T>(_ x: inout sending T) -> T {
+    let y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirectFor<T>(_ x: inout sending T) -> T {
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVarFor<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    for _ in 0..<1 {
+      if getBool() {
+        return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+        // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+      }
+    }
+    print(y)
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingDirectlyGuard<T>(_ x: inout sending T) -> T {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionLetGuard<T>(_ x: inout sending T) -> T {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingRegionVarGuard<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return y // expected-warning {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperGuard<T>(_ x: inout sending T) -> T {
+    let y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingHelperDirectGuard<T>(_ x: inout sending T) -> T {
+    guard getBool() else {
+      print(x)
+      return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
+      // expected-note @-1 {{returning 'x' risks concurrent access as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useValueAndReturnGeneric(x) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+
+  func returnGenericInOutSendingViaHelperVarGuard<T>(_ x: inout sending T) -> T {
+    var y = x
+    y = x
+    guard getBool() else {
+      print(y)
+      return y // expected-warning {{'y' cannot be returned}}
+      // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+    }
+    return useValueAndReturnGeneric(y) // expected-warning {{result of global function 'useValueAndReturnGeneric' cannot be returned}}
+    // expected-note @-1 {{returning result of global function 'useValueAndReturnGeneric' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' is not actor-isolated and result is main actor-isolated}}
+  }
+}
+
+//////////////////////
+// MARK: Misc Tests //
+//////////////////////
 
 func taskIsolatedCaptureInSendingClosureLiteral(_ x: NonSendableKlass) {
   Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -98,6 +98,7 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
     case PartitionOpError::InOutSendingNotInitializedAtExit:
     case PartitionOpError::InOutSendingNotDisconnectedAtExit:
     case PartitionOpError::NonSendableIsolationCrossingResult:
+    case PartitionOpError::InOutSendingReturned:
       llvm_unreachable("Unsupported");
     case PartitionOpError::LocalUseAfterSend: {
       auto state = error.getLocalUseAfterSendError();


### PR DESCRIPTION
We want 'inout sending' parameters to have the semantics that not only are they
disconnected on return from the function but additionally they are guaranteed to
be in their own disconnected region on return. This implies that we must emit
errors when an 'inout sending' parameter or any element that is in the same
region as the current value within an 'inout sending' parameter is
returned. This commit contains a new diagnostic for RegionIsolation that adds
specific logic for detecting and emitting errors in these situations.

To implement this, we introduce 3 new diagnostics with each individual
diagnostic being slightly different to reflect the various ways that this error
can come up in source:

* Returning 'inout sending' directly:

```swift
func returnInOutSendingDirectly(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
  return x // expected-warning {{cannot return 'inout sending' parameter 'x' from global function 'returnInOutSendingDirectly'}}
  // expected-note @-1 {{returning 'x' risks concurrent access since caller assumes that 'x' and the result of global function 'returnInOutSendingDirectly' can be safely sent to different isolation domains}}
}
```

* Returning a value in the same region as an 'inout sending' parameter. E.x.:

```swift
func returnInOutSendingRegionVar(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
  var y = x
  y = x
  return y // expected-warning {{cannot return 'y' from global function 'returnInOutSendingRegionVar'}}
  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' since the caller assumes that 'x' and the result of global function 'returnInOutSendingRegionVar' can be safely sent to different isolation domains}}
}
```

* Returning the result of a function or computed property that is in the same
region as the 'inout parameter'.

```swift
func returnInOutSendingViaHelper(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
  let y = x
  return useNonSendableKlassAndReturn(y) // expected-warning {{cannot return result of global function 'useNonSendableKlassAndReturn' from global function 'returnInOutSendingViaHelper'}}
  // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' since the caller assumes that 'x' and the result of global function 'returnInOutSendingViaHelper' can be safely sent to different isolation domains}}
}
```

Additionally, I had to introduce a specific variant for each of these
diagnostics for cases where due to us being in a method, we are actually in our
caller causing the 'inout sending' parameter to be in the same region as an
actor isolated value:

* Returning 'inout sending' directly:

```swift
extension MyActor {
  func returnInOutSendingDirectly(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
    return x // expected-warning {{cannot return 'inout sending' parameter 'x' from instance method 'returnInOutSendingDirectly'}}
    // expected-note @-1 {{returning 'x' risks concurrent access since caller assumes that 'x' is not actor-isolated and the result of instance method 'returnInOutSendingDirectly' is 'self'-isolated}}
  }
}
```

* Returning a value in the same region as an 'inout sending' parameter. E.x.:

```swift
extension MyActor {
  func returnInOutSendingRegionLet(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
    let y = x
    return y // expected-warning {{cannot return 'y' from instance method 'returnInOutSendingRegionLet'}}
    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' since the caller assumes that 'x' is not actor-isolated and the result of instance method 'returnInOutSendingRegionLet' is 'self'-isolated}}
  }
}
```

* Returning the result of a function or computed property that is in the same region as the 'inout parameter'.

```swift
extension MyActor {
  func returnInOutSendingViaHelper(_ x: inout sending NonSendableKlass) -> NonSendableKlass {
    let y = x
    return useNonSendableKlassAndReturn(y) // expected-warning {{cannot return result of global function 'useNonSendableKlassAndReturn' from instance method 'returnInOutSendingViaHelper'; this is an error in the Swift 6 language mode}}
    // expected-note @-1 {{returning result of global function 'useNonSendableKlassAndReturn' risks concurrent access to 'inout sending' parameter 'x' since the caller assumes that 'x' is not actor-isolated and the result of instance method 'returnInOutSendingViaHelper' is 'self'-isolated}}
  }
}
```

To implement this, I used two different approaches depending on whether or not
the returned value was generic or not.

* Concrete

In the case where we had a concrete value, I was able to in simple cases emit
diagnostics based off of the values returned by the return inst. In cases where
we phied together results due to multiple results in the same function, we
determine which of the incoming phied values caused the error by grabbing the
exit partition information of each of the incoming value predecessors and seeing
if an InOutSendingAtFunctionExit would emit an error.

* Generic

In the case of generic code, it is a little more interesting since the result is
a value stored in an our parameter instead of being a value directly returned by
a return inst. To work around this, I use PrunedLiveness to determine the last
values stored into the out parameter in the function to avoid having to do a
full dataflow. Then I take the exit blocks where we assign each of those values
and run the same check as we do in the direct phi case to emit the appropriate
error.

rdar://152454571

