### PR TITLE
[Embedded] Remove -mergeable-symbols

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -498,8 +498,6 @@ public:
   /// Internalize symbols (static library) - do not export any public symbols.
   unsigned InternalizeSymbols : 1;
 
-  unsigned MergeableSymbols : 1;
-
   /// Emit a section with references to class_ro_t* in generic class patterns.
   unsigned EmitGenericRODatas : 1;
 
@@ -645,7 +643,7 @@ public:
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         AnnotateCondFailMessage(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
-        MergeableSymbols(false), EmitGenericRODatas(true),
+        EmitGenericRODatas(true),
         NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -57,15 +57,10 @@ public:
   /// be promoted to public external. Used by the LLDB expression evaluator.
   bool ForcePublicDecls;
 
-  /// When true, allows duplicate external and hidden declarations by marking
-  /// them as linkonce / weak.
-  bool MergeableSymbols;
-
   explicit UniversalLinkageInfo(IRGenModule &IGM);
 
   UniversalLinkageInfo(const llvm::Triple &triple, bool hasMultipleIGMs,
-                       bool forcePublicDecls, bool isStaticLibrary,
-                       bool mergeableSymbols);
+                       bool forcePublicDecls, bool isStaticLibrary);
 
   /// In case of multiple llvm modules (in multi-threaded compilation) all
   /// private decls must be visible from other files.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -51,7 +51,11 @@ private:
 
   /// The SIL module that the global variable belongs to.
   SILModule &Module;
-  
+
+  /// The module that defines this global variable. This member should only be
+  /// when a global variable is deserialized to be emitted into another module.
+  ModuleDecl *ParentModule = nullptr;
+
   /// The mangled name of the variable, which will be propagated to the
   /// binary.  A pointer into the module's lookup table.
   StringRef Name;
@@ -119,6 +123,15 @@ public:
   ~SILGlobalVariable();
 
   SILModule &getModule() const { return Module; }
+
+  /// Returns the module that defines this function.
+  ModuleDecl *getParentModule() const;
+
+  /// Sets \c ParentModule as fallback if \c DeclCtxt is not available to
+  /// provide the parent module.
+  void setParentModule(ModuleDecl *module) {
+    ParentModule = module;
+  }
 
   SILType getLoweredType() const { return LoweredType; }
   CanSILFunctionType getLoweredFunctionType() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3766,10 +3766,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.InternalizeSymbols = FrontendOpts.Static;
 
-  if (Args.hasArg(OPT_mergeable_symbols)) {
-    Opts.MergeableSymbols = true;
-  }
-
   if (Args.hasArg(OPT_disable_preallocated_instantiation_caches)) {
     Opts.NoPreallocatedInstantiationCaches = true;
   }
@@ -3905,6 +3901,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.EmitCASIDFile |= Args.hasArg(OPT_cas_emit_casid_file);
 
   Opts.DebugCallsiteInfo |= Args.hasArg(OPT_debug_callsite_info);
+
+  if (Args.hasArg(OPT_mergeable_symbols))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-mergeable-symbols");
 
   return false;
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2332,8 +2332,6 @@ getIRLinkage(StringRef name, const UniversalLinkageInfo &info,
 
     if (hasNonUniqueDefinition)
       linkage = llvm::GlobalValue::WeakODRLinkage;
-    else if (info.MergeableSymbols)
-      linkage = llvm::GlobalValue::WeakODRLinkage;
 
     return {linkage, PublicDefinitionVisibility,
             info.Internalize ? llvm::GlobalValue::DefaultStorageClass
@@ -2351,8 +2349,6 @@ getIRLinkage(StringRef name, const UniversalLinkageInfo &info,
 
   case SILLinkage::Hidden:
     if (hasNonUniqueDefinition)
-      return RESULT(WeakODR, Hidden, Default);
-    if (info.MergeableSymbols)
       return RESULT(WeakODR, Hidden, Default);
 
     return RESULT(External, Hidden, Default);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -82,19 +82,16 @@ bool swift::irgen::useDllStorage(const llvm::Triple &triple) {
 UniversalLinkageInfo::UniversalLinkageInfo(IRGenModule &IGM)
     : UniversalLinkageInfo(IGM.Triple, IGM.IRGen.hasMultipleIGMs(),
                            IGM.IRGen.Opts.ForcePublicLinkage,
-                           IGM.IRGen.Opts.InternalizeSymbols,
-                           IGM.IRGen.Opts.MergeableSymbols) {}
+                           IGM.IRGen.Opts.InternalizeSymbols) {}
 
 UniversalLinkageInfo::UniversalLinkageInfo(const llvm::Triple &triple,
                                            bool hasMultipleIGMs,
                                            bool forcePublicDecls,
-                                           bool isStaticLibrary,
-                                           bool mergeableSymbols)
+                                           bool isStaticLibrary)
     : IsELFObject(triple.isOSBinFormatELF()),
       IsMSVCEnvironment(triple.isWindowsMSVCEnvironment()),
       UseDLLStorage(useDllStorage(triple)), Internalize(isStaticLibrary),
-      HasMultipleIGMs(hasMultipleIGMs), ForcePublicDecls(forcePublicDecls),
-      MergeableSymbols(mergeableSymbols) {}
+      HasMultipleIGMs(hasMultipleIGMs), ForcePublicDecls(forcePublicDecls) {}
 
 LinkEntity LinkEntity::forSILGlobalVariable(SILGlobalVariable *G,
                                             IRGenModule &IGM) {

--- a/lib/IRGen/TBDGenVisitor.h
+++ b/lib/IRGen/TBDGenVisitor.h
@@ -124,7 +124,7 @@ public:
                 APIRecorder &recorder)
       : DataLayoutDescription(dataLayoutString),
         UniversalLinkInfo(target, opts.HasMultipleIGMs, /*forcePublic*/ false,
-                          /*static=*/false, /*mergeableSymbols*/false),
+                          /*static=*/false),
         SwiftModule(swiftModule), Opts(opts), recorder(recorder),
         previousInstallNameMap(parsePreviousModuleInstallNameMap()) {}
 

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -231,8 +231,6 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
   auto onceSILTy
     = SILType::getPrimitiveObjectType(onceTy->getCanonicalType());
 
-  // TODO: include the module in the onceToken's name mangling.
-  // Then we can make it fragile.
   auto onceToken = SILGlobalVariable::create(M, SILLinkage::Private,
                                              IsNotSerialized,
                                              onceTokenBuffer, onceSILTy);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -4078,9 +4078,11 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
 
   TypeID TyID;
   DeclID dID;
+  ModuleID parentModuleID;
   unsigned rawLinkage, serializedKind, IsDeclaration, IsLet, IsUsed;
   SILGlobalVarLayout::readRecord(scratch, rawLinkage, serializedKind,
-                                 IsDeclaration, IsLet, IsUsed, TyID, dID);
+                                 IsDeclaration, IsLet, IsUsed, TyID, dID,
+                                 parentModuleID);
   if (TyID == 0) {
     LLVM_DEBUG(llvm::dbgs() << "SILGlobalVariable typeID is 0.\n");
     return nullptr;
@@ -4114,6 +4116,9 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
   v->setMarkedAsUsed(IsUsed);
   globalVarOrOffset.set(v, true /*isFullyDeserialized*/);
   v->setDeclaration(IsDeclaration);
+
+  if (parentModuleID)
+    v->setParentModule(MF->getModule(parentModuleID));
 
   if (Callback)
     Callback->didDeserialize(MF->getAssociatedModule(), v);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 959; // Removed assign_by_wrapper SILGen instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 960; // SILGlobalVariable parent module
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -296,7 +296,8 @@ namespace sil_block {
     BCFixed<1>,          // Is this a let variable.
     BCFixed<1>,          // Is this marked as "used".
     TypeIDField,
-    DeclIDField
+    DeclIDField,
+    ModuleIDField        // Parent ModuleDecl *
   >;
 
   using DifferentiabilityWitnessLayout = BCRecordLayout<

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3114,6 +3114,11 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
   GlobalVarOffset.push_back(Out.GetCurrentBitNo());
   TypeID TyID = S.addTypeRef(g.getLoweredType().getRawASTType());
   DeclID dID = S.addDeclRef(g.getDecl());
+
+  ModuleID parentModuleID;
+  if (auto *parentModule = g.getParentModule())
+    parentModuleID = S.addModuleRef(parentModule);
+
   SILGlobalVarLayout::emitRecord(Out, ScratchRecord,
                                  SILAbbrCodes[SILGlobalVarLayout::Code],
                                  toStableSILLinkage(g.getLinkage()),
@@ -3121,7 +3126,7 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
                                  (unsigned)!g.isDefinition(),
                                  (unsigned)g.isLet(),
                                  (unsigned)g.markedAsUsed(),
-                                 TyID, dID);
+                                 TyID, dID, parentModuleID);
 
   // Don't emit the initializer instructions if not marked as "serialized".
   if (!g.isAnySerialized())

--- a/test/embedded/linkage-custom-entry-point.swift
+++ b/test/embedded/linkage-custom-entry-point.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -module-name Application -parse-as-library -entry-point-function-name Application_main -mergeable-symbols    -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend %s -module-name Application -parse-as-library -entry-point-function-name Application_main -mergeable-symbols -O -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name Application -parse-as-library -entry-point-function-name Application_main    -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name Application -parse-as-library -entry-point-function-name Application_main -O -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/linkage-mergeable-dead-strip.swift
+++ b/test/embedded/linkage-mergeable-dead-strip.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -emit-ir | %FileCheck %s --check-prefix=CHECK-IR
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -O %s -emit-ir | %FileCheck %s --check-prefix=CHECK-IR
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -O %s -c -o %t/a.o
 // RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -dead_strip
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=CHECK-NM
 // RUN: %target-run %t/a.out | %FileCheck %s
@@ -16,8 +16,8 @@ public func a_this_is_unused() { }
 @_used
 public func b_this_is_unused_but_explicitly_retained() { }
 
-// CHECK-IR: define weak_odr {{.*}}@"$e4main16a_this_is_unusedyyF"()
-// CHECK-IR: define weak_odr {{.*}}@"$e4main40b_this_is_unused_but_explicitly_retainedyyF"()
+// CHECK-IR: define {{.*}}@"$e4main16a_this_is_unusedyyF"()
+// CHECK-IR: define {{.*}}@"$e4main40b_this_is_unused_but_explicitly_retainedyyF"()
 
 // CHECK-NM-NOT: $e4main14this_is_unusedyyF
 // CHECK-NM: $e4main40b_this_is_unused_but_explicitly_retainedyyF

--- a/test/embedded/linkage-mergeable.swift
+++ b/test/embedded/linkage-mergeable.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -mergeable-symbols -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -mergeable-symbols -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
 // RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-mergeable2.swift
+++ b/test/embedded/linkage-mergeable2.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -mergeable-symbols -O -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -mergeable-symbols -O -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -O -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -O -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
 // RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-mergeable3.swift
+++ b/test/embedded/linkage-mergeable3.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-clang %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-embedded-link %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-public-exports.swift
+++ b/test/embedded/linkage-public-exports.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -mergeable-symbols    -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend %s -mergeable-symbols -O -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s    -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded


### PR DESCRIPTION
As with SIL functions, track the parent module where a SIL global variable was originally defined so that we can determine whether we are outside of its original module for linkage purposes. Use this to make sure we emit via a weak definition when emitting to a module other than the originating module.

With this fix in place, we no longer need `-mergeable-symbols`, because the default model uses weak definitions for imported entities consistently.

Fixes rdar://160153163 & rdar://158364032.

