### PR TITLE
[CS] Strengthen check for completion in CSApply

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -452,7 +452,7 @@ namespace {
     void addLocalDeclToTypeCheck(Decl *D) {
       // If we're doing code completion, avoid doing any further type-checking,
       // that should instead be handled by TypeCheckASTNodeAtLocRequest.
-      if (ctx.CompletionCallback)
+      if (ctx.SourceMgr.hasIDEInspectionTargetBuffer())
         return;
 
       LocalDeclsToTypeCheck.push_back(D);
@@ -461,7 +461,7 @@ namespace {
     void addMacroToExpand(MacroExpansionExpr *E) {
       // If we're doing code completion, avoid doing any further type-checking,
       // that should instead be handled by TypeCheckASTNodeAtLocRequest.
-      if (ctx.CompletionCallback)
+      if (ctx.SourceMgr.hasIDEInspectionTargetBuffer())
         return;
 
       MacrosToExpand.push_back(E);

--- a/validation-test/IDE/crashers_fixed/ce6e7a44344828a0.swift
+++ b/validation-test/IDE/crashers_fixed/ce6e7a44344828a0.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","signature":"(anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*)"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 enum a }
 {
 var b: a func c { switch b {

--- a/validation-test/IDE/crashers_fixed/e7327cfd8bafcd86.swift
+++ b/validation-test/IDE/crashers_fixed/e7327cfd8bafcd86.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"bc7ab9d8","signature":"swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, swift::FunctionRefInfo, swift::constraints::ConstraintLocatorBuilder, swift::DeclContext*, swift::constraints::PreparedOverloadBuilder*)","signatureAssert":"Assertion failed: (func->isOperator() && \"Lookup should only find operators\"), function getTypeOfReference"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 {
   func a(query: String) {
     {


### PR DESCRIPTION
Turns out we don't always set a completion callback for some unqualified completion positions. Upgrade the check for a completion callback to a check for a completion buffer to account for this. This avoids unnecessary type-checker work as well as fixing a couple of double-type-checking crashers.