### PR TITLE
[Observation] #84145: comment after annotation causing invalid macro expansion

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -283,7 +283,7 @@ extension VariableDeclSyntax {
       leadingTrivia: leadingTrivia,
       attributes: newAttributes,
       modifiers: modifiers.privatePrefixed(prefix, in: context),
-      bindingSpecifier: TokenSyntax(bindingSpecifier.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
+      bindingSpecifier: TokenSyntax(bindingSpecifier.tokenKind, leadingTrivia: .newline, trailingTrivia: .space, presence: .present),
       bindings: bindings.privatePrefixed(prefix, in: context),
       trailingTrivia: trailingTrivia
     )

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -301,6 +301,18 @@ final class DeinitTriggeredObserver {
   }
 }
 
+@Observable
+final class CommentOnLineBeforeOtherAnnotation {
+  // This comment should not break the observation-ignored annotation added by the Observable macro.
+  @MainActor
+  var it = 0
+}
+
+@Observable
+final class CommentOnSameLineAsOtherAnnotation {
+  @MainActor // This comment should not break the observation-ignored annotation added by the Observable macro.
+  var it = 0
+}
 
 @main
 struct Validator {


### PR DESCRIPTION
Resolves #84145.

# Before

This code would fail to compile:

```swift
@Observable
final class MyClass {
  @MainActor // some comment here
  var it = 0
}
```

This is because the comment after `@MainActor` was ending up as a prefix on the same line as the generated `_it` variable in the expanded code.

# After

The code compiles because the `_it` variable is moved to a new line instead of at the end of the line with the comment.
