### PR TITLE
SIL: Audit some `llvm::APInt` constructions to not hit an assertion with `implicitTrunc` set to false on rebranch

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -712,10 +712,10 @@ public:
   IntegerLiteralInst *createIntegerLiteral(IntegerLiteralExpr *E);
 
   IntegerLiteralInst *createIntegerLiteral(SILLocation Loc, SILType Ty,
-                                           intmax_t Value) {
-    return insert(
-        IntegerLiteralInst::create(getSILDebugLocation(Loc), Ty, Value,
-                                   getModule()));
+                                           intmax_t Value,
+                                           bool treatAsSigned = false) {
+    return insert(IntegerLiteralInst::create(
+        getSILDebugLocation(Loc), Ty, Value, treatAsSigned, getModule()));
   }
   IntegerLiteralInst *createIntegerLiteral(SILLocation Loc, SILType Ty,
                                            const APInt &Value) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4480,7 +4480,8 @@ class IntegerLiteralInst final
   static IntegerLiteralInst *create(IntegerLiteralExpr *E,
                                     SILDebugLocation Loc, SILModule &M);
   static IntegerLiteralInst *create(SILDebugLocation Loc, SILType Ty,
-                                    intmax_t Value, SILModule &M);
+                                    intmax_t Value, bool treatAsSigned,
+                                    SILModule &M);
   static IntegerLiteralInst *create(SILDebugLocation Loc, SILType Ty,
                                     const APInt &Value, SILModule &M);
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1142,10 +1142,11 @@ IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc,
   return ::new (buf) IntegerLiteralInst(Loc, Ty, Value);
 }
 
-static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value) {
+static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value,
+                      bool treatAsSigned) {
   // If we're forming a fixed-width type, build using the greatest width.
   if (auto intTy = dyn_cast<BuiltinIntegerType>(anyIntTy))
-    return APInt(intTy->getGreatestWidth(), value);
+    return APInt(intTy->getGreatestWidth(), value, treatAsSigned);
 
   // Otherwise, build using the size of the type and then truncate to the
   // minimum width necessary.
@@ -1154,11 +1155,12 @@ static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value) {
   return result;
 }
 
-IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc,
-                                               SILType Ty, intmax_t Value,
+IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc, SILType Ty,
+                                               intmax_t Value,
+                                               bool treatAsSigned,
                                                SILModule &M) {
   auto intTy = Ty.castTo<AnyBuiltinIntegerType>();
-  return create(Loc, Ty, getAPInt(intTy, Value), M);
+  return create(Loc, Ty, getAPInt(intTy, Value, treatAsSigned), M);
 }
 
 static SILType getGreatestIntegerType(Type type, SILModule &M) {

--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -67,12 +67,12 @@ static SILValue emitAvailabilityCheck(SILGenFunction &SGF, SILLocation loc,
   SILValue result =
       B.createApply(loc, availabilityGTEFn, SubstitutionMap(), silArgs);
 
-  // If this is an unavailability check, invert the result using xor with -1.
+  // If this is an unavailability check, invert the result using 1-bit xor
+  // with 1.
   if (query.isUnavailability()) {
     SILType i1 = SILType::getBuiltinIntegerType(1, ctx);
-    SILValue minusOne = B.createIntegerLiteral(loc, i1, -1);
-    result =
-        B.createBuiltinBinaryFunction(loc, "xor", i1, i1, {result, minusOne});
+    SILValue one = B.createIntegerLiteral(loc, i1, 1);
+    result = B.createBuiltinBinaryFunction(loc, "xor", i1, i1, {result, one});
   }
 
   return result;

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -1363,7 +1363,8 @@ BoundsCheckOpts::findAndOptimizeInductionVariables(SILLoop *loop) {
           if (isComparisonKnownTrue(builtin, *ivar)) {
             if (!trueVal)
               trueVal = builder.createIntegerLiteral(builtin->getLoc(),
-                                                     builtin->getType(), -1);
+                                                     builtin->getType(), -1,
+                                                     /*treatAsSigned=*/true);
             builtin->replaceAllUsesWith(trueVal);
             changed = true;
             continue;

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -573,7 +573,7 @@ static SILValue getSub(SILLocation Loc, SILValue Val, unsigned SubVal,
   SmallVector<SILValue, 4> Args(1, Val);
   Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), SubVal));
   Args.push_back(B.createIntegerLiteral(
-      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), -1));
+      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
 
   auto *AI = B.createBuiltinBinaryFunctionWithOverflow(
       Loc, "ssub_with_overflow", Args);
@@ -585,7 +585,7 @@ static SILValue getAdd(SILLocation Loc, SILValue Val, unsigned AddVal,
   SmallVector<SILValue, 4> Args(1, Val);
   Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), AddVal));
   Args.push_back(B.createIntegerLiteral(
-      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), -1));
+      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
 
   auto *AI = B.createBuiltinBinaryFunctionWithOverflow(
       Loc, "sadd_with_overflow", Args);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2976,7 +2976,8 @@ static SILValue testAllControlVariableBits(SILLocation Loc,
   if (IVType->getFixedWidth() == 1)
     return CondVal;
 
-  SILValue AllBitsSet = B.createIntegerLiteral(Loc, CondVal->getType(), -1);
+  SILValue AllBitsSet = B.createIntegerLiteral(Loc, CondVal->getType(), -1,
+                                               /*treatAsSigned=*/true);
   if (!CmpEqFn.get())
     CmpEqFn = getBinaryFunction("cmp_eq", CondVal->getType(),
                                 B.getASTContext());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -304,7 +304,8 @@ static SILValue createValueForEdge(SILInstruction *UserInst,
 
   if (auto *CBI = dyn_cast<CondBranchInst>(DominatingTerminator))
     return Builder.createIntegerLiteral(
-        CBI->getLoc(), CBI->getCondition()->getType(), EdgeIdx == 0 ? -1 : 0);
+        CBI->getLoc(), CBI->getCondition()->getType(), EdgeIdx == 0 ? -1 : 0,
+        /*treatAsSigned=*/true);
 
   auto *SEI = cast<SwitchEnumInst>(DominatingTerminator);
   auto *DstBlock = SEI->getSuccessors()[EdgeIdx].getBB();
@@ -1480,7 +1481,8 @@ static SILValue invertExpectAndApplyTo(SILBuilder &Builder,
   if (!IL)
     return V;
   SILValue NegatedExpectedValue = Builder.createIntegerLiteral(
-      IL->getLoc(), Args[1]->getType(), IL->getValue() == 0 ? -1 : 0);
+      IL->getLoc(), Args[1]->getType(), IL->getValue() == 0 ? -1 : 0,
+      /*treatAsSigned=*/true);
   return Builder.createBuiltin(BI->getLoc(), BI->getName(), BI->getType(), {},
                                {V, NegatedExpectedValue});
 }


### PR DESCRIPTION
[This](https://github.com/swiftlang/llvm-project/blob/61244eb1726bc4d0028bea003d1d33fdeb6c2f54/llvm/include/llvm/ADT/APInt.h#L127-L128) assertion in particular with `-1`.