### PR TITLE
[demangling] make printRoot virtual

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -890,7 +890,7 @@ public:
 
   virtual ~NodePrinter() = default;
 
-  void printRoot(NodePointer root) {
+  virtual void printRoot(NodePointer root) {
     isValid = true;
     print(root, 0);
   }


### PR DESCRIPTION
This patch makes the `NodePrinter::printRoot` method virtual to allow it to be overwritten in:
- https://github.com/swiftlang/llvm-project/pull/11352