### PR TITLE
[CS] Fix an overly strict assert

### DIFF
--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -784,7 +784,7 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
   assert((kind != ConstraintKind::ConformsTo &&
           kind != ConstraintKind::NonisolatedConformsTo &&
           kind != ConstraintKind::TransitivelyConformsTo) ||
-         second->isExistentialType());
+         second->isAnyExistentialType());
 
   // Literal protocol conformances expect a protocol.
   assert((kind != ConstraintKind::LiteralConformsTo) ||

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -119,3 +119,17 @@ func parameterizedExistentials() {
   var ppt: any PP4<Int>.Type
   pt = ppt // expected-error {{cannot assign value of type 'any PP4<Int>.Type' to type 'any P4<Int>.Type'}}
 }
+
+func testNestedMetatype() {
+  struct S: P {}
+
+  func bar<T>(_ x: T) -> T.Type { type(of: x) }
+  func foo(_ x: P.Type.Type) { }
+
+  // Make sure we don't crash.
+  foo(bar(S.self))
+
+  // FIXME: Bad diagnostic
+  // https://github.com/swiftlang/swift/issues/83991
+  foo(bar(0)) // expected-error {{failed to produce diagnostic for expression}}
+}

--- a/validation-test/compiler_crashers_2_fixed/c5955772856ea0fa.swift
+++ b/validation-test/compiler_crashers_2_fixed/c5955772856ea0fa.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::constraints::Constraint::create(swift::constraints::ConstraintSystem&, swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocator*, llvm::ArrayRef<swift::TypeVariableType*>)","signatureAssert":"Assertion failed: ((kind != ConstraintKind::ConformsTo && kind != ConstraintKind::NonisolatedConformsTo && kind != ConstraintKind::TransitivelyConformsTo) || second->isExistentialType()), function create"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a let : a.Type.Type = b->c


### PR DESCRIPTION
`matchExistentialTypes` can handle existential metatypes, fix the assert to handle that.