### PR TITLE
Runtimes: disable implicit import of StringProcessing for Observation

### DIFF
--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -69,6 +69,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   $<$<COMPILE_LANGUAGE:Swift>:-enable-builtin-module>
   $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature RawLayout>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StaticExclusiveOnly>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"


### PR DESCRIPTION
This matches what we are doing in the current build system, and ensures we are not pulling unexpected dependencies (especially in Apple vendor configurations).

Addresses rdar://160353441