### PR TITLE
Add a flag to annotate all functions with the `optremark` (`@_assemblyVision`) attribute

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -327,6 +327,9 @@ public:
   /// The format used for serializing remarks (default: YAML)
   llvm::remarks::Format OptRecordFormat = llvm::remarks::Format::YAML;
 
+  /// Whether to apply _assemblyVision to all functions.
+  bool EnableGlobalAssemblyVision = false;
+
   /// Are there any options that indicate that functions should not be preserved
   /// for the debugger?
   bool ShouldFunctionsBePreservedToDebugger = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -318,6 +318,12 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOptionIg
     Joined<["-"], "formal-cxx-interoperability-mode=">,
     HelpText<"What version of C++ interoperability a textual interface was originally generated with">,
     MetaVarName<"<cxx-interop-version>|off">;
+  def enable_assembly_vision_all
+      : Flag<["-"], "enable-assembly-vision-all">,
+        HelpText<"Enable assembly vision for all functions">;
+  def disable_assembly_vision_all
+      : Flag<["-"], "disable-assembly-vision-all">,
+        HelpText<"Disable assembly vision for all functions">;
 }
 
 // Flags that are saved into module interfaces

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3075,6 +3075,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     Opts.OptRecordFormat = *formatOrErr;
   }
 
+  Opts.EnableGlobalAssemblyVision = Args.hasFlag(
+      OPT_enable_assembly_vision_all, OPT_disable_assembly_vision_all,
+      Opts.EnableGlobalAssemblyVision);
+
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_passes))
     Opts.OptRecordPasses = A->getValue();
 

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -61,7 +61,8 @@ void SILFunctionBuilder::addFunctionAttributes(
   // function as force emitting all optremarks including assembly vision
   // remarks. This allows us to emit the assembly vision remarks without needing
   // to change any of the underlying optremark mechanisms.
-  if (Attrs.getAttribute(DeclAttrKind::EmitAssemblyVisionRemarks))
+  if (Attrs.getAttribute(DeclAttrKind::EmitAssemblyVisionRemarks) ||
+      M.getOptions().EnableGlobalAssemblyVision)
     F->addSemanticsAttr(semantics::FORCE_EMIT_OPT_REMARK_PREFIX);
 
   // Propagate @_specialize.

--- a/test/SILOptimizer/assemblyvision_remark/all.swift
+++ b/test/SILOptimizer/assemblyvision_remark/all.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -enable-assembly-vision-all -emit-sil %s -Osize -o - -module-name main 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -enable-assembly-vision-all -emit-sil %s -Osize -o - -module-name main 2>&1 | %FileCheck %s --check-prefix=REMARK
+
+public class C {
+
+  // CHECK: sil [transparent] [_semantics "optremark"] @$s4main1CC1iSivg
+  public var i: Int = 0
+
+  // CHECK: sil hidden [_semantics "optremark"] @$s4main1CCACycfc
+  init() {
+      print("\(i)")
+  }
+
+  // CHECK: sil [_semantics "optremark"] @$s4main1CC6methodSiyF
+  public func method() -> Int {
+// REMARK: 17:14: remark: begin exclusive access to value of type 'Int'
+      return i
+// REMARK: 17:14: remark: end exclusive access to value of type 'Int'
+  }
+
+  // CHECK: sil [_semantics "optremark"] @$s4main1CCfd
+}
+
+// CHECK sil [_semantics "optremark"] @$s4main12freestandingAA1CCyF
+public func freestanding() -> C {
+    return C()
+}


### PR DESCRIPTION

rdar://159291169