### PR TITLE
[Windows] ClangImporter: Work around duplicate link declaration error…

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1218,6 +1218,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     llvm::for_each(driverArgs, [&](const std::string &Arg) {
       invocationArgs.push_back(Arg.c_str());
     });
+    invocationArgs.push_back("-Wno-module-link-redeclaration");
 
     if (ctx.ClangImporterOpts.DumpClangDiagnostics) {
       llvm::errs() << "clang importer driver args: '";


### PR DESCRIPTION
… in implicit modulemaps

https://github.com/swiftlang/llvm-project/pull/11265 broke Windows CI for rebranch because our Windows modulemaps contain implicit submodules with link declarations. This is a temporary workaround to unblock investigation on any downstream issues.