### PR TITLE
[6.2][Compile Time Constant Extraction] Support for open existential expressions

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -355,6 +355,19 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         }
       }
 
+      if (functionKind == ExprKind::FunctionConversion) {
+        auto functionConversionExpr = cast<FunctionConversionExpr>(callExpr->getFn());
+        if (functionConversionExpr->getSubExpr()->getKind() == ExprKind::DeclRef) {
+          auto declRefExpr = cast<DeclRefExpr>(functionConversionExpr->getSubExpr());
+          auto identifier =
+              declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
+
+          std::vector<FunctionParameter> parameters =
+              extractFunctionArguments(callExpr->getArgs(), declContext);
+          return std::make_shared<FunctionCallValue>(identifier, parameters);
+        }
+      }
+
       break;
     }
 
@@ -507,6 +520,12 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       auto derivedExpr = cast<DerivedToBaseExpr>(expr);
       return extractCompileTimeValue(derivedExpr->getSubExpr(), declContext);
     }
+
+    case ExprKind::OpenExistential: {
+      auto openExistentialExpr = cast<OpenExistentialExpr>(expr);
+      return extractCompileTimeValue(openExistentialExpr->getExistentialValue(), declContext);
+    }
+
     default: {
       break;
     }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -302,10 +302,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
     case ExprKind::Call: {
       auto callExpr = cast<CallExpr>(expr);
-      auto functionKind = callExpr->getFn()->getKind();
 
-      if (functionKind == ExprKind::DeclRef) {
-        auto declRefExpr = cast<DeclRefExpr>(callExpr->getFn());
+      if (auto declRefExpr = dyn_cast<DeclRefExpr>(callExpr->getFn())) {
         auto identifier =
             declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
@@ -314,17 +312,15 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         return std::make_shared<FunctionCallValue>(identifier, parameters);
       }
 
-      if (functionKind == ExprKind::ConstructorRefCall) {
+      if (auto constructorRefCall = dyn_cast<ConstructorRefCallExpr>(callExpr->getFn())) {
         std::vector<FunctionParameter> parameters =
             extractFunctionArguments(callExpr->getArgs(), declContext);
         return std::make_shared<InitCallValue>(callExpr->getType(), parameters);
       }
 
-      if (functionKind == ExprKind::DotSyntaxCall) {
-        auto dotSyntaxCallExpr = cast<DotSyntaxCallExpr>(callExpr->getFn());
+      if (auto dotSyntaxCallExpr = dyn_cast<DotSyntaxCallExpr>(callExpr->getFn())) {
         auto fn = dotSyntaxCallExpr->getFn();
-        if (fn->getKind() == ExprKind::DeclRef) {
-          auto declRefExpr = cast<DeclRefExpr>(fn);
+        if (auto declRefExpr = dyn_cast<DeclRefExpr>(fn)) {
           auto baseIdentifierName =
               declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
@@ -355,10 +351,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         }
       }
 
-      if (functionKind == ExprKind::FunctionConversion) {
-        auto functionConversionExpr = cast<FunctionConversionExpr>(callExpr->getFn());
-        if (functionConversionExpr->getSubExpr()->getKind() == ExprKind::DeclRef) {
-          auto declRefExpr = cast<DeclRefExpr>(functionConversionExpr->getSubExpr());
+      if (auto functionConversionExpr = dyn_cast<FunctionConversionExpr>(callExpr->getFn())) {
+        if (auto declRefExpr = dyn_cast<DeclRefExpr>(functionConversionExpr->getSubExpr())) {
           auto identifier =
               declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
@@ -374,8 +368,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
     case ExprKind::DotSyntaxCall: {
       auto dotSyntaxCallExpr = cast<DotSyntaxCallExpr>(expr);
       auto fn = dotSyntaxCallExpr->getFn();
-      if (fn->getKind() == ExprKind::DeclRef) {
-        auto declRefExpr = cast<DeclRefExpr>(fn);
+      if (auto declRefExpr = dyn_cast<DeclRefExpr>(fn)) {
         auto caseName =
             declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
         return std::make_shared<EnumValue>(caseName, std::nullopt);

--- a/test/ConstExtraction/ExtractKeyPaths.swift
+++ b/test/ConstExtraction/ExtractKeyPaths.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: echo "[MyProto]" > %t/protocols.json
 
-// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractKeyPaths.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: %target-swift-frontend -enable-upcoming-feature InferSendableFromCaptures -typecheck -emit-const-values-path %t/ExtractKeyPaths.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
 // RUN: cat %t/ExtractKeyPaths.swiftconstvalues 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_InferSendableFromCaptures
 
 protocol MyProto {}
 
@@ -59,7 +61,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:       "line": 31,
+// CHECK-NEXT:       "line": 33,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "foo",
@@ -79,7 +81,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 32,
+// CHECK-NEXT:        "line": 34,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "foo",
@@ -99,7 +101,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 33,
+// CHECK-NEXT:        "line": 35,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "foo",
@@ -119,7 +121,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 34,
+// CHECK-NEXT:        "line": 36,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "bar",
@@ -139,7 +141,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 35,
+// CHECK-NEXT:        "line": 37,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "bar",
@@ -154,12 +156,12 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:      },
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "label": "nestedKeyPath",
-// CHECK-NEXT:        "type": "Swift.WritableKeyPath<ExtractKeyPaths.MyType, Swift.String>",
+// CHECK-NEXT:        "type": "any Swift.WritableKeyPath<ExtractKeyPaths.MyType, Swift.String> & Swift.Sendable",
 // CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 36,
+// CHECK-NEXT:        "line": 38,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:         "path": "nested.foo.bar.baz",

--- a/test/ConstExtraction/ExtractOpenExistential.swift
+++ b/test/ConstExtraction/ExtractOpenExistential.swift
@@ -1,0 +1,70 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractOpenExistential.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractOpenExistential.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+protocol ExampleProtocol {
+    var protocolProperty: String { get }
+}
+
+struct ConcreteType: ExampleProtocol {
+    let protocolProperty: String = "Concrete implementation"
+}
+
+func useExistential(_ example: any ExampleProtocol) -> String {
+    return example.protocolProperty
+}
+
+public struct External: MyProto {
+    static let existentialValue = useExistential(ConcreteType())
+}
+
+
+// CHECK: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "ExtractOpenExistential.External",
+// CHECK-NEXT:     "mangledTypeName": "22ExtractOpenExistential8ExternalV",
+// CHECK-NEXT:     "kind": "struct",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractOpenExistential.swift",
+// CHECK-NEXT:     "line": 21,
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "ExtractOpenExistential.MyProto"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractOpenExistential.MyProto"
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractOpenExistential"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:     "properties": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "existentialValue",
+// CHECK-NEXT:         "type": "Swift.String",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "true",
+// CHECK-NEXT:         "isComputed": "false",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractOpenExistential.swift",
+// CHECK-NEXT:         "line": 22,
+// CHECK-NEXT:         "valueKind": "FunctionCall",
+// CHECK-NEXT:         "value": {
+// CHECK-NEXT:           "name": "useExistential",
+// CHECK-NEXT:           "arguments": [
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "label": "",
+// CHECK-NEXT:               "type": "any ExtractOpenExistential.ExampleProtocol",
+// CHECK-NEXT:               "valueKind": "InitCall",
+// CHECK-NEXT:               "value": {
+// CHECK-NEXT:                 "type": "ExtractOpenExistential.ConcreteType",
+// CHECK-NEXT:                 "arguments": []
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           ]
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]


### PR DESCRIPTION
- **Explanation**: Adding support for extracting open existential expressions that may impact extraction for Swift 6
- **Scope**: Low impact as it only adds support for open existential statements in const extract
- **Issues**: Resolves issues stemming from failure to extract wrapping open existential expressions in Swift 6
- **Original PRs**: https://github.com/swiftlang/swift/pull/83008
- **Risk**: Similar to scope impact, it is low risk as it only adds support for open existential statements in const extract
- **Testing**: Tests have been added to verify changes
- **Reviewers**: @xedin @slavapestov 