### PR TITLE
[6.2.0] Update the runtime version to 6.2.0

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -54,7 +54,7 @@ if($ENV{BUILD_NUMBER})
 endif()
 project(SwiftCore
   LANGUAGES C CXX Swift
-  VERSION 6.1.0${BUILD_NUMBER})
+  VERSION 6.2.0${BUILD_NUMBER})
 
 # The Swift standard library is not intended for use as a sub-library as part of
 # another project. It is tightly coupled with the compiler version.

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -20,7 +20,7 @@ if($ENV{BUILD_NUMBER})
 endif()
 project(SwiftOverlay
   LANGUAGES C CXX Swift
-  VERSION 6.1.0${BUILD_NUMBER})
+  VERSION 6.2.0${BUILD_NUMBER})
 
 find_package(SwiftCore)
 

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -10,7 +10,7 @@ if($ENV{BUILD_NUMBER})
 endif()
 project(SwiftStringProcessing
   LANGUAGES Swift C
-  VERSION 6.1.0${BUILD_NUMBER})
+  VERSION 6.2.0${BUILD_NUMBER})
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(FATAL_ERROR "Swift StringProcessing must build as a standalone project")


### PR DESCRIPTION
**Explanation**: Runtime version is set to 6.1.0 in release/6.2 branch
**Scope**: Update the runtime version to 6.2.0
**Issues**: The runtime version we not updated
**Original PRs:** 

* `main`- https://github.com/swiftlang/swift/pull/83748 
* `release/6.2` - https://github.com/swiftlang/swift/pull/83935

**Risk**: Low
**Testing**: CI Testing
**Reviewers**: @compnerd @etcwilde