### PR TITLE
FreeBSD: Disable known/in-progress test failures

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -13,6 +13,10 @@
 //
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 
+// Undefined hidden symbol to C++ voidify in libcxx
+// rdar://121551667
+// XFAIL: OS=freebsd
+
 import StdlibUnittest
 #if !BRIDGING_HEADER
 import StdMap

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -5,6 +5,10 @@
 //
 // REQUIRES: executable_test
 
+// Undefined hidden symbol to C++ voidify in libcxx
+// rdar://121551667
+// XFAIL: OS=freebsd
+
 import StdlibUnittest
 import StdOptional
 import CxxStdlib

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -9,6 +9,12 @@
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix} -L%t/../../.. -lBlocksRuntime
 // RUN: %target-swift-reflection-dump %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
+// lld on FreeBSD relocates some of the metadata sections resulting in invalid
+// offsets in section headers, breaking the Swift reflection data ELF parser
+// resulting in missing metadata.
+// rdar://159139154
+// XFAIL: OS=freebsd
+
 sil_stage canonical
 
 import Builtin

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -23,6 +23,12 @@
 
 // UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
+// lld on FreeBSD relocates some of the metadata sections resulting in invalid
+// offsets in section headers, breaking the Swift reflection data ELF parser
+// resulting in missing metadata.
+// rdar://159139154
+// XFAIL: OS=freebsd
+
 // CHECK-32: FIELDS:
 // CHECK-32: =======
 // CHECK-32: TypesToReflect.HasCTypes

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -10,6 +10,9 @@
 // Thread destruction interceptor marks the thread ignored and then checks that
 // the thread isn't being ignored.
 // rdar://158450231
+// TSan is also occasionally detecting race conditions in the concurrency
+// runtime on FreeBSD.
+// rdar://158355890
 // XFAIL: OS=freebsd
 
 var scratchBuffer: UnsafeMutableBufferPointer<Int> = .allocate(capacity: 1000)

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -6,6 +6,12 @@
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Bug in TSan on FreeBSD
+// Thread destruction interceptor marks the thread ignored and then checks that
+// the thread isn't being ignored.
+// rdar://158450231
+// XFAIL: OS=freebsd
+
 var scratchBuffer: UnsafeMutableBufferPointer<Int> = .allocate(capacity: 1000)
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -6,6 +6,12 @@
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Bug in TSan on FreeBSD
+// Thread destruction interceptor marks the thread ignored and then checks that
+// the thread isn't being ignored.
+// rdar://158450231
+// XFAIL: OS=freebsd
+
 import Dispatch
 
 #if canImport(Darwin)

--- a/test/Sanitizers/tsan/mainactor.swift
+++ b/test/Sanitizers/tsan/mainactor.swift
@@ -7,6 +7,12 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: threading_none
 
+// Bug in TSan on FreeBSD
+// Thread destruction interceptor marks the thread ignored and then checks that
+// the thread isn't being ignored.
+// rdar://158450231
+// XFAIL: OS=freebsd
+
 import Dispatch
 
 /// @returns true iff the expected answer is actually the case, i.e., correct.

--- a/test/Sanitizers/tsan/norace-task-group-cancellation.swift
+++ b/test/Sanitizers/tsan/norace-task-group-cancellation.swift
@@ -7,6 +7,12 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Bug in TSan on FreeBSD
+// Thread destruction interceptor marks the thread ignored and then checks that
+// the thread isn't being ignored.
+// rdar://158450231
+// XFAIL: OS=freebsd
+
 @main
 public struct TSANDataRaceOnCancel {
   public static func main() async throws {

--- a/test/Sanitizers/tsan/once.swift
+++ b/test/Sanitizers/tsan/once.swift
@@ -17,6 +17,12 @@
 // on some platforms TSan wasn't seeing the synchronization, so would report
 // a false positive.
 
+// TSan is detecting race conditions in the concurrency runtime.
+// This might be an issue in how it is hooked into the underlying threading
+// model on FreeBSD.
+// rdar://158355890
+// XFAIL: OS=freebsd
+
 import Dispatch
 
 var count = 0

--- a/test/Sanitizers/tsan/tsan.swift
+++ b/test/Sanitizers/tsan/tsan.swift
@@ -14,6 +14,12 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
+// TSan is detecting race conditions in the concurrency runtime.
+// This might be an issue in how it is hooked into the underlying threading
+// model on FreeBSD.
+// rdar://158355890
+// XFAIL: OS=freebsd
+
 #if canImport(Darwin)
   import Darwin
 #elseif canImport(Glibc)

--- a/validation-test/Sanitizers/tsan-inout.swift
+++ b/validation-test/Sanitizers/tsan-inout.swift
@@ -8,6 +8,12 @@
 // REQUIRES: stress_test
 // REQUIRES: tsan_runtime
 
+// Bug in TSan on FreeBSD
+// Thread destruction interceptor marks the thread ignored and then checks that
+// the thread isn't being ignored.
+// rdar://158450231
+// XFAIL: OS=freebsd
+
 // Test ThreadSanitizer execution end-to-end when calling
 // an uninstrumented module with inout parameters
 


### PR DESCRIPTION
Disabling the known test failures that are in progress on FreeBSD to make progress in CI.

## rdar://121551667: Missing libcxx symbols

Disables:
  - Interop/Cxx/stdlib/use-std-map.swift
  - Interop/Cxx/stdlib/use-std-optional.swift

```
[2025-08-25T14:24:03.682Z] ld.lld: error: undefined hidden symbol: void* std::__1::__voidify[abi:se190107]<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&)
[2025-08-25T14:24:03.682Z] >>> referenced by use-std-optional-a50ecf.o
[2025-08-25T14:24:03.682Z] >>>               /tmp/lit-tmp-_7a7wdmg/use-std-optional-a50ecf.o:(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>* std::__1::__construct_at[abi:se190107]<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&))
[2025-08-25T14:24:03.682Z] >>> referenced by use-std-optional-a50ecf.o
[2025-08-25T14:24:03.682Z] >>>               /tmp/lit-tmp-_7a7wdmg/use-std-optional-a50ecf.o:(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>* std::__1::__construct_at[abi:se190107]<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&))
[2025-08-25T14:24:03.682Z] clang: error: linker command failed with exit code 1 (use -v to see invocation)
[2025-08-25T14:24:03.682Z] <unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
```
## rdar://159139154: Failure to load runtime metadata sections

Speculative fix: https://github.com/swiftlang/swift/pull/83851
This appears to be an issue in how `scanELFType` is implemented and missing details on how relocated sections work.

Disables:
   - Reflection/capture_descriptors.sil
   - Reflection/typeref_decoding_imported.swift

## rdar://158450231: ThreadSanitizer: thread finished with ignores enabled
The `thr_exit` sanitizer interceptor looks like it creates a scoped interceptor, marking the thread as ignored. Then promptly checks that the thread is not being ignored before the end of the scoped interceptor's lifetime, which would stop ignoring the thread. Since the thread is being ignored by the internal workings of TSan, TSan sees it as ignored and fails the test.

Disables:
 - Sanitizers/tsan/async_taskgroup_next.swift
 - Sanitizers/tsan/basic_future.swift
 - Sanitizers/tsan/mainactor.swift
 - Sanitizers/tsan/norace-task-group-cancellation.swift
 - Sanitizers/tsan-inout.swift

```
ThreadSanitizer: main thread finished with ignores enabled
  One of the following ignores was not ended (in order of probability)
```
Note that TSan cannot list any locations that are ignored because the code under test is not actually ignoring anything.

## rdar://158355890: Concurrency/TSan: Runtime dataraces

Disables:
 - Sanitizers/tsan/once.swift
 - Sanitizers/tsan/tsan.swift
 - Sanitizers/tsan/async_taskgroup_next.swift

There are a handful of data races that TSan is calling out. This is the first time that we are building the runtimes with the [pthread](https://github.com/swiftlang/swift/blob/main/lib/Threading/Pthreads.cpp) threading backend. The [Linux](https://github.com/swiftlang/swift/blob/main/lib/Threading/Linux.cpp) implementation is separate with its own mechanisms for informing TSan what is and isn't safe, so it's entirely possible that this is related to the issue.



