### PR TITLE
[6.2] fix build system tests that assume CMake is in the search path

### DIFF
--- a/utils/swift_build_support/tests/test_toolchain.py
+++ b/utils/swift_build_support/tests/test_toolchain.py
@@ -53,9 +53,8 @@ class ToolchainTestCase(unittest.TestCase):
         tc = host_toolchain()
 
         # CMake
-        self.assertIsNotNone(tc.cmake)
-        self.assertTrue(
-            os.path.basename(tc.cmake).startswith('cmake'))
+        self.assertTrue(tc.cmake is None or
+                        os.path.basename(tc.cmake).startswith('cmake'))
 
         # Ninja
         self.assertTrue(tc.ninja is None or

--- a/validation-test/BuildSystem/build_worktree.test
+++ b/validation-test/BuildSystem/build_worktree.test
@@ -12,7 +12,7 @@
 # RUN: git -C %t/swift worktree add --detach %t/swift-worktree
 
 # Invoke the build script from the worktree.
-# RUN: %t/swift-worktree/utils/build-script --dry-run | %FileCheck -DARCH=%target-arch %s
+# RUN: %t/swift-worktree/utils/build-script --dry-run --cmake %cmake | %FileCheck -DARCH=%target-arch %s
 
 # We should generate a build system for the linked worktree, not the main
 # worktree.


### PR DESCRIPTION
- **Explanation**:
Backport two changes from `main` to ensure that a couple build system tests do not fail if CMake is built from source code as part of the `build-script` invocation (as that's currently the case for some bots in CI).
- **Scope**:
Tests that need to know the path to CMake.
- **Issues**: rdar://160182427
- **Original PRs**:
for `Python/swift_build_support.swift` -- https://github.com/swiftlang/swift/pull/83464/commits/4e854dea88bbb2b1a0ac4e218d0f37903291309a
for `BuildSystem/build_worktree.test`-- https://github.com/swiftlang/swift/pull/83577
- **Risk**:
Low -- these changes only affect test code
- **Testing**:
Ensured at desk tests pass when CMake is built as part of `build-script`
- **Reviewers**: none at this time