### PR TITLE
Include remarks in SourceKit diagnostics responses

### DIFF
--- a/test/SourceKit/Diagnostics/remarks.swift
+++ b/test/SourceKit/Diagnostics/remarks.swift
@@ -1,0 +1,15 @@
+// RUN: env %sourcekitd-test -req=diags %s -- %s -Xfrontend -Rmodule-api-import | %FileCheck %s
+public typealias Foo = String
+
+// CHECK:      {
+// CHECK-NEXT:   key.diagnostics: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:       key.line: 2,
+// CHECK-NEXT:       key.column: 24,
+// CHECK-NEXT:       key.filepath: "{{.*}}",
+// CHECK-NEXT:       key.severity: source.diagnostic.severity.remark,
+// CHECK-NEXT:       key.id: "module_api_import",
+// CHECK-NEXT:       key.description: "struct 'String' is imported via 'Swift'"
+// CHECK-NEXT:   }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -213,7 +213,8 @@ struct FilterRule {
 
 enum class DiagnosticSeverityKind {
   Warning,
-  Error
+  Error,
+  Remark
 };
 
 enum class DiagnosticCategory {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -147,18 +147,11 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   if (Info.ID == diag::lex_editor_placeholder.ID ||
       Info.ID == diag::oslog_invalid_log_message.ID)
     return;
-
   bool IsNote = (Info.Kind == DiagnosticKind::Note);
 
   if (IsNote && !haveLastDiag())
     // Is this possible?
     return;
-
-  if (Info.Kind == DiagnosticKind::Remark) {
-    // FIXME: we may want to handle optimization remarks in sourcekitd.
-    LOG_WARN_FUNC("unhandled optimization remark");
-    return;
-  }
 
   DiagnosticEntryInfo SKInfo;
 
@@ -237,7 +230,6 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
     getLastDiag().Notes.push_back(std::move(SKInfo));
     return;
   }
-
   switch (Info.Kind) {
   case DiagnosticKind::Error:
     SKInfo.Severity = DiagnosticSeverityKind::Error;
@@ -245,8 +237,10 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   case DiagnosticKind::Warning:
     SKInfo.Severity = DiagnosticSeverityKind::Warning;
     break;
-  case DiagnosticKind::Note:
   case DiagnosticKind::Remark:
+    SKInfo.Severity = DiagnosticSeverityKind::Remark;
+    break;
+  case DiagnosticKind::Note:
     llvm_unreachable("already covered");
   }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -4057,12 +4057,16 @@ fillDictionaryForDiagnosticInfo(ResponseBuilder::Dictionary Elem,
   UIdent SeverityUID;
   static UIdent UIDKindDiagWarning(KindDiagWarning.str());
   static UIdent UIDKindDiagError(KindDiagError.str());
+  static UIdent UIDKindDiagRemark(KindDiagRemark.str());
   switch (Info.Severity) {
   case DiagnosticSeverityKind::Warning:
     SeverityUID = UIDKindDiagWarning;
     break;
   case DiagnosticSeverityKind::Error:
     SeverityUID = UIDKindDiagError;
+    break;
+  case DiagnosticSeverityKind::Remark:
+    SeverityUID = UIDKindDiagRemark;
     break;
   }
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -477,6 +477,7 @@ UID_KINDS = [
     KIND('DiagNote', 'source.diagnostic.severity.note'),
     KIND('DiagWarning', 'source.diagnostic.severity.warning'),
     KIND('DiagError', 'source.diagnostic.severity.error'),
+    KIND('DiagRemark', 'source.diagnostic.severity.remark'),
     KIND('DiagDeprecation', 'source.diagnostic.category.deprecation'),
     KIND('DiagNoUsage', 'source.diagnostic.category.no_usage'),
     KIND('CodeCompletionEverything', 'source.codecompletion.everything'),


### PR DESCRIPTION
Remarks are increasingly used as a way of allowing users to additional opt-in information about a compile, and it makes sense to make this information available to clients of SourceKit as well.