### PR TITLE
build.ps1: simplify `Build-Foundation`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2910,58 +2910,19 @@ function Test-Dispatch {
   }
 }
 
-function Build-Foundation {
-  [CmdletBinding(PositionalBinding = $false)]
-  param
-  (
-    [Parameter(Position = 0, Mandatory = $true)]
-    [Hashtable] $Platform,
-    [switch] $Static = $false
-  )
-
-  $FoundationBinaryCache = if ($Static) {
-    Get-ProjectBinaryCache $Platform ExperimentalStaticFoundation
-  } else {
-    Get-ProjectBinaryCache $Platform DynamicFoundation
-  }
-
-  $FoundationImage = if ($Static) {
-    "$(Get-SwiftSDK $Platform.OS -Identifier "$($Platform.OS)Experimental")\usr"
-  } else {
-    "$(Get-SwiftSDK $Platform.OS)\usr"
-  }
-
-  $SwiftSDK = if ($Static) {
-    Get-SwiftSDK $Platform.OS -Identifier "$($Platform.OS)Experimental"
-  } else {
-    Get-SwiftSDK $Platform.OS
-  }
-
-  $SwiftFlags = if ($Static) {
-    @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir")
-  } else {
-    @()
-  }
-
-  $DispatchCMakeModules = if ($Static) {
-    Get-ProjectCMakeModules $Platform ExperimentalStaticDispatch
-  } else {
-    Get-ProjectCMakeModules $Platform Dispatch
-  }
-
+function Build-Foundation([Hashable] $Platform) {
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-foundation `
-    -Bin $FoundationBinaryCache `
-    -InstallTo $FoundationImage `
+    -Bin (Get-ProjectBinaryCache $Platform DynamicFoundation) `
+    -InstallTo "$(Get-SwiftSDK $Platform.OS)\usr" `
     -Platform $Platform `
     -UseBuiltCompilers C,CXX,Swift `
-    -SwiftSDK $SwiftSDK `
+    -SwiftSDK (Get-SwiftSDK $Platform.OS) `
     -Defines @{
-      BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
+      BUILD_SHARED_LIBS = "YES";
       # FIXME(compnerd) - workaround ARM64 build failure when cross-compiling.
       CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
-      CMAKE_Swift_FLAGS = $SwiftFlags;
       FOUNDATION_BUILD_TOOLS = if ($Platform.OS -eq [OS]::Windows) { "YES" } else { "NO" };
       CURL_DIR = "$BinaryCache\$($Platform.Triple)\usr\lib\cmake\CURL";
       LibXml2_DIR = "$BinaryCache\$($Platform.Triple)\usr\lib\cmake\libxml2-2.11.5";
@@ -2971,7 +2932,7 @@ function Build-Foundation {
         "$BinaryCache\$($Platform.Triple)\usr\lib\libz.a"
       };
       ZLIB_INCLUDE_DIR = "$BinaryCache\$($Platform.Triple)\usr\include";
-      dispatch_DIR = $DispatchCMakeModules;
+      dispatch_DIR = (Get-ProjectCMakeModules $Platform Dispatch);
       _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
       _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
       _SwiftCollections_SourceDIR = "$SourceCache\swift-collections";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2910,7 +2910,7 @@ function Test-Dispatch {
   }
 }
 
-function Build-Foundation([Hashable] $Platform) {
+function Build-Foundation([Hashtable] $Platform) {
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-foundation `
     -Bin (Get-ProjectBinaryCache $Platform DynamicFoundation) `


### PR DESCRIPTION
`Build-Foundation` will not be retained once the legacy SDK is eliminated. This simplifies the logic to handle the current invocation only.