### PR TITLE
[CS] Allow contextual types with errors

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2681,8 +2681,11 @@ bool TypeVarBindingProducer::computeNext() {
       // let's have it try `Void` as well because there is an
       // implicit conversion `() -> T` to `() -> Void` and this
       // helps to avoid creating a thunk to support it.
+      // Avoid doing this is we already have a hole binding since
+      // introducing Void will just cause local solution ambiguities.
       if (getLocator()->isLastElement<LocatorPathElt::ClosureResult>() &&
-          binding.Kind == AllowedBindingKind::Supertypes) {
+          binding.Kind == AllowedBindingKind::Supertypes &&
+          !binding.BindingType->isPlaceholder()) {
         auto voidType = CS.getASTContext().TheEmptyTupleType;
         addNewBinding(binding.withSameSource(voidType, BindingKind::Exact));
       }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1716,8 +1716,13 @@ namespace {
         CS.recordFix(
             IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(locator)));
 
-        return CS.createTypeVariable(CS.getConstraintLocator(repr),
-                                     TVO_CanBindToHole);
+        // Immediately bind the result to a hole since we know it's invalid and
+        // want it to propagate rather than allowing other type variables to
+        // become holes.
+        auto *tv = CS.createTypeVariable(CS.getConstraintLocator(repr),
+                                         TVO_CanBindToHole);
+        CS.recordTypeVariablesAsHoles(tv);
+        return tv;
       }
       // Diagnose top-level usages of placeholder types.
       if (auto *ty = dyn_cast<PlaceholderTypeRepr>(repr->getWithoutParens())) {

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -845,12 +845,6 @@ private:
         ContextualPattern::forPatternBindingDecl(patternBinding, index);
     Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
 
-    // Fail early if pattern couldn't be type-checked.
-    if (!patternType || patternType->hasError()) {
-      hadError = true;
-      return;
-    }
-
     auto target = getTargetForPattern(patternBinding, index, patternType);
     if (!target) {
       hadError = true;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -876,11 +876,6 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
       auto contextualPattern = ContextualPattern::forRawPattern(pattern, DC);
       patternType = typeCheckPattern(contextualPattern);
     }
-
-    if (patternType->hasError()) {
-      PBD->setInvalid();
-      return true;
-    }
   }
 
   bool hadError = TypeChecker::typeCheckBinding(pattern, init, DC, patternType,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1075,7 +1075,7 @@ public:
     assert(TheFunc && "Should have bailed from pre-check if this is None");
 
     Type ResultTy = TheFunc->getBodyResultType();
-    if (!ResultTy || ResultTy->hasError())
+    if (!ResultTy)
       return nullptr;
 
     if (!RS->hasResult()) {

--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -19,3 +19,4 @@ Redeclaration.NSStringToNSString(AppKit.NSStringToNSString("abc")) // expected-w
 
 let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1()
 let forwardDecl: Redeclaration.Tribool = AppKit.Tribool() // expected-error {{no type named 'Tribool' in module 'Redeclaration'}}
+// expected-error@-1 {{missing argument for parameter #1 in call}}

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -27,4 +27,5 @@ protocol Collection : _Collection, Sequence {
 }
 func insertionSort<C: Mutable> (_ elements: inout C, i: C.Index) { // expected-error {{cannot find type 'Mutable' in scope}} expected-error {{'Index' is not a member type of type 'C'}}
   var x: C.Iterator.Element = elements[i] // expected-error {{'Iterator' is not a member type of type 'C'}}
+  // expected-error@-1 {{value of type 'C' has no subscripts}}
 }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -834,3 +834,10 @@ func testUndefinedTypeInPattern(_ x: Int) {
     }
   }
 }
+
+func testUndefinedInClosureVar() {
+  // Make sure we don't produce "unable to infer closure type without a type annotation"
+  _ = {
+    var x: Undefined // expected-error {{cannot find type 'Undefined' in scope}}
+  }
+}

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -142,7 +142,7 @@ struct A2 {
   subscript (i : Int) -> // expected-error{{expected subscripting element type}}
      {
     get {
-      return stored
+      return stored // expected-error {{cannot find 'stored' in scope}}
     }
     set {
       stored = newValue // expected-error{{cannot find 'stored' in scope}}

--- a/test/SPI/implicit_spi_import.swift
+++ b/test/SPI/implicit_spi_import.swift
@@ -95,7 +95,9 @@ import Lib
 public func useImplicit() -> _Klass { return _Klass() } // expected-error{{cannot use class '_Klass' here; it is an SPI imported from 'Lib'}}
 
 @_spi(core)
-public func useSPICore() -> CoreStruct { return CoreStruct() } // expected-error{{cannot find type 'CoreStruct' in scope}}
+public func useSPICore() -> CoreStruct { return CoreStruct() }
+// expected-error@-1 {{cannot find type 'CoreStruct' in scope}}
+// expected-error@-2 {{cannot find 'CoreStruct' in scope}}
 
 public func useMain() -> APIProtocol? { return nil }
 

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -257,6 +257,7 @@ func mismatchedReturnTypes() -> _ { // expected-error {{type placeholder may not
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 func opaque() -> some _ { // expected-error {{type placeholder not allowed here}}
   return Just<Int>().setFailureType(to: _.self)
+  // expected-error@-1 {{type placeholder not allowed here}}
 }
 
 enum EnumWithPlaceholders {

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -126,7 +126,12 @@ func test21057425() -> (Int, Int) {
 // rdar://problem/21081340
 func test21081340() {
   func foo() { }
+
+  // FIXME: The double diagnostic here is a little unfortunate but is a result of
+  // the fact that we essentially type-check the pattern twice, once on its own,
+  // and again as part of the initialization.
   let (x: a, y: b): () = foo() // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+  // expected-error@-1 {{pattern of type '(x: _, y: _)' cannot match '()'}}
 }
 
 // <rdar://problem/22322266> Swift let late initialization in top level control flow statements

--- a/validation-test/compiler_crashers_2_fixed/64bfdff1cfbfc74.swift
+++ b/validation-test/compiler_crashers_2_fixed/64bfdff1cfbfc74.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::simplifySameShapeConstraint(swift::Type, swift::Type, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a < each b {
   c(d : repeat each b) {
     c(preacidte : b) {

--- a/validation-test/compiler_crashers_2_fixed/issue-52031.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-52031.swift
@@ -16,5 +16,6 @@ extension S: P where N: P {
   // expected-error@-3 {{'A' is not a member type of type 'X'}}
   // expected-error@-4 {{'A' is not a member type of type 'X'}}
     return S<X.A>()
+    // expected-error@-1 {{'A' is not a member type of type 'X'}}
   }
 }


### PR DESCRIPTION
Previously we would skip type-checking the result expression of a `return` or the initialization expression of a binding if the contextual type had an error, but that misses out on useful diagnostics and prevents code completion and cursor info from working. Change the logic such that we open ErrorTypes as holes and continue to type-check.