### PR TITLE
Isolation fixes for closures and defer bodies

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -28,6 +28,7 @@ class raw_ostream;
 
 namespace swift {
 class DeclContext;
+class Initializer;
 class ModuleDecl;
 class VarDecl;
 class NominalTypeDecl;
@@ -433,6 +434,10 @@ InferredActorIsolation getInferredActorIsolation(ValueDecl *value);
 /// Trampoline for AbstractClosureExpr::getActorIsolation.
 ActorIsolation
 __AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE);
+
+/// Determine how the given initialization context is isolated.
+ActorIsolation getActorIsolation(Initializer *init,
+                                 bool ignoreDefaultArguments = false);
 
 /// Determine how the given declaration context is isolated.
 /// \p getClosureActorIsolation allows the specification of actor isolation for

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3285,6 +3285,9 @@ public:
   /// `AbstractStorageDecl`, returns `false`.
   bool isAsync() const;
 
+  /// Returns whether this function represents a defer body.
+  bool isDeferBody() const;
+
 private:
   bool isObjCDynamic() const {
     return isObjC() && isDynamic();

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -38,6 +38,7 @@ namespace swift {
   enum class EffectsKind : uint8_t;
   class AbstractFunctionDecl;
   class AbstractClosureExpr;
+  class ActorIsolation;
   class ValueDecl;
   class FuncDecl;
   class ClosureExpr;
@@ -507,6 +508,8 @@ struct SILDeclRef {
     result.loc = decl;
     return result;
   }
+
+  ActorIsolation getActorIsolation() const;
 
   /// True if the decl ref references a thunk from a natively foreign
   /// declaration to Swift calling convention.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11879,6 +11879,12 @@ PrecedenceGroupDecl *InfixOperatorDecl::getPrecedenceGroup() const {
       nullptr);
 }
 
+bool ValueDecl::isDeferBody() const {
+  if (auto fn = dyn_cast<FuncDecl>(this))
+    return fn->isDeferBody();
+  return false;
+}
+
 bool FuncDecl::isDeferBody() const {
   return getBaseIdentifier() == getASTContext().getIdentifier("$defer");
 }
@@ -12072,12 +12078,16 @@ ActorIsolation swift::getActorIsolationOfContext(
         getClosureActorIsolation) {
   auto &ctx = dc->getASTContext();
   auto dcToUse = dc;
-  // Defer bodies share actor isolation of their enclosing context.
-  if (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
-    if (FD->isDeferBody()) {
-      dcToUse = FD->getDeclContext();
-    }
+
+  // Defer bodies share the actor isolation of their enclosing context.
+  // We don't actually have to do this check here because
+  // getActorIsolation does consider it already, but it's nice to
+  // avoid some extra request evaluation in a trivial case.
+  while (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
+    if (!FD->isDeferBody()) break;
+    dcToUse = FD->getDeclContext();
   }
+
   if (auto *vd = dyn_cast_or_null<ValueDecl>(dcToUse->getAsDecl()))
     return getActorIsolation(vd);
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2412,32 +2412,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
   }
 
   if (constant) {
-    // TODO: It should to be possible to `getActorIsolation` if
-    // reference is to a decl instead of trying to get isolation
-    // from the reference kind, the attributes, or the context.
-
-    if (constant->kind == SILDeclRef::Kind::Deallocator) {
-      return ActorIsolation::forNonisolated(false);
-    }
-
-    if (auto *decl = constant->getAbstractFunctionDecl()) {
-      if (auto *nonisolatedAttr =
-              decl->getAttrs().getAttribute<NonisolatedAttr>()) {
-        if (nonisolatedAttr->isNonSending())
-          return ActorIsolation::forCallerIsolationInheriting();
-      }
-
-      if (decl->getAttrs().hasAttribute<ConcurrentAttr>()) {
-        return ActorIsolation::forNonisolated(false /*unsafe*/);
-      }
-    }
-
-    if (auto *closure = constant->getAbstractClosureExpr()) {
-      if (auto isolation = closure->getActorIsolation())
-        return isolation;
-    }
-
-    return getActorIsolationOfContext(constant->getInnermostDeclContext());
+    return constant->getActorIsolation();
   }
 
   if (substFnInterfaceType->hasExtInfo() &&

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -190,7 +190,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     }
 
     case ActorIsolation::CallerIsolationInheriting:
-      assert(F.isAsync());
+      assert(F.isAsync() || F.isDefer());
       setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
 
@@ -255,7 +255,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
           RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
           executor,
           /*mandatory*/ false);
-    } else {
+    } else if (wantDataRaceChecks) {
       // For a synchronous function, check that we're on the same executor.
       // Note: if we "know" that the code is completely Sendable-safe, this
       // is unnecessary. The type checker will need to make this determination.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6353,6 +6353,14 @@ static bool shouldSelfIsolationOverrideDefault(
 
 static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
                                                     ValueDecl *value) {
+  // Defer bodies share the actor isolation of their enclosing context.
+  if (value->isDeferBody()) {
+    return {
+      getActorIsolationOfContext(value->getDeclContext()),
+      IsolationSource()
+    };
+  }
+
   // If this declaration has actor-isolated "self", it's isolated to that
   // actor.
   if (evaluateOrDefault(evaluator, HasIsolatedSelfRequest{value}, false)) {

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -36,6 +36,16 @@ func testNonDefer_negative() {
 // CHECK-NEXT:    function_ref
 // CHECK-NEXT:    apply
 
+@MainActor func testGlobalActor_nested_positive() {
+  defer {
+    defer {
+      requiresMainActor()
+    }
+    doSomething()
+  }
+  doSomething()
+}
+
 #if NEGATIVES
 // expected-note @+1 {{add '@MainActor' to make global function 'testGlobalActor_negative()' part of global actor 'MainActor'}}
 func testGlobalActor_negative() {

--- a/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
+++ b/test/Concurrency/isolated_nonsending_isolation_macro_sil.swift
@@ -19,3 +19,69 @@ func take(iso: (any Actor)?) {}
 // CHECK:   apply [[FUNC]]([[ACTOR]]) : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
 // CHECK:   release_value [[ACTOR]]
 // CHECK: } // end sil function '$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF'
+
+//   Check that we emit #isolation correctly in closures.
+// CHECK-LABEL: // closure #1 in containsClosure()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    // function_ref take(iso:)
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @
+// CHECK-NEXT:    apply [[FN]](%0)
+func containsClosure() {
+  let closure: nonisolated(nonsending) () async -> Void = {
+    take(iso: #isolation)
+  }
+}
+
+//   Check that we emit #isolation correctly in defer bodies.
+nonisolated(nonsending)
+func hasDefer() async {
+  defer {
+    take(iso: #isolation)
+  }
+  do {}
+}
+// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil8hasDeferyyYaF :
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in hasDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    // function_ref take(iso:)
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @
+// CHECK-NEXT:    apply [[FN]](%0)
+
+//   Check that we emit #isolation correctly in nested defer bodies.
+nonisolated(nonsending)
+func hasNestedDefer() async {
+  defer {
+    defer {
+      take(iso: #isolation)
+    }
+    do {}
+  }
+  do {}
+}
+
+// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil14hasNestedDeferyyYaF :
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK:         // function_ref $defer #1 () in $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:    [[DEFER:%.*]] = function_ref
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: // $defer #1 () in $defer #1 () in hasNestedDefer()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    // function_ref take(iso:)
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @
+// CHECK-NEXT:    apply [[FN]](%0)

--- a/test/SILGen/isolated_default_arguments.swift
+++ b/test/SILGen/isolated_default_arguments.swift
@@ -28,6 +28,10 @@ func main_actor_int_pair() -> (Int, Int) {
   return (0,0)
 }
 
+func make_int(isolated isolation: (any Actor)? = #isolation) -> Int {
+  return 0
+}
+
 // This test breaks because the intermediate argument is `nil`, which
 // we treat as non-isolated.
 @MainActor
@@ -121,3 +125,39 @@ func tupleIsolatedDefaultArg(x: (Int,Int) = main_actor_int_pair(),
 func testTupleIsolatedDefaultArg() async {
   await tupleIsolatedDefaultArg(y: 0)
 }
+
+// When a function is caller-isolated, its default argument generators
+// should probably also be caller-isolated and forward their isolation
+// properly when #isolation is used. Currently, however, that's not what
+// we're doing, so test for the current behavior.
+
+nonisolated(nonsending)
+func callerIsolatedDefaultArg(x: Int = make_int()) async {}
+
+@MainActor
+func useCallerIsolatedDefaultArg() async {
+  await callerIsolatedDefaultArg()
+}
+
+//   Check that the default argument generator isn't caller-isolated.
+// CHECK-LABEL: // default argument 0 of test.callerIsolatedDefaultArg
+// CHECK-NEXT:  // Isolation: unspecified
+// CHECK-NEXT:  sil hidden [ossa] @$s4test24callerIsolatedDefaultArg1xySi_tYaFfA_ :
+// CHECK:       bb0:
+//   Check that we provide a nil isolation for #isolation
+// CHECK-NEXT:    [[NIL_ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none
+// CHECK-NEXT:    // function_ref test.make_int
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @$s4test8make_int8isolatedSiScA_pSg_tF :
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FN]]([[NIL_ISOLATION]])
+// CHECK-NEXT:    return [[RESULT]]
+
+//   Check that we pass the right isolation to the generator.
+// CHECK-LABEL: sil hidden [ossa] @$s4test27useCallerIsolatedDefaultArgyyYaF :
+//   Get the main actor reference.
+// CHECK:         [[GET_MAIN_ACTOR:%.*]] = function_ref @$sScM6sharedScMvgZ :
+// CHECK-NEXT:    [[T0:%.*]] = apply [[GET_MAIN_ACTOR]](
+// CHECK-NEXT:    [[MAIN_ACTOR:%.*]] = begin_borrow [[T0]]
+//   Call the accessor.
+// CHECK:         // function_ref default argument 0 of
+// CHECK-NEXT:    [[GEN:%.*]] = function_ref @$s4test24callerIsolatedDefaultArg1xySi_tYaFfA_ :
+// CHECK-NEXT:    [[ARG:%.*]] = apply [[GEN]]()

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -466,7 +466,7 @@ func testAutoclosureInStaticMethod() {
     //
     // Get standard.
     // CHECK: [[METATYPE:%.*]] = metatype $@objc_metatype SlowServer.Type
-    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method %1 : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
+    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method [[METATYPE]] : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
     // CHECK: [[STANDARD:%.*]] = apply [[GET_STANDARD_FUNC]]([[METATYPE]])
     //
     // Then grab value.
@@ -592,7 +592,7 @@ func testAutoclosureInStaticMethod() {
     //
     // Get standard.
     // CHECK: [[METATYPE:%.*]] = metatype $@objc_metatype SlowServer.Type
-    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method %1 : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
+    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method [[METATYPE]] : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
     // CHECK: [[STANDARD:%.*]] = apply [[GET_STANDARD_FUNC]]([[METATYPE]])
     //
     // Then grab value.

--- a/validation-test/compiler_crashers_2_fixed/8d73bb4170a0c447.swift
+++ b/validation-test/compiler_crashers_2_fixed/8d73bb4170a0c447.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::ParamDecl::setTypeCheckedDefaultExpr(swift::Expr*)","signatureAssert":"Assertion failed: (E || getDefaultArgumentKind() == DefaultArgumentKind::Inherited), function setTypeCheckedDefaultExpr"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<b>(b= a(


### PR DESCRIPTION
I was trying to just fix a bug where `#isolation` wasn't evaluated properly in closure expressions, but I realized that my fix had the potential to affect other cases, and my investigations revealed three other bugs:
- The isolation computation for decl contexts was not recursively looking through `defer` scopes, so nested `defer` bodies were being treated as non-isolated.
- The isolation computation for the hidden function containing the `defer` body did not look upwards at all, so `defer` bodies were not treated as being isolated the same way as their parent function. I think we might have compensated for this in a lot of ways, but `#isolation` could not possibly have evaluated correctly in caller-isolated contexts because the `defer` body simply didn't get the isolation passed to it.
- Similarly, the isolation computation for default argument generators of `nonisolated(nonsending)` functions was never returning caller-isolated, so these functions were not receiving implicit isolation parameters or using them correctly.

I ended up going around in circles on the default-arguments bug a lot, and eventually I settled on implementing most of the structure necessary for fixing it but not actually fixing it. Changing the computation of the isolation should now just make everything in SILGen work.

The other bugs with closures and `defer` should all be fixed.