### PR TITLE
AST: Introduce an "always enabled" custom availability domain kind

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -226,11 +226,12 @@ public:
 
   /// Returns true if this domain is considered active in the current
   /// compilation context.
-  bool isActive(const ASTContext &ctx) const;
+  bool isActive(const ASTContext &ctx, bool forTargetVariant = false) const;
 
   /// Returns true if this domain is a platform domain and is considered active
   /// in the current compilation context.
-  bool isActivePlatform(const ASTContext &ctx) const;
+  bool isActivePlatform(const ASTContext &ctx,
+                        bool forTargetVariant = false) const;
 
   /// Returns the domain's minimum available range for type checking. For
   /// example, for the domain of the platform that compilation is targeting,
@@ -332,6 +333,9 @@ public:
   enum class Kind {
     /// A domain that is known to be enabled at compile time.
     Enabled,
+    /// A domain that is known to be enabled at compile time and is also assumed
+    /// to be enabled for all deployments.
+    AlwaysEnabled,
     /// A domain that is known to be disabled at compile time.
     Disabled,
     /// A domain with an enablement state that must be queried at runtime.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -615,6 +615,8 @@ public:
   struct CustomAvailabilityDomains {
     /// Domains defined with `-define-enabled-availability-domain=`.
     llvm::SmallVector<std::string> EnabledDomains;
+    /// Domains defined with `-define-always-enabled-availability-domain=`.
+    llvm::SmallVector<std::string> AlwaysEnabledDomains;
     /// Domains defined with `-define-disabled-availability-domain=`.
     llvm::SmallVector<std::string> DisabledDomains;
     /// Domains defined with `-define-dynamic-availability-domain=`.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -576,6 +576,14 @@ def define_enabled_availability_domain : Separate<["-"], "define-enabled-availab
     HelpText<"Defines a custom availability domain that is available at compile time">,
     MetaVarName<"<domain>">;
 
+def define_always_enabled_availability_domain
+    : Separate<["-"], "define-always-enabled-availability-domain">,
+      Flags<[HelpHidden, FrontendOption, NoInteractiveOption,
+             ModuleInterfaceOptionIgnorable]>,
+      HelpText<"Defines a custom availability domain that is available for all "
+               "deployments">,
+      MetaVarName<"<domain>">;
+
 def define_disabled_availability_domain : Separate<["-"], "define-disabled-availability-domain">,
     Flags<[HelpHidden, FrontendOption, NoInteractiveOption, ModuleInterfaceOptionIgnorable]>,
     HelpText<"Defines a custom availability domain that is unavailable at compile time">,

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -33,6 +33,7 @@ getCustomDomainKind(clang::FeatureAvailKind featureAvailKind) {
     return CustomAvailabilityDomain::Kind::Disabled;
   case clang::FeatureAvailKind::Dynamic:
     return CustomAvailabilityDomain::Kind::Dynamic;
+  // FIXME: [availability] Add support for AlwaysEnabled.
   default:
     llvm::report_fatal_error("unexpected kind");
   }
@@ -53,6 +54,7 @@ customDomainForClangDecl(ValueDecl *decl) {
     return nullptr;
 
   // Check that the domain has a supported availability kind.
+  // FIXME: [availability] Add support for AlwaysEnabled.
   switch (featureInfo.second.Kind) {
   case clang::FeatureAvailKind::Available:
   case clang::FeatureAvailKind::Unavailable:
@@ -181,7 +183,8 @@ bool AvailabilityDomain::supportsQueries() const {
   }
 }
 
-bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
+bool AvailabilityDomain::isActive(const ASTContext &ctx,
+                                  bool forTargetVariant) const {
   switch (getKind()) {
   case Kind::Universal:
   case Kind::SwiftLanguage:
@@ -189,7 +192,7 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   case Kind::Embedded:
     return true;
   case Kind::Platform:
-    return isPlatformActive(getPlatformKind(), ctx.LangOpts);
+    return isPlatformActive(getPlatformKind(), ctx.LangOpts, forTargetVariant);
   case Kind::Custom:
     // For now, custom domains are always active but it's conceivable that in
     // the future someone might want to define a domain but leave it inactive.
@@ -197,11 +200,12 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   }
 }
 
-bool AvailabilityDomain::isActivePlatform(const ASTContext &ctx) const {
+bool AvailabilityDomain::isActivePlatform(const ASTContext &ctx,
+                                          bool forTargetVariant) const {
   if (!isPlatform())
     return false;
 
-  return isActive(ctx);
+  return isActive(ctx, forTargetVariant);
 }
 
 static std::optional<llvm::VersionTuple>
@@ -224,8 +228,23 @@ getDeploymentVersion(const AvailabilityDomain &domain, const ASTContext &ctx) {
 
 std::optional<AvailabilityRange>
 AvailabilityDomain::getDeploymentRange(const ASTContext &ctx) const {
-  if (auto version = getDeploymentVersion(*this, ctx))
-    return AvailabilityRange{*version};
+  if (isVersioned()) {
+    if (auto version = getDeploymentVersion(*this, ctx))
+      return AvailabilityRange{*version};
+
+    return std::nullopt;
+  }
+
+  if (auto customDomain = getCustomDomain()) {
+    switch (customDomain->getKind()) {
+    case CustomAvailabilityDomain::Kind::AlwaysEnabled:
+      return AvailabilityRange::alwaysAvailable();
+    case CustomAvailabilityDomain::Kind::Enabled:
+    case CustomAvailabilityDomain::Kind::Disabled:
+    case CustomAvailabilityDomain::Kind::Dynamic:
+      return std::nullopt;
+    }
+  }
   return std::nullopt;
 }
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -33,7 +33,8 @@ getCustomDomainKind(clang::FeatureAvailKind featureAvailKind) {
     return CustomAvailabilityDomain::Kind::Disabled;
   case clang::FeatureAvailKind::Dynamic:
     return CustomAvailabilityDomain::Kind::Dynamic;
-  // FIXME: [availability] Add support for AlwaysEnabled.
+  case clang::FeatureAvailKind::AlwaysAvailable:
+    return CustomAvailabilityDomain::Kind::AlwaysEnabled;
   default:
     llvm::report_fatal_error("unexpected kind");
   }
@@ -54,11 +55,11 @@ customDomainForClangDecl(ValueDecl *decl) {
     return nullptr;
 
   // Check that the domain has a supported availability kind.
-  // FIXME: [availability] Add support for AlwaysEnabled.
   switch (featureInfo.second.Kind) {
   case clang::FeatureAvailKind::Available:
   case clang::FeatureAvailKind::Unavailable:
   case clang::FeatureAvailKind::Dynamic:
+  case clang::FeatureAvailKind::AlwaysAvailable:
     break;
   default:
     return nullptr;

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -881,6 +881,7 @@ private:
 
       switch (customDomain->getKind()) {
       case CustomAvailabilityDomain::Kind::Enabled:
+      case CustomAvailabilityDomain::Kind::AlwaysEnabled:
         return AvailabilityQuery::constant(domain, true);
       case CustomAvailabilityDomain::Kind::Disabled:
         return AvailabilityQuery::constant(domain, false);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -586,6 +586,7 @@ bool ArgsToFrontendOptionsConverter::computeAvailabilityDomains() {
 
   for (const Arg *A :
        Args.filtered_reverse(OPT_define_enabled_availability_domain,
+                             OPT_define_always_enabled_availability_domain,
                              OPT_define_disabled_availability_domain,
                              OPT_define_dynamic_availability_domain)) {
     std::string domain = A->getValue();
@@ -602,6 +603,8 @@ bool ArgsToFrontendOptionsConverter::computeAvailabilityDomains() {
     auto &option = A->getOption();
     if (option.matches(OPT_define_enabled_availability_domain))
       Opts.AvailabilityDomains.EnabledDomains.emplace_back(domain);
+    if (option.matches(OPT_define_always_enabled_availability_domain))
+      Opts.AvailabilityDomains.AlwaysEnabledDomains.emplace_back(domain);
     else if (option.matches(OPT_define_disabled_availability_domain))
       Opts.AvailabilityDomains.DisabledDomains.emplace_back(domain);
     else if (option.matches(OPT_define_dynamic_availability_domain))

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1455,6 +1455,9 @@ static void configureAvailabilityDomains(const ASTContext &ctx,
 
   for (auto enabled : opts.AvailabilityDomains.EnabledDomains)
     createAndInsertDomain(enabled, CustomAvailabilityDomain::Kind::Enabled);
+  for (auto alwaysEnabled : opts.AvailabilityDomains.AlwaysEnabledDomains)
+    createAndInsertDomain(alwaysEnabled,
+                          CustomAvailabilityDomain::Kind::AlwaysEnabled);
   for (auto disabled : opts.AvailabilityDomains.DisabledDomains)
     createAndInsertDomain(disabled, CustomAvailabilityDomain::Kind::Disabled);
   for (auto dynamic : opts.AvailabilityDomains.DynamicDomains)

--- a/test/ClangImporter/Inputs/availability_custom_domains_other.swift
+++ b/test/ClangImporter/Inputs/availability_custom_domains_other.swift
@@ -9,4 +9,26 @@ func availableInMediterranean() { }
 func testOtherClangDecls() { // expected-note {{add '@available' attribute to enclosing global function}}
   available_in_baltic() // expected-error {{'available_in_baltic()' is only available in Baltic}}
   // expected-note@-1 {{add 'if #available' version check}}
+  available_in_bering() // ok, Bering is always available
+  unavailable_in_bering() // expected-error {{'unavailable_in_bering()' is unavailable}}
+}
+
+@available(Baltic)
+func availableInBalticOther() {
+  available_in_baltic()
+  available_in_bering() // ok, Bering is always available
+  unavailable_in_bering() // expected-error {{'unavailable_in_bering()' is unavailable}}
+}
+
+@available(Bering)
+func availableInBering() { // expected-note {{add '@available' attribute to enclosing global function}}
+  available_in_baltic() // expected-error {{'available_in_baltic()' is only available in Baltic}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  available_in_bering()
+  unavailable_in_bering() // expected-error {{'unavailable_in_bering()' is unavailable}}
+}
+
+@available(Bering, unavailable)
+func unavailableInBering() {
+  unavailable_in_bering()
 }

--- a/test/IRGen/availability_custom_domains.swift
+++ b/test/IRGen/availability_custom_domains.swift
@@ -1,12 +1,14 @@
 // RUN: %target-swift-emit-irgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
 // RUN:   -Onone | %FileCheck %s --check-prefixes=CHECK
 
 // RUN: %target-swift-emit-irgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
 // RUN:   -O | %FileCheck %s --check-prefixes=CHECK
 
@@ -29,6 +31,17 @@ public func ifAvailableEnabledDomain() {
   }
 }
 
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test30ifAvailableAlwaysEnabledDomainyyF"()
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+public func ifAvailableAlwaysEnabledDomain() {
+  if #available(AlwaysEnabledDomain) {
+    always()
+  } else {
+    never()
+  }
+}
+
 // CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
 // CHECK: call swiftcc void @always()
@@ -44,6 +57,17 @@ public func ifAvailableDisabledDomain() {
 // CHECK-NOT: call swiftcc void @never()
 // CHECK: call swiftcc void @always()
 public func ifUnavailableEnabledDomain() {
+  if #unavailable(EnabledDomain) {
+    never()
+  } else {
+    always()
+  }
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test32ifUnavailableAlwaysEnabledDomainyyF"()
+// CHECK-NOT: call swiftcc void @never()
+// CHECK: call swiftcc void @always()
+public func ifUnavailableAlwaysEnabledDomain() {
   if #unavailable(EnabledDomain) {
     never()
   } else {

--- a/test/Inputs/custom-modules/availability-domains/Seas.h
+++ b/test/Inputs/custom-modules/availability-domains/Seas.h
@@ -3,6 +3,7 @@
 int aegean_pred(void);
 
 CLANG_ENABLED_AVAILABILITY_DOMAIN(Baltic);
+CLANG_ALWAYS_ENABLED_AVAILABILITY_DOMAIN(Bering);
 CLANG_DISABLED_AVAILABILITY_DOMAIN(Mediterranean);
 CLANG_DYNAMIC_AVAILABILITY_DOMAIN(Aegean, aegean_pred);
 
@@ -11,6 +12,12 @@ CLANG_DYNAMIC_AVAILABILITY_DOMAIN(Aegean, aegean_pred);
 
 __attribute__((availability(domain:Baltic, AVAIL)))
 void available_in_baltic(void);
+
+__attribute__((availability(domain:Bering, AVAIL)))
+void available_in_bering(void);
+
+__attribute__((availability(domain:Bering, UNAVAIL)))
+void unavailable_in_bering(void);
 
 #undef UNAVAIL
 #undef AVAIL

--- a/test/SILGen/availability_query_custom_domains.swift
+++ b/test/SILGen/availability_query_custom_domains.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-silgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
 // RUN:   -define-dynamic-availability-domain DynamicDomain \
 // RUN:   | %FileCheck %s
@@ -12,6 +13,12 @@ public func availableInEnabledDomain() { }
 
 @available(EnabledDomain, unavailable)
 public func unavailableInEnabledDomain() { }
+
+@available(AlwaysEnabledDomain)
+public func availableInAlwaysEnabledDomain() { }
+
+@available(AlwaysEnabledDomain, unavailable)
+public func unavailableInAlwaysEnabledDomain() { }
 
 @available(DisabledDomain)
 public func availableInDisabledDomain() { }
@@ -62,6 +69,44 @@ public func testIfUnavailableEnabledDomain() {
   }
 }
 // CHECK: end sil function '$s4Test30testIfUnavailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test34testIfAvailableAlwaysEnabledDomainyyF : $@convention(thin) () -> ()
+public func testIfAvailableAlwaysEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test30availableInAlwaysEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test32unavailableInAlwaysEnabledDomainyyF
+  if #available(AlwaysEnabledDomain) {
+    availableInAlwaysEnabledDomain()
+  } else {
+    unavailableInAlwaysEnabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test34testIfAvailableAlwaysEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test36testIfUnavailableAlwaysEnabledDomainyyF : $@convention(thin) () -> ()
+public func testIfUnavailableAlwaysEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test32unavailableInAlwaysEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test30availableInAlwaysEnabledDomainyyF
+  if #unavailable(AlwaysEnabledDomain) {
+    unavailableInAlwaysEnabledDomain()
+  } else {
+    availableInAlwaysEnabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test36testIfUnavailableAlwaysEnabledDomainyyF'
 
 // CHECK-LABEL: sil{{.*}}$s4Test29testIfAvailableDisabledDomainyyF : $@convention(thin) () -> ()
 public func testIfAvailableDisabledDomain() {

--- a/test/SILGen/unavailable_decl_custom_domain.swift
+++ b/test/SILGen/unavailable_decl_custom_domain.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-silgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
 // RUN:   -define-dynamic-availability-domain DynamicDomain \
 // RUN:   | %FileCheck %s --check-prefixes=CHECK,CHECK-NOOPT
@@ -8,6 +9,7 @@
 // RUN: %target-swift-emit-silgen -module-name Test %s -verify \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:   -define-disabled-availability-domain DisabledDomain \
 // RUN:   -define-dynamic-availability-domain DynamicDomain \
 // RUN:   -unavailable-decl-optimization=complete \
@@ -25,6 +27,14 @@ public func availableInEnabledDomain() { }
 // CHECK-NOT: s4Test26unavailableInEnabledDomainyyF
 @available(EnabledDomain, unavailable)
 public func unavailableInEnabledDomain() { }
+
+// CHECK: s4Test30availableInAlwaysEnabledDomainyyF
+@available(AlwaysEnabledDomain)
+public func availableInAlwaysEnabledDomain() { }
+
+// CHECK-NOT: s4Test32unavailableInAlwaysEnabledDomainyyF
+@available(AlwaysEnabledDomain, unavailable)
+public func unavailableInAlwaysEnabledDomain() { }
 
 // CHECK-NOT: s4Test25availableInDisabledDomainyyF
 @available(DisabledDomain)

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:  -enable-experimental-feature CustomAvailability \
 // RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-always-enabled-availability-domain AlwaysEnabledDomain \
 // RUN:  -define-enabled-availability-domain RedefinedDomain \
 // RUN:  -define-disabled-availability-domain DisabledDomain \
 // RUN:  -define-dynamic-availability-domain DynamicDomain \
@@ -22,6 +23,9 @@ func availableInEnabledDomainWithWildcard() { }
 @available(EnabledDomain, introduced: 1.0) // expected-error {{unexpected version number for EnabledDomain}}
 func introducedInEnabledDomain() { }
 
+@available(AlwaysEnabledDomain, introduced: 1.0) // expected-error {{unexpected version number for AlwaysEnabledDomain}}
+func introducedInAlwaysEnabledDomain() { }
+
 @available(EnabledDomain 1.0) // expected-error {{unexpected version number for EnabledDomain}}
 func introducedInEnabledDomainShort() { }
 
@@ -30,6 +34,9 @@ func introducedInEnabledDomainShortWithWildcard() { }
 
 @available(macOS 10.10, EnabledDomain, *) // expected-error {{EnabledDomain availability must be specified alone}}
 func introducedInMacOSAndAvailableInEnabledDomain() { }
+
+@available(macOS 10.10, AlwaysEnabledDomain, *) // expected-error {{AlwaysEnabledDomain availability must be specified alone}}
+func introducedInMacOSAndAvailableInAlwaysEnabledDomain() { }
 
 @available(EnabledDomain, macOS 10.10, *) // expected-error {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
 // expected-error@-1 {{expected declaration}}


### PR DESCRIPTION
An always enabled availability domain is implicitly available in all contexts, so uses of declarations that are marked as `@available` in the domain are never rejected. This is useful for an availability domain representing a feature flag that has become permanently enabled.

Resolves rdar://157593409.