### PR TITLE
build.ps1: remove some unnecessary flags

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1868,11 +1868,7 @@ function Build-SPMProject {
     $Arguments = @(
       "--scratch-path", $Bin,
       "--package-path", $Src,
-      "-c", $Configuration,
-      "-Xbuild-tools-swiftc", "-I${env:SDKROOT}\usr\lib\swift",
-      "-Xbuild-tools-swiftc", "-L${env:SDKROOT}\usr\lib\swift\windows",
-      "-Xcc", "-I${env:SDKROOT}\usr\lib\swift",
-      "-Xlinker", "-L${env:SDKROOT}\usr\lib\swift\windows"
+      "-c", $Configuration
     )
     if ($DebugInfo) {
       if ($Platform.OS -eq [OS]::Windows -and $SwiftDebugFormat -eq "codeview") {


### PR DESCRIPTION
Adjust the build to remove some flags for `swift build` that are no longer necessary now that we stage the toolchain better and setup the environment, we can simplify the build.
