### PR TITLE
Add error messages for Swift module map parser

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -360,8 +360,8 @@ ERROR(explicit_swift_module_map_missing,none,
       (StringRef))
 
 ERROR(explicit_swift_module_map_corrupted,none,
-      "explicit Swift module map from %0 is malformed",
-      (StringRef))
+      "explicit Swift module map from %0 is malformed: %1",
+      (StringRef, StringRef))
 
 ERROR(const_extract_protocol_list_input_file_missing,none,
       "cannot open constant extraction protocol list input file from %0",

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1604,8 +1604,12 @@ static bool generateReproducer(CompilerInstance &Instance,
     }
     auto map = llvm::json::parse(mapProxy->getData());
     if (!map) {
-      diags.diagnose(SourceLoc(), diag::explicit_swift_module_map_corrupted,
-                     mapOpts);
+      llvm::handleAllErrors(
+          map.takeError(), [&diags, &mapOpts](const llvm::json::ParseError &E) {
+            diags.diagnose(SourceLoc(),
+                           diag::explicit_swift_module_map_corrupted, mapOpts,
+                           E.message());
+          });
       return true;
     }
     if (auto array = map->getAsArray()) {

--- a/test/Frontend/explicit-swift-module-map-file-parser.swift
+++ b/test/Frontend/explicit-swift-module-map-file-parser.swift
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend -typecheck %t/test.swift \
+// RUN:   -explicit-swift-module-map-file %t/invalid_root_object.json \
+// RUN:   2>&1 | %FileCheck %s -check-prefix=CHECK-ROOT
+
+// CHECK-ROOT: malformed: invalid JSON root object
+
+// RUN: not %target-swift-frontend -typecheck %t/test.swift \
+// RUN:   -explicit-swift-module-map-file %t/invalid_entry_type.json \
+// RUN:   2>&1 | %FileCheck %s -check-prefix=CHECK-ENTRY-TYPE
+
+// CHECK-ENTRY-TYPE: malformed: incorrect entry type
+
+// RUN: not %target-swift-frontend -typecheck %t/test.swift \
+// RUN:   -explicit-swift-module-map-file %t/missing_module_name.json \
+// RUN:   2>&1 | %FileCheck %s -check-prefix=CHECK-NAME
+
+// CHECK-NAME: malformed: entry is missing module name
+
+// RUN: not %target-swift-frontend -typecheck %t/test.swift \
+// RUN:   -explicit-swift-module-map-file %t/duplicate_swift_module.json \
+// RUN:   2>&1 | %FileCheck %s -check-prefix=CHECK-DUP-SWIFT
+
+// CHECK-DUP-SWIFT: malformed: duplicate Swift module with name SwiftMod
+
+// RUN: not %target-swift-frontend -typecheck %t/test.swift \
+// RUN:   -explicit-swift-module-map-file %t/duplicate_clang_module.json \
+// RUN:   2>&1 | %FileCheck %s -check-prefix=CHECK-DUP-CLANG
+
+// CHECK-DUP-CLANG: malformed: duplicate Clang module with name ClangMod
+
+//--- invalid_root_object.json
+{
+    "some_key": "some_val"
+}
+//--- invalid_entry_type.json
+[
+    [
+        {"some_key": "some_val"}
+    ]
+]
+//--- missing_module_name.json
+[
+    {
+        "isFramework": false,
+        "modulePath": "/some/path"
+    }
+]
+//--- duplicate_swift_module.json
+[
+    {
+        "isFramework": false,
+        "moduleName": "SwiftMod",
+        "modulePath": "/some/path"
+    },
+    {
+        "isFramework": false,
+        "moduleName": "SwiftMod",
+        "modulePath": "/some/path"
+    }
+]
+//--- duplicate_clang_module.json
+[
+    {
+        "isFramework": false,
+        "moduleName": "ClangMod",
+        "clangModulePath": "/some/path"
+    },
+    {
+        "isFramework": false,
+        "moduleName": "ClangMod",
+        "clangModulePath": "/some/path"
+    }
+]
+//--- test.swift
+import Swift


### PR DESCRIPTION
Parser errors with large Swift module map files can be hard to diagnose. Refactor the parser to return an llvm::Error so clearer diagnostics can be passed to the user.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
