### PR TITLE
[WIP] [cxx-interop] [StrictMemorySafety] Use the StrictMemorySafety diagGroup to warn about unannotated C++ APIs that return SWIFT_SHARED_REFERENCE

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2202,7 +2202,7 @@ ERROR(expose_nested_type_to_cxx,none,
       "nested %kind0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_macro_to_cxx,none,
       "Swift macro can not yet be represented in C++", (ValueDecl *))
-WARNING(warn_unannotated_cxx_func_returning_frt, none,
+GROUPED_WARNING(warn_unannotated_cxx_func_returning_frt, StrictMemorySafety, none,
         "cannot infer the ownership of the returned value, annotate %0 with "
         "either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED",
         (const ValueDecl *))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6423,6 +6423,9 @@ static bool shouldDiagnoseMissingReturnsRetained(const clang::NamedDecl *ND,
   if (!Ctx.LangOpts.hasFeature(Feature::WarnUnannotatedReturnOfCxxFrt))
     return false;
 
+  if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
+    return false;
+
   auto attrInfo = importer::ReturnOwnershipInfo(ND);
   if (attrInfo.hasRetainAttr())
     return false;

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -verify-additional-file %S/Inputs/cxx-functions-and-methods-returning-frt.h -Xcc -Wno-return-type -Xcc -Wno-nullability-completeness
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -strict-memory-safety -verify-additional-file %S/Inputs/cxx-functions-and-methods-returning-frt.h -Xcc -Wno-return-type -Xcc -Wno-nullability-completeness
 
 // XFAIL: OS=windows-msvc
 // TODO: Enable this on windows when -verify-additional-file issue on Windows Swift CI is resolved 
@@ -15,23 +15,23 @@ let frtLocalVar3 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrt() /
 let frtLocalVar4 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrtWithAnnotation()
 let frtLocalVar5 = global_function_returning_cxx_frt() // expected-warning {{cannot infer the ownership of the returned value, annotate 'global_function_returning_cxx_frt()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let frtLocalVar6 = global_function_returning_cxx_frt_with_annotations()
-let frtLocalVar7 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrt()
-let frtLocalVar8 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrtWithAnnotation()
-let frtLocalVar9 = global_function_returning_non_cxx_frt()
-let frtLocalVar10 = global_function_returning_non_cxx_frt_with_annotations()
+let frtLocalVar7 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrt() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let frtLocalVar8 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrtWithAnnotation() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let frtLocalVar9 = global_function_returning_non_cxx_frt() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let frtLocalVar10 = global_function_returning_non_cxx_frt_with_annotations() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let frtLocalVar11 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReference()
 let frtLocalVar12 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReferenceWithAnnotation()
 let frtLocalVar13 = global_function_returning_immortal_reference()
 let frtLocalVar14 = global_function_returning_immortal_reference_with_annotations()
-let frtLocalVar16 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReferenceWithAnnotation()
-let frtLocalVar17 = global_function_returning_unsafe_reference()
-let frtLocalVar18 = global_function_returning_unsafe_reference_with_annotations()
+let frtLocalVar16 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReferenceWithAnnotation() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let frtLocalVar17 = global_function_returning_unsafe_reference() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let frtLocalVar18 = global_function_returning_unsafe_reference_with_annotations() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let x = returnFRTOverloadedOperators() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnFRTOverloadedOperators()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let y = returnFRTOverloadedOperators() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnFRTOverloadedOperators()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let z = x + y
 let w = x - y
-let f = FunctionVoidToFRTStruct()
-let frt = f()
+let f = FunctionVoidToFRTStruct() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{argument 'self' in call to initializer 'init' has unsafe type}} expected-note {{reference to unsafe type}} expected-note {{initializer 'init()' involves unsafe type}}
+let frt = f() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{argument 'self' in call to instance method 'callAsFunction' has unsafe type}} expected-note {{reference to let 'f' involves unsafe type}}
 let nonFrt = NonFRTStruct()
 let nonFrtLocalVar1 = global_function_returning_templated_retrun_frt_owned(nonFrt)
 let _ = DefaultOwnershipConventionOnCXXForeignRefType.returnRefTyDefUnretained()

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S%{fs-sep}Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
+// RUN: %target-swift-frontend -typecheck -verify -I %S%{fs-sep}Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -strict-memory-safety -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
 
 // REQUIRES: swift_feature_WarnUnannotatedReturnOfCxxFrt
 
@@ -8,30 +8,29 @@ import Inheritance
 let _ = ImmortalRefereceExample.returnImmortalRefType()
 let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromImmortalRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = ExplicitAnnotationHasPrecedence1.returnValueType()
+let _ = ExplicitAnnotationHasPrecedence1.returnValueType() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = ExplicitAnnotationHasPrecedence1.returnRefType() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
-let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueType()
+let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueType() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueTypeAndAnnotated() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromValueTypeAndAnnotated()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromRefType() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromRefTypeAndAnnotated() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromRefTypeAndAnnotated()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndB()
+let _ = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndB() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndBAnnotated() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromRefTypeAAndBAnnotated()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = BasicInheritanceExample.returnValueType()
+let _ = BasicInheritanceExample.returnValueType() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = BasicInheritanceExample.returnRefType() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let _ = BasicInheritanceExample.returnDerivedFromRefType() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = MultipleInheritanceExample1.returnDerivedFromBaseRef1AndBaseRef2()
+let _ = MultipleInheritanceExample1.returnDerivedFromBaseRef1AndBaseRef2() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = MultipleInheritanceExample1.returnDerivedFromBaseRef3() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDerivedFromBaseRef3()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = MultipleInheritanceExample2.returnD()
-
-let _ = MultipleInheritanceExample3.returnD()
+let _ = MultipleInheritanceExample2.returnD() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
+let _ = MultipleInheritanceExample3.returnD() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 
 let _ = OverloadedRetainRelease.returnD() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnD()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
-let _ = RefTypeDiamondInheritance.returnDiamond()
+let _ = RefTypeDiamondInheritance.returnDiamond() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
 let _ = RefTypeDiamondInheritance.returnVirtualDiamond() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnVirtualDiamond()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 
 let _ = NonRefTypeDiamondInheritance.returnDiamond() // expected-warning {{cannot infer the ownership of the returned value, annotate 'returnDiamond()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}

--- a/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt-diagnostics.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt-diagnostics.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -verify-additional-file %S/Inputs/cxx-frt.h -Xcc -Wno-return-type
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -strict-memory-safety -verify-additional-file %S/Inputs/cxx-frt.h -Xcc -Wno-return-type
 
 // REQUIRES: swift_feature_WarnUnannotatedReturnOfCxxFrt
 
@@ -8,6 +8,6 @@ import CxxForeignRef
 // REQUIRES: objc_interop
 func testObjCMethods() {
     _ = Bridge.objCMethodReturningFRTBothAnnotations()
-    _ = Bridge.objCMethodReturningNonCxxFrtAnannotated()
+    _ = Bridge.objCMethodReturningNonCxxFrtAnannotated() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}} expected-note {{involves unsafe type}}
     _ = Bridge.objCMethodReturningFRTUnannotated() // expected-warning {{cannot infer the ownership of the returned value, annotate 'objCMethodReturningFRTUnannotated()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 }


### PR DESCRIPTION
These warnings are still gated behind the experimental-feature-flag `WarnUnannotatedReturnOfCxxFrt`. But additionally this patch adds these warnings under `StrictMemorySafety` diagnostic group.

So now these warnings would be emitted only if both flags are passed to the swift compiler invocation: `-enable-experimental-feature WarnUnannotatedReturnOfCxxFrt -strict-memory-safety`
