### PR TITLE
[ASTDumper] Check null for `getExtendedTypeRepr`

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2131,9 +2131,9 @@ namespace {
       printFlag(!ED->hasBeenBound(), "unbound");
       if (ED->hasBeenBound()) {
         printTypeField(ED->getExtendedType(), Label::optional("extended_type"));
-      } else {
+      } else if (auto *extTypeRepr = ED->getExtendedTypeRepr()) {
         printNameRaw([&](raw_ostream &OS) {
-          ED->getExtendedTypeRepr()->print(OS);
+          extTypeRepr->print(OS);
         }, Label::optional("extended_type"));
       }
       printCommonPost(ED);

--- a/validation-test/compiler_crashers_2_fixed/empty_extension_print.swift
+++ b/validation-test/compiler_crashers_2_fixed/empty_extension_print.swift
@@ -1,0 +1,2 @@
+// RUN: not %target-swift-frontend %s -dump-parse
+extension {}


### PR DESCRIPTION
This can be null for `extension {}`.