### PR TITLE
Fix @_opaqueReturnTypeOf module interface syntax for parameter packs

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -158,6 +158,8 @@ public:
 
   Type createBoundGenericType(GenericTypeDecl *decl, ArrayRef<Type> args);
   
+  OpaqueTypeDecl *resolveOpaqueTypeDecl(NodePointer opaqueDescriptor);
+
   Type resolveOpaqueType(NodePointer opaqueDescriptor,
                          ArrayRef<ArrayRef<Type>> args,
                          unsigned ordinal);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -581,8 +581,7 @@ namespace {
     void addGenericParameters() {
       GenericSignature sig = asImpl().getGenericSignature();
       auto metadata =
-        irgen::addGenericParameters(IGM, B,
-                                    asImpl().getGenericSignature(),
+        irgen::addGenericParameters(IGM, B, sig,
                                     /*implicit=*/false);
       assert(metadata.NumParams == metadata.NumParamsEmitted &&
              "We can't use implicit GenericParamDescriptors here");

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -827,6 +827,130 @@ namespace {
   };
 }
 
+/// Returns true on error.
+static bool resolveGenericArguments(ValueDecl *decl,
+                                    const GenericContext *genCtx,
+                                    const TypeResolution &resolution,
+                                    SILTypeResolutionContext *silContext,
+                                    DeclRefTypeRepr *repr,
+                                    SmallVectorImpl<Type> &args) {
+  auto options = resolution.getOptions();
+  auto &ctx = decl->getASTContext();
+
+  auto genericParams = genCtx->getGenericParams();
+  auto hasParameterPack = llvm::any_of(*genericParams, [](auto *paramDecl) {
+    return paramDecl->isParameterPack();
+  });
+  auto hasValueParam = llvm::any_of(*genericParams, [](auto *paramDecl) {
+    return paramDecl->isValue();
+  });
+
+  // If the type declares at least one parameter pack, allow pack expansions
+  // anywhere in the argument list. We'll use the PackMatcher to ensure that
+  // everything lines up. Otherwise, don't allow pack expansions to appear
+  // at all.
+  auto argOptions = options.withoutContext().withContext(
+      hasParameterPack
+      ? TypeResolverContext::VariadicGenericArgument
+      : TypeResolverContext::ScalarGenericArgument);
+  if (hasValueParam)
+    argOptions = argOptions.withContext(TypeResolverContext::ValueGenericArgument);
+  auto genericResolution = resolution.withOptions(argOptions);
+
+  // In SIL mode, Optional<T> interprets T as a SIL type.
+  if (options.contains(TypeResolutionFlags::SILType)) {
+    if (auto nominal = dyn_cast<NominalTypeDecl>(genCtx)) {
+      if (nominal->isOptionalDecl()) {
+        genericResolution = resolution;
+      }
+    }
+  }
+
+  auto genericArgs = repr->getGenericArgs();
+  auto loc = repr->getNameLoc().getBaseNameLoc();
+
+  // Resolve the types of the generic arguments.
+  for (auto tyR : genericArgs) {
+    // Propagate failure.
+    Type substTy = genericResolution.resolveType(tyR, silContext);
+    if (!substTy || substTy->hasError())
+      return true;
+
+    args.push_back(substTy);
+  }
+
+  // Make sure we have the right number of generic arguments.
+  if (!hasParameterPack) {
+    // For generic types without type parameter packs, we require
+    // the number of declared generic parameters match the number of
+    // arguments.
+    if (genericArgs.size() != genericParams->size()) {
+      if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
+        diagnoseInvalidGenericArguments(
+            loc, decl, genericArgs.size(), genericParams->size(),
+            /*hasParameterPack=*/false, repr->getAngleBrackets());
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // For generic types with type parameter packs, we only require
+  // that the number of arguments is enough to saturate the number of
+  // regular generic parameters. The parameter pack will absorb
+  // zero or arguments.
+  SmallVector<Type, 2> params;
+  for (auto paramDecl : genericParams->getParams()) {
+    auto paramType = paramDecl->getDeclaredInterfaceType();
+    params.push_back(paramDecl->isParameterPack()
+                     ? PackExpansionType::get(paramType, paramType)
+                     : paramType);
+  }
+
+  PackMatcher matcher(params, args, ctx);
+  if (matcher.match() || matcher.pairs.size() != params.size()) {
+    if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
+      diagnoseInvalidGenericArguments(
+          loc, decl, genericArgs.size(), genericParams->size(),
+          /*hasParameterPack=*/true, repr->getAngleBrackets());
+    }
+    return true;
+  }
+
+  args.clear();
+  for (unsigned i : indices(params)) {
+    auto found = std::find_if(matcher.pairs.begin(),
+                              matcher.pairs.end(),
+                              [&](const MatchedPair &pair) -> bool {
+                                return pair.lhsIdx == i;
+                              });
+    assert(found != matcher.pairs.end());
+
+    auto arg = found->rhs;
+
+    // PackMatcher will always produce a PackExpansionType as the
+    // arg for a pack parameter, if necessary by wrapping a PackType
+    // in one.  (It's a weird representation.)  Look for that pattern
+    // and unwrap the pack.  Otherwise, we must have matched with a
+    // single component which happened to be an expansion; wrap that
+    // in a PackType.  In either case, we always want arg to end up
+    // a PackType.
+    if (auto *expansionType = arg->getAs<PackExpansionType>()) {
+      auto pattern = expansionType->getPatternType();
+      if (auto pack = pattern->getAs<PackType>()) {
+        arg = pack;
+      } else {
+        arg = PackType::get(ctx, {expansionType});
+      }
+    }
+
+    args.push_back(arg);
+  }
+
+  return false;
+}
+
 /// Apply generic arguments to the given type.
 ///
 /// If the type is itself not generic, this does nothing.
@@ -1005,112 +1129,10 @@ static Type applyGenericArguments(Type type,
   auto *unboundType = type->castTo<UnboundGenericType>();
   auto *decl = unboundType->getDecl();
 
-  auto genericParams = decl->getGenericParams();
-  auto hasParameterPack = llvm::any_of(*genericParams, [](auto *paramDecl) {
-    return paramDecl->isParameterPack();
-  });
-  auto hasValueParam = llvm::any_of(*genericParams, [](auto *paramDecl) {
-    return paramDecl->isValue();
-  });
-
-  // If the type declares at least one parameter pack, allow pack expansions
-  // anywhere in the argument list. We'll use the PackMatcher to ensure that
-  // everything lines up. Otherwise, don't allow pack expansions to appear
-  // at all.
-  auto argOptions = options.withoutContext().withContext(
-      hasParameterPack
-      ? TypeResolverContext::VariadicGenericArgument
-      : TypeResolverContext::ScalarGenericArgument);
-  if (hasValueParam)
-    argOptions = argOptions.withContext(TypeResolverContext::ValueGenericArgument);
-  auto genericResolution = resolution.withOptions(argOptions);
-
-  // In SIL mode, Optional<T> interprets T as a SIL type.
-  if (options.contains(TypeResolutionFlags::SILType)) {
-    if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
-      if (nominal->isOptionalDecl()) {
-        genericResolution = resolution;
-      }
-    }
-  }
-
   // Resolve the types of the generic arguments.
   SmallVector<Type, 2> args;
-  for (auto tyR : genericArgs) {
-    // Propagate failure.
-    Type substTy = genericResolution.resolveType(tyR, silContext);
-    if (!substTy || substTy->hasError())
-      return ErrorType::get(ctx);
-
-    args.push_back(substTy);
-  }
-
-  // Make sure we have the right number of generic arguments.
-  if (!hasParameterPack) {
-    // For generic types without type parameter packs, we require
-    // the number of declared generic parameters match the number of
-    // arguments.
-    if (genericArgs.size() != genericParams->size()) {
-      if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-        diagnoseInvalidGenericArguments(
-            loc, decl, genericArgs.size(), genericParams->size(),
-            /*hasParameterPack=*/false, repr->getAngleBrackets());
-      }
-      return ErrorType::get(ctx);
-    }
-  } else {
-    // For generic types with type parameter packs, we only require
-    // that the number of arguments is enough to saturate the number of
-    // regular generic parameters. The parameter pack will absorb
-    // zero or arguments.
-    SmallVector<Type, 2> params;
-    for (auto paramDecl : genericParams->getParams()) {
-      auto paramType = paramDecl->getDeclaredInterfaceType();
-      params.push_back(paramDecl->isParameterPack()
-                       ? PackExpansionType::get(paramType, paramType)
-                       : paramType);
-    }
-
-    PackMatcher matcher(params, args, ctx);
-    if (matcher.match() || matcher.pairs.size() != params.size()) {
-      if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-        diagnoseInvalidGenericArguments(
-            loc, decl, genericArgs.size(), genericParams->size(),
-            /*hasParameterPack=*/true, repr->getAngleBrackets());
-      }
-      return ErrorType::get(ctx);
-    }
-
-    args.clear();
-    for (unsigned i : indices(params)) {
-      auto found = std::find_if(matcher.pairs.begin(),
-                                matcher.pairs.end(),
-                                [&](const MatchedPair &pair) -> bool {
-                                  return pair.lhsIdx == i;
-                                });
-      assert(found != matcher.pairs.end());
-
-      auto arg = found->rhs;
-
-      // PackMatcher will always produce a PackExpansionType as the
-      // arg for a pack parameter, if necessary by wrapping a PackType
-      // in one.  (It's a weird representation.)  Look for that pattern
-      // and unwrap the pack.  Otherwise, we must have matched with a
-      // single component which happened to be an expansion; wrap that
-      // in a PackType.  In either case, we always want arg to end up
-      // a PackType.
-      if (auto *expansionType = arg->getAs<PackExpansionType>()) {
-        auto pattern = expansionType->getPatternType();
-        if (auto pack = pattern->getAs<PackType>()) {
-          arg = pack;
-        } else {
-          arg = PackType::get(ctx, {expansionType});
-        }
-      }
-
-      args.push_back(arg);
-    }
-  }
+  if (resolveGenericArguments(decl, decl, resolution, silContext, repr, args))
+    return ErrorType::get(ctx);
 
   // Construct the substituted type.
   const auto result = resolution.applyUnboundGenericArguments(
@@ -1130,6 +1152,7 @@ static Type applyGenericArguments(Type type,
   if (auto clangDecl = decl->getClangDecl()) {
     if (auto classTemplateDecl =
             dyn_cast<clang::ClassTemplateDecl>(clangDecl)) {
+      // FIXME: Why does this resolve the types twice?
       SmallVector<Type, 2> typesOfGenericArgs;
       for (auto typeRepr : genericArgs) {
         typesOfGenericArgs.push_back(resolution.resolveType(typeRepr));

--- a/test/ModuleInterface/invalid-opaque-result-types.swift
+++ b/test/ModuleInterface/invalid-opaque-result-types.swift
@@ -17,7 +17,6 @@
 //
 // RUN: not %target-swift-frontend -typecheck %s -I %t 2>&1 | %FileCheck %s
 
-// CHECK: cannot find type 'InvalidParameter' in scope
 // CHECK: unable to resolve type for _opaqueReturnTypeOf attribute
 // CHECK: failed to build module 'InvalidOpaqueResultType' for importation
 import InvalidOpaqueResultType

--- a/test/ModuleInterface/variadic-opaque-result-types.swift
+++ b/test/ModuleInterface/variadic-opaque-result-types.swift
@@ -1,0 +1,122 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/VariadicOpaqueResultTypes.swiftinterface) %s -module-name VariadicOpaqueResultTypes -target %target-swift-5.9-abi-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t/VariadicOpaqueResultTypes.swiftinterface) -module-name VariadicOpaqueResultTypes
+// RUN: %FileCheck %s < %t/VariadicOpaqueResultTypes.swiftinterface
+
+
+///
+/// First, make sure pack expansions can appear in the generic argument list of an opaque return type.
+///
+
+public struct I1<each T>: IteratorProtocol {
+  public mutating func next() -> (some Any)? { return 3 }
+}
+
+// CHECK: public struct I1<each T> : Swift.IteratorProtocol {
+// CHECK:  public mutating func next() -> (some Any)?
+// CHECK:  public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2I1V4nextQrSgyF", 0) __<repeat each T>
+// CHECK: }
+
+
+public struct S1<each T>: Sequence {
+  public func makeIterator() -> some IteratorProtocol {
+    return I1<repeat each T>()
+  }
+}
+
+// CHECK: public struct S1<each T> : Swift.Sequence {
+// CHECK:   public func makeIterator() -> some Swift.IteratorProtocol
+// CHECK:   public typealias Element = (@_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2S1V12makeIteratorQryF", 0) __<repeat each T>).Element
+// CHECK:   public typealias Iterator = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2S1V12makeIteratorQryF", 0) __<repeat each T>
+// CHECK: }
+
+
+public struct Scalar<T> {
+  public struct I2<U>: IteratorProtocol {
+    public mutating func next() -> (some Any)? { return 3 }
+  }
+}
+
+
+///
+/// Now, test nested types. The next example uses the old "flat" syntax, because parameter packs are not involved.
+///
+
+
+// CHECK: public struct Scalar<T> {
+// CHECK:   public struct I2<U> : Swift.IteratorProtocol {
+// CHECK:     public mutating func next() -> (some Any)?
+// CHECK:     public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes6ScalarV2I2V4nextQrSgyF", 0) __<T, U>
+// CHECK:   }
+// CHECK: }
+
+
+public struct S2: Sequence {
+  public func makeIterator() -> Scalar<Int>.I2<Bool> {
+    return .init()
+  }
+}
+
+// CHECK: public struct S2 : Swift.Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Scalar<Swift.Int>.I2<Swift.Bool>
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes6ScalarV2I2V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Scalar<Swift.Int>.I2<Swift.Bool>
+// CHECK: }
+
+
+///
+/// The remaining examples use the new nested syntax.
+///
+
+// CHECK: public struct Variadic<each T> {
+public struct Variadic<each T> {
+  public struct I3<each U>: IteratorProtocol {
+    public mutating func next() -> (some Any)? { return 3 }
+  }
+
+  // CHECK: public struct I3<each U> : Swift.IteratorProtocol {
+  // CHECK:   public mutating func next() -> (some Any)?
+  // CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V2I3V4nextQrSgyF", 0) __<repeat each T>.__<repeat each U>
+  // CHECK: }
+
+  public struct Middle {
+    public struct Inner<each U> {
+      public struct I4: IteratorProtocol {
+        public mutating func next() -> (some Any)? { return 3 }
+      }
+    }
+  }
+
+  // CHECK: public struct Middle {
+  // CHECK:   public struct Inner<each U> {
+  // CHECK:     public struct I4 : Swift.IteratorProtocol {
+  // CHECK:       public mutating func next() -> (some Any)?       
+  // CHECK:       public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V6MiddleV5InnerV2I4V4nextQrSgyF", 0) __<repeat each T>.__<repeat each U>
+  // CHECK:     }
+  // CHECK:   }
+  // CHECK: }
+}
+// CHECK: }
+
+// CHECK: public struct S3 : Swift.Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.I3<Swift.Float, Swift.Double>
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V2I3V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>.__<Swift.Float, Swift.Double>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.I3<Swift.Float, Swift.Double>
+// CHECK: }
+public struct S3: Sequence {
+  public func makeIterator() -> Variadic<Int, Bool>.I3<Float, Double> {
+    return .init()
+  }
+}
+
+// CHECK: public struct S4 : Swift.Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.Middle.Inner<Swift.Float, Swift.Double>.I4
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V6MiddleV5InnerV2I4V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>.__<Swift.Float, Swift.Double>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.Middle.Inner<Swift.Float, Swift.Double>.I4
+// CHECK: }
+public struct S4: Sequence {
+  public func makeIterator() -> Variadic<Int, Bool>.Middle.Inner<Float, Double>.I4 {
+    return .init()
+  }
+}
+


### PR DESCRIPTION
We now allow the dummy identifier to be a qualified reference, so
that we can reconstruct generic parameter lists from multiple levels:

    @_opaqueReturnTypeOf(...) __<OuterArgs...>.__<InnerArgs...>

This fixes an ambiguity with parameter packs, where flattening the
packs from multiple levels of nested types no longer produced an
unambiguous result.

To maintain backward compatibility, we still accept the old "flat"
form when no parameter packs are present.

- Fixes https://github.com/swiftlang/swift/issues/81455.
- Fixes rdar://problem/151171381.