### PR TITLE
[test] Prototypes/HypoArray: Don’t force test into Swift 6 mode

### DIFF
--- a/test/Prototypes/Hypoarray.swift
+++ b/test/Prototypes/Hypoarray.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 6 -o %t/a.out %s
+// RUN: %target-build-swift -o %t/a.out %s
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test


### PR DESCRIPTION
The goal of this test is to exercise some `~Copyable` features, and those are supposed to work in all language modes. The prototype also opted into Swift 6 language mode, but it appears StdlibUnittest is not quite ready for that. For instance, it results in `MainActor` references in test closures (presumably due to StdlibUnittest's use of global variables) that appear to cause back deployment trouble.

rdar://159026079

