### PR TITLE
[DNM] Showcase lack of crash outputs in lit

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3037,6 +3037,13 @@ public:
   /// `distributed var get { }` accessors.
   bool isDistributedGetAccessor() const;
 
+  /// Is this a 'distributed thunk'?
+  ///
+  /// Distributed thunks are synthesized functions which perform the "is remote?"
+  /// check, before dispatching to a 'system.remoteCall' (if actor was remote).
+  /// They are always 'async' and 'throws'.
+  bool isDistributedThunk() const;
+
   bool hasName() const { return bool(Name); }
   bool isOperator() const { return Name.isOperator(); }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1367,6 +1367,13 @@ bool ValueDecl::isDistributedGetAccessor() const {
   return false;
 }
 
+bool ValueDecl::isDistributedThunk() const {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(this)) {
+    return func->isDistributedThunk();
+  }
+  return false;
+}
+
 ConstructorDecl *
 NominalTypeDecl::getDistributedRemoteCallTargetInitFunction() const {
   auto mutableThis = const_cast<NominalTypeDecl *>(this);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -737,6 +737,7 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
+  // TODO(distributed): These would benefit from becoming nonisolated(nonsending)
   thunk->getAttrs().add(NonisolatedAttr::createImplicit(C));
 
   return thunk;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5212,6 +5212,13 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
     if (decl->getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
       if (auto *value = dyn_cast<ValueDecl>(decl)) {
+        // TODO(distributed): make distributed thunks nonisolated(nonsending) and remove this if
+        if (value->isAsync() && value->isDistributedThunk()) {
+          // don't change isolation of distributed thunks until we make them nonisolated(nonsending),
+          // since the runtime calling them assumes they're just nonisolated right now.
+          return ActorIsolation::forNonisolated(nonisolatedAttr->isUnsafe());
+        }
+
         if (value->isAsync() &&
             value->getModuleContext() == decl->getASTContext().MainModule) {
           return ActorIsolation::forCallerIsolationInheriting();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5212,12 +5212,12 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
     if (decl->getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
       if (auto *value = dyn_cast<ValueDecl>(decl)) {
-        // TODO(distributed): make distributed thunks nonisolated(nonsending) and remove this if
-        if (value->isAsync() && value->isDistributedThunk()) {
-          // don't change isolation of distributed thunks until we make them nonisolated(nonsending),
-          // since the runtime calling them assumes they're just nonisolated right now.
-          return ActorIsolation::forNonisolated(nonisolatedAttr->isUnsafe());
-        }
+        // // TODO(distributed): make distributed thunks nonisolated(nonsending) and remove this if
+        // if (value->isAsync() && value->isDistributedThunk()) {
+        //   // don't change isolation of distributed thunks until we make them nonisolated(nonsending),
+        //   // since the runtime calling them assumes they're just nonisolated right now.
+        //   return ActorIsolation::forNonisolated(nonisolatedAttr->isUnsafe());
+        // }
 
         if (value->isAsync() &&
             value->getModuleContext() == decl->getASTContext().MainModule) {

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
@@ -1,8 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule \
+// RUN:     -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple \
+// RUN:     %S/../Inputs/FakeDistributedActorSystems.swift
+
+// RUN: %target-build-swift -module-name main -enable-upcoming-feature NonisolatedNonsendingByDefault \
+// RUN:     -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s \
+// RUN:     %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --enable-var-scope
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
@@ -8,7 +8,9 @@
 // RUN:     %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --enable-var-scope
+
+// NOTE: not even file-checking it!
+// RUN: %target-run %t/a.out
 
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 


### PR DESCRIPTION
This showcases lack of failure output.

When we run
```
clear; export DIR=../build/Ninja-RelWithDebInfoAssert/ ; ninja bin/swift-frontend -C $DIR/swift-macosx-$(uname -m) && ../llvm-project/llvm/utils/lit/lit.py -j32 -s -vv --show-pass --show-unsupported -a $DIR/swift-macosx-$(uname -m)/test-macosx-$(uname -m) --filter=Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
```

nowadays we don't get any failure output: 

```
RUN: at line 10: /Users/ktoso/code/swift-project/swift/utils/swift-darwin-postprocess.py /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
+ /Users/ktoso/code/swift-project/swift/utils/swift-darwin-postprocess.py /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out: replacing existing signature
RUN: at line 13: /usr/bin/env DYLD_LIBRARY_PATH='/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/macosx'  /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
+ /usr/bin/env DYLD_LIBRARY_PATH=/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/macosx /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.script: line 5: 51130 Segmentation fault: 11  /usr/bin/env DYLD_LIBRARY_PATH='/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/macosx' /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out

--

********************
********************
Failed Tests (1):
  Swift(macosx-arm64) :: Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
```

notice that this isn't even FileCheck-ing the output, just a plain run, yet we get no output at all. 

This makes diagnosing issues very difficult, especially when unable to reproduce a crash at desk.

---

When we run the same command outside of lit:

```
/usr/bin/env DYLD_LIBRARY_PATH='/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/macosx' /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
```

we get complete output:

```
-> % /usr/bin/env DYLD_LIBRARY_PATH='/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/macosx' /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Distributed/Runtime/Output/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift.tmp/a.out
| assign id: ActorAddress(address: "<unique-id>") for Greeter
| actor ready: Greeter(ActorAddress(address: "<unique-id>"))
| resolve ActorAddress(address: "<unique-id>") as remote // this system always resolves as remote
 > encode argument name:name, value: Caplin
 > encode return type: Swift.String
 > done recording
  >> remoteCall: on:Greeter(ActorAddress(address: "<unique-id>")), target:main.Greeter.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
 > execute distributed target: main.Greeter.echo(name:), identifier: $s4main7GreeterC4echo4nameS2S_tYaKFTE
  > decode return type: Swift.String
  > decode argument: Caplin

💣 Program crashed: Bad pointer dereference at 0xfffffffffffffff8

Platform: arm64 macOS 26.0 (25A345)

Thread 1 crashed:

  0 0x000000010096b374 Greeter.echo(name:) + 300 in a.out
  1 swift_distributed_execute_target_resume(swift::AsyncContext*, swift::SwiftError*) in libswiftDistributed.dylib at /Users/ktoso/code/swift-project/swift/stdlib/public/Distributed/DistributedActor.cpp:103

   101│ static void swift_distributed_execute_target_resume(
   102│     SWIFT_ASYNC_CONTEXT AsyncContext *context,
   103│     SWIFT_CONTEXT SwiftError *error) {
      │     ▲
   104│   auto parentCtx = context->Parent;
   105│   auto resumeInParent =
```