### PR TITLE
[CSSimplify] Fix key path to function conversion to check key path re…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -411,6 +411,14 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     }
   }
 
+  // If this is a key path to function conversion, the requirements come
+  // from a key path type implicitly formed by the solver.
+  if (isExpr<KeyPathExpr>(getRawAnchor()) &&
+      getLocator()->isFirstElement<LocatorPathElt::KeyPathType>() &&
+      getOwnerType()->is<FunctionType>()) {
+    return getASTContext().getKeyPathDecl();
+  }
+
   return getAffectedDeclFromType(getOwnerType());
 }
 

--- a/test/Sema/keypaths_noncopyable.swift
+++ b/test/Sema/keypaths_noncopyable.swift
@@ -53,9 +53,9 @@ public func testKeypath<V: ~Copyable>(m: consuming M<V>) {
   // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
 
   let b = Box(NC())
-  _ = b.with(\.data)
-  _ = b.with(\.next)
-  _ = b.with(\.next?.wrapped) // expected-error {{key path cannot refer to noncopyable type 'NC'}}
+  _ = b.with(\.data) // expected-error {{key path cannot refer to noncopyable type 'NC'}}
+  _ = b.with(\.next) // expected-error {{key path cannot refer to noncopyable type 'NC'}}
+  _ = b.with(\.next?.wrapped) // expected-error 2 {{key path cannot refer to noncopyable type 'NC'}}
   _ = b.with(\.next!.wrapped.data) // expected-error {{key path cannot refer to noncopyable type 'NC'}}
 }
 
@@ -67,4 +67,17 @@ func testKeypath2(_ someA: A) -> Int {
 func testAsFunc(_ someA: A) -> Int {
   let fn: (A) -> Int = \A.b.c.d // expected-error {{key path cannot refer to noncopyable type 'B'}}
   return fn(someA)
+}
+
+// https://github.com/swiftlang/swift/issues/84150
+func testKeyPathToFunctionConversion() {
+  struct HasID: ~Copyable {
+    let id: Int
+  }
+
+  func map(_ operation: (consuming HasID) -> Int) {}
+
+  map(\.id) // expected-error {{key path cannot refer to noncopyable type 'HasID'}}
+
+  let _: (consuming HasID) -> Int = \.id // expected-error {{key path cannot refer to noncopyable type 'HasID'}}
 }


### PR DESCRIPTION
…quirements

`KeyPath` types now have conformance requirements placed on their `Root` and `Value` types which need to be checked even when there is a key path to function conversion involved, otherwise the solver would be accepting invalid code.

Note that without function conversion the requirements come from a type opened during assignment - https://github.com/swiftlang/swift/pull/80081/files.

Resolves: https://github.com/swiftlang/swift/issues/84150

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
