### PR TITLE
[ClangImporter] Set the debug info level to full debug info.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1377,6 +1377,8 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
     // The Clang modules produced by ClangImporter are always embedded in an
     // ObjectFilePCHContainer and contain -gmodules debug info.
     importer->Impl.Invocation->getCodeGenOpts().DebugTypeExtRefs = true;
+    importer->Impl.Invocation->getCodeGenOpts().setDebugInfo(
+        llvm::codegenoptions::FullDebugInfo);
 
     auto PCHContainerOperations =
       std::make_shared<clang::PCHContainerOperations>();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2089,6 +2089,12 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     GenericArgs.push_back("-enable-experimental-feature");
     GenericArgs.push_back("Embedded");
   }
+
+  if (langOpts.DebuggerSupport) {
+    subClangImporterOpts.ExtraArgs.push_back("-gmodules");
+    subClangImporterOpts.ExtraArgs.push_back("-g");
+  }
+
 }
 
 /// Calculate an output filename in \p genericSubInvocation's cache path that


### PR DESCRIPTION
Upstream clang has introduced a new default level for Linux that sits between no debug info and full debug info.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
