### PR TITLE
Sema: Diagnose key paths when `MemberImportVisibility` is enabled

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -30,6 +30,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
@@ -6377,6 +6378,13 @@ static void diagnoseMissingMemberImports(const Expr *E, const DeclContext *DC) {
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto declRef = E->getReferencedDecl())
         checkDecl(declRef.getDecl(), E->getLoc());
+
+      if (auto *KPE = dyn_cast<KeyPathExpr>(E)) {
+        for (const auto &component : KPE->getComponents()) {
+          if (component.hasDeclRef())
+            checkDecl(component.getDeclRef().getDecl(), component.getLoc());
+        }
+      }
 
       return Action::Continue(E);
     }

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_MemberImportVisibility
 
 import members_C
-// expected-member-visibility-note 18{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 20{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -43,6 +43,16 @@ func testExtensionMembers(x: X, y: Y<Z>) {
   let _: Int = disfavoredResult // expected-member-visibility-error{{cannot convert value of type 'Bool' to specified type 'Int'}}
   let _: Bool = x.ambiguousDisfavored()
   let _: Int = x.ambiguousDisfavored() // expected-member-visibility-error{{instance method 'ambiguousDisfavored()' is not available due to missing import of defining module 'members_B'}}
+
+  func takesKeyPath<T, U>(_ t: T, _ keyPath: KeyPath<T, U>) -> () { }
+
+  takesKeyPath(x, \.propXinA)
+  takesKeyPath(x, \.propXinB) // expected-member-visibility-error{{property 'propXinB' is not available due to missing import of defining module 'members_B'}}
+  takesKeyPath(x, \.propXinC)
+
+  takesKeyPath(x, \.propXinA.description)
+  takesKeyPath(x, \.propXinB.description) // expected-member-visibility-error{{property 'propXinB' is not available due to missing import of defining module 'members_B'}}
+  takesKeyPath(x, \.propXinC.description)
 }
 
 func testOperatorMembers(x: X, y: Y<Z>) {


### PR DESCRIPTION
The diagnostic pass that checks whether expressions reference member declarations that have not been imported failed to handle key path expressions.

Resolves rdar://159093481.
