### PR TITLE
[presets] Add a special preset for Amazon Linux 2

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -967,6 +967,13 @@ mixin-preset=buildbot_linux_base
 
 no-assertions
 
+[preset: buildbot_amazon_linux_2]
+mixin-preset=buildbot_linux
+
+skip-test-sourcekit-lsp
+skip-test-lldb
+
+extra-cmake-options=-DLLDB_ENABLE_PYTHON=NO
 
 [preset: mixin_buildbot_linux,no_test]
 skip-test-cmark


### PR DESCRIPTION
This preset inherits from buildbot_linux, the preset currently used to build on AL2. Additionally, it:
* Disables sourcekit-lsp testing. We do not expect people to be using AL2 as a Swift development platform at this point, and some sourcekit-lsp tests fail only on AL2.
* Disables LLDB testing and Python scripting support for LLDB. The Python requirement for both is too high for AL2.