### PR TITLE
A few pattern cleanups + fixes

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1222,13 +1222,12 @@ class CaseStmt final
 
   llvm::PointerIntPair<BraceStmt *, 1, bool> BodyAndHasFallthrough;
 
-  std::optional<ArrayRef<VarDecl *>> CaseBodyVariables;
+  ArrayRef<VarDecl *> CaseBodyVariables;
 
   CaseStmt(CaseParentKind ParentKind, SourceLoc ItemIntroducerLoc,
            ArrayRef<CaseLabelItem> CaseLabelItems, SourceLoc UnknownAttrLoc,
            SourceLoc ItemTerminatorLoc, BraceStmt *Body,
-           std::optional<ArrayRef<VarDecl *>> CaseBodyVariables,
-           std::optional<bool> Implicit,
+           ArrayRef<VarDecl *> CaseBodyVariables, std::optional<bool> Implicit,
            NullablePtr<FallthroughStmt> fallthroughStmt);
 
 public:
@@ -1248,7 +1247,7 @@ public:
   create(ASTContext &C, CaseParentKind ParentKind, SourceLoc ItemIntroducerLoc,
          ArrayRef<CaseLabelItem> CaseLabelItems, SourceLoc UnknownAttrLoc,
          SourceLoc ItemTerminatorLoc, BraceStmt *Body,
-         std::optional<ArrayRef<VarDecl *>> CaseBodyVariables,
+         ArrayRef<VarDecl *> CaseBodyVariables,
          std::optional<bool> Implicit = std::nullopt,
          NullablePtr<FallthroughStmt> fallthroughStmt = nullptr);
 
@@ -1293,7 +1292,7 @@ public:
   void setBody(BraceStmt *body) { BodyAndHasFallthrough.setPointer(body); }
 
   /// True if the case block declares any patterns with local variable bindings.
-  bool hasBoundDecls() const { return CaseBodyVariables.has_value(); }
+  bool hasCaseBodyVariables() const { return !CaseBodyVariables.empty(); }
 
   /// Get the source location of the 'case', 'default', or 'catch' of the first
   /// label.
@@ -1345,20 +1344,8 @@ public:
   }
 
   /// Return an ArrayRef containing the case body variables of this CaseStmt.
-  ///
-  /// Asserts if case body variables was not explicitly initialized. In contexts
-  /// where one wants a non-asserting version, \see
-  /// getCaseBodyVariablesOrEmptyArray.
   ArrayRef<VarDecl *> getCaseBodyVariables() const {
-    return *CaseBodyVariables;
-  }
-
-  bool hasCaseBodyVariables() const { return CaseBodyVariables.has_value(); }
-
-  ArrayRef<VarDecl *> getCaseBodyVariablesOrEmptyArray() const {
-    if (!CaseBodyVariables)
-      return ArrayRef<VarDecl *>();
-    return *CaseBodyVariables;
+    return CaseBodyVariables;
   }
 
   /// Find the next case statement within the same 'switch' or 'do-catch',

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1222,12 +1222,12 @@ class CaseStmt final
 
   llvm::PointerIntPair<BraceStmt *, 1, bool> BodyAndHasFallthrough;
 
-  std::optional<MutableArrayRef<VarDecl *>> CaseBodyVariables;
+  std::optional<ArrayRef<VarDecl *>> CaseBodyVariables;
 
   CaseStmt(CaseParentKind ParentKind, SourceLoc ItemIntroducerLoc,
            ArrayRef<CaseLabelItem> CaseLabelItems, SourceLoc UnknownAttrLoc,
            SourceLoc ItemTerminatorLoc, BraceStmt *Body,
-           std::optional<MutableArrayRef<VarDecl *>> CaseBodyVariables,
+           std::optional<ArrayRef<VarDecl *>> CaseBodyVariables,
            std::optional<bool> Implicit,
            NullablePtr<FallthroughStmt> fallthroughStmt);
 
@@ -1248,7 +1248,7 @@ public:
   create(ASTContext &C, CaseParentKind ParentKind, SourceLoc ItemIntroducerLoc,
          ArrayRef<CaseLabelItem> CaseLabelItems, SourceLoc UnknownAttrLoc,
          SourceLoc ItemTerminatorLoc, BraceStmt *Body,
-         std::optional<MutableArrayRef<VarDecl *>> CaseBodyVariables,
+         std::optional<ArrayRef<VarDecl *>> CaseBodyVariables,
          std::optional<bool> Implicit = std::nullopt,
          NullablePtr<FallthroughStmt> fallthroughStmt = nullptr);
 
@@ -1350,32 +1350,14 @@ public:
   /// where one wants a non-asserting version, \see
   /// getCaseBodyVariablesOrEmptyArray.
   ArrayRef<VarDecl *> getCaseBodyVariables() const {
-    ArrayRef<VarDecl *> a = *CaseBodyVariables;
-    return a;
+    return *CaseBodyVariables;
   }
 
   bool hasCaseBodyVariables() const { return CaseBodyVariables.has_value(); }
 
-  /// Return an MutableArrayRef containing the case body variables of this
-  /// CaseStmt.
-  ///
-  /// Asserts if case body variables was not explicitly initialized. In contexts
-  /// where one wants a non-asserting version, \see
-  /// getCaseBodyVariablesOrEmptyArray.
-  MutableArrayRef<VarDecl *> getCaseBodyVariables() {
-    return *CaseBodyVariables;
-  }
-
   ArrayRef<VarDecl *> getCaseBodyVariablesOrEmptyArray() const {
     if (!CaseBodyVariables)
       return ArrayRef<VarDecl *>();
-    ArrayRef<VarDecl *> a = *CaseBodyVariables;
-    return a;
-  }
-
-  MutableArrayRef<VarDecl *> getCaseBodyVariablesOrEmptyArray() {
-    if (!CaseBodyVariables)
-      return MutableArrayRef<VarDecl *>();
     return *CaseBodyVariables;
   }
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1244,12 +1244,16 @@ public:
                                        BraceStmt *Body);
 
   static CaseStmt *
+  createImplicit(ASTContext &ctx, CaseParentKind parentKind,
+                 ArrayRef<CaseLabelItem> caseLabelItems, BraceStmt *body,
+                 NullablePtr<FallthroughStmt> fallthroughStmt = nullptr);
+
+  static CaseStmt *
   create(ASTContext &C, CaseParentKind ParentKind, SourceLoc ItemIntroducerLoc,
          ArrayRef<CaseLabelItem> CaseLabelItems, SourceLoc UnknownAttrLoc,
          SourceLoc ItemTerminatorLoc, BraceStmt *Body,
-         ArrayRef<VarDecl *> CaseBodyVariables,
-         std::optional<bool> Implicit = std::nullopt,
-         NullablePtr<FallthroughStmt> fallthroughStmt = nullptr);
+         ArrayRef<VarDecl *> CaseBodyVariables, std::optional<bool> Implicit,
+         NullablePtr<FallthroughStmt> fallthroughStmt);
 
   CaseParentKind getParentKind() const { return ParentKind; }
 

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -378,10 +378,10 @@ bool CaseLabelItemScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
 }
 
 bool CaseStmtBodyScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
-  for (auto *var : stmt->getCaseBodyVariablesOrEmptyArray())
+  for (auto *var : stmt->getCaseBodyVariables()) {
     if (consumer.consume({var}))
-        return true;
-
+      return true;
+  }
   return false;
 }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2795,7 +2795,7 @@ public:
         // guarantee that all case label items bind corresponding patterns and
         // the case body var decls of a case stmt are created from the var decls
         // of the first case label items.
-        if (!caseStmt->hasBoundDecls()) {
+        if (!caseStmt->hasCaseBodyVariables()) {
           Out << "parent CaseStmt of VarDecl does not have any case body "
                  "decls?!\n";
           abort();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8164,7 +8164,7 @@ findParentPatternCaseStmtAndPattern(const VarDecl *inputVD) {
   auto getMatchingPattern = [&](CaseStmt *cs) -> Pattern * {
     // Check if inputVD is in our case body var decls if we have any. If we do,
     // treat its pattern as our first case label item pattern.
-    for (auto *vd : cs->getCaseBodyVariablesOrEmptyArray()) {
+    for (auto *vd : cs->getCaseBodyVariables()) {
       if (vd == inputVD) {
         return cs->getMutableCaseLabelItems().front().getPattern();
       }
@@ -8345,7 +8345,7 @@ bool VarDecl::isCaseBodyVariable() const {
   auto *caseStmt = dyn_cast_or_null<CaseStmt>(getRecursiveParentPatternStmt());
   if (!caseStmt)
     return false;
-  return llvm::any_of(caseStmt->getCaseBodyVariablesOrEmptyArray(),
+  return llvm::any_of(caseStmt->getCaseBodyVariables(),
                       [&](VarDecl *vd) { return vd == this; });
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8227,16 +8227,7 @@ VarDecl *VarDecl::getCanonicalVarDecl() const {
 }
 
 Stmt *VarDecl::getRecursiveParentPatternStmt() const {
-  // If our parent is already a pattern stmt, just return that.
-  if (auto *stmt = getParentPatternStmt())
-    return stmt;
-
-  // Otherwise, see if we have a parent var decl. If we do not, then return
-  // nullptr. Otherwise, return the case stmt that we found.
-  auto result = findParentPatternCaseStmtAndPattern(this);
-  if (!result.has_value())
-    return nullptr;
-  return result->first;
+  return getCanonicalVarDecl()->getParentPatternStmt();
 }
 
 /// Return the Pattern involved in initializing this VarDecl.  Recall that the

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -208,10 +208,14 @@ namespace {
       return Action::Continue(P);
     }
 
-    // Only walk into an expression insofar as it doesn't open a new scope -
-    // that is, don't walk into a closure body.
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-      if (isa<ClosureExpr>(E)) {
+      // Only walk into an expression insofar as it doesn't open a new scope -
+      // that is, don't walk into a closure body, TapExpr, or
+      // SingleValueStmtExpr. Also don't walk into key paths since any nested
+      // VarDecls are invalid there, and after being diagnosed by key path
+      // resolution the ASTWalker won't visit them.
+      if (isa<ClosureExpr>(E) || isa<TapExpr>(E) ||
+          isa<SingleValueStmtExpr>(E) || isa<KeyPathExpr>(E)) {
         return Action::SkipNode(E);
       }
       return Action::Continue(E);

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -897,11 +897,23 @@ CaseStmt *CaseStmt::createParsedDoCatch(ASTContext &ctx, SourceLoc catchLoc,
 }
 
 CaseStmt *
-CaseStmt::create(ASTContext &ctx, CaseParentKind ParentKind, SourceLoc caseLoc,
-                 ArrayRef<CaseLabelItem> caseLabelItems,
-                 SourceLoc unknownAttrLoc, SourceLoc colonLoc, BraceStmt *body,
-                 ArrayRef<VarDecl *> caseVarDecls, std::optional<bool> implicit,
-                 NullablePtr<FallthroughStmt> fallthroughStmt) {
+CaseStmt::createImplicit(ASTContext &ctx, CaseParentKind parentKind,
+                         ArrayRef<CaseLabelItem> caseLabelItems,
+                         BraceStmt *body,
+                         NullablePtr<FallthroughStmt> fallthroughStmt) {
+  auto caseVarDecls = getCaseVarDecls(ctx, caseLabelItems);
+  return create(ctx, parentKind, /*catchLoc*/ SourceLoc(), caseLabelItems,
+                /*unknownAttrLoc*/ SourceLoc(), /*colonLoc*/ SourceLoc(), body,
+                caseVarDecls, /*implicit*/ true, fallthroughStmt);
+}
+
+CaseStmt *CaseStmt::create(ASTContext &ctx, CaseParentKind ParentKind,
+                           SourceLoc caseLoc,
+                           ArrayRef<CaseLabelItem> caseLabelItems,
+                           SourceLoc unknownAttrLoc, SourceLoc colonLoc,
+                           BraceStmt *body, ArrayRef<VarDecl *> caseVarDecls,
+                           std::optional<bool> implicit,
+                           NullablePtr<FallthroughStmt> fallthroughStmt) {
   void *mem =
       ctx.Allocate(totalSizeToAlloc<FallthroughStmt *, CaseLabelItem>(
                        fallthroughStmt.isNonNull(), caseLabelItems.size()),

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -773,33 +773,63 @@ CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,
   MutableArrayRef<CaseLabelItem> items{getTrailingObjects<CaseLabelItem>(),
                                        static_cast<size_t>(Bits.CaseStmt.NumPatterns)};
 
-  // At the beginning mark all of our var decls as being owned by this
-  // statement. In the typechecker we wireup the case stmt var decl list since
-  // we know everything is lined up/typechecked then.
   for (unsigned i : range(Bits.CaseStmt.NumPatterns)) {
     new (&items[i]) CaseLabelItem(caseLabelItems[i]);
-    items[i].getPattern()->markOwnedByStatement(this);
-  }
-  for (auto *vd : getCaseBodyVariables()) {
-    vd->setParentPatternStmt(this);
+    // Mark the CaseStmt as the parent for any canonical VarDecls in the
+    // pattern.
+    items[i].getPattern()->forEachVariable([&](VarDecl *VD) {
+      if (!VD->getParentVarDecl())
+        VD->setParentPatternStmt(this);
+    });
   }
 }
 
 namespace {
-static ArrayRef<VarDecl *>
-getCaseVarDecls(ASTContext &ctx, ArrayRef<CaseLabelItem> labelItems) {
-  // Grab the first case label item pattern and use it to initialize the case
-  // body var decls.
-  SmallVector<VarDecl *, 4> tmp;
-  labelItems.front().getPattern()->collectVariables(tmp);
-  return ctx.AllocateTransform<VarDecl *>(
-      llvm::ArrayRef(tmp), [&](VarDecl *vOld) -> VarDecl * {
-        auto *vNew = new (ctx) VarDecl(
-            /*IsStatic*/ false, vOld->getIntroducer(), vOld->getNameLoc(),
-            vOld->getName(), vOld->getDeclContext());
-        vNew->setImplicit();
-        return vNew;
-      });
+/// Produces an array of internal case body variables, and binds all of the
+/// pattern variables that occur within the case to their "parent" pattern
+/// variables, forming chains of variables with the same name.
+///
+/// Given a case such as:
+/// \code
+/// case .a(let x), .b(let x), .c(let x):
+/// \endcode
+///
+/// Each case item contains a (different) pattern variable named `x`. This
+/// function will set the "parent" variable of the second and third `x`
+/// variables to the `x` variable immediately to its left. A fourth `x` will be
+/// the body case variable, whose parent will be set to the `x` within the final
+/// case item.
+static ArrayRef<VarDecl *> getCaseVarDecls(ASTContext &ctx,
+                                           ArrayRef<CaseLabelItem> labelItems) {
+  SmallVector<VarDecl *, 4> caseVars;
+  llvm::SmallDenseMap<Identifier, VarDecl *, 4> allVars;
+
+  auto foundVar = [&](VarDecl *VD) {
+    if (!VD->hasName())
+      return;
+
+    auto &entry = allVars[VD->getName()];
+    if (entry) {
+      VD->setParentVarDecl(entry);
+    } else {
+      auto *caseVar = new (ctx) VarDecl(
+          /*IsStatic*/ false, VD->getIntroducer(), VD->getNameLoc(),
+          VD->getName(), VD->getDeclContext());
+      caseVar->setImplicit();
+      caseVars.push_back(caseVar);
+    }
+    entry = VD;
+  };
+
+  for (auto &caseItem : labelItems)
+    caseItem.getPattern()->forEachVariable(foundVar);
+
+  // Now that we've collected the case variables, ensure they're parented to
+  // the last pattern variables we saw.
+  for (auto caseVar : caseVars)
+    foundVar(caseVar);
+
+  return ctx.AllocateCopy(caseVars);
 }
 
 struct FallthroughFinder : ASTWalker {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -753,7 +753,7 @@ CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,
                    ArrayRef<CaseLabelItem> caseLabelItems,
                    SourceLoc unknownAttrLoc, SourceLoc itemTerminatorLoc,
                    BraceStmt *body,
-                   std::optional<MutableArrayRef<VarDecl *>> caseBodyVariables,
+                   std::optional<ArrayRef<VarDecl *>> caseBodyVariables,
                    std::optional<bool> implicit,
                    NullablePtr<FallthroughStmt> fallthroughStmt)
     : Stmt(StmtKind::Case, getDefaultImplicitFlag(implicit, itemIntroducerLoc)),
@@ -781,13 +781,13 @@ CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,
     new (&items[i]) CaseLabelItem(caseLabelItems[i]);
     items[i].getPattern()->markOwnedByStatement(this);
   }
-  for (auto *vd : caseBodyVariables.value_or(MutableArrayRef<VarDecl *>())) {
+  for (auto *vd : getCaseBodyVariablesOrEmptyArray()) {
     vd->setParentPatternStmt(this);
   }
 }
 
 namespace {
-static MutableArrayRef<VarDecl *>
+static ArrayRef<VarDecl *>
 getCaseVarDecls(ASTContext &ctx, ArrayRef<CaseLabelItem> labelItems) {
   // Grab the first case label item pattern and use it to initialize the case
   // body var decls.
@@ -871,7 +871,7 @@ CaseStmt *
 CaseStmt::create(ASTContext &ctx, CaseParentKind ParentKind, SourceLoc caseLoc,
                  ArrayRef<CaseLabelItem> caseLabelItems,
                  SourceLoc unknownAttrLoc, SourceLoc colonLoc, BraceStmt *body,
-                 std::optional<MutableArrayRef<VarDecl *>> caseVarDecls,
+                 std::optional<ArrayRef<VarDecl *>> caseVarDecls,
                  std::optional<bool> implicit,
                  NullablePtr<FallthroughStmt> fallthroughStmt) {
   void *mem =

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -752,8 +752,7 @@ SourceLoc CaseLabelItem::getEndLoc() const {
 CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,
                    ArrayRef<CaseLabelItem> caseLabelItems,
                    SourceLoc unknownAttrLoc, SourceLoc itemTerminatorLoc,
-                   BraceStmt *body,
-                   std::optional<ArrayRef<VarDecl *>> caseBodyVariables,
+                   BraceStmt *body, ArrayRef<VarDecl *> caseBodyVariables,
                    std::optional<bool> implicit,
                    NullablePtr<FallthroughStmt> fallthroughStmt)
     : Stmt(StmtKind::Case, getDefaultImplicitFlag(implicit, itemIntroducerLoc)),
@@ -781,7 +780,7 @@ CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,
     new (&items[i]) CaseLabelItem(caseLabelItems[i]);
     items[i].getPattern()->markOwnedByStatement(this);
   }
-  for (auto *vd : getCaseBodyVariablesOrEmptyArray()) {
+  for (auto *vd : getCaseBodyVariables()) {
     vd->setParentPatternStmt(this);
   }
 }
@@ -871,8 +870,7 @@ CaseStmt *
 CaseStmt::create(ASTContext &ctx, CaseParentKind ParentKind, SourceLoc caseLoc,
                  ArrayRef<CaseLabelItem> caseLabelItems,
                  SourceLoc unknownAttrLoc, SourceLoc colonLoc, BraceStmt *body,
-                 std::optional<ArrayRef<VarDecl *>> caseVarDecls,
-                 std::optional<bool> implicit,
+                 ArrayRef<VarDecl *> caseVarDecls, std::optional<bool> implicit,
                  NullablePtr<FallthroughStmt> fallthroughStmt) {
   void *mem =
       ctx.Allocate(totalSizeToAlloc<FallthroughStmt *, CaseLabelItem>(

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2836,7 +2836,7 @@ void PatternMatchEmission::initSharedCaseBlockDest(CaseStmt *caseBlock,
   result.first->second.first = block;
 
   // Add args for any pattern variables if we have any.
-  for (auto *vd : caseBlock->getCaseBodyVariablesOrEmptyArray()) {
+  for (auto *vd : caseBlock->getCaseBodyVariables()) {
     if (!vd->hasName())
       continue;
 
@@ -2867,7 +2867,7 @@ void PatternMatchEmission::emitAddressOnlyAllocations() {
     // If we have a shared case with bound decls, setup the arguments for the
     // shared block by emitting the temporary allocation used for the arguments
     // of the shared block.
-    for (auto *vd : caseBlock->getCaseBodyVariablesOrEmptyArray()) {
+    for (auto *vd : caseBlock->getCaseBodyVariables()) {
       if (!vd->hasName())
         continue;
 

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2958,7 +2958,7 @@ void PatternMatchEmission::emitSharedCaseBlocks(
     SWIFT_DEFER { assert(SGF.getCleanupsDepth() == PatternMatchStmtDepth); };
 
     if (!caseBlock->hasCaseBodyVariables()) {
-      emitCaseBody(caseBlock);
+      bodyEmitter(caseBlock);
       continue;
     }
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -650,7 +650,7 @@ protected:
         caseStmt->getCaseLabelItems(),
         caseStmt->hasUnknownAttr() ? caseStmt->getStartLoc() : SourceLoc(),
         caseStmt->getItemTerminatorLoc(), cloneBraceWith(body, newBody),
-        caseStmt->getCaseBodyVariablesOrEmptyArray(), caseStmt->isImplicit(),
+        caseStmt->getCaseBodyVariables(), caseStmt->isImplicit(),
         caseStmt->getFallthroughStmt());
 
     return std::make_pair(caseVarRef.get(), newCase);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1378,7 +1378,7 @@ private:
       pattern->forEachVariable([&](VarDecl *var) { recordVar(var); });
     }
 
-    for (auto bodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+    for (auto bodyVar : caseStmt->getCaseBodyVariables()) {
       if (!bodyVar->hasName())
         continue;
 
@@ -2007,7 +2007,7 @@ private:
 
     bindSwitchCasePatternVars(context.getAsDeclContext(), caseStmt);
 
-    for (auto *expected : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+    for (auto *expected : caseStmt->getCaseBodyVariables()) {
       assert(expected->hasName());
       auto prev = expected->getParentVarDecl();
       auto type = solution.getResolvedType(prev)->mapTypeOutOfContext();

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -738,23 +738,6 @@ private:
                   LocatorPathElt::ContextualType(context.purpose)});
     cs.addConstraint(ConstraintKind::Equal, context.getType(), patternType,
                      loc);
-
-    // For any pattern variable that has a parent variable (i.e., another
-    // pattern variable with the same name in the same case), require that
-    // the types be equivalent.
-    pattern->forEachNode([&](Pattern *pattern) {
-      auto namedPattern = dyn_cast<NamedPattern>(pattern);
-      if (!namedPattern)
-        return;
-
-      auto var = namedPattern->getDecl();
-      if (auto parentVar = var->getParentVarDecl()) {
-        cs.addConstraint(
-            ConstraintKind::Equal, cs.getType(parentVar), cs.getType(var),
-            cs.getConstraintLocator(
-                locator, LocatorPathElt::PatternMatch(namedPattern)));
-      }
-    });
   }
 
   void visitPatternBinding(PatternBindingDecl *patternBinding,

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2005,7 +2005,7 @@ private:
       }
     }
 
-    bindSwitchCasePatternVars(context.getAsDeclContext(), caseStmt);
+    diagnoseCaseVarMutabilityMismatch(context.getAsDeclContext(), caseStmt);
 
     for (auto *expected : caseStmt->getCaseBodyVariables()) {
       assert(expected->hasName());

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -805,9 +805,8 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
     assignExpr->setType(TupleType::getEmpty(C));
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(assignExpr),
                                   SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     /*case body vardecls*/ std::nullopt));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   // generate: switch enumVar { }
@@ -967,9 +966,7 @@ CaseStmt *DerivedConformance::unavailableEnumElementCaseStmt(
   auto *callExpr =
       DerivedConformance::createDiagnoseUnavailableCodeReachedCallExpr(C);
   auto body = BraceStmt::create(C, SourceLoc(), {callExpr}, SourceLoc());
-  return CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(), labelItem,
-                          SourceLoc(), SourceLoc(), body, {},
-                          /*implicit*/ true);
+  return CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body);
 }
 
 /// Creates a named variable based on a prefix character and a numeric index.

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -946,7 +946,7 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
     // .<elt>(let a0, let a1, ...)
     SmallVector<VarDecl *, 3> payloadVars;
     Pattern *subpattern = nullptr;
-    std::optional<MutableArrayRef<VarDecl *>> caseBodyVarDecls;
+    ArrayRef<VarDecl *> caseBodyVarDecls;
 
     if (createSubpattern) {
       subpattern = DerivedConformance::enumElementPayloadSubpattern(
@@ -965,7 +965,7 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
           vNew->setImplicit();
           copy[i] = vNew;
         }
-        caseBodyVarDecls.emplace(copy);
+        caseBodyVarDecls = copy;
       }
     }
 
@@ -988,8 +988,7 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
       auto stmt =
           CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(), labelItem,
                            SourceLoc(), SourceLoc(), caseBody,
-                           /*case body vardecls*/
-                           createSubpattern ? caseBodyVarDecls : std::nullopt);
+                           caseBodyVarDecls);
       cases.push_back(stmt);
     }
   }

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -946,27 +946,10 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
     // .<elt>(let a0, let a1, ...)
     SmallVector<VarDecl *, 3> payloadVars;
     Pattern *subpattern = nullptr;
-    ArrayRef<VarDecl *> caseBodyVarDecls;
 
     if (createSubpattern) {
       subpattern = DerivedConformance::enumElementPayloadSubpattern(
           elt, 'a', DC, payloadVars, /* useLabels */ true);
-
-      auto hasBoundDecls = !payloadVars.empty();
-      if (hasBoundDecls) {
-        // We allocated a direct copy of our var decls for the case
-        // body.
-        auto copy = C.Allocate<VarDecl *>(payloadVars.size());
-        for (unsigned i : indices(payloadVars)) {
-          auto *vOld = payloadVars[i];
-          auto *vNew = new (C) VarDecl(
-              /*IsStatic*/ false, vOld->getIntroducer(), vOld->getNameLoc(),
-              vOld->getName(), vOld->getDeclContext());
-          vNew->setImplicit();
-          copy[i] = vNew;
-        }
-        caseBodyVarDecls = copy;
-      }
     }
 
     // CodingKeys.x
@@ -985,10 +968,8 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
                                                      subpattern, DC);
 
       auto labelItem = CaseLabelItem(pat);
-      auto stmt =
-          CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(), labelItem,
-                           SourceLoc(), SourceLoc(), caseBody,
-                           caseBodyVarDecls);
+      auto stmt = CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem,
+                                           caseBody);
       cases.push_back(stmt);
     }
   }

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
@@ -222,10 +222,8 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
       auto *returnStmt = ReturnStmt::createImplicit(C, caseValue);
       auto *caseBody = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                          SourceLoc());
-      cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                       labelItem, SourceLoc(), SourceLoc(),
-                                       caseBody,
-                                       /*case body var decls*/ std::nullopt));
+      cases.push_back(CaseStmt::createImplicit(C, CaseParentKind::Switch,
+                                               labelItem, caseBody));
     }
 
     auto *selfRef = DerivedConformance::createSelfDeclRef(strValDecl);
@@ -292,9 +290,8 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
 
     auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(assignment),
                                    SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     /*case body var decls*/ std::nullopt));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   auto *anyPat = AnyPattern::createImplicit(C);
@@ -303,10 +300,8 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
   auto *dfltReturnStmt = new (C) FailStmt(SourceLoc(), SourceLoc());
   auto *dfltBody = BraceStmt::create(C, SourceLoc(), ASTNode(dfltReturnStmt),
                                      SourceLoc());
-  cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                   dfltLabelItem, SourceLoc(), SourceLoc(),
-                                   dfltBody,
-                                   /*case body var decls*/ std::nullopt));
+  cases.push_back(CaseStmt::createImplicit(C, CaseParentKind::Switch,
+                                           dfltLabelItem, dfltBody));
 
   auto *stringValueDecl = initDecl->getParameters()->get(0);
   auto *stringValueRef = new (C) DeclRefExpr(stringValueDecl, DeclNameLoc(),

--- a/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
@@ -127,23 +127,6 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
     auto *rhsElemPat = EnumElementPattern::createImplicit(
         enumType, elt, rhsSubpattern, /*DC*/ ltDecl);
 
-    auto hasBoundDecls = !lhsPayloadVars.empty();
-    ArrayRef<VarDecl *> caseBodyVarDecls;
-    if (hasBoundDecls) {
-      // We allocated a direct copy of our lhs var decls for the case
-      // body.
-      auto copy = C.Allocate<VarDecl *>(lhsPayloadVars.size());
-      for (unsigned i : indices(lhsPayloadVars)) {
-        auto *vOld = lhsPayloadVars[i];
-        auto *vNew = new (C) VarDecl(
-            /*IsStatic*/ false, vOld->getIntroducer(),
-            vOld->getNameLoc(), vOld->getName(), vOld->getDeclContext());
-        vNew->setImplicit();
-        copy[i] = vNew;
-      }
-      caseBodyVarDecls = copy;
-    }
-
     // case (.<elt>(let l0, let l1, ...), .<elt>(let r0, let r1, ...))
     auto caseTuplePattern = TuplePattern::createImplicit(C, {
       TuplePatternElt(lhsElemPat), TuplePatternElt(rhsElemPat) });
@@ -177,9 +160,8 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
 
     auto body = BraceStmt::create(C, SourceLoc(), statementsInCase,
                                   SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     caseBodyVarDecls));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   // default: result = <enum index>(lhs) < <enum index>(rhs)
@@ -190,10 +172,8 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
     auto defaultPattern = AnyPattern::createImplicit(C);
     auto defaultItem = CaseLabelItem::getDefault(defaultPattern);
     auto body = deriveBodyComparable_enum_noAssociatedValues_lt(ltDecl, nullptr).first;
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     defaultItem, SourceLoc(), SourceLoc(),
-                                     body,
-                                     /*case body var decls*/ std::nullopt));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, defaultItem, body));
   }
 
   // switch (a, b) { <case statements> }

--- a/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
@@ -128,7 +128,7 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
         enumType, elt, rhsSubpattern, /*DC*/ ltDecl);
 
     auto hasBoundDecls = !lhsPayloadVars.empty();
-    std::optional<MutableArrayRef<VarDecl *>> caseBodyVarDecls;
+    ArrayRef<VarDecl *> caseBodyVarDecls;
     if (hasBoundDecls) {
       // We allocated a direct copy of our lhs var decls for the case
       // body.
@@ -141,7 +141,7 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
         vNew->setImplicit();
         copy[i] = vNew;
       }
-      caseBodyVarDecls.emplace(copy);
+      caseBodyVarDecls = copy;
     }
 
     // case (.<elt>(let l0, let l1, ...), .<elt>(let r0, let r1, ...))

--- a/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
@@ -193,23 +193,6 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto *rhsElemPat = EnumElementPattern::createImplicit(
         enumType, elt, rhsSubpattern, /*DC*/ eqDecl);
 
-    auto hasBoundDecls = !lhsPayloadVars.empty();
-    ArrayRef<VarDecl *> caseBodyVarDecls;
-    if (hasBoundDecls) {
-      // We allocated a direct copy of our lhs var decls for the case
-      // body.
-      auto copy = C.Allocate<VarDecl *>(lhsPayloadVars.size());
-      for (unsigned i : indices(lhsPayloadVars)) {
-        auto *vOld = lhsPayloadVars[i];
-        auto *vNew = new (C) VarDecl(
-            /*IsStatic*/ false, vOld->getIntroducer(),
-            vOld->getNameLoc(), vOld->getName(), vOld->getDeclContext());
-        vNew->setImplicit();
-        copy[i] = vNew;
-      }
-      caseBodyVarDecls = copy;
-    }
-
     // case (.<elt>(let l0, let l1, ...), .<elt>(let r0, let r1, ...))
     auto caseTuplePattern = TuplePattern::createImplicit(C, {
       TuplePatternElt(lhsElemPat), TuplePatternElt(rhsElemPat) });
@@ -244,9 +227,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
 
     auto body = BraceStmt::create(C, SourceLoc(), statementsInCase,
                                   SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     caseBodyVarDecls));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   // default: result = false
@@ -261,10 +243,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto *returnStmt = ReturnStmt::createImplicit(C, falseExpr);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                   SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     defaultItem, SourceLoc(), SourceLoc(),
-                                     body,
-                                     /*case body var decls*/ std::nullopt));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, defaultItem, body));
   }
 
   // switch (a, b) { <case statements> }
@@ -735,26 +715,9 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
       statements.emplace_back(ASTNode(combineExpr));
     }
 
-    auto hasBoundDecls = !payloadVars.empty();
-    ArrayRef<VarDecl *> caseBodyVarDecls;
-    if (hasBoundDecls) {
-      auto copy = C.Allocate<VarDecl *>(payloadVars.size());
-      for (unsigned i : indices(payloadVars)) {
-        auto *vOld = payloadVars[i];
-        auto *vNew = new (C) VarDecl(
-            /*IsStatic*/ false, vOld->getIntroducer(),
-            vOld->getNameLoc(), vOld->getName(), vOld->getDeclContext());
-        vNew->setImplicit();
-        copy[i] = vNew;
-      }
-      caseBodyVarDecls = copy;
-    }
-
     auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     caseBodyVarDecls,
-                                     /*implicit*/ true));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   // generate: switch enumVar { }

--- a/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
@@ -194,7 +194,7 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
         enumType, elt, rhsSubpattern, /*DC*/ eqDecl);
 
     auto hasBoundDecls = !lhsPayloadVars.empty();
-    std::optional<MutableArrayRef<VarDecl *>> caseBodyVarDecls;
+    ArrayRef<VarDecl *> caseBodyVarDecls;
     if (hasBoundDecls) {
       // We allocated a direct copy of our lhs var decls for the case
       // body.
@@ -207,7 +207,7 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
         vNew->setImplicit();
         copy[i] = vNew;
       }
-      caseBodyVarDecls.emplace(copy);
+      caseBodyVarDecls = copy;
     }
 
     // case (.<elt>(let l0, let l1, ...), .<elt>(let r0, let r1, ...))
@@ -736,7 +736,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
     }
 
     auto hasBoundDecls = !payloadVars.empty();
-    std::optional<MutableArrayRef<VarDecl *>> caseBodyVarDecls;
+    ArrayRef<VarDecl *> caseBodyVarDecls;
     if (hasBoundDecls) {
       auto copy = C.Allocate<VarDecl *>(payloadVars.size());
       for (unsigned i : indices(payloadVars)) {
@@ -747,7 +747,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
         vNew->setImplicit();
         copy[i] = vNew;
       }
-      caseBodyVarDecls.emplace(copy);
+      caseBodyVarDecls = copy;
     }
 
     auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -129,9 +129,8 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
     auto body = BraceStmt::create(C, SourceLoc(),
                                   ASTNode(returnStmt), SourceLoc());
 
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     labelItem, SourceLoc(), SourceLoc(), body,
-                                     /*case body var decls*/ std::nullopt));
+    cases.push_back(
+        CaseStmt::createImplicit(C, CaseParentKind::Switch, labelItem, body));
   }
 
   auto selfRef = DerivedConformance::createSelfDeclRef(toRawDecl);
@@ -363,10 +362,8 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
                                   stmts, SourceLoc());
 
     // cases.append("case \(litPat): \(body)")
-    cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                     CaseLabelItem(litPat), SourceLoc(),
-                                     SourceLoc(), body,
-                                     /*case body var decls*/ std::nullopt));
+    cases.push_back(CaseStmt::createImplicit(C, CaseParentKind::Switch,
+                                             CaseLabelItem(litPat), body));
     ++Idx;
   }
 
@@ -376,10 +373,8 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   auto dfltReturnStmt = new (C) FailStmt(SourceLoc(), SourceLoc());
   auto dfltBody = BraceStmt::create(C, SourceLoc(),
                                     ASTNode(dfltReturnStmt), SourceLoc());
-  cases.push_back(CaseStmt::create(C, CaseParentKind::Switch, SourceLoc(),
-                                   dfltLabelItem, SourceLoc(), SourceLoc(),
-                                   dfltBody,
-                                   /*case body var decls*/ std::nullopt));
+  cases.push_back(CaseStmt::createImplicit(C, CaseParentKind::Switch,
+                                           dfltLabelItem, dfltBody));
 
   auto rawDecl = initDecl->getParameters()->get(0);
   auto rawRef = new (C) DeclRefExpr(rawDecl, DeclNameLoc(), /*implicit*/true);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4007,12 +4007,8 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
 
     if (auto *caseStmt =
             dyn_cast_or_null<CaseStmt>(var->getRecursiveParentPatternStmt())) {
-      // Only diagnose VarDecls from the first CaseLabelItem in CaseStmts, as
-      // the remaining items must match it anyway.
-      auto caseItems = caseStmt->getCaseLabelItems();
-      assert(!caseItems.empty() &&
-             "If we have any case stmt var decls, we should have a case item");
-      if (!caseItems.front().getPattern()->containsVarDecl(var))
+      // Only diagnose for the parent-most VarDecl.
+      if (var->getParentVarDecl())
         continue;
 
       auto *childVar = var->getCorrespondingCaseBodyVariable().get();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3459,7 +3459,7 @@ public:
 
     // Make sure that we setup our case body variables.
     if (auto *caseStmt = dyn_cast<CaseStmt>(S)) {
-      for (auto *vd : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+      for (auto *vd : caseStmt->getCaseBodyVariables()) {
         VarDecls[vd] |= RK_Defined;
       }
     }

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -307,6 +307,12 @@ void SyntacticElementTarget::markInvalid() const {
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
       P->setType(ErrorType::get(Ctx));
+
+      // For a named pattern, set it on the variable. This stops us from
+      // attempting to double-type-check variables we've already type-checked.
+      if (auto *NP = dyn_cast<NamedPattern>(P))
+        NP->getDecl()->setNamingPattern(NP);
+
       return Action::Continue(P);
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2715,7 +2715,7 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
   }
 
   if (!namingPattern) {
-    if (auto parentStmt = VD->getParentPatternStmt()) {
+    if (auto parentStmt = VD->getRecursiveParentPatternStmt()) {
       // Try type checking parent control statement.
       if (auto condStmt = dyn_cast<LabeledConditionalStmt>(parentStmt)) {
         // The VarDecl is defined inside a condition of a `if` or `while` stmt.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -126,7 +126,7 @@ namespace {
       // The ASTWalker doesn't walk the case body variables, contextualize them
       // ourselves.
       if (auto *CS = dyn_cast<CaseStmt>(S)) {
-        for (auto *CaseVar : CS->getCaseBodyVariablesOrEmptyArray())
+        for (auto *CaseVar : CS->getCaseBodyVariables())
           CaseVar->setDeclContext(ParentDC);
       }
       // A few statements store DeclContexts, update them.
@@ -341,7 +341,7 @@ namespace {
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto caseStmt = dyn_cast<CaseStmt>(S)) {
-        for (auto var : caseStmt->getCaseBodyVariablesOrEmptyArray())
+        for (auto var : caseStmt->getCaseBodyVariables())
           setLocalDiscriminator(var);
       }
       return Action::Continue(S);
@@ -970,7 +970,7 @@ bool swift::checkFallthroughStmt(FallthroughStmt *FS) {
   // decls. So if we match against the case body var decls,
   // transitively we will match all of the other case label items in
   // the fallthrough destination as well.
-  auto previousVars = previousBlock->getCaseBodyVariablesOrEmptyArray();
+  auto previousVars = previousBlock->getCaseBodyVariables();
   for (auto *expected : vars) {
     bool matched = false;
     if (!expected->hasName())
@@ -1600,7 +1600,7 @@ public:
       }
 
       // Setup the types of our case body var decls.
-      for (auto *expected : caseBlock->getCaseBodyVariablesOrEmptyArray()) {
+      for (auto *expected : caseBlock->getCaseBodyVariables()) {
         assert(expected->hasName());
         auto prev = expected->getParentVarDecl();
         if (prev->hasInterfaceType())
@@ -3302,7 +3302,7 @@ void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
   }
 
   // Wire up the case body variables to the latest patterns.
-  for (auto bodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+  for (auto bodyVar : caseStmt->getCaseBodyVariables()) {
     recordVar(nullptr, bodyVar);
   }
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1581,9 +1581,7 @@ public:
 
     // First pass: check all of the bindings.
     for (auto *caseBlock : make_range(casesBegin, casesEnd)) {
-      // Bind all of the pattern variables together so we can follow the
-      // "parent" pointers later on.
-      bindSwitchCasePatternVars(DC, caseBlock);
+      diagnoseCaseVarMutabilityMismatch(DC, caseBlock);
 
       auto caseLabelItemArray = caseBlock->getMutableCaseLabelItems();
       for (auto &labelItem : caseLabelItemArray) {
@@ -3238,7 +3236,8 @@ void swift::checkUnknownAttrRestrictions(
   }
 }
 
-void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
+void swift::diagnoseCaseVarMutabilityMismatch(DeclContext *dc,
+                                              CaseStmt *caseStmt) {
   llvm::SmallDenseMap<Identifier, std::pair<VarDecl *, bool>, 4> latestVars;
   auto recordVar = [&](Pattern *pattern, VarDecl *var) {
     if (!var->hasName())
@@ -3248,16 +3247,10 @@ void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
     // parent of this new variable.
     auto &entry = latestVars[var->getName()];
     if (entry.first) {
-      assert(!var->getParentVarDecl() ||
-             var->getParentVarDecl() == entry.first);
-      var->setParentVarDecl(entry.first);
-
       // Check for a mutability mismatch.
-      if (pattern && entry.second != var->isLet()) {
+      if (entry.second != var->isLet()) {
         // Find the original declaration.
-        auto initialCaseVarDecl = entry.first;
-        while (auto parentVar = initialCaseVarDecl->getParentVarDecl())
-          initialCaseVarDecl = parentVar;
+        auto initialCaseVarDecl = entry.first->getCanonicalVarDecl();
 
         auto diag = var->diagnose(diag::mutability_mismatch_multiple_pattern_list,
                                   var->isLet(), initialCaseVarDecl->isLet());
@@ -3268,10 +3261,10 @@ void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
             if (VP->getSingleVar() == var)
               foundVP = VP;
         });
-        if (foundVP)
+        if (foundVP) {
           diag.fixItReplace(foundVP->getLoc(),
                             initialCaseVarDecl->isLet() ? "let" : "var");
-
+        }
         var->setInvalid();
         initialCaseVarDecl->setInvalid();
       }
@@ -3283,8 +3276,6 @@ void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
     entry.first = var;
   };
 
-  // Wire up the parent var decls for each variable that occurs within
-  // the patterns of each case item. in source order.
   for (auto &caseItem : caseStmt->getMutableCaseLabelItems()) {
     // Resolve the pattern.
     auto *pattern = caseItem.getPattern();
@@ -3299,11 +3290,6 @@ void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
     pattern->forEachVariable( [&](VarDecl *var) {
       recordVar(pattern, var);
     });
-  }
-
-  // Wire up the case body variables to the latest patterns.
-  for (auto bodyVar : caseStmt->getCaseBodyVariables()) {
-    recordVar(nullptr, bodyVar);
   }
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1416,26 +1416,9 @@ bool checkFallthroughStmt(FallthroughStmt *stmt);
 void checkUnknownAttrRestrictions(
     ASTContext &ctx, CaseStmt *caseBlock, bool &limitExhaustivityChecks);
 
-/// Bind all of the pattern variables that occur within a case statement and
-/// all of its case items to their "parent" pattern variables, forming chains
-/// of variables with the same name.
-///
-/// Given a case such as:
-/// \code
-/// case .a(let x), .b(let x), .c(let x):
-/// \endcode
-///
-/// Each case item contains a (different) pattern variable named.
-/// "x". This function will set the "parent" variable of the
-/// second and third "x" variables to the "x" variable immediately
-/// to its left. A fourth "x" will be the body case variable,
-/// whose parent will be set to the "x" within the final case
-/// item.
-///
-/// Each of the "x" variables must eventually have the same type, and agree on
-/// let vs. var. This function does not perform any of that validation, leaving
-/// it to later stages.
-void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
+/// Diagnoses any mutability mismatches for any same-named variables bound by
+/// given CaseStmt.
+void diagnoseCaseVarMutabilityMismatch(DeclContext *dc, CaseStmt *stmt);
 
 /// If \p attr was added by an access note, wraps the error in
 /// \c diag::wrap_invalid_attr_added_by_access_note and limits it as an access

--- a/test/Constraints/issue-66553.swift
+++ b/test/Constraints/issue-66553.swift
@@ -4,7 +4,7 @@
 
 func baz(y: [Int], z: Int) -> Int {
   switch z {
-  case y[let z]: // expected-error 2{{'let' binding pattern cannot appear in an expression}}
+  case y[let z]: // expected-error {{'let' binding pattern cannot appear in an expression}}
     z
   default:
     z

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -406,7 +406,7 @@ func testNonBinding5(_ x: Int, y: [Int]) {
 func testNonBinding6(y: [Int], z: Int) -> Int {
   switch 0 {
   // We treat 'z' here as a binding, which is invalid.
-  case let y[z]: // expected-error 2{{pattern variable binding cannot appear in an expression}}
+  case let y[z]: // expected-error {{pattern variable binding cannot appear in an expression}}
     z
   case y[z]: // This is fine
     0

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -200,10 +200,10 @@ switch t {
 case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (_, 2), (var a, _): // expected-error {{'a' must be bound in every pattern}}
+case (_, 2), (var a, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
 case (var a, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{17-17= break}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
@@ -221,7 +221,7 @@ case (1, var b): // expected-warning {{variable 'b' was never used; consider rep
 case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{case is already handled by previous patterns; consider removing it}}
+case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
 // OK

--- a/test/SILGen/pr-84149.swift
+++ b/test/SILGen/pr-84149.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen %s -verify
+
+enum E : Error {
+  case a(Int), b(Int)
+}
+
+func bar() throws {}
+
+// Make sure we can correctly emit this without crashing.
+func foo() throws {
+  do {
+    try bar()
+  } catch E.a, E.b {
+  }
+}

--- a/unittests/Sema/ConstraintGenerationTests.cpp
+++ b/unittests/Sema/ConstraintGenerationTests.cpp
@@ -286,10 +286,8 @@ TEST_F(SemaTest, TestSwitchExprLocator) {
       {IntegerLiteralExpr::createFromUnsigned(Context, 1, SourceLoc())});
   auto *truePattern = ExprPattern::createImplicit(
       Context, new (Context) BooleanLiteralExpr(true, SourceLoc()), DC);
-  auto *trueCase =
-      CaseStmt::create(Context, CaseParentKind::Switch, SourceLoc(),
-                       {CaseLabelItem(truePattern)}, SourceLoc(), SourceLoc(),
-                       trueBrace, /*caseBodyVars*/ std::nullopt);
+  auto *trueCase = CaseStmt::createImplicit(
+      Context, CaseParentKind::Switch, {CaseLabelItem(truePattern)}, trueBrace);
 
   // case false: 2
   auto *falseBrace = BraceStmt::createImplicit(
@@ -298,9 +296,8 @@ TEST_F(SemaTest, TestSwitchExprLocator) {
   auto *falsePattern = ExprPattern::createImplicit(
       Context, new (Context) BooleanLiteralExpr(false, SourceLoc()), DC);
   auto *falseCase =
-      CaseStmt::create(Context, CaseParentKind::Switch, SourceLoc(),
-                       {CaseLabelItem(falsePattern)}, SourceLoc(), SourceLoc(),
-                       falseBrace, /*caseBodyVars*/ std::nullopt);
+      CaseStmt::createImplicit(Context, CaseParentKind::Switch,
+                               {CaseLabelItem(falsePattern)}, falseBrace);
 
   auto *subject = new (Context) BooleanLiteralExpr(true, SourceLoc());
 

--- a/validation-test/IDE/crashers_fixed/2a9258ff5360857f.swift
+++ b/validation-test/IDE/crashers_fixed/2a9258ff5360857f.swift
@@ -1,0 +1,6 @@
+// {"kind":"complete","original":"19b878fc","signature":"swift::NamingPatternRequest::evaluate(swift::Evaluator&, swift::VarDecl*) const","signatureAssert":"Assertion failed: (foundVarDecl && \"VarDecl not declared in its parent?\"), function evaluate"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+{
+  guard let \a = answer
+    a
+    #^^#

--- a/validation-test/compiler_crashers_2_fixed/22119c306663e633.swift
+++ b/validation-test/compiler_crashers_2_fixed/22119c306663e633.swift
@@ -1,5 +1,5 @@
 // {"signature":"swift::NamingPatternRequest::evaluate(swift::Evaluator&, swift::VarDecl*) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   let a = $0.c ;
   switch a {

--- a/validation-test/compiler_crashers_2_fixed/7d3e143ce48c791.swift
+++ b/validation-test/compiler_crashers_2_fixed/7d3e143ce48c791.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::NamingPatternRequest::evaluate(swift::Evaluator&, swift::VarDecl*) const","signatureAssert":"Assertion failed: (foundVarDecl && \"VarDecl not declared in its parent?\"), function evaluate"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   if
   case.(let \ a) { a

--- a/validation-test/compiler_crashers_2_fixed/9ae5dcaffa1a80.swift
+++ b/validation-test/compiler_crashers_2_fixed/9ae5dcaffa1a80.swift
@@ -1,5 +1,5 @@
 // {"signature":"void (anonymous namespace)::StmtChecker::checkSiblingCaseStmts<swift::CaseStmt* const*>(swift::CaseStmt* const*, swift::CaseStmt* const*, swift::CaseParentKind, bool&, swift::Type)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a func b(c : a) -> Int {
   switch
     c {


### PR DESCRIPTION
- Wire up the parent VarDecl chain when we create a CaseStmt rather than during type-checking
- Introduce `CaseStmt::createImplicit` and re-use the existing implementation for creating the case body variables
- Simplify the implementations of `VarDecl::getParentPattern` and `VarDecl::getRecursiveParentPatternStmt` and remove `findParentPatternCaseStmtAndPattern`
- Improve handling of CaseStmts where the canonical VarDecl isn't in the first pattern in VarDeclUsageChecker
- Avoid walking a few more expression nodes in WalkToVarDecls
- Ensure we set the naming pattern in `markInvalid` to avoid double-type-checking