### PR TITLE
ASTGen: Fix disable implicit string processing import

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -15,7 +15,7 @@ if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
     "${COMPILER_REGEX_PARSER_SOURCES}"
   )
   target_compile_options(_CompilerRegexParser PRIVATE
-    -disable-implicit-string-processing-module-import)
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
 else()
   # Dummy target for dependencies
   add_custom_target(_CompilerRegexParser)


### PR DESCRIPTION
The C++ driver doesn't see this flag as a valid driver flag, only as a frontend flag resulting in an error message on bootstrap jobs.

```
<unknown>:0: error: unknown argument: '-disable-implicit-string-processing-module-import'
```
https://ci.swift.org/job/swift-bootstrap-ubuntu-24_04-x86_64/425/