### PR TITLE
[update-checkout] lower the default number of parallel processes

### DIFF
--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -46,11 +46,13 @@ class ParallelRunner:
         pool_args: List[Union[RunnerArguments, AdditionalSwiftSourcesArguments]],
         n_processes: int = 0,
     ):
-        self._monitor_polling_period = 0.1
         if n_processes == 0:
-            n_processes = cpu_count() * 2
-        self._terminal_width = shutil.get_terminal_size().columns
+            # Limit the number of processes as the performance regresses after
+            # if the number is too high.
+            n_processes = min(cpu_count() * 2, 16)
         self._n_processes = n_processes
+        self._monitor_polling_period = 0.1
+        self._terminal_width = shutil.get_terminal_size().columns
         self._pool_args = pool_args
         self._fn = fn
         self._pool = Pool(processes=self._n_processes)


### PR DESCRIPTION
This patch caps the maximum number of parallel processes in update-checkout to 16.

This has the side effect of fixing an issue on Windows on systems with >= 16 CPU cores:

The implementation of `multiprocessing.Pool` in Python uses [`WaitForMultipleObjects`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects) on Windows. The maximum value of processes this function can take is capped by `MAXIMUM_WAIT_OBJECTS`, which is 64.

This avoids `Pool` to throw on Windows on systems with a high number of CPU cores (a 16 cores CPU will encounter this error).

rdar://159749646