### PR TITLE
[CS] Bail from conjunction for non-zero `SK_Hole`

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1957,6 +1957,8 @@ namespace {
     void addSpecializationConstraint(ConstraintLocator *locator, Type boundType,
                                      SourceLoc lAngleLoc,
                                      ArrayRef<TypeRepr *> specializationArgs) {
+      auto &ctx = CS.getASTContext();
+
       // Resolve each type.
       SmallVector<Type, 2> specializationArgTypes;
       auto options =
@@ -1971,6 +1973,7 @@ namespace {
           options |= TypeResolutionFlags::AllowPackReferences;
           elementEnv = OuterExpansions.back();
         }
+        auto alreadyInvalid = specializationArg->isInvalid();
         auto result = TypeResolution::resolveContextualType(
             specializationArg, CurDC, options,
             // Introduce type variables for unbound generics.
@@ -1980,19 +1983,20 @@ namespace {
             OpenGenericTypeRequirements(CS, locator,
                                         /*preparedOverload*/ nullptr));
         if (result->hasError()) {
-          auto &ctxt = CS.getASTContext();
+          if (!alreadyInvalid) {
+            ctx.Diags.diagnose(lAngleLoc,
+                               diag::while_parsing_as_left_angle_bracket);
+          }
           CS.recordFix(IgnoreInvalidASTNode::create(
               CS, CS.getConstraintLocator(argLocator)));
-          result = PlaceholderType::get(ctxt, specializationArg);
-          ctxt.Diags.diagnose(lAngleLoc,
-                              diag::while_parsing_as_left_angle_bracket);
+          result = PlaceholderType::get(ctx, specializationArg);
         }
         specializationArgTypes.push_back(result);
       }
 
       auto constraint = Constraint::create(
           CS, ConstraintKind::ExplicitGenericArguments, boundType,
-          PackType::get(CS.getASTContext(), specializationArgTypes), locator);
+          PackType::get(ctx, specializationArgTypes), locator);
       CS.addUnsolvedConstraint(constraint);
       CS.activateConstraint(constraint);
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1981,6 +1981,8 @@ namespace {
                                         /*preparedOverload*/ nullptr));
         if (result->hasError()) {
           auto &ctxt = CS.getASTContext();
+          CS.recordFix(IgnoreInvalidASTNode::create(
+              CS, CS.getConstraintLocator(argLocator)));
           result = PlaceholderType::get(ctxt, specializationArg);
           ctxt.Diags.diagnose(lAngleLoc,
                               diag::while_parsing_as_left_angle_bracket);

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -1113,3 +1113,18 @@ func testHolePropagation() {
   _ = { () -> (S<R>, Int) in return (makeT(), 0) } // expected-error {{type 'R' does not conform to protocol 'P'}}
   _ = { () -> (S<R>, Int) in (); return (makeT(), 0) } // expected-error {{type 'R' does not conform to protocol 'P'}}
 }
+
+@freestanding(expression) macro overloadedMacro<T>() -> String = #file
+@freestanding(expression) macro overloadedMacro<T>(_ x: T = 0) -> String = #file
+
+do {
+  func foo(_ fn: () -> Int) {}
+  func foo(_ fn: () -> String) {}
+
+  // Make sure we only emit a single note here.
+  foo {
+    #overloadedMacro < Undefined >
+    // expected-error@-1 {{cannot find type 'Undefined' in scope}}
+    // expected-note@-2 {{while parsing this '<' as a type parameter bracket}}
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/2d5e95ea862946ed.swift
+++ b/validation-test/compiler_crashers_2_fixed/2d5e95ea862946ed.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a {
   {
     \ b() a

--- a/validation-test/compiler_crashers_2_fixed/d14a9abe37cc3bca.swift
+++ b/validation-test/compiler_crashers_2_fixed/d14a9abe37cc3bca.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::SolverTrail::~SolverTrail()","signatureAssert":"Assertion failed: (Changes.empty() && \"Trail corrupted\"), function ~SolverTrail"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a< b { case c(}
          func d< b >(b->a< b >) d(a< e >.c let a


### PR DESCRIPTION
Previously we would only do this for `SK_Fix`, do the same for `SK_Hole` since otherwise the score clearing logic for the conjunction could result in losing the hole score.