### PR TITLE
[Legacy Driver][wasm] Pass `--table-base` to reserve low function addresses

### DIFF
--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -194,6 +194,10 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   Arguments.push_back(context.Args.MakeArgString(
       Twine("--global-base=") +
       std::to_string(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)));
+  Arguments.push_back("-Xlinker");
+  Arguments.push_back(context.Args.MakeArgString(
+      Twine("--table-base=") +
+      std::to_string(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)));
 
   // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -188,8 +188,8 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
 
   // WebAssembly doesn't reserve low addresses But without "extra inhabitants"
   // of the pointer representation, runtime performance and memory footprint are
-  // worse. So assume that compiler driver uses wasm-ld and --global-base=1024
-  // to reserve low 1KB.
+  // worse. So assume that compiler driver uses wasm-ld and --global-base=4096
+  // to reserve low 4KB.
   Arguments.push_back("-Xlinker");
   Arguments.push_back(context.Args.MakeArgString(
       Twine("--global-base=") +

--- a/stdlib/public/SwiftShims/swift/shims/System.h
+++ b/stdlib/public/SwiftShims/swift/shims/System.h
@@ -220,8 +220,8 @@
 
 // WebAssembly doesn't reserve low addresses. But without "extra inhabitants" of
 // the pointer representation, runtime performance and memory footprint are
-// worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
-// reserve low 1KB.
+// worse. So assume that compiler driver uses wasm-ld and --global-base=4096 to
+// reserve low 4KB.
 #define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 4096
 
 #endif // SWIFT_STDLIB_SHIMS_ABI_SYSTEM_H

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -191,7 +191,11 @@ class WasmStdlib(cmake_product.CMakeProduct):
         # Test configuration
         self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
-        lit_test_paths = ['IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded']
+        lit_test_paths = [
+            'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded',
+            # TODO(katei): Enable all interpreter tests
+            'Interpreter/enum.swift',
+        ]
         lit_test_paths = [os.path.join(
             self.build_dir, 'test-wasi-wasm32', path) for path in lit_test_paths]
         self.cmake_options.define('SWIFT_LIT_TEST_PATHS:STRING',


### PR DESCRIPTION
WebAssembly does not have a reserved address space by default, so we need to explicitly reserve low addresses for extra inhabitants for enum types with pointer payloads. https://github.com/swiftlang/swift/pull/39300 added `--global-base` to reserve low data addresses, but we also need to reserve low function addresses with `--table-base` for function pointers because WebAssembly uses a separate address space for function pointers.

Corresponding new-driver PR: https://github.com/swiftlang/swift-driver/pull/1987

<details>

<summary>Minimum problematic code</summary>

```
# Expected
step 1
step 2
END OF ENTRY
Context deinit
# Actual
step 1
Context deinit
step 2
END OF ENTRY
```

```swift
@inline(never)
func blackhole<T>(_ value: T) {}

final class Context {
    func doSomething() {
    }
    deinit {
        print("Context deinit")
    }
}

final class _GenericStorage<Value> {
    let value: Value?

    init(value: Value) {
        self.value = value
    }

    func unwrapAndCopy() {
        if let value = value {
            blackhole(value)
        }
    }
}

func main() {
    let childNode = _GenericStorage(
        value: Context().doSomething,
    )
    print("step 1")
    childNode.unwrapAndCopy()
    print("step 2")
    childNode.unwrapAndCopy()
    print("END OF ENTRY")
}

main()
```
</details>