### PR TITLE
[stdlib] Conform `Unicode.Scalar` to `Strideable`

### DIFF
--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1139,3 +1139,10 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 // Obsolete/broken SPIs removed in 6.3
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
+
+// Conform `Unicode.Scalar` to `Strideable`
+Added: _$ss7UnicodeO6ScalarVSxsMc
+Added: _$ss7UnicodeO6ScalarVSxsWP
+Added: _$ss7UnicodeO6ScalarV8distance2toSiAD_tF
+Added: _$ss7UnicodeO6ScalarV8advanced2byADSi_tF
+Added: _$ss7UnicodeO6ScalarV5_step5after4from2bySiSg5index_AD5valuetAiJ_AdKt_ADSitFZ

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1139,3 +1139,10 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 // Obsolete/broken SPIs removed in 6.3
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
+
+// Conform `Unicode.Scalar` to `Strideable`
+Added: _$ss7UnicodeO6ScalarVSxsMc
+Added: _$ss7UnicodeO6ScalarVSxsWP
+Added: _$ss7UnicodeO6ScalarV8distance2toSiAD_tF
+Added: _$ss7UnicodeO6ScalarV8advanced2byADSi_tF
+Added: _$ss7UnicodeO6ScalarV5_step5after4from2bySiSg5index_AD5valuetAiJ_AdKt_ADSitFZ

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -868,4 +868,6 @@ Func ==(_:_:) has parameter 0 type change from (any Any.Type)? to τ_0_0
 Func ==(_:_:) has parameter 1 type change from (any Any.Type)? to τ_0_0                              
 Func type(of:) has been removed
 
+Struct Unicode.Scalar has added a conformance to an existing protocol Strideable
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -154,9 +154,9 @@ StrideTestSuite.test("Closed") {
 }
 
 StrideTestSuite.test("OperatorOverloads") {
-  var r1 = R(50)
-  var r2 = R(70)
-  var stride: Int = 5
+  let r1 = R(50)
+  let r2 = R(70)
+  let stride: Int = 5
 
   do {
     var result = r1.advanced(by: stride)
@@ -278,5 +278,42 @@ if #available(SwiftStdlib 5.6, *) {
   }
 }
 
-runAllTests()
+if #available(SwiftStdlib 6.3, *) {
+  StrideTestSuite.test("Unicode.Scalar") {
+    func checkAxioms(x: Unicode.Scalar, y: Unicode.Scalar, n: Int) {
+      expectEqual(x.distance(to: y), +n)
+      expectEqual(y.distance(to: x), -n)
+      expectEqual(x.advanced(by: +n), y)
+      expectEqual(y.advanced(by: -n), x)
+      expectEqual(Unicode.Scalar._step(after: (0, x), from: x, by: +n).value, y)
+      expectEqual(Unicode.Scalar._step(after: (0, y), from: y, by: -n).value, x)
+    }
+    let surrogates: ClosedRange<UInt32> = 0xD800 ... 0xDFFF
+    expectEqual(surrogates.count, 2048)
+    checkAxioms(x: "\0", y: "\0", n: 0)
+    checkAxioms(x: "\0", y: "\u{0001}", n: 1)
+    checkAxioms(x: "\u{D7FE}", y: "\u{D7FE}", n: 0)
+    checkAxioms(x: "\u{D7FE}", y: "\u{D7FF}", n: 1)
+    checkAxioms(x: "\u{D7FE}", y: "\u{E000}", n: 2)
+    checkAxioms(x: "\u{D7FE}", y: "\u{E001}", n: 3)
+    checkAxioms(x: "\u{D7FF}", y: "\u{D7FF}", n: 0)
+    checkAxioms(x: "\u{D7FF}", y: "\u{E000}", n: 1)
+    checkAxioms(x: "\u{D7FF}", y: "\u{E001}", n: 2)
+    checkAxioms(x: "\u{E000}", y: "\u{E000}", n: 0)
+    checkAxioms(x: "\u{E000}", y: "\u{E001}", n: 1)
+    checkAxioms(x: "\u{E001}", y: "\u{E001}", n: 0)
+    checkAxioms(x: "\u{10FFFF}", y: "\u{10FFFF}", n: 0)
+    checkAxioms(x: "\u{10FFFE}", y: "\u{10FFFF}", n: 1)
+    checkAxioms(x: "\0", y: "\u{D7FE}", n: 0xD7FE)
+    checkAxioms(x: "\0", y: "\u{D7FF}", n: 0xD7FF)
+    checkAxioms(x: "\0", y: "\u{E000}", n: 0xD800)
+    checkAxioms(x: "\0", y: "\u{E001}", n: 0xD801)
+    checkAxioms(x: "\u{D7FE}", y: "\u{10FFFF}", n: 0x10FFFF - 0xDFFE)
+    checkAxioms(x: "\u{D7FF}", y: "\u{10FFFF}", n: 0x10FFFF - 0xDFFF)
+    checkAxioms(x: "\u{E000}", y: "\u{10FFFF}", n: 0x10FFFF - 0xE000)
+    checkAxioms(x: "\u{E001}", y: "\u{10FFFF}", n: 0x10FFFF - 0xE001)
+    checkAxioms(x: "\0", y: "\u{10FFFF}", n: 0x10FFFF - surrogates.count)
+  }
+}
 
+runAllTests()

--- a/validation-test/stdlib/Stride.swift
+++ b/validation-test/stdlib/Stride.swift
@@ -26,4 +26,37 @@ StrideTestSuite.test("through") {
   }
 }
 
+if #available(SwiftStdlib 6.3, *) {
+  StrideTestSuite.test("Unicode.Scalar") {
+    func checkValues(
+      actual: some RandomAccessCollection<Unicode.Scalar>,
+      expected: Range<UInt32>...
+    ) {
+      let actualValues = actual.lazy.map { $0.value }
+      let expectedValues = expected.joined()
+      expectTrue(expectedValues.elementsEqual(actualValues))
+    }
+    let lowerRange: Range<UInt32> = 0 ..< 0xD800
+    let upperRange: Range<UInt32> = 0xE000 ..< 0x110000
+    do {
+      let a: Range<Unicode.Scalar> = "\0" ..< "\u{10FFFF}"
+      let b = stride(from: a.lowerBound, to: a.upperBound, by: +1)
+      let c = stride(from: a.upperBound, to: a.lowerBound, by: -1)
+      checkValues(actual: a, expected: lowerRange, upperRange.dropLast())
+      expectEqual(a.count, lowerRange.count + upperRange.count - 1)
+      expectTrue(a.elementsEqual(b))
+      expectTrue(a.dropFirst().reversed().elementsEqual(c.dropFirst()))
+    }
+    do {
+      let a: ClosedRange<Unicode.Scalar> = "\0" ... "\u{10FFFF}"
+      let b = stride(from: a.lowerBound, through: a.upperBound, by: +1)
+      let c = stride(from: a.upperBound, through: a.lowerBound, by: -1)
+      checkValues(actual: a, expected: lowerRange, upperRange)
+      expectEqual(a.count, lowerRange.count + upperRange.count)
+      expectTrue(a.elementsEqual(b))
+      expectTrue(a.reversed().elementsEqual(c))
+    }
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
Pitch: <https://forums.swift.org/t/conform-unicode-scalar-to-strideable/82103>