### PR TITLE
[demangling] make printGenericSignature virtual

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -949,7 +949,7 @@ protected:
 
   void printImplFunctionType(NodePointer fn, unsigned depth);
 
-  void printGenericSignature(NodePointer Node, unsigned depth);
+  virtual void printGenericSignature(NodePointer Node, unsigned depth);
 
   void printFunctionSigSpecializationParams(NodePointer Node, unsigned depth);
 


### PR DESCRIPTION
(cherry picked from commit 6324f203186a9d55c043a22cbde8300381620584)

This is needed to unblock the bots after some automerger shenanigans.