### PR TITLE
[6.2] [test] Update availability_returns_twice.swift for Darwin module refactoring.

### DIFF
--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -11,7 +11,10 @@
 // XFAIL: OS=linux-android
 // XFAIL: OS=openbsd
 
-#if canImport(Darwin)
+#if canImport(setjmp_h)
+  import setjmp_h
+  typealias JumpBuffer = Int32
+#elseif canImport(Darwin)
   import Darwin
   typealias JumpBuffer = Int32
 #elseif canImport(Glibc)


### PR DESCRIPTION
Explanation: The test now fails on macOS 26 and the fix needs to be moved to the 6.2 branch for swift CI testing.
Testing: Tested by availability_returns_twice.swift 
Issue: rdar://159305318
Reviewer: @tbkka
Main branch PR: https://github.com/swiftlang/swift/pull/83431