### PR TITLE
[cxx-interop] Fix crash when importing C++ forward-declared template specializations in typedefs

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
+++ b/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
@@ -1,0 +1,19 @@
+#ifndef FORWARD_DECLARED_SPECIALIZATION_H
+#define FORWARD_DECLARED_SPECIALIZATION_H
+
+template <typename T> 
+struct MyTemplate { 
+  T value; 
+};
+
+template <> 
+struct MyTemplate<int>;
+typedef MyTemplate<int> MyIntTemplate;
+
+template <> 
+struct MyTemplate<double> {
+  double value;
+};
+typedef MyTemplate<double> MyCompleteIntTemplate;
+
+#endif // FORWARD_DECLARED_SPECIALIZATION_H

--- a/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
+++ b/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
@@ -1,19 +1,63 @@
 #ifndef FORWARD_DECLARED_SPECIALIZATION_H
 #define FORWARD_DECLARED_SPECIALIZATION_H
 
-template <typename T> 
-struct MyTemplate { 
-  T value; 
+// Basic template definition
+template <typename T>
+struct BasicTemplate {
+  T value;
 };
 
-template <> 
-struct MyTemplate<int>;
-typedef MyTemplate<int> MyIntTemplate;
+// Case 1: Forward-declared specialization (should NOT import)
+template <>
+struct BasicTemplate<int>;
+typedef BasicTemplate<int> ForwardDeclaredInt;
 
-template <> 
-struct MyTemplate<double> {
+// Case 2: Complete specialization (should import successfully)
+template <>
+struct BasicTemplate<double> {
+  double value;
+  double getValue() const { return value; }
+};
+typedef BasicTemplate<double> CompleteDouble;
+
+// Case 3: Specialization defined after typedef (should import)
+template <>
+struct BasicTemplate<float>;
+typedef BasicTemplate<float> FloatTypedef;
+
+template <>
+struct BasicTemplate<float> {
+  float value;
+};
+
+// Case 4: For comparison - forward-declared non-templated struct (have same behavior)
+struct ForwardDeclaredStruct;
+typedef ForwardDeclaredStruct ForwardDeclaredStructType;
+
+// Case 5: Complete non-templated struct (imports successfully)
+struct CompleteStruct {
+  int value;
+};
+typedef CompleteStruct CompleteStructType;
+
+// Template for partial specialization test
+template <typename T, typename U>
+struct PartialTemplate {
+  T first;
+  U second;
+};
+
+// Case 6: Forward-declared partial specialization (should NOT import - same as explicit)
+template <typename T>
+struct PartialTemplate<T*, int>;  // Forward declaration only
+typedef PartialTemplate<double*, int> ForwardDeclaredPartial;
+
+// Case 7: Complete partial specialization (should import successfully)
+template <typename T>
+struct PartialTemplate<T*, double> {
+  T* ptr;
   double value;
 };
-typedef MyTemplate<double> MyCompleteIntTemplate;
+typedef PartialTemplate<int*, double> CompletePartial;
 
-#endif // FORWARD_DECLARED_SPECIALIZATION_H
+#endif

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -182,3 +182,8 @@ module VariableTemplate {
   header "variable-template.h"
   requires cplusplus
 }
+
+module ForwardDeclaredSpecialization {
+  header "ForwardDeclaredSpecialization.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/forward-declared-specialization.swift
+++ b/test/Interop/Cxx/templates/forward-declared-specialization.swift
@@ -2,8 +2,31 @@
 
 import ForwardDeclaredSpecialization
 
-func testForwardDeclaredSpecialization(_ param: MyIntTemplate) { // expected-error {{cannot find type 'MyIntTemplate' in scope}}
+func testForwardDeclaredSpecialization(_ param: ForwardDeclaredInt) {
+  // expected-error@-1 {{cannot find type 'ForwardDeclaredInt' in scope}}
 }
 
-func testCompleteSpecialization(_ param: MyCompleteIntTemplate) {
+func testCompleteSpecialization(_ param: CompleteDouble) {
+  let _ = param.getValue()
+}
+
+func testSpecializationDefinedAfter(_ param: FloatTypedef) {
+  let _ = param.value
+}
+
+func testForwardDeclaredStruct(_ param: ForwardDeclaredStructType) {
+  // expected-error@-1 {{cannot find type 'ForwardDeclaredStructType' in scope}}
+}
+
+func testCompleteStruct(_ param: CompleteStructType) {
+  let _ = param.value
+}
+
+func testForwardDeclaredPartial(_ param: ForwardDeclaredPartial) {
+  // expected-error@-1 {{cannot find type 'ForwardDeclaredPartial' in scope}}
+}
+
+func testCompletePartial(_ param: CompletePartial) {
+  let _ = param.ptr
+  let _ = param.value
 }

--- a/test/Interop/Cxx/templates/forward-declared-specialization.swift
+++ b/test/Interop/Cxx/templates/forward-declared-specialization.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import ForwardDeclaredSpecialization
+
+func testForwardDeclaredSpecialization(_ param: MyIntTemplate) { // expected-error {{cannot find type 'MyIntTemplate' in scope}}
+}
+
+func testCompleteSpecialization(_ param: MyCompleteIntTemplate) {
+}


### PR DESCRIPTION
Swift crashes when importing C++ typedefs to forward-declared explicit template specializations. In assert build we see this assertion failure happening in clang:
`Assertion failed: (!T->isDependentType() && "should not see dependent types here"), function getTypeInfoImpl, file TypeNodes.inc, line 79.`

  Example that crashes:
  ```cpp
  template <typename T> struct MyTemplate { T value; };
  template <> struct MyTemplate<int>;  // Forward-declared specialization
  typedef MyTemplate<int> MyIntTemplate;
  ```

In this patch, I propose detecting forward-declared explicit specializations in typedef imports. Instead of crashing, these specializations should be blocked from being imported with a diagnostic similar to the forward declared (but not defined) structs.

rdar://147595723
