### PR TITLE
Windows: annotate unsafe constructs in the overlay

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -78,13 +78,29 @@ public var stdin: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdin() }
 public var stdout: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdout() }
 public var stderr: UnsafeMutablePointer<FILE> { return _swift_stdlib_stderr() }
 #elseif os(Windows)
-public var stdin: UnsafeMutablePointer<FILE> { return __acrt_iob_func(0) }
-public var stdout: UnsafeMutablePointer<FILE> { return __acrt_iob_func(1) }
-public var stderr: UnsafeMutablePointer<FILE> { return __acrt_iob_func(2) }
+public var stdin: UnsafeMutablePointer<FILE> {
+  return unsafe __acrt_iob_func(0)
+}
 
-public var STDIN_FILENO: Int32 { return _fileno(stdin) }
-public var STDOUT_FILENO: Int32 { return _fileno(stdout) }
-public var STDERR_FILENO: Int32 { return _fileno(stderr) }
+public var stdout: UnsafeMutablePointer<FILE> {
+  return unsafe __acrt_iob_func(1)
+}
+
+public var stderr: UnsafeMutablePointer<FILE> {
+  return unsafe __acrt_iob_func(2)
+}
+
+public var STDIN_FILENO: Int32 {
+  return unsafe _fileno(stdin)
+}
+
+public var STDOUT_FILENO: Int32 {
+  return unsafe _fileno(stdout)
+}
+
+public var STDERR_FILENO: Int32 {
+  return unsafe _fileno(stderr)
+}
 #endif
 
 
@@ -272,10 +288,10 @@ public var SIG_HOLD: sighandler_t {
 #elseif os(Windows)
 public var SIG_DFL: _crt_signal_t? { return nil }
 public var SIG_IGN: _crt_signal_t {
-  return unsafeBitCast(1, to: _crt_signal_t.self)
+  return unsafe unsafeBitCast(1, to: _crt_signal_t.self)
 }
 public var SIG_ERR: _crt_signal_t {
-  return unsafeBitCast(-1, to: _crt_signal_t.self)
+  return unsafe unsafeBitCast(-1, to: _crt_signal_t.self)
 }
 #elseif os(WASI)
 // No signals support on WASI yet, see https://github.com/WebAssembly/WASI/issues/166.

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -295,7 +295,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 @_transparent
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
   var quo = Int32(0)
-  let rem = remquo${f}(${CT}(x), ${CT}(y), &quo)
+  let rem = unsafe remquo${f}(${CT}(x), ${CT}(y), &quo)
   return (${T}(rem), Int(quo))
 }
 %  if T == 'Float80':
@@ -313,7 +313,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 @_transparent
 @_unavailableInEmbedded
 public func nan(_ tag: String) -> ${T} {
-  return ${T}(nan${f}(tag))
+  return ${T}(unsafe nan${f}(tag))
 }
 %  if T == 'Float80':
 #endif

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -56,7 +56,7 @@ public var STD_ERROR_HANDLE: DWORD {
 // handleapi.h
 @inlinable
 public var INVALID_HANDLE_VALUE: HANDLE {
-  HANDLE(bitPattern: -1)!
+  unsafe HANDLE(bitPattern: -1)!
 }
 
 // shellapi.h
@@ -163,78 +163,78 @@ public var PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: DWORD_PTR {
 // windef.h
 @inlinable
 public var DPI_AWARENESS_CONTEXT_UNAWARE: DPI_AWARENESS_CONTEXT {
-  DPI_AWARENESS_CONTEXT(bitPattern: -1)!
+  unsafe DPI_AWARENESS_CONTEXT(bitPattern: -1)!
 }
 
 @inlinable
 public var DPI_AWARENESS_CONTEXT_SYSTEM_AWARE: DPI_AWARENESS_CONTEXT {
-  DPI_AWARENESS_CONTEXT(bitPattern: -2)!
+  unsafe DPI_AWARENESS_CONTEXT(bitPattern: -2)!
 }
 
 @inlinable
 public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE: DPI_AWARENESS_CONTEXT {
-  DPI_AWARENESS_CONTEXT(bitPattern: -3)!
+  unsafe DPI_AWARENESS_CONTEXT(bitPattern: -3)!
 }
 
 @inlinable
 public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT {
-  DPI_AWARENESS_CONTEXT(bitPattern: -4)!
+  unsafe DPI_AWARENESS_CONTEXT(bitPattern: -4)!
 }
 
 @inlinable
 public var DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT {
-  DPI_AWARENESS_CONTEXT(bitPattern: -5)!
+  unsafe DPI_AWARENESS_CONTEXT(bitPattern: -5)!
 }
 
 // winreg.h
 @inlinable
 public var HKEY_CLASSES_ROOT: HKEY {
-  HKEY(bitPattern: UInt(0x80000000))!
+  unsafe HKEY(bitPattern: UInt(0x80000000))!
 }
 
 @inlinable
 public var HKEY_CURRENT_USER: HKEY {
-  HKEY(bitPattern: UInt(0x80000001))!
+  unsafe HKEY(bitPattern: UInt(0x80000001))!
 }
 
 @inlinable
 public var HKEY_LOCAL_MACHINE: HKEY {
-  HKEY(bitPattern: UInt(0x80000002))!
+  unsafe HKEY(bitPattern: UInt(0x80000002))!
 }
 
 @inlinable
 public var HKEY_USERS: HKEY {
-  HKEY(bitPattern: UInt(0x80000003))!
+  unsafe HKEY(bitPattern: UInt(0x80000003))!
 }
 
 @inlinable
 public var HKEY_PERFORMANCE_DATA: HKEY {
-  HKEY(bitPattern: UInt(0x80000004))!
+  unsafe HKEY(bitPattern: UInt(0x80000004))!
 }
 
 @inlinable
 public var HKEY_PERFORMANCE_TEXT: HKEY {
-  HKEY(bitPattern: UInt(0x80000050))!
+  unsafe HKEY(bitPattern: UInt(0x80000050))!
 }
 
 @inlinable
 public var HKEY_PERFORMANCE_NLSTEXT: HKEY {
-  HKEY(bitPattern: UInt(0x80000060))!
+  unsafe HKEY(bitPattern: UInt(0x80000060))!
 }
 
 @inlinable
 public var HKEY_CURRENT_CONFIG: HKEY {
-  HKEY(bitPattern: UInt(0x80000005))!
+  unsafe HKEY(bitPattern: UInt(0x80000005))!
 }
 
 @inlinable
 public var HKEY_DYN_DATA: HKEY {
-  HKEY(bitPattern: UInt(0x80000006))!
+  unsafe HKEY(bitPattern: UInt(0x80000006))!
 }
 
 @inlinable
 public var HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY {
-  HKEY(bitPattern: UInt(0x80000007))!
+  unsafe HKEY(bitPattern: UInt(0x80000007))!
 }
 
 // Richedit.h


### PR DESCRIPTION
Mark a number of overlay calls as `unsafe` to account for the new memory safety work.