### PR TITLE
FreeBSD: Disable driver/filelists.swift test

### DIFF
--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -1,3 +1,7 @@
+// This test is flaky on FreeBSD. The compiler is occasionally killed.
+// rdar://159456203
+// UNSUPPORTED: OS=freebsd
+
 // UNSUPPORTED: OS=windows-msvc
 // RUN: %empty-directory(%t)
 // RUN: touch %t/a.swift %t/b.swift %t/c.swift


### PR DESCRIPTION
This test is flaky and creates noise. The compiler is occasionally killed for some reason.

rdar://159456203