### PR TITLE
[Sema] Avoid crashing in `IsAccessorTransparentRequest` for implicit setter

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2896,8 +2896,11 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
         break;
       }
 
-      // Anything else should not have a synthesized setter.
-      LLVM_FALLTHROUGH;
+      // Anything else we'll synthesize an invalid setter for in
+      // `synthesizeSetterBody`, this happens for cases such as stored
+      // properties defined in extensions or enums, we implicitly treat them as
+      // computed.
+      return false;
     case WriteImplKind::Immutable:
       if (accessor->getASTContext().LangOpts.AllowModuleWithCompilerErrors)
         return false;

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -484,6 +484,13 @@ extension ProtocolWithExtension1 {
   static var fooExtStatic = 4 // expected-error{{static stored properties not supported in protocol extensions}}
 }
 
+// https://github.com/swiftlang/swift/issues/83969
+// Make sure we don't crash.
+public struct PublicTypeWithExt {}
+extension PublicTypeWithExt {
+  public var foo: Int? // expected-error {{extensions must not contain stored properties}}
+}
+
 protocol ProtocolWithExtension2 {
   var bar: String { get }
 }


### PR DESCRIPTION
We can synthesize these for invalid stored properties in extensions and enums, just return `false` instead of asserting.

Resolves #83969