### PR TITLE
[6.2][Distributed] Allow disabling SerializationRequirement by using Any 

### DIFF
--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -281,8 +281,7 @@ void InitializeDistActorIdentity::dump(SILGenFunction &) const {
 
 bool SILGenFunction::shouldReplaceConstantForApplyWithDistributedThunk(
     FuncDecl *func) const {
-  auto isDistributedFuncOrAccessor =
-      func->isDistributed();
+  auto isDistributedFuncOrAccessor = func->isDistributed();
   if (auto acc = dyn_cast<AccessorDecl>(func)) {
     isDistributedFuncOrAccessor =
         acc->getStorage()->isDistributed();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9262,9 +9262,10 @@ bool NoopCheckedCast::diagnoseForcedCastExpr() const {
   }
 
   if (fromType->isEqual(toType)) {
-    auto castTypeRepr = expr->getCastTypeRepr();
-    emitDiagnostic(diag::forced_downcast_noop, toType)
-        .fixItRemove(SourceRange(diagLoc, castTypeRepr->getSourceRange().End));
+    auto diag = emitDiagnostic(diag::forced_downcast_noop, toType);
+    if (auto castTypeRepr = expr->getCastTypeRepr()) {
+      diag.fixItRemove(SourceRange(diagLoc, castTypeRepr->getSourceRange().End));
+    }
 
   } else {
     emitDiagnostic(diag::forced_downcast_coercion, fromType, toType)

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -332,17 +332,24 @@ deriveBodyDistributed_invokeHandlerOnReturn(AbstractFunctionDecl *afd,
     metatypeVar->setImplicit();
     metatypeVar->setSynthesized();
 
+    // If the SerializationRequirement requires it, we need to emit a cast:
     // metatype as! <<concrete SerializationRequirement.Type>>
+    bool serializationRequirementIsAny =
+      serializationRequirementMetaTypeTy->getMetatypeInstanceType()->isEqual(
+            C.getAnyExistentialType());
+
     auto metatypeRef =
         new (C) DeclRefExpr(ConcreteDeclRef(metatypeParam), dloc, implicit);
-    auto metatypeSRCastExpr = ForcedCheckedCastExpr::createImplicit(
-        C, metatypeRef, serializationRequirementMetaTypeTy);
-
     auto metatypePattern = NamedPattern::createImplicit(C, metatypeVar);
-    auto metatypePB = PatternBindingDecl::createImplicit(
-        C, swift::StaticSpellingKind::None, metatypePattern,
-        /*expr=*/metatypeSRCastExpr, func);
 
+    PatternBindingDecl *metatypePB = serializationRequirementIsAny ?
+      PatternBindingDecl::createImplicit(
+          C, swift::StaticSpellingKind::None, metatypePattern,
+          /*expr=*/metatypeRef, func) :
+      PatternBindingDecl::createImplicit(
+          C, swift::StaticSpellingKind::None, metatypePattern,
+          /*expr=*/ForcedCheckedCastExpr::createImplicit(
+          C, metatypeRef, serializationRequirementMetaTypeTy), func);
     stmts.push_back(metatypePB);
     stmts.push_back(metatypeVar);
   }
@@ -399,7 +406,6 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
   auto system = derived.Nominal;
   auto &C = system->getASTContext();
 
-  // auto serializationRequirementType = getDistributedActorSystemType(decl);
   auto resultHandlerType = getDistributedActorSystemResultHandlerType(system);
   auto unsafeRawPointerType = C.getUnsafeRawPointerType();
   auto anyTypeType = ExistentialMetatypeType::get(C.TheAnyType); // Any.Type
@@ -436,7 +442,7 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
                                /*throws=*/true,
                                /*ThrownType=*/Type(),
                                /*genericParams=*/nullptr, params,
-                               /*returnType*/ TupleType::getEmpty(C), system);
+                               /*returnType=*/TupleType::getEmpty(C), system);
   funcDecl->setSynthesized(true);
   funcDecl->copyFormalAccessFrom(system, /*sourceIsParentContext=*/true);
   funcDecl->setBodySynthesizer(deriveBodyDistributed_invokeHandlerOnReturn);

--- a/test/Distributed/distributed_actor_system_serialization_requirement_any.swift
+++ b/test/Distributed/distributed_actor_system_serialization_requirement_any.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+final class CrashActorSystem: DistributedActorSystem {
+  typealias ActorID = CrashActorID
+  typealias InvocationEncoder = CrashInvocationEncoder
+  typealias InvocationDecoder = CrashInvocationDecoder
+  typealias ResultHandler = CrashResultHandler
+
+  typealias SerializationRequirement = Any
+
+  func assignID<Actor: DistributedActor>(_: Actor.Type) -> ActorID where Actor.ID == ActorID {
+    fatalError()
+  }
+
+  func resignID(_: ActorID) {
+    // nothing
+  }
+
+  func actorReady<Actor: DistributedActor>(_: Actor) where Actor.ID == ActorID { }
+
+  func resolve<Actor: DistributedActor>(id _: ActorID, as _: Actor.Type) throws -> Actor? where Actor.ID == ActorID {
+    return nil
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+    return InvocationEncoder()
+  }
+
+  func remoteCallVoid<Actor: DistributedActor, Failure: Error>(
+    on _: Actor,
+    target _: RemoteCallTarget,
+    invocation _: inout InvocationEncoder,
+    throwing _: Failure.Type
+  ) async throws where Actor.ID == ActorID {
+    return
+  }
+
+  func remoteCall<Actor: DistributedActor, Failure: Error, Success: SerializationRequirement>(
+    on _: Actor,
+    target _: RemoteCallTarget,
+    invocation _: inout InvocationEncoder,
+    throwing _: Failure.Type,
+    returning _: Success.Type
+  ) async throws -> Success where Actor.ID == ActorID {
+    fatalError()
+  }
+
+}
+
+struct CrashActorID: Hashable {
+  func hash(into hasher: inout Hasher) { }
+}
+
+struct CrashInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = CrashActorSystem.SerializationRequirement
+
+  func recordGenericSubstitution<GenericSubstitution>(_: GenericSubstitution.Type) throws { }
+  mutating func recordArgument<Argument: SerializationRequirement>(_: RemoteCallArgument<Argument>) throws { }
+  mutating func recordReturnType<Success: SerializationRequirement>(_: Success.Type) throws { }
+  func recordErrorType<Failure: Error>(_: Failure.Type) throws { }
+  func doneRecording() throws { }
+}
+
+struct CrashInvocationDecoder: DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = CrashActorSystem.SerializationRequirement
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] {
+    return []
+  }
+
+  mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
+    fatalError()
+  }
+
+  func decodeReturnType() throws -> Any.Type? {
+    return nil
+  }
+
+  func decodeErrorType() throws -> Any.Type? {
+    return nil
+  }
+
+}
+
+struct CrashResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = CrashActorSystem.SerializationRequirement
+
+  func onReturn<Success: SerializationRequirement>(value _: Success) async throws { }
+  func onReturnVoid() async throws { }
+  func onThrow<Failure: Error>(error _: Failure) async throws { }
+}


### PR DESCRIPTION
**Description**: It is possible to customize the SerializationRequirement that DistributedActorSystem enforces on all parameters/return types. When this was set to `Any`, which can be useful for some special in memory transports, the compiler would emit incorrect code and cause a crash due to another bug null-pointer-dereferencing a type while emitting a diagnostic.

This PR resolves both the issue in the diagnostic emitting, as well as the underlying issue -- which was an un-necessary cast to `as Any.Type` which then would result in emitting an error diagnostic.

**Scope/Impact**: Specifically actor systems which use Any as the serialization requirement. They would previously crash the compiler, and with this fix can work correctly.

**Risk:** Low, specific to Any using DistributedActorSystems. Has no impact on other types. The diagnostic fix just avoids null pointers.

**Testing**: Added test to exercise the problem.

**Reviewed by**: @xedin 

**Original PR:** https://github.com/swiftlang/swift/pull/84119
**Radar:** resolves rdar://159285863