### PR TITLE
[Distributed] We're currently not using this isDistributedThunk func

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3045,13 +3045,6 @@ public:
   /// `distributed var get { }` accessors.
   bool isDistributedGetAccessor() const;
 
-  /// Is this a 'distributed thunk'?
-  ///
-  /// Distributed thunks are synthesized functions which perform the "is remote?"
-  /// check, before dispatching to a 'system.remoteCall' (if actor was remote).
-  /// They are always 'async' and 'throws'.
-  bool isDistributedThunk() const;
-
   bool hasName() const { return bool(Name); }
   bool isOperator() const { return Name.isOperator(); }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1367,13 +1367,6 @@ bool ValueDecl::isDistributedGetAccessor() const {
   return false;
 }
 
-bool ValueDecl::isDistributedThunk() const {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(this)) {
-    return func->isDistributedThunk();
-  }
-  return false;
-}
-
 ConstructorDecl *
 NominalTypeDecl::getDistributedRemoteCallTargetInitFunction() const {
   auto mutableThis = const_cast<NominalTypeDecl *>(this);


### PR DESCRIPTION
We're currently not using this func so removing for now.

May revisit in future cleanups