### PR TITLE
[cxx-interop] Basic support for anonymous structs with non-copyable fields

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3112,11 +3112,12 @@ namespace {
             }
           }
         }
-        if (copyCtor && !isExplicitlyNonCopyable) {
+        if (copyCtor && !isExplicitlyNonCopyable &&
+            !decl->isAnonymousStructOrUnion()) {
           clangSema.DefineImplicitCopyConstructor(clang::SourceLocation(),
                                                   copyCtor);
         }
-        if (moveCtor) {
+        if (moveCtor && !decl->isAnonymousStructOrUnion()) {
           clangSema.DefineImplicitMoveConstructor(clang::SourceLocation(),
                                                   moveCtor);
         }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6940,6 +6940,10 @@ namespace {
     }
 
     void addValueWitnessTable() {
+      if (auto cd = Target->getClangDecl())
+        if (auto rd = dyn_cast<clang::RecordDecl>(cd))
+          if (rd->isAnonymousStructOrUnion())
+            return;
       auto vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
       B.addSignedPointer(vwtPointer,
                          IGM.getOptions().PointerAuth.ValueWitnessTable,

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -56,4 +56,16 @@ struct NonCopyableHolderDerivedDerived: NonCopyableHolderDerived {
 inline NonCopyable *getNonCopyablePtr() { return nullptr; }
 inline NonCopyableDerived *getNonCopyableDerivedPtr() { return nullptr; }
 
+template <typename T>
+struct FieldInAnonStruct {
+  FieldInAnonStruct() : field(5) {}
+  FieldInAnonStruct(const FieldInAnonStruct &) = delete;
+  FieldInAnonStruct(FieldInAnonStruct &&) = default;
+  struct {
+    T field;
+  };
+};
+
+using FieldInAnonStructNC = FieldInAnonStruct<NonCopyable>;
+
 #endif // TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -70,4 +70,8 @@ MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   expectEqual(c.x.x, 5)
 }
 
+MoveOnlyCxxValueType.test("Test move only field in anonymous struct") {
+  let a = FieldInAnonStructNC()
+  let b = a
+}
 runAllTests()


### PR DESCRIPTION
Anonymous structs cannot be copied or moved, these operations only can happen to their enclosing non-anonymous types. Stop trying to emit special member functions and value witness tables for these structs.
