### PR TITLE
[cxx-interop] Check if copy constructor is eligible

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8164,6 +8164,7 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
   // struct.
   return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
     return ctor->isCopyConstructor() && !ctor->isDeleted() &&
+           !ctor->isIneligibleOrNotSelected() &&
            // FIXME: Support default arguments (rdar://142414553)
            ctor->getNumParams() == 1 &&
            ctor->getAccess() == clang::AccessSpecifier::AS_public;

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify - -I %t/Inputs %t/test.swift
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %t/Inputs %t/test.swift
+
+//--- Inputs/module.modulemap
+module Test {
+    header "noncopyable.h"
+    requires cplusplus
+}
+
+//--- Inputs/noncopyable.h
+#include <string>
+
+struct NonCopyable {
+    NonCopyable() = default;
+    NonCopyable(const NonCopyable& other) = delete;
+    NonCopyable(NonCopyable&& other) = default;
+};
+
+template <typename T>
+struct OwnsT {
+    T element;
+    OwnsT() {}
+    OwnsT(const OwnsT &other) : element(other.element) {}
+    OwnsT(OwnsT&& other) {}
+};
+
+using OwnsNonCopyable = OwnsT<NonCopyable>;
+
+#if __cplusplus >= 202002L
+template <typename T>
+struct RequiresCopyableT {
+    T element;
+    RequiresCopyableT() {}
+    RequiresCopyableT(const RequiresCopyableT &other) requires std::is_copy_constructible_v<T> : element(other.element) {}
+    RequiresCopyableT(RequiresCopyableT&& other) {}
+};
+
+using NonCopyableRequires = RequiresCopyableT<NonCopyable>;
+
+#endif
+
+//--- test.swift
+import Test
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+// expected-note@-1 {{'where T: Copyable' is implicit here}}
+// expected-cpp20-note@-2 {{'where T: Copyable' is implicit here}}
+
+func userDefinedTypes() {
+    let nCop = NonCopyable()
+    takeCopyable(nCop) // expected-error {{global function 'takeCopyable' requires that 'NonCopyable' conform to 'Copyable'}}
+
+    let ownsT = OwnsNonCopyable()
+    takeCopyable(ownsT) // no error, OwnsNonCopyable imported as Copyable
+
+}
+
+#if CPP20
+func useOfRequires() {
+    let nCop = NonCopyableRequires()
+    takeCopyable(nCop) // expected-cpp20-error {{global function 'takeCopyable' requires that 'NonCopyableRequires' (aka 'RequiresCopyableT<NonCopyable>') conform to 'Copyable'}}
+}
+#endif
+


### PR DESCRIPTION
Since C++20, we can use the `requires` expression to make a copy constructor available or not depending on a set of constraints. So, when importing a type as copyable, make sure its copy constructor is eligible.

rdar://159929115