### PR TITLE
[windows][lldb] deactivate DebugInfo/basic.swift while it's being fixed

### DIFF
--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -1,4 +1,5 @@
 // A (no longer) basic test for debug info.
+// XFAIL: OS=windows-msvc
 // --------------------------------------------------------------------
 // Verify that we don't emit any debug info by default.
 // RUN: %target-swift-frontend %s -emit-ir -o - \


### PR DESCRIPTION
Deactivate the `DebugInfo/basic.swift` test which is failing on Windows.