### PR TITLE
Fill in two missing functions for Embedded Swift

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -149,6 +149,13 @@ func alignedAlloc(size: Int, alignment: Int) -> UnsafeMutableRawPointer? {
   return unsafe r
 }
 
+@_cdecl("swift_coroFrameAlloc")
+public func swift_coroFrameAlloc(_ size: Int, _ type: UInt) -> UnsafeMutableRawPointer? {
+  return unsafe alignedAlloc(
+    size: size,
+    alignment: _swift_MinAllocationAlignment)
+}
+
 @_cdecl("swift_slowAlloc")
 public func swift_slowAlloc(_ size: Int, _ alignMask: Int) -> UnsafeMutableRawPointer? {
   let alignment: Int
@@ -176,6 +183,14 @@ func swift_allocObject(metadata: UnsafeMutablePointer<ClassMetadata>, requiredSi
   unsafe _swift_embedded_set_heap_object_metadata_pointer(object, metadata)
   unsafe object.pointee.refcount = 1
   return unsafe object
+}
+
+@_cdecl("swift_deallocUninitializedObject")
+public func swift_deallocUninitializedObject(object: Builtin.RawPointer, allocatedSize: Int, allocatedAlignMask: Int) {
+  unsafe swift_deallocObject(
+    object: UnsafeMutablePointer<HeapObject>(object),
+    allocatedSize: allocatedSize,
+    allocatedAlignMask: allocatedAlignMask)
 }
 
 @_cdecl("swift_deallocObject")

--- a/test/embedded/accessors.swift
+++ b/test/embedded/accessors.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -Onone -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+public class C {
+  public var x: Int {
+    _read {
+      yield(y)
+    }
+    _modify {
+      yield(&y)
+    }
+  }
+
+  var y: Int = 27
+}
+
+@main
+struct Main {
+  static func main() {
+    print("1") // CHECK: 1
+    let c = C() // CHECK: 27
+    print(c.y)
+    c.y = 28
+    print(c.y) // CHECK: 28
+    print("")
+
+    print("2") // CHECK: 2
+    print("")
+  }
+}

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -8,6 +8,10 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 
+
+
+func f() -> Bool? { return nil }
+
 public class MyClass {
   var handler: (()->())? = nil
   func foo() {
@@ -32,5 +36,12 @@ struct Main {
     o!.foo() // CHECK: capture local
     print(local == 43 ? "43" : "???") // CHECK: 43
     o = nil // CHECK: deinit
+
+    let closure = {
+         guard var b = f() else { print("success"); return }
+         let c = { b = true }
+         _ = (b, c)
+    }
+    closure()   // CHECK: success
   }
 }


### PR DESCRIPTION
`swift_coroFrameAlloc` is needed by `_read`/`_modify` accessors

`swift_deallocUninitializedObject` is needed for certain closure captures

Resolves rdar://157028375
Resolves rdar://157276375