### PR TITLE
Require build of StringProcessing for some Macros tests

### DIFF
--- a/test/Macros/expand_on_imported.swift
+++ b/test/Macros/expand_on_imported.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test, concurrency
+// REQUIRES: swift_swift_parser, concurrency, string_processing
 // REQUIRES: swift_feature_MacrosOnImports
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/expand_on_imported_objc.swift
+++ b/test/Macros/expand_on_imported_objc.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test, objc_interop, concurrency
+// REQUIRES: swift_swift_parser, objc_interop, concurrency, string_processing
 // REQUIRES: swift_feature_MacrosOnImports
 // REQUIRES: OS=macosx
 

--- a/test/Macros/imported_type_error.swift
+++ b/test/Macros/imported_type_error.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test
+// REQUIRES: swift_swift_parser, string_processing
 // REQUIRES: swift_feature_MacrosOnImports
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/print_clang_expand_on_imported.swift
+++ b/test/Macros/print_clang_expand_on_imported.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test, concurrency
+// REQUIRES: swift_swift_parser, concurrency, string_processing
 // REQUIRES: swift_feature_MacrosOnImports
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/print_clang_expand_on_imported_objc.swift
+++ b/test/Macros/print_clang_expand_on_imported_objc.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test, objc_interop, concurrency
+// REQUIRES: swift_swift_parser, objc_interop, concurrency, string_processing
 // REQUIRES: swift_feature_MacrosOnImports
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
Also mark them as not executable, since they don't call `%target-run`.
    
This is needed back deployment configurations where StringProcessing is
not supported.
    
Addresses rdar://159635486