### PR TITLE
[CS] Avoid forming DependentMemberType with hole base in `InferableTypeOpener`

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/a8575b8261697c42.swift
+++ b/validation-test/compiler_crashers_2_fixed/a8575b8261697c42.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","original":"9e6249db","signature":"(anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+(a as Sequence).Element {
+}

--- a/validation-test/compiler_crashers_2_fixed/fddb1549773c253.swift
+++ b/validation-test/compiler_crashers_2_fixed/fddb1549773c253.swift
@@ -1,0 +1,7 @@
+// {"kind":"typecheck","original":"5e6f691d","signature":"(anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+protocol a {
+  associatedtype b
+  struct c<d, a {
+e {
+  d.b {


### PR DESCRIPTION
Type substitution can form DependentMemberTypes with error base types, avoid forming a DependentMemberType with a hole base in `InferableTypeOpener`, instead form a hole that covers the entire type.