### PR TITLE
[test][Windows] Fix `Reflection/wasm.test` failure on rebranch

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,7 +135,8 @@ function(get_test_dependencies SDK result_var_name)
       llvm-strings
       llvm-readtapi
       not
-      split-file)
+      split-file
+      yaml2obj)
   endif()
 
   if(("${SDK}" STREQUAL "IOS") OR


### PR DESCRIPTION
This test needs `yaml2obj`, which we weren't building on Windows.