### PR TITLE
[cxx-interop] Refactor copyability out of CxxRecordSemantics

### DIFF
--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -45,6 +45,9 @@ SWIFT_REQUEST(ClangImporter, CustomRefCountingOperation,
 SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
               CxxEscapability(EscapabilityLookupDescriptor), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, CxxValueSemantics,
+              CxxValueSemanticsKind(CxxValueSemanticsDescriptor), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
               ExplicitSafety(CxxDeclExplicitSafetyDescriptor), Cached,
               NoLocationInfo)


### PR DESCRIPTION
`CxxRecordSemantics` determines how C++ APIs are imported to Swift, e.g., as owned, reference or iterator types. Since this is orthogonal to importing a type as copyable or move-only, we separate `CxxRecordSemantics` from `CxxValueSemantics`.