### PR TITLE
[Concurrency/Distributed] nonisolated-nonsending by default breaks distributed thunks

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3037,6 +3037,13 @@ public:
   /// `distributed var get { }` accessors.
   bool isDistributedGetAccessor() const;
 
+  /// Is this a 'distributed thunk'?
+  ///
+  /// Distributed thunks are synthesized functions which perform the "is remote?"
+  /// check, before dispatching to a 'system.remoteCall' (if actor was remote).
+  /// They are always 'async' and 'throws'.
+  bool isDistributedThunk() const;
+
   bool hasName() const { return bool(Name); }
   bool isOperator() const { return Name.isOperator(); }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1367,6 +1367,13 @@ bool ValueDecl::isDistributedGetAccessor() const {
   return false;
 }
 
+bool ValueDecl::isDistributedThunk() const {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(this)) {
+    return func->isDistributedThunk();
+  }
+  return false;
+}
+
 ConstructorDecl *
 NominalTypeDecl::getDistributedRemoteCallTargetInitFunction() const {
   auto mutableThis = const_cast<NominalTypeDecl *>(this);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -737,6 +737,7 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
+  // TODO(distributed): These would benefit from becoming nonisolated(nonsending)
   thunk->getAttrs().add(NonisolatedAttr::createImplicit(C));
 
   return thunk;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5212,6 +5212,13 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
     if (decl->getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
       if (auto *value = dyn_cast<ValueDecl>(decl)) {
+        // TODO(distributed): make distributed thunks nonisolated(nonsending) and remove this if
+        if (value->isAsync() && value->isDistributedThunk()) {
+          // don't change isolation of distributed thunks until we make them nonisolated(nonsending),
+          // since the runtime calling them assumes they're just nonisolated right now.
+          return ActorIsolation::forNonisolated(nonisolatedAttr->isUnsafe());
+        }
+
         if (value->isAsync() &&
             value->getModuleContext() == decl->getASTContext().MainModule) {
           return ActorIsolation::forCallerIsolationInheriting();

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
@@ -1,8 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule \
+// RUN:     -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple \
+// RUN:     %S/../Inputs/FakeDistributedActorSystems.swift
+
+// RUN: %target-build-swift -module-name main -enable-upcoming-feature NonisolatedNonsendingByDefault \
+// RUN:     -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s \
+// RUN:     %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --enable-var-scope
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency


### PR DESCRIPTION
the new `NonisolatedNonsendingByDefault` upcoming feature breaks remote calls in distributed actors, because the expected isolation doesn't match and the runtime swift_distributed_execute_target_resume will crash.

This is a short term fix to unblock adopters, however preferably we should mark the thunks as nonisolated(nonsending), though that seems to be more involved.

resolves rdar://159247975
