### PR TITLE
SILGen: Use lowered function type parameters in objc-to-swift thunks for initializers.

### DIFF
--- a/test/SILGen/Inputs/protocol-static-reqt-objc-class-impl.h
+++ b/test/SILGen/Inputs/protocol-static-reqt-objc-class-impl.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface C: NSObject
+
++(_Nonnull instancetype)foo;
+
+@end

--- a/test/SILGen/protocol-static-reqt-objc-class-impl.swift
+++ b/test/SILGen/protocol-static-reqt-objc-class-impl.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/protocol-static-reqt-objc-class-impl.h %s -verify
+// REQUIRES: objc_interop
+
+protocol P {
+	static func foo() -> Self
+}
+
+extension C: P {}
+


### PR DESCRIPTION
Fixes a regression caused by the `self` declaration being given a `DynamicSelfType` even though the formal type of the enclosing function sometimes still uses the concrete base class type.

Fixes #83876 | rdar://158956768.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
