### PR TITLE
[cxx-interop] Avoid trying to instantiate copy constructor of `std::optional<NonCopyable>`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3026,7 +3026,16 @@ namespace {
           decl->getIdentifier() &&
           (decl->getName() == "tzdb" || decl->getName() == "time_zone_link" ||
            decl->getName() == "__compressed_pair" ||
+           decl->getName() == "__optional_copy_assign_base" || // libc++
+           decl->getName() == "__optional_move_assign_base" || // libc++
            decl->getName() == "time_zone"))
+        return nullptr;
+      // Bail if this is one of the base types of std::optional. Those types are
+      // mixins that are not designed to be used directly.
+      if (decl->getDeclContext()->isNamespace() && decl->isInStdNamespace() &&
+          decl->getIdentifier() &&
+          (decl->getName() == "_Optional_payload_base" ||
+           decl->getName() == "_Optional_payload"))
         return nullptr;
 
       auto &clangSema = Impl.getClangSema();

--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -17,6 +17,14 @@ struct HasConstexprCtor {
 };
 using StdOptionalHasConstexprCtor = std::optional<HasConstexprCtor>;
 
+struct HasDeletedCopyCtor {
+  int value;
+  HasDeletedCopyCtor(int value) : value(value) {}
+  HasDeletedCopyCtor(const HasDeletedCopyCtor &other) = delete;
+  HasDeletedCopyCtor(HasDeletedCopyCtor &&other) = default;
+};
+using StdOptionalHasDeletedCopyCtor = std::optional<HasDeletedCopyCtor>;
+
 struct HasDeletedMoveCtor {
   int value;
   HasDeletedMoveCtor(int value) : value(value) {}
@@ -29,7 +37,12 @@ inline StdOptionalInt getNonNilOptional() { return {123}; }
 
 inline StdOptionalInt getNilOptional() { return {std::nullopt}; }
 
+inline StdOptionalHasDeletedCopyCtor getNonNilOptionalHasDeletedCopyCtor() {
+  return StdOptionalHasDeletedCopyCtor(HasDeletedCopyCtor(654));
+}
+
 inline bool takesOptionalInt(std::optional<int> arg) { return (bool)arg; }
 inline bool takesOptionalString(std::optional<std::string> arg) { return (bool)arg; }
+inline bool takesOptionalHasDeletedCopyCtor(std::optional<HasDeletedCopyCtor> arg) { return (bool)arg; }
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -25,6 +25,9 @@ StdOptionalTestSuite.test("pointee") {
   modifiedOpt.pointee = 777
   expectEqual(777, modifiedOpt.pointee)
 #endif
+
+  let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
+  expectEqual(654, nonNilOptNonCopyable.pointee.value)
 }
 
 StdOptionalTestSuite.test("std::optional => Swift.Optional") {


### PR DESCRIPTION
In libc++, `std::optional` inherits from several mixin base types. Some of those base types do not declare a deleted copy constructor for non-copyable value types, which works fine because clients are not supposed to use those base types directly from C++.

Swift, however, imports all of the transitive base types when importing a C++ type. As part of this, ClangImporter will attempt to instantiate e.g. `std::__optional_copy_assign_base<NonCopyable>`, and will fail with a hard error while doing so.

rdar://152718041

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
