### PR TITLE
build.ps1: accommodate the split SPM runtime build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -764,6 +764,7 @@ enum Project {
   Subprocess
   Build
   PackageManager
+  PackageManagerRuntime
   Markdown
   Format
   LMDB
@@ -3497,6 +3498,14 @@ function Build-PackageManager([Hashtable] $Platform) {
       SQLite3_INCLUDE_DIR = "$SourceCache\swift-toolchain-sqlite\Sources\CSQLite\include";
       SQLite3_LIBRARY = "$(Get-ProjectBinaryCache $Platform SQLite)\SQLite3.lib";
     }
+
+  Build-CMakeProject `
+    -Src "$SrcDir\Sources\Runtime" `
+    -Bin (Get-ProjectBinaryCache $Platform PackageManagerRuntime) `
+    -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
+    -Platform $Platform `
+    -UseBuiltCompilers C,Swift `
+    -SwiftSDK (Get-SwiftSDK -OS $Platform.OS)
 }
 
 function Build-Markdown([Hashtable] $Platform) {


### PR DESCRIPTION
Adjust the build to accommodate the split SPM manifest runtime build. In order to support building the toolchain without the just built compiler, we need to split out the SPM runtime which is used by the new toolchain. We must build the SPM manifest runtime against the just built runtime as this is the compiler consuming the runtime.