### PR TITLE
[6.2] Isolation fixes for closures and defer bodies

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -28,6 +28,7 @@ class raw_ostream;
 
 namespace swift {
 class DeclContext;
+class Initializer;
 class ModuleDecl;
 class VarDecl;
 class NominalTypeDecl;
@@ -433,6 +434,10 @@ InferredActorIsolation getInferredActorIsolation(ValueDecl *value);
 /// Trampoline for AbstractClosureExpr::getActorIsolation.
 ActorIsolation
 __AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE);
+
+/// Determine how the given initialization context is isolated.
+ActorIsolation getActorIsolation(Initializer *init,
+                                 bool ignoreDefaultArguments = false);
 
 /// Determine how the given declaration context is isolated.
 /// \p getClosureActorIsolation allows the specification of actor isolation for

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3241,6 +3241,9 @@ public:
   /// `AbstractStorageDecl`, returns `false`.
   bool isAsync() const;
 
+  /// Returns whether this function represents a defer body.
+  bool isDeferBody() const;
+
 private:
   bool isObjCDynamic() const {
     return isObjC() && isDynamic();

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -38,6 +38,7 @@ namespace swift {
   enum class EffectsKind : uint8_t;
   class AbstractFunctionDecl;
   class AbstractClosureExpr;
+  class ActorIsolation;
   class ValueDecl;
   class FuncDecl;
   class ClosureExpr;
@@ -497,6 +498,8 @@ struct SILDeclRef {
     result.loc = decl;
     return result;
   }
+
+  ActorIsolation getActorIsolation() const;
 
   /// True if the decl ref references a thunk from a natively foreign
   /// declaration to Swift calling convention.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9405,7 +9405,18 @@ void ParamDecl::setDefaultExpr(Expr *E) {
 }
 
 void ParamDecl::setTypeCheckedDefaultExpr(Expr *E) {
-  assert(E || getDefaultArgumentKind() == DefaultArgumentKind::Inherited);
+  // The type-checker will only produce a null expression here if the
+  // default argument is inherited, so if we're called with a null pointer
+  // in any other case, it must be from a request cycle. Don't crash;
+  // just wrap the original expression with an ErrorExpr and proceed.
+  if (!E && getDefaultArgumentKind() != DefaultArgumentKind::Inherited) {
+    auto *initExpr = getStructuralDefaultExpr();
+    assert(initExpr);
+    auto &ctx = getASTContext();
+    E = new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx),
+                            initExpr);
+  }
+
   setDefaultExpr(E);
 
   auto *defaultInfo = DefaultValueAndFlags.getPointer();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12008,7 +12008,6 @@ ActorIsolation swift::getActorIsolationOfContext(
     DeclContext *dc,
     llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
-  auto &ctx = dc->getASTContext();
   auto dcToUse = dc;
 
   // Defer bodies share the actor isolation of their enclosing context.
@@ -12023,42 +12022,77 @@ ActorIsolation swift::getActorIsolationOfContext(
   if (auto *vd = dyn_cast_or_null<ValueDecl>(dcToUse->getAsDecl()))
     return getActorIsolation(vd);
 
-  // In the context of the initializing or default-value expression of a
-  // stored property:
-  //   - For a static stored property, the isolation matches the VarDecl.
-  //     Static properties are initialized upon first use, so the isolation
-  //     of the initializer must match the isolation required to access the
-  //     property.
-  //   - For a field of a nominal type, the expression can require the same
-  //     actor isolation as the field itself. That default expression may only
-  //     be used from inits that meet the required isolation.
-  if (auto *var = dcToUse->getNonLocalVarDecl()) {
-    // If IsolatedDefaultValues are enabled, treat this context as having
-    // unspecified isolation. We'll compute the required isolation for
-    // the initializer and validate that it matches the isolation of the
-    // var itself in the DefaultInitializerIsolation request.
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues))
-      return ActorIsolation::forUnspecified();
-
-    return getActorIsolation(var);
-  }
-
   if (auto *closure = dyn_cast<AbstractClosureExpr>(dcToUse)) {
     return getClosureActorIsolation(closure);
   }
 
+  if (auto *init = dyn_cast<Initializer>(dcToUse)) {
+    // FIXME: force default argument initializers to report a meaningless
+    // isolation in order to break a bunch of cycles with the way that
+    // isolation is computed for them.
+    return getActorIsolation(init, /*ignoreDefaultArguments*/ true);
+  }
+
   if (isa<TopLevelCodeDecl>(dcToUse)) {
+    auto &ctx = dc->getASTContext();
     if (dcToUse->isAsyncContext() ||
-        dcToUse->getASTContext().LangOpts.StrictConcurrencyLevel >=
-            StrictConcurrency::Complete) {
-      if (Type mainActor = dcToUse->getASTContext().getMainActorType())
+        ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete) {
+      if (Type mainActor = ctx.getMainActorType())
         return ActorIsolation::forGlobalActor(mainActor)
-            .withPreconcurrency(
-                !dcToUse->getASTContext().isSwiftVersionAtLeast(6));
+            .withPreconcurrency(!ctx.isSwiftVersionAtLeast(6));
     }
   }
 
   return ActorIsolation::forUnspecified();
+}
+
+ActorIsolation swift::getActorIsolation(Initializer *init,
+                                        bool ignoreDefaultArguments) {
+  switch (init->getInitializerKind()) {
+  case InitializerKind::PatternBinding:
+    // In the context of the initializing or default-value expression of a
+    // stored property:
+    //   - For a static stored property, the isolation matches the VarDecl.
+    //     Static properties are initialized upon first use, so the isolation
+    //     of the initializer must match the isolation required to access the
+    //     property.
+    //   - For a field of a nominal type, the expression can require the same
+    //     actor isolation as the field itself. That default expression may only
+    //     be used from inits that meet the required isolation.
+    if (auto *var = init->getNonLocalVarDecl()) {
+      auto &ctx = var->getASTContext();
+
+      // If IsolatedDefaultValues are enabled, treat this context as having
+      // unspecified isolation. We'll compute the required isolation for
+      // the initializer and validate that it matches the isolation of the
+      // var itself in the DefaultInitializerIsolation request.
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues))
+        return ActorIsolation::forUnspecified();
+
+      return getActorIsolation(var);
+    }
+
+    return ActorIsolation::forUnspecified();
+
+  case InitializerKind::DefaultArgument: {
+    auto defArgInit = cast<DefaultArgumentInitializer>(init);
+
+    // A hack when used from getActorIsolationOfContext to maintain the
+    // current behavior and avoid request cycles.
+    if (ignoreDefaultArguments)
+      return ActorIsolation::forUnspecified();
+
+    auto fn = cast<ValueDecl>(defArgInit->getParent()->getAsDecl());
+    auto param = getParameterAt(fn, defArgInit->getIndex());
+    assert(param);
+    return param->getInitializerIsolation();
+  }
+
+  case InitializerKind::PropertyWrapper:
+  case InitializerKind::CustomAttribute:
+    return ActorIsolation::forUnspecified();
+  }
+  llvm_unreachable("bad initializer kind");
 }
 
 bool swift::isSameActorIsolated(ValueDecl *value, DeclContext *dc) {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1873,3 +1873,21 @@ bool SILDeclRef::isCalleeAllocatedCoroutine() const {
 
   return getASTContext().SILOpts.CoroutineAccessorsUseYieldOnce2;
 }
+
+ActorIsolation SILDeclRef::getActorIsolation() const {
+  // Deallocating destructor is always nonisolated. Isolation of the deinit
+  // applies only to isolated deallocator and destroyer.
+  if (kind == SILDeclRef::Kind::Deallocator) {
+    return ActorIsolation::forNonisolated(false);
+  }
+
+  // Default argument generators use the isolation of the initializer,
+  // not the general isolation of the function.
+  if (isDefaultArgGenerator()) {
+    auto param = getParameterAt(getDecl(), defaultArgIndex);
+    assert(param);
+    return param->getInitializerIsolation();
+  }
+
+  return getActorIsolationOfContext(getInnermostDeclContext());
+}

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2419,32 +2419,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
   }
 
   if (constant) {
-    // TODO: It should to be possible to `getActorIsolation` if
-    // reference is to a decl instead of trying to get isolation
-    // from the reference kind, the attributes, or the context.
-
-    if (constant->kind == SILDeclRef::Kind::Deallocator) {
-      return ActorIsolation::forNonisolated(false);
-    }
-
-    if (auto *decl = constant->getAbstractFunctionDecl()) {
-      if (auto *nonisolatedAttr =
-              decl->getAttrs().getAttribute<NonisolatedAttr>()) {
-        if (nonisolatedAttr->isNonSending())
-          return ActorIsolation::forCallerIsolationInheriting();
-      }
-
-      if (decl->getAttrs().hasAttribute<ConcurrentAttr>()) {
-        return ActorIsolation::forNonisolated(false /*unsafe*/);
-      }
-    }
-
-    if (auto *closure = constant->getAbstractClosureExpr()) {
-      if (auto isolation = closure->getActorIsolation())
-        return isolation;
-    }
-
-    return getActorIsolationOfContext(constant->getInnermostDeclContext());
+    return constant->getActorIsolation();
   }
 
   if (substFnInterfaceType->hasExtInfo() &&

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1262,6 +1262,11 @@ public:
 
   ConventionsKind getKind() const { return kind; }
 
+  bool hasCallerIsolationParameter() const {
+    return kind == ConventionsKind::Default ||
+           kind == ConventionsKind::Deallocator;
+  }
+
   virtual ParameterConvention
   getIndirectParameter(unsigned index,
                        const AbstractionPattern &type,
@@ -1706,14 +1711,10 @@ private:
       };
     }
 
-    // If we are an async function that is unspecified or nonisolated, insert an
-    // isolated parameter if NonisolatedNonsendingByDefault is enabled.
-    //
-    // NOTE: The parameter is not inserted for async functions imported
-    // from ObjC because they are handled in a special way that doesn't
-    // require it.
+    // If the function has nonisolated(nonsending) isolation, insert the
+    // implicit isolation parameter.
     if (IsolationInfo && IsolationInfo->isCallerIsolationInheriting() &&
-        extInfoBuilder.isAsync() && !Foreign.async) {
+        Convs.hasCallerIsolationParameter()) {
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);
       auto actorType =
           ExistentialType::get(actorProtocol->getDeclaredInterfaceType());

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -768,32 +768,6 @@ static bool isEmittedOnDemand(SILModule &M, SILDeclRef constant) {
   return false;
 }
 
-static ActorIsolation getActorIsolationForFunction(SILFunction &fn) {
-  if (auto constant = fn.getDeclRef()) {
-    if (constant.kind == SILDeclRef::Kind::Deallocator) {
-      // Deallocating destructor is always nonisolated. Isolation of the deinit
-      // applies only to isolated deallocator and destroyer.
-      return ActorIsolation::forNonisolated(false);
-    }
-
-    // If we have a closure expr, check if our type is
-    // nonisolated(nonsending). In that case, we use that instead.
-    if (auto *closureExpr = constant.getAbstractClosureExpr()) {
-      if (auto actorIsolation = closureExpr->getActorIsolation())
-        return actorIsolation;
-    }
-
-    // If we have actor isolation for our constant, put the isolation onto the
-    // function. If the isolation is unspecified, we do not return it.
-    if (auto isolation =
-            getActorIsolationOfContext(constant.getInnermostDeclContext()))
-      return isolation;
-  }
-
-  // Otherwise, return for unspecified.
-  return ActorIsolation::forUnspecified();
-}
-
 SILFunction *SILGenModule::getFunction(SILDeclRef constant,
                                        ForDefinition_t forDefinition) {
   // If we already emitted the function, return it.
@@ -820,7 +794,7 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
       });
 
   F->setDeclRef(constant);
-  F->setActorIsolation(getActorIsolationForFunction(*F));
+  F->setActorIsolation(constant.getActorIsolation());
 
   assert(F && "SILFunction should have been defined");
 
@@ -1316,7 +1290,7 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   F->setDeclRef(constant);
 
   // Set our actor isolation.
-  F->setActorIsolation(getActorIsolationForFunction(*F));
+  F->setActorIsolation(constant.getActorIsolation());
 
   LLVM_DEBUG(llvm::dbgs() << "lowering ";
              F->printName(llvm::dbgs());

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -190,7 +190,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     }
 
     case ActorIsolation::CallerIsolationInheriting:
-      assert(F.isAsync());
+      assert(F.isAsync() || F.isDefer());
       setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
 
@@ -255,7 +255,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
           RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
           executor,
           /*mandatory*/ false);
-    } else {
+    } else if (wantDataRaceChecks) {
       // For a synchronous function, check that we're on the same executor.
       // Note: if we "know" that the code is completely Sendable-safe, this
       // is unnecessary. The type checker will need to make this determination.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2871,12 +2871,22 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
   ArgumentScope argScope(*this, loc);
 
-  SmallVector<ManagedValue, 4> captures;
+  SmallVector<ManagedValue, 4> args;
+
+  // Add the implicit leading isolation argument for a
+  // nonisolated(nonsending) default argument generator.
+  if (fnType->maybeGetIsolatedParameter()) {
+    auto executor = emitExpectedExecutor(loc);
+    args.push_back(emitActorInstanceIsolation(
+                     loc, executor, executor.getType().getASTType()));
+  }
+
+  // If there are captures, those come at the end.
   emitCaptures(loc, generator, CaptureEmission::ImmediateApplication,
-               captures);
+               args);
 
   return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef, subs,
-                   captures, calleeTypeInfo, ApplyOptions(), C, std::nullopt);
+                   args, calleeTypeInfo, ApplyOptions(), C, std::nullopt);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -7299,15 +7299,38 @@ RValue RValueEmitter::visitMacroExpansionExpr(MacroExpansionExpr *E,
   return RValue();
 }
 
+/// getActorIsolationOfContext doesn't return the right isolation for
+/// initializer contexts. Fixing that is a lot of work, so just
+/// hack around it for now here.
+static ActorIsolation getRealActorIsolationOfContext(DeclContext *DC) {
+  if (auto init = dyn_cast<Initializer>(DC)) {
+    return getActorIsolation(init);
+  } else {
+    return getActorIsolationOfContext(DC);
+  }
+}
+
 RValue RValueEmitter::visitCurrentContextIsolationExpr(
     CurrentContextIsolationExpr *E, SGFContext C) {
-  auto afd =
-    dyn_cast_or_null<AbstractFunctionDecl>(SGF.F.getDeclRef().getDecl());
-  if (afd) {
-    auto isolation = getActorIsolation(afd);
-    auto ctor = dyn_cast_or_null<ConstructorDecl>(afd);
+
+  auto isolation = getRealActorIsolationOfContext(SGF.FunctionDC);
+
+  if (isolation == ActorIsolation::CallerIsolationInheriting) {
+    auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
+    assert(isolatedArg &&
+           "Caller Isolation Inheriting without isolated parameter");
+    ManagedValue isolatedMV;
+    if (isolatedArg->getOwnershipKind() == OwnershipKind::Guaranteed) {
+      isolatedMV = ManagedValue::forBorrowedRValue(isolatedArg);
+    } else {
+      isolatedMV = ManagedValue::forUnmanagedOwnedValue(isolatedArg);
+    }
+    return RValue(SGF, E, isolatedMV);
+  }
+
+  if (isolation == ActorIsolation::ActorInstance) {
+    auto ctor = dyn_cast<ConstructorDecl>(SGF.FunctionDC);
     if (ctor && ctor->isDesignatedInit() &&
-        isolation == ActorIsolation::ActorInstance &&
         isolation.getActorInstance() == ctor->getImplicitSelfDecl()) {
       // If we are in an actor initializer that is isolated to self, the
       // current isolation is flow-sensitive; use that instead of the
@@ -7316,21 +7339,11 @@ RValue RValueEmitter::visitCurrentContextIsolationExpr(
         SGF.emitFlowSensitiveSelfIsolation(E, isolation);
       return RValue(SGF, E, isolationValue);
     }
-
-    if (isolation == ActorIsolation::CallerIsolationInheriting) {
-      auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
-      assert(isolatedArg &&
-             "Caller Isolation Inheriting without isolated parameter");
-      ManagedValue isolatedMV;
-      if (isolatedArg->getOwnershipKind() == OwnershipKind::Guaranteed) {
-        isolatedMV = ManagedValue::forBorrowedRValue(isolatedArg);
-      } else {
-        isolatedMV = ManagedValue::forUnmanagedOwnedValue(isolatedArg);
-      }
-      return RValue(SGF, E, isolatedMV);
-    }
   }
 
+  // Otherwise, just trust the underlying expression. We really don't
+  // need to do this at all --- we assume we can produce the isolation
+  // value from scratch in other situations --- but whatever.
   return visit(E->getActor(), C);
 }
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -66,6 +66,7 @@ class FindCapturedVars : public ASTWalker {
   DeclContext *CurDC;
   bool NoEscape, ObjC;
   bool HasGenericParamCaptures;
+  bool HasUsesOfCurrentIsolation = false;
 
 public:
   FindCapturedVars(SourceLoc CaptureLoc,
@@ -89,6 +90,10 @@ public:
                        OpaqueValue, HasGenericParamCaptures,
                        CapturedEnvironments.getArrayRef(),
                        CapturedTypes);
+  }
+
+  bool hasUsesOfCurrentIsolation() const {
+    return HasUsesOfCurrentIsolation;
   }
 
   bool hasGenericParamCaptures() const {
@@ -694,6 +699,31 @@ public:
       checkType(typeValue->getParamType(), E->getLoc());
     }
 
+    // Record that we saw an #isolation expression that hasn't been filled in.
+    if (auto currentIsolation = dyn_cast<CurrentContextIsolationExpr>(E)) {
+      if (!currentIsolation->getActor())
+        HasUsesOfCurrentIsolation = true;
+    }
+
+    // Record that we saw an apply of a function with caller isolation.
+    if (auto apply = dyn_cast<ApplyExpr>(E)) {
+      if (auto type = apply->getFn()->getType()) {
+        if (auto fnType = type->getAs<AnyFunctionType>();
+            fnType && fnType->getIsolation().isNonIsolatedCaller()) {
+          HasUsesOfCurrentIsolation = true;
+        }
+      }
+    }
+
+    // Look into caller-side default arguments.
+    if (auto defArg = dyn_cast<DefaultArgumentExpr>(E)) {
+      if (defArg->isCallerSide()) {
+        if (auto callerSideExpr = defArg->getCallerSideDefaultExpr()) {
+          callerSideExpr->walk(*this);
+        }
+      }
+    }
+
     return Action::Continue(E);
   }
 
@@ -748,12 +778,17 @@ public:
 /// Given that a local function is isolated to the given var, should we
 /// force a capture of the var?
 static bool shouldCaptureIsolationInLocalFunc(AbstractFunctionDecl *AFD,
-                                              VarDecl *var) {
+                                              VarDecl *var,
+                                              bool hasUsesOfCurrentIsolation) {
   assert(isa<ParamDecl>(var));
 
   // Don't try to capture an isolated parameter of the function itself.
   if (var->getDeclContext() == AFD)
     return false;
+
+  // Force capture if we have uses of the isolation in the function body.
+  if (hasUsesOfCurrentIsolation)
+    return true;
 
   // We only *need* to force a capture of the isolation in an async function
   // (in which case it's needed for executor switching) or if we're in the
@@ -793,7 +828,8 @@ CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
     auto actorIsolation = getActorIsolation(AFD);
     if (actorIsolation.getKind() == ActorIsolation::ActorInstance) {
       if (auto *var = actorIsolation.getActorInstance()) {
-        if (shouldCaptureIsolationInLocalFunc(AFD, var))
+        if (shouldCaptureIsolationInLocalFunc(AFD, var,
+                                              finder.hasUsesOfCurrentIsolation()))
           finder.addCapture(CapturedValue(var, 0, AFD->getLoc()));
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6374,6 +6374,14 @@ static bool shouldSelfIsolationOverrideDefault(
 
 static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
                                                     ValueDecl *value) {
+  // Defer bodies share the actor isolation of their enclosing context.
+  if (value->isDeferBody()) {
+    return {
+      getActorIsolationOfContext(value->getDeclContext()),
+      IsolationSource()
+    };
+  }
+
   // If this declaration has actor-isolated "self", it's isolated to that
   // actor.
   if (evaluateOrDefault(evaluator, HasIsolatedSelfRequest{value}, false)) {

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -38,6 +38,16 @@ func testNonDefer_negative() {
 // CHECK-NEXT:    function_ref
 // CHECK-NEXT:    apply
 
+@MainActor func testGlobalActor_nested_positive() {
+  defer {
+    defer {
+      requiresMainActor()
+    }
+    doSomething()
+  }
+  doSomething()
+}
+
 #if NEGATIVES
 // expected-note @+1 {{add '@MainActor' to make global function 'testGlobalActor_negative()' part of global actor 'MainActor'}}
 func testGlobalActor_negative() {

--- a/test/Concurrency/isolation_macro_sil.swift
+++ b/test/Concurrency/isolation_macro_sil.swift
@@ -27,6 +27,7 @@ func takeDefaulted(iso: isolated (any Actor)? = #isolation) {}
 // CHECK-LABEL: // closure #1 in containsClosure()
 // CHECK-NEXT:  // Isolation: caller_isolation_inheriting
 // CHECK:       bb0(%0 : $Optional<any Actor>):
+// CHECK-NEXT:    hop_to_executor %0
 // CHECK-NEXT:    // function_ref take(iso:)
 // CHECK-NEXT:    [[FN:%.*]] = function_ref @
 // CHECK-NEXT:    apply [[FN]](%0)

--- a/test/Concurrency/isolation_macro_sil.swift
+++ b/test/Concurrency/isolation_macro_sil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -emit-sil %s -module-name test | %FileCheck %s
 
 // REQUIRES: concurrency
 
@@ -9,17 +9,19 @@ nonisolated(nonsending) func nonisolatedNonsending() async {
 
 func take(iso: (any Actor)?) {}
 
+func takeDefaulted(iso: isolated (any Actor)? = #isolation) {}
+
 // CHECK-LABEL: // nonisolatedNonsending()
 // CHECK-NEXT: // Isolation: caller_isolation_inheriting
-// CHECK-NEXT: sil hidden @$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
+// CHECK-NEXT: sil hidden @$s4test21nonisolatedNonsendingyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 // CHECK:      bb0([[ACTOR:%.*]] : $Optional<any Actor>):
 // CHECK:   hop_to_executor [[ACTOR]]
 // CHECK:   retain_value [[ACTOR]]
 // CHECK:   debug_value [[ACTOR]], let, name "iso"
-// CHECK:   [[FUNC:%.*]] = function_ref @$s39isolated_nonsending_isolation_macro_sil4take3isoyScA_pSg_tF : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4test4take3isoyScA_pSg_tF : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
 // CHECK:   apply [[FUNC]]([[ACTOR]]) : $@convention(thin) (@guaranteed Optional<any Actor>) -> ()
 // CHECK:   release_value [[ACTOR]]
-// CHECK: } // end sil function '$s39isolated_nonsending_isolation_macro_sil21nonisolatedNonsendingyyYaF'
+// CHECK: } // end sil function '$s4test21nonisolatedNonsendingyyYaF'
 
 //   Check that we emit #isolation correctly in closures.
 // CHECK-LABEL: // closure #1 in containsClosure()
@@ -34,6 +36,49 @@ func containsClosure() {
   }
 }
 
+//   Check that we capture variables as necessary to emit #isolation
+//   correctly in defer bodies.
+func deferWithIsolatedParam(_ iso: isolated (any Actor)) {
+  defer {
+    take(iso: #isolation)
+  }
+  do {}
+}
+// CHECK-LABEL: sil hidden @$s4test22deferWithIsolatedParamyyScA_pYiF :
+// CHECK:       bb0(%0 : $any Actor)
+// CHECK:         [[DEFER:%.*]] = function_ref @$s4test22deferWithIsolatedParamyyScA_pYiF6$deferL_yyF :
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: sil private @$s4test22deferWithIsolatedParamyyScA_pYiF6$deferL_yyF :
+// CHECK:       bb0(%0 : @closureCapture $any Actor):
+// CHECK:         [[T0:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, %0
+// CHECK:         [[FN:%.*]] = function_ref @$s4test4take3isoyScA_pSg_tF :
+// CHECK-NEXT:    apply [[FN]]([[T0]])
+
+//   Check that that happens even with uses in caller-side default
+//   arguments, which capture analysis was not previously walking into.
+func deferWithIsolatedParam_defaultedUse(_ iso: isolated (any Actor)) {
+  defer {
+    takeDefaulted()
+  }
+  do {}
+}
+
+// CHECK-LABEL: sil hidden @$s4test35deferWithIsolatedParam_defaultedUseyyScA_pYiF :
+// CHECK:       bb0(%0 : $any Actor):
+// CHECK:         [[DEFER:%.*]] = function_ref @$s4test35deferWithIsolatedParam_defaultedUseyyScA_pYiF6$deferL_yyF :
+// CHECK-NEXT:    apply [[DEFER]](%0)
+
+// CHECK-LABEL: sil private @$s4test35deferWithIsolatedParam_defaultedUseyyScA_pYiF6$deferL_yyF :
+// CHECK:       bb0(%0 : @closureCapture $any Actor):
+// CHECK:         [[T0:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, %0
+// CHECK:         [[FN:%.*]] = function_ref @$s4test13takeDefaulted3isoyScA_pSgYi_tF :
+// CHECK-NEXT:    apply [[FN]]([[T0]])
+
+// TODO: we can't currently call nonisolated(nonsending) functions in
+// defer bodies because they have to be async, but that should be
+// tested here as well.
+
 //   Check that we emit #isolation correctly in defer bodies.
 nonisolated(nonsending)
 func hasDefer() async {
@@ -42,7 +87,7 @@ func hasDefer() async {
   }
   do {}
 }
-// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil8hasDeferyyYaF :
+// CHECK-LABEL: sil hidden @$s4test8hasDeferyyYaF :
 // CHECK:       bb0(%0 : $Optional<any Actor>):
 // CHECK:         // function_ref $defer
 // CHECK-NEXT:    [[DEFER:%.*]] = function_ref
@@ -67,7 +112,7 @@ func hasNestedDefer() async {
   do {}
 }
 
-// CHECK-LABEL: sil hidden @$s39isolated_nonsending_isolation_macro_sil14hasNestedDeferyyYaF :
+// CHECK-LABEL: sil hidden @$s4test14hasNestedDeferyyYaF :
 // CHECK:       bb0(%0 : $Optional<any Actor>):
 // CHECK:         // function_ref $defer #1 () in hasNestedDefer()
 // CHECK-NEXT:    [[DEFER:%.*]] = function_ref

--- a/test/SILGen/isolated_default_arguments.swift
+++ b/test/SILGen/isolated_default_arguments.swift
@@ -28,6 +28,10 @@ func main_actor_int_pair() -> (Int, Int) {
   return (0,0)
 }
 
+func make_int(isolated isolation: (any Actor)? = #isolation) -> Int {
+  return 0
+}
+
 // This test breaks because the intermediate argument is `nil`, which
 // we treat as non-isolated.
 @MainActor
@@ -121,3 +125,39 @@ func tupleIsolatedDefaultArg(x: (Int,Int) = main_actor_int_pair(),
 func testTupleIsolatedDefaultArg() async {
   await tupleIsolatedDefaultArg(y: 0)
 }
+
+// When a function is caller-isolated, its default argument generators
+// should probably also be caller-isolated and forward their isolation
+// properly when #isolation is used. Currently, however, that's not what
+// we're doing, so test for the current behavior.
+
+nonisolated(nonsending)
+func callerIsolatedDefaultArg(x: Int = make_int()) async {}
+
+@MainActor
+func useCallerIsolatedDefaultArg() async {
+  await callerIsolatedDefaultArg()
+}
+
+//   Check that the default argument generator isn't caller-isolated.
+// CHECK-LABEL: // default argument 0 of test.callerIsolatedDefaultArg
+// CHECK-NEXT:  // Isolation: unspecified
+// CHECK-NEXT:  sil hidden [ossa] @$s4test24callerIsolatedDefaultArg1xySi_tYaFfA_ :
+// CHECK:       bb0:
+//   Check that we provide a nil isolation for #isolation
+// CHECK-NEXT:    [[NIL_ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none
+// CHECK-NEXT:    // function_ref test.make_int
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @$s4test8make_int8isolatedSiScA_pSg_tF :
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FN]]([[NIL_ISOLATION]])
+// CHECK-NEXT:    return [[RESULT]]
+
+//   Check that we pass the right isolation to the generator.
+// CHECK-LABEL: sil hidden [ossa] @$s4test27useCallerIsolatedDefaultArgyyYaF :
+//   Get the main actor reference.
+// CHECK:         [[GET_MAIN_ACTOR:%.*]] = function_ref @$sScM6sharedScMvgZ :
+// CHECK-NEXT:    [[T0:%.*]] = apply [[GET_MAIN_ACTOR]](
+// CHECK-NEXT:    [[MAIN_ACTOR:%.*]] = begin_borrow [[T0]]
+//   Call the accessor.
+// CHECK:         // function_ref default argument 0 of
+// CHECK-NEXT:    [[GEN:%.*]] = function_ref @$s4test24callerIsolatedDefaultArg1xySi_tYaFfA_ :
+// CHECK-NEXT:    [[ARG:%.*]] = apply [[GEN]]()

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -466,7 +466,7 @@ func testAutoclosureInStaticMethod() {
     //
     // Get standard.
     // CHECK: [[METATYPE:%.*]] = metatype $@objc_metatype SlowServer.Type
-    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method %1 : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
+    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method [[METATYPE]] : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
     // CHECK: [[STANDARD:%.*]] = apply [[GET_STANDARD_FUNC]]([[METATYPE]])
     //
     // Then grab value.
@@ -592,7 +592,7 @@ func testAutoclosureInStaticMethod() {
     //
     // Get standard.
     // CHECK: [[METATYPE:%.*]] = metatype $@objc_metatype SlowServer.Type
-    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method %1 : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
+    // CHECK: [[GET_STANDARD_FUNC:%.*]] = objc_method [[METATYPE]] : $@objc_metatype SlowServer.Type, #SlowServer.standard!getter.foreign : (SlowServer.Type) -> () -> SlowServer, $@convention(objc_method) (@objc_metatype SlowServer.Type) -> @autoreleased SlowServer
     // CHECK: [[STANDARD:%.*]] = apply [[GET_STANDARD_FUNC]]([[METATYPE]])
     //
     // Then grab value.

--- a/validation-test/compiler_crashers_2_fixed/8d73bb4170a0c447.swift
+++ b/validation-test/compiler_crashers_2_fixed/8d73bb4170a0c447.swift
@@ -1,0 +1,3 @@
+// {"kind":"typecheck","signature":"swift::ParamDecl::setTypeCheckedDefaultExpr(swift::Expr*)","signatureAssert":"Assertion failed: (E || getDefaultArgumentKind() == DefaultArgumentKind::Inherited), function setTypeCheckedDefaultExpr"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a<b>(b= a(


### PR DESCRIPTION
6.2 version of https://github.com/swiftlang/swift/pull/84181 and https://github.com/swiftlang/swift/pull/84206.

Scope: SILGen changes to the emission of `nonisolated(nonsending)` functions; a few related fixes to `defer` bodies; also fixes an adjacent crash-on-request-cycle
Reviewed by: @ktoso
Risk: Fairly low. Most of the impact is to `nonisolated(nonsending)` functions, which are a new feature in Swift 6.2. That fix includes a fix to `defer` bodies which has revealed a series of related bugs in `defer`. I believe this PR fully plumbs the `defer` bugs, but it's possible that there some problems still lurking.
Testing: several new regression tests