### PR TITLE
Don't run this test in backdeployed / host stdlib configs

### DIFF
--- a/test/stdlib/OSLogExecutionTest.swift
+++ b/test/stdlib/OSLogExecutionTest.swift
@@ -10,6 +10,8 @@
 // REQUIRES: foundation
 //
 // REQUIRES: VENDOR=apple
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 // Run-time tests for testing the correctness of the optimizations that optimize the
 // construction of the format string and the byte buffer from a string interpolation.


### PR DESCRIPTION
libswiftOSLogTestHelper is built with add_swift_target_library, which is used for runtime components, and we only support building those for 13.0+. These back-deploy bots are meant to test against the OS's libraries, since that's what's actually used when back-deploying, but that's not right for this library.

resolves rdar://159026163