### PR TITLE
[6.2][cxx-interop] Do not define inherited copy/move operations

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2991,7 +2991,9 @@ namespace {
                             usingShadowDecl)) {
                   auto baseCtorDecl = dyn_cast<clang::CXXConstructorDecl>(
                       ctorUsingShadowDecl->getTargetDecl());
-                  if (!baseCtorDecl || baseCtorDecl->isDeleted())
+                  if (!baseCtorDecl || baseCtorDecl->isDeleted() ||
+                      baseCtorDecl->isCopyConstructor() ||
+                      baseCtorDecl->isMoveConstructor())
                     continue;
                   auto loc = ctorUsingShadowDecl->getLocation();
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -48,8 +48,6 @@
 // CHECK-NEXT: }
 
 // CHECK:      public struct UsingBaseConstructorWithParam {
-// CHECK-NEXT:   public init(consuming _: consuming IntBox)
-// CHECK-NEXT:   public init(_: IntBox)
 // CHECK-NEXT:   public init(_: UInt32)
 // CHECK-NEXT:   public init(_: Int32)
 // CHECK-NEXT:   public var value: Int32
@@ -57,8 +55,6 @@
 
 // CHECK:      public struct UsingBaseConstructorEmpty {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public init(consuming _: consuming Empty)
-// CHECK-NEXT:   public init(_: Empty)
 // CHECK-NEXT:   public var value: Int32
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -115,6 +115,43 @@ namespace NS {
     }
 }
 
+namespace rdar153081347 {
+namespace Detail {
+template<typename T>
+class SWIFT_NONESCAPABLE Span {
+public:
+   constexpr Span() = default;
+   constexpr Span(T* p [[clang::lifetimebound]], unsigned long s) : m_ptr(p), m_size(s) {}
+
+   template<unsigned long size>
+   constexpr Span(T (&a)[size]) : m_ptr(a), m_size(size) {}
+protected:
+  T* m_ptr { nullptr };
+  unsigned long m_size { 0 };
+};
+} // namespace Detail
+
+template <typename T>
+class SWIFT_NONESCAPABLE Span : public Detail::Span<T> {
+public:
+  using Detail::Span<T>::Span;
+
+  constexpr Span() = default;
+
+  constexpr T const* data() const { return this->m_ptr; }
+  constexpr T* data() { return this->m_ptr; }
+
+  constexpr unsigned long size() const { return this->m_size; }
+
+};
+
+template<typename T>
+using ReadonlySpan = Span<T const>;
+
+using ReadonlyBytes = ReadonlySpan<unsigned char>;
+using Bytes = Span<unsigned char>;
+} // namespace rdar153081347
+
 // CHECK: sil [clang makeOwner] {{.*}}: $@convention(c) () -> Owner
 // CHECK: sil [clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow address_for_deps 0) @owned View
 // CHECK: sil [clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow address_for_deps 0) @owned View
@@ -157,3 +194,5 @@ public func test() {
 public func test2(_ x: AggregateView) {
     let _ = AggregateView(member: x.member)
 }
+
+func testInheritedCtors(_ s: rdar153081347.Bytes) {}


### PR DESCRIPTION
Explanationi: When inheriting constructors, we define the inherited ctors in the derived class. We should not do that for copy and move operations as these operations can never be invoked (the implicit/defined/deleted ctor in the derived class always takes precedence). This fixes an issue where the lifetime parameters are not getting inferred for these spurious constructor definitions. This should also save us from doing some redundant work in the importer.
Issues: rdar://153081347
Original PRs: #83694
Risk: Low, we do not import some ctors that can never be called.
Testing: Added a compiler test.
Reviewers: @egorzhdan