### PR TITLE
[6.2][cxx-interop] Fix duplicate symbol error with default arguments

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
@@ -2522,6 +2523,8 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
       ImporterImpl.ImportedHeaderUnit);
   funcDecl->setBodySynthesizer(synthesizeDefaultArgumentBody, (void *)param);
   funcDecl->setAccess(AccessLevel::Public);
+  funcDecl->getAttrs().add(new (ctx)
+                               AlwaysEmitIntoClientAttr(/*IsImplicit=*/true));
 
   ImporterImpl.defaultArgGenerators[param] = funcDecl;
 

--- a/test/Interop/Cxx/function/default-arguments-multifile.swift
+++ b/test/Interop/Cxx/function/default-arguments-multifile.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir -p %t/artifacts
+
+// Multiple usages in the same module.
+// RUN: %target-build-swift %t/main.swift %t/b.swift %t/c.swift -cxx-interoperability-mode=upcoming-swift -I %S/Inputs -o %t/artifacts/out
+// RUN: %empty-directory(%t/artifacts)
+
+// Multiple usages across different modules.
+// RUN: %target-build-swift -emit-library -module-name BarLibrary -emit-module -emit-module-path %t/artifacts/BarLibrary.swiftmodule %t/b.swift %t/c.swift -cxx-interoperability-mode=upcoming-swift -I %S/Inputs -o %t/artifacts/%target-library-name(BarLibrary)
+// RUN: %target-build-swift %t/uses-library.swift -cxx-interoperability-mode=upcoming-swift -I %S/Inputs -I %t/artifacts -L %t/artifacts -lBarLibrary -o %t/artifacts/uses-library
+
+// FIXME: Windows test can be enabled once merge-modules step is removed from the old driver,
+// or the Windows CI starts to use the new driver to compile the compiler.
+// The windows toolchains still use the new driver so the CI failure worked
+// around here should not affect users on Windows.
+// UNSUPPORTED: OS=windows-msvc
+
+//--- main.swift
+import DefaultArguments
+public func foo() {
+  let _ = isZero()
+}
+foo()
+bar()
+baz()
+
+//--- b.swift
+import DefaultArguments
+public func bar() {
+  let _ = isZero()
+}
+
+//--- c.swift
+import DefaultArguments
+public func baz() {
+  let _ = isZero(123)
+}
+
+//--- uses-library.swift
+import DefaultArguments
+import BarLibrary
+
+let _ = isZero()
+bar()
+baz()

--- a/test/Interop/Cxx/function/lit.local.cfg
+++ b/test/Interop/Cxx/function/lit.local.cfg
@@ -1,0 +1,6 @@
+# Make a local copy of the environment.
+config.environment = dict(config.environment)
+
+# FIXME: deserialization failure with the old driver in default-arguments-multifile.swift
+if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']


### PR DESCRIPTION
Explanation: We synthesize a Swift function that only calls a C++ funtion that produces the default argument. We produce this function for each module that imports the C++ function with the default argument. This symbol needs to be public as it is created in the context of the Clang module and used from the Swift module. To avoid the linker errors, we always emit this function into the client which is also the right thing to do as the whole body is a single function call.
Issues: rdar://160182651
Original PRs: #82333
Risk: Low, this is merged to main in early July and no one complained yet. And the change is straightforward.
Testing: Added a compiler test.
Reviewers: @egorzhdan

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
