### PR TITLE
tests: small improvement for Misc/verify-swift-feature-testing.test-sh

### DIFF
--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -114,6 +114,7 @@ def find_matches(swift_src_root):
             # Be careful to not use RUN with a colon after it or Lit will pick
             # it up.
             "RUN[:].*-enable-(experimental|upcoming)-feature",
+            "--",
             "test",
             "validation-test",
         ],


### PR DESCRIPTION
The `git grep` command fails if the repository has a branch named `test`. Inserting a `--` in the git command line makes it clear that `test` is the directory and not the branch
