### PR TITLE
[cxx-interop] Remove redundant `-disable-availability-checking` in test

### DIFF
--- a/test/Interop/SwiftToCxx/class/swift-actor-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-actor-execution.cpp
@@ -1,19 +1,19 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/actor.h -disable-availability-checking
+// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/actor.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-actor-execution.o
-// RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t/swift-actor-execution -Xlinker %t/swift-actor-execution.o -module-name Actor -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -disable-availability-checking
+// RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t/swift-actor-execution -Xlinker %t/swift-actor-execution.o -module-name Actor -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/swift-actor-execution
 // RUN: %target-run %t/swift-actor-execution | %FileCheck %s
 
 // RUN: %empty-directory(%t-evo)
 
-// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo/actor.h -disable-availability-checking
+// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo/actor.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-actor-execution.o
-// RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t-evo/swift-actor-execution-evo -Xlinker %t-evo/swift-actor-execution.o -module-name Actor -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -disable-availability-checking
+// RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t-evo/swift-actor-execution-evo -Xlinker %t-evo/swift-actor-execution.o -module-name Actor -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t-evo/swift-actor-execution-evo
 // RUN: %target-run %t-evo/swift-actor-execution-evo | %FileCheck %s


### PR DESCRIPTION
rdar://159026025

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
