### PR TITLE
[Embedded] Only reserve 4KB in embedded Darwin targets

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -49,7 +49,10 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
   }
   setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_ARM64_IS_OBJC_BIT);
 
-  if (triple.isOSDarwin()) {
+  // Non-embedded Darwin reserves the low 4GB of address space.
+  if (triple.isOSDarwin() &&
+      !IGM.getSwiftModule()->getASTContext().LangOpts.hasFeature(
+          Feature::Embedded)) {
     target.LeastValidPointerValue =
       SWIFT_ABI_DARWIN_ARM64_LEAST_VALID_POINTER;
   }
@@ -104,7 +107,9 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
               SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK);
   }
 
-  if (triple.isOSDarwin()) {
+  if (triple.isOSDarwin() &&
+      !IGM.getSwiftModule()->getASTContext().LangOpts.hasFeature(
+          Feature::Embedded)) {
     target.LeastValidPointerValue =
       SWIFT_ABI_DARWIN_X86_64_LEAST_VALID_POINTER;
   }

--- a/test/embedded/min-pointer-value-default-darwin.swift
+++ b/test/embedded/min-pointer-value-default-darwin.swift
@@ -1,0 +1,22 @@
+
+// RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Embedded -O -min-valid-pointer-value=0x1000  | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Embedded -O | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+public func testit(_ s: S?) -> Bool {
+  return s != nil
+}
+
+class C {}
+
+public struct S {
+  var a = InlineArray<57, UInt8>(repeating: 0)
+  var b = C()
+  var c = InlineArray<49, UInt8>(repeating: 0)
+}
+
+// CHECK-LABEL: define {{.*}} @"$e4main1SVSgWOg"(ptr %0)
+// CHECK:         icmp {{.*}}, 4095
+// CHECK-LABEL: }


### PR DESCRIPTION
Non-embedded Darwin targets reserve the first 4GB of address space. All other targets reserve 4KB of address space. Make Embedded Darwin targets only reserve the first 4KB (as with other targets), since they aren't in userspace.

Fixes rdar://158981013.
