### PR TITLE
[IDE] Add internal parameter names in signature help

### DIFF
--- a/test/SourceKit/SignatureHelp/signature_help_currying.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_currying.swift
@@ -82,6 +82,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Int, Int) -> Int",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -92,6 +93,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (inout Int) -> ()",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -102,6 +104,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (AdditiveArithmetic, AdditiveArithmetic) -> AdditiveArithmetic",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -112,6 +115,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Double?, Float, Int) -> Double",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -122,6 +126,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Double, Float, Int) -> Double",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -132,6 +137,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Double...) -> Double",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -142,6 +148,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Int, Int, (Int, Int) throws -> Int) throws -> Int?",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -152,6 +159,7 @@ func testCurryMemberFull() {
       key.name: "add(_ self: Adder) -> (Int) -> (Int) -> Int",
       key.parameters: [
         {
+          key.name: "self",
           key.nameoffset: 4,
           key.namelength: 13
         }
@@ -168,10 +176,12 @@ func testCurryMemberFull() {
       key.name: "(_ x: Int, to: Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 1,
           key.namelength: 8
         },
         {
+          key.name: "y",
           key.nameoffset: 11,
           key.namelength: 7
         }
@@ -182,6 +192,7 @@ func testCurryMemberFull() {
       key.name: "(oneTo: inout Int)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 1,
           key.namelength: 16
         }
@@ -192,10 +203,12 @@ func testCurryMemberFull() {
       key.name: "(_ x: AdditiveArithmetic, to: AdditiveArithmetic) -> AdditiveArithmetic",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 1,
           key.namelength: 23
         },
         {
+          key.name: "y",
           key.nameoffset: 26,
           key.namelength: 22
         }
@@ -206,14 +219,17 @@ func testCurryMemberFull() {
       key.name: "(first: Double!, second: Float, third: Int) -> Double",
       key.parameters: [
         {
+          key.name: "first",
           key.nameoffset: 1,
           key.namelength: 14
         },
         {
+          key.name: "second",
           key.nameoffset: 17,
           key.namelength: 13
         },
         {
+          key.name: "third",
           key.nameoffset: 32,
           key.namelength: 10
         }
@@ -224,14 +240,17 @@ func testCurryMemberFull() {
       key.name: "(arg1: Double, arg2: Float, arg3: Int) -> Double",
       key.parameters: [
         {
+          key.name: "param1",
           key.nameoffset: 1,
           key.namelength: 12
         },
         {
+          key.name: "arg2",
           key.nameoffset: 15,
           key.namelength: 11
         },
         {
+          key.name: "param3",
           key.nameoffset: 28,
           key.namelength: 9
         }
@@ -242,6 +261,7 @@ func testCurryMemberFull() {
       key.name: "(numbers: Double...) -> Double",
       key.parameters: [
         {
+          key.name: "numbers",
           key.nameoffset: 1,
           key.namelength: 18
         }
@@ -252,14 +272,17 @@ func testCurryMemberFull() {
       key.name: "(x: Int, y: Int, with: (Int, Int) throws -> Int) throws -> Int!",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 1,
           key.namelength: 6
         },
         {
+          key.name: "y",
           key.nameoffset: 9,
           key.namelength: 6
         },
         {
+          key.name: "adder",
           key.nameoffset: 17,
           key.namelength: 30
         }
@@ -270,6 +293,7 @@ func testCurryMemberFull() {
       key.name: "(x: Int) -> (Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 1,
           key.namelength: 6
         }

--- a/test/SourceKit/SignatureHelp/signature_help_default_args.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_default_args.swift
@@ -35,10 +35,12 @@ add()
       key.name: "add(_ x: Int = 10, to: Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 13
         },
         {
+          key.name: "y",
           key.nameoffset: 19,
           key.namelength: 7
         }
@@ -49,6 +51,7 @@ add()
       key.name: "add(oneTo: inout Int)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 16
         }
@@ -59,10 +62,12 @@ add()
       key.name: "add(_ x: Int, to: Int? = nil) -> String",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 8
         },
         {
+          key.name: "y",
           key.nameoffset: 14,
           key.namelength: 14
         }
@@ -73,14 +78,17 @@ add()
       key.name: "add(first: Double!, second: Float = .pi, third: Int) -> Double",
       key.parameters: [
         {
+          key.name: "first",
           key.nameoffset: 4,
           key.namelength: 14
         },
         {
+          key.name: "second",
           key.nameoffset: 20,
           key.namelength: 19
         },
         {
+          key.name: "third",
           key.nameoffset: 41,
           key.namelength: 10
         }
@@ -91,6 +99,7 @@ add()
       key.name: "add(s: S = S(a: false)) -> Double",
       key.parameters: [
         {
+          key.name: "s",
           key.nameoffset: 4,
           key.namelength: 18
         }
@@ -101,14 +110,17 @@ add()
       key.name: "add(x: Int, y: Int, with: (Int, Int) -> Int = { $0 + $1 }) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         },
         {
+          key.name: "y",
           key.nameoffset: 12,
           key.namelength: 6
         },
         {
+          key.name: "adder",
           key.nameoffset: 20,
           key.namelength: 37
         }
@@ -119,6 +131,7 @@ add()
       key.name: "add(x: Int = importantValue)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 23
         }
@@ -129,14 +142,17 @@ add()
       key.name: "add(x: Int, line: UInt = #line, file: StaticString = #file)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         },
         {
+          key.name: "line",
           key.nameoffset: 12,
           key.namelength: 18
         },
         {
+          key.name: "file",
           key.nameoffset: 32,
           key.namelength: 26
         }

--- a/test/SourceKit/SignatureHelp/signature_help_doc.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_doc.swift
@@ -30,10 +30,12 @@ add(x: )
       key.doc_comment: "Adds two integers.\n\n- Parameters:\n  - x: The first integer to add.\n  - y: The second integer to add.\n\nUsage:\n```swift\nadd(1, to: 2) // 3\n```\n\n- Returns: The sum of the two integers.",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 8
         },
         {
+          key.name: "y",
           key.nameoffset: 14,
           key.namelength: 7
         }

--- a/test/SourceKit/SignatureHelp/signature_help_enum_case.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_enum_case.swift
@@ -26,18 +26,22 @@ func testUnlabled() {
       key.name: "upc(numberSystem: Int, manufacturer: Int, product: Int, check: Int) -> Barcode",
       key.parameters: [
         {
+          key.name: "numberSystem",
           key.nameoffset: 4,
           key.namelength: 17
         },
         {
+          key.name: "manufacturer",
           key.nameoffset: 23,
           key.namelength: 17
         },
         {
+          key.name: "product",
           key.nameoffset: 42,
           key.namelength: 12
         },
         {
+          key.name: "check",
           key.nameoffset: 56,
           key.namelength: 10
         }

--- a/test/SourceKit/SignatureHelp/signature_help_init.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_init.swift
@@ -17,14 +17,17 @@ Person(name: "John", age: )
       key.name: "init(name: String, age: Int, profession: String)",
       key.parameters: [
         {
+          key.name: "name",
           key.nameoffset: 5,
           key.namelength: 12
         },
         {
+          key.name: "age",
           key.nameoffset: 19,
           key.namelength: 8
         },
         {
+          key.name: "job",
           key.nameoffset: 29,
           key.namelength: 18
         }

--- a/test/SourceKit/SignatureHelp/signature_help_member_func.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_member_func.swift
@@ -48,10 +48,12 @@ adder.add()
       key.name: "add(_ x: Int, to: Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 8
         },
         {
+          key.name: "y",
           key.nameoffset: 14,
           key.namelength: 7
         }
@@ -62,6 +64,7 @@ adder.add()
       key.name: "add(oneTo: inout Int)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 16
         }
@@ -72,10 +75,12 @@ adder.add()
       key.name: "add(_ x: AdditiveArithmetic, to: AdditiveArithmetic) -> AdditiveArithmetic",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 23
         },
         {
+          key.name: "y",
           key.nameoffset: 29,
           key.namelength: 22
         }
@@ -86,14 +91,17 @@ adder.add()
       key.name: "add(first: Double!, second: Float, third: Int) -> Double",
       key.parameters: [
         {
+          key.name: "first",
           key.nameoffset: 4,
           key.namelength: 14
         },
         {
+          key.name: "second",
           key.nameoffset: 20,
           key.namelength: 13
         },
         {
+          key.name: "third",
           key.nameoffset: 35,
           key.namelength: 10
         }
@@ -104,14 +112,17 @@ adder.add()
       key.name: "add(arg1: Double, arg2: Float, arg3: Int) -> Double",
       key.parameters: [
         {
+          key.name: "param1",
           key.nameoffset: 4,
           key.namelength: 12
         },
         {
+          key.name: "arg2",
           key.nameoffset: 18,
           key.namelength: 11
         },
         {
+          key.name: "param3",
           key.nameoffset: 31,
           key.namelength: 9
         }
@@ -122,6 +133,7 @@ adder.add()
       key.name: "add(numbers: Double...) -> Double",
       key.parameters: [
         {
+          key.name: "numbers",
           key.nameoffset: 4,
           key.namelength: 18
         }
@@ -132,14 +144,17 @@ adder.add()
       key.name: "add(x: Int, y: Int, with: (Int, Int) -> Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         },
         {
+          key.name: "y",
           key.nameoffset: 12,
           key.namelength: 6
         },
         {
+          key.name: "adder",
           key.nameoffset: 20,
           key.namelength: 23
         }
@@ -150,6 +165,7 @@ adder.add()
       key.name: "add(x: Int) -> (Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         }

--- a/test/SourceKit/SignatureHelp/signature_help_member_generic.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_member_generic.swift
@@ -20,6 +20,7 @@ vec.dot(with: )
       key.name: "dot(with: Vector<Double>) -> Double",
       key.parameters: [
         {
+          key.name: "other",
           key.nameoffset: 4,
           key.namelength: 20
         }

--- a/test/SourceKit/SignatureHelp/signature_help_member_subscript.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_member_subscript.swift
@@ -38,10 +38,12 @@ matrix[]
       key.name: "subscript(row: Int, column: Int) -> Int",
       key.parameters: [
         {
+          key.name: "row",
           key.nameoffset: 10,
           key.namelength: 8
         },
         {
+          key.name: "column",
           key.nameoffset: 20,
           key.namelength: 11
         }
@@ -52,6 +54,7 @@ matrix[]
       key.name: "subscript(row: Int) -> [Int]",
       key.parameters: [
         {
+          key.name: "r",
           key.nameoffset: 10,
           key.namelength: 8
         }
@@ -62,6 +65,7 @@ matrix[]
       key.name: "subscript(column: Int) -> [Int]",
       key.parameters: [
         {
+          key.name: "c",
           key.nameoffset: 10,
           key.namelength: 11
         }

--- a/test/SourceKit/SignatureHelp/signature_help_raw_identifier.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_raw_identifier.swift
@@ -5,7 +5,7 @@
 
 //--- input.swift
 struct `Raw Identifier` {
-  func `some method :)`(`param label?` `argument label!`: Int) {}
+  func `some method :)`(`argument label!` `param label?`: Int) {}
 }
 
 `Raw Identifier`().`some method :)`()
@@ -14,11 +14,12 @@ struct `Raw Identifier` {
 {
   key.signatures: [
     {
-      key.name: "`some method :)`(`param label?`: Int)",
+      key.name: "`some method :)`(`argument label!`: Int)",
       key.parameters: [
         {
+          key.name: "param label?",
           key.nameoffset: 17,
-          key.namelength: 19
+          key.namelength: 22
         }
       ],
       key.active_parameter: 0

--- a/test/SourceKit/SignatureHelp/signature_help_top_level.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_top_level.swift
@@ -45,10 +45,12 @@ add()
       key.name: "add(_ x: Int, to: Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 8
         },
         {
+          key.name: "y",
           key.nameoffset: 14,
           key.namelength: 7
         }
@@ -59,6 +61,7 @@ add()
       key.name: "add(oneTo: inout Int)",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 16
         }
@@ -69,10 +72,12 @@ add()
       key.name: "add(_ x: AdditiveArithmetic, to: AdditiveArithmetic) -> AdditiveArithmetic",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 23
         },
         {
+          key.name: "y",
           key.nameoffset: 29,
           key.namelength: 22
         }
@@ -83,14 +88,17 @@ add()
       key.name: "add(first: Double!, second: Float, third: Int) -> Double",
       key.parameters: [
         {
+          key.name: "first",
           key.nameoffset: 4,
           key.namelength: 14
         },
         {
+          key.name: "second",
           key.nameoffset: 20,
           key.namelength: 13
         },
         {
+          key.name: "third",
           key.nameoffset: 35,
           key.namelength: 10
         }
@@ -101,14 +109,17 @@ add()
       key.name: "add(arg1: Double, arg2: Float, arg3: Int) -> Double",
       key.parameters: [
         {
+          key.name: "param1",
           key.nameoffset: 4,
           key.namelength: 12
         },
         {
+          key.name: "arg2",
           key.nameoffset: 18,
           key.namelength: 11
         },
         {
+          key.name: "param3",
           key.nameoffset: 31,
           key.namelength: 9
         }
@@ -119,6 +130,7 @@ add()
       key.name: "add(numbers: Double...) -> Double",
       key.parameters: [
         {
+          key.name: "numbers",
           key.nameoffset: 4,
           key.namelength: 18
         }
@@ -129,14 +141,17 @@ add()
       key.name: "add(x: Int, y: Int, with: (Int, Int) -> Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         },
         {
+          key.name: "y",
           key.nameoffset: 12,
           key.namelength: 6
         },
         {
+          key.name: "adder",
           key.nameoffset: 20,
           key.namelength: 23
         }
@@ -147,6 +162,7 @@ add()
       key.name: "add(x: Int) -> (Int) -> Int",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 6
         }

--- a/test/SourceKit/SignatureHelp/signature_help_top_level_generic.swift
+++ b/test/SourceKit/SignatureHelp/signature_help_top_level_generic.swift
@@ -17,14 +17,17 @@ add(x: "A", y: "B", with: )
       key.name: "add(x: String, y: String, with: (String, String) -> String) -> String",
       key.parameters: [
         {
+          key.name: "x",
           key.nameoffset: 4,
           key.namelength: 9
         },
         {
+          key.name: "y",
           key.nameoffset: 15,
           key.namelength: 9
         },
         {
+          key.name: "adder",
           key.nameoffset: 26,
           key.namelength: 32
         }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1014,22 +1014,39 @@ public:
 
 struct SignatureHelpResponse {
   struct Parameter {
+    /// The offset of the parameter text in the signature text.
     unsigned Offset;
+
+    /// The length of the parameter text in the signature text.
     unsigned Length;
+
+    /// The documentation comment for the parameter.
     StringRef DocComment;
+
+    /// The internal parameter name.
     StringRef Name;
 
     Parameter() {}
   };
 
   struct Signature {
+    /// The text describing the signature.
     StringRef Text;
+
+    /// The documentation comment for the signature.
     StringRef Doc;
+
+    /// The index of the active parameter if any.
     std::optional<unsigned> ActiveParam;
+
+    /// The parameters for the signature.
     ArrayRef<Parameter> Params;
   };
 
+  /// The index of the active signature.
   unsigned ActiveSignature;
+
+  /// The available signatures/overloads.
   ArrayRef<Signature> Signatures;
 };
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1017,6 +1017,7 @@ struct SignatureHelpResponse {
     unsigned Offset;
     unsigned Length;
     StringRef DocComment;
+    StringRef Name;
 
     Parameter() {}
   };

--- a/tools/SourceKit/lib/SwiftLang/SwiftSignatureHelp.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSignatureHelp.cpp
@@ -180,9 +180,19 @@ static void getSignatureInfo(const DeclContext *DC, const Signature &Sig,
   Info.Text = copyAndClearString(Allocator, SS);
   Info.ActiveParam = Sig.ParamIdx;
 
+  // Parameter names.
+  const ParamDecl *ParamScratch;
+  auto ParamDecls =
+      getParameterArray(FD, Sig.IsImplicitlyCurried, ParamScratch);
+
+  if (!ParamDecls.empty()) {
+    for (unsigned i = 0; i < Info.Params.size(); ++i) {
+      Info.Params[i].Name = ParamDecls[i]->getParameterName().str();
+    }
+  }
+
   // Documentation.
   if (FD) {
-    // TODO(a7medev): Separate parameter documentation.
     ide::getRawDocumentationComment(FD, OS);
 
     Info.DocComment = copyAndClearString(Allocator, SS);

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -3666,6 +3666,9 @@ signatureHelp(StringRef PrimaryFilePath, int64_t Offset,
         for (auto Param : Signature.Params) {
           auto ParamElem = Params.appendDictionary();
 
+          if (!Param.Name.empty())
+            ParamElem.set(KeyName, Param.Name);
+
           ParamElem.set(KeyNameOffset, Param.Offset);
           ParamElem.set(KeyNameLength, Param.Length);
 


### PR DESCRIPTION
Adds internal parameter names for signature help parameters.

This allows SourceKit-LSP to parse the documentation comment, extract parameter documentation, and match it with the parameters using the parameter name.