### PR TITLE
utils: disable packaging on PR tests

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -83,7 +83,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   %SkipPackagingArg% ^
   %WindowsSDKArchitecturesArg% ^
   %TestArg% ^
-  -Stage %PackageRoot% ^
+  -SkipPackaging ^
   -IncludeSBoM ^
   -Summary || (exit /b 1)
 


### PR DESCRIPTION
The packaging can be tested with an explicit `please build toolchain Windows platform`.