### PR TITLE
[Mem2Reg] Add end_lifetime for more trivial case non-trivial enums.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2102,23 +2102,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
   }
   // There is still valid storage after visiting all instructions in this
   // block which are the only instructions involving this alloc_stack.
-  // That can only happen if:
-  // - all paths from this block end in unreachable
-
-  if (lexicalLifetimeEnsured(asi) &&
-      runningVals->value.getStored()->getOwnershipKind().isCompatibleWith(
-          OwnershipKind::Owned)) {
-    // An owned value was stored to the alloc_stack [lexical] but never
-    // destroy_addr'd.  Destroy it on the dominance boundary of the
-    // alloc_stack's parent block.
-    SmallVector<SILBasicBlock *, 4> boundary;
-    computeDominatedBoundaryBlocks(asi->getParent(), domInfo, boundary);
-    for (auto *block : boundary) {
-      auto *terminator = block->getTerminator();
-      runningVals->value.endLexicalLifetimeBeforeInstIfPossible(
-          asi, /*beforeInstruction=*/terminator, ctx);
-    }
-  }
+  // That can happen if:
+  // (1) this block is a dead-end. TODO: OSSACompleteLifetime: Complete such
+  //                                     lifetimes.
 }
 
 void MemoryToRegisters::collectStoredValues(AllocStackInst *asi,

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2214,7 +2214,8 @@ bool MemoryToRegisters::promoteAllocation(AllocStackInst *alloc,
   }
 
   // Remove write-only AllocStacks.
-  if (isWriteOnlyAllocation(alloc) && !lexicalLifetimeEnsured(alloc)) {
+  if (isWriteOnlyAllocation(alloc) && !alloc->getType().isOrHasEnum() &&
+      !lexicalLifetimeEnsured(alloc)) {
     LLVM_DEBUG(llvm::dbgs() << "*** Deleting store-only AllocStack: "<< *alloc);
     deleter.forceDeleteWithUsers(alloc);
     return true;

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -1591,3 +1591,84 @@ bb3:
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK:         [[IN:%[^,]+]] = load [copy]
+// CHECK:         [[IN_BORROW:%[^,]+]] = begin_borrow [[IN]]
+// CHECK:         switch_enum [[IN_BORROW]]
+// CHECK-SAME:        case #Result.success!enumelt: [[INT:bb[0-9]+]]
+// CHECK:       [[INT]]({{%[^,]+}} : $Int):
+// CHECK:         end_borrow [[IN_BORROW]]
+// CHECK:         end_lifetime [[IN]]
+// CHECK-LABEL: } // end sil function 'end_lifetime_at_trivial_case_dealloc_stack'
+sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack : $@convention(thin) (@in_guaranteed Result<Int, X>) -> () {
+entry(%in_addr : $*Result<Int, X>):
+  %main_addr = alloc_stack $Result<Int, X>
+  %in = load [copy] %in_addr
+  store %in to [init] %main_addr
+  %in_borrow = load_borrow %main_addr
+  switch_enum %in_borrow,
+      case #Result.success!enumelt: int,
+      case #Result.failure!enumelt: full
+
+int(%6 : $Int):
+  end_borrow %in_borrow
+  %temp = alloc_stack $Result<Int, X>
+  %in_copy = load [copy] %main_addr
+  store %in_copy to [init] %temp
+  br int2
+
+int2:
+  dealloc_stack %temp
+  br exit
+
+full(%13 : @guaranteed $X):
+  end_borrow %in_borrow
+  br exit
+
+exit:
+  destroy_addr %main_addr
+  dealloc_stack %main_addr
+  %18 = tuple ()
+  return %18
+}
+
+// CHECK-LABEL: sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack_2 : {{.*}} {
+// CHECK:       bb0([[IN_ADDR:%[^,]+]] :
+// CHECK:         [[IN_COPY:%[^,]+]] = load [copy] [[IN_ADDR]]
+// CHECK:         [[IN_BORROW:%[^,]+]] = begin_borrow [[IN_COPY]]
+// CHECK:         switch_enum [[IN_BORROW]]
+// CHECK:             case #Result.success!enumelt: [[INT:bb[0-9]+]]
+// CHECK:       [[INT]]
+// CHECK:         end_borrow [[IN_BORROW]]
+// CHECK:         end_lifetime [[IN_COPY]]
+// CHECK-LABEL: } // end sil function 'end_lifetime_at_trivial_case_dealloc_stack_2'
+sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack_2 : $@convention(thin) (@in_guaranteed Result<Int, X>) -> () {
+entry(%in_addr : $*Result<Int, X>):
+  %main_addr = alloc_stack $Result<Int, X>
+  %temp = alloc_stack $Result<Int, X>
+  %in = load [copy] %in_addr
+  store %in to [init] %main_addr
+  %in_borrow = load_borrow %main_addr
+  switch_enum %in_borrow,
+      case #Result.success!enumelt: int,
+      case #Result.failure!enumelt: x
+
+int(%int : $Int):
+  end_borrow %in_borrow
+  %in_copy = load [copy] %main_addr
+  store %in_copy to [init] %temp
+  br int2
+
+int2:
+  br exit
+
+x(%13 : @guaranteed $X):
+  end_borrow %in_borrow
+  br exit
+
+exit:
+  destroy_addr %main_addr
+  %retval = tuple ()
+  return %retval
+}

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -1669,6 +1669,45 @@ x(%13 : @guaranteed $X):
 
 exit:
   destroy_addr %main_addr
+  dealloc_stack %temp
+  dealloc_stack %main_addr
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack_3 : {{.*}} {
+// CHECK:       bb0([[IN_ADDR:%[^,]+]] :
+// CHECK:         [[IN_BORROW:%[^,]+]] = load_borrow [[IN_ADDR]]
+// CHECK:         switch_enum [[IN_BORROW]]
+// CHECK:             case #Result.success!enumelt: [[INT:bb[0-9]+]]
+// CHECK:       [[INT]]
+// CHECK:         end_borrow [[IN_BORROW]]
+// CHECK:         [[IN_COPY:%[^,]+]] = load [copy] [[IN_ADDR]]
+// CHECK:         end_lifetime [[IN_COPY]]
+// CHECK-LABEL: } // end sil function 'end_lifetime_at_trivial_case_dealloc_stack_3'
+sil [ossa] @end_lifetime_at_trivial_case_dealloc_stack_3 : $@convention(thin) (@in_guaranteed Result<Int, X>) -> () {
+entry(%in_addr : $*Result<Int, X>):
+  %in_borrow = load_borrow %in_addr
+  switch_enum %in_borrow,
+      case #Result.success!enumelt: int,
+      case #Result.failure!enumelt: x
+
+int(%int : $Int):
+  end_borrow %in_borrow
+  %temp = alloc_stack $Result<Int, X>
+  %in_copy = load [copy] %in_addr
+  store %in_copy to [init] %temp
+  dealloc_stack %temp
+  br int2
+
+int2:
+  br exit
+
+x(%13 : @guaranteed $X):
+  end_borrow %in_borrow
+  br exit
+
+exit:
   %retval = tuple ()
   return %retval
 }


### PR DESCRIPTION
Handle both write-only and single-block allocations the same way as the rest: destroying the value at its liveness boundary.  Clean up a few other things while we're here.

rdar://158139991
