### PR TITLE
[6.2] SILGen: Don't copy_addr [take] trivial address-only values.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5240,7 +5240,9 @@ void SILGenFunction::emitSemanticStore(SILLocation loc,
     assert(!silConv.useLoweredAddresses() ||
            (dest->getType().isAddressOnly(F) == rvalue->getType().isAddress()));
     if (rvalue->getType().isAddress()) {
-      B.createCopyAddr(loc, rvalue, dest, IsTake, isInit);
+      B.createCopyAddr(loc, rvalue, dest,
+                       rvalue->getType().isTrivial(F) ? IsNotTake : IsTake,
+                       isInit);
     } else {
       emitUnloweredStoreOfCopy(B, loc, rvalue, dest, isInit);
     }

--- a/test/SILGen/trivial_address_only_switch.swift
+++ b/test/SILGen/trivial_address_only_switch.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -verify -disable-availability-checking %s
+
+public enum StreamYieldResult<let count: Int>: Sendable {
+    case literal(buffer: InlineArray<count, UInt8>)
+    case end(buffer: InlineArray<count, UInt8>, endIndex: Int)
+    
+    public func buffer() -> InlineArray<count, UInt8> {
+        switch self {
+        case .literal(let b):
+            return b
+        case .end(let b, _):
+            return b
+        }
+    }
+}

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -102,7 +102,7 @@ public struct Container<each T> {
 //   Finally, the actual assignment.
 // CHECK-NEXT:    [[ACCESS:%.*]] = begin_access [modify] [unknown] %1 :
 // CHECK-NEXT:    [[FIELD:%.*]] = struct_element_addr [[ACCESS]] : $*Container<repeat each T>, #Container.storage
-// CHECK-NEXT:    copy_addr [take] [[COPY2]] to [[FIELD]] : $*(repeat Stored<each T>)
+// CHECK-NEXT:    copy_addr [[COPY2]] to [[FIELD]] : $*(repeat Stored<each T>)
 // CHECK-NEXT:    end_access [[ACCESS]]
 //   Clean up.
 // CHECK-NEXT:    dealloc_stack [[COPY2]]


### PR DESCRIPTION
Explanation: Fixes an assertion failure when `switch`-ing or potentially performing other operations on an `InlineArray` with a known-bitwise-copyable type but generic count.

Scope: Bug fix.

Issues: #84141, rdar://160007939

Original PR: https://github.com/swiftlang/swift/pull/84264

Risk: Low. Small change that should have no effect on most existing code.

Testing: Swift CI, test case from bug report

Reviewers: @meg-gupta, @atrick

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
