### PR TITLE
[WinSDK] Modularize `<guiddef.h>`

### DIFF
--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -18,7 +18,13 @@ roots:
     contents:
       - name: module.modulemap
         type: file
-        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk.modulemap"
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk_um.modulemap"
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk_shared.modulemap"
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/ucrt"
     type: directory
     contents:
@@ -47,5 +53,6 @@ install(FILES
   ucrt.modulemap
   vcruntime.apinotes
   vcruntime.modulemap
-  winsdk.modulemap
+  winsdk_um.modulemap
+  winsdk_shared.modulemap
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -158,7 +158,8 @@ message(STATUS "Windows modulemaps[${StdlibSources}/Platform] -> ${CMAKE_CURRENT
 copy_files(public/Platform Overlay/Windows/clang
   FILES
     ucrt.modulemap
-    winsdk.modulemap
+    winsdk_um.modulemap
+    winsdk_shared.modulemap
     vcruntime.modulemap
     vcruntime.apinotes)
 

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -482,14 +482,23 @@ void GetWindowsFileMappings(
                              WindowsSDK.Path, WindowsSDK.MajorVersion,
                              WindowsSDK.IncludeVersion,
                              WindowsSDK.LibraryVersion)) {
+    assert(WindowsSDK.MajorVersion > 8);
     llvm::SmallString<261> WinSDKInjection{WindowsSDK.Path};
     llvm::sys::path::append(WinSDKInjection, "Include");
-    if (WindowsSDK.MajorVersion > 8)
-      llvm::sys::path::append(WinSDKInjection, WindowsSDK.IncludeVersion, "um");
+    llvm::sys::path::append(WinSDKInjection, WindowsSDK.IncludeVersion, "um");
     llvm::sys::path::append(WinSDKInjection, "module.modulemap");
 
-    AuxiliaryFile =
-        GetPlatformAuxiliaryFile("windows", "winsdk.modulemap", SearchPathOpts);
+    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "winsdk_um.modulemap",
+                                             SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
+                                               AuxiliaryFile);
+
+    llvm::sys::path::remove_filename(WinSDKInjection);
+    llvm::sys::path::remove_filename(WinSDKInjection);
+    llvm::sys::path::append(WinSDKInjection, "shared", "module.modulemap");
+    AuxiliaryFile = GetPlatformAuxiliaryFile(
+        "windows", "winsdk_shared.modulemap", SearchPathOpts);
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
                                                AuxiliaryFile);

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -8,7 +8,13 @@ roots:
     contents:
       - name: module.modulemap
         type: file
-        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk.modulemap"
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk_um.modulemap"
+  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\shared"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk_shared.modulemap"
   - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\ucrt"
     type: directory
     contents:

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -467,7 +467,8 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
       ucrt.modulemap
       vcruntime.apinotes
       vcruntime.modulemap
-      winsdk.modulemap
+      winsdk_um.modulemap
+      winsdk_shared.modulemap
     DESTINATION "share"
     COMPONENT sdk-overlay)
 endif()

--- a/stdlib/public/Platform/winsdk_shared.modulemap
+++ b/stdlib/public/Platform/winsdk_shared.modulemap
@@ -1,0 +1,16 @@
+//===--- WinSDK_Shared.modulemap ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module _GUID {
+  header "guiddef.h"
+  export *
+}

--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -1,4 +1,4 @@
-//===--- WinSDK.modulemap -------------------------------------------------===//
+//===--- WinSDK_UM.modulemap ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import ucrt
+@_exported import _GUID
 @_exported import WinSDK // Clang module
 
 // WinBase.h

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -1,0 +1,9 @@
+// RUN: %target-build-swift %s
+// REQUIRES: OS=windows-msvc
+
+// Make sure that importing WinSDK brings in the GUID type, which is declared in
+// /shared and not in /um.
+
+import WinSDK
+
+public func usesGUID(_ x: GUID) {}


### PR DESCRIPTION
This fixes modularization errors that arise when importing a C++ header that contains `#include <guiddef.h>`, which might hijack this header from the WinSDK module where it belongs.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
