### PR TITLE
[6.2] [test] Import locale modules explicitly in PrintFloat.swift.gyb.

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -13,7 +13,9 @@
 
 import StdlibUnittest
 import SwiftPrivateLibcExtras
-#if canImport(Darwin)
+#if canImport(locale_h)
+  import locale_h
+#elseif canImport(Darwin)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc


### PR DESCRIPTION
Explanation:  The Darwin module is being split up and will stop immporting locale APIs. This test now fails on macOS 26 and the fix needs to be moved to the 6.2 branch for swift CI testing.
Testing: Tested by PrintFloat.swift.gyb and PrintFloatLocale.swift.gyb
Issue: rdar://159305532
Reviewer: @tbkka 
Main branch PR: https://github.com/swiftlang/swift/pull/80089