### PR TITLE
SwiftShims: `memcmp` parameters should be `_Nonnull` on Apple platforms

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -60,11 +60,8 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
-#if defined(__APPLE__)
-  // Darwin defines memcmp with optional pointers, preserve the same type here.
-  extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
 // FIXME: Is there a way to identify Glibc specifically?
-#elif (defined(__gnu_linux__) || defined(__ANDROID__)) && !defined(__musl__)
+#if (defined(__APPLE__) || defined(__gnu_linux__) || defined(__ANDROID__)) && !defined(__musl__)
   extern int memcmp(const void * _Nonnull, const void * _Nonnull, __swift_size_t);
 #else
   extern int memcmp(const void * _Null_unspecified, const void * _Null_unspecified, __swift_size_t);


### PR DESCRIPTION
Fix the `SwiftShims` local declaration of `memcmp` for its parameters to have the same optionality as the SDK version. They should be `_Nonnull` to mirror the `_string` version. This helps the compiler using both the `SwiftShims` and SDK versions interchangeably which avoids compiler crashes.

Follow-up to https://github.com/swiftlang/swift/pull/77964 which wasn't quite right.

rdar://140596571