### PR TITLE
Runtimes: add support to emit variant modules

### DIFF
--- a/Runtimes/Core/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Core/cmake/modules/CatalystSupport.cmake
@@ -42,4 +42,12 @@ if(SwiftCore_COMPILER_VARIANT_TARGET)
       message(CONFIGURE_LOG "Swift target variant deployment version: ${SwiftCore_VARIANT_DEPLOYMENT_VERSION}")
     endif()
   endif()
+
+  if(SwiftCore_EXPERIMENTAL_EMIT_VARIANT_MODULE)
+    check_compiler_flag(Swift "-experimental-emit-variant-module" HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    if(HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:Swift>:-experimental-emit-variant-module>")
+    endif()
+  endif()
 endif()

--- a/Runtimes/Overlay/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Overlay/cmake/modules/CatalystSupport.cmake
@@ -37,4 +37,12 @@ if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
     mark_as_advanced(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
     message(CONFIGURE_LOG "Swift target variant module triple: ${module_triple}")
   endif()
+
+  if(${PROJECT_NAME}_EXPERIMENTAL_EMIT_VARIANT_MODULE)
+    check_compiler_flag(Swift "-experimental-emit-variant-module" HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    if(HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:Swift>:-experimental-emit-variant-module>")
+    endif()
+  endif()
 endif()

--- a/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
@@ -37,4 +37,12 @@ if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
     mark_as_advanced(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
     message(CONFIGURE_LOG "Swift target variant module triple: ${module_triple}")
   endif()
+
+  if(${PROJECT_NAME}_EXPERIMENTAL_EMIT_VARIANT_MODULE)
+    check_compiler_flag(Swift "-experimental-emit-variant-module" HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    if(HAVE_Swift_EMIT_VARIANT_MODULE_FLAG)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:Swift>:-experimental-emit-variant-module>")
+    endif()
+  endif()
 endif()


### PR DESCRIPTION
This leverages the SwiftDriver flag added in
https://github.com/swiftlang/swift-driver/pull/1941

Leave this disabled by default, so we can stage its adoption in Apple vendor configurations.

Addresses rdar://158895783