### PR TITLE
[Completion] Avoid type-checking parent closure for unattached node

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2671,18 +2671,28 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
   // function, we unfortunately need to type-check everything since we need to
   // apply the solution.
   // FIXME: We ought to see if we can do better in that case.
-  if (auto *CE = DC->getInnermostClosureForCaptures()) {
-    if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
-      swift::typeCheckASTNodeAtLoc(
-          TypeCheckASTNodeAtLocContext::declContext(CE->getParent()),
-          CE->getLoc());
+  //
+  // We don't need to do this for unattached nodes since we already would have
+  // type-checked the surrounding context, and unattached nodes cannot be
+  // typechecked via DeclContext since they aren't actually part of the AST.
+  if (!typeCheckCtx.isForUnattachedNode()) {
+    if (auto *CE = DC->getInnermostClosureForCaptures()) {
+      // Walk up to the parent-most closure.
+      while (auto *parent = dyn_cast_or_null<ClosureExpr>(CE->getParent()))
+        CE = parent;
 
-      // If the context itself is a ClosureExpr, we should have type-checked
-      // the completion expression now. If it's a nested local declaration,
-      // fall through to type-check the AST node now that we've type-checked
-      // the surrounding closure.
-      if (isa<ClosureExpr>(DC))
-        return false;
+      if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
+        swift::typeCheckASTNodeAtLoc(
+            TypeCheckASTNodeAtLocContext::declContext(CE->getParent()),
+            CE->getLoc());
+
+        // If the context itself is a ClosureExpr, we should have type-checked
+        // the completion expression now. If it's a nested local declaration,
+        // fall through to type-check the AST node now that we've type-checked
+        // the surrounding closure.
+        if (isa<ClosureExpr>(DC))
+          return false;
+      }
     }
   }
 

--- a/validation-test/IDE/crashers_fixed/7b2825e90bfce47.swift
+++ b/validation-test/IDE/crashers_fixed/7b2825e90bfce47.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","signature":"swift::SourceManager::findBufferContainingLocInternal(swift::SourceLoc) const","signatureAssert":"Assertion failed: (Loc.isValid()), function findBufferContainingLocInternal"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 class a { lazy b: () = { answer {}#^^#

--- a/validation-test/IDE/crashers_fixed/928f167118f85cf.swift
+++ b/validation-test/IDE/crashers_fixed/928f167118f85cf.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"7bbb1dc5","signature":"swift::TypeRepr::print(swift::ASTPrinter&, swift::PrintOptions const&, swift::optionset::OptionSet<swift::NonRecursivePrintOption, unsigned int>) const","signatureAssert":"Assertion failed: (false && \"Expression wasn't type checked?\"), function getTypeForCompletion"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 a ? {
 init { b { extension
 }#^^#


### PR DESCRIPTION
We should have already type-checked a parent closure, and we wouldn't be able to correctly locate the node anyway since it's not actually part of the AST. While here, also walk up to the parent-most closure instead of recursing to avoid unnecessary stack frames for nested closures.