### PR TITLE
Fix two bugs with the isolation of defer bodies

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3285,6 +3285,9 @@ public:
   /// `AbstractStorageDecl`, returns `false`.
   bool isAsync() const;
 
+  /// Returns whether this function represents a defer body.
+  bool isDeferBody() const;
+
 private:
   bool isObjCDynamic() const {
     return isObjC() && isDynamic();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11879,6 +11879,12 @@ PrecedenceGroupDecl *InfixOperatorDecl::getPrecedenceGroup() const {
       nullptr);
 }
 
+bool ValueDecl::isDeferBody() const {
+  if (auto fn = dyn_cast<FuncDecl>(this))
+    return fn->isDeferBody();
+  return false;
+}
+
 bool FuncDecl::isDeferBody() const {
   return getBaseIdentifier() == getASTContext().getIdentifier("$defer");
 }
@@ -12072,12 +12078,16 @@ ActorIsolation swift::getActorIsolationOfContext(
         getClosureActorIsolation) {
   auto &ctx = dc->getASTContext();
   auto dcToUse = dc;
-  // Defer bodies share actor isolation of their enclosing context.
-  if (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
-    if (FD->isDeferBody()) {
-      dcToUse = FD->getDeclContext();
-    }
+
+  // Defer bodies share the actor isolation of their enclosing context.
+  // We don't actually have to do this check here because
+  // getActorIsolation does consider it already, but it's nice to
+  // avoid some extra request evaluation in a trivial case.
+  while (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
+    if (!FD->isDeferBody()) break;
+    dcToUse = FD->getDeclContext();
   }
+
   if (auto *vd = dyn_cast_or_null<ValueDecl>(dcToUse->getAsDecl()))
     return getActorIsolation(vd);
 

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -190,7 +190,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     }
 
     case ActorIsolation::CallerIsolationInheriting:
-      assert(F.isAsync());
+      assert(F.isAsync() || F.isDefer());
       setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
 
@@ -255,7 +255,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
           RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
           executor,
           /*mandatory*/ false);
-    } else {
+    } else if (wantDataRaceChecks) {
       // For a synchronous function, check that we're on the same executor.
       // Note: if we "know" that the code is completely Sendable-safe, this
       // is unnecessary. The type checker will need to make this determination.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6353,6 +6353,14 @@ static bool shouldSelfIsolationOverrideDefault(
 
 static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
                                                     ValueDecl *value) {
+  // Defer bodies share the actor isolation of their enclosing context.
+  if (value->isDeferBody()) {
+    return {
+      getActorIsolationOfContext(value->getDeclContext()),
+      IsolationSource()
+    };
+  }
+
   // If this declaration has actor-isolated "self", it's isolated to that
   // actor.
   if (evaluateOrDefault(evaluator, HasIsolatedSelfRequest{value}, false)) {

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -36,6 +36,16 @@ func testNonDefer_negative() {
 // CHECK-NEXT:    function_ref
 // CHECK-NEXT:    apply
 
+@MainActor func testGlobalActor_nested_positive() {
+  defer {
+    defer {
+      requiresMainActor()
+    }
+    doSomething()
+  }
+  doSomething()
+}
+
 #if NEGATIVES
 // expected-note @+1 {{add '@MainActor' to make global function 'testGlobalActor_negative()' part of global actor 'MainActor'}}
 func testGlobalActor_negative() {

--- a/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
+++ b/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
@@ -19,3 +19,56 @@ func take(iso: (any Actor)?) {}
 // CHECK:   apply [[FUNC]]([[ACTOR]]) : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
 // CHECK:   release_value [[ACTOR]]
 // CHECK: } // end sil function '$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF'
+
+//   Check that we emit #isolation correctly in defer bodies.
+nonisolated(nonsending)
+func hasDefer() async {
+  defer {
+    take(iso: #isolation)
+  }
+  do {}
+}
+// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil8hasDeferyyYaF :
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in hasDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    // function_ref take(iso:)
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @
+// CHECK-NEXT:    apply [[FN]](%0)
+
+//   Check that we emit #isolation correctly in nested defer bodies.
+nonisolated(nonsending)
+func hasNestedDefer() async {
+  defer {
+    defer {
+      take(iso: #isolation)
+    }
+    do {}
+  }
+  do {}
+}
+
+// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil14hasNestedDeferyyYaF :
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer #1 () in $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    // function_ref take(iso:)
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @
+// CHECK-NEXT:    apply [[FN]](%0)


### PR DESCRIPTION
The first bug is that we weren't computing isolation correctly for nested defers. This is an unlikely pattern of code, but it's good to fix.
    
The second bug is that `getActorIsolationOfContext` was looking through defers, but `getActorIsolation` itself was not. This was causing defer bodies to be emitted in SILGen without an isolation parameter, which meant that `#isolation` could not possibly provide the right value. Fixing this involves teaching SILGen that non-async functions can have `nonisolated(nonsending)` isolation, but that's relatively straightforward (and it's good future-proofing anyway).