### PR TITLE
[cxx-interop] Test initializing foreign reference type when passed by parameter

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/pass-as-parameter.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/pass-as-parameter.h
@@ -14,3 +14,7 @@ inline int extractValueFromRefToPtr(IntBox *&b) { return b->value; }
 inline int extractValueFromRefToConstPtr(IntBox const *&b) { return b->value; }
 inline int extractValueFromConstRefToPtr(IntBox *const &b) { return b->value; }
 inline int extractValueFromConstRefToConstPtr(IntBox const *const &b) { return b->value; }
+
+inline void initializeByPtr(int value, IntBox **b) {
+  *b = IntBox::create(value);
+}

--- a/test/Interop/Cxx/foreign-reference/pass-as-parameter-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pass-as-parameter-module-interface.swift
@@ -7,3 +7,5 @@
 // CHECK: func extractValueFromRefToConstPtr(_ b: inout IntBox!) -> Int32
 // CHECK: func extractValueFromConstRefToPtr(_ b: IntBox!) -> Int32
 // CHECK: func extractValueFromConstRefToConstPtr(_ b: IntBox!) -> Int32
+
+// CHECK: func initializeByPtr(_ value: Int32, _ b: UnsafeMutablePointer<IntBox?>!)

--- a/test/Interop/Cxx/foreign-reference/pass-as-parameter.swift
+++ b/test/Interop/Cxx/foreign-reference/pass-as-parameter.swift
@@ -53,4 +53,10 @@ PassAsParameterTestSuite.test("pass as const reference to const pointer") {
   expectEqual(aValue, 789)
 }
 
+PassAsParameterTestSuite.test("initialize by pointer") {
+  var a: IntBox!
+  initializeByPtr(987, &a)
+  expectEqual(a.value, 987)
+}
+
 runAllTests()


### PR DESCRIPTION
This only adds a test.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
