### PR TITLE
[rbi] Make all PartitionOpErrors noncopyable types.

### DIFF
--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -90,7 +90,7 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
                                      operandToStateMap),
         failureCallback(failureCallback) {}
 
-  void handleError(PartitionOpError error) {
+  void handleError(PartitionOpError &&error) {
     switch (error.getKind()) {
     case PartitionOpError::UnknownCodePattern:
     case PartitionOpError::SentNeverSendable:
@@ -101,7 +101,7 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
     case PartitionOpError::InOutSendingReturned:
       llvm_unreachable("Unsupported");
     case PartitionOpError::LocalUseAfterSend: {
-      auto state = error.getLocalUseAfterSendError();
+      auto state = std::move(error).getLocalUseAfterSendError();
       failureCallback(*state.op, state.sentElement, state.sendingOp);
     }
     }


### PR DESCRIPTION
I am going to be adding support to passes for emitting IsolationHistory behind a flag. As part of this, we need to store the state of the partition that created the error when the error is emitted. A partition stores heap memory so it makes sense to make these types noncopyable types so we just move the heap memory rather than copying it all over the place.