### PR TITLE
SIL: only use canonical substitution maps in SIL

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1337,7 +1337,7 @@ public:
                              SubstitutionMap forwardingSubs) {
     GenericEnv = env;
     CapturedEnvs = capturedEnvs;
-    ForwardingSubMap = forwardingSubs;
+    ForwardingSubMap = forwardingSubs.getCanonical();
   }
 
   /// Retrieve the generic signature from the generic environment of this

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2674,7 +2674,7 @@ protected:
       : Base(kind, DebugLoc, baseArgs...), SubstCalleeType(substCalleeType),
         SpecializationInfo(specializationInfo), NumCallArguments(args.size()),
         NumTypeDependentOperands(typeDependentOperands.size()),
-        Substitutions(subs) {
+        Substitutions(subs.getCanonical()) {
     assert(!!subs == !!callee->getType().castTo<SILFunctionType>()
         ->getInvocationGenericSignature());
 
@@ -5983,7 +5983,7 @@ private:
             Kind kind, SubstitutionMap subs)
       : UnaryInstructionWithTypeDependentOperandsBase(
             debugLoc, operand, typeDependentOperands, outputType),
-        kind(kind), substitutions(subs) {}
+        kind(kind), substitutions(subs.getCanonical()) {}
 
   static ThunkInst *create(SILDebugLocation debugLoc, SILValue operand,
                            SILModule &mod, SILFunction *func, Kind kind,
@@ -8650,7 +8650,7 @@ class InitBlockStorageHeaderInst
                              SILValue InvokeFunction, SILType BlockType,
                              SubstitutionMap Subs)
       : InstructionBase(DebugLoc, BlockType),
-        Substitutions(Subs),
+        Substitutions(Subs.getCanonical()),
         Operands(this, BlockStorage, InvokeFunction) {
   }
   

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -525,7 +525,7 @@ BuiltinInst::BuiltinInst(SILDebugLocation Loc, Identifier Name,
                          ArrayRef<SILValue> allOperands,
                          unsigned numNormalOperands)
     : InstructionBaseWithTrailingOperands(allOperands, Loc, ReturnType),
-      Name(Name), Substitutions(Subs), numNormalOperands(numNormalOperands) {}
+      Name(Name), Substitutions(Subs.getCanonical()), numNormalOperands(numNormalOperands) {}
 
 IncrementProfilerCounterInst *IncrementProfilerCounterInst::create(
     SILDebugLocation Loc, unsigned CounterIdx, StringRef PGOFuncName,
@@ -3176,7 +3176,7 @@ KeyPathInst::KeyPathInst(SILDebugLocation Loc,
     Pattern(Pattern),
     numPatternOperands(numPatternOperands),
     numTypeDependentOperands(allOperands.size() - numPatternOperands),
-    Substitutions(Subs)
+    Substitutions(Subs.getCanonical())
 {
   assert(allOperands.size() >= numPatternOperands);
   auto *operandsBuf = getTrailingObjects<Operand>();

--- a/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis.swift
+++ b/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis.swift
@@ -64,7 +64,7 @@ import API
 // CHECK-NEXT: [[OPTIONAL_TEST:%.*]] = enum $Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <Optional<Int>>>, #Optional.some!enumelt, [[CONVERTED_REABSTRACTED_TEST_REF]] :
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[COMPUTE_REF:%.*]] = function_ref @$s3API7computeyyyxcSglF : $@convention(thin) <τ_0_0> (@guaranteed Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>) -> ()
-// CHECK-NEXT: {{.*}} = apply [[COMPUTE_REF]]<Int?>([[OPTIONAL_TEST]]) : $@convention(thin) <τ_0_0> (@guaranteed Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>) -> ()
+// CHECK-NEXT: {{.*}} = apply [[COMPUTE_REF]]<Optional<Int>>([[OPTIONAL_TEST]]) : $@convention(thin) <τ_0_0> (@guaranteed Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>) -> ()
 @MainActor
 func testMainActorContext() {
   compute(test) // no warning

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -69,7 +69,7 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK: bb0([[GY:%[0-9]+]] : @guaranteed $GY<Int>):
   // CHECK:   [[GY_AS_GX:%[0-9]+]] = upcast [[GY]] : $GY<Int> to $GX<Array<Int>>
   // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX]] : $GX<Array<Int>>, #GX.f : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<Array<Int>>([[GY_AS_GX]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>
   _ = gy.f()

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -111,14 +111,14 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<Int>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<Int>>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -212,14 +212,14 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<any P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[any P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<any P>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<any P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<any P>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<[any P]>([[ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<any P>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<any P>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:
@@ -373,14 +373,14 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<GenericStruct<T>>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<GenericStruct<T>>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<[GenericStruct<T>]>([[ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<GenericStruct<T>>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:

--- a/test/SILGen/foreach_async.swift
+++ b/test/SILGen/foreach_async.swift
@@ -84,7 +84,7 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$sScIsE4next9isolation7ElementQzSgScA_pSgYi_tYa7FailureQzYKF : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure)
 // CHECK:   [[ERROR_SLOT:%[0-9]+]] = alloc_stack $Never
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
+// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<Array<Int>>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
 // CHECK: [[NORMAL_BB]](
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
@@ -117,7 +117,7 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$sScIsE4next9isolation7ElementQzSgScA_pSgYi_tYa7FailureQzYKF : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure)
 // CHECK:   [[ERROR_SLOT:%[0-9]+]] = alloc_stack $Never
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
+// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<Array<Int>>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
 // CHECK:  [[NORMAL_BB]](
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
@@ -177,7 +177,7 @@ func trivialStructBreak(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$sScIsE4next9isolation7ElementQzSgScA_pSgYi_tYa7FailureQzYKF : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure)
 // CHECK:   [[ERROR_SLOT:%[0-9]+]] = alloc_stack $Never
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
+// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<Array<Int>>.Iterator>([[NEXT_RESULT]], [[ERROR_SLOT]], [[ACTOR]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@sil_isolated @guaranteed Optional<any Actor>, @inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal [[NORMAL_BB:bb[0-2]+]], error [[ERROR_BB:bb[0-9]+]]
 // CHECK:  [[NORMAL_BB]](
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -369,7 +369,7 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_LIFETIME]]
     // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Bool>>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
-    // CHECK-NEXT: apply [[DELEG_INIT]]<Bool?>([[RESULT_ADDR]], [[SELF_META]])
+    // CHECK-NEXT: apply [[DELEG_INIT]]<Optional<Bool>>([[RESULT_ADDR]], [[SELF_META]])
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[RESULT_ADDR]]
     // CHECK-NEXT: assign [[RESULT]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -630,7 +630,7 @@ func castToCFunction(ptr: UnsafeRawPointer) {
   // CHECK: store %0 to [trivial] [[IN]] : $*UnsafeRawPointer
   // CHECK: [[META:%.*]] = metatype $@thick (@convention(c) (Optional<AnyObject>) -> ()).Type
   // CHECK: [[CASTFN:%.*]] = function_ref @$ss13unsafeBitCast_2toq_x_q_mtr0_lF
-  // CHECK: apply [[CASTFN]]<UnsafeRawPointer, @convention(c) (AnyObject?) -> ()>([[OUT]], [[IN]], [[META]]) : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @thick τ_0_1.Type) -> @out τ_0_1
+  // CHECK: apply [[CASTFN]]<UnsafeRawPointer, @convention(c) (Optional<AnyObject>) -> ()>([[OUT]], [[IN]], [[META]]) : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @thick τ_0_1.Type) -> @out τ_0_1
   // CHECK: [[RESULT:%.*]] = load [trivial] [[OUT]] : $*@convention(c) (Optional<AnyObject>) -> ()
   typealias Fn = @convention(c) (AnyObject?) -> Void
   unsafeBitCast(ptr, to: Fn.self)(nil)

--- a/test/SILGen/opaque_result_type_nested_optional.swift
+++ b/test/SILGen/opaque_result_type_nested_optional.swift
@@ -11,5 +11,5 @@ _ = bar(foo())
 // CHECK: [[UNUSED:%.*]] = alloc_stack $S<Optional<Int>>
 // CHECK: [[INNER:%.*]] = alloc_stack $S<Optional<Int>>
 // CHECK: [[FN:%.*]] = function_ref @$s40opaque_result_type_nested_optional_other3bary1AQzxAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
-// CHECK: apply [[FN]]<S<Int?>>([[OUTER]], [[INNER]]) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
+// CHECK: apply [[FN]]<S<Optional<Int>>>([[OUTER]], [[INNER]]) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
 // CHECK: return

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -168,7 +168,7 @@ func for_loops2() {
   // CHECK: alloc_stack $Optional<MyClass>
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
-  // CHECK-NEXT: apply [[NEXT]]<[MyClass]>
+  // CHECK-NEXT: apply [[NEXT]]<Array<MyClass>>
   let objects = [MyClass(), MyClass() ]
   for obj in objects {
     obj.foo()

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -498,7 +498,7 @@ func accessOptionalArray(_ dict : MyDict<Int, [Int]>) {
 // CHECK:   store %{{.*}} to [trivial]
 // ----- Call MyDict.subscript.getter.
 // CHECK-NOT: begin_access
-// CHECK:   apply %{{.*}}<Int, [Int]>
+// CHECK:   apply %{{.*}}<Int, Array<Int>>
 // ----- access the temporary array result of the getter
 // CHECK:   [[TEMPACCESS:%.*]] = begin_access [modify] [unsafe] [[TEMP]]
 // CHECK:   [[HAS_VALUE:%.*]] = select_enum_addr [[TEMPACCESS]]
@@ -518,7 +518,7 @@ func accessOptionalArray(_ dict : MyDict<Int, [Int]>) {
 // CHECK:   alloc_stack $Int
 // CHECK:   store %{{.*}} to [trivial]
 // ----- call MyDict.subscript.setter
-// CHECK: apply %{{.*}}<Int, [Int]>([[ARRAYCOPY]], %{{.*}}, [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout MyDict<τ_0_0, τ_0_1>) -> ()
+// CHECK: apply %{{.*}}<Int, Array<Int>>([[ARRAYCOPY]], %{{.*}}, [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout MyDict<τ_0_0, τ_0_1>) -> ()
 // CHECK:   br [[RETBB:bb[0-9]+]]
 //
 // CHECK: [[FALSEBB]]:
@@ -530,7 +530,7 @@ func accessOptionalArray(_ dict : MyDict<Int, [Int]>) {
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [trivial] [[TEMP3]] : $*Int
 // Call MyDict.subscript.setter
-// CHECK:   apply %{{.*}}<Int, [Int]>([[WRITEBACK]], [[TEMP3]], [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout MyDict<τ_0_0, τ_0_1>) -> ()
+// CHECK:   apply %{{.*}}<Int, Array<Int>>([[WRITEBACK]], [[TEMP3]], [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout MyDict<τ_0_0, τ_0_1>) -> ()
 // CHECK:   end_access [[TEMPACCESS]] : $*Optional<Array<Int>>
 // CHECK:   end_access [[BOXACCESS]] : $*MyDict<Int, Array<Int>>
 // CHECK:   br [[RETBB]]

--- a/test/Serialization/clang-function-types.swift
+++ b/test/Serialization/clang-function-types.swift
@@ -25,5 +25,5 @@ func test2() {
 // CHECK-LABEL: sil public_external [canonical] @$s24def_clang_function_types17use_fp_internallyyyF
 // CHECK:         enum $Optional<@convention(c, cType: "struct ForwardInTypedefForFP2 *(*)(void)") () -> Optional<OpaquePointer>>, #Optional.none!enumelt
 // CHECK:         [[FN:%.*]] = function_ref @$s24def_clang_function_types9use_inout3argyxz_tlF : $@convention(thin) <τ_0_0> (@inout τ_0_0) -> ()
-// CHECK:         apply [[FN]]<(@convention(c, cType: "OpaqueTypedefForFP2 (*)(void)") () -> OpaquePointer?)?>
+// CHECK:         apply [[FN]]<Optional<@convention(c, cType: "struct ForwardInTypedefForFP2 *(*)(void)") () -> Optional<OpaquePointer>>>
 // CHECK-LABEL: } // end sil function '$s24def_clang_function_types17use_fp_internallyyyF'

--- a/test/embedded/generic-specialization.swift
+++ b/test/embedded/generic-specialization.swift
@@ -1,0 +1,13 @@
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+func f<V>(_ a: [V]) -> [String] {
+    return a.indices.map { String($0 /* as Int*/) }  // adding `as Int` makes it compile
+}
+
+// CHECK: 0
+print(f(["A"]).joined())
+

--- a/validation-test/compiler_crashers_2_fixed/0144-issue-49620.swift
+++ b/validation-test/compiler_crashers_2_fixed/0144-issue-49620.swift
@@ -28,6 +28,6 @@ class Bar: Cl {
 
 // CHECK-LABEL: sil hidden @$s4main5crash4barsSbAA8GenClassCyAA3BarCG_tF
 func crash(bars: GenClass<Bar>) -> Bool {
-    // CHECK: apply [[FN:%.*]]<Bar, [Bar]>
+    // CHECK: apply [[FN:%.*]]<Bar, Array<Bar>>
     return Array(bars.filter { $0.x == nil }).isEmpty
 }


### PR DESCRIPTION
* When constructing instructions which have substitution maps: initialize those with the canonical SubstitutionMap
* Also initialize SILFunction::ForwardingSubMap with the canonical one

Non-canonical substitution maps may prevent generic specializations. This fixes a problem in Embedded Swift where an error is given because a function cannot be specialized, although it should.

https://github.com/swiftlang/swift/issues/83895
rdar://159065157
