### PR TITLE
stdlib: enable `String.withCString` in Embedded Swift

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -231,13 +231,13 @@ extension _SmallString: RandomAccessCollection, MutableCollection {
 extension _SmallString {
   @inlinable @inline(__always)
   @safe
-  internal func withUTF8<Result>(
-    _ f: (UnsafeBufferPointer<UInt8>) throws -> Result
-  ) rethrows -> Result {
+  internal func withUTF8<Success, Failure: Error>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
     let count = self.count
     var raw = self.zeroTerminatedRawCodeUnits
-    return try unsafe Swift._withUnprotectedUnsafeBytes(of: &raw) {
-      let rawPtr = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked
+    return try unsafe Swift._withUnprotectedUnsafeBytes(of: &raw) { (bytes) throws(Failure) in
+      let rawPtr = unsafe bytes.baseAddress._unsafelyUnwrappedUnchecked
       // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the
       // duration of the closure. Accessing self after this rebind is undefined.
       let ptr = unsafe rawPtr.bindMemory(to: UInt8.self, capacity: count)
@@ -379,7 +379,7 @@ extension _SmallString {
     }
     self._invariantCheck()
   }
-  
+
   @_effects(readonly) // @opaque
   internal init?(taggedASCIICocoa cocoa: AnyObject) {
     self.init()

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -694,10 +694,35 @@ extension String {
   ///   `withCString(_:)` method. The pointer argument is valid only for the
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
+  @abi(
+    func withCString<Result>(
+      _ body: (UnsafePointer<Int8>) throws -> Result
+    ) rethrows -> Result
+  )
   @inlinable // fast-path: already C-string compatible
-  public func withCString<Result>(
+  func __rethrows_withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  ) throws -> Result {
+    return try unsafe _guts.withCString(body)
+  }
+
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of UTF-8 code units.
+  ///
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(_:)`. Do not store or return the pointer for
+  /// later use.
+  ///
+  /// - Parameter body: A closure with a pointer parameter that points to a
+  ///   null-terminated sequence of UTF-8 code units. If `body` has a return
+  ///   value, that value is also used as the return value for the
+  ///   `withCString(_:)` method. The pointer argument is valid only for the
+  ///   duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  @inlinable // fast-path: already C-string compatible
+  public func withCString<Success, Failure: Error>(
+    _ body: (UnsafePointer<Int8>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
     return try unsafe _guts.withCString(body)
   }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -700,7 +700,8 @@ extension String {
     ) rethrows -> Result
   )
   @inlinable // fast-path: already C-string compatible
-  func __rethrows_withCString<Result>(
+  @usableFromInline
+  internal func __rethrows_withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) throws -> Result {
     return try unsafe _guts.withCString(body)
@@ -720,6 +721,7 @@ extension String {
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable // fast-path: already C-string compatible
+  @_alwaysEmitIntoClient
   public func withCString<Success, Failure: Error>(
     _ body: (UnsafePointer<Int8>) throws(Failure) -> Success
   ) throws(Failure) -> Success {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -64,7 +64,7 @@ extension _StringGuts {
   internal init(_ storage: __SharedStringStorage) {
     self.init(_StringObject(storage))
   }
-  
+
 #if !$Embedded
 internal init(
   constantCocoa cocoa: AnyObject,
@@ -159,9 +159,9 @@ extension _StringGuts {
   }
 
   @inlinable @inline(__always)
-  internal func withFastUTF8<R>(
-    _ f: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
+  internal func withFastUTF8<Success, Failure: Error>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
     _internalInvariant(isFastUTF8)
 
     if self.isSmall { return try _SmallString(_object).withUTF8(f) }
@@ -181,10 +181,10 @@ extension _StringGuts {
   }
 
   @inlinable @inline(__always)
-  internal func withFastCChar<R>(
-    _ f: (UnsafeBufferPointer<CChar>) throws -> R
-  ) rethrows -> R {
-    return try unsafe self.withFastUTF8 { utf8 in
+  internal func withFastCChar<Success, Failure: Error>(
+    _ f: (UnsafeBufferPointer<CChar>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
+    return try unsafe self.withFastUTF8 { (utf8) throws(Failure) in
       return try unsafe utf8.withMemoryRebound(to: CChar.self, f)
     }
   }
@@ -219,26 +219,39 @@ extension _StringGuts {
 // C String interop
 extension _StringGuts {
   @inlinable @inline(__always) // fast-path: already C-string compatible
-  internal func withCString<Result>(
-    _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  internal func withCString<Success, Failure: Error>(
+    _ body: (UnsafePointer<Int8>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
     if _slowPath(!_object.isFastZeroTerminated) {
       return try unsafe _slowWithCString(body)
     }
 
-    return try unsafe self.withFastCChar {
-      return try unsafe body($0.baseAddress._unsafelyUnwrappedUnchecked)
+    return try unsafe self.withFastCChar { (pointer) throws(Failure) in
+      return try unsafe body(pointer.baseAddress._unsafelyUnwrappedUnchecked)
     }
+  }
+
+  @abi(
+    func _slowWithCString<Result>(
+      _ body: (UnsafePointer<Int8>) throws -> Result
+    ) rethrows -> Result
+  )
+  @inline(never) // slow-path
+  @usableFromInline
+  internal func __rethrows_slowWithCString<Result>(
+    _ body: (UnsafePointer<Int8>) throws -> Result
+  ) throws -> Result {
+    return try unsafe self._slowWithCString(body)
   }
 
   @inline(never) // slow-path
   @usableFromInline
-  internal func _slowWithCString<Result>(
-    _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  internal func _slowWithCString<Success, Failure: Error>(
+    _ body: (UnsafePointer<Int8>) throws(Failure) -> Success
+  ) throws(Failure) -> Success {
     _internalInvariant(!_object.isFastZeroTerminated)
-    return try unsafe String(self).utf8CString.withUnsafeBufferPointer {
-      let ptr = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked
+    return try unsafe String(self).utf8CString.withUnsafeBufferPointer { (bufferPointer) throws(Failure) in
+      let ptr = unsafe bufferPointer.baseAddress._unsafelyUnwrappedUnchecked
       return try unsafe body(ptr)
     }
   }
@@ -285,7 +298,7 @@ extension _StringGuts {
       unsafe ptr += 1
       numWritten += 1
     }
-    
+
     return numWritten
     #else
     fatalError("No foreign strings on Linux in this version of Swift")

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -246,6 +246,7 @@ extension _StringGuts {
 
   @inline(never) // slow-path
   @usableFromInline
+  @_alwaysEmitIntoClient
   internal func _slowWithCString<Success, Failure: Error>(
     _ body: (UnsafePointer<Int8>) throws(Failure) -> Success
   ) throws(Failure) -> Success {

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -28,7 +28,7 @@
   "swift".#^LITERAL4^#
 }
 
-// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws(Failure) -> Success##(UnsafePointer<Int8>) throws(Failure) -> Success#})[' throws(Failure)'][#Success#]; name=withCString(:){{$}}
+// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws(Error) -> Success##(UnsafePointer<Int8>) throws(Error) -> Success#})[' throws'][#Success#]; name=withCString(:){{$}}
 
 // FIXME: we should show the qualified String.Index type.
 // rdar://problem/20788802

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -28,7 +28,7 @@
   "swift".#^LITERAL4^#
 }
 
-// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws -> Result##(UnsafePointer<Int8>) throws -> Result#})[' rethrows'][#Result#]; name=withCString(:){{$}}
+// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws(Failure) -> Success##(UnsafePointer<Int8>) throws(Failure) -> Success#})[' throws(Failure)'][#Success#]; name=withCString(:){{$}}
 
 // FIXME: we should show the qualified String.Index type.
 // rdar://problem/20788802

--- a/test/embedded/withCString.swift
+++ b/test/embedded/withCString.swift
@@ -1,7 +1,8 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_Embedded
+// This test requires stdlib function that are currently only available in WASI-libc.
+// REQUIRES: OS=wasip1
 
 enum E: Error {
   case foo

--- a/test/embedded/withCString.swift
+++ b/test/embedded/withCString.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // This test requires stdlib function that are currently only available in WASI-libc.
 // REQUIRES: OS=wasip1
+// REQUIRES: swift_feature_Embedded
 
 enum E: Error {
   case foo

--- a/test/embedded/withCString.swift
+++ b/test/embedded/withCString.swift
@@ -10,9 +10,9 @@ enum E: Error {
 @main struct Main {
   static func main() {
     do throws(E) {
-      try "Hello".withCString {
+      try "Hello".withCString { (pointer) throws(E) in
         var i = 0
-        var pointer = $0
+        var pointer = pointer
         while pointer.pointee != 0 {
           i += 1
           pointer += 1

--- a/test/embedded/withCString.swift
+++ b/test/embedded/withCString.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+enum E: Error {
+  case foo
+}
+
+@main struct Main {
+  static func main() {
+    do throws(E) {
+      try "Hello".withCString {
+        var i = 0
+        var pointer = $0
+        while pointer.pointee != 0 {
+          i += 1
+          pointer += 1
+        }
+        print(i) // CHECK: 5
+        throw E.foo
+      }
+    } catch {
+      print("error caught") // CHECK: error caught
+    }
+  }
+}


### PR DESCRIPTION
The function currently uses untyped throws, a version with typed throws is added and a shim for untyped throws is provided via the `@abi` attribute.

rdar://159276849