### PR TITLE
[cxx-interop] Fix a crash when calling `std::any_cast` from Swift

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -1,3 +1,9 @@
+module StdAny {
+  header "std-any.h"
+  requires cplusplus
+  export *
+}
+
 module StdNumeric {
   header "std-numeric.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-any.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-any.h
@@ -1,0 +1,6 @@
+#include <any>
+#include <string>
+
+inline std::any getStdAnyString() {
+  return std::string("abc210");
+}

--- a/test/Interop/Cxx/stdlib/use-std-any.swift
+++ b/test/Interop/Cxx/stdlib/use-std-any.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// REQUIRES: executable_test
+
+// In Microsoft STL, all overloads of std::any_cast return a dependent templated
+// type, which Swift isn't able to instantiate. 
+// UNSUPPORTED: OS=windows-msvc
+
+import StdlibUnittest
+import StdAny
+import CxxStdlib
+
+var StdAnyTestSuite = TestSuite("StdAny")
+
+StdAnyTestSuite.test("std.any_cast<std.string>") {
+  let a1 = getStdAnyString()
+  let c1 = std.any_cast(a1) as std.string
+  expectEqual(c1, std.string("abc210"))
+}
+
+runAllTests()


### PR DESCRIPTION
In libc++, `std::any_cast` is declared as a friend function of `std::any`.

ClangImporter was not correctly handling friend functions declared within structs within namespaces correctly.

rdar://147261941

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
