### PR TITLE
[update-checkout] add a check for locked repositories

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -169,10 +169,11 @@ def setup_mock_remote(base_dir, base_config):
 
 BASEDIR_ENV_VAR = 'UPDATECHECKOUT_TEST_WORKSPACE_DIR'
 CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+UPDATE_CHECKOUT_EXECUTABLE = 'update-checkout.cmd' if os.name == 'nt' else 'update-checkout'
 UPDATE_CHECKOUT_PATH = os.path.abspath(os.path.join(CURRENT_FILE_DIR,
                                                     os.path.pardir,
                                                     os.path.pardir,
-                                                    'update-checkout'))
+                                                    UPDATE_CHECKOUT_EXECUTABLE))
 
 
 class SchemeMockTestCase(unittest.TestCase):

--- a/utils/update_checkout/tests/test_locked_repository.py
+++ b/utils/update_checkout/tests/test_locked_repository.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+
+from update_checkout.update_checkout import _is_any_repository_locked
+
+class TestIsAnyRepositoryLocked(unittest.TestCase):
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_repository_with_lock_file(self, mock_listdir, mock_isdir, mock_exists):
+        pool_args = [
+            ("/fake_path", None, "repo1"),
+            ("/fake_path", None, "repo2"),
+        ]
+
+        def listdir_side_effect(path):
+            if "repo1" in path:
+                return ["index.lock", "config"]
+            elif "repo2" in path:
+                return ["HEAD", "config"]
+            return []
+
+        mock_exists.return_value = True
+        mock_isdir.return_value = True
+        mock_listdir.side_effect = listdir_side_effect
+
+        result = _is_any_repository_locked(pool_args)
+        self.assertEqual(result, {"repo1"})
+
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_repository_without_git_dir(self, mock_listdir, mock_isdir, mock_exists):
+        pool_args = [
+            ("/fake_path", None, "repo1"),
+        ]
+
+        mock_exists.return_value = False
+        mock_isdir.return_value = False
+        mock_listdir.return_value = []
+
+        result = _is_any_repository_locked(pool_args)
+        self.assertEqual(result, set())
+
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_repository_with_git_file(self, mock_listdir, mock_isdir, mock_exists):
+        pool_args = [
+            ("/fake_path", None, "repo1"),
+        ]
+
+        mock_exists.return_value = True
+        mock_isdir.return_value = False
+        mock_listdir.return_value = []
+
+        result = _is_any_repository_locked(pool_args)
+        self.assertEqual(result, set())
+
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_repository_with_multiple_lock_files(self, mock_listdir, mock_isdir, mock_exists):
+        pool_args = [
+            ("/fake_path", None, "repo1"),
+        ]
+
+        mock_exists.return_value = True
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ["index.lock", "merge.lock", "HEAD"]
+
+        result = _is_any_repository_locked(pool_args)
+        self.assertEqual(result, {"repo1"})
+
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_repository_with_no_lock_files(self, mock_listdir, mock_isdir, mock_exists):
+        pool_args = [
+            ("/fake_path", None, "repo1"),
+        ]
+
+        mock_exists.return_value = True
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ["HEAD", "config", "logs"]
+
+        result = _is_any_repository_locked(pool_args)
+        self.assertEqual(result, set())
+


### PR DESCRIPTION
This patch adds a check for locked repositories in `update_checkout`.

If a repository is locked by another program (or if a `.lock` file was not properly deleted by `git`), `update_checkout` will hang on a random repository. The error message will be spread across multiple cloning logs.

Before running the `update` part of `update-checkout`, we check if there is any locked repository and prompt the user to fix the issue before returning early. If `libxml2` is locked:

```
C:\S>python "C:\S\swift\utils\\update-checkout" --reset-to-remote --scheme main --skip-repository llvm-project
+ pushd 'C:\S\swift'
+ popd
Skipping update of 'llvm-project', requested by user
======UPDATE FAILURES======
'libxml2' is locked by git. Cannot update it.
update-checkout failed, fix errors and try again
```

The added tests were ran at desk.

rdar://159749530