### PR TITLE
[Test] Don't test builtin_bridge_object.swift on older OSes.

### DIFF
--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -3,6 +3,8 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // rdar://124700033
 // UNSUPPORTED: OS=xros
 


### PR DESCRIPTION
This test sets a specific target triple which is too new for some older OSes. There's no need to run this test in back-deployment testing, so make it only run when testing a fresh-built runtime.

rdar://159026118