### PR TITLE
[Test] Gate newer objc_getClass tests on OS version.

### DIFF
--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -256,17 +256,25 @@ testSuite.test("NotPresent") {
   // Swift.Int is not a class type.
   expectNil(NSClassFromString("Si"))
 
-  // Mangled names with byte sequences that look like symbolic references
-  // should not be demangled.
-  expectNil(NSClassFromString("\u{1}badnews"));
-  expectNil(NSClassFromString("$s\u{1}badnews"));
-  expectNil(NSClassFromString("_T\u{1}badnews"));
+  if #available(StdlibDeploymentTarget 5.3, *) {
+    // Mangled names with byte sequences that look like symbolic references
+    // should not be demangled. Use indirect references to test. Direct
+    // references often resolve to readable memory, and then the data there
+    // often looks like a descriptor with an unknown kind and the lookup code
+    // then fails gracefully. With an indirect reference, the indirected pointer
+    // is typically garbage and dereferencing it will crash.
+    expectNil(NSClassFromString("\u{2}badnews"));
+    expectNil(NSClassFromString("$s\u{2}badnews"));
+    expectNil(NSClassFromString("_T\u{2}badnews"));
+  }
 
-  // Correct mangled names with additional text afterwards should not resolve.
-  expectNil(NSClassFromString("_TtC4main20MangledSwiftSubclass_"))
-  expectNil(NSClassFromString("_TtC4main22MangledSwiftSuperclassXYZ"))
-  expectNil(NSClassFromString("_TtC4main19MangledObjCSubclass123"))
-  expectNil(NSClassFromString("_TtC4main21MangledObjCSuperclasswhee"))
+  if #available(StdlibDeploymentTarget 5.3, *) {
+    // Correct mangled names with additional text afterwards should not resolve.
+    expectNil(NSClassFromString("_TtC4main20MangledSwiftSubclass_"))
+    expectNil(NSClassFromString("_TtC4main22MangledSwiftSuperclassXYZ"))
+    expectNil(NSClassFromString("_TtC4main19MangledObjCSubclass123"))
+    expectNil(NSClassFromString("_TtC4main21MangledObjCSuperclasswhee"))
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
The last two tests in the NotPresent test check for fixes that went into 5.3. Testing these against earlier runtimes will fail. Add availability checks so we only test when the fix is present.

While we're here, switch the symbolic references test to use indirect references. Direct references are very likely to pass the test even without the fix, as the reference is likely to point to readable memory. Indirect references make this much more likely to crash by then reading and dereferencing a pointer from the memory the relative pointer points to.

rdar://159034772