### PR TITLE
Mutable[Raw]Span.init() does not need @_unsafeNonescapableResult

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -42,7 +42,6 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   }
 
   @unsafe
-  @_unsafeNonescapableResult
   @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
   internal init(

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -43,7 +43,6 @@ public struct MutableSpan<Element: ~Copyable>
   }
 
   @unsafe
-  @_unsafeNonescapableResult
   @_alwaysEmitIntoClient
   @lifetime(borrow start)
   internal init(


### PR DESCRIPTION
It isn't clear why @_unsafeNonescapableResult was applied to
Mutable[Raw]Span.init(). It was either a mistake or temporary workaround for
some compiler bug.
