### PR TITLE
[cxx-interop] Handle Unowned values in implicit value ctors

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdio.h>
+#include <swift/bridging>
+
+class SharedFRT {
+public:
+  SharedFRT() : _refCount(1) { logMsg("Ctor"); }
+
+private:
+  void logMsg(const char *s) const {
+    printf("RefCount: %d, message: %s\n", _refCount, s);
+  }
+
+  ~SharedFRT() { logMsg("Dtor"); }
+  SharedFRT(const SharedFRT &) = delete;
+  SharedFRT &operator=(const SharedFRT &) = delete;
+  SharedFRT(SharedFRT &&) = delete;
+  SharedFRT &operator=(SharedFRT &&) = delete;
+
+  int _refCount;
+
+  friend void retainSharedFRT(SharedFRT *_Nonnull);
+  friend void releaseSharedFRT(SharedFRT *_Nonnull);
+} SWIFT_SHARED_REFERENCE(retainSharedFRT, releaseSharedFRT);
+
+class MyToken {
+public:
+  MyToken() = default;
+  MyToken(MyToken const &) {}
+};
+
+inline void retainSharedFRT(SharedFRT *_Nonnull x) {
+  ++x->_refCount;
+  x->logMsg("retain");
+}
+
+inline void releaseSharedFRT(SharedFRT *_Nonnull x) {
+  --x->_refCount;
+  x->logMsg("release");
+  if (x->_refCount == 0)
+    delete x;
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -77,3 +77,8 @@ module VirtMethodWithRvalRef {
   header "virtual-methods-with-rvalue-reference.h"
   requires cplusplus
 }
+
+module LoggingFrts {
+    header "logging-frts.h"
+    requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
+++ b/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import LoggingFrts
+
+struct SwiftStruct {
+    var frt: SharedFRT
+    var token: MyToken
+}
+
+func go() {
+    let frt = SharedFRT()
+    let token = MyToken()
+    let _ = SwiftStruct(frt: frt, token: token)
+    let _ = SwiftStruct(frt: frt, token: token)
+    let _ = SwiftStruct(frt: frt, token: token)
+}
+
+go()
+
+// CHECK:      RefCount: 1, message: Ctor
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 0, message: release
+// CHECK-NEXT: RefCount: 0, message: Dtor


### PR DESCRIPTION
We usually have unowned values when dealing with foreign types. Make sure the implicit value ctors will do a +1 to balance the releases. In a release build we had a use after free over-releasing the object. In assert builds we had an assertion failure:

Assertion failed: (value->getOwnershipKind() == OwnershipKind::Guaranteed), function forBorrowedObjectRValue, file ManagedValue.h, line 181.

rdar://160232360