### PR TITLE
[test] Adjust `api-digester/dump-module.swift` for rebranch

### DIFF
--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -2156,13 +2156,6 @@
           },
           {
             "kind": "Conformance",
-            "name": "P1",
-            "printedName": "P1",
-            "usr": "s:4cake2P1P",
-            "mangledName": "$s4cake2P1P"
-          },
-          {
-            "kind": "Conformance",
             "name": "Encodable",
             "printedName": "Encodable",
             "usr": "s:SE",
@@ -2351,6 +2344,13 @@
             "printedName": "BitwiseCopyable",
             "usr": "s:s15BitwiseCopyableP",
             "mangledName": "$ss15BitwiseCopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "P1",
+            "printedName": "P1",
+            "usr": "s:4cake2P1P",
+            "mangledName": "$s4cake2P1P"
           }
         ]
       }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -2050,13 +2050,6 @@
           },
           {
             "kind": "Conformance",
-            "name": "P1",
-            "printedName": "P1",
-            "usr": "s:4cake2P1P",
-            "mangledName": "$s4cake2P1P"
-          },
-          {
-            "kind": "Conformance",
             "name": "Encodable",
             "printedName": "Encodable",
             "usr": "s:SE",
@@ -2238,6 +2231,13 @@
             "printedName": "BitwiseCopyable",
             "usr": "s:s15BitwiseCopyableP",
             "mangledName": "$ss15BitwiseCopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "P1",
+            "printedName": "P1",
+            "usr": "s:4cake2P1P",
+            "mangledName": "$s4cake2P1P"
           }
         ]
       }


### PR DESCRIPTION
The API digester queries the top-level declarations for the Swift module `cake`. The first file in that module is a `ClangModuleUnit`, so we proceed to import that file into Swift. The clang importer fetches the lookup table, then looks up and imports everything in it.

rebranch:
1. The lookup table ends up containing `__Int64x2_t`, a new "neon vector type". These are not built-in types, but neither are they declared anywhere. You express them using an attribute combined with an integral type, e.g. `__attribute__((neon_vector_type(8))) int8_t`. For whatever reason, these types are for AArch64 only, which explains why we don't see the test failure on x86 runners.
2. The neon vector type is imported via `SwiftTypeConverter::VisitVectorType`, where we use `NominalTypeDecl::lookupConformance` to verify that the vector type's element type (imported as `Int` in this case) conforms to `SIMDScalar`.
3. Conformance lookup triggers extension loading. Because we haven't added any extensions to `Int` yet, and the standard library happens to come before `cake` in the list of module loaders, extensions from `cake` are added last.

main:
1. No neon vector types, so we happen not to look up `Int`'s conformances during importation of `cake.h`.
2. The next file is `cake.swift`. In the process of deserializing the AST for that file, we encounter `Int` extensions and add them to the nominal.

Eventually, while processing the collected top-level declarations, the API digester calls `getAllConformances` on `Int`, and we see a difference in the index of `P1` between main and rebranch because conformances from extensions are added to the table in the order those extensions were added to the nominal.