### PR TITLE
AST: Remove AbstractFunctionDecl::hasDynamicSelfResult()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8321,10 +8321,6 @@ public:
   /// Asserts if not in type context.
   Type getMethodInterfaceType() const;
 
-  /// Tests if this is a function returning a DynamicSelfType, or a
-  /// constructor.
-  bool hasDynamicSelfResult() const;
-
   /// The async function marked as the alternative to this function, if any.
   AbstractFunctionDecl *getAsyncAlternative() const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9925,12 +9925,6 @@ Type AbstractFunctionDecl::getMethodInterfaceType() const {
   return Ty->castTo<AnyFunctionType>()->getResult();
 }
 
-bool AbstractFunctionDecl::hasDynamicSelfResult() const {
-  if (auto *funcDecl = dyn_cast<FuncDecl>(this))
-    return funcDecl->getResultInterfaceType()->hasDynamicSelfType();
-  return isa<ConstructorDecl>(this);
-}
-
 AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
   // Async functions can't have async alternatives
   if (hasAsync())


### PR DESCRIPTION
Also reorganize the curry thunk construction code in buildMemberRef(), which is still way too long of a method.