### PR TITLE
🍒 [cxx-interop] Prevent crash when importing a std::optional of nonescapable

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2377,8 +2377,18 @@ namespace {
         }
 
         auto *vd = cast<VarDecl>(member);
-        if (!isNonEscapable) {
-          if (const auto *fd = dyn_cast<clang::FieldDecl>(nd))
+        auto getFieldDecl =
+            [](const clang::NamedDecl *decl) -> const clang::FieldDecl * {
+          if (const clang::FieldDecl *fd = dyn_cast<clang::FieldDecl>(decl))
+            return fd;
+          if (const clang::IndirectFieldDecl *ind =
+                  dyn_cast<clang::IndirectFieldDecl>(decl))
+            return ind->getAnonField();
+          return nullptr;
+        };
+
+        if (!isNonEscapable && !decl->isAnonymousStructOrUnion()) {
+          if (const auto *fd = getFieldDecl(nd)) {
             if (evaluateOrDefault(
                     Impl.SwiftContext.evaluator,
                     ClangTypeEscapability({fd->getType().getTypePtr(), &Impl}),
@@ -2391,6 +2401,7 @@ namespace {
                   decl->getLocation());
               return nullptr;
             }
+          }
         }
         members.push_back(vd);
       }


### PR DESCRIPTION
  - **Explanation**: Fixes an assertion failure when importing anonymous unions/structs with nonescapable fields. We would also run into this assertion failure when importing a `std::optional` of nonescapable type. 
  - **Issue**: rdar://156704699
  - **Original PR**: https://github.com/swiftlang/swift/pull/83973
  - **Risk**: Low
  - **Testing**: Added a few compiler tests.
  - **Reviewers**: @Xazax-hun 
