### PR TITLE
[cxx-interop] Attempt to fix some windows test failures on rebranch

### DIFF
--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -171,8 +171,13 @@ struct SymbolicP {
 } __attribute__((packed));
 
 SWIFT_INLINE_THUNK const void *_Nullable getErrorMetadata() {
+// We do not care about these symbols being duplicated across multiple shared
+// libraries for now.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunique-object-duplication"
   static SymbolicP errorSymbol;
   static int *_Nonnull got_ss5ErrorMp = &$ss5ErrorMp;
+#pragma clang diagnostic pop
   errorSymbol._1 = 2;
   errorSymbol._2 =
       static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&got_ss5ErrorMp) -

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -4,7 +4,6 @@
 
 // This test is specific to msvcprt and therefore only runs on Windows.
 // REQUIRES: OS=windows-msvc
-// REQUIRES: rdar159879290
 
 // CHECK-STD: import CxxStdlib.iosfwd
 // CHECK-STD: import CxxStdlib.string
@@ -16,8 +15,9 @@
 // CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<CWideChar, std.char_traits<CWideChar>, std.allocator<CWideChar>> : CxxRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = CWideChar
+// CHECK-STRING:   struct basic_string<CChar16, std.char_traits<CChar16>, std.allocator<CChar16>> : CxxRandomAccessCollection {
+// CHECK-STRING:     typealias value_type = UInt16
+// FIXME: why the value type is different from CChar16?
 // CHECK-STRING:   }
 // CHECK-STRING:   typealias string = std.basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>>
 // CHECK-STRING:   typealias wstring = std.basic_string<CWideChar, std.char_traits<CWideChar>, std.allocator<CWideChar>>

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -5,7 +5,6 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
 
 // REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
-// REQUIRES: rdar159879290
 
 // CHECK-LABEL: namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 


### PR DESCRIPTION
Unfortunately, I did not find an easy way to fix the warning so suppressed it for now. But I don't think we care about those symbols being duplicated across different shared libraries.

rdar://159879290
