### PR TITLE
CMake: Runtime: Extract runtime version number

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -43,23 +43,16 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 
 set(SwiftCore_CMAKE_MODULES_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
-list(APPEND CMAKE_MODULE_PATH ${SwiftCore_CMAKE_MODULES_DIR})
+list(APPEND CMAKE_MODULE_PATH
+  ${SwiftCore_CMAKE_MODULES_DIR}
+  "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 include(CMakeWorkarounds)
-# NOTE: always use the 3-component style as the expansion as
-# `${PROJECT_VERSION}` will not extend this to the complete form and this can
-# change the behaviour for comparison with non-SemVer compliant parsing. If
-# possible, use the 4-version component as that is used to differentiate the
-# builds of the runtime for Windows.
-if($ENV{BUILD_NUMBER})
-  # NOTE: SxS modules have a limit on each component being [0-65535].
-  # https://learn.microsoft.com/en-us/windows/win32/sbscs/assembly-versions
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+
+include(SwiftProjectVersion)
 project(SwiftCore
   LANGUAGES C CXX Swift
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 # The Swift standard library is not intended for use as a sub-library as part of
 # another project. It is tightly coupled with the compiler version.

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -10,26 +10,18 @@ set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-# NOTE: always use the 3-component style as the expansion as
-# `${PROJECT_VERSION}` will not extend this to the complete form and this can
-# change the behaviour for comparison with non-SemVer compliant parsing. If
-# possible, use the 4-version component as that is used to differentiate the
-# builds of the runtime for Windows.
-if($ENV{BUILD_NUMBER})
-  # NOTE: SxS modules have a limit on each component being [0-65535].
-  # https://learn.microsoft.com/en-us/windows/win32/sbscs/assembly-versions
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+include(SwiftProjectVersion)
 project(SwiftOverlay
   LANGUAGES C CXX Swift
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 set(CMAKE_Swift_LANGUAGE_VERSION 5)
 

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -9,13 +9,14 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftDifferentiation
   LANGUAGES Swift C
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Differentiation must build as a standalone project")
@@ -23,8 +24,6 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 set(CMAKE_Swift_LANGUAGE_VERSION 5)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -9,13 +9,14 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftDistributed
   LANGUAGES C CXX Swift
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Distributed must build as a standalone project")
@@ -33,8 +34,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 
 set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -9,13 +9,14 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftObservation
   LANGUAGES Swift CXX
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Observation must build as a standalone project")
@@ -25,8 +26,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -9,21 +9,21 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftStringProcessing
   LANGUAGES Swift C
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(FATAL_ERROR "Swift StringProcessing must build as a standalone project")
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -9,13 +9,15 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftSynchronization
   LANGUAGES Swift
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
+
 # FIXME(compnerd) this is a workaround for `GNUInstallDirs` which cannot be used
 # with a pure Swift project.
 enable_language(C)
@@ -25,8 +27,6 @@ if(NOT PROJECT_IS_TOP_LEVEL)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/Supplemental/Volatile/CMakeLists.txt
+++ b/Runtimes/Supplemental/Volatile/CMakeLists.txt
@@ -9,13 +9,15 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
-if($ENV{BUILD_NUMBER})
-  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
-  set(BUILD_NUMBER ".${BUILD_NUMBER}")
-endif()
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
 project(SwiftVolatile
   LANGUAGES Swift
-  VERSION 6.3.0${BUILD_NUMBER})
+  VERSION ${SWIFT_RUNTIME_VERSION})
+
 # FIXME(compnerd) this is a workaround for `GNUInstallDirs` which cannot be used
 # with a pure Swift project.
 enable_language(C)
@@ -23,8 +25,6 @@ enable_language(C)
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Observation must build as a standalone project")
 endif()
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"

--- a/Runtimes/cmake/modules/SwiftProjectVersion.cmake
+++ b/Runtimes/cmake/modules/SwiftProjectVersion.cmake
@@ -1,0 +1,23 @@
+# This module sets the Swift version number variable consistently across the
+# Swift runtime projects.
+
+## Result Variable
+#
+# ``SWIFT_RUNTIME_VERSION``
+#   The computed version number applied to apply to the project.
+#   If ``SWIFT_RUNTIME_VERSION`` is set prior to entering the module, the version
+#   is not modified.
+
+block(PROPAGATE SWIFT_RUNTIME_VERSION)
+  if(SWIFT_RUNTIME_VERSION)
+    return()
+  endif()
+
+  if($ENV{BUILD_NUMBER})
+    # Microsoft build numbers limit each version number component to [0 - 65535]
+    # https://learn.microsoft.com/en-us/windows/win32/sbscs/assembly-versions
+    math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
+    set(BUILD_NUMBER ".${BUILD_NUMBER}")
+  endif()
+  set(SWIFT_RUNTIME_VERSION 6.3.0${BUILD_NUMBER})
+endblock()


### PR DESCRIPTION
This extracts the version number computation out into a separate module to be shared between the runtimes.
Setting `SWIFT_RUNTIME_VERSION` allows external build orchestration tools to override the version number specified in source if necessary, while centralizing the location of the default version number across the runtime libraries.