### PR TITLE
[presets] Escalate `uninitialized` warnings to errors in macOS smoke test

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6808,7 +6808,7 @@ TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   // Handle contextual type, result type, and returnsSelf.
   Type contextType = afd->getDeclContext()->getDeclaredInterfaceType();
   Type resultType;
-  bool returnsSelf;
+  bool returnsSelf = false;
 
   if (auto func = dyn_cast<FuncDecl>(afd)) {
     resultType = func->getResultInterfaceType();

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -681,7 +681,7 @@ enable-new-runtime-build
 
 # Escalate certain C++ warnings to errors for Swift.
 extra-swift-cmake-options=
-   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused"
+   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized"
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx


### PR DESCRIPTION
See https://clang.llvm.org/docs/DiagnosticsReference.html#wuninitialized.