### PR TITLE
[6.2] SILCombine: fix `convert_function` -> `apply` peephole for generic function types

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -172,6 +172,18 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   auto oldOpParamTypes = substConventions.getParameterSILTypes(context);
   auto newOpParamTypes = convertConventions.getParameterSILTypes(context);
 
+  // Currently we cannot deal with generic arguments/returns. Bail in this case.
+  for (auto newRetTy : newOpRetTypes) {
+    if (newRetTy.hasTypeParameter())
+      return nullptr;
+  }
+  for (auto newParamTy : newOpParamTypes) {
+    if (newParamTy.hasTypeParameter())
+      return nullptr;
+  }
+  if (newIndirectErrorResultType && newIndirectErrorResultType.hasTypeParameter())
+    return nullptr;
+
   llvm::SmallVector<SILValue, 8> Args;
   llvm::SmallVector<BeginBorrowInst *, 8> Borrows;
   auto convertOp = [&](SILValue Op, SILType OldOpType, SILType NewOpType,

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -583,6 +583,24 @@ bb0:
   return %return : $()
 }
 
+class GenC<T> {
+}
+
+sil @takeGenC : $@convention(thin) <τ_0_0> (@owned GenC<τ_0_0>) -> ()
+
+// CHECK-LABEL: sil [ossa] @convert_function_with_generic_arg :
+// CHECK:         [[C:%.*]] = convert_function
+// CHECK:         apply [[C]]
+// CHECK:       } // end sil function 'convert_function_with_generic_arg'
+sil [ossa] @convert_function_with_generic_arg : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %2 = function_ref @takeGenC : $@convention(thin) <τ_0_0> (@owned GenC<τ_0_0>) -> ()
+  %9 = convert_function %2 to $@convention(thin) (@owned AnyObject) -> ()
+  %30 = apply %9(%0) : $@convention(thin) (@owned AnyObject) -> ()
+  %r = tuple ()
+  return %r
+}
+
 sil shared [transparent] [thunk] @genericClosure : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   %12 = tuple ()


### PR DESCRIPTION
* **Explanation**: Fixes a crash in a SILCombine peephole optimization which simplifying apply instructions of `convert_function` instructions. We cannot deal with generic arguments/returns. Therefore bail in this case.
* **Risk**: Low. It's a simple fix which adds an additional bail-out condition to the peephole optimization.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://158809851
* **Reviewer**:  @nate-chandler
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/83912
