### PR TITLE
[Dependency Scanning] Configure a serialized diagnostics consumer for in-memory scans

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -15,20 +15,34 @@
 
 #include "swift-c/DependencyScan/DependencyScan.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/DependencyScan/ScanDependencies.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/StringSaver.h"
 
 namespace swift {
 namespace dependencies {
 class DependencyScanningTool;
-class DependencyScanDiagnosticCollector;
+class DepScanInMemoryDiagnosticCollector;
 
-struct ScanQueryInstance {
-  std::unique_ptr<CompilerInstance> ScanInstance;
-  std::shared_ptr<DependencyScanDiagnosticCollector> ScanDiagnostics;
+struct ScanQueryContext {
+  /// Primary CompilerInstance configured for this scanning action
+  llvm::ErrorOr<std::unique_ptr<CompilerInstance>> ScanInstance;
+  /// An thread-safe diagnostic consumer which collects all emitted
+  /// diagnostics in the scan to be reporte via libSwiftScan API
+  std::unique_ptr<DepScanInMemoryDiagnosticCollector> InMemoryDiagnosticCollector;
+  /// A thread-safe serialized diagnostics consumer.
+  /// Note, although type-erased, this must be an instance of
+  /// 'ThreadSafeSerializedDiagnosticConsumer'
+  std::unique_ptr<DiagnosticConsumer> SerializedDiagnosticConsumer;
+
+  ~ScanQueryContext() {
+    if (SerializedDiagnosticConsumer)
+      SerializedDiagnosticConsumer->finishProcessing();
+  }
 };
 
 /// Pure virtual Diagnostic consumer intended for collecting
@@ -47,12 +61,16 @@ public:
 };
 
 /// Diagnostic consumer that simply collects the diagnostics emitted so-far
-class DependencyScanDiagnosticCollector : public ThreadSafeDiagnosticCollector {
+/// and uses a representation agnostic from any specific CompilerInstance state
+/// which may have been used to emit the diagnostic
+class DepScanInMemoryDiagnosticCollector
+    : public ThreadSafeDiagnosticCollector {
 private:
   struct ScannerDiagnosticInfo {
     std::string Message;
     llvm::SourceMgr::DiagKind Severity;
-    std::optional<ScannerImportStatementInfo::ImportDiagnosticLocationInfo> ImportLocation;
+    std::optional<ScannerImportStatementInfo::ImportDiagnosticLocationInfo>
+        ImportLocation;
   };
   std::vector<ScannerDiagnosticInfo> Diagnostics;
 
@@ -61,7 +79,7 @@ protected:
 
 public:
   friend DependencyScanningTool;
-  DependencyScanDiagnosticCollector() {}
+  DepScanInMemoryDiagnosticCollector() {}
   void reset() { Diagnostics.clear(); }
   const std::vector<ScannerDiagnosticInfo> &getDiagnostics() const {
     return Diagnostics;
@@ -97,10 +115,9 @@ public:
 
   /// Using the specified invocation command, instantiate a CompilerInstance
   /// that will be used for this scan.
-  llvm::ErrorOr<ScanQueryInstance>
-  initCompilerInstanceForScan(ArrayRef<const char *> Command,
-                              StringRef WorkingDirectory,
-                              std::shared_ptr<DependencyScanDiagnosticCollector> scannerDiagnosticsCollector);
+  ScanQueryContext
+  createScanQueryContext(ArrayRef<const char *> Command,
+                         StringRef WorkingDirectory);
 
 private:
   /// Shared cache of module dependencies, re-used by individual full-scan queries
@@ -113,7 +130,7 @@ private:
   llvm::StringSaver Saver;
 };
 
-swiftscan_diagnostic_set_t *mapCollectedDiagnosticsForOutput(const DependencyScanDiagnosticCollector *diagnosticCollector);
+swiftscan_diagnostic_set_t *mapCollectedDiagnosticsForOutput(const DepScanInMemoryDiagnosticCollector *diagnosticCollector);
 
 } // end namespace dependencies
 } // end namespace swift

--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -43,7 +43,7 @@ using ModuleDependencyIDSet =
 class SwiftDependencyScanningService;
 
 namespace dependencies {
-class DependencyScanDiagnosticCollector;
+struct ScanQueryContext;
 
 using CompilerArgInstanceCacheMap =
     llvm::StringMap<std::tuple<std::unique_ptr<CompilerInstance>,
@@ -62,16 +62,15 @@ bool prescanDependencies(CompilerInstance &instance);
 /// Scans the dependencies of the main module of \c instance.
 llvm::ErrorOr<swiftscan_dependency_graph_t>
 performModuleScan(SwiftDependencyScanningService &service,
-                  CompilerInstance &instance,
                   ModuleDependenciesCache &cache,
-                  DependencyScanDiagnosticCollector *diagnostics = nullptr);
+                  ScanQueryContext &queryContext);
 
 /// Scans the main module of \c instance for all direct module imports
 llvm::ErrorOr<swiftscan_import_set_t>
 performModulePrescan(SwiftDependencyScanningService &service,
-                     CompilerInstance &instance,
                      ModuleDependenciesCache &cache,
-                     DependencyScanDiagnosticCollector *diagnostics = nullptr);
+                     ScanQueryContext &queryContext);
+
 
 namespace incremental {
 /// For the given module dependency graph captured in the 'cache',

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -37,6 +37,15 @@ namespace swift {
     /// \returns A new diagnostic consumer that serializes diagnostics.
     std::unique_ptr<DiagnosticConsumer>
     createConsumer(llvm::StringRef outputPath, bool emitMacroExpansionFiles);
+
+    /// Create a thread-safe DiagnosticConsumer that serializes diagnostics to a file,
+    /// using Clang's serialized diagnostics format.
+    ///
+    /// \param outputPath the file path to write the diagnostics to.
+    ///
+    /// \returns A new diagnostic consumer that serializes diagnostics.
+    std::unique_ptr<DiagnosticConsumer>
+    createThreadSafeConsumer(llvm::StringRef outputPath, bool emitMacroExpansionFiles);
   }
 }
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2107,6 +2107,13 @@ def emit_module_serialize_diagnostics_path:
            "<path>">,
   MetaVarName<"<path>">;
 
+def dependency_scan_serialize_diagnostics_path:
+  Separate<["-"], "dependency-scan-serialize-diagnostics-path">,
+  Flags<[ArgumentIsPath, SupplementaryOutput, NewDriverOnlyOption]>,
+  HelpText<"Emit a serialized diagnostics file for the dependency scanning task to "
+           "<path>">,
+  MetaVarName<"<path>">;
+
 def emit_module_dependencies_path:
   Separate<["-"], "emit-module-dependencies-path">,
   Flags<[ArgumentIsPath, SupplementaryOutput, NewDriverOnlyOption]>,

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -966,10 +966,10 @@ static swiftscan_dependency_graph_t generateFullDependencyGraph(
   swiftscan_dependency_graph_t result = new swiftscan_dependency_graph_s;
   result->main_module_name = create_clone(mainModuleName.c_str());
   result->dependencies = dependencySet;
-  result->diagnostics =
-      diagnosticCollector
-          ? mapCollectedDiagnosticsForOutput(diagnosticCollector)
-          : nullptr;
+  result->diagnostics = diagnosticCollector
+                            ? mapCollectedDiagnosticsForOutput(
+                                  diagnosticCollector->getDiagnostics())
+                            : nullptr;
   return result;
 }
 
@@ -1452,14 +1452,14 @@ static llvm::ErrorOr<swiftscan_import_set_t> performModulePrescanImpl(
                     return importInfo.importIdentifier;
                   });
   importSet->imports = create_set(importIdentifiers);
-  importSet->diagnostics =
-      diagnosticCollector
-          ? mapCollectedDiagnosticsForOutput(diagnosticCollector)
-          : nullptr;
-  importSet->diagnostics =
-      diagnosticCollector
-          ? mapCollectedDiagnosticsForOutput(diagnosticCollector)
-          : nullptr;
+  importSet->diagnostics = diagnosticCollector
+                               ? mapCollectedDiagnosticsForOutput(
+                                     diagnosticCollector->getDiagnostics())
+                               : nullptr;
+  importSet->diagnostics = diagnosticCollector
+                               ? mapCollectedDiagnosticsForOutput(
+                                     diagnosticCollector->getDiagnostics())
+                               : nullptr;
   return importSet;
 }
 } // namespace
@@ -1551,7 +1551,7 @@ llvm::ErrorOr<swiftscan_dependency_graph_t>
 swift::dependencies::performModuleScan(SwiftDependencyScanningService &service,
                                        ModuleDependenciesCache &cache,
                                        ScanQueryContext &queryContext) {
-  return performModuleScanImpl(service, queryContext.ScanInstance->get(), cache,
+  return performModuleScanImpl(service, queryContext.ScanInstance.get(), cache,
                                queryContext.InMemoryDiagnosticCollector.get());
 }
 
@@ -1559,7 +1559,7 @@ llvm::ErrorOr<swiftscan_import_set_t> swift::dependencies::performModulePrescan(
     SwiftDependencyScanningService &service, ModuleDependenciesCache &cache,
     ScanQueryContext &queryContext) {
   return performModulePrescanImpl(
-      service, queryContext.ScanInstance->get(), cache,
+      service, queryContext.ScanInstance.get(), cache,
       queryContext.InMemoryDiagnosticCollector.get());
 }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -44,6 +44,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/FrontendOptions.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
+#include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "swift/Strings.h"
 #include "clang/CAS/IncludeTree.h"
 #include "llvm/ADT/STLExtras.h"
@@ -737,7 +738,7 @@ static swiftscan_macro_dependency_set_t *createMacroDependencySet(
 
 static swiftscan_dependency_graph_t generateFullDependencyGraph(
     const CompilerInstance &instance,
-    const DependencyScanDiagnosticCollector *diagnosticCollector,
+    const DepScanInMemoryDiagnosticCollector *diagnosticCollector,
     const ModuleDependenciesCache &cache,
     const ArrayRef<ModuleDependencyID> allModules) {
   if (allModules.empty()) {
@@ -1246,90 +1247,6 @@ static bool diagnoseCycle(const CompilerInstance &instance,
   closeSet.clear();
   return false;
 }
-} // namespace
-
-bool swift::dependencies::scanDependencies(CompilerInstance &CI) {
-  ASTContext &ctx = CI.getASTContext();
-  std::string depGraphOutputPath =
-      CI.getInvocation()
-          .getFrontendOptions()
-          .InputsAndOutputs.getSingleOutputFilename();
-  // `-scan-dependencies` invocations use a single new instance
-  // of a module cache
-  SwiftDependencyScanningService *service =
-      ctx.Allocate<SwiftDependencyScanningService>();
-  ModuleDependenciesCache cache(CI.getMainModule()->getNameStr().str(),
-                                CI.getInvocation().getModuleScanningHash());
-
-  if (service->setupCachingDependencyScanningService(CI))
-    return true;
-
-  // Execute scan
-  llvm::ErrorOr<swiftscan_dependency_graph_t> dependenciesOrErr =
-      performModuleScan(*service, CI, cache);
-
-  if (dependenciesOrErr.getError())
-    return true;
-  auto dependencies = std::move(*dependenciesOrErr);
-
-  if (writeJSONToOutput(ctx.Diags, CI.getOutputBackend(), depGraphOutputPath,
-                        dependencies))
-    return true;
-
-  // This process succeeds regardless of whether any errors occurred.
-  // FIXME: We shouldn't need this, but it's masking bugs in our scanning
-  // logic where we don't create a fresh context when scanning Swift interfaces
-  // that includes their own command-line flags.
-  ctx.Diags.resetHadAnyError();
-  return false;
-}
-
-bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
-  ASTContext &Context = instance.getASTContext();
-  const FrontendOptions &opts = instance.getInvocation().getFrontendOptions();
-  std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
-  // `-scan-dependencies` invocations use a single new instance
-  // of a module cache
-  SwiftDependencyScanningService *singleUseService =
-      Context.Allocate<SwiftDependencyScanningService>();
-  ModuleDependenciesCache cache(
-      instance.getMainModule()->getNameStr().str(),
-      instance.getInvocation().getModuleScanningHash());
-
-  // Execute import prescan, and write JSON output to the output stream
-  auto importSetOrErr =
-      performModulePrescan(*singleUseService, instance, cache);
-  if (importSetOrErr.getError())
-    return true;
-  auto importSet = std::move(*importSetOrErr);
-
-  // Serialize and output main module dependencies only and exit.
-  if (writePrescanJSONToOutput(Context.Diags, instance.getOutputBackend(), path,
-                               importSet))
-    return true;
-
-  // This process succeeds regardless of whether any errors occurred.
-  // FIXME: We shouldn't need this, but it's masking bugs in our scanning
-  // logic where we don't create a fresh context when scanning Swift interfaces
-  // that includes their own command-line flags.
-  Context.Diags.resetHadAnyError();
-  return false;
-}
-
-std::string
-swift::dependencies::createEncodedModuleKindAndName(ModuleDependencyID id) {
-  switch (id.Kind) {
-  case ModuleDependencyKind::SwiftInterface:
-  case ModuleDependencyKind::SwiftSource:
-    return "swiftTextual:" + id.ModuleName;
-  case ModuleDependencyKind::SwiftBinary:
-    return "swiftBinary:" + id.ModuleName;
-  case ModuleDependencyKind::Clang:
-    return "clang:" + id.ModuleName;
-  default:
-    llvm_unreachable("Unhandled dependency kind.");
-  }
-}
 
 static bool resolveDependencyCommandLineArguments(
     ModuleDependencyScanner &scanner, CompilerInstance &instance,
@@ -1429,13 +1346,13 @@ static void resolveImplicitLinkLibraries(const CompilerInstance &instance,
   cache.updateDependency(mainModuleID, mainModuleDepInfo);
 }
 
-llvm::ErrorOr<swiftscan_dependency_graph_t>
-swift::dependencies::performModuleScan(
-    SwiftDependencyScanningService &service, CompilerInstance &instance,
+static llvm::ErrorOr<swiftscan_dependency_graph_t>
+performModuleScanImpl(
+    SwiftDependencyScanningService &service, CompilerInstance *instance,
     ModuleDependenciesCache &cache,
-    DependencyScanDiagnosticCollector *diagnosticCollector) {
-  const ASTContext &ctx = instance.getASTContext();
-  const FrontendOptions &opts = instance.getInvocation().getFrontendOptions();
+    DepScanInMemoryDiagnosticCollector *diagnosticCollector) {
+  const ASTContext &ctx = instance->getASTContext();
+  const FrontendOptions &opts = instance->getInvocation().getFrontendOptions();
   // Load the dependency cache if -reuse-dependency-scan-cache
   // is specified
   if (opts.ReuseDependencyScannerCache) {
@@ -1453,43 +1370,43 @@ swift::dependencies::performModuleScan(
 
     if (!loadFailure && opts.ValidatePriorDependencyScannerCache) {
       auto mainModuleID =
-          ModuleDependencyID{instance.getMainModule()->getNameStr().str(),
+          ModuleDependencyID{instance->getMainModule()->getNameStr().str(),
                              ModuleDependencyKind::SwiftSource};
       incremental::validateInterModuleDependenciesCache(
-          mainModuleID, cache, instance.getSharedCASInstance(),
-          serializedCacheTimeStamp, *instance.getSourceMgr().getFileSystem(),
+          mainModuleID, cache, instance->getSharedCASInstance(),
+          serializedCacheTimeStamp, *instance->getSourceMgr().getFileSystem(),
           ctx.Diags, opts.EmitDependencyScannerCacheRemarks);
     }
   }
 
   auto scanner = ModuleDependencyScanner(
-      service, instance.getInvocation(), instance.getSILOptions(),
-      instance.getASTContext(), *instance.getDependencyTracker(),
-      instance.getSharedCASInstance(), instance.getSharedCacheInstance(),
-      instance.getDiags(),
-      instance.getInvocation().getFrontendOptions().ParallelDependencyScan);
+      service, instance->getInvocation(), instance->getSILOptions(),
+      instance->getASTContext(), *instance->getDependencyTracker(),
+      instance->getSharedCASInstance(), instance->getSharedCacheInstance(),
+      instance->getDiags(),
+      instance->getInvocation().getFrontendOptions().ParallelDependencyScan);
 
   // Identify imports of the main module and add an entry for it
   // to the dependency graph.
-  auto mainModuleName = instance.getMainModule()->getNameStr();
+  auto mainModuleName = instance->getMainModule()->getNameStr();
   auto mainModuleID = ModuleDependencyID{mainModuleName.str(),
                                          ModuleDependencyKind::SwiftSource};
   if (!cache.hasDependency(mainModuleID))
     cache.recordDependency(mainModuleName, *scanner.getMainModuleDependencyInfo(
-                                               instance.getMainModule()));
+                                               instance->getMainModule()));
 
   // Perform the full module scan starting at the main module.
   auto allModules = scanner.performDependencyScan(mainModuleID, cache);
-  if (diagnoseCycle(instance, cache, mainModuleID))
+  if (diagnoseCycle(*instance, cache, mainModuleID))
     return std::make_error_code(std::errc::not_supported);
 
   auto topologicallySortedModuleList =
       computeTopologicalSortOfExplicitDependencies(allModules, cache);
 
-  resolveDependencyCommandLineArguments(scanner, instance, cache,
+  resolveDependencyCommandLineArguments(scanner, *instance, cache,
                                         topologicallySortedModuleList);
-  resolveImplicitLinkLibraries(instance, cache);
-  updateDependencyTracker(instance, cache, allModules);
+  resolveImplicitLinkLibraries(*instance, cache);
+  updateDependencyTracker(*instance, cache, allModules);
 
   if (ctx.Stats)
     ctx.Stats->getFrontendCounters().NumDepScanFilesystemLookups =
@@ -1500,29 +1417,29 @@ swift::dependencies::performModuleScan(
   if (opts.SerializeDependencyScannerCache) {
     auto savePath = opts.SerializedDependencyScannerCachePath;
     module_dependency_cache_serialization::writeInterModuleDependenciesCache(
-        ctx.Diags, instance.getOutputBackend(), savePath, cache);
+        ctx.Diags, instance->getOutputBackend(), savePath, cache);
     if (opts.EmitDependencyScannerCacheRemarks)
       ctx.Diags.diagnose(SourceLoc(), diag::remark_save_cache, savePath);
   }
 
-  return generateFullDependencyGraph(instance, diagnosticCollector, cache,
-                                     topologicallySortedModuleList);
+  return generateFullDependencyGraph(*instance, diagnosticCollector,
+                                     cache, topologicallySortedModuleList);
 }
 
-llvm::ErrorOr<swiftscan_import_set_t> swift::dependencies::performModulePrescan(
-    SwiftDependencyScanningService &service, CompilerInstance &instance,
+static llvm::ErrorOr<swiftscan_import_set_t> performModulePrescanImpl(
+    SwiftDependencyScanningService &service, CompilerInstance *instance,
     ModuleDependenciesCache &cache,
-    DependencyScanDiagnosticCollector *diagnosticCollector) {
+    DepScanInMemoryDiagnosticCollector *diagnosticCollector) {
   // Setup the scanner
   auto scanner = ModuleDependencyScanner(
-      service, instance.getInvocation(), instance.getSILOptions(),
-      instance.getASTContext(), *instance.getDependencyTracker(),
-      instance.getSharedCASInstance(), instance.getSharedCacheInstance(),
-      instance.getDiags(),
-      instance.getInvocation().getFrontendOptions().ParallelDependencyScan);
+      service, instance->getInvocation(), instance->getSILOptions(),
+      instance->getASTContext(), *instance->getDependencyTracker(),
+      instance->getSharedCASInstance(), instance->getSharedCacheInstance(),
+      instance->getDiags(),
+      instance->getInvocation().getFrontendOptions().ParallelDependencyScan);
   // Execute import prescan, and write JSON output to the output stream
   auto mainDependencies =
-      scanner.getMainModuleDependencyInfo(instance.getMainModule());
+      scanner.getMainModuleDependencyInfo(instance->getMainModule());
   if (!mainDependencies)
     return mainDependencies.getError();
   auto *importSet = new swiftscan_import_set_s;
@@ -1544,6 +1461,106 @@ llvm::ErrorOr<swiftscan_import_set_t> swift::dependencies::performModulePrescan(
           ? mapCollectedDiagnosticsForOutput(diagnosticCollector)
           : nullptr;
   return importSet;
+}
+} // namespace
+
+bool swift::dependencies::scanDependencies(CompilerInstance &CI) {
+  ASTContext &ctx = CI.getASTContext();
+  std::string depGraphOutputPath =
+      CI.getInvocation()
+          .getFrontendOptions()
+          .InputsAndOutputs.getSingleOutputFilename();
+  // `-scan-dependencies` invocations use a single new instance
+  // of a module cache
+  SwiftDependencyScanningService *service =
+      ctx.Allocate<SwiftDependencyScanningService>();
+  ModuleDependenciesCache cache(CI.getMainModule()->getNameStr().str(),
+                                CI.getInvocation().getModuleScanningHash());
+
+  if (service->setupCachingDependencyScanningService(CI))
+    return true;
+
+  // Execute scan
+  llvm::ErrorOr<swiftscan_dependency_graph_t> dependenciesOrErr =
+      performModuleScanImpl(*service, &CI, cache, nullptr);
+
+  if (dependenciesOrErr.getError())
+    return true;
+  auto dependencies = std::move(*dependenciesOrErr);
+
+  if (writeJSONToOutput(ctx.Diags, CI.getOutputBackend(), depGraphOutputPath,
+                        dependencies))
+    return true;
+
+  // This process succeeds regardless of whether any errors occurred.
+  // FIXME: We shouldn't need this, but it's masking bugs in our scanning
+  // logic where we don't create a fresh context when scanning Swift interfaces
+  // that includes their own command-line flags.
+  ctx.Diags.resetHadAnyError();
+  return false;
+}
+
+bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
+  ASTContext &Context = instance.getASTContext();
+  const FrontendOptions &opts = instance.getInvocation().getFrontendOptions();
+  std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
+  // `-scan-dependencies` invocations use a single new instance
+  // of a module cache
+  SwiftDependencyScanningService *singleUseService =
+      Context.Allocate<SwiftDependencyScanningService>();
+  ModuleDependenciesCache cache(
+      instance.getMainModule()->getNameStr().str(),
+      instance.getInvocation().getModuleScanningHash());
+
+  // Execute import prescan, and write JSON output to the output stream
+  auto importSetOrErr =
+      performModulePrescanImpl(*singleUseService, &instance, cache, nullptr);
+  if (importSetOrErr.getError())
+    return true;
+  auto importSet = std::move(*importSetOrErr);
+
+  // Serialize and output main module dependencies only and exit.
+  if (writePrescanJSONToOutput(Context.Diags, instance.getOutputBackend(), path,
+                               importSet))
+    return true;
+
+  // This process succeeds regardless of whether any errors occurred.
+  // FIXME: We shouldn't need this, but it's masking bugs in our scanning
+  // logic where we don't create a fresh context when scanning Swift interfaces
+  // that includes their own command-line flags.
+  Context.Diags.resetHadAnyError();
+  return false;
+}
+
+std::string
+swift::dependencies::createEncodedModuleKindAndName(ModuleDependencyID id) {
+  switch (id.Kind) {
+  case ModuleDependencyKind::SwiftInterface:
+  case ModuleDependencyKind::SwiftSource:
+    return "swiftTextual:" + id.ModuleName;
+  case ModuleDependencyKind::SwiftBinary:
+    return "swiftBinary:" + id.ModuleName;
+  case ModuleDependencyKind::Clang:
+    return "clang:" + id.ModuleName;
+  default:
+    llvm_unreachable("Unhandled dependency kind.");
+  }
+}
+
+llvm::ErrorOr<swiftscan_dependency_graph_t>
+swift::dependencies::performModuleScan(SwiftDependencyScanningService &service,
+                                       ModuleDependenciesCache &cache,
+                                       ScanQueryContext &queryContext) {
+  return performModuleScanImpl(service, queryContext.ScanInstance->get(), cache,
+                               queryContext.InMemoryDiagnosticCollector.get());
+}
+
+llvm::ErrorOr<swiftscan_import_set_t> swift::dependencies::performModulePrescan(
+    SwiftDependencyScanningService &service, ModuleDependenciesCache &cache,
+    ScanQueryContext &queryContext) {
+  return performModulePrescanImpl(
+      service, queryContext.ScanInstance->get(), cache,
+      queryContext.InMemoryDiagnosticCollector.get());
 }
 
 void swift::dependencies::incremental::validateInterModuleDependenciesCache(

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -14,6 +14,8 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Platform.h"
 #include "swift/DependencyScan/DependencyScanImpl.h"
+#include "clang/Frontend/SerializedDiagnosticReader.h"
+#include "clang/Frontend/SerializedDiagnostics.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
@@ -244,12 +246,118 @@ public func overlayFuncA() { }\n"));
     CommandB.push_back(command.c_str());
   }
 
-  auto ScanDiagnosticConsumer = std::make_shared<DependencyScanDiagnosticCollector>();
-  auto instanceA = ScannerTool.initCompilerInstanceForScan(CommandA, {}, ScanDiagnosticConsumer);
-  auto instanceB = ScannerTool.initCompilerInstanceForScan(CommandB, {}, ScanDiagnosticConsumer);
+  auto queryAContext = ScannerTool.createScanQueryContext(CommandA, {});
+  auto queryBContext = ScannerTool.createScanQueryContext(CommandB, {});
   // Ensure that scans that only differ in module name have distinct scanning context hashes
-  ASSERT_NE(instanceA->ScanInstance.get()->getInvocation().getModuleScanningHash(),
-            instanceB->ScanInstance.get()->getInvocation().getModuleScanningHash());
+  ASSERT_NE(queryAContext.ScanInstance.get()->getInvocation().getModuleScanningHash(),
+            queryBContext.ScanInstance.get()->getInvocation().getModuleScanningHash());
+}
+
+namespace {
+class DiagnosticChecker : public clang::serialized_diags::SerializedDiagnosticReader {
+public:
+  std::vector<std::string> errorMessages;
+  std::vector<std::string> warningMessages;
+
+protected:
+  std::error_code visitDiagnosticRecord(
+      unsigned Severity, const clang::serialized_diags::Location &Location,
+      unsigned Category, unsigned Flag, StringRef Message) override {
+      switch (static_cast<clang::serialized_diags::Level>(Severity)) {
+        case clang::serialized_diags::Warning:
+          warningMessages.push_back(Message.str());
+          break;
+        case clang::serialized_diags::Error:
+          errorMessages.push_back(Message.str());
+          break;
+        default:
+          break;
+      }
+      return std::error_code();
+  }
+};
+}
+
+
+TEST_F(ScanTest, TestSerializedDiagnosticOutput) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestSerializedDiagnosticOutput", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
+  // Create test input file
+  std::string TestPathStr = createFilename(tempDir, "foo.swift");
+  ASSERT_FALSE(emitFileWithContents(tempDir, "foo.swift", "import A\n\
+#warning(\"This is a warning\")\n"));
+
+  // Create include directory
+  std::string SwiftDirPath = createFilename(tempDir, "Swift");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(SwiftDirPath));
+
+  // Create output directory
+  std::string OutputDirPath = createFilename(tempDir, "Output");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(OutputDirPath));
+  std::string SerializedDiagnosticsOutputPath =
+      createFilename(OutputDirPath, "scan-diags.dia");
+
+  // Create imported module Swift interface files
+  ASSERT_FALSE(emitFileWithContents(SwiftDirPath, "A.swiftinterface",
+                                    "// swift-interface-format-version: 1.0\n\
+// swift-module-flags: -module-name A\n\
+import Swift\n\
+#error(\"This is an error\")\n\
+public func funcA() { }\n"));
+
+  // Paths to shims and stdlib
+  llvm::SmallString<128> ShimsLibDir = StdLibDir;
+  llvm::sys::path::append(ShimsLibDir, "shims");
+  auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
+
+  // Generate command line
+  std::vector<std::string> CommandStr = {
+      TestPathStr,
+      std::string("-I ") + SwiftDirPath,
+      std::string("-I ") + StdLibDir.str().str(),
+      std::string("-I ") + ShimsLibDir.str().str(),
+      "-serialize-diagnostics-path",
+      SerializedDiagnosticsOutputPath,
+      "-module-name",
+      "testSerializedDiagnosticOutput"};
+  // On Windows we need to add an extra escape for path separator characters
+  // because otherwise the command line tokenizer will treat them as escape
+  // characters.
+  for (size_t i = 0; i < CommandStr.size(); ++i) {
+    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
+  }
+  std::vector<const char *> Command;
+  for (auto &command : CommandStr)
+    Command.push_back(command.c_str());
+
+  {
+    auto ScanningService = std::make_unique<SwiftDependencyScanningService>();
+    auto QueryContext = ScannerTool.createScanQueryContext(Command, {});
+    ASSERT_FALSE(QueryContext.ScanInstance.getError());
+
+    ModuleDependenciesCache ScanCache(
+        QueryContext.ScanInstance.get()->getMainModule()->getNameStr().str(),
+        QueryContext.ScanInstance.get()
+            ->getInvocation()
+            .getModuleScanningHash());
+    auto DependenciesOrErr =
+        performModuleScan(*ScanningService, ScanCache, QueryContext);
+
+    ASSERT_FALSE(DependenciesOrErr.getError());
+  }
+  ASSERT_TRUE(llvm::sys::fs::exists(SerializedDiagnosticsOutputPath));
+
+  auto DiagnosticsReader = DiagnosticChecker();
+  auto ReadError = DiagnosticsReader.readDiagnostics(SerializedDiagnosticsOutputPath);
+  ASSERT_FALSE(ReadError);
+  ASSERT_TRUE(DiagnosticsReader.errorMessages.size() == 1);
+  ASSERT_TRUE(DiagnosticsReader.warningMessages.size() == 1);
+  ASSERT_TRUE(DiagnosticsReader.errorMessages.front() == "This is an error");
+  ASSERT_TRUE(DiagnosticsReader.warningMessages.front() == "This is a warning");
 }
 
 TEST_F(ScanTest, TestModuleCycle) {


### PR DESCRIPTION
This change introduces a thread-safe version of the `SerializedDiagnosticConsumer` and refactors scanning compilation instance creation code to ensure this consumer gets added when the scanner query configuration command-line includes '-serialized-diagnostics-path' option. 

This change ties creation of diagnostic consumers used with in-memory scanning to the same place where the scanner instance gets created, and ties their lifetime to the Scanner Query Context, generated in `initCompilerInstanceForScan`. 

This change also adds a new-driver-only flag `-dependency-scan-serialize-diagnostics-path` to allow the driver to configure scanner-only serialized diagnostic output. 