### PR TITLE
Unsafe[Mutable]Pointer<Pointee: ~Copyable & ~Escapable>

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -343,3 +343,17 @@ public func _overrideLifetime<
 ) -> T {
   dependent
 }
+
+/// Unsafely discard any lifetime dependency on the `dependent` inout
+/// argument. Return a value identical to `dependent` with a lifetime dependency
+/// on the caller's borrow scope of the `source` argument.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(dependent: borrow source)
+public func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: inout T, borrowing source: borrowing U
+) {}

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -35,7 +35,7 @@ public protocol _Pointer:
   /// A type that represents the distance between two pointers.
   typealias Distance = Int
 
-  associatedtype Pointee: ~Copyable
+  associatedtype Pointee: ~Copyable & ~Escapable
 
   /// The underlying raw pointer value.
   var _rawValue: Builtin.RawPointer { get }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -418,6 +418,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   /// - Parameter i: The position of the element to access. `i` must be in the
   ///   range `0..<count`.
   @_alwaysEmitIntoClient
+  @lifetime(borrow self)
   public subscript(i: Int) -> Element {
     @_transparent
     unsafeAddress {
@@ -437,6 +438,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
 
   // Skip all debug and runtime checks
   @_alwaysEmitIntoClient
+  @lifetime(borrow self)
   internal subscript(_unchecked i: Int) -> Element {
     @_transparent
     unsafeAddress {
@@ -1353,9 +1355,11 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable & ~Escapable {
   ///   - index: The index of the buffer element to retrieve and deinitialize.
   /// - Returns: The instance referenced by this index in this buffer.
   @_alwaysEmitIntoClient
+  @lifetime(borrow self)
   public func moveElement(from index: Index) -> Element {
     _debugPrecondition(startIndex <= index && index < endIndex)
-    return unsafe baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index).move()
+    let p = unsafe baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
+    return unsafe _overrideLifetime(p.move(), copying: self)
   }
 
   /// Deinitializes the memory underlying the element at `index`.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -31,7 +31,7 @@
 /// referenced memory and into the new collection.
 @frozen // unsafe-performance
 @unsafe
-public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable>: Copyable {
+public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable & ~Escapable>: Copyable, Escapable {
 
   @usableFromInline
   @_preInverseGenerics
@@ -116,12 +116,12 @@ public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable>: Copyable {
 
 // FIXME: The ASTPrinter should print this synthesized conformance.
 // rdar://140291657
-extension Unsafe${Mutable}BufferPointer: BitwiseCopyable where Element: ~Copyable {}
+extension Unsafe${Mutable}BufferPointer: BitwiseCopyable where Element: ~Copyable & ~Escapable {}
 
 @available(*, unavailable)
-extension Unsafe${Mutable}BufferPointer: Sendable where Element: ~Copyable {}
+extension Unsafe${Mutable}BufferPointer: Sendable where Element: ~Copyable & ~Escapable {}
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   /// A pointer to the first element of the buffer.
   ///
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
@@ -225,7 +225,7 @@ extension Unsafe${Mutable}BufferPointer: @unsafe Sequence {
   }
 }
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   public typealias Index = Int
 
   /// A Boolean value indicating whether the buffer is empty.
@@ -479,7 +479,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
 }
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   /// Constructs a standalone buffer pointer over the items within the supplied
   /// range of positions in the memory region addressed by this buffer pointer.
   ///
@@ -574,6 +574,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 }
 
+// TODO: Support Span<Element: ~Escapable>
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
@@ -807,7 +808,7 @@ extension Unsafe${Mutable}BufferPointer:
 %  end
 }
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
@@ -884,7 +885,7 @@ extension Unsafe${Mutable}BufferPointer {
   }
 }
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   /// Deallocates the memory block previously allocated at this buffer pointer’s
   /// base address.
   ///
@@ -902,7 +903,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 }
 
 % if Mutable:
-extension UnsafeMutableBufferPointer where Element: ~Copyable {
+extension UnsafeMutableBufferPointer where Element: ~Copyable & ~Escapable {
   /// Allocates uninitialized memory for the specified number of instances of
   /// type `Element`.
   ///
@@ -1153,7 +1154,7 @@ extension UnsafeMutableBufferPointer {
   }
 }
 
-extension UnsafeMutableBufferPointer where Element: ~Copyable {
+extension UnsafeMutableBufferPointer where Element: ~Copyable & ~Escapable {
   /// Moves every element of an initialized source buffer into the uninitialized
   /// memory referenced by this buffer, leaving the source memory uninitialized
   /// and this buffer's memory initialized.
@@ -1232,7 +1233,7 @@ extension UnsafeMutableBufferPointer {
   }
 }
 
-extension UnsafeMutableBufferPointer where Element: ~Copyable {
+extension UnsafeMutableBufferPointer where Element: ~Copyable & ~Escapable {
   /// Updates this buffer's initialized memory by moving
   /// every element from the source buffer, leaving the source memory
   /// uninitialized.
@@ -1304,7 +1305,7 @@ extension UnsafeMutableBufferPointer {
   }
 }
 
-extension UnsafeMutableBufferPointer where Element: ~Copyable {
+extension UnsafeMutableBufferPointer where Element: ~Copyable & ~Escapable {
   /// Deinitializes every instance in this buffer.
   ///
   /// The region of memory underlying this buffer must be fully initialized.
@@ -1374,7 +1375,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
 }
 % end
 
-extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable & ~Escapable {
   /// Executes the given closure while temporarily binding the memory referenced
   /// by this buffer to the given type.
   ///
@@ -1431,7 +1432,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient @_transparent
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (_ buffer: ${Self}<T>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -1485,7 +1486,7 @@ extension Unsafe${Mutable}BufferPointer {
 @_unavailableInEmbedded
 @_preInverseGenerics
 extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible
-where Element: ~Copyable {
+where Element: ~Copyable & ~Escapable {
   /// A textual representation of the buffer, suitable for debugging.
   @_preInverseGenerics
   @safe

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -205,7 +205,7 @@
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
 @unsafe
-public struct UnsafePointer<Pointee: ~Copyable>: Copyable {
+public struct UnsafePointer<Pointee: ~Copyable & ~Escapable>: Copyable, Escapable {
 
   /// The underlying raw (untyped) pointer.
   @_preInverseGenerics
@@ -221,19 +221,19 @@ public struct UnsafePointer<Pointee: ~Copyable>: Copyable {
 }
 
 @available(*, unavailable)
-extension UnsafePointer: Sendable where Pointee: ~Copyable {}
+extension UnsafePointer: Sendable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafePointer: _Pointer where Pointee: ~Copyable {
+extension UnsafePointer: _Pointer where Pointee: ~Copyable & ~Escapable {
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int
 }
 
 @_preInverseGenerics
-extension UnsafePointer: Equatable where Pointee: ~Copyable {}
+extension UnsafePointer: Equatable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafePointer: Hashable where Pointee: ~Copyable {
+extension UnsafePointer: Hashable where Pointee: ~Copyable & ~Escapable {
   // Note: This explicit `hashValue` applies @_preInverseGenerics to emulate the
   // original (pre-6.0) compiler-synthesized version.
   @_preInverseGenerics
@@ -243,23 +243,23 @@ extension UnsafePointer: Hashable where Pointee: ~Copyable {
   }
 }
 @_preInverseGenerics
-extension UnsafePointer: Comparable where Pointee: ~Copyable {}
+extension UnsafePointer: Comparable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafePointer: Strideable where Pointee: ~Copyable {}
+extension UnsafePointer: Strideable where Pointee: ~Copyable & ~Escapable {}
 
 #if !$Embedded
 @_preInverseGenerics
 extension UnsafePointer: CustomDebugStringConvertible
-where Pointee: ~Copyable {}
+where Pointee: ~Copyable & ~Escapable {}
 #endif
 
 #if SWIFT_ENABLE_REFLECTION
 @_preInverseGenerics
-extension UnsafePointer: CustomReflectable where Pointee: ~Copyable {}
+extension UnsafePointer: CustomReflectable where Pointee: ~Copyable & ~Escapable {}
 #endif
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   /// Deallocates the memory block previously allocated at this pointer.
   ///
   /// This pointer must be a pointer to the start of a previously allocated
@@ -276,7 +276,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   /// Accesses the instance referenced by this pointer.
   ///
   /// When reading from the `pointee` property, the instance referenced by
@@ -302,7 +302,7 @@ extension UnsafePointer {
   }
 }
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   /// Accesses the pointee at the specified offset from this pointer.
   ///
   /// For a pointer `p`, the memory at `p + i` must be initialized.
@@ -332,7 +332,7 @@ extension UnsafePointer {
   }
 }
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   /// Executes the given closure while temporarily binding memory to
   /// the specified number of instances of type `T`.
   ///
@@ -395,7 +395,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
     _ body: (_ pointer: UnsafePointer<T>) throws(E) -> Result
@@ -459,7 +459,7 @@ extension UnsafePointer {
   }
 }
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   @inlinable // unsafe-performance
   @_preInverseGenerics
   internal static var _max: UnsafePointer {
@@ -469,7 +469,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafePointer where Pointee: ~Copyable {
+extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
@@ -664,7 +664,7 @@ extension UnsafePointer where Pointee: ~Copyable {
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
 @unsafe
-public struct UnsafeMutablePointer<Pointee: ~Copyable>: Copyable {
+public struct UnsafeMutablePointer<Pointee: ~Copyable & ~Escapable>: Copyable, Escapable {
   /// The underlying raw (untyped) pointer.
   @_preInverseGenerics
   @safe
@@ -679,19 +679,19 @@ public struct UnsafeMutablePointer<Pointee: ~Copyable>: Copyable {
 }
 
 @available(*, unavailable)
-extension UnsafeMutablePointer: Sendable where Pointee: ~Copyable {}
+extension UnsafeMutablePointer: Sendable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafeMutablePointer: _Pointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer: _Pointer where Pointee: ~Copyable & ~Escapable {
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int
 }
 
 @_preInverseGenerics
-extension UnsafeMutablePointer: Equatable where Pointee: ~Copyable {}
+extension UnsafeMutablePointer: Equatable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafeMutablePointer: Hashable where Pointee: ~Copyable {
+extension UnsafeMutablePointer: Hashable where Pointee: ~Copyable & ~Escapable {
   // Note: This explicit `hashValue` applies @_preInverseGenerics to emulate the
   // original (pre-6.0) compiler-synthesized version.
   @_preInverseGenerics
@@ -702,23 +702,23 @@ extension UnsafeMutablePointer: Hashable where Pointee: ~Copyable {
 }
 
 @_preInverseGenerics
-extension UnsafeMutablePointer: Comparable where Pointee: ~Copyable {}
+extension UnsafeMutablePointer: Comparable where Pointee: ~Copyable & ~Escapable {}
 
 @_preInverseGenerics
-extension UnsafeMutablePointer: Strideable where Pointee: ~Copyable {}
+extension UnsafeMutablePointer: Strideable where Pointee: ~Copyable & ~Escapable {}
 
 #if !$Embedded
 @_preInverseGenerics
 extension UnsafeMutablePointer: CustomDebugStringConvertible
-where Pointee: ~Copyable {}
+where Pointee: ~Copyable & ~Escapable {}
 #endif
 
 #if SWIFT_ENABLE_REFLECTION
 @_preInverseGenerics
-extension UnsafeMutablePointer: CustomReflectable where Pointee: ~Copyable {}
+extension UnsafeMutablePointer: CustomReflectable where Pointee: ~Copyable & ~Escapable {}
 #endif
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Creates a mutable typed pointer referencing the same memory as the given
   /// immutable pointer.
   ///
@@ -766,7 +766,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Allocates uninitialized memory for the specified number of instances of
   /// type `Pointee`.
   ///
@@ -822,7 +822,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Deallocates the memory block previously allocated at this pointer.
   ///
   /// This pointer must be a pointer to the start of a previously allocated
@@ -839,7 +839,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Reads or updates the instance referenced by this pointer.
   ///
   /// When reading from the `pointee` property, the instance referenced by this
@@ -903,7 +903,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Initializes this pointer's memory with a single instance of the given
   /// value.
   ///
@@ -928,7 +928,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Retrieves and returns the referenced instance, returning the pointer's
   /// memory to an uninitialized state.
   ///
@@ -1035,7 +1035,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Moves instances from initialized source memory into the uninitialized
   /// memory referenced by this pointer, leaving the source memory
   /// uninitialized and the memory referenced by this pointer initialized.
@@ -1118,7 +1118,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Update this pointer's initialized memory by moving the specified number
   /// of instances the source pointer's memory, leaving the source memory
   /// uninitialized.
@@ -1168,7 +1168,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Deinitializes the specified number of values starting at this pointer.
   ///
   /// The region of memory starting at this pointer and covering `count`
@@ -1192,7 +1192,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Executes the given closure while temporarily binding memory to
   /// the specified number of instances of the given type.
   ///
@@ -1254,7 +1254,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @unsafe
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws(E) -> Result
@@ -1293,7 +1293,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// Reads or updates the pointee at the specified offset from this pointer.
   ///
   /// For a pointer `p`, the memory at `p + i` must be initialized when reading
@@ -1384,7 +1384,7 @@ extension UnsafeMutablePointer {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   @inlinable // unsafe-performance
   @_preInverseGenerics
   internal static var _max: UnsafeMutablePointer {
@@ -1394,7 +1394,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-extension UnsafeMutablePointer where Pointee: ~Copyable {
+extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -310,6 +310,7 @@ extension UnsafePointer where Pointee: ~Copyable & ~Escapable {
   /// - Parameter i: The offset from this pointer at which to access an
   ///   instance, measured in strides of the pointer's `Pointee` type.
   @_alwaysEmitIntoClient
+  @lifetime(borrow self)
   public subscript(i: Int) -> Pointee {
     @_transparent
     unsafeAddress {
@@ -947,6 +948,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// - Returns: The instance referenced by this pointer.
   @inlinable
   @_preInverseGenerics
+  @lifetime(borrow self)
   public func move() -> Pointee {
     return Builtin.take(_rawValue)
   }
@@ -1308,6 +1310,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   /// - Parameter i: The offset from this pointer at which to access an
   ///   instance, measured in strides of the pointer's `Pointee` type.
   @_alwaysEmitIntoClient
+  @lifetime(borrow self)
   public subscript(i: Int) -> Pointee {
     @_transparent
     unsafeAddress {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -917,7 +917,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
   ///   - value: The instance to initialize this pointer's pointee to.
   @_alwaysEmitIntoClient
   public func initialize(to value: consuming Pointee) {
-    Builtin.initialize(value, self._rawValue)
+    unsafe Builtin.initialize(_overrideLifetime(value, borrowing: ()), self._rawValue)
   }
 }
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -1190,7 +1190,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
     // Note: When count is statically known to be 1 the compiler will optimize
     // away a call to swift_arrayDestroy into the type's specific destroy.
     Builtin.destroyArray(Pointee.self, _rawValue, count._builtinWordValue)
-    return unsafe UnsafeMutableRawPointer(self)
+    return UnsafeMutableRawPointer(self)
   }
 }
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -1188,7 +1188,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable & ~Escapable {
     // Note: When count is statically known to be 1 the compiler will optimize
     // away a call to swift_arrayDestroy into the type's specific destroy.
     Builtin.destroyArray(Pointee.self, _rawValue, count._builtinWordValue)
-    return UnsafeMutableRawPointer(self)
+    return unsafe UnsafeMutableRawPointer(self)
   }
 }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -656,7 +656,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @inlinable @_transparent
   @_preInverseGenerics
   @safe
-  public init<T: ~Copyable>(_ buffer: UnsafeMutableBufferPointer<T>) {
+  public init<T: ~Copyable & ~Escapable>(_ buffer: UnsafeMutableBufferPointer<T>) {
     unsafe self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
@@ -669,7 +669,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @inlinable @_transparent
   @_preInverseGenerics
   @safe
-  public init<T: ~Copyable>(_ buffer: UnsafeBufferPointer<T>) {
+  public init<T: ~Copyable & ~Escapable>(_ buffer: UnsafeBufferPointer<T>) {
     unsafe self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
@@ -971,7 +971,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     base address as this buffer, and its count is equal to `source.count`.
   @discardableResult
   @_alwaysEmitIntoClient
-  public func moveInitializeMemory<T: ~Copyable>(
+  public func moveInitializeMemory<T: ~Copyable & ~Escapable>(
     as type: T.Type,
     fromContentsOf source: UnsafeMutableBufferPointer<T>
   ) -> UnsafeMutableBufferPointer<T> {
@@ -1055,7 +1055,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @_transparent
   @_preInverseGenerics
   @discardableResult
-  public func bindMemory<T: ~Copyable>(
+  public func bindMemory<T: ~Copyable & ~Escapable>(
     to type: T.Type
   ) -> Unsafe${Mutable}BufferPointer<T> {
     guard let base = unsafe _position else {
@@ -1113,7 +1113,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   - buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient @_transparent
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     _ body: (_ buffer: Unsafe${Mutable}BufferPointer<T>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -1150,7 +1150,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @_alwaysEmitIntoClient @_transparent
-  public func assumingMemoryBound<T: ~Copyable>(
+  public func assumingMemoryBound<T: ~Copyable & ~Escapable>(
     to: T.Type
   ) -> Unsafe${Mutable}BufferPointer<T> {
     guard let s = unsafe _position else {
@@ -1284,10 +1284,11 @@ extension ${Self} {
 ///     of the closure's execution.
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
-public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
+public func withUnsafeMutableBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
   let pointer = UnsafeMutableRawPointer(Builtin.addressof(&value))
   return try unsafe body(unsafe .init(start: pointer, count: MemoryLayout<T>.size))
 }
@@ -1316,11 +1317,12 @@ func __abi_se0413_withUnsafeMutableBytes<T, Result>(
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeMutableBytes<
-  T: ~Copyable, E: Error, Result: ~Copyable
+  T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
 #if $BuiltinUnprotectedAddressOf
   let pointer = UnsafeMutableRawPointer(Builtin.unprotectedAddressOf(&value))
 #else
@@ -1353,10 +1355,11 @@ public func _withUnprotectedUnsafeMutableBytes<
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
-public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
+public func withUnsafeBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
   let address = UnsafeRawPointer(Builtin.addressof(&value))
   return try unsafe body(unsafe .init(start: address, count: MemoryLayout<T>.size))
 }
@@ -1384,11 +1387,12 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeBytes<
-  T: ~Copyable, E: Error, Result: ~Copyable
+  T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
 #if $BuiltinUnprotectedAddressOf
   let p = UnsafeRawPointer(Builtin.unprotectedAddressOf(&value))
 #else
@@ -1416,6 +1420,10 @@ public func _withUnprotectedUnsafeBytes<
 ///     If you want to mutate a value by writing through a pointer, use
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
+//
+// FIXME: Support `T: ~Copyablbe & ~Escapable` when we have an _overrideLifetime
+// that returns a borrowed value. This may require that the compiler track
+// Builtin.Borrow<T> as ~Escapable.
 @_alwaysEmitIntoClient
 public func withUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable
@@ -1448,6 +1456,10 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 ///
 /// This function is similar to `withUnsafeBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
+//
+// FIXME: Support `T: ~Copyablbe & ~Escapable` when we have an _overrideLifetime
+// that returns a borrowed value. This may require that the compiler track
+// Builtin.Borrow<T> as ~Escapable.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -464,14 +464,16 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T : BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T : BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
     _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
-    return unsafe baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
+    let value = unsafe baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
+    return unsafe _overrideLifetime(value, borrowing: self)
   }
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -559,7 +559,7 @@ extension UnsafeRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedUp<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -577,7 +577,7 @@ extension UnsafeRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedDown<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -1563,7 +1563,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedUp<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -1581,7 +1581,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedDown<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -442,7 +442,8 @@ extension UnsafeRawPointer {
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
   @inlinable
-  public func load<T>(
+  @lifetime(borrow self)
+  public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
@@ -488,7 +489,8 @@ extension UnsafeRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T: BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -442,6 +442,7 @@ extension UnsafeRawPointer {
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
   @inlinable
+  @_preInverseGenerics
   @lifetime(borrow self)
   // This custom silgen name is chosen to preserve the old ABI
   @_silgen_name("$sSV4load14fromByteOffset2asxSi_xmtlF")
@@ -491,6 +492,7 @@ extension UnsafeRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
+  @_preInverseGenerics
   @lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1085,7 +1085,7 @@ extension UnsafeMutableRawPointer {
     as type: T.Type, to value: consuming T
   ) -> UnsafeMutablePointer<T> {
     Builtin.bindMemory(_rawValue, (1)._builtinWordValue, type)
-    Builtin.initialize(consume value, _rawValue)
+    unsafe Builtin.initialize(_overrideLifetime(consume value, borrowing: ()), _rawValue)
     return unsafe UnsafeMutablePointer(_rawValue)
   }
 

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -443,6 +443,8 @@ extension UnsafeRawPointer {
   ///   with the value in the memory referenced by this pointer.
   @inlinable
   @lifetime(borrow self)
+  // This custom silgen name is chosen to preserve the old ABI
+  @_silgen_name("$sSV4load14fromByteOffset2asxSi_xmtlF")
   public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1284,6 +1286,8 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the memory referenced by this pointer.
   @inlinable
   @lifetime(borrow self)
+  // This custom silgen name is chosen to preserve the old ABI
+  @_silgen_name("$sSv4load14fromByteOffset2asxSi_xmtlF")
   public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1283,7 +1283,8 @@ extension UnsafeMutableRawPointer {
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
   @inlinable
-  public func load<T>(
+  @lifetime(borrow self)
+  public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
@@ -1330,7 +1331,8 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T: BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -200,7 +200,7 @@ extension UnsafeRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init<T: ~Copyable>(@_nonEphemeral _ other: UnsafePointer<T>) {
+  public init<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafePointer<T>) {
     _rawValue = other._rawValue
   }
 
@@ -215,7 +215,7 @@ extension UnsafeRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init?<T: ~Copyable>(@_nonEphemeral _ other: UnsafePointer<T>?) {
+  public init?<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafePointer<T>?) {
     guard let unwrapped = unsafe other else { return nil }
     _rawValue = unwrapped._rawValue
   }
@@ -262,7 +262,7 @@ extension UnsafeRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init<T: ~Copyable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
+  public init<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
@@ -277,7 +277,7 @@ extension UnsafeRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init?<T: ~Copyable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
+  public init?<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
     guard let unwrapped = unsafe other else { return nil }
     _rawValue = unwrapped._rawValue
   }
@@ -335,7 +335,7 @@ extension UnsafeRawPointer {
   @_transparent
   @_preInverseGenerics
   @discardableResult
-  public func bindMemory<T: ~Copyable>(
+  public func bindMemory<T: ~Copyable & ~Escapable>(
     to type: T.Type, capacity count: Int
   ) -> UnsafePointer<T> {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
@@ -394,7 +394,7 @@ extension UnsafeRawPointer {
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
     _ body: (_ pointer: UnsafePointer<T>) throws(E) -> Result
@@ -421,7 +421,7 @@ extension UnsafeRawPointer {
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @_transparent
   @_preInverseGenerics
-  public func assumingMemoryBound<T: ~Copyable>(
+  public func assumingMemoryBound<T: ~Copyable & ~Escapable>(
     to: T.Type
   ) -> UnsafePointer<T> {
     return unsafe UnsafePointer<T>(_rawValue)
@@ -820,7 +820,7 @@ extension UnsafeMutableRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init<T: ~Copyable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
+  public init<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
@@ -835,7 +835,7 @@ extension UnsafeMutableRawPointer {
   @_transparent
   @_preInverseGenerics
   @safe
-  public init?<T: ~Copyable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
+  public init?<T: ~Copyable & ~Escapable>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
     guard let unwrapped = unsafe other else { return nil }
     _rawValue = unwrapped._rawValue
   }
@@ -960,7 +960,7 @@ extension UnsafeMutableRawPointer {
   @_transparent
   @_preInverseGenerics
   @discardableResult
-  public func bindMemory<T: ~Copyable>(
+  public func bindMemory<T: ~Copyable & ~Escapable>(
     to type: T.Type, capacity count: Int
   ) -> UnsafeMutablePointer<T> {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
@@ -1017,7 +1017,7 @@ extension UnsafeMutableRawPointer {
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws(E) -> Result
@@ -1044,7 +1044,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @_transparent
   @_preInverseGenerics
-  public func assumingMemoryBound<T: ~Copyable>(
+  public func assumingMemoryBound<T: ~Copyable & ~Escapable>(
     to: T.Type
   ) -> UnsafeMutablePointer<T> {
     return unsafe UnsafeMutablePointer<T>(_rawValue)
@@ -1081,7 +1081,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: A typed pointer to the memory referenced by this raw pointer.
   @discardableResult
   @_alwaysEmitIntoClient
-  public func initializeMemory<T: ~Copyable>(
+  public func initializeMemory<T: ~Copyable & ~Escapable>(
     as type: T.Type, to value: consuming T
   ) -> UnsafeMutablePointer<T> {
     Builtin.bindMemory(_rawValue, (1)._builtinWordValue, type)
@@ -1239,7 +1239,7 @@ extension UnsafeMutableRawPointer {
   @inlinable
   @_preInverseGenerics
   @discardableResult
-  public func moveInitializeMemory<T: ~Copyable>(
+  public func moveInitializeMemory<T: ~Copyable & ~Escapable>(
     as type: T.Type, from source: UnsafeMutablePointer<T>, count: Int
   ) -> UnsafeMutablePointer<T> {
     _debugPrecondition(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1424,10 +1424,11 @@ extension UnsafeMutableRawPointer {
   ///   - type: The type of `value`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func storeBytes<T: BitwiseCopyable>(
+  public func storeBytes<T: BitwiseCopyable & ~Escapable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
-    unsafe Builtin.storeRaw(value, (self + offset)._rawValue)
+    let immortalValue = unsafe _overrideLifetime(value, borrowing: ())
+    unsafe Builtin.storeRaw(immortalValue, (self + offset)._rawValue)
   }
 
   /// Stores the given value's bytes into raw memory at the specified offset.

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -52,12 +52,16 @@ class Vector<T> {
         .bindMemory(to: T.self, capacity: newcapacity))
       for i in 0..<length {
         (newbase + i).initialize(to: (base+i).move())
+        // expected-warning@-1{{'initialize(to:count:)' is deprecated: renamed to 'initialize(repeating:count:)'}}
+        // expected-note@-2{{use 'initialize(repeating:count:)' instead}}
       }
       c_free(base)
       base = newbase
       capacity = newcapacity
     }
     (base+length).initialize(to: elem)
+    // expected-warning@-1{{'initialize(to:count:)' is deprecated: renamed to 'initialize(repeating:count:)'}}
+    // expected-note@-2{{use 'initialize(repeating:count:)' instead}}
     length += 1
   }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -291,6 +291,8 @@ func pointerArithmetic(_ x: UnsafeMutablePointer<Int>, y: UnsafeMutablePointer<I
 func genericPointerArithmetic<T>(_ x: UnsafeMutablePointer<T>, i: Int, t: T) -> UnsafeMutablePointer<T> {
   let p = x + i
   p.initialize(to: t)
+  // expected-warning@-1{{'initialize(to:count:)' is deprecated: renamed to 'initialize(repeating:count:)'}}
+  // expected-note@-2{{use 'initialize(repeating:count:)' instead}}
 }
 
 func passPointerToClosure(_ f: (UnsafeMutablePointer<Int>) -> Int) -> Int { }

--- a/test/SILGen/borrow_accessor.swift
+++ b/test/SILGen/borrow_accessor.swift
@@ -1120,15 +1120,16 @@ class KlassBorrowMutateUMBP<Element> {
 // CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
 // CHECK:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK:   [[REG4:%.*]] = load [trivial] [[REG2]]
-// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 :
+// ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   store [[REG6]] to [trivial] [[REG3]]
 // CHECK:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG11:%.*]] = load [trivial] [[REG8]]
-// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
 // CHECK:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
 // CHECK:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
@@ -1144,15 +1145,16 @@ class KlassBorrowMutateUMBP<Element> {
 // CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
 // CHECK:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK:   [[REG4:%.*]] = load [trivial] [[REG2]]
-// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 :
+// ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   store [[REG6]] to [trivial] [[REG3]]
 // CHECK:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG11:%.*]] = load [trivial] [[REG8]]
-// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
 // CHECK:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
 // CHECK:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
@@ -1182,15 +1184,15 @@ class KlassBorrowMutateUMBP<Element> {
 // CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
 // CHECK-SIL:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK-SIL:   [[REG4:%.*]] = load [trivial] [[REG2]]
-// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK-SIL:   store [[REG6]] to [trivial] [[REG3]]
 // CHECK-SIL:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK-SIL:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK-SIL:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK-SIL:   [[REG11:%.*]] = load [trivial] [[REG8]]
-// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK-SIL:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
 // CHECK-SIL:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
 // CHECK-SIL:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
@@ -1206,15 +1208,15 @@ class KlassBorrowMutateUMBP<Element> {
 // CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
 // CHECK-SIL:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK-SIL:   [[REG4:%.*]] = load [trivial] [[REG2]]
-// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK-SIL:   store [[REG6]] to [trivial] [[REG3]]
 // CHECK-SIL:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK-SIL:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK-SIL:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK-SIL:   [[REG11:%.*]] = load [trivial] [[REG8]]
-// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK-SIL:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
 // CHECK-SIL:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
 // CHECK-SIL:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]

--- a/test/SILGen/borrow_accessor_container.swift
+++ b/test/SILGen/borrow_accessor_container.swift
@@ -41,15 +41,15 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   [[REG4:%.*]] = begin_borrow [[REG2]]
 // CHECK:   [[REG5:%.*]] = struct_extract [[REG0]], #Container._storage
 // CHECK:   [[REG6:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
-// CHECK:   [[REG7:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG8:%.*]] = apply [[REG7]]<Element>([[REG5]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG7:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG8:%.*]] = apply [[REG7]]<Element>([[REG5]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   store [[REG8]] to [trivial] [[REG6]]
 // CHECK:   [[REG10:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK:   [[REG11:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG12:%.*]] = apply [[REG11]]<UnsafeMutablePointer<Element>>([[REG10]], [[REG6]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG13:%.*]] = load [trivial] [[REG10]]
-// CHECK:   [[REG14:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG15:%.*]] = apply [[REG14]]<Element>([[REG13]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG14:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG15:%.*]] = apply [[REG14]]<Element>([[REG13]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG16:%.*]] = struct_extract [[REG15]], #UnsafePointer._rawValue
 // CHECK:   [[REG17:%.*]] = pointer_to_address [[REG16]] to [strict] $*Element
 // CHECK:   [[REG18:%.*]] = mark_dependence [unresolved] [[REG17]] on [[REG13]]
@@ -70,15 +70,15 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   [[REG3:%.*]] = struct_element_addr [[REG2]], #Container._storage
 // CHECK:   [[REG4:%.*]] = load [trivial] [[REG3]]
 // CHECK:   [[REG5:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
-// CHECK:   [[REG6:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG7:%.*]] = apply [[REG6]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG7:%.*]] = apply [[REG6]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   store [[REG7]] to [trivial] [[REG5]]
 // CHECK:   [[REG9:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK:   [[REG10:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG11:%.*]] = apply [[REG10]]<UnsafeMutablePointer<Element>>([[REG9]], [[REG5]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
 // CHECK:   [[REG12:%.*]] = load [trivial] [[REG9]]
-// CHECK:   [[REG13:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
-// CHECK:   [[REG14:%.*]] = apply [[REG13]]<Element>([[REG12]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG13:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG14:%.*]] = apply [[REG13]]<Element>([[REG12]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
 // CHECK:   [[REG15:%.*]] = struct_extract [[REG14]], #UnsafeMutablePointer._rawValue
 // CHECK:   [[REG16:%.*]] = pointer_to_address [[REG15]] to [strict] $*Element
 // CHECK:   [[REG17:%.*]] = mark_dependence [unresolved] [[REG16]] on [[REG12]]
@@ -97,8 +97,8 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   [[REG6:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
 // CHECK:   [[REG7:%.*]] = begin_borrow [[REG4]]
 // CHECK:   [[REG8:%.*]] = struct_extract [[REG7]], #Container._storage
-// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG10:%.*]] = apply [[REG9]]<Element>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG10:%.*]] = apply [[REG9]]<Element>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG11:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK:   store [[REG10]] to [trivial] [[REG11]]
 // CHECK:   [[REG13:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
@@ -114,8 +114,8 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   dealloc_stack [[REG11]]
 // CHECK:   end_borrow [[REG7]]
 // CHECK:   [[REG25:%.*]] = load [trivial] [[REG6]]
-// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG27:%.*]] = apply [[REG26]]<Element>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG27:%.*]] = apply [[REG26]]<Element>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG28:%.*]] = struct_extract [[REG27]], #UnsafePointer._rawValue
 // CHECK:   [[REG29:%.*]] = pointer_to_address [[REG28]] to [strict] $*Element
 // CHECK:   [[REG30:%.*]] = mark_dependence [unresolved] [[REG29]] on [[REG25]]
@@ -137,8 +137,8 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   [[REG7:%.*]] = struct_element_addr [[REG6]], #Container._storage
 // CHECK:   [[REG8:%.*]] = load [trivial] [[REG7]]
 // CHECK:   end_access [[REG6]]
-// CHECK:   [[REG10:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG11:%.*]] = apply [[REG10]]<Element>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG10:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG11:%.*]] = apply [[REG10]]<Element>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG12:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
 // CHECK:   store [[REG11]] to [trivial] [[REG12]]
 // CHECK:   [[REG14:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
@@ -153,8 +153,8 @@ extension Container: Copyable where Element: Copyable {}
 // CHECK:   dealloc_stack [[REG14]]
 // CHECK:   dealloc_stack [[REG12]]
 // CHECK:   [[REG25:%.*]] = load [trivial] [[REG5]]
-// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
-// CHECK:   [[REG27:%.*]] = apply [[REG26]]<Element>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG27:%.*]] = apply [[REG26]]<Element>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
 // CHECK:   [[REG28:%.*]] = struct_extract [[REG27]], #UnsafeMutablePointer._rawValue
 // CHECK:   [[REG29:%.*]] = pointer_to_address [[REG28]] to [strict] $*Element
 // CHECK:   [[REG30:%.*]] = mark_dependence [unresolved] [[REG29]] on [[REG25]]
@@ -201,8 +201,8 @@ public struct CopyableContainer {
 // CHECK: bb0([[REG0:%.*]] : $Int, [[REG1:%.*]] : $CopyableContainer):
 // CHECK:   [[REG4:%.*]] = alloc_stack $UnsafeMutablePointer<S>
 // CHECK:   [[REG5:%.*]] = struct_extract [[REG1]], #CopyableContainer._storage
-// CHECK:   [[REG6:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG7:%.*]] = apply [[REG6]]<S>([[REG5]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG7:%.*]] = apply [[REG6]]<S>([[REG5]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG8:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<S>>
 // CHECK:   store [[REG7]] to [trivial] [[REG8]]
 // CHECK:   [[REG10:%.*]] = alloc_stack $UnsafeMutablePointer<S>
@@ -217,8 +217,8 @@ public struct CopyableContainer {
 // CHECK:   dealloc_stack [[REG10]]
 // CHECK:   dealloc_stack [[REG8]]
 // CHECK:   [[REG21:%.*]] = load [trivial] [[REG4]]
-// CHECK:   [[REG22:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG23:%.*]] = apply [[REG22]]<S>([[REG21]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG22:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG23:%.*]] = apply [[REG22]]<S>([[REG21]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG24:%.*]] = struct_extract [[REG23]], #UnsafePointer._rawValue
 // CHECK:   [[REG25:%.*]] = pointer_to_address [[REG24]] to [strict] $*S
 // CHECK:   [[REG26:%.*]] = mark_dependence [unresolved] [[REG25]] on [[REG21]]
@@ -241,8 +241,8 @@ public struct CopyableContainer {
 // CHECK:   [[REG6:%.*]] = struct_element_addr [[REG5]], #CopyableContainer._storage
 // CHECK:   [[REG7:%.*]] = load [trivial] [[REG6]]
 // CHECK:   end_access [[REG5]]
-// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG10:%.*]] = apply [[REG9]]<S>([[REG7]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG10:%.*]] = apply [[REG9]]<S>([[REG7]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG11:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<S>>
 // CHECK:   store [[REG10]] to [trivial] [[REG11]]
 // CHECK:   [[REG13:%.*]] = alloc_stack $UnsafeMutablePointer<S>
@@ -257,8 +257,8 @@ public struct CopyableContainer {
 // CHECK:   dealloc_stack [[REG13]]
 // CHECK:   dealloc_stack [[REG11]]
 // CHECK:   [[REG24:%.*]] = load [trivial] [[REG4]]
-// CHECK:   [[REG25:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
-// CHECK:   [[REG26:%.*]] = apply [[REG25]]<S>([[REG24]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG25:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG26:%.*]] = apply [[REG25]]<S>([[REG24]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
 // CHECK:   [[REG27:%.*]] = struct_extract [[REG26]], #UnsafeMutablePointer._rawValue
 // CHECK:   [[REG28:%.*]] = pointer_to_address [[REG27]] to [strict] $*S
 // CHECK:   [[REG29:%.*]] = mark_dependence [unresolved] [[REG28]] on [[REG24]]
@@ -305,8 +305,8 @@ public struct NonCopyableContainer : ~Copyable {
 // CHECK:   [[REG6:%.*]] = alloc_stack $UnsafeMutablePointer<NC>
 // CHECK:   [[REG7:%.*]] = begin_borrow [[REG4]]
 // CHECK:   [[REG8:%.*]] = struct_extract [[REG7]], #NonCopyableContainer._storage
-// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG10:%.*]] = apply [[REG9]]<NC>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG9:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG10:%.*]] = apply [[REG9]]<NC>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG11:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<NC>>
 // CHECK:   store [[REG10]] to [trivial] [[REG11]]
 // CHECK:   [[REG13:%.*]] = alloc_stack $UnsafeMutablePointer<NC>
@@ -322,8 +322,8 @@ public struct NonCopyableContainer : ~Copyable {
 // CHECK:   dealloc_stack [[REG11]]
 // CHECK:   end_borrow [[REG7]]
 // CHECK:   [[REG25:%.*]] = load [trivial] [[REG6]]
-// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
-// CHECK:   [[REG27:%.*]] = apply [[REG26]]<NC>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG27:%.*]] = apply [[REG26]]<NC>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 // CHECK:   [[REG28:%.*]] = struct_extract [[REG27]], #UnsafePointer._rawValue
 // CHECK:   [[REG29:%.*]] = pointer_to_address [[REG28]] to [strict] $*NC
 // CHECK:   [[REG30:%.*]] = mark_dependence [unresolved] [[REG29]] on [[REG25]]
@@ -348,8 +348,8 @@ public struct NonCopyableContainer : ~Copyable {
 // CHECK:   [[REG7:%.*]] = struct_element_addr [[REG6]], #NonCopyableContainer._storage
 // CHECK:   [[REG8:%.*]] = load [trivial] [[REG7]]
 // CHECK:   end_access [[REG6]]
-// CHECK:   [[REG10:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
-// CHECK:   [[REG11:%.*]] = apply [[REG10]]<NC>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG10:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG11:%.*]] = apply [[REG10]]<NC>([[REG8]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
 // CHECK:   [[REG12:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<NC>>
 // CHECK:   store [[REG11]] to [trivial] [[REG12]]
 // CHECK:   [[REG14:%.*]] = alloc_stack $UnsafeMutablePointer<NC>
@@ -364,8 +364,8 @@ public struct NonCopyableContainer : ~Copyable {
 // CHECK:   dealloc_stack [[REG14]]
 // CHECK:   dealloc_stack [[REG12]]
 // CHECK:   [[REG25:%.*]] = load [trivial] [[REG5]]
-// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
-// CHECK:   [[REG27:%.*]] = apply [[REG26]]<NC>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG26:%.*]] = function_ref @$sSpsRi_zRi0_zrlE7pointeexvau : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK:   [[REG27:%.*]] = apply [[REG26]]<NC>([[REG25]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
 // CHECK:   [[REG28:%.*]] = struct_extract [[REG27]], #UnsafeMutablePointer._rawValue
 // CHECK:   [[REG29:%.*]] = pointer_to_address [[REG28]] to [strict] $*NC
 // CHECK:   [[REG30:%.*]] = mark_dependence [unresolved] [[REG29]] on [[REG25]]

--- a/test/SILGen/borrow_from_load_expr.swift
+++ b/test/SILGen/borrow_from_load_expr.swift
@@ -12,7 +12,7 @@ public struct FA<T> {
   public subscript(_ int: Int) -> T {
 // CHECK-LABEL: sil [ossa] @read : {{.*}} {
                   // function_ref UnsafeMutablePointer.subscript.unsafeAddressor
-// CHECK:         [[ADDRESSOR:%[^,]+]] = function_ref @$sSpsRi_zrlEyxSicilu
+// CHECK:         [[ADDRESSOR:%[^,]+]] = function_ref @$sSpsRi_zRi0_zrlEyxSicilu
 // CHECK:         [[POINTER:%[^,]+]] = apply [[ADDRESSOR]]
 // CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[POINTER]]
 // CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -1023,7 +1023,7 @@ func testPointerInit(x: Int, y: UnsafeMutablePointer<Int>) {
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify15testPointerInit1x1yySi_SpySiGtF : $@convention(thin) (Int, UnsafeMutablePointer<Int>) -> () {
 // CHECK: bb0(%0 : $Int, %1 : $UnsafeMutablePointer<Int>):
 // call addressor
-// CHECK: [[POINTEE:%.*]] = apply %{{.*}}<Int>(%1) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK: [[POINTEE:%.*]] = apply %{{.*}}<Int>(%1) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
 // CHECK: [[RAWPTR:%.*]] = struct_extract [[POINTEE]] : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
 // CHECK: [[ADR:%.*]] = pointer_to_address [[RAWPTR]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[ADR]] : $*Int on %1 : $UnsafeMutablePointer<Int> // user: %9

--- a/test/SILOptimizer/lifetime_dependence/pointer_to_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/pointer_to_span.swift
@@ -1,0 +1,228 @@
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
+// RUN:   -strict-memory-safety \
+// RUN:   -enable-experimental-feature Lifetimes
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+
+@safe
+func getRawPointer() -> UnsafeRawPointer {
+  UnsafeRawPointer(UnsafeMutablePointer<RawSpan>.allocate(capacity: 1))
+}
+
+@safe
+func getMutRawPointer() -> UnsafeMutableRawPointer {
+  UnsafeMutableRawPointer(UnsafeMutablePointer<RawSpan>.allocate(capacity: 1))
+}
+
+@safe
+func getPointerToSpan() -> UnsafePointer<RawSpan> {
+  unsafe UnsafePointer(UnsafeMutablePointer<RawSpan>.allocate(capacity: 1))
+}
+
+@safe
+func getMutPointerToSpan() -> UnsafeMutablePointer<RawSpan> {
+  UnsafeMutablePointer<RawSpan>.allocate(capacity: 1)
+}
+
+@safe
+func getBufferPointerToSpan() -> UnsafeBufferPointer<RawSpan> {
+  UnsafeBufferPointer(UnsafeMutableBufferPointer<RawSpan>.allocate(capacity: 1))
+}
+
+@safe
+func getMutBufferPointerToSpan() -> UnsafeMutableBufferPointer<RawSpan> {
+  UnsafeMutableBufferPointer<RawSpan>.allocate(capacity: 1)
+}
+
+@available(Span 0.1, *)
+func useSpan(_ span: RawSpan) {}
+
+//===----------------------------------------------------------------------===//
+// raw pointer .initialize()
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+func goodInitializeRawLocal(array: [Int]) {
+  let p = getMutRawPointer()
+  unsafe p.initializeMemory(as: RawSpan.self, to: array.span.bytes)
+  unsafe useSpan(p.load(as: RawSpan.self))
+}
+
+@available(Span 0.1, *)
+func goodInitializeRawArg(array: [Int], p: UnsafeMutableRawPointer) {
+  unsafe p.initializeMemory(as: RawSpan.self, to: array.span.bytes)
+  unsafe useSpan(p.load(as: RawSpan.self))
+}
+
+//===----------------------------------------------------------------------===//
+// .pointee
+//===----------------------------------------------------------------------===//
+
+// TODO: innaccurate diagnostic: 'p' is not itself lifetime-dependent.
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badPointeeGet() -> RawSpan {
+  let p = getPointerToSpan() // expected-error{{lifetime-dependent variable 'p' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'p'}}
+  return unsafe p.pointee // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodPointeeGet(p: UnsafePointer<RawSpan>) -> RawSpan {
+  unsafe useSpan(p.pointee)
+  return unsafe p.pointee
+}
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badMutPointeeGet() -> RawSpan {
+  let p = getMutPointerToSpan() // expected-error{{lifetime-dependent variable 'p' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'p'}}
+  return unsafe p.pointee // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+func goodMutPointeeGet(p: UnsafeMutablePointer<RawSpan>) {
+  unsafe useSpan(p.pointee)
+}
+
+@available(Span 0.1, *)
+func mutPointeeSet(array: [Int], p: UnsafeMutablePointer<RawSpan>) {
+  unsafe p.pointee = array.span.bytes
+}
+
+//===----------------------------------------------------------------------===//
+// pointer subscript
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badSubscriptGet() -> RawSpan {
+  let p = getPointerToSpan() // expected-error{{lifetime-dependent variable 'p' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'p'}}
+  return unsafe p[0] // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodSubscriptGet(p: UnsafePointer<RawSpan>) -> RawSpan {
+  unsafe useSpan(p[0])
+  return unsafe p[0]
+}
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badMutSubscriptGet() -> RawSpan {
+  let p = getMutPointerToSpan() // expected-error{{lifetime-dependent variable 'p' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'p'}}
+  return unsafe p[0] // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+func goodMutSubscriptGet(p: UnsafeMutablePointer<RawSpan>) {
+  unsafe useSpan(p[0])
+}
+
+@available(Span 0.1, *)
+func mutSubscriptSet(array: [Int], p: UnsafeMutablePointer<RawSpan>) {
+  unsafe p[0] = array.span.bytes
+}
+
+//===----------------------------------------------------------------------===//
+// initialize
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+func goodInitializeLocal(array: [Int]) {
+  let p = getMutPointerToSpan()
+  unsafe p.initialize(to: array.span.bytes)
+  unsafe useSpan(p[0])
+}
+
+@available(Span 0.1, *)
+func goodInitializeArg(array: [Int], p: UnsafeMutablePointer<RawSpan>) {
+  unsafe p.initialize(to: array.span.bytes)
+  unsafe useSpan(p[0])
+}
+
+//===----------------------------------------------------------------------===//
+// move
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badMove() -> RawSpan {
+  let p = getMutPointerToSpan()
+  return unsafe p.move() // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'p'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodMove(p: UnsafeMutablePointer<RawSpan>) -> RawSpan {
+  unsafe p.move()
+}
+
+//===----------------------------------------------------------------------===//
+// buffer subscript
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badBufferSubscriptGet() -> RawSpan {
+  let buf = getBufferPointerToSpan() // expected-error{{lifetime-dependent variable 'buf' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'buf'}}
+  return unsafe buf[0] // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow buf)
+func goodBufferSubscriptGet(buf: UnsafeBufferPointer<RawSpan>) -> RawSpan {
+  unsafe useSpan(buf[0])
+  return unsafe buf[0]
+}
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badMutBufferSubscriptGet() -> RawSpan {
+  let buf = getMutBufferPointerToSpan() // expected-error{{lifetime-dependent variable 'buf' escapes its scope}}
+    // expected-note@-1{{it depends on the lifetime of variable 'buf'}}
+  return unsafe buf[0] // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+func goodMutBufferSubscriptGet(buf: UnsafeMutableBufferPointer<RawSpan>) {
+  unsafe useSpan(buf[0])
+}
+
+@available(Span 0.1, *)
+func mutBufferSubscriptSet(array: [Int], buf: UnsafeMutableBufferPointer<RawSpan>) {
+  unsafe buf[0] = array.span.bytes
+}
+
+//===----------------------------------------------------------------------===//
+// moveElement
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badMoveElement() -> RawSpan {
+  let buf = getMutBufferPointerToSpan()
+  return unsafe buf.moveElement(from: 0) // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'buf'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow buf)
+func goodMoveElement(buf: UnsafeMutableBufferPointer<RawSpan>) -> RawSpan {
+  unsafe buf.moveElement(from: 0)
+}

--- a/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
+// RUN:   -strict-memory-safety \
+// RUN:   -enable-experimental-feature Lifetimes
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+
+@safe
+@_silgen_name("getRawPointer")
+func getRawPointer() -> UnsafeRawPointer
+
+@safe
+@_silgen_name("getMutRawPointer")
+func getMutRawPointer() -> UnsafeMutableRawPointer
+
+func useSpan(_: RawSpan) {}
+
+//===----------------------------------------------------------------------===//
+// raw pointer .load()
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badLoad() -> RawSpan {
+  let p = getRawPointer()
+  return unsafe p.load(as: RawSpan.self) // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'p'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodLoad(p: UnsafeRawPointer) -> RawSpan {
+  unsafe useSpan(p.load(as: RawSpan.self))
+  return unsafe p.load(as: RawSpan.self)
+}
+
+//===----------------------------------------------------------------------===//
+// raw pointer .loadUnaligned()
+//
+// TODO: test non-BitwiseCopyable loadUnaligned
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badBitwiseLoadUnaligned() -> RawSpan {
+  let p = getRawPointer()
+  return unsafe p.loadUnaligned(as: RawSpan.self) // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'p'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodBitwiseLoadUnaligned(p: UnsafeRawPointer) -> RawSpan {
+  unsafe useSpan(p.loadUnaligned(as: RawSpan.self))
+  return unsafe p.loadUnaligned(as: RawSpan.self)
+}
+
+/* TODO: support loadUnaligned<T: ~BitwiseCopyable>
+@_lifetime(immortal)
+func badGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> T {
+  let p = getRawPointer()
+  return unsafe p.loadUnaligned(as: T.self) // ERROR
+}
+
+@_lifetime(borrow p)
+func goodGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> T {
+  return unsafe p.loadUnaligned(as: T.self) // OK
+}
+*/

--- a/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
@@ -74,3 +74,20 @@ func goodGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> 
   return unsafe p.loadUnaligned(as: T.self) // OK
 }
 */
+
+//===----------------------------------------------------------------------===//
+// raw pointer .storeBytes()
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+func storeSpan(span: RawSpan) {
+  let p = getMutRawPointer()
+  unsafe p.storeBytes(of: span, as: RawSpan.self)
+}
+
+/* TODO: support storeBytes<T: ~BitwiseCopyable>
+func storeGeneric<T: ~Escapable>(value: T) {
+  let p = getMutRawPointer()
+  unsafe p.storeBytes(of: value, as: T.self)
+}
+*/

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -6273,6 +6273,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.ref.protocol,
         key.name: "Copyable",
         key.usr: "s:s8CopyableP"
+      },
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "Escapable",
+        key.usr: "s:s9EscapableP"
       }
     ]
   },

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -245,20 +245,20 @@ Accessor ManagedBufferPointer.header.Set() has generic signature change from <He
 Accessor MemoryLayout.alignment.Get() has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Accessor MemoryLayout.size.Get() has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Accessor MemoryLayout.stride.Get() has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
-Accessor UnsafeBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutablePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Accessor UnsafeBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutablePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Accessor UnsafeMutablePointer.pointee.Get() has been removed
-Accessor UnsafeMutablePointer.pointee.Set() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Accessor UnsafeMutablePointer.pointee.Set() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Accessor UnsafeMutablePointer.subscript(_:).Get() has been removed
-Accessor UnsafeMutablePointer.subscript(_:).Set() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Accessor UnsafeMutablePointer.subscript(_:).Set() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Accessor UnsafePointer.pointee.Get() has been removed
 Accessor UnsafePointer.subscript(_:).Get() has been removed
 Class ManagedBuffer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
@@ -270,16 +270,16 @@ Constructor Optional.init(_:) has generic signature change from <Wrapped> to <Wr
 Constructor Optional.init(_:) has parameter 0 changing from Default to Owned
 Constructor Optional.init(nilLiteral:) has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable>
 Constructor Result.init(catching:) has generic signature change from <Success, Failure where Failure == any Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable>
-Constructor UnsafeBufferPointer.init(_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutableBufferPointer.init(mutating:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutableBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutablePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Constructor UnsafeMutablePointer.init(mutating:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Constructor UnsafeMutableRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeMutableRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
+Constructor UnsafeBufferPointer.init(_:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutableBufferPointer.init(mutating:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutableBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutablePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Constructor UnsafeMutablePointer.init(mutating:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Constructor UnsafeMutableRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeMutableRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Enum MemoryLayout has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Enum Optional has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable>
 Enum Result has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable, Success : ~Escapable>
@@ -304,67 +304,68 @@ Func Optional.~=(_:_:) has parameter 1 changing from Default to Shared
 Func Result.get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable, Success : ~Escapable>
 Func Result.get() has self access kind changing from NonMutating to Consuming
 Func Result.mapError(_:) has self access kind changing from NonMutating to Consuming
-Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.allocate(capacity:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.swapAt(_:_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutablePointer.allocate(capacity:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.deinitialize(count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.initialize(to:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.allocate(capacity:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.swapAt(_:_:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutablePointer.allocate(capacity:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.deinitialize(count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.initialize(to:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Func UnsafeMutablePointer.initialize(to:) has parameter 0 changing from Default to Owned
-Func UnsafeMutablePointer.move() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeMutablePointer.move() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
-Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func withUnsafeBytes(of:_:) has parameter 0 changing from Default to Shared
-Func withUnsafeMutableBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func withUnsafeMutableBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func withUnsafeMutablePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func withUnsafePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func withUnsafePointer(to:_:) has parameter 0 changing from Default to Shared
 Struct ManagedBufferPointer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
-Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>
-Struct UnsafeMutableBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>
-Struct UnsafeMutablePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Struct UnsafePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Subscript UnsafeMutablePointer.subscript(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Subscript UnsafePointer.subscript(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafeBufferPointer.Index has generic signature change from <Element> to <Element where Element : ~Copyable>
-TypeAlias UnsafeMutableBufferPointer.Index has generic signature change from <Element> to <Element where Element : ~Copyable>
-TypeAlias UnsafeMutablePointer.Distance has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafeMutablePointer.Pointee has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafeMutablePointer.Stride has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafePointer.Distance has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafePointer.Pointee has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-TypeAlias UnsafePointer.Stride has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Struct UnsafeMutableBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Struct UnsafeMutablePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Struct UnsafePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Subscript UnsafeMutablePointer.subscript(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Subscript UnsafePointer.subscript(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafeBufferPointer.Index has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+TypeAlias UnsafeMutableBufferPointer.Index has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+TypeAlias UnsafeMutablePointer.Distance has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafeMutablePointer.Pointee has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafeMutablePointer.Stride has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafePointer.Distance has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafePointer.Pointee has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+TypeAlias UnsafePointer.Stride has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
-Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
 Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
 Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) is now without rethrows
 Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
@@ -387,13 +388,13 @@ Func Result.flatMapError(_:) has generic signature change from <Success, Failure
 Func Result.flatMapError(_:) has self access kind changing from NonMutating to Consuming
 Func Result.map(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
 Func Result.mapError(_:) has generic signature change from <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error> to <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error, Success : ~Copyable, Success : ~Escapable>
-Func UnsafeBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, T : ~Copyable, Result : ~Copyable>
+Func UnsafeBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, Element : ~Escapable, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func UnsafeBufferPointer.withMemoryRebound(to:_:) is now without rethrows
-Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, T : ~Copyable, Result : ~Copyable>
+Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, Element : ~Escapable, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) is now without rethrows
-Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, T : ~Copyable, Result : ~Copyable>
+Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, Pointee : ~Escapable, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) is now without rethrows
-Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, T : ~Copyable, Result : ~Copyable>
+Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, Pointee : ~Escapable, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) is now without rethrows
 Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func withExtendedLifetime(_:_:) is now without rethrows
@@ -432,8 +433,8 @@ Protocol CodingKey has added inherited protocol SendableMetatype
 Protocol Error has added inherited protocol SendableMetatype
 
 Accessor Optional.unsafelyUnwrapped.Get() has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Escapable>
-Accessor UnsafeBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Accessor UnsafeBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
 
 Func type(of:) has generic signature change from <T, Metatype> to <T, Metatype where T : ~Copyable, T : ~Escapable>
 Func type(of:) has parameter 0 changing from Default to Shared

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -332,11 +332,13 @@ Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature chan
 Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -707,6 +707,9 @@ Func UnsafeRawPointer.assumingMemoryBound(to:) is now with @_preInverseGenerics
 Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>'
 Func UnsafeRawPointer.bindMemory(to:capacity:) is now with @_preInverseGenerics
+Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
+Func UnsafeRawPointer.load(fromByteOffset:as:) has mangled name changing from 'Swift.UnsafeRawPointer.load<A>(fromByteOffset: Swift.Int, as: A.Type) -> A' to 'Swift.UnsafeRawPointer.load<A where A: ~Swift.Escapable>(fromByteOffset: Swift.Int, as: A.Type) -> A'
+Func UnsafeRawPointer.load(fromByteOffset:as:) is now with @_preInverseGenerics
 Func _fixLifetime(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Func _fixLifetime(_:) has mangled name changing from 'Swift._fixLifetime<A>(A) -> ()' to 'Swift._fixLifetime<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(A) -> ()'
 Func _fixLifetime(_:) has parameter 0 changing from Default to Shared

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -437,42 +437,42 @@ Accessor MemoryLayout.size.Get() has generic signature change from <T> to <T whe
 Accessor MemoryLayout.size.Get() has mangled name changing from 'static Swift.MemoryLayout.size.getter : Swift.Int' to 'static (extension in Swift):Swift.MemoryLayout< where A: ~Swift.Copyable, A: ~Swift.Escapable>.size.getter : Swift.Int'
 Accessor MemoryLayout.stride.Get() has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Accessor MemoryLayout.stride.Get() has mangled name changing from 'static Swift.MemoryLayout.stride.getter : Swift.Int' to 'static (extension in Swift):Swift.MemoryLayout< where A: ~Swift.Copyable, A: ~Swift.Escapable>.stride.getter : Swift.Int'
-Accessor UnsafeBufferPointer._position.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer._position.Get() has mangled name changing from 'Swift.UnsafeBufferPointer._position.getter : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>._position.getter : Swift.Optional<Swift.UnsafePointer<A>>'
-Accessor UnsafeBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.baseAddress.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.baseAddress.getter : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.baseAddress.getter : Swift.Optional<Swift.UnsafePointer<A>>'
-Accessor UnsafeBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.count.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.count.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.count.getter : Swift.Int'
-Accessor UnsafeBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.endIndex.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.endIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.endIndex.getter : Swift.Int'
-Accessor UnsafeBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.startIndex.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.startIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.startIndex.getter : Swift.Int'
-Accessor UnsafeMutableBufferPointer._position.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer._position.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer._position.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>._position.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
-Accessor UnsafeMutableBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.baseAddress.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.baseAddress.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.baseAddress.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
-Accessor UnsafeMutableBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.count.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.count.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.count.getter : Swift.Int'
-Accessor UnsafeMutableBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.endIndex.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.endIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.endIndex.getter : Swift.Int'
-Accessor UnsafeMutableBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.startIndex.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.startIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.startIndex.getter : Swift.Int'
+Accessor UnsafeBufferPointer._position.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer._position.Get() has mangled name changing from 'Swift.UnsafeBufferPointer._position.getter : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._position.getter : Swift.Optional<Swift.UnsafePointer<A>>'
+Accessor UnsafeBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.baseAddress.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.baseAddress.getter : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.baseAddress.getter : Swift.Optional<Swift.UnsafePointer<A>>'
+Accessor UnsafeBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.count.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.count.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.count.getter : Swift.Int'
+Accessor UnsafeBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.endIndex.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.endIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.endIndex.getter : Swift.Int'
+Accessor UnsafeBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.startIndex.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.startIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.startIndex.getter : Swift.Int'
+Accessor UnsafeMutableBufferPointer._position.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer._position.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer._position.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._position.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Accessor UnsafeMutableBufferPointer.baseAddress.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.baseAddress.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.baseAddress.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.baseAddress.getter : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Accessor UnsafeMutableBufferPointer.count.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.count.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.count.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.count.getter : Swift.Int'
+Accessor UnsafeMutableBufferPointer.endIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.endIndex.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.endIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.endIndex.getter : Swift.Int'
+Accessor UnsafeMutableBufferPointer.startIndex.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.startIndex.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.startIndex.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.startIndex.getter : Swift.Int'
 Accessor UnsafeMutablePointer._cVarArgEncoding.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Accessor UnsafeMutablePointer._cVarArgEncoding.Get() has mangled name changing from 'Swift.UnsafeMutablePointer._cVarArgEncoding.getter : Swift.Array<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._cVarArgEncoding.getter : Swift.Array<Swift.Int>'
-Accessor UnsafeMutablePointer._max.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafeMutablePointer._max.Get() has mangled name changing from 'static Swift.UnsafeMutablePointer._max.getter : Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._max.getter : Swift.UnsafeMutablePointer<A>'
-Accessor UnsafeMutablePointer._rawValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafeMutablePointer._rawValue.Get() has mangled name changing from 'Swift.UnsafeMutablePointer._rawValue.getter : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._rawValue.getter : Builtin.RawPointer'
-Accessor UnsafeMutablePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafeMutablePointer.hashValue.Get() has mangled name changing from 'Swift.UnsafeMutablePointer.hashValue.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.hashValue.getter : Swift.Int'
+Accessor UnsafeMutablePointer._max.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafeMutablePointer._max.Get() has mangled name changing from 'static Swift.UnsafeMutablePointer._max.getter : Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._max.getter : Swift.UnsafeMutablePointer<A>'
+Accessor UnsafeMutablePointer._rawValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafeMutablePointer._rawValue.Get() has mangled name changing from 'Swift.UnsafeMutablePointer._rawValue.getter : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._rawValue.getter : Builtin.RawPointer'
+Accessor UnsafeMutablePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafeMutablePointer.hashValue.Get() has mangled name changing from 'Swift.UnsafeMutablePointer.hashValue.getter : Swift.Int' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.hashValue.getter : Swift.Int'
 Accessor UnsafePointer._cVarArgEncoding.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Accessor UnsafePointer._cVarArgEncoding.Get() has mangled name changing from 'Swift.UnsafePointer._cVarArgEncoding.getter : Swift.Array<Swift.Int>' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._cVarArgEncoding.getter : Swift.Array<Swift.Int>'
-Accessor UnsafePointer._max.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafePointer._max.Get() has mangled name changing from 'static Swift.UnsafePointer._max.getter : Swift.UnsafePointer<A>' to 'static (extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._max.getter : Swift.UnsafePointer<A>'
-Accessor UnsafePointer._rawValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafePointer._rawValue.Get() has mangled name changing from 'Swift.UnsafePointer._rawValue.getter : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._rawValue.getter : Builtin.RawPointer'
-Accessor UnsafePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Accessor UnsafePointer.hashValue.Get() has mangled name changing from 'Swift.UnsafePointer.hashValue.getter : Swift.Int' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>.hashValue.getter : Swift.Int'
+Accessor UnsafePointer._max.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafePointer._max.Get() has mangled name changing from 'static Swift.UnsafePointer._max.getter : Swift.UnsafePointer<A>' to 'static (extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._max.getter : Swift.UnsafePointer<A>'
+Accessor UnsafePointer._rawValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafePointer._rawValue.Get() has mangled name changing from 'Swift.UnsafePointer._rawValue.getter : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._rawValue.getter : Builtin.RawPointer'
+Accessor UnsafePointer.hashValue.Get() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Accessor UnsafePointer.hashValue.Get() has mangled name changing from 'Swift.UnsafePointer.hashValue.getter : Swift.Int' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.hashValue.getter : Swift.Int'
 Class ManagedBuffer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Constructor ExpressibleByNilLiteral.init(nilLiteral:) has generic signature change from <Self where Self : Swift.ExpressibleByNilLiteral> to <Self where Self : Swift.ExpressibleByNilLiteral, Self : ~Copyable, Self : ~Escapable>
 Constructor ManagedBuffer.init(_doNotCallMe:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
@@ -507,52 +507,52 @@ Constructor Optional.init(_:) is now with @_preInverseGenerics
 Constructor Optional.init(nilLiteral:) has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable>
 Constructor Optional.init(nilLiteral:) has mangled name changing from 'Swift.Optional.init(nilLiteral: ()) -> Swift.Optional<A>' to '(extension in Swift):Swift.Optional< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(nilLiteral: ()) -> Swift.Optional<A>'
 Constructor Optional.init(nilLiteral:) is now with @_preInverseGenerics
-Constructor UnsafeBufferPointer.init(_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.init(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeBufferPointer<A>'
+Constructor UnsafeBufferPointer.init(_:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeBufferPointer<A>'
 Constructor UnsafeBufferPointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafeBufferPointer.init(_empty:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeBufferPointer.init(_empty:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(_empty: ()) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.init(_empty: ()) -> Swift.UnsafeBufferPointer<A>'
+Constructor UnsafeBufferPointer.init(_empty:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeBufferPointer.init(_empty:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(_empty: ()) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(_empty: ()) -> Swift.UnsafeBufferPointer<A>'
 Constructor UnsafeBufferPointer.init(_empty:) is now with @_preInverseGenerics
-Constructor UnsafeBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeBufferPointer.init(start:count:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(start: Swift.Optional<Swift.UnsafePointer<A>>, count: Swift.Int) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.init(start: Swift.Optional<Swift.UnsafePointer<A>>, count: Swift.Int) -> Swift.UnsafeBufferPointer<A>'
+Constructor UnsafeBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeBufferPointer.init(start:count:) has mangled name changing from 'Swift.UnsafeBufferPointer.init(start: Swift.Optional<Swift.UnsafePointer<A>>, count: Swift.Int) -> Swift.UnsafeBufferPointer<A>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(start: Swift.Optional<Swift.UnsafePointer<A>>, count: Swift.Int) -> Swift.UnsafeBufferPointer<A>'
 Constructor UnsafeBufferPointer.init(start:count:) is now with @_preInverseGenerics
-Constructor UnsafeMutableBufferPointer.init(_empty:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutableBufferPointer.init(_empty:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(_empty: ()) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.init(_empty: ()) -> Swift.UnsafeMutableBufferPointer<A>'
+Constructor UnsafeMutableBufferPointer.init(_empty:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutableBufferPointer.init(_empty:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(_empty: ()) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(_empty: ()) -> Swift.UnsafeMutableBufferPointer<A>'
 Constructor UnsafeMutableBufferPointer.init(_empty:) is now with @_preInverseGenerics
-Constructor UnsafeMutableBufferPointer.init(mutating:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutableBufferPointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(mutating: Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.init(mutating: Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeMutableBufferPointer<A>'
+Constructor UnsafeMutableBufferPointer.init(mutating:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutableBufferPointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(mutating: Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(mutating: Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeMutableBufferPointer<A>'
 Constructor UnsafeMutableBufferPointer.init(mutating:) is now with @_preInverseGenerics
-Constructor UnsafeMutableBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Constructor UnsafeMutableBufferPointer.init(start:count:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(start: Swift.Optional<Swift.UnsafeMutablePointer<A>>, count: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.init(start: Swift.Optional<Swift.UnsafeMutablePointer<A>>, count: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>'
+Constructor UnsafeMutableBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Constructor UnsafeMutableBufferPointer.init(start:count:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.init(start: Swift.Optional<Swift.UnsafeMutablePointer<A>>, count: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(start: Swift.Optional<Swift.UnsafeMutablePointer<A>>, count: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>'
 Constructor UnsafeMutableBufferPointer.init(start:count:) is now with @_preInverseGenerics
-Constructor UnsafeMutablePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Builtin.RawPointer) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.init(Builtin.RawPointer) -> Swift.UnsafeMutablePointer<A>'
-Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.init(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>'
-Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.init(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutablePointer<A>'
+Constructor UnsafeMutablePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Builtin.RawPointer) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(Builtin.RawPointer) -> Swift.UnsafeMutablePointer<A>'
+Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Constructor UnsafeMutablePointer.init(_:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutablePointer<A>'
 Constructor UnsafeMutablePointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafeMutablePointer.init(mutating:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Constructor UnsafeMutablePointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(mutating: Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.init(mutating: Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>'
-Constructor UnsafeMutablePointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(mutating: Swift.UnsafePointer<A>) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.init(mutating: Swift.UnsafePointer<A>) -> Swift.UnsafeMutablePointer<A>'
+Constructor UnsafeMutablePointer.init(mutating:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Constructor UnsafeMutablePointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(mutating: Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(mutating: Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Constructor UnsafeMutablePointer.init(mutating:) has mangled name changing from 'Swift.UnsafeMutablePointer.init(mutating: Swift.UnsafePointer<A>) -> Swift.UnsafeMutablePointer<A>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(mutating: Swift.UnsafePointer<A>) -> Swift.UnsafeMutablePointer<A>'
 Constructor UnsafeMutablePointer.init(mutating:) is now with @_preInverseGenerics
-Constructor UnsafeMutableRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeMutableRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawBufferPointer.init<A>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeMutableRawBufferPointer' to 'Swift.UnsafeMutableRawBufferPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeMutableRawBufferPointer'
+Constructor UnsafeMutableRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeMutableRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawBufferPointer.init<A>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeMutableRawBufferPointer' to 'Swift.UnsafeMutableRawBufferPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeMutableRawBufferPointer'
 Constructor UnsafeMutableRawBufferPointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafeMutableRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeMutableRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutableRawPointer>' to 'Swift.UnsafeMutableRawPointer.init<A where A: ~Swift.Copyable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutableRawPointer>'
-Constructor UnsafeMutableRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutableRawPointer' to 'Swift.UnsafeMutableRawPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutableRawPointer'
+Constructor UnsafeMutableRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeMutableRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutableRawPointer>' to 'Swift.UnsafeMutableRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeMutableRawPointer>'
+Constructor UnsafeMutableRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutableRawPointer' to 'Swift.UnsafeMutableRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeMutableRawPointer'
 Constructor UnsafeMutableRawPointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Constructor UnsafePointer.init(_:) has mangled name changing from 'Swift.UnsafePointer.init(Builtin.RawPointer) -> Swift.UnsafePointer<A>' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>.init(Builtin.RawPointer) -> Swift.UnsafePointer<A>'
+Constructor UnsafePointer.init(_:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Constructor UnsafePointer.init(_:) has mangled name changing from 'Swift.UnsafePointer.init(Builtin.RawPointer) -> Swift.UnsafePointer<A>' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.init(Builtin.RawPointer) -> Swift.UnsafePointer<A>'
 Constructor UnsafePointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafeRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.init<A>(Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeRawBufferPointer' to 'Swift.UnsafeRawBufferPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeRawBufferPointer'
-Constructor UnsafeRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.init<A>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeRawBufferPointer' to 'Swift.UnsafeRawBufferPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeRawBufferPointer'
+Constructor UnsafeRawBufferPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.init<A>(Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeRawBufferPointer' to 'Swift.UnsafeRawBufferPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafeBufferPointer<A>) -> Swift.UnsafeRawBufferPointer'
+Constructor UnsafeRawBufferPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.init<A>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeRawBufferPointer' to 'Swift.UnsafeRawBufferPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafeMutableBufferPointer<A>) -> Swift.UnsafeRawBufferPointer'
 Constructor UnsafeRawBufferPointer.init(_:) is now with @_preInverseGenerics
-Constructor UnsafeRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable>
-Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>'
-Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable>(Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>'
-Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeRawPointer' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeRawPointer'
-Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.UnsafePointer<A>) -> Swift.UnsafeRawPointer' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable>(Swift.UnsafePointer<A>) -> Swift.UnsafeRawPointer'
+Constructor UnsafeRawPointer.init(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>'
+Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.Optional<Swift.UnsafePointer<A>>) -> Swift.Optional<Swift.UnsafeRawPointer>'
+Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeRawPointer' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafeMutablePointer<A>) -> Swift.UnsafeRawPointer'
+Constructor UnsafeRawPointer.init(_:) has mangled name changing from 'Swift.UnsafeRawPointer.init<A>(Swift.UnsafePointer<A>) -> Swift.UnsafeRawPointer' to 'Swift.UnsafeRawPointer.init<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(Swift.UnsafePointer<A>) -> Swift.UnsafeRawPointer'
 Constructor UnsafeRawPointer.init(_:) is now with @_preInverseGenerics
 Enum MemoryLayout has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Enum Optional has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable>
@@ -613,99 +613,101 @@ Func Optional.~=(_:_:) has parameter 1 changing from Default to Shared
 Func Optional.~=(_:_:) is now with @_preInverseGenerics
 Func Result.get() has been removed
 Func Result.mapError(_:) has been removed
-Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.deallocate() has mangled name changing from 'Swift.UnsafeBufferPointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.deallocate() -> ()'
+Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.deallocate() has mangled name changing from 'Swift.UnsafeBufferPointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.deallocate() -> ()'
 Func UnsafeBufferPointer.deallocate() is now with @_preInverseGenerics
-Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.distance(from:to:) has mangled name changing from 'Swift.UnsafeBufferPointer.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int'
+Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.distance(from:to:) has mangled name changing from 'Swift.UnsafeBufferPointer.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int'
 Func UnsafeBufferPointer.distance(from:to:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.formIndex(after:) has mangled name changing from 'Swift.UnsafeBufferPointer.formIndex(after: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.formIndex(after: inout Swift.Int) -> ()'
+Func UnsafeBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.formIndex(after:) has mangled name changing from 'Swift.UnsafeBufferPointer.formIndex(after: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.formIndex(after: inout Swift.Int) -> ()'
 Func UnsafeBufferPointer.formIndex(after:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.formIndex(before:) has mangled name changing from 'Swift.UnsafeBufferPointer.formIndex(before: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.formIndex(before: inout Swift.Int) -> ()'
+Func UnsafeBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.formIndex(before:) has mangled name changing from 'Swift.UnsafeBufferPointer.formIndex(before: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.formIndex(before: inout Swift.Int) -> ()'
 Func UnsafeBufferPointer.formIndex(before:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(_:offsetBy:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int'
+Func UnsafeBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(_:offsetBy:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int'
 Func UnsafeBufferPointer.index(_:offsetBy:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>'
+Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>'
 Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(after:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(after: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.index(after: Swift.Int) -> Swift.Int'
+Func UnsafeBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(after:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(after: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(after: Swift.Int) -> Swift.Int'
 Func UnsafeBufferPointer.index(after:) is now with @_preInverseGenerics
-Func UnsafeBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.index(before:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(before: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.index(before: Swift.Int) -> Swift.Int'
+Func UnsafeBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeBufferPointer.index(before:) has mangled name changing from 'Swift.UnsafeBufferPointer.index(before: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(before: Swift.Int) -> Swift.Int'
 Func UnsafeBufferPointer.index(before:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.allocate(capacity:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.allocate(capacity:) has mangled name changing from 'static Swift.UnsafeMutableBufferPointer.allocate(capacity: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>' to 'static (extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.allocate(capacity: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>'
+Func UnsafeMutableBufferPointer.allocate(capacity:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.allocate(capacity:) has mangled name changing from 'static Swift.UnsafeMutableBufferPointer.allocate(capacity: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>' to 'static (extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.allocate(capacity: Swift.Int) -> Swift.UnsafeMutableBufferPointer<A>'
 Func UnsafeMutableBufferPointer.allocate(capacity:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.deallocate() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.deallocate() -> ()'
+Func UnsafeMutableBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.deallocate() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.deallocate() -> ()'
 Func UnsafeMutableBufferPointer.deallocate() is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.distance(from:to:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int'
+Func UnsafeMutableBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.distance(from:to:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.distance(from: Swift.Int, to: Swift.Int) -> Swift.Int'
 Func UnsafeMutableBufferPointer.distance(from:to:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.formIndex(after:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.formIndex(after: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.formIndex(after: inout Swift.Int) -> ()'
+Func UnsafeMutableBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.formIndex(after:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.formIndex(after: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.formIndex(after: inout Swift.Int) -> ()'
 Func UnsafeMutableBufferPointer.formIndex(after:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.formIndex(before:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.formIndex(before: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.formIndex(before: inout Swift.Int) -> ()'
+Func UnsafeMutableBufferPointer.formIndex(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.formIndex(before:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.formIndex(before: inout Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.formIndex(before: inout Swift.Int) -> ()'
 Func UnsafeMutableBufferPointer.formIndex(before:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(_:offsetBy:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int'
+Func UnsafeMutableBufferPointer.index(_:offsetBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(_:offsetBy:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(_: Swift.Int, offsetBy: Swift.Int) -> Swift.Int'
 Func UnsafeMutableBufferPointer.index(_:offsetBy:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>'
+Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(_: Swift.Int, offsetBy: Swift.Int, limitedBy: Swift.Int) -> Swift.Optional<Swift.Int>'
 Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(after:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(after: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.index(after: Swift.Int) -> Swift.Int'
+Func UnsafeMutableBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(after:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(after: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(after: Swift.Int) -> Swift.Int'
 Func UnsafeMutableBufferPointer.index(after:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.index(before:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(before: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.index(before: Swift.Int) -> Swift.Int'
+Func UnsafeMutableBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.index(before:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.index(before: Swift.Int) -> Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.index(before: Swift.Int) -> Swift.Int'
 Func UnsafeMutableBufferPointer.index(before:) is now with @_preInverseGenerics
-Func UnsafeMutableBufferPointer.swapAt(_:_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.swapAt(_:_:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.swapAt(Swift.Int, Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.swapAt(Swift.Int, Swift.Int) -> ()'
+Func UnsafeMutableBufferPointer.swapAt(_:_:) has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Func UnsafeMutableBufferPointer.swapAt(_:_:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.swapAt(Swift.Int, Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.swapAt(Swift.Int, Swift.Int) -> ()'
 Func UnsafeMutableBufferPointer.swapAt(_:_:) is now with @_preInverseGenerics
-Func UnsafeMutablePointer.allocate(capacity:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.allocate(capacity:) has mangled name changing from 'static Swift.UnsafeMutablePointer.allocate(capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.allocate(capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
+Func UnsafeMutablePointer.allocate(capacity:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.allocate(capacity:) has mangled name changing from 'static Swift.UnsafeMutablePointer.allocate(capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.allocate(capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutablePointer.allocate(capacity:) is now with @_preInverseGenerics
-Func UnsafeMutablePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.deallocate() has mangled name changing from 'Swift.UnsafeMutablePointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.deallocate() -> ()'
+Func UnsafeMutablePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.deallocate() has mangled name changing from 'Swift.UnsafeMutablePointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.deallocate() -> ()'
 Func UnsafeMutablePointer.deallocate() is now with @_preInverseGenerics
-Func UnsafeMutablePointer.deinitialize(count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.deinitialize(count:) has mangled name changing from 'Swift.UnsafeMutablePointer.deinitialize(count: Swift.Int) -> Swift.UnsafeMutableRawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.deinitialize(count: Swift.Int) -> Swift.UnsafeMutableRawPointer'
+Func UnsafeMutablePointer.deinitialize(count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.deinitialize(count:) has mangled name changing from 'Swift.UnsafeMutablePointer.deinitialize(count: Swift.Int) -> Swift.UnsafeMutableRawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.deinitialize(count: Swift.Int) -> Swift.UnsafeMutableRawPointer'
 Func UnsafeMutablePointer.deinitialize(count:) is now with @_preInverseGenerics
 Func UnsafeMutablePointer.initialize(to:) has been removed
-Func UnsafeMutablePointer.move() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.move() has mangled name changing from 'Swift.UnsafeMutablePointer.move() -> A' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.move() -> A'
+Func UnsafeMutablePointer.move() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.move() has mangled name changing from 'Swift.UnsafeMutablePointer.move() -> A' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.move() -> A'
 Func UnsafeMutablePointer.move() is now with @_preInverseGenerics
-Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.moveInitialize(from:count:) has mangled name changing from 'Swift.UnsafeMutablePointer.moveInitialize(from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.moveInitialize(from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> ()'
+Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafeMutablePointer.moveInitialize(from:count:) has mangled name changing from 'Swift.UnsafeMutablePointer.moveInitialize(from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> ()' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.moveInitialize(from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> ()'
 Func UnsafeMutablePointer.moveInitialize(from:count:) is now with @_preInverseGenerics
-Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawBufferPointer.bindMemory(to:) has mangled name changing from 'Swift.UnsafeMutableRawBufferPointer.bindMemory<A>(to: A.Type) -> Swift.UnsafeMutableBufferPointer<A>' to 'Swift.UnsafeMutableRawBufferPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type) -> Swift.UnsafeMutableBufferPointer<A>'
+Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawBufferPointer.bindMemory(to:) has mangled name changing from 'Swift.UnsafeMutableRawBufferPointer.bindMemory<A>(to: A.Type) -> Swift.UnsafeMutableBufferPointer<A>' to 'Swift.UnsafeMutableRawBufferPointer.bindMemory<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type) -> Swift.UnsafeMutableBufferPointer<A>'
 Func UnsafeMutableRawBufferPointer.bindMemory(to:) is now with @_preInverseGenerics
-Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.assumingMemoryBound<A>(to: A.Type) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.assumingMemoryBound<A where A: ~Swift.Copyable>(to: A.Type) -> Swift.UnsafeMutablePointer<A>'
+Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.assumingMemoryBound<A>(to: A.Type) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.assumingMemoryBound<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutableRawPointer.assumingMemoryBound(to:) is now with @_preInverseGenerics
-Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
+Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.bindMemory<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) is now with @_preInverseGenerics
-Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A where A: ~Swift.Copyable>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.load<A>(fromByteOffset: Swift.Int, as: A.Type) -> A' to 'Swift.UnsafeMutableRawPointer.load<A where A: ~Swift.Escapable>(fromByteOffset: Swift.Int, as: A.Type) -> A'
+Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) is now with @_preInverseGenerics
-Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafePointer.deallocate() has mangled name changing from 'Swift.UnsafePointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>.deallocate() -> ()'
+Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Func UnsafePointer.deallocate() has mangled name changing from 'Swift.UnsafePointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.deallocate() -> ()'
 Func UnsafePointer.deallocate() is now with @_preInverseGenerics
-Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeRawBufferPointer.bindMemory(to:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.bindMemory<A>(to: A.Type) -> Swift.UnsafeBufferPointer<A>' to 'Swift.UnsafeRawBufferPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type) -> Swift.UnsafeBufferPointer<A>'
+Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeRawBufferPointer.bindMemory(to:) has mangled name changing from 'Swift.UnsafeRawBufferPointer.bindMemory<A>(to: A.Type) -> Swift.UnsafeBufferPointer<A>' to 'Swift.UnsafeRawBufferPointer.bindMemory<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type) -> Swift.UnsafeBufferPointer<A>'
 Func UnsafeRawBufferPointer.bindMemory(to:) is now with @_preInverseGenerics
-Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeRawPointer.assumingMemoryBound(to:) has mangled name changing from 'Swift.UnsafeRawPointer.assumingMemoryBound<A>(to: A.Type) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.assumingMemoryBound<A where A: ~Swift.Copyable>(to: A.Type) -> Swift.UnsafePointer<A>'
+Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeRawPointer.assumingMemoryBound(to:) has mangled name changing from 'Swift.UnsafeRawPointer.assumingMemoryBound<A>(to: A.Type) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.assumingMemoryBound<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type) -> Swift.UnsafePointer<A>'
 Func UnsafeRawPointer.assumingMemoryBound(to:) is now with @_preInverseGenerics
-Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
-Func UnsafeRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>'
+Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func UnsafeRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.bindMemory<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>'
 Func UnsafeRawPointer.bindMemory(to:capacity:) is now with @_preInverseGenerics
 Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func UnsafeRawPointer.load(fromByteOffset:as:) has mangled name changing from 'Swift.UnsafeRawPointer.load<A>(fromByteOffset: Swift.Int, as: A.Type) -> A' to 'Swift.UnsafeRawPointer.load<A where A: ~Swift.Escapable>(fromByteOffset: Swift.Int, as: A.Type) -> A'
@@ -721,12 +723,12 @@ Func withUnsafeBytes(of:_:) has been removed
 Func withUnsafeMutableBytes(of:_:) has been removed
 Func withUnsafeMutablePointer(to:_:) has been removed
 Func withUnsafePointer(to:_:) has been removed
-Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.BitwiseCopyable, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self.Pointee : ~Copyable>
+Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.BitwiseCopyable, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self.Pointee : ~Copyable, Self.Pointee : ~Escapable>
 Struct ManagedBufferPointer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
-Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>
-Struct UnsafeMutableBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>
-Struct UnsafeMutablePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Struct UnsafePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
+Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Struct UnsafeMutableBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Struct UnsafeMutablePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
+Struct UnsafePointer has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable, Pointee : ~Escapable>
 Subscript UnsafeBufferPointer.subscript(_unchecked:) has been removed
 Subscript UnsafeMutableBufferPointer.subscript(_unchecked:) has been removed
 Subscript UnsafeMutablePointer.subscript(_:) has been removed
@@ -767,48 +769,48 @@ Var MemoryLayout.size has mangled name changing from 'static Swift.MemoryLayout.
 Var MemoryLayout.size is now with @_preInverseGenerics
 Var MemoryLayout.stride has mangled name changing from 'static Swift.MemoryLayout.stride : Swift.Int' to 'static (extension in Swift):Swift.MemoryLayout< where A: ~Swift.Copyable, A: ~Swift.Escapable>.stride : Swift.Int'
 Var MemoryLayout.stride is now with @_preInverseGenerics
-Var UnsafeBufferPointer._position has mangled name changing from 'Swift.UnsafeBufferPointer._position : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>._position : Swift.Optional<Swift.UnsafePointer<A>>'
+Var UnsafeBufferPointer._position has mangled name changing from 'Swift.UnsafeBufferPointer._position : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._position : Swift.Optional<Swift.UnsafePointer<A>>'
 Var UnsafeBufferPointer._position is now with @_preInverseGenerics
-Var UnsafeBufferPointer.baseAddress has mangled name changing from 'Swift.UnsafeBufferPointer.baseAddress : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.baseAddress : Swift.Optional<Swift.UnsafePointer<A>>'
+Var UnsafeBufferPointer.baseAddress has mangled name changing from 'Swift.UnsafeBufferPointer.baseAddress : Swift.Optional<Swift.UnsafePointer<A>>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.baseAddress : Swift.Optional<Swift.UnsafePointer<A>>'
 Var UnsafeBufferPointer.baseAddress is now with @_preInverseGenerics
-Var UnsafeBufferPointer.count has mangled name changing from 'Swift.UnsafeBufferPointer.count : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.count : Swift.Int'
+Var UnsafeBufferPointer.count has mangled name changing from 'Swift.UnsafeBufferPointer.count : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.count : Swift.Int'
 Var UnsafeBufferPointer.count is now with @_preInverseGenerics
-Var UnsafeBufferPointer.endIndex has mangled name changing from 'Swift.UnsafeBufferPointer.endIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.endIndex : Swift.Int'
+Var UnsafeBufferPointer.endIndex has mangled name changing from 'Swift.UnsafeBufferPointer.endIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.endIndex : Swift.Int'
 Var UnsafeBufferPointer.endIndex is now with @_preInverseGenerics
-Var UnsafeBufferPointer.startIndex has mangled name changing from 'Swift.UnsafeBufferPointer.startIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.startIndex : Swift.Int'
+Var UnsafeBufferPointer.startIndex has mangled name changing from 'Swift.UnsafeBufferPointer.startIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.startIndex : Swift.Int'
 Var UnsafeBufferPointer.startIndex is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer._position has mangled name changing from 'Swift.UnsafeMutableBufferPointer._position : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>._position : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Var UnsafeMutableBufferPointer._position has mangled name changing from 'Swift.UnsafeMutableBufferPointer._position : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._position : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
 Var UnsafeMutableBufferPointer._position is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer.baseAddress has mangled name changing from 'Swift.UnsafeMutableBufferPointer.baseAddress : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.baseAddress : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
+Var UnsafeMutableBufferPointer.baseAddress has mangled name changing from 'Swift.UnsafeMutableBufferPointer.baseAddress : Swift.Optional<Swift.UnsafeMutablePointer<A>>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.baseAddress : Swift.Optional<Swift.UnsafeMutablePointer<A>>'
 Var UnsafeMutableBufferPointer.baseAddress is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer.count has mangled name changing from 'Swift.UnsafeMutableBufferPointer.count : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.count : Swift.Int'
+Var UnsafeMutableBufferPointer.count has mangled name changing from 'Swift.UnsafeMutableBufferPointer.count : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.count : Swift.Int'
 Var UnsafeMutableBufferPointer.count is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer.endIndex has mangled name changing from 'Swift.UnsafeMutableBufferPointer.endIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.endIndex : Swift.Int'
+Var UnsafeMutableBufferPointer.endIndex has mangled name changing from 'Swift.UnsafeMutableBufferPointer.endIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.endIndex : Swift.Int'
 Var UnsafeMutableBufferPointer.endIndex is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer.startIndex has mangled name changing from 'Swift.UnsafeMutableBufferPointer.startIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.startIndex : Swift.Int'
+Var UnsafeMutableBufferPointer.startIndex has mangled name changing from 'Swift.UnsafeMutableBufferPointer.startIndex : Swift.Int' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.startIndex : Swift.Int'
 Var UnsafeMutableBufferPointer.startIndex is now with @_preInverseGenerics
 Var UnsafeMutablePointer._cVarArgEncoding has mangled name changing from 'Swift.UnsafeMutablePointer._cVarArgEncoding : Swift.Array<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._cVarArgEncoding : Swift.Array<Swift.Int>'
 Var UnsafeMutablePointer._cVarArgEncoding is now with @_preInverseGenerics
-Var UnsafeMutablePointer._max has mangled name changing from 'static Swift.UnsafeMutablePointer._max : Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._max : Swift.UnsafeMutablePointer<A>'
+Var UnsafeMutablePointer._max has mangled name changing from 'static Swift.UnsafeMutablePointer._max : Swift.UnsafeMutablePointer<A>' to 'static (extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._max : Swift.UnsafeMutablePointer<A>'
 Var UnsafeMutablePointer._max is now with @_preInverseGenerics
-Var UnsafeMutablePointer._rawValue has mangled name changing from 'Swift.UnsafeMutablePointer._rawValue : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>._rawValue : Builtin.RawPointer'
+Var UnsafeMutablePointer._rawValue has mangled name changing from 'Swift.UnsafeMutablePointer._rawValue : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._rawValue : Builtin.RawPointer'
 Var UnsafeMutablePointer._rawValue is now with @_preInverseGenerics
-Var UnsafeMutablePointer.hashValue has mangled name changing from 'Swift.UnsafeMutablePointer.hashValue : Swift.Int' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable>.hashValue : Swift.Int'
+Var UnsafeMutablePointer.hashValue has mangled name changing from 'Swift.UnsafeMutablePointer.hashValue : Swift.Int' to '(extension in Swift):Swift.UnsafeMutablePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.hashValue : Swift.Int'
 Var UnsafeMutablePointer.hashValue is now with @_preInverseGenerics
 Var UnsafeMutablePointer.pointee has been removed
 Var UnsafePointer._cVarArgEncoding has mangled name changing from 'Swift.UnsafePointer._cVarArgEncoding : Swift.Array<Swift.Int>' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._cVarArgEncoding : Swift.Array<Swift.Int>'
 Var UnsafePointer._cVarArgEncoding is now with @_preInverseGenerics
-Var UnsafePointer._max has mangled name changing from 'static Swift.UnsafePointer._max : Swift.UnsafePointer<A>' to 'static (extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._max : Swift.UnsafePointer<A>'
+Var UnsafePointer._max has mangled name changing from 'static Swift.UnsafePointer._max : Swift.UnsafePointer<A>' to 'static (extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._max : Swift.UnsafePointer<A>'
 Var UnsafePointer._max is now with @_preInverseGenerics
-Var UnsafePointer._rawValue has mangled name changing from 'Swift.UnsafePointer._rawValue : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>._rawValue : Builtin.RawPointer'
+Var UnsafePointer._rawValue has mangled name changing from 'Swift.UnsafePointer._rawValue : Builtin.RawPointer' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>._rawValue : Builtin.RawPointer'
 Var UnsafePointer._rawValue is now with @_preInverseGenerics
-Var UnsafePointer.hashValue has mangled name changing from 'Swift.UnsafePointer.hashValue : Swift.Int' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>.hashValue : Swift.Int'
+Var UnsafePointer.hashValue has mangled name changing from 'Swift.UnsafePointer.hashValue : Swift.Int' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.hashValue : Swift.Int'
 Var UnsafePointer.hashValue is now with @_preInverseGenerics
 Var UnsafePointer.pointee has been removed
-Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.debugDescription.getter : Swift.String'
-Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.debugDescription.getter : Swift.String'
+Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.debugDescription.getter : Swift.String'
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.debugDescription.getter : Swift.String'
 Constructor OpaquePointer.init(_:) has mangled name changing from 'Swift.OpaquePointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.OpaquePointer>' to 'Swift.OpaquePointer.init<A where A: ~Swift.Copyable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.OpaquePointer>'
 Constructor OpaquePointer.init(_:) has mangled name changing from 'Swift.OpaquePointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.OpaquePointer' to 'Swift.OpaquePointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutablePointer<A>) -> Swift.OpaquePointer'
 Func Optional.flatMap(_:) has been removed
@@ -817,9 +819,9 @@ Func Result.flatMap(_:) has been removed
 Func Result.flatMapError(_:) has been removed
 Func Result.map(_:) has been removed
 Func withExtendedLifetime(_:_:) has been removed
-Var UnsafeBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.debugDescription : Swift.String'
+Var UnsafeBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.debugDescription : Swift.String'
 Var UnsafeBufferPointer.debugDescription is now with @_preInverseGenerics
-Var UnsafeMutableBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.debugDescription : Swift.String'
+Var UnsafeMutableBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.debugDescription : Swift.String'
 Var UnsafeMutableBufferPointer.debugDescription is now with @_preInverseGenerics
 Func _isPOD(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Func _isPOD(_:) has mangled name changing from 'Swift._isPOD<A>(A.Type) -> Swift.Bool' to 'Swift._isPOD<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(A.Type) -> Swift.Bool'
@@ -901,13 +903,13 @@ Accessor Optional._unsafelyUnwrappedUnchecked.Get() has generic signature change
 Accessor Optional._unsafelyUnwrappedUnchecked.Get() has mangled name changing from 'Swift.Optional._unsafelyUnwrappedUnchecked.getter : A' to '(extension in Swift):Swift.Optional< where A: ~Swift.Escapable>._unsafelyUnwrappedUnchecked.getter : A'
 Var Optional._unsafelyUnwrappedUnchecked has mangled name changing from 'Swift.Optional._unsafelyUnwrappedUnchecked : A' to '(extension in Swift):Swift.Optional< where A: ~Swift.Escapable>._unsafelyUnwrappedUnchecked : A'
 Var Optional._unsafelyUnwrappedUnchecked is now with @_preInverseGenerics
-Accessor UnsafeBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeBufferPointer.indices.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.indices.getter : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.indices.getter : Swift.Range<Swift.Int>'
-Var UnsafeBufferPointer.indices has mangled name changing from 'Swift.UnsafeBufferPointer.indices : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.indices : Swift.Range<Swift.Int>'
+Accessor UnsafeBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeBufferPointer.indices.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.indices.getter : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.indices.getter : Swift.Range<Swift.Int>'
+Var UnsafeBufferPointer.indices has mangled name changing from 'Swift.UnsafeBufferPointer.indices : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.indices : Swift.Range<Swift.Int>'
 Var UnsafeBufferPointer.indices is now with @_preInverseGenerics
-Accessor UnsafeMutableBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
-Accessor UnsafeMutableBufferPointer.indices.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.indices.getter : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.indices.getter : Swift.Range<Swift.Int>'
-Var UnsafeMutableBufferPointer.indices has mangled name changing from 'Swift.UnsafeMutableBufferPointer.indices : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.indices : Swift.Range<Swift.Int>'
+Accessor UnsafeMutableBufferPointer.indices.Get() has generic signature change from <Element> to <Element where Element : ~Copyable, Element : ~Escapable>
+Accessor UnsafeMutableBufferPointer.indices.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.indices.getter : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.indices.getter : Swift.Range<Swift.Int>'
+Var UnsafeMutableBufferPointer.indices has mangled name changing from 'Swift.UnsafeMutableBufferPointer.indices : Swift.Range<Swift.Int>' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable, A: ~Swift.Escapable>.indices : Swift.Range<Swift.Int>'
 Var UnsafeMutableBufferPointer.indices is now with @_preInverseGenerics
 Func !=(_:_:) has been removed
 Func ==(_:_:) has been removed


### PR DESCRIPTION
Allow unsafe pointer to access a ~Escapable Pointee.

This is a placeholder for review and to drive implementation of compiler Builtins. I suspect @lorentey will ultimately have a PR with the standard library additions.