### PR TITLE
[Test] Add signaturehelp to supported requests list in sourcekitd-test

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -174,6 +174,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- complete.setpopularapi\n"
                      << "- typecontextinfo\n"
                      << "- conformingmethods\n"
+                     << "- signaturehelp\n"
                      << "- cursor\n"
                      << "- related-idents\n"
                      << "- syntax-map\n"


### PR DESCRIPTION
I added the `signaturehelp` request to `sourcekitd-test` in #83378 but forgot to add it to the list of available requests we print when a user enters an invalid request name.