### PR TITLE
[6.2][cxx-interop] Fix import virtual methods with rvalue ref params

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2168,11 +2168,18 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
   for (size_t i = 0; i < newMethod->getNumParams(); ++i) {
     auto *param = newMethod->getParamDecl(i);
     auto type = param->getType();
-    if (type->isReferenceType())
-      type = type->getPointeeType();
-    args.push_back(new (clangCtx) clang::DeclRefExpr(
-        clangCtx, param, false, type, clang::ExprValueKind::VK_LValue,
-        clang::SourceLocation()));
+    clang::Expr *argExpr = new (clangCtx) clang::DeclRefExpr(
+        clangCtx, param, false, type.getNonReferenceType(),
+        clang::ExprValueKind::VK_LValue, clang::SourceLocation());
+    if (type->isRValueReferenceType()) {
+      argExpr = clangSema
+                    .BuildCXXNamedCast(
+                        clang::SourceLocation(), clang::tok::kw_static_cast,
+                        clangCtx.getTrivialTypeSourceInfo(type), argExpr,
+                        clang::SourceRange(), clang::SourceRange())
+                    .get();
+    }
+    args.push_back(argExpr);
   }
   auto memberCall = clangSema.BuildCallExpr(
       nullptr, memberExpr, clang::SourceLocation(), args,

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -68,3 +68,8 @@ module Printed {
   header "printed.h"
   requires cplusplus
 }
+
+module VirtMethodWithRvalRef {
+  header "virtual-methods-with-rvalue-reference.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-with-rvalue-reference.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-with-rvalue-reference.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "swift/bridging"
+
+class CxxForeignRef;
+
+void retain(CxxForeignRef * obj);
+void release(CxxForeignRef * obj);
+
+struct NonTrivial {
+  NonTrivial(const NonTrivial &other);
+  ~NonTrivial();
+};
+
+class CxxForeignRef {
+public:
+  CxxForeignRef(const CxxForeignRef &) = delete;
+  CxxForeignRef() = default;
+
+  virtual void takesRValRef(NonTrivial &&);
+} SWIFT_SHARED_REFERENCE(retain, release);
+

--- a/test/Interop/Cxx/foreign-reference/reference-in-virtual-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-in-virtual-methods.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging %s -cxx-interoperability-mode=default -disable-availability-checking
+
+import VirtMethodWithRvalRef
+
+func f(_ x: CxxForeignRef, _ y: NonTrivial) {
+    x.takesRValRef(consuming: y)
+}


### PR DESCRIPTION
Explanation: We generate forwarding calls for virutal methods. These forwarding calls had a type error when the original parameter had an rvalue reference type. In those scenarios we need to insert a static cast to make the type checker happy. Issues: rdar://154969620
Original PRs: #83453
Risk: Low, narrow fix.
Testing: Added a compiler test.
Reviewers: @egorzhdan