### PR TITLE
[unittests] Fix compilation of Runtime unittests

### DIFF
--- a/unittests/runtime/CompatibilityOverrideRuntime.cpp
+++ b/unittests/runtime/CompatibilityOverrideRuntime.cpp
@@ -12,7 +12,7 @@
 
 #if defined(__APPLE__) && defined(__MACH__)
 
-#define SWIFT_TARGET_LIBRARY_NAME swiftRuntime
+#define SWIFT_TARGET_LIBRARY_NAME swiftRuntimeCore
 
 #include "../../stdlib/public/CompatibilityOverride/CompatibilityOverride.h"
 #include "swift/Runtime/Casting.h"
@@ -55,14 +55,14 @@ namespace  {
 
 struct OverrideSection {
   uintptr_t version;
-  
+
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
 #include "../../stdlib/public/CompatibilityOverride/CompatibilityOverrideRuntime.def"
 };
 
 OverrideSection RuntimeOverrides
-    __attribute__((section("__DATA," COMPATIBILITY_OVERRIDE_SECTION_NAME_swiftRuntime))) = {
+    __attribute__((section("__DATA," COMPATIBILITY_OVERRIDE_SECTION_NAME_swiftRuntimeCore))) = {
         0,
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   name ## Override,


### PR DESCRIPTION
PR#78516 performed a rename from `swiftRuntime` to `swiftRuntimeCore` but might have skipped these two instances because the code is rarely compiled in Darwin platforms (and it is not compiled in Linux/Windows platforms either). The code on the runtime unittests seems to be associated with the SDK overlays being built (either static or dynamic), which none are for Darwin platforms by default. Other platforms should build the dynamic SDK overlay, but the file is surrounded with checks for `__APPLE__` and `__MACH__`.

The normal CI would never hit this file, but someone might while building the static or dynamic SDK overlay if they so request it to the `build-script`.

