### PR TITLE
AST: Add printing support for `#available` and `#_hasSymbol` conditions

### DIFF
--- a/test/expr/print/conditions.swift
+++ b/test/expr/print/conditions.swift
@@ -14,6 +14,18 @@ if (5 + 5) == 9 {
 // CHECK: } else {
 // CHECK: }
 
+if #available(macOS 11, iOS 17, *) {
+} else if #unavailable(watchOS 11) {
+}
+// CHECK: if #available(macOS 11, iOS 17, *) {
+// CHECK: } else if #unavailable(watchOS 11) {
+// CHECK: }
+
+if #_hasSymbol(Int.self) {
+}
+// CHECK: if #_hasSymbol(Int.self) {
+// CHECK: }
+
 guard (5 + 5) == 10 else {
 }
 // CHECK: guard (5 + 5) == 10 else {


### PR DESCRIPTION
Teach `ASTPrinter` to print `if #available` and `if #_hasSymbol` statements.
