### PR TITLE
[Concurrency/Distributed] ensure distributed thunks are @concurrent

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -737,8 +737,11 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
-  // TODO(distributed): These would benefit from becoming nonisolated(nonsending)
   thunk->getAttrs().add(NonisolatedAttr::createImplicit(C));
+  // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
+  //                    this way we would not hop off the caller when calling system.remoteCall;
+  //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
+  thunk->getAttrs().add(new (C) ConcurrentAttr(/*IsImplicit=*/true));
 
   return thunk;
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5212,13 +5212,6 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
     if (decl->getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
       if (auto *value = dyn_cast<ValueDecl>(decl)) {
-        // TODO(distributed): make distributed thunks nonisolated(nonsending) and remove this if
-        if (value->isAsync() && value->isDistributedThunk()) {
-          // don't change isolation of distributed thunks until we make them nonisolated(nonsending),
-          // since the runtime calling them assumes they're just nonisolated right now.
-          return ActorIsolation::forNonisolated(nonisolatedAttr->isUnsafe());
-        }
-
         if (value->isAsync() &&
             value->getModuleContext() == decl->getASTContext().MainModule) {
           return ActorIsolation::forCallerIsolationInheriting();

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip_nonisolated_nonsending_by_default.swift
@@ -33,12 +33,20 @@ distributed actor Greeter: CustomStringConvertible {
     return "Echo: \(name) (impl on: \(self.id))"
   }
 
-  distributed func error() throws -> String {
-    throw SomeError()
-  }
-
   nonisolated var description: String {
     "\(Self.self)(\(id))"
+  }
+}
+
+extension Greeter {
+  distributed func echoInExtension(name: String) -> String {
+    return "Echo: \(name) (impl on: \(self.id))"
+  }
+}
+
+nonisolated extension Greeter {
+  distributed func echoInNonisolatedExtension(name: String) -> String {
+    return "Echo: \(name) (impl on: \(self.id))"
   }
 }
 
@@ -64,6 +72,12 @@ func test() async throws {
 
   print("got: \(reply)")
   // CHECK: got: Echo: Caplin (impl on: ActorAddress(address: "<unique-id>"))
+
+  // just double check there's no surprises with distributed thunks in extensions
+  _ = try await ref.echoInExtension(name: "Bob")
+  _ = try await ref.echoInNonisolatedExtension(name: "Alice")
+
+  print("OK") // CHECK: OK
 }
 
 @main struct Main {


### PR DESCRIPTION
Otherwise the "nonisolated nonsending by default" mode blows up as
distributed thunk signatures dont match expectations.

This is a follow up from https://github.com/swiftlang/swift/pull/83940

And solves the issue by instead adjusting the synthesis side of the distributed thunks,
such that they are `@concurrent` always -- which keeps their old semantics
basically, regardless of what "default" mode we have.


Resolves rdar://159247975