### PR TITLE
[git-clang-format-all] Apply fixup commits one at a time.

### DIFF
--- a/utils/git-clang-format-all.zsh
+++ b/utils/git-clang-format-all.zsh
@@ -65,14 +65,12 @@ for commit in "${COMMITS[@]}"; do
     echo "Processing commit: $commit ($(git log --oneline -1 $commit))"
     
     if ! git-clang-format "${commit}^" >/dev/null ; then
-        echo "    Committed fixup commit with formatting changes"
+        echo "    Formatting required"
         git commit --quiet -a --fixup "${commit}"
+        git -c sequence.editor=: rebase -i --autosquash --quiet "${commit}^"
     else
         echo "    No formatting changes needed"
     fi
 done
-
-echo "Squashing fixup commits using git rebase autosquash"
-git -c sequence.editor=: rebase -i --autosquash --quiet "${TARGET_HASH}^"
 
 echo "All commits formatted successfully"


### PR DESCRIPTION
I discovered while using this locally that it is possible to get a series of rebased commits that cause the rebase to failure. The problem goes away when one applies the changes one at a time rather than all at once. This is also just a more robust way to do this since we are not relying on git-clang-format's hunk logic and git's rebase hunk logic to be in sync.
