### PR TITLE
[6.2] CMake: make the libswiftCompatibilitySpan symlink relative symlink

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -466,15 +466,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   foreach(sdk ${SWIFT_SDKS})
     set(lib_dir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
     set(lib_path "${SWIFTLIB_DIR}/${lib_dir}")
-    set(compat_lib_name "${lib_path}/libswiftCompatibilitySpan.dylib")
 
     # This doesn't depend on libswiftCore.dylib because we don't actually need
     # for it to exist to create the symlink, nor is there any need to recreate
     # the symlink if the dylib changes.
     add_custom_command_target(unused_var
                               CUSTOM_TARGET_NAME "swiftCompatibilitySpan-symlink-${lib_dir}"
-                              OUTPUT "${compat_lib_name}"
-                              COMMAND ${CMAKE_COMMAND} "-E" "create_symlink" "${lib_path}/libswiftCore.dylib" "${compat_lib_name}")
+                              OUTPUT "${lib_path}/libswiftCompatibilitySpan.dylib"
+                              COMMAND ${CMAKE_COMMAND} "-E" "create_symlink" "libswiftCore.dylib" "libswiftCompatibilitySpan.dylib"
+                              WORKING_DIRECTORY ${lib_path})
     foreach(ARCH ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       add_dependencies("swiftCore-${lib_dir}-${ARCH}" "swiftCompatibilitySpan-symlink-${lib_dir}")
     endforeach()


### PR DESCRIPTION
- **Explanation**: create the symlink from libswiftCompatibilitySpan.dylib to libswiftCore.dylib in the Swift build folder as a relative one instead of an absolute one, to support device testing.
- **Scope**: CMake code that creates the symlink for libswiftCompatibilitySpan.dylib during builds
- **Issues**: rdar://159314722
- **Original PRs**:  #84200
- **Risk**: Low, scope is limited to configurations that run tests on a machine different form the builder, regular CI tests are not affected (since symlinks are valid on the builder itself), and packaging regenerates the symlink with a different mechanism.
- **Testing**: ensured at desk that `stdlib/Span` test can run on a different machine (i.e. using `remote-run`)
- **Reviewers**: waiting for reviews in the main PR