### PR TITLE
[Test] Disable nested private generic types test on old runtimes.

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -101,14 +101,9 @@ private struct Parent<Unused> {
 
 AssociatedTypeDemangleTests.test("nested private generic types in associated type witnesses") {
   // Fixed in Swift 5.1+ runtimes.
-  if #available(SwiftStdlib 5.1, *) {}
-  // Bug is still present in Swift 5.0 runtime.
-  else {
-    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
-    return
+  if #available(SwiftStdlib 5.1, *) {
+    _ = Parent<Never>.Nested(first: "String", second: 0).pair
   }
-
-  _ = Parent<Never>.Nested(first: "String", second: 0).pair
 }
 
 


### PR DESCRIPTION
This test tests a fix in Swift 5.1+. When running on 5.0, it uses expectCrashLater since 5.0 doesn't have the fix. This breaks if we're ever testing a newer runtime on an old OS. We don't need to test if old runtimes are broken (we know they are), just that new runtimes remain fixed. Don't run the test at all unless on 5.1+.

rdar://159026050