### PR TITLE
[cxx-interop] Provide overlay for `std::wstring`

### DIFF
--- a/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
@@ -20,6 +20,12 @@ inline std::size_t __swift_interopComputeHashOfU32String(const std::u32string &s
   return __swift_interopHashOfU32String()(str);
 }
 
+/// Used for std::wstring conformance to Swift.Hashable
+typedef std::hash<std::wstring> __swift_interopHashOfWString;
+inline std::size_t __swift_interopComputeHashOfWString(const std::wstring &str) {
+  return __swift_interopHashOfWString()(str);
+}
+
 inline std::chrono::seconds __swift_interopMakeChronoSeconds(int64_t seconds) {
   return std::chrono::seconds(seconds);
 }

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -150,6 +150,26 @@ StdStringTestSuite.test("std::u32string operators") {
     expectTrue(s1 == "something123literal")
 }
 
+StdStringTestSuite.test("std::wstring operators") {
+    var s1 = std.wstring("something")
+    let s2 = std.wstring("123")
+    let sum = s1 + s2
+    expectEqual(sum, std.wstring("something123"))
+
+    expectFalse(s1 == s2)
+    let s3 = std.wstring("something123")
+    expectFalse(s1 == s3)
+    expectFalse(s2 == s3)
+
+    s1 += s2
+    expectTrue(s1 == std.wstring("something123"))
+    expectTrue(s1 == s3)
+
+    // Make sure the operators work together with ExpressibleByStringLiteral conformance.
+    s1 += "literal"
+    expectTrue(s1 == "something123literal")
+}
+
 StdStringTestSuite.test("std::string::append") {
     var s1 = std.string("0123")
     let s2 = std.string("abc")
@@ -169,6 +189,13 @@ StdStringTestSuite.test("std::u32string::append") {
     let s2 = std.u32string("abc")
     s1.append(s2)
     expectEqual(s1, std.u32string("0123abc"))
+}
+
+StdStringTestSuite.test("std::wstring::append") {
+    var s1 = std.wstring("0123")
+    let s2 = std.wstring("abc")
+    s1.append(s2)
+    expectEqual(s1, std.wstring("0123abc"))
 }
 
 StdStringTestSuite.test("std::string comparison") {
@@ -207,6 +234,22 @@ StdStringTestSuite.test("std::u32string comparison") {
     let s1 = std.u32string("abc")
     let s2 = std.u32string("def")
     let s3 = std.u32string("abc")
+
+    expectTrue(s1 < s2)
+    expectFalse(s2 < s1)
+    expectTrue(s1 <= s2)
+    expectFalse(s2 <= s1)
+    expectTrue(s2 > s1)
+    expectFalse(s1 > s2)
+    expectTrue(s2 >= s1)
+    expectFalse(s1 >= s2)
+    expectTrue(s1 == s3)
+}
+
+StdStringTestSuite.test("std::wstring comparison") {
+    let s1 = std.wstring("abc")
+    let s2 = std.wstring("def")
+    let s3 = std.wstring("abc")
 
     expectTrue(s1 < s2)
     expectFalse(s2 < s1)
@@ -272,6 +315,27 @@ StdStringTestSuite.test("std::u32string as Hashable") {
     let h2 = s2.hashValue
 
     let s3 = std.u32string("something")
+    let h3 = s3.hashValue
+
+    expectEqual(h1, h3)
+    expectNotEqual(h0, h1)
+    expectNotEqual(h0, h2)
+    expectNotEqual(h0, h3)
+    expectNotEqual(h1, h2)
+    expectNotEqual(h2, h3)
+}
+
+StdStringTestSuite.test("std::wstring as Hashable") {
+    let s0 = std.wstring()
+    let h0 = s0.hashValue
+
+    let s1 = std.wstring("something")
+    let h1 = s1.hashValue
+
+    let s2 = std.wstring("something123")
+    let h2 = s2.hashValue
+
+    let s3 = std.wstring("something")
     let h3 = s3.hashValue
 
     expectEqual(h1, h3)
@@ -401,6 +465,14 @@ StdStringTestSuite.test("std::u32string as Swift.CustomDebugStringConvertible") 
     expectEqual(cxx3.debugDescription, "std.u32string(a�c)")
 }
 
+StdStringTestSuite.test("std::wstring as Swift.CustomDebugStringConvertible") {
+    let cxx1 = std.wstring()
+    expectEqual(cxx1.debugDescription, "std.wstring()")
+
+    let cxx2 = std.wstring("something123")
+    expectEqual(cxx2.debugDescription, "std.wstring(something123)")
+}
+
 StdStringTestSuite.test("std::string as Swift.Sequence") {
     let cxx1 = std.string()
     var iterated = false
@@ -474,6 +546,14 @@ StdStringTestSuite.test("std::u32string as Swift.CustomStringConvertible") {
         cxx4.push_back(scalar)
     }
     expectEqual(cxx4.description, "Hello, 世界")
+}
+
+StdStringTestSuite.test("std::wstring as Swift.CustomStringConvertible") {
+    let cxx1 = std.wstring()
+    expectEqual(cxx1.description, "")
+
+    let cxx2 = std.wstring("something123")
+    expectEqual(cxx2.description, "something123")
 }
 
 StdStringTestSuite.test("std::string from C string") {


### PR DESCRIPTION
This adds CxxStdlib overlay features to `std::wstring` similarly to `std::string`, `std::u16string`, etc.

This lets clients e.g. convert between Swift String and C++ wide string simply by calling an initializer.

rdar://159272493

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
