### PR TITLE
SwiftRemoteMirror: export symbols from the library on Windows

### DIFF
--- a/Runtimes/Core/SwiftRemoteMirror/CMakeLists.txt
+++ b/Runtimes/Core/SwiftRemoteMirror/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 add_library(swiftRemoteMirror
   SwiftRemoteMirror.cpp)
+target_compile_definitions(swiftRemoteMirror PUBLIC
+  $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:swiftRemoteMirror_STATIC>)
 target_link_libraries(swiftRemoteMirror PRIVATE
   swiftRemoteInspection)
 target_include_directories(swiftRemoteMirror PRIVATE

--- a/include/swift/SwiftRemoteMirror/Platform.h
+++ b/include/swift/SwiftRemoteMirror/Platform.h
@@ -23,20 +23,16 @@ extern "C" {
 # elif defined(__MACH__)
 #   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
 # else
-#   if defined(_WINDLL)
-#     define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllexport)
-#   else
-#     define SWIFT_REMOTE_MIRROR_LINKAGE
-#   endif
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllexport)
 # endif
 #else
 # if defined(__ELF__) || defined(__MACH__) || defined(__WASM__)
 #   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
 # else
-#   if defined(_WINDLL)
-#     define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllimport)
-#   else
+#   if defined(swiftRemoteMirror_STATIC)
 #     define SWIFT_REMOTE_MIRROR_LINKAGE
+#   else
+#     define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllimport)
 #   endif
 # endif
 #endif


### PR DESCRIPTION
When building a shared library on Windows, ensure that we export the symbols. We would previously export none of the interfaces making the dynamic library unusable. Simplify the macros as
`swiftRemoteMirror_EXPORTS` would only be defined when building a shared library.