### PR TITLE
[Reflection] Fix task reflection to strip signed pointers.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1857,7 +1857,10 @@ private:
           RemoteAddress(RecordObj->Parent, RemoteAddress::DefaultAddressSpace);
     }
 
-    const auto TaskResumeContext = AsyncTaskObj->ResumeContextAndReserved[0];
+    const auto TaskResumeContext = stripSignedPointer(
+      RemoteAddress(AsyncTaskObj->ResumeContextAndReserved[0],
+                    RemoteAddress::DefaultAddressSpace)
+    ).getRawAddress();
     Info.ResumeAsyncContext = TaskResumeContext;
 
     // Walk the async backtrace.


### PR DESCRIPTION
The task resume context may be signed, so we should strip the pointer before trying to read through it.

rdar://158728756
