### PR TITLE
AST: Use availability to control decl visibility in public swiftinterfaces

### DIFF
--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -354,14 +354,7 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(GeneralizedIsSameMetaTypeBuiltin)
-
-static bool usesFeatureCustomAvailability(Decl *decl) {
-  for (auto attr : decl->getSemanticAvailableAttrs()) {
-    if (attr.getDomain().isCustom())
-      return true;
-  }
-  return false;
-}
+UNINTERESTING_FEATURE(CustomAvailability)
 
 static bool usesFeatureAsyncExecutionBehaviorAttributes(Decl *decl) {
   // Explicit `@concurrent` attribute on the declaration.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2879,6 +2879,7 @@ bool SourceFile::hasTestableOrPrivateImport(
       });
 }
 
+// FIXME: This should probably be requestified.
 RestrictedImportKind SourceFile::getRestrictedImportKind(const ModuleDecl *module) const {
   auto &imports = getASTContext().getImportCache();
   RestrictedImportKind importKind = RestrictedImportKind::MissingImport;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -219,6 +219,40 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   return true;
 }
 
+/// Returns true if access to \p D should be diagnosed during exportability
+/// checking. These diagnostics would typically be handled by the access
+/// checker, and therefore should be suppressed to avoid duplicate diagnostics.
+/// However, extensions are special because they do not have an intrinsic access
+/// level and therefore the access checker does not currently handle them.
+/// Instead, diagnostics for decls referenced in extension signatures are
+/// deferred to exportability checking. An exportable extension is effectively a
+/// public extension.
+static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
+                                     const ExportContext &where) {
+  auto reason = where.getExportabilityReason();
+  auto DC = where.getDeclContext();
+
+  switch (*reason) {
+  case ExportabilityReason::ExtensionWithPublicMembers:
+  case ExportabilityReason::ExtensionWithConditionalConformances:
+    return true;
+  case ExportabilityReason::Inheritance:
+    return isa<ProtocolDecl>(D);
+  case ExportabilityReason::AvailableAttribute:
+    // If the context is an extension and that extension has an explicit
+    // access level then availability domains access has already been
+    // diagnosed.
+    if (auto *ED = dyn_cast_or_null<ExtensionDecl>(DC->getAsDecl()))
+      return !ED->getAttrs().getAttribute<AccessControlAttr>();
+    return false;
+
+  case ExportabilityReason::General:
+  case ExportabilityReason::ResultBuilder:
+  case ExportabilityReason::PropertyWrapper:
+    return false;
+  }
+}
+
 static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
                                               const ExportContext &where) {
   assert(where.mustOnlyReferenceExportedDecls());
@@ -247,41 +281,35 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
         }
       });
 
-  // Access levels from imports are reported with the others access levels.
-  // Except for extensions and protocol conformances, we report them here.
-  if (originKind == DisallowedOriginKind::NonPublicImport) {
-    bool reportHere = [&] {
-      switch (*reason) {
-        case ExportabilityReason::ExtensionWithPublicMembers:
-        case ExportabilityReason::ExtensionWithConditionalConformances:
-          return true;
-        case ExportabilityReason::Inheritance:
-          return isa<ProtocolDecl>(D);
-        case ExportabilityReason::AvailableAttribute:
-          // If the context is an extension and that extension has an explicit
-          // access level, then access has already been diagnosed for the
-          // @available attribute.
-          if (auto *ED = dyn_cast_or_null<ExtensionDecl>(DC->getAsDecl()))
-            return !ED->getAttrs().getAttribute<AccessControlAttr>();
-          return false;
-        default:
-          return false;
-      }
-    }();
-    if (!reportHere)
+  switch (originKind) {
+  case DisallowedOriginKind::None:
+    // The decl does not come from a source that needs to be checked for
+    // exportability.
+    return false;
+
+  case DisallowedOriginKind::NonPublicImport:
+    // With a few exceptions, access levels from imports are diagnosed during
+    // access checking and should be skipped here.
+    if (!shouldDiagnoseDeclAccess(D, where))
       return false;
+    break;
+
+  case DisallowedOriginKind::MissingImport:
+    // Some diagnostics emitted with the `MemberImportVisibility` feature
+    // enabled subsume these diagnostics.
+    if (ctx.LangOpts.hasFeature(Feature::MemberImportVisibility,
+                                /*allowMigration=*/true) &&
+        SF)
+      return false;
+    break;
+
+  case DisallowedOriginKind::SPIOnly:
+  case DisallowedOriginKind::ImplementationOnly:
+  case DisallowedOriginKind::SPIImported:
+  case DisallowedOriginKind::SPILocal:
+  case DisallowedOriginKind::FragileCxxAPI:
+    break;
   }
-
-  if (originKind == DisallowedOriginKind::None)
-    return false;
-
-  // Some diagnostics emitted with the `MemberImportVisibility` feature enabled
-  // subsume these diagnostics.
-  if (originKind == DisallowedOriginKind::MissingImport &&
-      ctx.LangOpts.hasFeature(Feature::MemberImportVisibility,
-                              /*allowMigration=*/true) &&
-      SF)
-    return false;
 
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {
     // Only diagnose accessors if their disallowed origin kind differs from

--- a/test/Inputs/custom-modules/availability-domains/Lakes.h
+++ b/test/Inputs/custom-modules/availability-domains/Lakes.h
@@ -1,6 +1,10 @@
 #include <availability_domain.h>
 
+int huron_pred(void);
+
 CLANG_ENABLED_AVAILABILITY_DOMAIN(Salt);
+CLANG_DISABLED_AVAILABILITY_DOMAIN(Erie);
+CLANG_DYNAMIC_AVAILABILITY_DOMAIN(Huron, huron_pred);
 
 #define AVAIL 0
 #define UNAVAIL 1

--- a/test/Inputs/custom-modules/availability-domains/Seas.h
+++ b/test/Inputs/custom-modules/availability-domains/Seas.h
@@ -1,7 +1,10 @@
 #include <availability_domain.h>
 
+int aegean_pred(void);
+
 CLANG_ENABLED_AVAILABILITY_DOMAIN(Baltic);
 CLANG_DISABLED_AVAILABILITY_DOMAIN(Mediterranean);
+CLANG_DYNAMIC_AVAILABILITY_DOMAIN(Aegean, aegean_pred);
 
 #define AVAIL 0
 #define UNAVAIL 1

--- a/test/ModuleInterface/availability_custom_domains.swift
+++ b/test/ModuleInterface/availability_custom_domains.swift
@@ -15,18 +15,16 @@
 
 import Oceans // re-exports Rivers
 
-// CHECK:      #if compiler(>=5.3) && $CustomAvailability
-// CHECK-NEXT: @available(Colorado)
+// CHECK-NOT:  $CustomAvailability
+
+// CHECK:      @available(Colorado)
 // CHECK-NEXT: public func availableInColorado()
-// CHECK-NEXT: #endif
 @available(Colorado)
 public func availableInColorado() { }
 
-// CHECK:      #if compiler(>=5.3) && $CustomAvailability
-// CHECK-NEXT: @available(Arctic, unavailable)
+// CHECK:      @available(Arctic, unavailable)
 // CHECK-NEXT: @available(Pacific)
 // CHECK-NEXT: public func unavailableInArcticButAvailableInPacific()
-// CHECK-NEXT: #endif
 @available(Arctic, unavailable)
 @available(Pacific)
 public func unavailableInArcticButAvailableInPacific() { }

--- a/test/ModuleInterface/availability_custom_domains_library_level_api.swift
+++ b/test/ModuleInterface/availability_custom_domains_library_level_api.swift
@@ -1,0 +1,120 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -enable-library-evolution -swift-version 5 -library-level api \
+// RUN:   -package-name TestPackage -module-name Test \
+// RUN:   -emit-module-interface-path %t/Test.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Test.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Test.package.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -module-name Test
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.private.swiftinterface) \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -module-name Test
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.package.swiftinterface) \
+// RUN:   -I %S/../Inputs/custom-modules/availability-domains \
+// RUN:   -module-name Test
+
+// RUN: %FileCheck %s --check-prefixes=CHECK --input-file %t/Test.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK-PUBLIC --input-file %t/Test.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-NONPUBLIC --input-file %t/Test.private.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-NONPUBLIC --input-file %t/Test.package.swiftinterface
+
+// REQUIRES: swift_feature_CustomAvailability
+
+import Lakes
+@_spiOnly import Seas
+
+// CHECK:                 @available(Salt)
+// CHECK:                 public func availableInPublicEnabledDomain()
+@available(Salt)
+public func availableInPublicEnabledDomain() { }
+
+// CHECK:                 @available(Erie)
+// CHECK:                 public func availableInPublicDisabledDomain()
+@available(Erie)
+public func availableInPublicDisabledDomain() { }
+
+// CHECK:                 @available(Huron)
+// CHECK:                 public func availableInPublicDynamicDomain()
+@available(Huron)
+public func availableInPublicDynamicDomain() { }
+
+// CHECK:                 @available(Salt, unavailable)
+// CHECK:                 public func unavailableInPublicEnabledDomain()
+@available(Salt, unavailable)
+public func unavailableInPublicEnabledDomain() { }
+
+// CHECK:                 @available(Erie, unavailable)
+// CHECK:                 public func unavailableInPublicDisabledDomain()
+@available(Erie, unavailable)
+public func unavailableInPublicDisabledDomain() { }
+
+// CHECK:                 @available(Huron, unavailable)
+// CHECK:                 public func unavailableInPublicDynamicDomain()
+@available(Huron, unavailable)
+public func unavailableInPublicDynamicDomain() { }
+
+// CHECK-NONPUBLIC:       @available(Baltic)
+// CHECK-PUBLIC-NOT:      Baltic
+// CHECK-LABEL:           public func availableInSPIOnlyEnabledDomain()
+@available(Baltic)
+public func availableInSPIOnlyEnabledDomain() { }
+
+// CHECK-NONPUBLIC:       @available(Mediterranean)
+// CHECK-NONPUBLIC-LABEL: public func availableInSPIOnlyDisabledDomain_Secret()
+// CHECK-PUBLIC-NOT:      Mediterranean
+// CHECK-PUBLIC-NOT:      availableInSPIOnlyDisabledDomain_Secret
+@available(Mediterranean)
+public func availableInSPIOnlyDisabledDomain_Secret() { }
+
+// CHECK-NONPUBLIC:       @available(Aegean)
+// CHECK-PUBLIC-NOT:      Aegean
+// CHECK-LABEL:           public func availableInSPIOnlyDynamicDomain()
+@available(Aegean)
+public func availableInSPIOnlyDynamicDomain() { }
+
+// CHECK-NONPUBLIC:       @available(Baltic, unavailable)
+// CHECK-NONPUBLIC-LABEL: public func unavailableInSPIOnlyEnabledDomain_Secret()
+// CHECK-PUBLIC-NOT:      Baltic
+// CHECK-PUBLIC-NOT:      unavailableInSPIOnlyEnabledDomain_Secret
+@available(Baltic, unavailable)
+public func unavailableInSPIOnlyEnabledDomain_Secret() { }
+
+// CHECK-NONPUBLIC:       @available(Mediterranean, unavailable)
+// CHECK-PUBLIC-NOT:      Mediterranean
+// CHECK-LABEL:           public func unavailableInSPIOnlyDisabledDomain()
+@available(Mediterranean, unavailable)
+public func unavailableInSPIOnlyDisabledDomain() { }
+
+// CHECK:                 @available(*, unavailable)
+// CHECK-NONPUBLIC:       @available(Baltic)
+// CHECK-PUBLIC-NOT:      Baltic
+// CHECK-LABEL:           public func availableInSPIOnlyEnabledDomainAndUnavailableUniversally()
+@available(*, unavailable)
+@available(Baltic)
+public func availableInSPIOnlyEnabledDomainAndUnavailableUniversally() { }
+
+// CHECK-NONPUBLIC:       @available(*, unavailable)
+// CHECK-NONPUBLIC:       @available(Mediterranean)
+// CHECK-NONPUBLIC-LABEL: public func availableInSPIOnlyDisabledDomainAndUnavailableUniversally_Secret()
+// CHECK-PUBLIC-NOT:      Mediterranean
+// CHECK-PUBLIC-NOT:      availableInSPIOnlyDisabledDomainAndUnavailableUniversally_Secret
+@available(*, unavailable)
+@available(Mediterranean)
+public func availableInSPIOnlyDisabledDomainAndUnavailableUniversally_Secret() { }
+
+// CHECK:                 @available(*, unavailable)
+// CHECK-NONPUBLIC:       @available(Aegean)
+// CHECK-PUBLIC-NOT:      Aegean
+// CHECK-LABEL:           public func availableInSPIOnlyDynamicDomainAndUnavailableUniversally()
+@available(*, unavailable)
+@available(Aegean)
+public func availableInSPIOnlyDynamicDomainAndUnavailableUniversally() { }


### PR DESCRIPTION
Declarations that are unavailable at runtime because of an `@available` attribute referencing a custom domain that was imported `@_spiOnly` should be hidden from public swiftinterface files in `-library-level=api` modules. For remaining declarations that do get printed in the public swiftinterface, skip printing any `@available` attribute that refers to the domains from those `@_spiOnly` dependencies. This allows API developers to control declaration visibility using availability defined by another module.

Resolves rdar://156512028.