### PR TITLE
[cxx-interop] Do not consider function types fragile

### DIFF
--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
@@ -39,6 +39,9 @@ struct CStruct {
 }
 #endif
 
+typedef void (*my_sighandler_t)(int);
+typedef void (*my_other_cb)(CxxStruct);
+
 //--- test.swift
 
 import CxxModule
@@ -54,4 +57,10 @@ public func useCxxEnum(_ x: CxxEnum) { // expected-error {{cannot use enum 'CxxE
 
 // expected-error@+1 {{cannot use struct 'CxxStruct' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 public func usesCxxStruct(_ x: CxxStruct) {
+}
+
+public func usesTypeAliasToFuncPtr(_ x: my_sighandler_t) {
+}
+
+public func usesTypeAliasToFuncPtr2(_ x: my_other_cb) { // expected-error {{cannot use type alias 'my_other_cb' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 }


### PR DESCRIPTION
We can refer to these types in resilient interfaces when compiled in ObjC interop mode.