### PR TITLE
[cxx-interop] Import complex macros consistently in C++ language mode

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -333,12 +333,16 @@ getIntegerConstantForMacroToken(ClangImporter::Implementation &impl,
     }
 
   // Macro identifier.
-  // TODO: for some reason when in C++ mode, "hasMacroDefinition" is often
-  // false: rdar://110071334
-  } else if (token.is(clang::tok::identifier) &&
-             token.getIdentifierInfo()->hasMacroDefinition()) {
+  } else if (token.is(clang::tok::identifier)) {
 
     auto rawID = token.getIdentifierInfo();
+
+    // When importing in (Objective-)C++ language mode, sometimes a macro might
+    // have an outdated identifier info, which would cause Clang preprocessor to
+    // assume that it does not have a definition.
+    if (rawID->isOutOfDate())
+      (void)impl.getClangPreprocessor().getLeafModuleMacros(rawID);
+
     auto definition = impl.getClangPreprocessor().getMacroDefinition(rawID);
     if (!definition)
       return std::nullopt;

--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -verify %s
-
-// Most of these don't pass: rdar://110071334
-// %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-cxx-interop -enable-objc-interop -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -cxx-interoperability-mode=default -enable-objc-interop -typecheck -verify %s
 
 @_exported import macros
 

--- a/test/Interop/Cxx/objc-correctness/darwin-macros.swift
+++ b/test/Interop/Cxx/objc-correctness/darwin-macros.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %S/Inputs %s
+
+// REQUIRES: OS=macosx
+
+import Darwin
+
+let _ = COPYFILE_ALL


### PR DESCRIPTION
This is similar to ced4cb06.

Clang stores macro information for each identifier inside of `IdentifierInfo`, which can sometimes get outdated. Clang solves this by updating the identifier info if necessary in `getLeafModuleMacros`. Let's do the same in Swift.

This makes sure that macros that reference other macros are correctly imported with C++ interop enabled.

rdar://145584369
rdar://110071334

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
