### PR TITLE
[6.2] Optimizer: fix an ownership violation when duplicating loops

### DIFF
--- a/include/swift/SILOptimizer/Utils/LoopUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoopUtils.h
@@ -28,6 +28,7 @@ class SILInstruction;
 class SILLoop;
 class DominanceInfo;
 class SILLoopInfo;
+class DeadEndBlocks;
 
 /// Canonicalize the loop for rotation and downstream passes.
 ///
@@ -40,7 +41,7 @@ bool canonicalizeAllLoops(DominanceInfo *DT, SILLoopInfo *LI);
 
 /// Check whether it is safe to duplicate this instruction when duplicating
 /// this loop by unrolling or versioning.
-bool canDuplicateLoopInstruction(SILLoop *L, SILInstruction *Inst);
+bool canDuplicateLoopInstruction(SILLoop *L, SILInstruction *Inst, DeadEndBlocks *deb);
 
 /// A visitor that visits loops in a function in a bottom up order. It only
 /// performs the visit.

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/SILCloner.h"
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
@@ -211,7 +212,8 @@ static std::optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
 /// heuristic that looks at the trip count and the cost of the instructions in
 /// the loop to determine whether we should unroll this loop.
 static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount,
-                                   IsSelfRecursiveAnalysis *SRA) {
+                                   IsSelfRecursiveAnalysis *SRA,
+                                   DeadEndBlocks *deb) {
   assert(Loop->getSubLoops().empty() && "Expect innermost loops");
   if (TripCount > 32)
     return false;
@@ -227,7 +229,7 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount,
     (Loop->getBlocks())[0]->getParent()->getModule().getOptions().UnrollThreshold;
   for (auto *BB : Loop->getBlocks()) {
     for (auto &Inst : *BB) {
-      if (!canDuplicateLoopInstruction(Loop, &Inst))
+      if (!canDuplicateLoopInstruction(Loop, &Inst, deb))
         return false;
       if (instructionInlineCost(Inst) != InlineCost::Free)
         ++Cost;
@@ -388,7 +390,7 @@ updateSSA(SILFunction *Fn, SILLoop *Loop,
 
 /// Try to fully unroll the loop if we can determine the trip count and the trip
 /// count is below a threshold.
-static bool tryToUnrollLoop(SILLoop *Loop, IsSelfRecursiveAnalysis *SRA) {
+static bool tryToUnrollLoop(SILLoop *Loop, IsSelfRecursiveAnalysis *SRA, DeadEndBlocks *deb) {
   assert(Loop->getSubLoops().empty() && "Expecting innermost loops");
 
   LLVM_DEBUG(llvm::dbgs() << "Trying to unroll loop : \n" << *Loop);
@@ -409,7 +411,7 @@ static bool tryToUnrollLoop(SILLoop *Loop, IsSelfRecursiveAnalysis *SRA) {
     return false;
   }
 
-  if (!canAndShouldUnrollLoop(Loop, MaxTripCount.value(), SRA)) {
+  if (!canAndShouldUnrollLoop(Loop, MaxTripCount.value(), SRA, deb)) {
     LLVM_DEBUG(llvm::dbgs() << "Not unrolling, exceeds cost threshold\n");
     return false;
   }
@@ -490,6 +492,7 @@ class LoopUnrolling : public SILFunctionTransform {
     auto *Fun = getFunction();
     SILLoopInfo *LoopInfo = PM->getAnalysis<SILLoopAnalysis>()->get(Fun);
     IsSelfRecursiveAnalysis *SRA = PM->getAnalysis<IsSelfRecursiveAnalysis>();
+    DeadEndBlocks *deb = PM->getAnalysis<DeadEndBlocksAnalysis>()->get(Fun);
 
     LLVM_DEBUG(llvm::dbgs() << "Loop Unroll running on function : "
                             << Fun->getName() << "\n");
@@ -517,7 +520,7 @@ class LoopUnrolling : public SILFunctionTransform {
 
     // Try to unroll innermost loops.
     for (auto *Loop : InnermostLoops)
-      Changed |= tryToUnrollLoop(Loop, SRA);
+      Changed |= tryToUnrollLoop(Loop, SRA, deb);
 
     if (Changed) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);

--- a/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
+++ b/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
@@ -76,6 +76,38 @@ bb3:
   return %4 : $MyBool
 }
 
+// Check that we don't crash with an ownership violation
+// CHECK-LABEL: sil [ossa] @borrow_use_in_dead_end : 
+// CHECK-LABEL: } // end sil function 'borrow_use_in_dead_end'
+sil [ossa] @borrow_use_in_dead_end : $@convention(thin) (@guaranteed MyArray<MyClass>) -> () {
+bb0(%0 : @guaranteed $MyArray<MyClass>):
+  br bb1
+
+bb1:
+  %2 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  %5 = apply %2(%0) : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  %10 = alloc_ref $MyClass
+  %11 = begin_borrow %10
+  cond_br undef, bb2, bb3
+
+bb2:
+  fix_lifetime %11
+  unreachable
+
+bb3:
+  end_borrow %11
+  destroy_value %10
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb1
+
+bb5:
+  %r = tuple ()
+  return %r
+}
+
+
 // CHECK-LABEL: sil [ossa] @load_and_copy_within_loop : 
 // CHECK: bb1:
 // CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative


### PR DESCRIPTION
* **Explanation**: Fixes a verifier crash caused by an optimization pass which duplicates a loop to specialize the Array's "isNative" check. If a guaranteed value is used in a dead-end exit block and the enclosing value is _not_ destroyed in this block, we end up missing the enclosing value as phi-argument after duplicating the loop.
* **Risk**: Low. It's a simple fix which adds an additional bail-out condition to the loop optimization.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://159125605
* **Reviewer**:  @nate-chandler
* **Main branch PR**: https://github.com/swiftlang/swift/pull/83977
