### PR TITLE
[TypeChecker] Avoid checking lazy property accessors if they haven't …

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -402,3 +402,7 @@ extension PublicStruct {
     lhs = rhs
   }
 }
+
+public class LazyPropertyWithClosureType {
+  public lazy var lazyVar: Int = { 2 }()
+}

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -142,3 +142,8 @@ func testOperators() {
   var a: PublicStruct
   a <<< PublicStruct(x: 2)
 }
+
+func testLazyPropertyWithInitClosureReference(t: LazyPropertyWithClosureType) {
+  _ = t.lazyVar
+  t.lazyVar = 42
+}


### PR DESCRIPTION
…been synthesized yet

Ttheir availability is going to match the property itself. This is a workaround for lazy type-checking because synthesis of accessors for such properties requires a reference to `self` which won't be available because pattern binding for the variable was skipped.

Resolves: rdar://129359362
Resolves: rdar://159463230
Resolves: https://github.com/swiftlang/swift/issues/84041

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
