### PR TITLE
Add __arm__ to Float16Support.cpp for arm 32-bit architectures

### DIFF
--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -31,7 +31,7 @@
 // Android NDK <r21 do not provide `__aeabi_d2h` in the compiler runtime,
 // provide shims in that case.
 #if (defined(__ANDROID__) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
-  ((defined(__i386__) || defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
+  ((defined(__i386__) || defined(__i686__) || defined(__arm__) || defined(__x86_64__)) && !defined(__APPLE__))
 
 #include "swift/shims/Visibility.h"
 


### PR DESCRIPTION
This is the only patch required to cross-compile Swift for armv6 and armv7 that is used here:

https://github.com/swift-embedded-linux/armhf-debian/blob/main/patches/0002-Add-arm-to-float16support-for-missing-symbol.patch

@MaxDesiatov I feel like this could be separate from my cross-compilation product, which will require/include this as well. I want to make sure this change will not negatively impact anything else.