### PR TITLE
[cxx-interop] Make sure the size of anonymous types metadata is unchanged

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6940,11 +6940,13 @@ namespace {
     }
 
     void addValueWitnessTable() {
+      llvm::Constant* vwtPointer = nullptr;
       if (auto cd = Target->getClangDecl())
         if (auto rd = dyn_cast<clang::RecordDecl>(cd))
           if (rd->isAnonymousStructOrUnion())
-            return;
-      auto vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
+            vwtPointer = llvm::Constant::getNullValue(IGM.WitnessTablePtrTy);
+      if (!vwtPointer)
+        vwtPointer = emitValueWitnessTable(/*relative*/ false).getValue();
       B.addSignedPointer(vwtPointer,
                          IGM.getOptions().PointerAuth.ValueWitnessTable,
                          PointerAuthEntity());


### PR DESCRIPTION
Add a null pointer to the value witness table instead of completely skipping emitting the pointer.
