### PR TITLE
[Test] Ignore potential nuw flag on getelementptr in IRGen/objc_super…

### DIFF
--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -116,7 +116,7 @@ class GenericRuncer<T> : Gizmo {
     // CHECK-NEXT: [[ISA_MASK:%.*]] = load i64, ptr @swift_isaMask, align 8
     // CHECK-NEXT: [[ISA_MASKED:%.*]] = and i64 [[ISA]], [[ISA_MASK]]
     // CHECK-NEXT: [[ISA_PTR:%.*]] = inttoptr i64 [[ISA_MASKED]] to ptr
-    // CHECK:      [[METACLASS_ADDR:%.*]] = getelementptr inbounds %objc_super, ptr %objc_super, i32 0, i32 1
+    // CHECK:      [[METACLASS_ADDR:%.*]] = getelementptr inbounds{{.*}} %objc_super, ptr %objc_super, i32 0, i32 1
     // CHECK-NEXT: store ptr [[ISA_PTR]], ptr [[METACLASS_ADDR]], align 8
     // CHECK-NEXT: [[SELECTOR:%.*]] = load ptr, ptr @"\01L_selector(runce)", align 8
     // CHECK-NEXT: call void @objc_msgSendSuper2(ptr %objc_super, ptr [[SELECTOR]])


### PR DESCRIPTION
….swift

rdar://159226959

The flag is irrelevant to the test and may or may not be present depending on LLVM version

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
