### PR TITLE
[IRGen] Lazily emit SIL global variables

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2300,6 +2300,22 @@ IRGenModule *IRGenerator::getGenModule(SILFunction *f) {
   return getPrimaryIGM();
 }
 
+IRGenModule *IRGenerator::getGenModule(SILGlobalVariable *v) {
+  if (GenModules.size() == 1) {
+    return getPrimaryIGM();
+  }
+
+  auto found = DefaultIGMForGlobalVariable.find(v);
+  if (found != DefaultIGMForGlobalVariable.end())
+    return found->second;
+
+  if (auto decl = v->getDecl()) {
+    return getGenModule(decl->getDeclContext());
+  }
+
+  return getPrimaryIGM();
+}
+
 uint32_t swift::irgen::getSwiftABIVersion() {
   return IRGenModule::swiftVersion;
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -228,6 +228,10 @@ private:
   // It is used if a function has no source-file association.
   llvm::DenseMap<SILFunction *, IRGenModule *> DefaultIGMForFunction;
 
+  // Stores the IGM from which a global variable is referenced the first time.
+  // It is used if a global variable has no source-file association.
+  llvm::DenseMap<SILGlobalVariable *, IRGenModule *> DefaultIGMForGlobalVariable;
+
   // The IGMs where specializations of functions are emitted. The key is the
   // non-specialized function.
   // Storing all specializations of a function in the same IGM increases the
@@ -327,6 +331,13 @@ private:
   /// The queue of SIL functions to emit.
   llvm::SmallVector<SILFunction *, 4> LazyFunctionDefinitions;
 
+  /// SIL global variables that have already been lazily emitted, or are
+  /// queued up.
+  llvm::SmallPtrSet<SILGlobalVariable *, 4> LazilyEmittedGlobalVariables;
+
+  /// The queue of SIL global variables to emit.
+  llvm::SmallVector<SILGlobalVariable *, 4> LazyGlobalVariables;
+
   /// Witness tables that have already been lazily emitted, or are queued up.
   llvm::SmallPtrSet<SILWitnessTable *, 4> LazilyEmittedWitnessTables;
 
@@ -387,6 +398,12 @@ public:
   /// be determined, returns the IGM from which the function is referenced the
   /// first time.
   IRGenModule *getGenModule(SILFunction *f);
+
+  /// Get an IRGenModule for a global variable.
+  /// Returns the IRGenModule of the containing source file, or if this cannot
+  /// be determined, returns the IGM from which the global variable is
+  /// referenced the first time.
+  IRGenModule *getGenModule(SILGlobalVariable *v);
 
   /// Returns the primary IRGenModule. This is the first added IRGenModule.
   /// It is used for everything which cannot be correlated to a specific source
@@ -453,6 +470,8 @@ public:
   void emitLazyDefinitions();
 
   void addLazyFunction(SILFunction *f);
+
+  void addLazyGlobalVariable(SILGlobalVariable *v);
 
   void addDynamicReplacement(SILFunction *f) { DynamicReplacements.insert(f); }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1426,8 +1426,14 @@ private:
   friend struct ::llvm::DenseMapInfo<swift::irgen::IRGenModule::FixedLayoutKey>;
   llvm::DenseMap<FixedLayoutKey, llvm::Constant *> PrivateFixedLayouts;
 
+  /// Captures a static object layout.
+  struct StaticObjectLayout {
+    std::unique_ptr<StructLayout> layout;
+    llvm::StructType *containerTy = nullptr;
+  };
+
   /// A cache for layouts of statically initialized objects.
-  llvm::DenseMap<SILGlobalVariable *, std::unique_ptr<StructLayout>>
+  llvm::DenseMap<SILGlobalVariable *, StaticObjectLayout>
     StaticObjectLayouts;
 
   /// A mapping from order numbers to the LLVM functions which we

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -84,6 +84,9 @@ bool SILGlobalVariable::isPossiblyUsedExternally() const {
   if (shouldBePreservedForDebugger())
     return true;
 
+  if (markedAsUsed())
+    return true;
+
   SILLinkage linkage = getLinkage();
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
 }

--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -11,7 +11,7 @@ struct T {
 }
 
 // CHECK: @global = hidden global %T4main1TV <{ i1 false, [3 x i8] undef, i32 0 }>, align 4
-sil_global hidden @global : $T = {
+sil_global hidden [used] @global : $T = {
   %2 = integer_literal $Builtin.Int1, 0
   %3 = integer_literal $Builtin.Int32, 0
   %initval = struct $T (%2 : $Builtin.Int1, %3 : $Builtin.Int32)

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -40,20 +40,20 @@ public struct LargeResilientStruct {
 sil_global [let] @largeGlobal : $LargeResilientStruct
 
 //
-// Size is known in this resilience domain, and global is hidden,
-// so allocate it directly.
-//
-
-// CHECK: @fixedGlobal = hidden global %T17global_resilience20LargeResilientStructV zeroinitializer
-sil_global hidden @fixedGlobal : $LargeResilientStruct
-
-//
 // Unknown size -- must call value witness functions for buffer
 // management.
 //
 
 // CHECK: @otherGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER]] zeroinitializer
 sil_global [let] @otherGlobal : $Size
+
+//
+// Size is known in this resilience domain, and global is hidden,
+// so allocate it directly.
+//
+
+// CHECK: @fixedGlobal = hidden global %T17global_resilience20LargeResilientStructV zeroinitializer
+sil_global hidden @fixedGlobal : $LargeResilientStruct
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @testSmallGlobal()
 sil @testSmallGlobal : $@convention(thin) () -> Int32 {

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-ir -primary-file %s | %FileCheck %s
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
-// CHECK: @"[[T:.*]]Wz" = internal global i64 0, align 8
 // CHECK: @"$s12lazy_globals1xSivp" = hidden global %TSi zeroinitializer, align 8
 // CHECK: @"$s12lazy_globals1ySivp" = hidden global %TSi zeroinitializer, align 8
 // CHECK: @"$s12lazy_globals1zSivp" = hidden global %TSi zeroinitializer, align 8
+// CHECK: @"[[T:.*]]Wz" = internal global i64 0, align 8
 
 // CHECK: define internal void @"[[T]]WZ"(ptr %0) {{.*}} {
 // CHECK: entry:
@@ -39,4 +39,3 @@ var (x, y, z) = (1, 2, 3)
 // CHECK:   ret i64 [[V]]
 // CHECK: }
 func getX() -> Int { return x }
-

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -21,9 +21,10 @@
 
 //--- Library.swift
 
-// TODO: Once global variables can be emitted lazily, these should be -NOT
-// again, then show up in the application binary if we use them.
-// LIBRARY-IR: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr {{(protected |dllexport )?}}global
+// Never referenced.
+// LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr {{(protected |dllexport )?}}global
+
+// Note: referenced by swift_allocEmptyBox.
 // LIBRARY-IR: @"$es16_emptyBoxStorageSi_Sitvp" = weak_odr {{(protected |dllexport )?}}global
 
 // LIBRARY-IR-NOT: define {{.*}}@"$e7Library5helloSaySiGyF"()

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -33,4 +33,4 @@ public func main() {
 // CHECK: @"$e4Main022global_in_client_used_c1_D0Sivp" = {{.*}}global %TSi zeroinitializer
 // CHECK: @"$e4Main024global_in_client_unused_c1_D0Sivp" = {{.*}}global %TSi zeroinitializer
 // CHECK: @"$e8MyModule022global_in_module_used_d1_E0Sivp" = {{.*}}global %TSi zeroinitializer
-// CHECK: @"$e8MyModule024global_in_module_unused_d1_E0Sivp" = {{.*}}global %TSi zeroinitializer
+// CHECK-NOT: @"$e8MyModule024global_in_module_unused_d1_E0Sivp" = {{.*}}global %TSi zeroinitializer


### PR DESCRIPTION
Delay the emission of SIL global variables that aren't externally visible until they are actually used. This is the same lazy emission approach that we use for a number of other entities, such as SIL functions.

Part of rdar://158363967.
