### PR TITLE
[Immediate] remove dead linkLLVMModules declaration (post-REPL removal)

### DIFF
--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -3,7 +3,6 @@ add_swift_host_library(swiftImmediate STATIC
   Immediate.cpp
   LLVM_LINK_COMPONENTS
     executionengine
-    linker
     mcjit
     orcjit
     orctargetprocess

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -43,8 +43,6 @@ void *loadSwiftRuntime(ArrayRef<std::string> runtimeLibPaths);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);
-bool linkLLVMModules(llvm::Module *Module,
-                     std::unique_ptr<llvm::Module> &&SubModule);
 bool autolinkImportedModules(ModuleDecl *M, const IRGenOptions &IRGenOpts);
 
 } // end namespace immediate

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -20,11 +20,6 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
-namespace llvm {
-  class Function;
-  class Module;
-}
-
 namespace swift {
   class CompilerInstance;
   class DiagnosticEngine;


### PR DESCRIPTION
Hi,

As I am educating myself with swift and swift Immediate, I came across some left over work after 

1) https://github.com/swiftlang/swift/commit/03b19f3f7e4acbae46fe6821c85f27a6afe51597#diff-73992018bbea619aae8603e5987b40a1ff06a3cb2f0a4f3bb1cca8ce134e1fa8

2) https://github.com/swiftlang/swift/pull/31187/files#diff-635e50e7c59a5dd7f130c96baa9d1ce900a6aa73a51546937f1ea812b6dfa8f2L45

I see that `linkLLVMModules` was used only by the integrated REPL. That REPL was removed; the function has no definition or callers. Also we aren't using `llvm::Linker::linkModules` (previously used through `linkLLVMModules`) I am guessing we can drop linker too from the link components ?

cc @slavapestov @CodaFi 