### PR TITLE
[CSOptimizer] Don't match `nil` to `_OptionalNilComparisonType`

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -260,13 +260,6 @@ static bool isStandardInfixLogicalOperator(Constraint *disjunction) {
   return false;
 }
 
-static bool isOperatorNamed(Constraint *disjunction, StringRef name) {
-  auto *choice = disjunction->getNestedConstraints()[0];
-  if (auto *decl = getOverloadChoiceDecl(choice))
-    return decl->isOperator() && decl->getBaseIdentifier().is(name);
-  return false;
-}
-
 static bool isArithmeticOperator(ValueDecl *decl) {
   return decl->isOperator() && decl->getBaseIdentifier().isArithmeticOperator();
 }
@@ -1022,19 +1015,6 @@ static void determineBestChoicesInContext(
                                            optionals.size());
             types.push_back({type,
                              /*fromLiteral=*/true});
-          } else if (literal.first ==
-                         cs.getASTContext().getProtocol(
-                             KnownProtocolKind::ExpressibleByNilLiteral) &&
-                     literal.second.IsDirectRequirement) {
-            // `==` and `!=` operators have special overloads that accept `nil`
-            // as `_OptionalNilComparisonType` which is preferred over a
-            // generic form `(T?, T?)`.
-            if (isOperatorNamed(disjunction, "==") ||
-                isOperatorNamed(disjunction, "!=")) {
-              auto nilComparisonTy =
-                  cs.getASTContext().get_OptionalNilComparisonTypeType();
-              types.push_back({nilComparisonTy, /*fromLiteral=*/true});
-            }
           }
         }
 

--- a/test/Constraints/rdar158063151.swift
+++ b/test/Constraints/rdar158063151.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Make sure that the type-checker selects an `Equatable.==` instead of one from stdlib that takes _OptionalNilComparisonType
+
+struct Value: Equatable, ExpressibleByNilLiteral {
+  init(nilLiteral: ()) {
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s13rdar1580631514test1vyAA5ValueV_tF : $@convention(thin) (Value) -> ()
+// function_ref static Value.__derived_struct_equals(_:_:)
+// CHECK: [[EQUALS_REF:%.*]] = function_ref @$s13rdar1580631515ValueV23__derived_struct_equalsySbAC_ACtFZ
+// CHECK-NEXT: apply [[EQUALS_REF]](%0, {{.*}})
+func test(v: Value) {
+  _ = v == nil
+}

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -282,7 +282,7 @@ public class U {
 }
 
 func == (l: S?, r: S?) -> Bool {
-  if l == nil && r == nil { return true }
+  if l == nil && r == nil { return true } // expected-warning {{function call causes an infinite recursion}}
   guard let l = l, let r = r else { return false }
   return l === r
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
@@ -5,6 +5,7 @@ let i: Int? = 1
 let j: Int?
 let k: Int? = 2
 
+// expected-error@+1 {{the compiler is unable to type-check this expression in reasonable time}}
 let _ = [i, j, k].reduce(0 as Int?) {
   $0 != nil && $1 != nil ? $0! + $1! : ($0 != nil ? $0! : ($1 != nil ? $1! : nil))
 }


### PR DESCRIPTION
This type is only intended for pattern matching against `nil` and the solver shouldn't early attempt to infer this type for `nil` for arguments of `==` and `!=` operators it should instead be inferred from other argument or result.

Resolves: rdar://158063151

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
