### PR TITLE
[cxx-interop] Remove dead logic in const import

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4591,15 +4591,11 @@ namespace {
       bool initIsEvaluatable = false;
       if (Impl.SwiftContext.ClangImporterOpts.EnableConstValueImporting) {
         if (auto init = decl->getInit()) {
-          // Don't import values for partial specializations. TODO: Should we 
-          // stop importing partially specialized variables completely?
-          bool partial = isa<clang::VarTemplatePartialSpecializationDecl>(decl);
-
           // Don't import values when type-dependent or value-dependent.
           bool typeDependent = decl->getType()->isDependentType();
           bool valueDependent = init->isValueDependent();
 
-          initIsEvaluatable = !partial && !typeDependent && !valueDependent;
+          initIsEvaluatable = !typeDependent && !valueDependent;
         }
       }
 


### PR DESCRIPTION
We no longer try to import partial specializations of variables after 77975524.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
