### PR TITLE
Sema: Don't stick CovariantReturnConversionExpr around property access with DynamicSelfType base

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1789,14 +1789,12 @@ namespace {
         base->setImplicit();
       }
 
-      const auto hasDynamicSelf = refTy->hasDynamicSelfType();
-
       auto memberRefExpr
         = new (ctx) MemberRefExpr(base, dotLoc, memberRef,
                                   memberLoc, Implicit, semantics);
       memberRefExpr->setIsSuper(isSuper);
 
-      if (hasDynamicSelf) {
+      if (refTy->hasDynamicSelfType()) {
         refTy = refTy->replaceDynamicSelfType(containerTy);
         adjustedRefTy = adjustedRefTy->replaceDynamicSelfType(
             containerTy);
@@ -1814,11 +1812,10 @@ namespace {
       // conversion around the resulting expression, with the destination
       // type having 'Self' swapped for the appropriate replacement
       // type -- usually the base object type.
-      if (hasDynamicSelf) {
-        const auto conversionTy = adjustedOpenedType;
-        if (!containerTy->isEqual(conversionTy)) {
+      if (adjustedOpenedType->hasDynamicSelfType()) {
+        if (!containerTy->isEqual(adjustedOpenedType)) {
           result = cs.cacheType(new (ctx) CovariantReturnConversionExpr(
-              result, conversionTy));
+              result, adjustedOpenedType));
         }
       }
 

--- a/test/SILGen/dynamic_self_as_lvalue_base.swift
+++ b/test/SILGen/dynamic_self_as_lvalue_base.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen %s
+
+class C: P1, P2 {
+  public func f(_ n: Int) -> Self {
+    self.x = n
+    self.y = n
+    self.z = n
+    return self
+  }
+
+  public var x: Int? {
+    get { fatalError() }
+    set { }
+  }
+}
+
+protocol P1: AnyObject {}
+protocol P2 {}
+
+extension P1 {
+  public var y: Int? {
+    get { fatalError() }
+    set { }
+  }
+}
+
+extension P2 {
+  public var z: Int? {
+    get { fatalError() }
+    nonmutating set { }
+  }
+}


### PR DESCRIPTION
It could be that `refTy->hasDynamicSelfType()` is true whereas `varDecl->getValueInterfaceType()->hasDynamicSelfType()` is false. This happens if the base of the access is dynamic Self, so the refTy is `(Self) -> @lvalue Int` or whatever.

Note that replaceDynamicSelfType() behaves correctly in this case; it leaves that Self in place, because it's in contravariant position.

However, the other place where we check the condition would then form a nonsensical CovariantReturnConversionExpr around the result of the access, even though no conversion was necessary here; the type of the returned value does not involve Self.

Simplify this logic further with the correct condition. This fixes a regression from 1fbdc20be1c715651f1b0fed1f7d1d99a65616f4.

Fixes rdar://159531634.