### PR TITLE
[6.2] Build CMake on macOS if one is not preinstalled

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -282,14 +282,9 @@ class CMake(object):
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')
 
-    # Get the path to CMake to use for the build
-    # This function will not build CMake for Apple platforms.
-    # For other platforms, this builds CMake if a new enough version is not
-    # available.
+    # Get the path to CMake to use for the build, this builds CMake if a new enough
+    # version is not available.
     def get_cmake_path(self, source_root, build_root):
-        if platform.system() == 'Darwin':
-            return self.toolchain.cmake
-
         cmake_source_dir = os.path.join(source_root, 'cmake')
         if not os.path.isdir(cmake_source_dir):
             return self.toolchain.cmake


### PR DESCRIPTION
- **Explanation**:
This closes a gap in the setup of the build -- while most of the macOS configurations install CMake before hand, this would avoid a hard failure when we forget to do so.
- **Scope**:
Builds on macOS that do not provide a prebuilt CMake before hand.
- **Issues**: rdar://159939866
- **Original PRs**:
https://github.com/swiftlang/swift/pull/81161
- **Risk**:
Low -- this only affects macOS configurations that do not have CMake already in the path, which are a small number of all configurations (since at desk we give clear instructions about installing prerequisites, and on CI we install those automatically).
- **Testing**:
Ensured at desk that on a macOS system with no CMake or ninja in the search path build-script is able to build those and get to the build of LLVM.
- **Reviewers**: myself in the original PR done by @MaxDesiatov 