### PR TITLE
[6.2][cxx-interop] Basic support for anonymous structs with non-copyable fields

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4598,6 +4598,10 @@ namespace {
         // FIXME: Temporarily unreachable because of check above.
         markAsVariant(result, *correctSwiftName);
 
+      if (decl->isAnonymousStructOrUnion())
+        Impl.markUnavailable(
+            result, "refer to the members of the anonymous type instead");
+
       return result;
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3064,11 +3064,11 @@ namespace {
             }
           }
         }
-        if (copyCtor) {
+        if (copyCtor && !decl->isAnonymousStructOrUnion()) {
           clangSema.DefineImplicitCopyConstructor(clang::SourceLocation(),
                                                   copyCtor);
         }
-        if (moveCtor) {
+        if (moveCtor && !decl->isAnonymousStructOrUnion()) {
           clangSema.DefineImplicitMoveConstructor(clang::SourceLocation(),
                                                   moveCtor);
         }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6935,11 +6935,13 @@ namespace {
     }
 
     void addValueWitnessTable() {
+      llvm::Constant* vwtPointer = nullptr;
       if (auto cd = Target->getClangDecl())
         if (auto rd = dyn_cast<clang::RecordDecl>(cd))
           if (rd->isAnonymousStructOrUnion())
-            return;
-      auto vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
+            vwtPointer = llvm::Constant::getNullValue(IGM.WitnessTablePtrTy);
+      if (!vwtPointer)
+        vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
       B.addSignedPointer(vwtPointer,
                          IGM.getOptions().PointerAuth.ValueWitnessTable,
                          PointerAuthEntity());

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6935,6 +6935,10 @@ namespace {
     }
 
     void addValueWitnessTable() {
+      if (auto cd = Target->getClangDecl())
+        if (auto rd = dyn_cast<clang::RecordDecl>(cd))
+          if (rd->isAnonymousStructOrUnion())
+            return;
       auto vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
       B.addSignedPointer(vwtPointer,
                          IGM.getOptions().PointerAuth.ValueWitnessTable,

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -590,10 +590,17 @@ unsigned irgen::getNumFields(const NominalTypeDecl *target) {
 }
 
 bool irgen::isExportableField(Field field) {
-  if (field.getKind() == Field::Kind::Var &&
-      field.getVarDecl()->getClangDecl() &&
-      field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
-    return false;
+  if (field.getKind() == Field::Kind::Var) {
+    if (field.getVarDecl()->getClangDecl() &&
+        field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
+      return false;
+    // We should not be able to refer to anonymous types.
+    if (const auto *vd = dyn_cast_or_null<clang::ValueDecl>(
+            field.getVarDecl()->getClangDecl()))
+      if (const auto *rd = vd->getType()->getAsRecordDecl())
+        if (rd->isAnonymousStructOrUnion())
+          return false;
+  }
   // All other fields are exportable
   return true;
 }

--- a/test/Interop/Cxx/class/Inputs/simple-structs.h
+++ b/test/Interop/Cxx/class/Inputs/simple-structs.h
@@ -17,6 +17,15 @@ struct HasPublicFieldsOnly {
   HasPublicFieldsOnly(int i1, int i2) : publ1(i1), publ2(i2) {}
 };
 
+struct HasAnonymousType {
+  HasAnonymousType(int a, int b, int c) : a(a), b(b), c(c) {}
+
+  struct {
+    int a, b;
+  };
+  int c;
+};
+
 struct HasPrivatePublicProtectedFields {
 private:
   int priv1;

--- a/test/Interop/Cxx/class/access-anonymous-field.swift
+++ b/test/Interop/Cxx/class/access-anonymous-field.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -swift-version 6 -cxx-interoperability-mode=upcoming-swift
+
+// CHECK: Foobar
+
+import SimpleStructs
+
+let s = HasAnonymousType(1, 2, 3)
+let _ = s.__Anonymous_field0 // expected-error {{'__Anonymous_field0' is unavailable: refer to the members of the anonymous type instead}}
+// Referring to the members of the anonymous type directly.
+let _ = s.a
+let _ = s.b
+let _ = s.c

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -56,4 +56,16 @@ struct NonCopyableHolderDerivedDerived: NonCopyableHolderDerived {
 inline NonCopyable *getNonCopyablePtr() { return nullptr; }
 inline NonCopyableDerived *getNonCopyableDerivedPtr() { return nullptr; }
 
+template <typename T>
+struct FieldInAnonStruct {
+  FieldInAnonStruct() : field(5) {}
+  FieldInAnonStruct(const FieldInAnonStruct &) = delete;
+  FieldInAnonStruct(FieldInAnonStruct &&) = default;
+  struct {
+    T field;
+  };
+};
+
+using FieldInAnonStructNC = FieldInAnonStruct<NonCopyable>;
+
 #endif // TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -76,4 +76,8 @@ MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
 }
 #endif
 
+MoveOnlyCxxValueType.test("Test move only field in anonymous struct") {
+  let a = FieldInAnonStructNC()
+  let b = a
+}
 runAllTests()

--- a/test/Interop/Cxx/class/print-simple-structs.swift
+++ b/test/Interop/Cxx/class/print-simple-structs.swift
@@ -24,6 +24,11 @@ func printCxxStructNested() {
     print(s)
 }
 
+func printCxxStructWithAnonType() {
+    let s = HasAnonymousType(1, 2, 3)
+    print(s)
+}
+
 printCxxStructPrivateFields() 
 // CHECK: HasPrivateFieldsOnly()
 
@@ -35,3 +40,6 @@ printCxxStructPrivatePublicProtectedFields()
 
 printCxxStructNested()
 // CHECK: Outer(publStruct: {{.*}}.HasPrivatePublicProtectedFields(publ1: 8, publ2: 12))
+
+printCxxStructWithAnonType()
+// CHECK: HasAnonymousType(c: 3)


### PR DESCRIPTION
Explanation: Anonymous structs cannot be copied or moved, these operations only can happen to their enclosing non-anonymous types. Stop trying to emit special member functions and value witness tables for these structs. This fix is required to unblock a high priority libc++ change that fixes an unintended ABI break.
Issues: rdar://159928354
Original PRs: #84105, #84152, #84199
Risk: Medium. I believe this is the right change but hard to anticipate if something depends on the presence of these operations (which is likely to be a bug). But this is required to unblock an important libc++ fix.
Testing: Added a compiler test.
Reviewers: @rjmccall
