### PR TITLE
[6.2.0][cxx-interop] Do not consider function types fragile

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -32,6 +32,7 @@
 #include "swift/Basic/Assertions.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/AST/Type.h"
 
 using namespace swift;
 
@@ -1862,6 +1863,15 @@ bool isFragileClangType(clang::QualType type) {
   // Builtin clang types are compatible with library evolution.
   if (underlyingTypePtr->isBuiltinType())
     return false;
+  if (const auto *ft = dyn_cast<clang::FunctionType>(underlyingTypePtr)) {
+    if (const auto *fpt =
+            dyn_cast<clang::FunctionProtoType>(underlyingTypePtr)) {
+      for (auto paramTy : fpt->getParamTypes())
+        if (isFragileClangType(paramTy))
+          return true;
+    }
+    return isFragileClangType(ft->getReturnType());
+  }
   // Pointers to non-fragile types are non-fragile.
   if (underlyingTypePtr->isPointerType())
     return isFragileClangType(underlyingTypePtr->getPointeeType());

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
@@ -39,6 +39,9 @@ struct CStruct {
 }
 #endif
 
+typedef void (*my_sighandler_t)(int);
+typedef void (*my_other_cb)(CxxStruct);
+
 //--- test.swift
 
 import CxxModule
@@ -54,4 +57,10 @@ public func useCxxEnum(_ x: CxxEnum) { // expected-error {{cannot use enum 'CxxE
 
 // expected-error@+1 {{cannot use struct 'CxxStruct' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 public func usesCxxStruct(_ x: CxxStruct) {
+}
+
+public func usesTypeAliasToFuncPtr(_ x: my_sighandler_t) {
+}
+
+public func usesTypeAliasToFuncPtr2(_ x: my_other_cb) { // expected-error {{cannot use type alias 'my_other_cb' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 }


### PR DESCRIPTION
This is a copy from @Xazax-hun's PR #84164 but for 6.2.0. I propose this to avoid regressing the 6.2.0 release since this fix is already included in release/6.2 and release/6.2.1. It fixes the following issue outlined here: [#83915](https://github.com/swiftlang/swift/issues/83915).

Explanation: Function pointer types wee always considered fragile in C++ mode, this manifested as a regression when interfacing with glibc.
Issues: rdar://159184118
Original PRs: https://github.com/swiftlang/swift/pull/84040
Risk: Low, this only removes a spurious error for library evolution.
Testing: Added a compiler test.
Reviewers: @egorzhdan