### PR TITLE
AliasAnalysis: fix aliasing of `ref_tail_addr` access bases

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -323,8 +323,19 @@ public enum AccessBase : CustomStringConvertible, Hashable {
              isDifferentAllocation(rea.instance, otherRea.instance) ||
              hasDifferentType(rea.instance, otherRea.instance)
     case (.tail(let rta), .tail(let otherRta)):
-      return isDifferentAllocation(rta.instance, otherRta.instance) ||
-             hasDifferentType(rta.instance, otherRta.instance)
+      if isDifferentAllocation(rta.instance, otherRta.instance) {
+        return true
+      }
+      if hasDifferentType(rta.instance, otherRta.instance),
+         // In contrast to `ref_element_addr`, tail addresses can also be obtained via a superclass
+         // (in case the derived class doesn't add any stored properties).
+         // Therefore if the instance types differ by sub-superclass relationship, the base is _not_ different.
+         !rta.instance.type.isExactSuperclass(of: otherRta.instance.type),
+         !otherRta.instance.type.isExactSuperclass(of: rta.instance.type)
+      {
+        return true
+      }
+      return false
     case (.argument(let arg), .argument(let otherArg)):
       return (arg.convention.isExclusiveIndirect || otherArg.convention.isExclusiveIndirect) && arg != otherArg
       

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -665,6 +665,25 @@ bb0:
   %99 = tuple ()
   return %99 : $()
 }
+
+class Derived: X {}
+ 
+// CHECK-LABEL: @test_tail_addr_and_upcast
+// CHECK:       PAIR #10.
+// CHECK-NEXT:    %2 = ref_tail_addr %1 : $X, $Int32
+// CHECK-NEXT:    %3 = ref_tail_addr %0 : $Derived, $Int32
+// CHECK-NEXT:  MayAlias
+sil @test_tail_addr_and_upcast : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $Derived
+  %1 = upcast %0 to $X
+  %2 = ref_tail_addr %1, $Int32
+  %3 = ref_tail_addr %0, $Int32
+  fix_lifetime %2
+  fix_lifetime %3
+  %r = tuple ()
+  return %r
+}
  
 class GenericClass<T> {
   var x : T


### PR DESCRIPTION
In contrast to `ref_element_addr`, tail addresses can also be obtained via a superclass (in case the derived class doesn't add any stored properties). Therefore if the instance types differ by sub-superclass relationship, they may alias.

Fixes a miscompile
rdar://159336503
