### PR TITLE
Sema: Clean up getTypeOfMemberReference() and buildMemberRef()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1344,6 +1344,10 @@ public:
   Type removeArgumentLabels(unsigned numArgumentLabels);
 
   /// Replace DynamicSelfType anywhere it appears in covariant position with
+  /// its underlying Self type.
+  Type eraseDynamicSelfType();
+
+  /// Replace DynamicSelfType anywhere it appears in covariant position with
   /// the given type.
   Type replaceDynamicSelfType(Type newSelfType);
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4456,30 +4456,6 @@ public:
                           DeclContext *useDC,
                           PreparedOverloadBuilder *preparedOverload);
 
-  /// Return the type-of-reference of the given value.
-  ///
-  /// \param baseType if non-null, return the type of a member reference to
-  ///   this value when the base has the given type
-  ///
-  /// \param UseDC The context of the access.  Some variables have different
-  ///   types depending on where they are used.
-  ///
-  /// \param locator The locator anchored at this value reference, when
-  /// it is a member reference.
-  ///
-  /// \param wantInterfaceType Whether we want the interface type, if available.
-  Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
-                                  DeclContext *UseDC,
-                                  ConstraintLocator *locator,
-                                  bool wantInterfaceType);
-
-  /// Given the opened type and a pile of information about a member reference,
-  /// determine the reference type of the member reference.
-  Type getMemberReferenceTypeFromOpenedType(
-      Type type, Type baseObjTy, ValueDecl *value, DeclContext *outerDC,
-      ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
-      ArrayRef<OpenedType> replacements);
-
   /// Retrieve the type of a reference to the given value declaration,
   /// as a member with a base of the given type.
   ///
@@ -4507,6 +4483,39 @@ public:
   }
 
 private:
+  DeclReferenceType getTypeOfMemberTypeReference(
+      Type baseObjTy, TypeDecl *typeDecl, ConstraintLocator *locator,
+      PreparedOverloadBuilder *preparedOverload);
+
+  /// Return the type-of-reference of the given value.
+  ///
+  /// \param baseType if non-null, return the type of a member reference to
+  ///   this value when the base has the given type
+  ///
+  /// \param UseDC The context of the access.  Some variables have different
+  ///   types depending on where they are used.
+  ///
+  /// \param locator The locator anchored at this value reference, when
+  /// it is a member reference.
+  ///
+  /// \param wantInterfaceType Whether we want the interface type, if available.
+  Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
+                                  DeclContext *UseDC,
+                                  ConstraintLocator *locator,
+                                  bool wantInterfaceType);
+
+  std::pair<Type, Type> getOpenedStorageType(
+      Type baseTy, AbstractStorageDecl *value, DeclContext *useDC,
+      bool hasAppliedSelf, ArrayRef<OpenedType> replacements,
+      ConstraintLocator *locator, PreparedOverloadBuilder *preparedOverload);
+
+  /// Given the opened type and a pile of information about a member reference,
+  /// determine the reference type of the member reference.
+  Type getMemberReferenceTypeFromOpenedType(
+      Type type, Type baseObjTy, ValueDecl *value,
+      ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
+      ArrayRef<OpenedType> replacements);
+
   /// Add the constraints needed to bind an overload's type variable.
   void bindOverloadType(const SelectedOverload &overload, Type boundType,
                         ConstraintLocator *locator, DeclContext *useDC);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4476,7 +4476,7 @@ public:
   /// Given the opened type and a pile of information about a member reference,
   /// determine the reference type of the member reference.
   Type getMemberReferenceTypeFromOpenedType(
-      Type &openedType, Type baseObjTy, ValueDecl *value, DeclContext *outerDC,
+      Type type, Type baseObjTy, ValueDecl *value, DeclContext *outerDC,
       ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
       ArrayRef<OpenedType> replacements);
 

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -312,7 +312,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         return std::make_shared<FunctionCallValue>(identifier, parameters);
       }
 
-      if (auto constructorRefCall = dyn_cast<ConstructorRefCallExpr>(callExpr->getFn())) {
+      if (isa<ConstructorRefCallExpr>(callExpr->getFn())) {
         std::vector<FunctionParameter> parameters =
             extractFunctionArguments(callExpr->getArgs(), declContext);
         return std::make_shared<InitCallValue>(callExpr->getType(), parameters);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2073,9 +2073,7 @@ namespace {
 
       Type refTySelf = refTy, adjustedRefTySelf = adjustedRefTy;
 
-      auto *func = dyn_cast<FuncDecl>(member);
-      if (func && func->getResultInterfaceType()->hasDynamicSelfType()) {
-        ASSERT(refTy->hasDynamicSelfType());
+      if (refTy->hasDynamicSelfType()) {
         refTySelf = refTy->replaceDynamicSelfType(containerTy);
         adjustedRefTySelf = adjustedRefTy->replaceDynamicSelfType(
             containerTy);
@@ -2177,11 +2175,8 @@ namespace {
             const Type replacementTy = getDynamicSelfReplacementType(
                 baseTy, member, memberLocator.getBaseLocator());
             if (!replacementTy->isEqual(containerTy)) {
-              if (isa<ConstructorDecl>(member)) {
-                adjustedRefTy = adjustedRefTy->withCovariantResultType();
-              } else {
-                ASSERT(adjustedRefTy->hasDynamicSelfType());
-              }
+              ASSERT(adjustedRefTy->hasDynamicSelfType());
+
               Type conversionTy =
                   adjustedRefTy->replaceDynamicSelfType(replacementTy);
               if (isSuperPartialApplication) {
@@ -2605,8 +2600,9 @@ namespace {
 
       // Wrap in covariant `Self` return if needed.
       if (ref.getDecl()->getDeclContext()->getSelfClassDecl()) {
-        auto covariantTy = resultTy->withCovariantResultType()
-          ->replaceDynamicSelfType(cs.getType(base)->getWithoutSpecifierType());
+        ASSERT(resultTy->hasDynamicSelfType());
+        auto covariantTy = resultTy->replaceDynamicSelfType(
+            cs.getType(base)->getWithoutSpecifierType());
         if (!covariantTy->isEqual(resultTy))
           ctorRef = cs.cacheType(
                new (ctx) CovariantFunctionConversionExpr(ctorRef, covariantTy));

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1789,23 +1789,23 @@ namespace {
         base->setImplicit();
       }
 
-      const auto hasDynamicSelf = refTy->hasDynamicSelfType();
-
       auto memberRefExpr
         = new (ctx) MemberRefExpr(base, dotLoc, memberRef,
                                   memberLoc, Implicit, semantics);
       memberRefExpr->setIsSuper(isSuper);
 
+      auto resultTy = resultType(refTy);
+      bool hasDynamicSelf = resultTy->hasDynamicSelfType();
       if (hasDynamicSelf) {
         refTy = refTy->replaceDynamicSelfType(containerTy);
         adjustedRefTy = adjustedRefTy->replaceDynamicSelfType(
             containerTy);
       }
 
-      cs.setType(memberRefExpr, resultType(refTy));
+      cs.setType(memberRefExpr, resultTy);
 
       Expr *result = memberRefExpr;
-      result = adjustTypeForDeclReference(result, resultType(refTy),
+      result = adjustTypeForDeclReference(result, resultTy,
                                           resultType(adjustedRefTy),
                                           locator);
       closeExistentials(result, locator);
@@ -1815,10 +1815,9 @@ namespace {
       // type having 'Self' swapped for the appropriate replacement
       // type -- usually the base object type.
       if (hasDynamicSelf) {
-        const auto conversionTy = adjustedOpenedType;
-        if (!containerTy->isEqual(conversionTy)) {
+        if (!resultTy->isEqual(adjustedOpenedType)) {
           result = cs.cacheType(new (ctx) CovariantReturnConversionExpr(
-              result, conversionTy));
+              result, adjustedOpenedType));
         }
       }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1796,7 +1796,10 @@ bool IgnoreAssignmentDestinationType::diagnoseForAmbiguity(
   if (!overload)
     return false;
 
-  auto memberName = overload->choice.getName().getBaseName();
+  auto declName = overload->choice.getName();
+  if (!declName)
+    return false;
+
   auto destType = solution.getType(assignment->getDest());
 
   auto &DE = cs.getASTContext().Diags;
@@ -1804,7 +1807,7 @@ bool IgnoreAssignmentDestinationType::diagnoseForAmbiguity(
   // for cases like this instead of using "contextual" one.
   DE.diagnose(assignment->getSrc()->getLoc(),
               diag::no_candidates_match_result_type,
-              memberName.userFacingName(),
+              declName.getBaseName().userFacingName(),
               solution.simplifyType(destType)->getRValueType());
 
   for (auto &entry : commonFixes) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2037,7 +2037,7 @@ DeclName OverloadChoice::getName() const {
     case OverloadChoiceKind::MaterializePack:
     case OverloadChoiceKind::TupleIndex:
     case OverloadChoiceKind::ExtractFunctionIsolation:
-      llvm_unreachable("no name!");
+      return DeclName();
   }
 
   llvm_unreachable("Unhandled OverloadChoiceKind in switch.");

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1558,18 +1558,17 @@ Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
   Type type = openedType;
 
   // Cope with dynamic 'Self'.
-  if (!outerDC->getSelfProtocolDecl()) {
-    const auto replacementTy =
-        getDynamicSelfReplacementType(baseObjTy, value, locator);
-
-    if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
-      if (isa<ConstructorDecl>(func) &&
-          func->getDeclContext()->getSelfClassDecl()) {
-        type = type->withCovariantResultType();
-      }
+  if (outerDC->getSelfClassDecl()) {
+    if (isa<ConstructorDecl>(value)) {
+      type = type->withCovariantResultType();
     }
 
-    type = type->replaceDynamicSelfType(replacementTy);
+    if (type->hasDynamicSelfType()) {
+      auto replacementTy = getDynamicSelfReplacementType(
+          baseObjTy, value, locator);
+
+      type = type->replaceDynamicSelfType(replacementTy);
+    }
   }
 
   // Check if we need to apply a layer of optionality to the uncurried type.

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1555,12 +1555,6 @@ Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
     Type &openedType, Type baseObjTy, ValueDecl *value, DeclContext *outerDC,
     ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
     ArrayRef<OpenedType> replacements) {
-  if (outerDC->getSelfClassDecl()) {
-    if (isa<ConstructorDecl>(value)) {
-      openedType = openedType->withCovariantResultType();
-    }
-  }
-
   // Check if we need to apply a layer of optionality to the uncurried type.
   if (!isRequirementOrWitness(locator)) {
     if (isDynamicLookup || value->getAttrs().hasAttribute<OptionalAttr>()) {
@@ -1766,6 +1760,12 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
     auto interfaceType = value->getInterfaceType();
     if (interfaceType->is<ErrorType>() || isa<MacroDecl>(value))
       return { interfaceType, interfaceType, interfaceType, interfaceType, Type() };
+
+    if (outerDC->getSelfClassDecl()) {
+      if (isa<ConstructorDecl>(value)) {
+        interfaceType = interfaceType->withCovariantResultType();
+      }
+    }
 
     // This is the easy case.
     openedType = interfaceType->castTo<AnyFunctionType>();

--- a/test/SILGen/dynamic_self_as_lvalue_base.swift
+++ b/test/SILGen/dynamic_self_as_lvalue_base.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen %s
+
+class C: P1, P2 {
+  public func f(_ n: Int) -> Self {
+    self.x = n
+    self.y = n
+    self.z = n
+    return self
+  }
+
+  public var x: Int? {
+    get { fatalError() }
+    set { }
+  }
+}
+
+protocol P1: AnyObject {}
+protocol P2 {}
+
+extension P1 {
+  public var y: Int? {
+    get { fatalError() }
+    set { }
+  }
+}
+
+extension P2 {
+  public var z: Int? {
+    get { fatalError() }
+    nonmutating set { }
+  }
+}

--- a/test/SILGen/dynamic_self_substitution.swift
+++ b/test/SILGen/dynamic_self_substitution.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-silgen %s
+
+class C {
+  func f1() -> Self? {
+    return D<Self>().g(self)
+  }
+
+  func f2() -> Self? {
+    return D<Self>()[self]
+  }
+
+  func f3() -> Self? {
+    return D<Self>().x
+  }
+}
+
+class D<T> {
+  func g(_ t: T) -> T? {
+    return t
+  }
+
+  subscript(_ t: T) -> T? {
+    return t
+  }
+
+  var x: T? {
+    fatalError()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/c3a89a7cea373695.swift
+++ b/validation-test/compiler_crashers_2_fixed/c3a89a7cea373695.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::constraints::doesMemberRefApplyCurriedSelf(swift::Type, swift::ValueDecl const*)","signatureAssert":"Assertion failed: (decl->getDeclContext()->isTypeContext() && \"Expected a member reference\"), function doesMemberRefApplyCurriedSelf"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 Swift < .Int

--- a/validation-test/compiler_crashers_2_fixed/d4a53522d2dce157.swift
+++ b/validation-test/compiler_crashers_2_fixed/d4a53522d2dce157.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"e0be092d","signature":"swift::constraints::IgnoreAssignmentDestinationType::diagnoseForAmbiguity(llvm::ArrayRef<std::__1::pair<swift::constraints::Solution const*, swift::constraints::ConstraintFix const*>>) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 stride = (a:2).0


### PR DESCRIPTION
Both of these functions are ridiculously complex. Chip away at the debt just a little bit.