### PR TITLE
[ASTPrinter] Escape @_lifetime arguments when needed

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -141,17 +141,7 @@ public:
     return getName().str() == "immortal";
   }
 
-  std::string getString() const {
-    switch (kind) {
-    case DescriptorKind::Named:
-      return getName().str().str();
-    case DescriptorKind::Ordered:
-      return std::to_string(getIndex());
-    case DescriptorKind::Self:
-      return "self";
-    }
-    llvm_unreachable("Invalid DescriptorKind");
-  }
+  std::string getString() const;
 };
 
 class LifetimeEntry final

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -28,6 +28,18 @@
 
 namespace swift {
 
+std::string LifetimeDescriptor::getString() const {
+  switch (kind) {
+  case DescriptorKind::Named:
+    return getName().str().str();
+  case DescriptorKind::Ordered:
+    return std::to_string(getIndex());
+  case DescriptorKind::Self:
+    return "self";
+  }
+  llvm_unreachable("Invalid DescriptorKind");
+}
+
 LifetimeEntry *
 LifetimeEntry::create(const ASTContext &ctx, SourceLoc startLoc,
                       SourceLoc endLoc, ArrayRef<LifetimeDescriptor> sources,

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/LifetimeDependence.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -30,8 +31,14 @@ namespace swift {
 
 std::string LifetimeDescriptor::getString() const {
   switch (kind) {
-  case DescriptorKind::Named:
+  case DescriptorKind::Named: {
+    bool shouldEscape =
+        escapeIdentifierInContext(getName(), PrintNameContext::Normal);
+    if (shouldEscape) {
+      return ("`" + getName().str() + "`").str();
+    }
     return getName().str().str();
+  }
   case DescriptorKind::Ordered:
     return std::to_string(getIndex());
   case DescriptorKind::Self:

--- a/test/IDE/print_lifetime_attr.swift
+++ b/test/IDE/print_lifetime_attr.swift
@@ -1,0 +1,39 @@
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_LifetimeDependence
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence -print-swift-file-interface -source-filename %t/test.swift > %t/interface.txt
+// RUN: diff %t/interface.txt %t/interface.txt.expected
+
+//--- test.swift
+public struct S : ~Escapable {
+    @_lifetime(immortal)
+    init() {}
+}
+
+@_lifetime(foo: copy foo)
+public func fooFunc(_ foo: inout S) {}
+
+@_lifetime(&bar)
+public func barFunc(_ bar: inout S) -> S {
+    return bar
+}
+
+@_lifetime(`func`: copy `func`)
+public func funcFunc(func: inout S) {}
+
+//--- interface.txt.expected
+
+public struct S : ~Escapable {
+
+    @_lifetime(immortal)
+    internal init()
+}
+@_lifetime(foo: copy foo)
+public func fooFunc(_ foo: inout S)
+@_lifetime(&bar)
+public func barFunc(_ bar: inout S) -> S
+@_lifetime(func: copy func)
+public func funcFunc(func: inout S)

--- a/test/IDE/print_lifetime_attr.swift
+++ b/test/IDE/print_lifetime_attr.swift
@@ -24,6 +24,14 @@ public func barFunc(_ bar: inout S) -> S {
 @_lifetime(`func`: copy `func`)
 public func funcFunc(func: inout S) {}
 
+public struct T : ~Escapable {
+    let s: S
+    @_lifetime(borrow self)
+    func selfFunc() -> S { return s }
+    @_lifetime(borrow `self`)
+    func selfFunc2(`self`: S) -> S { return `self` }
+}
+
 //--- interface.txt.expected
 
 public struct S : ~Escapable {
@@ -35,5 +43,16 @@ public struct S : ~Escapable {
 public func fooFunc(_ foo: inout S)
 @_lifetime(&bar)
 public func barFunc(_ bar: inout S) -> S
-@_lifetime(func: copy func)
+@_lifetime(`func`: copy `func`)
 public func funcFunc(func: inout S)
+
+public struct T : ~Escapable {
+
+    internal let s: S
+
+    @_lifetime(borrow self)
+    internal func selfFunc() -> S
+
+    @_lifetime(borrow `self`)
+    internal func selfFunc2(self: S) -> S
+}

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -18,7 +18,7 @@ import CountedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(`func`: copy `func`)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func clash(func: inout MutableSpan<Int32>?, clash where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -38,7 +38,7 @@ import CountedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(`func`: copy `func`)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcRenamed(func: inout MutableSpan<Int32>?, extension: Int32, init: Int32, open: Int32, var: Int32, is: Int32, as: Int32, in: Int32, guard: Int32, where: Int32) -> UnsafeMutableRawPointer!
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -53,7 +53,7 @@ import CountedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(`func`: copy `func`)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func keyword(_ func: inout MutableSpan<Int32>?, _ extension: Int32, _ init: Int32, _ open: Int32, _ var: Int32, _ is: Int32, _ as: Int32, _ in: Int32, _ guard: Int32, _ where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -83,7 +83,7 @@ import CountedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(`func`: copy `func`)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func open(func: inout MutableSpan<Int32>?, open where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop


### PR DESCRIPTION
Printing a LifetimeDescriptor would never wrap it in backticks (even if originally wrapped in backticks). This would result in the output not being able to be parsed 

rdar://159992995