### PR TITLE
🍒 [demangling] make printRoot virtual

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -871,7 +871,7 @@ public:
 
   virtual ~NodePrinter() = default;
 
-  void printRoot(NodePointer root) {
+  virtual void printRoot(NodePointer root) {
     isValid = true;
     print(root, 0);
   }


### PR DESCRIPTION
- **Explanation**:
This patch makes the `NodePrinter::printRoot` method virtual in order to allow for an NFC patch to be merged in `swiftlang/llvm-project` (https://github.com/swiftlang/llvm-project/pull/11352).

- **Scope**:
This change impacts the Swift demangler.
- **Issues**:

- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/84169
- **Risk**:
Low,  this patch only makes a method `virtual`, it's pretty much NFC.
- **Testing**:
Built and tested at desk on macOS.
- **Reviewers**:
  - @adrian-prantl 