### PR TITLE
ASTGen: prevent _StringProcessing from being loaded

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -14,6 +14,8 @@ if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   add_pure_swift_host_library(_CompilerRegexParser STATIC
     "${COMPILER_REGEX_PARSER_SOURCES}"
   )
+  target_compile_options(_CompilerRegexParser PRIVATE
+    -disable-implicit-string-processing-module-import)
 else()
   # Dummy target for dependencies
   add_custom_target(_CompilerRegexParser)


### PR DESCRIPTION
When building the ASTGen library, we are building `_StringProcessing`. If the SDK version is loaded, it causes confusion over the local definition and the SDK definition. Avoid the implicit loading of the module.