### PR TITLE
[6.2] [AST & Runtime] Correctly mangle extended existentials with inverse requirements

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2352,12 +2352,7 @@ public:
   }
   
   bool isCopyable() const {
-    if (!hasGeneralizationSignature()) {
-      return true;
-    }
-    auto *reqts = getGenSigRequirements();
-    for (unsigned i = 0, e = getNumGenSigRequirements(); i < e; ++i) {
-      auto &reqt = reqts[i];
+    for (auto &reqt : getRequirementSignature().getRequirements()) {
       if (reqt.getKind() != GenericRequirementKind::InvertedProtocols) {
         continue;
       }

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -117,9 +117,24 @@ struct ExistentialLayout {
 
   LayoutConstraint getLayoutConstraint() const;
 
+  /// Whether this layout has any inverses within its signature.
+  bool hasInverses() const {
+    return !inverses.empty();
+  }
+
+  /// Whether this existential needs to have an extended existential shape. This
+  /// is relevant for the mangler to mangle as a symbolic link where possible
+  /// and for IRGen directly emitting some existentials.
+  ///
+  /// If 'allowInverses' is false, then regardless of if this existential layout
+  /// has inverse requirements those will not influence the need for having a
+  /// shape.
+  bool needsExtendedShape(bool allowInverses = true) const;
+
 private:
   SmallVector<ProtocolDecl *, 4> protocols;
   SmallVector<ParameterizedProtocolType *, 4> parameterized;
+  InvertibleProtocolSet inverses;
 };
 
 }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1620,7 +1620,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
       // ExtendedExistentialTypeShapes consider existential metatypes to
       // be part of the existential, so if we're symbolically referencing
       // shapes, we need to handle that at this level.
-      if (EMT->hasParameterizedExistential()) {
+      if (EMT->getExistentialLayout().needsExtendedShape(AllowInverses)) {
         auto referent = SymbolicReferent::forExtendedExistentialTypeShape(EMT);
         if (canSymbolicReference(referent)) {
           appendSymbolicExtendedExistentialType(referent, EMT, sig, forDecl);
@@ -1629,7 +1629,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
       }
 
       if (EMT->getInstanceType()->isExistentialType() &&
-          EMT->hasParameterizedExistential())
+          EMT->getExistentialLayout().needsExtendedShape(AllowInverses))
         appendConstrainedExistential(EMT->getInstanceType(), sig, forDecl);
       else
         appendType(EMT->getInstanceType(), sig, forDecl);
@@ -1685,8 +1685,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
           return appendType(strippedTy, sig, forDecl);
       }
 
-      if (PCT->hasParameterizedExistential()
-          || (PCT->hasInverse() && AllowInverses))
+      if (PCT->getExistentialLayout().needsExtendedShape(AllowInverses))
         return appendConstrainedExistential(PCT, sig, forDecl);
 
       // We mangle ProtocolType and ProtocolCompositionType using the
@@ -1700,7 +1699,8 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
     case TypeKind::Existential: {
       auto *ET = cast<ExistentialType>(tybase);
-      if (ET->hasParameterizedExistential()) {
+
+      if (ET->getExistentialLayout().needsExtendedShape(AllowInverses)) {
         auto referent = SymbolicReferent::forExtendedExistentialTypeShape(ET);
         if (canSymbolicReference(referent)) {
           appendSymbolicExtendedExistentialType(referent, ET, sig, forDecl);
@@ -1710,6 +1710,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
         return appendConstrainedExistential(ET->getConstraintType(), sig,
                                             forDecl);
       }
+
       return appendType(ET->getConstraintType(), sig, forDecl);
     }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -320,6 +320,8 @@ ExistentialLayout::ExistentialLayout(CanProtocolType type) {
                            !protoDecl->isMarkerProtocol());
   representsAnyObject = false;
 
+  inverses = InvertibleProtocolSet();
+
   protocols.push_back(protoDecl);
   expandDefaults(protocols, InvertibleProtocolSet(), type->getASTContext());
 }
@@ -353,7 +355,7 @@ ExistentialLayout::ExistentialLayout(CanProtocolCompositionType type) {
     protocols.push_back(protoDecl);
   }
 
-  auto inverses = type->getInverses();
+  inverses = type->getInverses();
   expandDefaults(protocols, inverses, type->getASTContext());
 
   representsAnyObject = [&]() {
@@ -431,6 +433,16 @@ Type ExistentialLayout::getSuperclass() const {
   }
 
   return Type();
+}
+
+bool ExistentialLayout::needsExtendedShape(bool allowInverses) const {
+  if (!getParameterizedProtocols().empty())
+    return true;
+
+  if (allowInverses && hasInverses())
+    return true;
+
+  return false;
 }
 
 bool TypeBase::isObjCExistentialType() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7857,8 +7857,10 @@ irgen::emitExtendedExistentialTypeShape(IRGenModule &IGM,
 
     // You can have a superclass with a generic parameter pack in a composition,
     // like `C<each T> & P<Int>`
-    assert(genHeader->GenericPackArguments.empty() &&
+    if (genSig) {
+      assert(genHeader->GenericPackArguments.empty() &&
            "Generic parameter packs not supported here yet");
+    }
 
     return b.finishAndCreateFuture();
   }, [&](llvm::GlobalVariable *var) {

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -465,6 +465,69 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
   return _buildDemanglingForContext(description, demangledGenerics, Dem);
 }
 
+static Demangle::NodePointer
+_replaceGeneralizationArg(Demangle::NodePointer type,
+                          SubstGenericParametersFromMetadata substitutions,
+                          Demangle::Demangler &Dem) {
+  assert(type->getKind() == Node::Kind::Type);
+  auto genericParam = type->getChild(0);
+
+  if (genericParam->getKind() != Node::Kind::DependentGenericParamType)
+    return type;
+
+  auto depth = genericParam->getChild(0)->getIndex();
+  auto index = genericParam->getChild(1)->getIndex();
+
+  auto arg = substitutions.getMetadata(depth, index);
+  assert(arg.isMetadata());
+  return _swift_buildDemanglingForMetadata(arg.getMetadata(), Dem);
+}
+
+static Demangle::NodePointer
+_buildDemanglingForExtendedExistential(const Metadata *type,
+                                       Demangle::Demangler &Dem) {
+  auto ee = cast<ExtendedExistentialTypeMetadata>(type);
+
+  auto demangledExistential = Dem.demangleType(ee->Shape->ExistentialType.get(),
+                                               ResolveToDemanglingForContext(Dem));
+
+  if (!ee->Shape->hasGeneralizationSignature())
+    return demangledExistential;
+
+  SubstGenericParametersFromMetadata substitutions(ee->Shape,
+                                              ee->getGeneralizationArguments());
+
+  // Dig out the requirement list.
+  auto constrainedExistential = demangledExistential->getChild(0);
+  assert(constrainedExistential->getKind() == Node::Kind::ConstrainedExistential);
+  auto reqList = constrainedExistential->getChild(1);
+  assert(reqList->getKind() == Node::Kind::ConstrainedExistentialRequirementList);
+
+  auto newReqList = Dem.createNode(Node::Kind::ConstrainedExistentialRequirementList);
+
+  for (auto req : *reqList) {
+    // Currently, the only requirements that can create generalization arguments
+    // are same types.
+    if (req->getKind() != Node::Kind::DependentGenericSameTypeRequirement) {
+      newReqList->addChild(req, Dem);
+      continue;
+    }
+
+    auto lhs = _replaceGeneralizationArg(req->getChild(0), substitutions, Dem);
+    auto rhs = _replaceGeneralizationArg(req->getChild(1), substitutions, Dem);
+
+    auto newReq = Dem.createNode(Node::Kind::DependentGenericSameTypeRequirement);
+    newReq->addChild(lhs, Dem);
+    newReq->addChild(rhs, Dem);
+
+    newReqList->addChild(newReq, Dem);
+  }
+
+  constrainedExistential->replaceChild(1, newReqList);
+
+  return demangledExistential;
+}
+
 // Build a demangled type tree for a type.
 //
 // FIXME: This should use MetadataReader.h.
@@ -596,13 +659,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     return proto_list;
   }
   case MetadataKind::ExtendedExistential: {
-    // FIXME: Implement this by demangling the extended existential and
-    // substituting the generalization arguments into the demangle tree.
-    // For now, unconditional casts will report '<<< invalid type >>>' when
-    // they fail.
-    // TODO: for clients that need to guarantee round-tripping, demangle
-    // to a SymbolicExtendedExistentialType.
-    return nullptr;
+    return _buildDemanglingForExtendedExistential(type, Dem);
   }
   case MetadataKind::ExistentialMetatype: {
     auto metatype = static_cast<const ExistentialMetatypeMetadata *>(type);

--- a/test/Interpreter/extended_existential.swift
+++ b/test/Interpreter/extended_existential.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -target %target-cpu-apple-macos15.0 %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+
+protocol A<B>: ~Copyable {
+  associatedtype B
+}
+
+protocol B: ~Copyable {}
+
+let a: Any = (any ~Copyable).self
+// CHECK: any Any<Self: ~Swift.Copyable>
+print(a)
+
+let b: Any = (any ~Escapable).self
+// CHECK: any Any<Self: ~Swift.Escapable>
+print(b)
+
+let c: Any = (any ~Copyable & ~Escapable).self
+// CHECK: any Any<Self: ~Swift.Copyable, Self: ~Swift.Escapable>
+print(c)
+
+let d: Any = (any A).self
+// CHECK: A
+print(d)
+
+let e: Any = (any B).self
+// CHECK: B
+print(e)
+
+let f: Any = (any A & B).self
+// CHECK: A & B
+print(f)
+
+let g: Any = (any A & ~Copyable).self
+// CHECK: any A<Self: ~Swift.Copyable>
+print(g)
+
+let h: Any = (any B & ~Copyable).self
+// CHECK: any B<Self: ~Swift.Copyable>
+print(h)
+
+let i: Any = (any A & B & ~Copyable).self
+// CHECK: any A & B<Self: ~Swift.Copyable>
+print(i)


### PR DESCRIPTION
* **Explanation**: Currently, the ASTMangler has 2 ways of emitting an extended existential mangling: 1. if the extended existential is parameterized, it will eagerly try to symbolically reference the extended shape or 2. just as a flat string. For extended existentials that have inverses, it was taking the 2nd option. The runtime does not currently have the capabilities to decode an extended existential without a shape referenced in the type mangling, so when attempting to create metadata for something like any ~Copyable it would fail spectacularly.
* **Risk**: Medium. Changes how the compiler mangles extended existentials with inverse requirements. It doesn't add or remove mangling rules, just uses a different form of mangling it already knows how to demangle at runtime.
* **Testing**: Tested by an interpreter test.
* **Issue**: rdar://150219645
* **Reviewer**: @slavapestov 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/81365