### PR TITLE
[IRGen] Fix computation of spare bits for fixed arrays

### DIFF
--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -248,9 +248,15 @@ protected:
     
     // Take spare bits from the first element only.
     SpareBitVector result = elementTI.getSpareBits();
+
     // We can use the padding to the next element as spare bits too.
-    result.appendSetBits(getArraySize(arraySize, elementTI).getValueInBits()
-                           - result.size());
+    auto padding = elementTI.getFixedStride() - elementTI.getFixedSize();
+    result.appendSetBits(padding.getValueInBits());
+
+    // spare bits of any other elements should not be considered
+    result.appendClearBits(
+        getArraySize(arraySize - 1, elementTI).getValueInBits());
+
     return result;
   }
   

--- a/test/IRGen/inline_array_enum_tags.swift
+++ b/test/IRGen/inline_array_enum_tags.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -disable-availability-checking -O -emit-ir %s | %FileCheck %s
+
+public struct Foo {
+    let x: UInt64
+    let y: InlineArray<2, UInt64>
+}
+
+public struct Bar {
+    let x: UInt64
+    let y: [UInt64]
+}
+
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias nocapture readonly %value, ptr nocapture readnone %Baz)
+// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds i8, ptr %value, {{i64|i32}} 24
+// CHECK:   [[TAG_VAL:%.*]] = load i8, ptr [[TAG_ADDR]], align 8
+// CHECK:   [[TAG_EXT:%.*]] = zext i8 [[TAG_VAL]] to i32
+// CHECK:   ret i32 [[TAG_EXT]]
+// CHECK: }
+public enum Baz {
+    case foo(Foo)
+    case bar(Bar)
+}
+
+public struct Padded {
+    let x: UInt64
+    let y: InlineArray<2, (UInt16, UInt8)>
+}
+
+
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias nocapture readonly %value, ptr nocapture readnone %WithPaddedPayload)
+// CHECK: entry:
+// CHECK:   [[ADDR:%.*]] = getelementptr inbounds i8, ptr %value, {{i64|i32}} 8
+// CHECK:   [[VAL:%.*]] = load {{i64|i32}}, ptr [[ADDR]], align 8
+// CHECK:   [[TAG:%.*]] = lshr i32 {{%.*}}, 31
+// CHECK:   ret i32 [[TAG]]
+// CHECK: }
+public enum WithPaddedPayload {
+    case a(Padded)
+    case b(Padded)
+}

--- a/test/Interpreter/inline_array_enum_tags.swift
+++ b/test/Interpreter/inline_array_enum_tags.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+
+struct Foo {
+    let x: UInt64
+    let y: InlineArray<2, UInt64>
+}
+
+struct Bar {
+    let x: UInt64
+    let y: [UInt64]
+}
+
+enum Baz {
+    case foo(Foo)
+    case bar(Bar)
+}
+
+@inline(never)
+func createEnum() -> Baz {
+    return .foo(Foo(x: 0, y: [0, 0xff00000000000000]))
+}
+
+
+let x = createEnum()
+
+// CHECK: 0 - 18374686479671623680
+switch x {
+    case .bar: fatalError("Expected .foo")
+    case .foo(let x): print("\(x.y[0]) - \(x.y[1])")
+}


### PR DESCRIPTION
rdar://159143492

Previously all bits after the spare bits of the first element were marked as spare bits. This caused enum tags to be stored in bits used by the payload.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
