### PR TITLE
[AST] Walk ErrorExpr's original expr in ASTWalker

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -610,7 +610,8 @@ public:
 
   SourceRange getSourceRange() const { return Range; }
   Expr *getOriginalExpr() const { return OriginalExpr; }
-  
+  void setOriginalExpr(Expr *newExpr) { OriginalExpr = newExpr; }
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Error;
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3425,6 +3425,8 @@ public:
 
   void visitErrorExpr(ErrorExpr *E, Label label) {
     printCommon(E, "error_expr", label);
+    if (auto *origExpr = E->getOriginalExpr())
+      printRec(origExpr, Label::optional("original_expr"));
     printFoot();
   }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -616,7 +616,15 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }                                                      \
   } while (false)
 
-  Expr *visitErrorExpr(ErrorExpr *E) { return E; }
+  Expr *visitErrorExpr(ErrorExpr *E) {
+    if (auto *origExpr = E->getOriginalExpr()) {
+      auto *newOrigExpr = doIt(origExpr);
+      if (!newOrigExpr)
+        return nullptr;
+      E->setOriginalExpr(newOrigExpr);
+    }
+    return E;
+  }
   Expr *visitCodeCompletionExpr(CodeCompletionExpr *E) {
     if (Expr *baseExpr = E->getBase()) {
       Expr *newBaseExpr = doIt(baseExpr);

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -587,15 +587,6 @@ private:
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-    // Walk through error expressions.
-    if (auto *EE = dyn_cast<ErrorExpr>(E)) {
-      if (auto *OE = EE->getOriginalExpr()) {
-        llvm::SaveAndRestore<ASTWalker::ParentTy>(Parent, EE);
-        OE->walk(*this);
-      }
-      return Action::Continue(E);
-    }
-
     if (E->isImplicit())
       return Action::Continue(E);
 
@@ -1487,17 +1478,6 @@ private:
           StringLiteralRange =
               Lexer::getCharSourceRangeFromSourceRange(SM, E->getSourceRange());
 
-        return Action::SkipNode(E);
-      }
-    }
-
-    // Walk through error expressions.
-    if (auto *EE = dyn_cast<ErrorExpr>(E)) {
-      if (Action.shouldVisitChildren()) {
-        if (auto *OE = EE->getOriginalExpr()) {
-          llvm::SaveAndRestore<ASTWalker::ParentTy>(Parent, EE);
-          OE->walk(*this);
-        }
         return Action::SkipNode(E);
       }
     }

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -49,11 +49,6 @@ CompletionContextFinder::walkToExprPre(Expr *E) {
 
   if (auto *Error = dyn_cast<ErrorExpr>(E)) {
     Contexts.push_back({ContextKind::ErrorExpression, E});
-    if (auto *OrigExpr = Error->getOriginalExpr()) {
-      OrigExpr->walk(*this);
-      if (hasCompletionExpr())
-        return Action::Stop();
-    }
   }
 
   if (auto *CCE = dyn_cast<CodeCompletionExpr>(E)) {

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1252,7 +1252,8 @@ public:
         }
 
         if (isa<UnresolvedDotExpr>(parentExpr) ||
-            isa<MemberRefExpr>(parentExpr)) {
+            isa<MemberRefExpr>(parentExpr) ||
+            isa<ErrorExpr>(parentExpr)) {
           return true;
         } else if (auto *SE = dyn_cast<SubscriptExpr>(parentExpr)) {
           // 'super[]' is valid, but 'x[super]' is not.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1578,3 +1578,10 @@ func testAddMemberVsRemoveCall() {
   let b = Foo_74617()
   let c = (a + b).bar() // expected-error {{cannot call value of non-function type 'Float'}} {{22-24=}}
 }
+
+// Make sure we can still type-check the closure.
+do {
+  _ = {
+    let x: String = 0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+  }. // expected-error {{expected member name following '.'}}
+}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -550,7 +550,8 @@ func exprPostfix2() {
 
 class ExprSuper {
   init() {
-    super. // expected-error {{expected member name following '.'}} 
+    super. // expected-error {{expected member name following '.'}}
+    // expected-error@-1 {{'super' cannot be used in class 'ExprSuper' because it has no superclass}}
   }
 }
 

--- a/test/SourceKit/CursorInfo/rdar130771574.swift
+++ b/test/SourceKit/CursorInfo/rdar130771574.swift
@@ -1,0 +1,10 @@
+struct S {
+  var x: Int
+}
+
+// Make sure we can still resolve 'x' even with the trailing dot.
+func foo(_ s: S) {
+  s.x.
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):5 %s -- %s -module-name main | %FileCheck %s
+}
+// CHECK: s:4main1SV1xSivp

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -445,6 +445,7 @@ _ = ^/"/"
 _ = ^/"[/"
 // expected-error@-1 {{'^' is not a prefix unary operator}}
 // expected-error@-2 {{unterminated string literal}}
+// expected-error@-3 {{cannot parse regular expression: expected custom character class members}}
 
 _ = (^/)("/")
 

--- a/validation-test/IDE/crashers_fixed/dc8881dce3e968b.swift
+++ b/validation-test/IDE/crashers_fixed/dc8881dce3e968b.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","original":"6384b7fc","signature":"swift::TypeChecker::typeCheckForCodeCompletion(swift::constraints::SyntacticElementTarget&, bool, llvm::function_ref<void (swift::constraints::Solution const&)>)","signatureAssert":"Assertion failed: (fallback->E != expr), function typeCheckForCodeCompletion"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 func a -> b
 a > (c > a #^^# )'


### PR DESCRIPTION
We set an original expression on ErrorExpr for cases where we have something invalid that doesn't fit into the AST, but is still something that the user has explicitly written. For example this is how we represent unresolved dots without member names (`x.`). We still want to type-check the underlying expression though since it can provide useful diagnostics and allows semantic functionality such as completion and cursor info to work correctly.

rdar://130771574