### PR TITLE
[cxx-interop] Restrict the uses of anonymous types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4546,6 +4546,10 @@ namespace {
         // FIXME: Temporarily unreachable because of check above.
         markAsVariant(result, *correctSwiftName);
 
+      if (decl->isAnonymousStructOrUnion())
+        Impl.markUnavailable(
+            result, "refer to the members of the anonymous type instead");
+
       return result;
     }
 

--- a/test/Interop/Cxx/class/Inputs/simple-structs.h
+++ b/test/Interop/Cxx/class/Inputs/simple-structs.h
@@ -17,6 +17,15 @@ struct HasPublicFieldsOnly {
   HasPublicFieldsOnly(int i1, int i2) : publ1(i1), publ2(i2) {}
 };
 
+struct HasAnonymousType {
+  HasAnonymousType(int a, int b, int c) : a(a), b(b), c(c) {}
+
+  struct {
+    int a, b;
+  };
+  int c;
+};
+
 struct HasPrivatePublicProtectedFields {
 private:
   int priv1;

--- a/test/Interop/Cxx/class/access-anonymous-field.swift
+++ b/test/Interop/Cxx/class/access-anonymous-field.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -swift-version 6 -cxx-interoperability-mode=upcoming-swift
+
+// CHECK: Foobar
+
+import SimpleStructs
+
+let s = HasAnonymousType(1, 2, 3)
+let _ = s.__Anonymous_field0 // expected-error {{'__Anonymous_field0' is unavailable: refer to the members of the anonymous type instead}}
+// Referring to the members of the anonymous type directly.
+let _ = s.a
+let _ = s.b
+let _ = s.c

--- a/test/Interop/Cxx/class/print-simple-structs.swift
+++ b/test/Interop/Cxx/class/print-simple-structs.swift
@@ -24,6 +24,11 @@ func printCxxStructNested() {
     print(s)
 }
 
+func printCxxStructWithAnonType() {
+    let s = HasAnonymousType(1, 2, 3)
+    print(s)
+}
+
 printCxxStructPrivateFields() 
 // CHECK: HasPrivateFieldsOnly()
 
@@ -35,3 +40,6 @@ printCxxStructPrivatePublicProtectedFields()
 
 printCxxStructNested()
 // CHECK: Outer(publStruct: {{.*}}.HasPrivatePublicProtectedFields(publ1: 8, publ2: 12))
+
+printCxxStructWithAnonType()
+// CHECK: HasAnonymousType(c: 3)


### PR DESCRIPTION
Make sure they are excluded from the reflection metadata (although in the future we want to make sure indirect fields are included). Make sure the users cannot refer to the anonymous field, only its members.
