### PR TITLE
Remove TypeBase::replaceCovariantResultType()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1350,10 +1350,6 @@ public:
   /// Hack to deal with ConstructorDecl interface types.
   Type withCovariantResultType();
 
-  /// Deprecated in favor of the above.
-  Type replaceCovariantResultType(Type newResultType,
-                                  unsigned uncurryLevel);
-
   /// Returns a new function type exactly like this one but with the self
   /// parameter replaced. Only makes sense for function members of types.
   Type replaceSelfParameterType(Type newSelf);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1393,37 +1393,6 @@ Type TypeBase::withCovariantResultType() {
                            fnType->getExtInfo());
 }
 
-Type TypeBase::replaceCovariantResultType(Type newResultType,
-                                          unsigned uncurryLevel) {
-  if (uncurryLevel == 0) {
-    bool isLValue = is<LValueType>();
-
-    auto loadedTy = getWithoutSpecifierType();
-    if (auto objectType = loadedTy->getOptionalObjectType()) {
-      newResultType = OptionalType::get(
-          objectType->replaceCovariantResultType(newResultType, uncurryLevel));
-    }
-
-    return isLValue ? LValueType::get(newResultType) : newResultType;
-  }
-
-  // Determine the input and result types of this function.
-  auto fnType = this->castTo<AnyFunctionType>();
-  auto inputType = fnType->getParams();
-  Type resultType =
-    fnType->getResult()->replaceCovariantResultType(newResultType,
-                                                    uncurryLevel - 1);
-
-  // Produce the resulting function type.
-  if (auto genericFn = dyn_cast<GenericFunctionType>(fnType)) {
-    return GenericFunctionType::get(genericFn->getGenericSignature(),
-                                    inputType, resultType,
-                                    fnType->getExtInfo());
-  }
-  
-  return FunctionType::get(inputType, resultType, fnType->getExtInfo());
-}
-
 /// Whether this parameter accepts an unlabeled trailing closure argument
 /// using the more-restrictive forward-scan rule.
 static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1814,20 +1814,20 @@ namespace {
       // This can occur in code that does something like: 'type(of: x).a' where
       // 'a' is the static value generic member.
       if (auto gp = dyn_cast<GenericTypeParamDecl>(member)) {
-        if (gp->isValue()) {
-          auto refType = adjustedOpenedType;
-          auto ref = TypeValueExpr::createForDecl(memberLoc, gp, dc);
-          cs.setType(ref, refType);
+        ASSERT(gp->isValue());
 
-          auto gpTy = gp->getDeclaredInterfaceType();
-          auto subs = baseTy->getContextSubstitutionMap();
-          ref->setParamType(gpTy.subst(subs));
+        auto refType = adjustedOpenedType;
+        auto ref = TypeValueExpr::createForDecl(memberLoc, gp, dc);
+        cs.setType(ref, refType);
 
-          auto result = new (ctx) DotSyntaxBaseIgnoredExpr(base, dotLoc, ref,
-                                                           refType);
-          cs.setType(result, refType);
-          return result;
-        }
+        auto gpTy = gp->getDeclaredInterfaceType();
+        auto subs = baseTy->getContextSubstitutionMap();
+        ref->setParamType(gpTy.subst(subs));
+
+        auto result = new (ctx) DotSyntaxBaseIgnoredExpr(base, dotLoc, ref,
+                                                         refType);
+        cs.setType(result, refType);
+        return result;
       }
 
       // If we're referring to a member type, it's just a type


### PR DESCRIPTION
Some of the surrounding code is a bit messy, but this is a step towards untangling it further. Also, split up buildMemberRef() a bit.