### PR TITLE
[SILVerifier] Ease this over-strict verification.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4208,8 +4208,9 @@ public:
 
     auto lookupType = AMI->getLookupType();
     if (getLocalArchetypeOf(lookupType) || lookupType->hasDynamicSelfType()) {
-      require(AMI->getTypeDependentOperands().size() == 1,
-              "Must have a type dependent operand for the opened archetype");
+      require(!AMI->getTypeDependentOperands().empty(),
+              "Must have at least one type-dependent operand when there's a "
+              "local archetype or dynamic self.");
       verifyLocalArchetype(AMI, lookupType);
     } else {
       require(AMI->getTypeDependentOperands().empty() || lookupType->hasLocalArchetype(),

--- a/validation-test/SILOptimizer/rdar159211502.swift
+++ b/validation-test/SILOptimizer/rdar159211502.swift
@@ -1,0 +1,14 @@
+// RUN: %target-build-swift %s -O -Xfrontend -sil-verify-all
+
+protocol PA<I> {
+  associatedtype I: P
+  func get() -> I
+}
+
+protocol P {
+  var pa: any PA<Self> { get }
+}
+
+func f(_ p: any P) {
+  p.pa.get()
+}


### PR DESCRIPTION
It's permitted for a `witness_method` instruction to have multiple type-dependent operands.  This can happen when for example when one local archetype is defined in terms of another.

rdar://159211502
