### PR TITLE
[6.2][Legacy Driver][wasm] Pass `--table-base` to reserve low function addresses

### DIFF
--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -194,6 +194,10 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   Arguments.push_back(context.Args.MakeArgString(
       Twine("--global-base=") +
       std::to_string(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)));
+  Arguments.push_back("-Xlinker");
+  Arguments.push_back(context.Args.MakeArgString(
+      Twine("--table-base=") +
+      std::to_string(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)));
 
   // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -188,8 +188,8 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
 
   // WebAssembly doesn't reserve low addresses But without "extra inhabitants"
   // of the pointer representation, runtime performance and memory footprint are
-  // worse. So assume that compiler driver uses wasm-ld and --global-base=1024
-  // to reserve low 1KB.
+  // worse. So assume that compiler driver uses wasm-ld and --global-base=4096
+  // to reserve low 4KB.
   Arguments.push_back("-Xlinker");
   Arguments.push_back(context.Args.MakeArgString(
       Twine("--global-base=") +

--- a/stdlib/public/SwiftShims/swift/shims/System.h
+++ b/stdlib/public/SwiftShims/swift/shims/System.h
@@ -220,8 +220,8 @@
 
 // WebAssembly doesn't reserve low addresses. But without "extra inhabitants" of
 // the pointer representation, runtime performance and memory footprint are
-// worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
-// reserve low 1KB.
+// worse. So assume that compiler driver uses wasm-ld and --global-base=4096 to
+// reserve low 4KB.
 #define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 4096
 
 #endif // SWIFT_STDLIB_SHIMS_ABI_SYSTEM_H


### PR DESCRIPTION
Explanation: Fix memory corruption on WebAssembly by properly reserving low-function addresses
Original PRs: https://github.com/swiftlang/swift/pull/84285
Risk: Low, this only removes a spurious error for library evolution.
Testing: Ensured at desk that the minimum problematic code won't perform bad memory access with ASan instrumentation
Reviewers: @bnbarham 