### PR TITLE
[Runtime] Fix overload resolution when targeting Haswell.

### DIFF
--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -71,11 +71,11 @@ static _Float16 fromEncoding(unsigned short s) {
 // but who knows what could go wrong, and they're tiny functions.
 # include <immintrin.h>
 
-SWIFT_RUNTIME_EXPORT float __gnu_h2f_ieee(short h) {
+SWIFT_RUNTIME_EXPORT float __gnu_h2f_ieee(unsigned short h) {
   return _mm_cvtss_f32(_mm_cvtph_ps(_mm_set_epi64x(0,h)));
 }
 
-SWIFT_RUNTIME_EXPORT short __gnu_f2h_ieee(float f) {
+SWIFT_RUNTIME_EXPORT unsigned short __gnu_f2h_ieee(float f) {
   return (unsigned short)_mm_cvtsi128_si32(
     _mm_cvtps_ph(_mm_set_ss(f), _MM_FROUND_CUR_DIRECTION)
   );


### PR DESCRIPTION
I hit this issue when I tried targeting Haswell instead of Sandy/Ivy Bridge with our internal build of the toolchain:

```
Float16Support.cpp:165:10: error: call to 'fromEncoding' is ambiguous
  165 |   return fromEncoding(__gnu_f2h_ieee(f));
      |          ^~~~~~~~~~~~
Float16Support.cpp:45:14: note: candidate function
   45 | static float fromEncoding(unsigned int e) {
      |              ^
Float16Support.cpp:59:17: note: candidate function
   59 | static _Float16 fromEncoding(unsigned short s) {
      |                 ^
```

I thought it was an issue with our setup, but it repros in isolation on Godbolt: https://godbolt.org/z/9hTqrzPvr

Switching the `__F16C__`-guarded definitions from `short` to `unsigned short` to match the other signatures appears to resolve the issue in our builds.