### PR TITLE
RequirementMachine: Fix crash-on-invalid with concrete type requirements involving packs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3421,6 +3421,9 @@ ERROR(invalid_shape_requirement,none,
 ERROR(unsupported_same_element,none,
       "same-element requirements are not yet supported",
       ())
+ERROR(unsupported_pack_same_type,none,
+      "same-type requirements between packs and concrete types are not yet supported",
+      ())
 
 ERROR(requires_generic_params_made_equal,none,
       "same-type requirement makes generic parameters %0 and %1 equivalent",

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -226,6 +226,15 @@ bool swift::rewriting::diagnoseRequirementErrors(
       break;
     }
 
+    case RequirementError::Kind::UnsupportedPackSameType: {
+      if (error.getRequirement().hasError())
+        break;
+
+      ctx.Diags.diagnose(loc, diag::unsupported_pack_same_type);
+      diagnosedError = true;
+      break;
+    }
+
     case RequirementError::Kind::InvalidValueGenericType: {
       auto req = error.getRequirement();
 

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -53,6 +53,9 @@ struct RequirementError {
     RecursiveRequirement,
     /// A not-yet-supported same-element requirement, e.g. each T == Int.
     UnsupportedSameElement,
+    /// A not-yet-supported same-type requirement involving packs and concrete
+    /// types, e.g. (repeat each T) == (Int, repeat each U).
+    UnsupportedPackSameType,
     /// An unexpected value type used in a value generic,
     /// e.g. 'let N: String'.
     InvalidValueGenericType,
@@ -160,6 +163,10 @@ public:
 
   static RequirementError forSameElement(Requirement req, SourceLoc loc) {
     return {Kind::UnsupportedSameElement, req, loc};
+  }
+
+  static RequirementError forPackSameType(Requirement req, SourceLoc loc) {
+    return {Kind::UnsupportedPackSameType, req, loc};
   }
 
   static RequirementError forInvalidValueGenericType(Type subjectType,

--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -44,7 +44,7 @@ struct S {
 }
 
 struct ExpansionRequirementTest<each T> {}
-extension ExpansionRequirementTest where repeat each T == Int {} // expected-error {{same-element requirements are not yet supported}}
+extension ExpansionRequirementTest where repeat each T == Int {} // expected-error {{same-type requirements between packs and concrete types are not yet supported}}
 
 
 #warning("this is a warning") // expected-warning {{this is a warning}}

--- a/test/Generics/pack_same_type_requirements.swift
+++ b/test/Generics/pack_same_type_requirements.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol PipelineItem {
+    associatedtype Input
+    associatedtype Output
+}
+
+// This example will never work; eventually, it will produce a more precise diagnostic.
+func bad<First : PipelineItem,
+         each T : PipelineItem,
+         Last : PipelineItem>(_ first: First, _ rest: repeat each T, last: Last)
+    where (First.Output, repeat (each T).Output) == (repeat (each T).Input, Last.Input) {}
+    // expected-error@-1 2{{same-type requirements between packs and concrete types are not yet supported}}
+
+// This is also invalid.
+func bad2<First : PipelineItem,
+          each T : PipelineItem>(_ first: First, _ rest: repeat each T)
+    where repeat (each T).Output == (First, repeat (each T).Input) {}
+    // expected-error@-1 {{same-type requirements between packs and concrete types are not yet supported}}
+
+// This could eventually be made to work.
+func good<First : PipelineItem,
+          each T : PipelineItem>(_ first: First, _ rest: repeat each T)
+    where (repeat (each T).Output) == (First, repeat (each T).Input) {}
+    // expected-error@-1 {{generic signature requires types '(repeat (each T).Output)' and '(First, repeat (each T).Input)' to be the same}}

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -125,7 +125,7 @@ struct WithPack<each T> {}
 // FIXME: The diagnostics are misleading.
 
 extension WithPack<Int, Int> {}
-// expected-error@-1 {{same-element requirements are not yet supported}}
+// expected-error@-1 {{same-type requirements between packs and concrete types are not yet supported}}
 
 extension WithPack where (repeat each T) == (Int, Int) {}
 // expected-error@-1 {{generic signature requires types '(repeat each T)' and '(Int, Int)' to be the same}}


### PR DESCRIPTION
We would crash in some cases, or produce a slightly misleading diagnostic about same-element requirements, which are related but not quite the same.

In the fullness of time, we should figure out this corner of the language. Until then, add a new diagnostic since this is really about same-type requirements between concrete types and packs.

Fixes rdar://159790557.