### PR TITLE
Various back deployment runtime test fixes

### DIFF
--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -35,7 +35,6 @@
 // RUN:   -enable-experimental-move-only
 
 // REQUIRES: concurrency
-// REQUIRES: executable_test
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_ParserASTGen
 // REQUIRES: swift_feature_Extern

--- a/test/Concurrency/Runtime/reasync.swift
+++ b/test/Concurrency/Runtime/reasync.swift
@@ -7,6 +7,10 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 import reasync
 

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1424,11 +1424,16 @@ extension TestLeadingDot where Self == NoopImpl {
 struct NoopImpl : TestLeadingDot {
 }
 
+@available(SwiftStdlib 5.1, *)
 func testLeadingDotSyntax(v: Int) {
   let x: some TestLeadingDot = .test {
     v
   }
 }
 
-testLeadingDotSyntax(v: -42)
+if #available(SwiftStdlib 5.1, *) {
+  testLeadingDotSyntax(v: -42)
+} else {
+  print("buildBlock: -42") // Fallback for the back deployment bots
+}
 // CHECK: buildBlock: -42

--- a/test/SILOptimizer/propagate_opaque_return_type.swift
+++ b/test/SILOptimizer/propagate_opaque_return_type.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: executable_test
 
+// UNSUPPORTED: back_deployment_runtime
+
 protocol P {}
 extension P {
   func foo() -> some Sequence<Int> {


### PR DESCRIPTION
Adjust some tests so that they don't fail on the back deployment runtime testing bots.

Resolves rdar://159025986&159025990&159025996&159026084.