### PR TITLE
[Distributed] Failure decoding type info for generic with assoc type 

### DIFF
--- a/include/swift/Runtime/Distributed.h
+++ b/include/swift/Runtime/Distributed.h
@@ -1,0 +1,39 @@
+//===--- Concurrency.h - Runtime interface for Distributed module ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The runtime interface for the distributed actors runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_DISTRIBUTED_H
+#define SWIFT_RUNTIME_DISTRIBUTED_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+
+namespace swift {
+
+#if 1
+
+#define SWIFT_DISTRIBUTED_DEBUG_ENABLED 1
+#define SWIFT_DISTRIBUTED_DEBUG_LOG(fmt, ...)                                  \
+fprintf(stderr, "[distributed] [%s:%d](%s) " fmt "\n",                         \
+__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#else
+#define SWIFT_DISTRIBUTED_DEBUG_ENABLED 0
+#define SWIFT_DISTRIBUTED_DEBUG_LOG(fmt ...) (void)0
+#endif
+
+}
+#pragma clang diagnostic pop
+
+#endif

--- a/stdlib/public/Distributed/DistributedActor.cpp
+++ b/stdlib/public/Distributed/DistributedActor.cpp
@@ -20,6 +20,7 @@
 #include "swift/Basic/Casting.h"
 #include "swift/Runtime/AccessibleFunction.h"
 #include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Distributed.h"
 
 using namespace swift;
 
@@ -39,7 +40,10 @@ SWIFT_EXPORT_FROM(swiftDistributed)
 void *swift_distributed_getGenericEnvironment(const char *targetNameStart,
                                               size_t targetNameLength) {
   auto *accessor = findDistributedAccessor(targetNameStart, targetNameLength);
-  return accessor ? accessor->GenericEnvironment.get() : nullptr;
+  SWIFT_DISTRIBUTED_DEBUG_LOG("accessor for target: %s ->%p", targetNameStart, accessor);
+  auto genericEnv = accessor ? accessor->GenericEnvironment.get() : nullptr;
+  SWIFT_DISTRIBUTED_DEBUG_LOG("found accessor->GenericEnvironment: %p", genericEnv);
+  return genericEnv;
 }
 
 /// func _executeDistributedTarget<D: DistributedTargetInvocationDecoder>(

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -27,6 +27,7 @@
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Distributed.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/LibPrespecialized.h"
@@ -2919,7 +2920,12 @@ unsigned swift_func_getParameterCount(const char *typeNameStart,
     return -1;
 
   auto parameterList = getParameterList(funcType);
-  return parameterList->getNumChildren();
+  auto count = parameterList->getNumChildren();
+  SWIFT_DISTRIBUTED_DEBUG_LOG("parameter count of: %s, is: %lu", typeNameStart, count);
+  #if SWIFT_DISTRIBUTED_DEBUG_ENABLED
+  parameterList->dump();
+  #endif
+  return count;
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
@@ -2976,6 +2982,7 @@ swift_func_getParameterTypeInfo(
 
   StackAllocatedDemangler<1024> demangler;
 
+  SWIFT_DISTRIBUTED_DEBUG_LOG("Decode parameter type infos for target: %s", typeNameStart);
   auto *funcType =
       extractFunctionTypeFromMethod(demangler, typeNameStart, typeNameLength);
   if (!funcType)
@@ -2990,9 +2997,21 @@ swift_func_getParameterTypeInfo(
 
   SubstGenericParametersFromMetadata substFn(genericEnv, genericArguments);
 
+  for (unsigned index = 0; index != typesLength; ++index) {
+    auto nodePointer = parameterList->getChild(index);
+    #if SWIFT_DISTRIBUTED_DEBUG_ENABLED
+    SWIFT_DISTRIBUTED_DEBUG_LOG("Node pointer[%d/%d]", index, typesLength);
+    nodePointer->dump();
+    #endif
+  }
+
   // for each parameter (TupleElement), store it into the provided buffer
   for (unsigned index = 0; index != typesLength; ++index) {
     auto nodePointer = parameterList->getChild(index);
+    #if SWIFT_DISTRIBUTED_DEBUG_ENABLED
+    SWIFT_DISTRIBUTED_DEBUG_LOG("Attempt to decode type node pointer at index:%d (of %d)", index, typesLength);
+    nodePointer->dump();
+    #endif
 
     if (nodePointer->getKind() == Node::Kind::TupleElement) {
       assert(nodePointer->getNumChildren() == 1);
@@ -3015,6 +3034,7 @@ swift_func_getParameterTypeInfo(
       });
 
     if (typeInfoOrErr.isError()) {
+      SWIFT_DISTRIBUTED_DEBUG_LOG("TypeInfo invalid at index %d (of %d)", index, typesLength);
       return -3; // Failed to decode a type.
     }
 
@@ -3032,6 +3052,7 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
                                    const void *const *genericArguments) {
   assert(genericEnv);
   assert(genericArguments);
+  SWIFT_DISTRIBUTED_DEBUG_LOG("get witness table, env = %p, generic arguments = %p", genericEnv, genericArguments);
 
   llvm::SmallVector<const void *, 4> witnessTables;
   SubstGenericParametersFromMetadata substFn(genericEnv, genericArguments);

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_generic_dependent.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_generic_dependent.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --enable-var-scope
+
+// X: %target-run-simple-swift( -Xfrontend -module-name=main -target %target-swift-5.7-abi-triple  -parse-as-library -Xfrontend -I -Xfrontend %t ) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol Greeting: Codable {
+  associatedtype Inner: Codable
+}
+
+struct ExampleGreeting: Greeting {
+  typealias Inner = String
+}
+
+distributed actor Greeter<G: Greeting>: CustomStringConvertible {
+  distributed func echo(_ value: G.Inner) -> String {
+    return "Echo: \(value) (impl on: \(self.id))"
+  }
+
+  nonisolated var description: String {
+    "\(Self.self)(\(id))"
+  }
+}
+
+struct SomeError: Error {}
+
+// ==== Test -------------------------------------------------------------------
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let local = Greeter<ExampleGreeting>(actorSystem: system)
+  let ref = try Greeter<ExampleGreeting>.resolve(id: local.id, using: system)
+
+  let replyLocal = try await local.echo("Test")
+  print("replyLocal = \(replyLocal)")
+
+  let reply = try await ref.echo("Caplin")
+  // CHECK: > encode argument name:name, value: Caplin
+  // CHECK-NOT: > encode error type
+  // CHECK: > encode return type: Swift.String
+  // CHECK: > done recording
+  // CHECK: >> remoteCall
+  // CHECK: > decode return type: Swift.String
+  // CHECK: > decode argument: Caplin
+  // CHECK: << onReturn: Echo: Caplin (impl on: ActorAddress(address: "<unique-id>"))
+
+  print("got: \(reply)")
+  // CHECK: got: Echo: Caplin (impl on: ActorAddress(address: "<unique-id>"))
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}


### PR DESCRIPTION
It seems distributed function type decoding fails when a parameter uses an associated type of a generic as parameter type in a distributed func.

For now this only reproduces the issue, didn't solve it yet

resolves rdar://159258884