### PR TITLE
[test] Adjust IRGen test to succeed both on main and rebranch

### DIFF
--- a/test/IRGen/inline_array_enum_tags.swift
+++ b/test/IRGen/inline_array_enum_tags.swift
@@ -10,8 +10,8 @@ public struct Bar {
     let y: [UInt64]
 }
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias nocapture readonly %value, ptr nocapture readnone %Baz)
-// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds i8, ptr %value, {{i64|i32}} 24
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias{{( nocapture)?}} readonly{{( captures\(none\))?}} %value, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %Baz)
+// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 24
 // CHECK:   [[TAG_VAL:%.*]] = load i8, ptr [[TAG_ADDR]], align 8
 // CHECK:   [[TAG_EXT:%.*]] = zext i8 [[TAG_VAL]] to i32
 // CHECK:   ret i32 [[TAG_EXT]]
@@ -27,9 +27,9 @@ public struct Padded {
 }
 
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias nocapture readonly %value, ptr nocapture readnone %WithPaddedPayload)
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias{{( nocapture)?}} readonly{{( captures\(none\))?}} %value, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %WithPaddedPayload)
 // CHECK: entry:
-// CHECK:   [[ADDR:%.*]] = getelementptr inbounds i8, ptr %value, {{i64|i32}} 8
+// CHECK:   [[ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 8
 // CHECK:   [[VAL:%.*]] = load {{i64|i32}}, ptr [[ADDR]], align 8
 // CHECK:   [[TAG:%.*]] = lshr i32 {{%.*}}, 31
 // CHECK:   ret i32 [[TAG]]


### PR DESCRIPTION
* `getelementptr inbounds` -> `getelementptr inbounds nuw`. This attribute was introduced in https://github.com/llvm/llvm-project/pull/107257 (llvm-project). Match it using a wildcard regex, since it is irrelevant to this test.
* Both the syntax and relative order of the LLVM `nocapture` parameter attribute changed in https://github.com/llvm/llvm-project/pull/123181. Adjust the FileCheck patterns to expect both syntaxes/orders. This change is temporary and will be cleaned up once rebranch is merged into main.
