### PR TITLE
[cxx-interop] Import functions that return `auto`

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2382,6 +2382,12 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   bool allowNSUIntegerAsInt =
       shouldAllowNSUIntegerAsInt(isFromSystemModule, clangDecl);
 
+  // If this function uses 'auto' return type, try to deduce the actual type.
+  if (clangDecl->getReturnType()->isUndeducedType())
+    getClangSema().DeduceReturnType(
+        const_cast<clang::FunctionDecl *>(clangDecl), clangDecl->getLocation(),
+        /*Diagnose=*/false);
+
   // Only eagerly import the return type if it's not too expensive (the current
   // heuristic for that is if it's not a record type).
   ImportDiagnosticAdder addDiag(*this, clangDecl,

--- a/test/Interop/Cxx/templates/Inputs/auto-return-type.h
+++ b/test/Interop/Cxx/templates/Inputs/auto-return-type.h
@@ -1,0 +1,26 @@
+template <typename T>
+inline auto canNotDeduce(T a, T b) { return a + b; }
+
+template <typename T>
+struct HasMethodReturningAuto {
+  T t;
+
+  auto getT() const {
+    return t;
+  }
+  auto getPtrT() const {
+    return &t;
+  }
+  auto getConstant() const {
+    return 42.42;
+  }
+
+  auto outOfLineDefinition() const;
+};
+
+template <typename T>
+auto HasMethodReturningAuto<T>::outOfLineDefinition() const {
+  return t;
+}
+
+using HasMethodReturningAutoInt = HasMethodReturningAuto<int>;

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -1,3 +1,8 @@
+module AutoReturnType {
+  header "auto-return-type.h"
+  export *
+}
+
 module FunctionTemplates {
   header "function-templates.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/auto-return-type-module-interface.swift
+++ b/test/Interop/Cxx/templates/auto-return-type-module-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=AutoReturnType -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK-NOT: func canNotDeduce(_ a: Int32, _ b: Int32)
+
+// CHECK: struct HasMethodReturningAuto<CInt> {
+// CHECK:   func getT() -> Int32
+// CHECK:   func getPtrT() -> UnsafePointer<Int32>!
+// CHECK:   func getConstant() -> Double
+// CHECK:   func outOfLineDefinition() -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/templates/auto-return-type.swift
+++ b/test/Interop/Cxx/templates/auto-return-type.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
+
+// REQUIRES: executable_test
+
+import AutoReturnType
+import StdlibUnittest
+
+var AutoTestSuite = TestSuite("AutoReturnTypeTestSuite")
+
+AutoTestSuite.test("method from class template") {
+  let x = HasMethodReturningAutoInt(t: 123)
+  expectEqual(x.getT(), 123)
+  expectEqual(x.getConstant(), 42.42)
+}
+
+runAllTests()


### PR DESCRIPTION
Previously Swift would not import such C++ functions.

rdar://159282319

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
