### PR TITLE
LifetimeDependenceDiagnostics: check for on-stack trivial copies

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -381,7 +381,29 @@ extension LifetimeDependence.Scope {
   }
 }
 
+// Scope helpers.
 extension LifetimeDependence.Scope {
+  // If the LifetimeDependenceScope is .initialized, then return the alloc_stack.
+  var allocStackInstruction: AllocStackInst? {
+    switch self {
+    case let .initialized(initializer):
+      switch initializer {
+      case let .store(initializingStore: store, initialAddress):
+        if let allocStackInst = initialAddress as? AllocStackInst {
+          return allocStackInst
+        }
+        if let sb = store as? StoreBorrowInst {
+          return sb.allocStack
+        }
+        return nil
+      default:
+        return nil
+      }
+      default:
+        return nil
+    }
+  }
+
   /// Ignore "irrelevant" borrow scopes: load_borrow or begin_borrow without [var_decl]
   func ignoreBorrowScope(_ context: some Context) -> LifetimeDependence.Scope? {
     guard case let .borrowed(beginBorrowVal) = self else {

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -87,6 +87,11 @@ public struct AThing : ~Copyable {
   init(somethings: UnsafeMutableRawBufferPointer)
 }
 
+@_addressableForDependencies
+public struct InlineInt {
+  var i: Int
+}
+
 sil @getContainer : $@convention(thin) (@inout AThing) -> @lifetime(borrow address_for_deps 0) @out Container
 sil @getMutableView : $@convention(thin) (@in_guaranteed Container) -> @lifetime(copy 0) @out Optional<MutableView>
 sil @modAThing : $@convention(thin) (@inout AThing) -> ()
@@ -137,6 +142,10 @@ sil @getHolder : $@convention(thin) () -> @owned Holder
 sil @getAddressableObj : $@convention(method) (@guaranteed Holder) -> @owned AddressableForDepsObj
 
 sil @getAddressableObj_NE : $@convention(thin) (@in_guaranteed AddressableForDepsObj) -> @owned NE
+
+sil @globalAddress : $@convention(thin) () -> Builtin.RawPointer
+sil @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+sil @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
 
 // NCContainer.wrapper._read:
 //   var wrapper: Wrapper {
@@ -913,4 +922,51 @@ bb2:
   end_borrow %2
   dealloc_box [dead_end] %1
   unreachable
+}
+
+// Test trivial alloc_stack extension when used by an addressable dependency.
+//
+// CHECK-LABEL: sil hidden [noinline] [ossa] @testTempTrivialStackCopy : $@convention(thin) () -> () {
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack $InlineInt
+// CHECK:   [[MD:%[0-9]+]] = mark_dependence [unresolved] %{{.*}} on [[STK]]
+// CHECK:   [[VAR:%[0-9]+]] = move_value [var_decl] [[MD]]
+// CHECK: bb3:                                              // Preds: bb2 bb1
+// CHECK:   [[BORROW:%[0-9]+]] = begin_borrow [[VAR]]
+// CHECK:   apply %{{.*}}([[BORROW]]) : $@convention(thin) (@guaranteed Span<Int>) -> ()
+// CHECK:   destroy_value [[VAR]]
+// CHECK:   dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'testTempTrivialStackCopy'
+sil hidden [noinline] [ossa] @testTempTrivialStackCopy : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @globalAddress : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 to [strict] $*InlineInt
+  %3 = begin_access [read] [dynamic] %2
+  %4 = load [trivial] %3
+  end_access %3
+  %6 = alloc_stack $InlineInt
+  store %4 to [trivial] %6
+
+  %8 = function_ref @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %9 = apply %8(%6) : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %10 = mark_dependence [unresolved] %9 on %6
+  %11 = move_value [var_decl] %10
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %6
+  br bb3
+bb2:
+  dealloc_stack %6
+  br bb3
+
+bb3:
+  %13 = begin_borrow %11
+
+  %14 = function_ref @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  %15 = apply %14(%13) : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  end_borrow %13
+  destroy_value %11
+  %18 = tuple ()
+  return %18
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -67,6 +67,8 @@ public struct InlineInt {
 }
 sil @globalAddress : $@convention(thin) () -> Builtin.RawPointer
 sil @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+sil @addressOfInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow address 0) @owned Span<Int>
+sil @noAddressInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow 0) @owned Span<Int>
 sil @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
 
 // Test returning a owned dependence on a trivial value
@@ -259,10 +261,12 @@ bb0(%0 : $*NE, %1 : $*Holder):
 // extends to the dealloc_stack.
 //
 // SILGen should never generate temporary stack copies for addressable dependencies, but we need to diagnose them anyway
-// so that a SILGen bug does not become a miscompile.
+// so that a SILGen bug does not become a miscompile. Furthermore, LifetimeDependenceScopeFixup now automatically
+// extends such local allocations, so this diagnostic only fires on source-level tests when scope extension is
+// impossible.
 //
 // rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy of a global array)
-sil hidden [noinline] [ossa] @testTrivialStackCopy : $@convention(thin) () -> () {
+sil hidden [noinline] [ossa] @testTempTrivialStackCopy : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @globalAddress : $@convention(thin) () -> Builtin.RawPointer
   %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
@@ -280,6 +284,67 @@ bb0:
   dealloc_stack %6
   %13 = begin_borrow %11
 
+  %14 = function_ref @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  %15 = apply %14(%13) : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  end_borrow %13
+  destroy_value %11 // expected-note{{this use of the lifetime-dependent value is out of scope}}
+  %18 = tuple ()
+  return %18
+}
+
+// Test an address dependency on a trivial value temporarily copied to the stack. The value's addressable range only
+// extends to the dealloc_stack. This represents the SIL from @testTempTrivialStackCopy after
+// LifetimeDependenceScopeFixup has extended the local allocation.
+sil hidden [noinline] [ossa] @testExtendedTrivialStackCopy : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @globalAddress : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 to [strict] $*InlineInt
+  %3 = begin_access [read] [dynamic] %2
+  %4 = load [trivial] %3
+  end_access %3
+  %6 = alloc_stack $InlineInt
+  store %4 to [trivial] %6
+
+  %8 = function_ref @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %9 = apply %8(%6) : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %10 = mark_dependence [unresolved] %9 on %6
+  %11 = move_value [var_decl] %10
+  %13 = begin_borrow %11
+
+  %14 = function_ref @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  %15 = apply %14(%13) : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  end_borrow %13
+  destroy_value %11
+  dealloc_stack %6
+  %18 = tuple ()
+  return %18
+}
+
+// Test two address dependencies on the same temporay. The first dependency is addressable; it's uses are covered by the
+// stack allocation. The second dependency is non-addressable; it's uses are not covered by the stack allocation. So,
+// this is correct SIL but is falsely diagnosed as a lifetime error. This conservative error is fine because SILGen
+// never reuses a temporary allocaiton for both an addressable and non-addressable dependency.
+sil hidden [noinline] [ossa] @testFalseTempTrivialStackCopy : $@convention(thin) (Int) -> () {
+bb0(%0: $Int):
+  %1 = alloc_stack $Int
+  store %0 to [trivial] %1
+
+  %3 = function_ref @addressOfInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow address 0) @owned Span<Int>
+  %4 = apply %3(%1) : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow address 0) @owned Span<Int>
+  %5 = mark_dependence [unresolved] %4 on %1
+  %6 = move_value [var_decl] %5
+  destroy_value %6
+
+  %8 = function_ref @noAddressInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow 0) @owned Span<Int>
+  %9 = apply %8(%1) : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow 0) @owned Span<Int>
+  %10 = mark_dependence [unresolved] %9 on %1
+  %11 = move_value [var_decl] %10 // expected-error{{lifetime-dependent value escapes its scope}}
+  // expected-note@-15{{it depends on the lifetime of an argument of 'testFalseTempTrivialStackCopy'}}
+
+  dealloc_stack %1
+
+  %13 = begin_borrow %11
   %14 = function_ref @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
   %15 = apply %14(%13) : $@convention(thin) (@guaranteed Span<Int>) -> ()
   end_borrow %13

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -2,21 +2,21 @@
 // RUN:   --lifetime-dependence-diagnostics \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -module-name Swift \
 // RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature AddressableTypes \
 // RUN:   -o /dev/null
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
 
 // Verify diagnostics from the LifetimeDependenceDiagnostics pass.
 
 sil_stage raw
 
 import Builtin
-
-@_marker protocol Copyable: ~Escapable {}
-@_marker protocol Escapable: ~Copyable {}
+import Swift
+import SwiftShims
 
 class C {}
 
@@ -60,6 +60,14 @@ sil @getTrivialNE : $@convention(thin) (@in_guaranteed TrivialHolder) -> @lifeti
 
 sil @makeHolder: $@convention(method) (@thin Holder.Type) -> @owned Holder // user: %6
 sil @getGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : ~Escapable> (@guaranteed Holder, @thick τ_0_0.Type) -> @lifetime(borrow 0) @out τ_0_0 // user: %12
+
+@_addressableForDependencies
+public struct InlineInt {
+  var i: Int
+}
+sil @globalAddress : $@convention(thin) () -> Builtin.RawPointer
+sil @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+sil @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
 
 // Test returning a owned dependence on a trivial value
 sil [ossa] @return_trivial_dependence : $@convention(thin) (@guaranteed C) -> @lifetime(borrow 0) @owned NE {
@@ -243,6 +251,39 @@ bb0(%0 : $*NE, %1 : $*Holder):
   dealloc_stack %5
   destroy_value %4
   dealloc_stack %2
+  %18 = tuple ()
+  return %18
+}
+
+// Test a address dependency on a trivial value temporarily copied to the stack. The value's addressable range only
+// extends to the dealloc_stack.
+//
+// SILGen should never generate temporary stack copies for addressable dependencies, but we need to diagnose them anyway
+// so that a SILGen bug does not become a miscompile.
+//
+// rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy of a global array)
+sil hidden [noinline] [ossa] @testTrivialStackCopy : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @globalAddress : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 to [strict] $*InlineInt
+  %3 = begin_access [read] [dynamic] %2 // expected-note{{it depends on this scoped access to variable ''}}
+  %4 = load [trivial] %3
+  end_access %3
+  %6 = alloc_stack $InlineInt
+  store %4 to [trivial] %6
+
+  %8 = function_ref @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %9 = apply %8(%6) : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+  %10 = mark_dependence [unresolved] %9 on %6
+  %11 = move_value [var_decl] %10 // expected-error{{lifetime-dependent value escapes its scope}}
+  dealloc_stack %6
+  %13 = begin_borrow %11
+
+  %14 = function_ref @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  %15 = apply %14(%13) : $@convention(thin) (@guaranteed Span<Int>) -> ()
+  end_borrow %13
+  destroy_value %11 // expected-note{{this use of the lifetime-dependent value is out of scope}}
   %18 = tuple ()
   return %18
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -324,8 +324,16 @@ var values: InlineArray<_, Int> = [0, 1, 2]
 
 // rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy of a global array)
 @available(Span 0.1, *)
-func test() -> Int {
+func readGlobalSpan() -> Int {
+  let span = values.span
+  return span[3]
+}
+
+// TODO: rdar://151320168 ([nonescapable] support immortal span over global array)
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func returnGlobalSpan() -> Span<Int> {
   let span = values.span // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
   // expected-note@-1{{it depends on this scoped access to variable 'values'}}
-  return span[3] // expected-note{{this use of the lifetime-dependent value is out of scope}}
+  return span // expected-note{{this use causes the lifetime-dependent value to escape}}
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -322,6 +322,12 @@ func inoutToImmortal(_ s: inout RawSpan) {
 @available(Span 0.1, *)
 var values: InlineArray<_, Int> = [0, 1, 2]
 
+@available(Span 0.1, *)
+func getValues() -> InlineArray<3, Int> { values }
+
+// Test a trivial global variable used by addressableForDependencies (InlineArray.span). This either requires a direct address
+// to the global or it requires extension of the local stack allocation by LifetimeDependenceScopeFixup.
+//
 // rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy of a global array)
 @available(Span 0.1, *)
 func readGlobalSpan() -> Int {
@@ -329,11 +335,50 @@ func readGlobalSpan() -> Int {
   return span[3]
 }
 
-// TODO: rdar://151320168 ([nonescapable] support immortal span over global array)
+// Test a trivial global variable used by addressableForDependencies (InlineArray.span).
+//
+// TODO: This will no longer be an error when SILGen passes a direct address to the global instead of a temporary stack
+// allocation: rdar://151320168 ([nonescapable] support immortal span over global array)
 @available(Span 0.1, *)
 @_lifetime(immortal)
 func returnGlobalSpan() -> Span<Int> {
   let span = values.span // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
   // expected-note@-1{{it depends on this scoped access to variable 'values'}}
+  return span // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+// Test a trivial temporary stack allocation used by addressableForDependencies
+// (InlineArray.span). LifetimeDependenceScopeFixup needs to extend the local stack allocation.
+@available(Span 0.1, *)
+func readTempSpan() -> Int {
+  let span = getValues().span
+  return span[3]
+}
+
+// Test a trivial temporary stack allocation used by addressableForDependencies (InlineArray.span). This illegally
+// returns an address into a temporary.
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func returnTempSpan() -> Span<Int> {
+  let span = getValues().span // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
+  // expected-note@-1{{it depends on the lifetime of this parent value}}
+  return span // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+// Test a trivial temporary stack allocation used by an addressable parameter
+// (Borrow.init). LifetimeDependenceScopeFixup needs to extend the local stack allocation.
+@available(Span 0.1, *)
+func readTempBorrow() -> Int {
+  let borrow = Borrow(3)
+  return borrow[]
+}
+
+// Test a trivial temporary stack allocation used by an addressable parameter (Borrow.init). This illegally returns an
+// address into a temporary.
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func returnTempBorrow() -> Borrow<Int> {
+  let span = Borrow(3) // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
+  // expected-note@-1{{it depends on the lifetime of this parent value}}
   return span // expected-note{{this use causes the lifetime-dependent value to escape}}
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil \
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -emit-sil \
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
@@ -315,3 +315,17 @@ func inoutToImmortal(_ s: inout RawSpan) {
   s = _overrideLifetime(tmp, borrowing: ())
 }
 
+// =============================================================================
+// addressable dependencies
+// =============================================================================
+
+@available(Span 0.1, *)
+var values: InlineArray<_, Int> = [0, 1, 2]
+
+// rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy of a global array)
+@available(Span 0.1, *)
+func test() -> Int {
+  let span = values.span // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
+  // expected-note@-1{{it depends on this scoped access to variable 'values'}}
+  return span[3] // expected-note{{this use of the lifetime-dependent value is out of scope}}
+}


### PR DESCRIPTION
Add a diagnostic to catch addressable dependencies on a trivial values that have
been copied to a temporary stack location. SILGen should never copy the source
of an addressable dependency to a temporary stack location, but this diagnostic
catches such compiler bugs rather than allowing miscompilation.

Extend temporary allocations in LifetimeDependenceScopeFixup. This is required once we start diagnosing addressable stack locations. Otherwise, generic functions that return a Span will break with a diagnostic error:

    protocol HasSpan {
      @_lifetime(borrow self)
      func getSpan() -> RawSpan
    }
    func getSpan<T: HasSpan>(owner: T) -> RawSpan {
      owner.getSpan()
    }
    
    let span = getSpan(owner: getOwner()) // ERROR: lifetime-dependent variable 'span' escapes its scope

Fixes rdar://159680262 ([nonescapable] diagnose dependence on a temporary copy
of a global array)
