### PR TITLE
[Concurrency] Add availability to one of the ExecutorJob extensions

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -454,6 +454,7 @@ extension ExecutorJob {
 
 // Helper to create a trampoline job to execute a job on a specified
 // executor.
+@available(StdlibDeploymentTarget 6.2, *)
 extension ExecutorJob {
 
   /// Create a trampoline to enqueue the specified job on the specified


### PR DESCRIPTION
Without this, we may fail building Concurrency when enforcing strict availability.

Addresses rdar://159473855