### PR TITLE
[IDE] Use `nullableTypesEqual` in `AfterPoundExprCompletion::sawSolutionImpl`

### DIFF
--- a/lib/IDE/AfterPoundExprCompletion.cpp
+++ b/lib/IDE/AfterPoundExprCompletion.cpp
@@ -28,7 +28,7 @@ void AfterPoundExprCompletion::sawSolutionImpl(const constraints::Solution &S) {
 
   // If ExpectedTy is a duplicate of any other result, ignore this solution.
   auto IsEqual = [&](const Result &R) {
-    return R.ExpectedTy->isEqual(ExpectedTy);
+    return nullableTypesEqual(R.ExpectedTy, ExpectedTy);
   };
   if (!llvm::any_of(Results, IsEqual)) {
     bool IsImpliedResult = isImpliedResult(S, CompletionExpr);

--- a/validation-test/IDE/crashers/7dfd3dd444f43abb.swift
+++ b/validation-test/IDE/crashers/7dfd3dd444f43abb.swift
@@ -1,4 +1,0 @@
-// {"kind":"complete","signature":"swift::TypeBase::isEqual(swift::Type) const"}
-// RUN: not --crash %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
-Set(
-##^COMPLETE^#

--- a/validation-test/IDE/crashers_fixed/2310a05b9a395ec4.swift
+++ b/validation-test/IDE/crashers_fixed/2310a05b9a395ec4.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","signature":"swift::ide::AfterPoundExprCompletion::sawSolutionImpl(swift::constraints::Solution const&)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 {##^COMPLETE^#

--- a/validation-test/IDE/crashers_fixed/7dfd3dd444f43abb.swift
+++ b/validation-test/IDE/crashers_fixed/7dfd3dd444f43abb.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::TypeBase::isEqual(swift::Type) const"}
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
+Set(
+##^COMPLETE^#


### PR DESCRIPTION
Avoid crashing if we can't compute the expected type.