### PR TITLE
[ObjC][GenDecl] Emit ObjC properties in __objc_methname section

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1065,7 +1065,7 @@ void IRGenModule::SetCStringLiteralSection(llvm::GlobalVariable *GV,
       GV->setSection("__TEXT,__objc_methtype,cstring_literals");
       return;
     case ObjCLabelType::PropertyName:
-      GV->setSection("__TEXT,__cstring,cstring_literals");
+      GV->setSection("__TEXT,__objc_methname,cstring_literals");
       return;
     }
   case llvm::Triple::ELF:


### PR DESCRIPTION
Clang emits ObjC properties in the `__TEXT__objc_methname` section.

https://github.com/llvm/llvm-project/blob/d5e7c27d53887e6ae490d8e26193a54987728458/clang/lib/CodeGen/CGObjCMac.cpp#L4056-L4072

This change was made in https://github.com/llvm/llvm-project/commit/75af694a6da5157cc6a688c2fa77ff5200f46e11 to allow property names to be deduplicated with their method names.

This could also improve page faults during startup due to better grouping of types of strings to their specific sections. Basically, it moves method names out of the `__cstring` section so strings are more compact and thus more efficient with respect to memory pages.