### PR TITLE
Revert "[rebranch] SIL: Restore old behavior in `llvm::APInt` ctor call"

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1145,9 +1145,7 @@ IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc,
 static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value) {
   // If we're forming a fixed-width type, build using the greatest width.
   if (auto intTy = dyn_cast<BuiltinIntegerType>(anyIntTy))
-    // TODO: Avoid implicit trunc?
-    return APInt(intTy->getGreatestWidth(), value, /*isSigned=*/false,
-                 /*implicitTrunc=*/true);
+    return APInt(intTy->getGreatestWidth(), value);
 
   // Otherwise, build using the size of the type and then truncate to the
   // minimum width necessary.


### PR DESCRIPTION
This reverts commit 73c70ee338c515fba37baf3faff93c6389558a5c.

Reverting to prevent a conflict with https://github.com/swiftlang/swift/pull/83945 in the automergers.