### PR TITLE
[cmake] Use correct identifier for CFBundleIdentifier

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -158,5 +158,5 @@ emit_swift_interface(swift_Concurrency)
 install_swift_interface(swift_Concurrency)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swift_Concurrency)
+generate_plist(swift_Concurrency "${CMAKE_PROJECT_VERSION}" swift_Concurrency)
 embed_manifest(swift_Concurrency)

--- a/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
+++ b/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
@@ -41,5 +41,5 @@ emit_swift_interface(swiftSwiftOnoneSupport)
 install_swift_interface(swiftSwiftOnoneSupport)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftSwiftOnoneSupport)
+generate_plist(swiftSwiftOnoneSupport "${CMAKE_PROJECT_VERSION}" swiftSwiftOnoneSupport)
 embed_manifest(swiftSwiftOnoneSupport)

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -383,7 +383,7 @@ emit_swift_interface(swiftCore)
 install_swift_interface(swiftCore)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftCore)
+generate_plist(swiftCore "${CMAKE_PROJECT_VERSION}" swiftCore)
 embed_manifest(swiftCore)
 
 include("${SwiftCore_VENDOR_MODULE_DIR}/swiftCore.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -132,7 +132,7 @@ emit_swift_interface(swift_Differentiation)
 install_swift_interface(swift_Differentiation)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swift_Differentiation)
+generate_plist(swift_Differentiation "${CMAKE_PROJECT_VERSION}" swift_Differentiation)
 embed_manifest(swift_Differentiation)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swift_Differentiation.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -156,7 +156,7 @@ emit_swift_interface(swiftDistributed)
 install_swift_interface(swiftDistributed)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftDistributed)
+generate_plist(swiftDistributed "${CMAKE_PROJECT_VERSION}" swiftDistributed)
 embed_manifest(swiftDistributed)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swiftDistributed.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -116,7 +116,7 @@ emit_swift_interface(swiftObservation)
 install_swift_interface(swiftObservation)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftObservation)
+generate_plist(swiftObservation "${CMAKE_PROJECT_VERSION}" swiftObservation)
 embed_manifest(swiftObservation)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swiftObservation.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -151,7 +151,7 @@ emit_swift_interface(swiftSynchronization)
 install_swift_interface(swiftSynchronization)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swiftSynchronization)
+generate_plist(swiftSynchronization "${CMAKE_PROJECT_VERSION}" swiftSynchronization)
 embed_manifest(swiftSynchronization)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swiftSynchronization.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/Volatile/CMakeLists.txt
+++ b/Runtimes/Supplemental/Volatile/CMakeLists.txt
@@ -97,7 +97,7 @@ emit_swift_interface(swift_Volatile)
 install_swift_interface(swift_Volatile)
 
 # Configure plist creation for Darwin platforms.
-generate_plist("${CMAKE_PROJECT_NAME}" "${CMAKE_PROJECT_VERSION}" swift_Volatile)
+generate_plist(swift_Volatile "${CMAKE_PROJECT_VERSION}" swift_Volatile)
 embed_manifest(swift_Volatile)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/swift_Volatile.cmake" OPTIONAL)


### PR DESCRIPTION
Use the associated library name for the `CFBundleIdentifier` within the plist. This will prevent cases where we have projects with multiple targets referencing the project name itself (i.e swiftSwiftOnoneSupport had it's bundle name set to SwiftCore)
