### PR TITLE
Diagnostics change for ambiguous overloads previously specifying 'this'

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3212,7 +3212,11 @@ public:
   /// GenericSignature inside the type.
   Type getInterfaceType() const;
   bool hasInterfaceType() const;
-
+  
+  // Retrieve the "interface" type, but remove any curried Self type references
+  Type getInterfaceTypeNoSelfParam() const;
+  Type getInterfaceTypeNoSelfParam(Type existingInterfaceType) const;
+  
   /// Set the interface type for the given value.
   void setInterfaceType(Type type);
   

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4541,13 +4541,14 @@ WARNING(warn_use_async_alternative,none,
 // MARK: Type Check Expressions
 //------------------------------------------------------------------------------
 
-NOTE(found_candidate,none,
-     "found this candidate", ())
+// NOTE(found_candidate,none, "found this candidate", ())
 NOTE(found_candidate_in_module,none,
-     "found this candidate %select{|in module %1}0",
-     (bool, const ModuleDecl *))
+     "found candidate with type %2 %select{|in module %1}0",
+     (bool, const ModuleDecl *, Type))
 NOTE(found_candidate_type,none,
      "found candidate with type %0", (Type))
+NOTE(found_candidate_decl,none,
+     "found candidate %0", (const ValueDecl *))
 
 ERROR(no_MaxBuiltinFloatType_found,none,
    "standard library error: _MaxBuiltinFloatType is not properly defined", ())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4572,6 +4572,19 @@ Type ValueDecl::getInterfaceType() const {
                        [&ctx]() { return ErrorType::get(ctx); });
 }
 
+Type ValueDecl::getInterfaceTypeNoSelfParam() const {
+  auto type = this->getInterfaceType();
+  return this->getInterfaceTypeNoSelfParam(type);
+}
+
+Type ValueDecl::getInterfaceTypeNoSelfParam(Type existingInterfaceType) const {
+  if (this->hasCurriedSelf()) {
+    return existingInterfaceType->castTo<AnyFunctionType>()->getResult();
+  }
+  return existingInterfaceType;
+}
+
+
 void ValueDecl::setInterfaceType(Type type) {
   assert(!type.isNull() && "Resetting the interface type to null is forbidden");
   getASTContext().evaluator.cacheOutput(InterfaceTypeRequest{this},

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2218,7 +2218,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
   InferredAssociatedTypesByWitness inferred;
   inferred.Witness = witness;
 
-  auto reqType = swift::TypeChecker::removeSelfParam(req, req->getInterfaceType());
+  auto reqType = req->getInterfaceTypeNoSelfParam();
   Type witnessType;
 
   if (witness->isRecursiveValidation()) {
@@ -2240,7 +2240,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
     LLVM_DEBUG(llvm::dbgs() << "Witness type for matching is "
                             << witnessType << "\n";);
 
-    witnessType = swift::TypeChecker::removeSelfParam(witness, witnessType);
+    witnessType = witness->getInterfaceTypeNoSelfParam(witnessType);
 
     Type reqThrownError;
     Type witnessThrownError;

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2047,13 +2047,13 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
 }
 
 /// Remove the 'self' type from the given type, if it's a method type.
-static Type removeSelfParam(ValueDecl *value, Type type) {
+/*Type removeSelfParam(ValueDecl *value, Type type) {
   if (value->hasCurriedSelf()) {
     return type->castTo<AnyFunctionType>()->getResult();
   }
 
   return type;
-}
+}*/
 
 InferredAssociatedTypesByWitnesses
 AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
@@ -2227,7 +2227,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
   InferredAssociatedTypesByWitness inferred;
   inferred.Witness = witness;
 
-  auto reqType = removeSelfParam(req, req->getInterfaceType());
+  auto reqType = swift::TypeChecker::removeSelfParam(req, req->getInterfaceType());
   Type witnessType;
 
   if (witness->isRecursiveValidation()) {
@@ -2249,7 +2249,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
     LLVM_DEBUG(llvm::dbgs() << "Witness type for matching is "
                             << witnessType << "\n";);
 
-    witnessType = removeSelfParam(witness, witnessType);
+    witnessType = swift::TypeChecker::removeSelfParam(witness, witnessType);
 
     Type reqThrownError;
     Type witnessThrownError;

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2046,15 +2046,6 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
   });
 }
 
-/// Remove the 'self' type from the given type, if it's a method type.
-/*Type removeSelfParam(ValueDecl *value, Type type) {
-  if (value->hasCurriedSelf()) {
-    return type->castTo<AnyFunctionType>()->getResult();
-  }
-
-  return type;
-}*/
-
 InferredAssociatedTypesByWitnesses
 AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
                    AssociatedTypeDecl *assocType) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4101,7 +4101,8 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
 bool SubscriptMisuseFailure::diagnoseAsNote() {
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
     auto decl = overload->choice.getDecl();
-    emitDiagnosticAt(decl, diag::found_candidate_type, swift::TypeChecker::removeSelfParam(decl,decl->getInterfaceType()));
+    emitDiagnosticAt(decl, diag::found_candidate_type,
+                     decl->getInterfaceTypeNoSelfParam());
     return true;
   }
   return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -16,6 +16,7 @@
 
 #include "CSDiagnostics.h"
 #include "MiscDiagnostics.h"
+#include "TypeChecker.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
@@ -4100,7 +4101,7 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
 bool SubscriptMisuseFailure::diagnoseAsNote() {
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
     auto decl = overload->choice.getDecl();
-    emitDiagnosticAt(decl, diag::found_candidate_type, decl->getOverloadSignatureType());
+    emitDiagnosticAt(decl, diag::found_candidate_type, swift::TypeChecker::removeSelfParam(decl,decl->getInterfaceType()));
     return true;
   }
   return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2961,7 +2961,7 @@ bool ContextualFailure::diagnoseAsNote() {
                      toFnType->getNumParams());
     return true;
   }
-
+  
   emitDiagnosticAt(decl, diag::found_candidate_type, getFromType());
   return true;
 }
@@ -4099,7 +4099,8 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
 
 bool SubscriptMisuseFailure::diagnoseAsNote() {
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
-    emitDiagnosticAt(overload->choice.getDecl(), diag::found_candidate);
+    auto decl = overload->choice.getDecl();
+    emitDiagnosticAt(decl, diag::found_candidate_type, decl->getOverloadSignatureType());
     return true;
   }
   return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3385,10 +3385,10 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
         if (EmittedDecls.insert(decl).second) {
           auto declModule = decl->getDeclContext()->getParentModule();
           bool printModuleName = declModule != DC->getParentModule();
-          auto overloadType = decl->getOverloadSignatureType();
+          auto diagnoseType = swift::TypeChecker::removeSelfParam(decl, decl->getInterfaceType());
           
           DE.diagnose(decl, diag::found_candidate_in_module,
-                      printModuleName, declModule, overloadType);
+                      printModuleName, declModule, diagnoseType);
         }
         break;
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2755,7 +2755,7 @@ static bool diagnoseAmbiguity(
           if (candidateTypes.insert(type->getCanonicalType()).second)
             DE.diagnose(getLoc(commonAnchor), diag::found_candidate_type, type);
         } else {
-          DE.diagnose(noteLoc, diag::found_candidate);
+          DE.diagnose(noteLoc, diag::found_candidate_type, type);
         }
       };
 
@@ -3385,8 +3385,10 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
         if (EmittedDecls.insert(decl).second) {
           auto declModule = decl->getDeclContext()->getParentModule();
           bool printModuleName = declModule != DC->getParentModule();
+          auto overloadType = decl->getOverloadSignatureType();
+          
           DE.diagnose(decl, diag::found_candidate_in_module,
-                      printModuleName, declModule);
+                      printModuleName, declModule, overloadType);
         }
         break;
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3385,7 +3385,7 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
         if (EmittedDecls.insert(decl).second) {
           auto declModule = decl->getDeclContext()->getParentModule();
           bool printModuleName = declModule != DC->getParentModule();
-          auto diagnoseType = swift::TypeChecker::removeSelfParam(decl, decl->getInterfaceType());
+          auto diagnoseType = decl->getInterfaceTypeNoSelfParam();
           
           DE.diagnose(decl, diag::found_candidate_in_module,
                       printModuleName, declModule, diagnoseType);

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1326,7 +1326,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
     ctx.Diags.diagnose(importLoc, diag::ambiguous_decl_in_module,
                        accessPath.front().Item, module->getName());
     for (auto next : decls)
-      ctx.Diags.diagnose(next, diag::found_candidate);
+      ctx.Diags.diagnose(next, diag::found_candidate_decl, next);
 
   } else if (!isCompatibleImportKind(importKind, *actualKind)) {
     std::optional<InFlightDiagnostic> emittedDiag;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1851,7 +1851,8 @@ resolveUnqualifiedIdentTypeRepr(const TypeResolution &resolution,
                     repr->getNameRef())
           .highlight(repr->getNameLoc().getSourceRange());
       for (auto entry : globals) {
-        entry.getValueDecl()->diagnose(diag::found_candidate);
+        auto *VD = entry.getValueDecl();
+        VD->diagnose(diag::found_candidate_decl, VD);
       }
     }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -765,6 +765,13 @@ bool TypeChecker::diagnoseInvalidFunctionType(
   return hadAnyError;
 }
 
+Type swift::TypeChecker::removeSelfParam(ValueDecl *value, Type type){
+ if (value->hasCurriedSelf()) {
+   return type->castTo<AnyFunctionType>()->getResult();
+ }
+ return type;
+}
+
 extern "C" intptr_t swift_ASTGen_evaluatePoundIfCondition(
                         BridgedASTContext astContext,
                         void *_Nonnull diagEngine,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1147,6 +1147,9 @@ std::optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
 /// Attempt to omit needless words from the name of the given declaration.
 std::optional<Identifier> omitNeedlessWords(VarDecl *var);
 
+/// Method to strip Self parameter from types for diagnostics
+Type removeSelfParam(ValueDecl *value, Type type);
+
 /// Calculate edit distance between declaration names.
 unsigned getCallEditDistance(DeclNameRef writtenName, DeclName correctedName,
                              unsigned maxEditDistance);

--- a/test/ASTGen/embedded_availability.swift
+++ b/test/ASTGen/embedded_availability.swift
@@ -24,8 +24,8 @@ public func universally_unavailable() { }
 @_unavailableInEmbedded
 public func unused() { } // no error
 
-public struct S1 {} // expected-note 2 {{found this candidate}}
-public struct S2 {} // expected-note 2 {{found this candidate}}
+public struct S1 {} // expected-note 2 {{found candidate with type '(S1.Type) -> S1'}}
+public struct S2 {} // expected-note 2 {{found candidate with type '(S2.Type) -> S2'}}
 
 @_unavailableInEmbedded
 public func has_unavailable_in_embedded_overload(_ s1: S1) { }

--- a/test/ASTGen/embedded_availability.swift
+++ b/test/ASTGen/embedded_availability.swift
@@ -24,8 +24,8 @@ public func universally_unavailable() { }
 @_unavailableInEmbedded
 public func unused() { } // no error
 
-public struct S1 {} // expected-note 2 {{found candidate with type '(S1.Type) -> S1'}}
-public struct S2 {} // expected-note 2 {{found candidate with type '(S2.Type) -> S2'}}
+public struct S1 {} // expected-note 2 {{found candidate with type '() -> S1'}}
+public struct S2 {} // expected-note 2 {{found candidate with type '() -> S2'}}
 
 @_unavailableInEmbedded
 public func has_unavailable_in_embedded_overload(_ s1: S1) { }

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -188,7 +188,7 @@ extension Vector: Differentiable where T: Differentiable {
   mutating func move(by offset: TangentVector) { fatalError() }
 }
 
-// expected-note@+1 2 {{found this candidate}}
+// expected-note@+1 2 {{found candidate with type '(@differentiable(reverse) (Vector<Int>) -> Vector<Int>) -> ()'}}
 func inferredConformancesGeneric<T, U>(_: @differentiable(reverse) (Vector<T>) -> Vector<U>) {}
 
 // expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(_linear)'}}
@@ -223,7 +223,7 @@ extension Linear: Differentiable where T: Differentiable, T == T.TangentVector {
   typealias TangentVector = Self
 }
 
-// expected-note @+1 2 {{found this candidate}}
+// expected-note @+1 2 {{found candidate with type '(@differentiable(reverse) (Linear<Int>) -> Linear<Int>) -> ()'}}
 func inferredConformancesGeneric<T, U>(_: @differentiable(reverse) (Linear<T>) -> Linear<U>) {}
 
 // expected-note  @+2 2 {{where 'T' = 'Int'}}

--- a/test/Availability/availability_macos.swift
+++ b/test/Availability/availability_macos.swift
@@ -2,8 +2,8 @@
 
 // REQUIRES: OS=macosx
 
-struct A {} // expected-note * {{found candidate with type '(A.Type) -> A'}}
-struct B {} // expected-note * {{found candidate with type '(B.Type) -> B'}}
+struct A {} // expected-note * {{found candidate with type '() -> A'}}
+struct B {} // expected-note * {{found candidate with type '() -> B'}}
 
 func ambiguousInFarFuture(_: A) {}
 

--- a/test/Availability/availability_macos.swift
+++ b/test/Availability/availability_macos.swift
@@ -3,7 +3,7 @@
 // REQUIRES: OS=macosx
 
 struct A {} // expected-note * {{found candidate with type '(A.Type) -> A'}}
-struct B {} // expected-note * {{found candidate '(B.Type) -> B'}}
+struct B {} // expected-note * {{found candidate with type '(B.Type) -> B'}}
 
 func ambiguousInFarFuture(_: A) {}
 

--- a/test/Availability/availability_macos.swift
+++ b/test/Availability/availability_macos.swift
@@ -2,8 +2,8 @@
 
 // REQUIRES: OS=macosx
 
-struct A {} // expected-note * {{found this candidate}}
-struct B {} // expected-note * {{found this candidate}}
+struct A {} // expected-note * {{found candidate with type '(A.Type) -> A'}}
+struct B {} // expected-note * {{found candidate '(B.Type) -> B'}}
 
 func ambiguousInFarFuture(_: A) {}
 

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -194,7 +194,7 @@ func test_nested_pointers() {
   nested_pointer_audited2(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
 }
 
-func exit(_: Float) {} // expected-note {{found this candidate}}
+func exit(_: Float) {} // expected-note {{found candidate with type '() -> Float'}}
 func test_ambiguous() {
   exit(5) // expected-error {{ambiguous use of 'exit'}}
 }

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -194,7 +194,7 @@ func test_nested_pointers() {
   nested_pointer_audited2(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
 }
 
-func exit(_: Float) {} // expected-note {{found candidate with type '() -> Float'}}
+func exit(_: Float) {} // expected-note {{found candidate with type '(Float) -> ()'}}
 func test_ambiguous() {
   exit(5) // expected-error {{ambiguous use of 'exit'}}
 }

--- a/test/Concurrency/reasync_ranking.swift
+++ b/test/Concurrency/reasync_ranking.swift
@@ -18,8 +18,8 @@ func referencesAsyncOverloadAsync() async {
   _ = asyncOverload // we prefer the async overload
 }
 
-func reasyncOverload(_: () async -> (), _: Int) reasync {} // expected-note {{found this candidate}}
-func reasyncOverload(_: () -> (), _: String) {} // expected-note {{found this candidate}}
+func reasyncOverload(_: () async -> (), _: Int) reasync {} // expected-note {{found  candidate with type '(() -> (), Int) async -> ()}}
+func reasyncOverload(_: () -> (), _: String) {} // expected-note {{found candidate with type '(() -> (), String) -> ()'}}
 
 func referencesReasyncOverload() {
   _ = reasyncOverload // expected-error {{ambiguous use of 'reasyncOverload'}}

--- a/test/Concurrency/reasync_ranking.swift
+++ b/test/Concurrency/reasync_ranking.swift
@@ -18,7 +18,7 @@ func referencesAsyncOverloadAsync() async {
   _ = asyncOverload // we prefer the async overload
 }
 
-func reasyncOverload(_: () async -> (), _: Int) reasync {} // expected-note {{found  candidate with type '(() -> (), Int) async -> ()}}
+func reasyncOverload(_: () async -> (), _: Int) reasync {} // expected-note {{found candidate with type '(() async -> (), Int) async -> ()'}}
 func reasyncOverload(_: () -> (), _: String) {} // expected-note {{found candidate with type '(() -> (), String) -> ()'}}
 
 func referencesReasyncOverload() {

--- a/test/Constraints/ambiguity_diagnostics.swift
+++ b/test/Constraints/ambiguity_diagnostics.swift
@@ -41,8 +41,8 @@ func test() {
   func __findValue<T: ExpressibleByStringLiteral>(_: String, fallback: T) -> T { fatalError() }
   func __findValue<T: ExpressibleByExtendedGraphemeClusterLiteral>(_: String, fallback: T) -> T { fatalError() }
 
-  func ambiguitySource() -> AnyShapeStyle { fatalError() } // expected-note {{found this candidate}}
-  func ambiguitySource() -> AnyGradient { fatalError() }   // expected-note {{found this candidate}}
+  func ambiguitySource() -> AnyShapeStyle { fatalError() } // expected-note {{found candidate with type '() -> AnyShapeStyle'}}
+  func ambiguitySource() -> AnyGradient { fatalError() }   // expected-note {{found candidate with type '() -> AnyGradient'}}
 
   Text("Test")
     .title(__findValue("someKey", fallback: "<unknown>"))

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -793,7 +793,7 @@ func f20371273() {
 // rdar://problem/42337247
 
 func overloaded(_ handler: () -> Int) {} // expected-note {{found candidate with type '(() -> Int) -> ()'}}
-func overloaded(_ handler: () -> Void) {} // expected-note {{found candidate with type '(() -> ()) -> ()'}}
+func overloaded(_ handler: () -> Void) {} // expected-note {{found candidate with type '(() -> Void) -> ()'}}
 
 overloaded { } // empty body => inferred as returning ()
 
@@ -1046,7 +1046,7 @@ func rdar52204414() {
 // order of argument resolution and made it ambiguous.
 
 func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note{{found candidate with type '(() -> Int, Int, Int) -> ()'}}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found candidate with type '(() -> Int, Int, Int) -> ()'}}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found candidate with type '(Int, Int, () -> Int) -> ()'}}
 
 overloaded_with_default { 0 } // expected-error{{ambiguous use of 'overloaded_with_default'}}
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -792,8 +792,8 @@ func f20371273() {
 
 // rdar://problem/42337247
 
-func overloaded(_ handler: () -> Int) {} // expected-note {{found this candidate}}
-func overloaded(_ handler: () -> Void) {} // expected-note {{found this candidate}}
+func overloaded(_ handler: () -> Int) {} // expected-note {{found candidate with type '(() -> Int) -> ()'}}
+func overloaded(_ handler: () -> Void) {} // expected-note {{found candidate with type '(() -> ()) -> ()'}}
 
 overloaded { } // empty body => inferred as returning ()
 
@@ -1045,8 +1045,8 @@ func rdar52204414() {
 // Note that this was accepted prior to Swift 5.3. SE-0286 changed the
 // order of argument resolution and made it ambiguous.
 
-func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note{{found this candidate}}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found this candidate}}
+func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note{{found candidate with type '(() -> Int, Int, Int) -> ()'}}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found candidate with type '(() -> Int, Int, Int) -> ()'}}
 
 overloaded_with_default { 0 } // expected-error{{ambiguous use of 'overloaded_with_default'}}
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
-func f0(_ i: Int, _ d: Double) {} // expected-note{{found this candidate}}
-func f0(_ d: Double, _ i: Int) {} // expected-note{{found this candidate}}
+func f0(_ i: Int, _ d: Double) {} // expected-note{{found candidate with type '(Int, Double) -> ()'}}
+func f0(_ d: Double, _ i: Int) {} // expected-note{{found candidate with type '(Double, Int) -> ()'}}
 
 f0(1, 2) // expected-error{{ambiguous use of 'f0'}}
 
@@ -22,15 +22,15 @@ class C {
   init(_ action: (Int, Int) -> ()) {} 
 }
 
-func g(_ x: Int) -> () {} // expected-note{{found this candidate}}
-func g(_ x: Int, _ y: Int) -> () {} // expected-note{{found this candidate}}
+func g(_ x: Int) -> () {} // expected-note{{found candidate with type '(Int) -> ()'}}
+func g(_ x: Int, _ y: Int) -> () {} // expected-note{{found candidate with type '(Int, Int) -> ()'}}
 C(g) // expected-error{{ambiguous use of 'g'}}
 
 func h<T>(_ x: T) -> () {}
 _ = C(h) // OK - init(_: (Int) -> ())
 
-func rdar29691909_callee(_ o: AnyObject?) -> Any? { return o } // expected-note {{found this candidate}}
-func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{found this candidate}}
+func rdar29691909_callee(_ o: AnyObject?) -> Any? { return o } // expected-note {{found candidate with type '(AnyObject?) -> Any?'}}
+func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{found candidate with type '(AnyObject) -> Any'}}
 
 func rdar29691909(o: AnyObject) -> Any? {
   return rdar29691909_callee(o) // expected-error{{ambiguous use of 'rdar29691909_callee'}}
@@ -99,8 +99,8 @@ func f2_57380<T : Numeric>(_ a: T, _ b: T) {
 // rdar://94360230 - diagnosing 'filter' instead of ambiguity in its body
 func test_diagnose_deepest_ambiguity() {
   struct S {
-    func ambiguous(_: Int = 0) -> Bool { true }     // expected-note 2 {{found this candidate}}
-    func ambiguous(_: String = "") -> Bool { true } // expected-note 2 {{found this candidate}}
+    func ambiguous(_: Int = 0) -> Bool { true }     // expected-note 2 {{found candidate with type '(Int) -> Bool'}}
+    func ambiguous(_: String = "") -> Bool { true } // expected-note 2 {{found candidate with type '(String) -> Bool'}}
   }
 
   func test_single(arr: [S]) {

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -6,7 +6,7 @@ func f0(_ d: Double, _ i: Int) {} // expected-note{{found candidate with type '(
 f0(1, 2) // expected-error{{ambiguous use of 'f0'}}
 
 func f1(_ i: Int16) {} // expected-note{{found candidate with type '(Int16) -> ()'}}
-func f1(_ i: Int32) {} // expected-note{{found candidate type '(Int32) -> ()'}}
+func f1(_ i: Int32) {} // expected-note{{found candidate with type '(Int32) -> ()'}}
 
 f1(0) // expected-error{{ambiguous use of 'f1'}}
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -5,15 +5,15 @@ func f0(_ d: Double, _ i: Int) {} // expected-note{{found candidate with type '(
 
 f0(1, 2) // expected-error{{ambiguous use of 'f0'}}
 
-func f1(_ i: Int16) {} // expected-note{{found this candidate}}
-func f1(_ i: Int32) {} // expected-note{{found this candidate}}
+func f1(_ i: Int16) {} // expected-note{{found candidate with type '(Int16) -> ()'}}
+func f1(_ i: Int32) {} // expected-note{{found candidate type '(Int32) -> ()'}}
 
 f1(0) // expected-error{{ambiguous use of 'f1'}}
 
 infix operator +++
 
-func +++(i: Int, d: Double) {} // expected-note{{found this candidate}}
-func +++(d: Double, i: Int) {} // expected-note{{found this candidate}}
+func +++(i: Int, d: Double) {} // expected-note{{found candidate with type '(Int, Double) -> ()'}}
+func +++(d: Double, i: Int) {} // expected-note{{found candidate with type '(Double, Int) -> ()'}}
 
 1 +++ 2 // expected-error{{ambiguous use of operator '+++'}}
 

--- a/test/Constraints/diag_ambiguities_module.swift
+++ b/test/Constraints/diag_ambiguities_module.swift
@@ -7,9 +7,9 @@ import has_ambiguities
 maybeTrans(0) // expected-error{{ambiguous use of 'maybeTrans'}}
 // CHECK: ambiguous use of 'maybeTrans'
 // CHECK: maybeTrans(0)
-// CHECK: found this candidate
+// CHECK: found candidate with type '(Int16) -> ()' in module 'has_ambiguities'
 // CHECK-NOT: transparent
 // CHECK: maybeTrans(_ i: Int16)
-// CHECK: found this candidate
 // CHECK-NOT: transparent
 // CHECK: maybeTrans(_ i: Int32)
+// CHECK: found candidate with type '(Int32) -> ()' in module 'has_ambiquities'

--- a/test/Constraints/diag_ambiguities_module.swift
+++ b/test/Constraints/diag_ambiguities_module.swift
@@ -12,4 +12,3 @@ maybeTrans(0) // expected-error{{ambiguous use of 'maybeTrans'}}
 // CHECK: maybeTrans(_ i: Int16)
 // CHECK-NOT: transparent
 // CHECK: maybeTrans(_ i: Int32)
-// CHECK: found candidate with type '(Int32) -> ()' in module 'has_ambiquities'

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1005,8 +1005,8 @@ do {
 
 // Ambiguous overload inside a trailing closure
 
-func ambiguousCall() -> Int {} // expected-note {{found this candidate}}
-func ambiguousCall() -> Float {} // expected-note {{found this candidate}}
+func ambiguousCall() -> Int {} // expected-note {{found candidate with type '() -> Int'}}
+func ambiguousCall() -> Float {} // expected-note {{found candidate with type '() -> Float'}}
 
 func takesClosure(fn: () -> ()) {}
 

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -27,10 +27,10 @@ class X {
   @objc func foo(_ i: Int) { }
   @objc func bar() { }
 
-  @objc func ovl2() -> A { } // expected-note{{found this candidate}}
+  @objc func ovl2() -> A { } // expected-note{{found candidate with type '(X) -> () -> A'}}
 
   @objc func ovl4() -> B { }
-  @objc func ovl5() -> B { } // expected-note{{found this candidate}}
+  @objc func ovl5() -> B { } // expected-note{{found candidate with type '(X) -> () -> B'}}
 
   @objc class func staticFoo(_ i : Int) { }
 
@@ -46,7 +46,7 @@ class Y : P {
   @objc func ovl1() -> A { }
 
   @objc func ovl4() -> B { }
-  @objc func ovl5() -> C { } // expected-note{{found this candidate}}
+  @objc func ovl5() -> C { } // expected-note{{found candidate with type '(Y) -> () -> C'}}
 
   @objc var prop1 : Int {
     get {
@@ -81,7 +81,7 @@ class Y : P {
 
 class Z : Y {
   @objc override func ovl1() -> B { }
-  @objc func ovl2() -> C { } // expected-note{{found this candidate}}
+  @objc func ovl2() -> C { } // expected-note{{found candidate with type '(Z) -> () -> C'}}
   @objc(ovl3_A) func ovl3() -> A { }
   @objc func ovl3() -> B { }
   func generic4<T>(_ x : T) { }
@@ -356,37 +356,37 @@ func dynamicInitCrash(ao: AnyObject.Type) {
 // Test that we correctly diagnose ambiguity for different typed members available
 // through dynamic lookup.
 @objc protocol P3 {
-  var ambiguousProperty: String { get } // expected-note {{found this candidate}}
+  var ambiguousProperty: String { get } // expected-note {{found candidate with type '() -> String'}}
   var unambiguousProperty: Int { get }
 
-  func ambiguousMethod() -> String // expected-note 2{{found this candidate}}
+  func ambiguousMethod() -> String // expected-note 2{{found candidate with type '() -> String'}}
   func unambiguousMethod() -> Int
 
-  func ambiguousMethodParam(_ x: String) // expected-note {{found this candidate}}
+  func ambiguousMethodParam(_ x: String) // expected-note {{found candidate with type '(String) -> ()'}}
   func unambiguousMethodParam(_ x: Int)
 
-  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found this candidate}}
+  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found candidate with type '(Int) -> String'}}
   subscript(unambiguousSubscript _: String) -> Int { get }
 
-  subscript(differentSelectors _: Int) -> Int { // expected-note {{found this candidate}}
+  subscript(differentSelectors _: Int) -> Int { // expected-note {{found candidate with type '(Int) -> Int'}}
     @objc(differentSelector1:) get
   }
 }
 
 class C1 {
-  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found this candidate}}
+  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found candidate with type '() -> Int'}}
   @objc var unambiguousProperty: Int { return 0 }
 
-  @objc func ambiguousMethod() -> Int { return 0 } // expected-note 2{{found this candidate}}
+  @objc func ambiguousMethod() -> Int { return 0 } // expected-note 2{{found candidate with type '() -> Int'}}
   @objc func unambiguousMethod() -> Int { return 0 }
 
-  @objc func ambiguousMethodParam(_ x: Int) {} // expected-note {{found this candidate}}
+  @objc func ambiguousMethodParam(_ x: Int) {} // expected-note {{found candidate with type '(Int) -> ()'}}
   @objc func unambiguousMethodParam(_ x: Int) {}
 
-  @objc subscript(ambiguousSubscript _: Int) -> Int { return 0 } // expected-note {{found this candidate}}
+  @objc subscript(ambiguousSubscript _: Int) -> Int { return 0 } // expected-note {{found candidate with type '(Int) -> Int'}}
   @objc subscript(unambiguousSubscript _: String) -> Int { return 0 }
 
-  @objc subscript(differentSelectors _: Int) -> Int { // expected-note {{found this candidate}}
+  @objc subscript(differentSelectors _: Int) -> Int { // expected-note {{found candidate with type '(Int) -> Int'}}
     @objc(differentSelector2:) get { return 0 }
   }
 }

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -27,10 +27,10 @@ class X {
   @objc func foo(_ i: Int) { }
   @objc func bar() { }
 
-  @objc func ovl2() -> A { } // expected-note{{found candidate with type '(X) -> () -> A'}}
+  @objc func ovl2() -> A { } // expected-note{{found candidate with type '() -> A'}}
 
   @objc func ovl4() -> B { }
-  @objc func ovl5() -> B { } // expected-note{{found candidate with type '(X) -> () -> B'}}
+  @objc func ovl5() -> B { } // expected-note{{found candidate with type '() -> B'}}
 
   @objc class func staticFoo(_ i : Int) { }
 
@@ -46,7 +46,7 @@ class Y : P {
   @objc func ovl1() -> A { }
 
   @objc func ovl4() -> B { }
-  @objc func ovl5() -> C { } // expected-note{{found candidate with type '(Y) -> () -> C'}}
+  @objc func ovl5() -> C { } // expected-note{{found candidate with type '() -> C'}}
 
   @objc var prop1 : Int {
     get {
@@ -81,7 +81,7 @@ class Y : P {
 
 class Z : Y {
   @objc override func ovl1() -> B { }
-  @objc func ovl2() -> C { } // expected-note{{found candidate with type '(Z) -> () -> C'}}
+  @objc func ovl2() -> C { } // expected-note{{found candidate with type '() -> C'}}
   @objc(ovl3_A) func ovl3() -> A { }
   @objc func ovl3() -> B { }
   func generic4<T>(_ x : T) { }
@@ -356,7 +356,7 @@ func dynamicInitCrash(ao: AnyObject.Type) {
 // Test that we correctly diagnose ambiguity for different typed members available
 // through dynamic lookup.
 @objc protocol P3 {
-  var ambiguousProperty: String { get } // expected-note {{found candidate with type '() -> String'}}
+  var ambiguousProperty: String { get } // expected-note {{found candidate with type 'String'}}
   var unambiguousProperty: Int { get }
 
   func ambiguousMethod() -> String // expected-note 2{{found candidate with type '() -> String'}}
@@ -365,16 +365,16 @@ func dynamicInitCrash(ao: AnyObject.Type) {
   func ambiguousMethodParam(_ x: String) // expected-note {{found candidate with type '(String) -> ()'}}
   func unambiguousMethodParam(_ x: Int)
 
-  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found candidate with type '(Int) -> String'}}
+  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found candidate with type '<Self where Self : P3> (ambiguousSubscript: Int) -> String'}}
   subscript(unambiguousSubscript _: String) -> Int { get }
 
-  subscript(differentSelectors _: Int) -> Int { // expected-note {{found candidate with type '(Int) -> Int'}}
+  subscript(differentSelectors _: Int) -> Int { // expected-note {{found candidate with type '<Self where Self : P3> (differentSelectors: Int) -> Int'}}
     @objc(differentSelector1:) get
   }
 }
 
 class C1 {
-  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found candidate with type '() -> Int'}}
+  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found candidate with type 'Int'}}
   @objc var unambiguousProperty: Int { return 0 }
 
   @objc func ambiguousMethod() -> Int { return 0 } // expected-note 2{{found candidate with type '() -> Int'}}

--- a/test/Constraints/old_hack_related_ambiguities.swift
+++ b/test/Constraints/old_hack_related_ambiguities.swift
@@ -365,7 +365,7 @@ do {
   @_disfavoredOverload
   func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) async throws {}
   func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, Int) -> ()'}}
-  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate '(Int, String, Int) -> ()'}}
+  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, Int) -> ()'}}
 
   func performLocal(v: Int, block: @escaping (Int) throws -> Void) async throws {
     try await test(over: v, block: block) // expected-error {{ambiguous use of 'test'}}

--- a/test/Constraints/old_hack_related_ambiguities.swift
+++ b/test/Constraints/old_hack_related_ambiguities.swift
@@ -20,8 +20,8 @@ func test_ternary(v: Test) -> Int? {
 
 do {
   struct TestFloat {
-    func test(_ v: Float) -> Float { v } // expected-note {{found this candidate}}
-    func test(_ v: Float?) -> Float? { v } // expected-note {{found this candidate}}
+    func test(_ v: Float) -> Float { v } // expected-note {{found candidate with type '(Float) -> Float'}}
+    func test(_ v: Float?) -> Float? { v } // expected-note {{found candidate with type '(Float?) -> Float?'}}
   }
 
   func test_ternary_non_default_literal(v: TestFloat) -> Float? {
@@ -364,8 +364,8 @@ class TestFailableOnly {
 do {
   @_disfavoredOverload
   func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) async throws {}
-  func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found this candidate}}
-  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found this candidate}}
+  func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, Int) -> ()'}}
+  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate '(Int, String, Int) -> ()'}}
 
   func performLocal(v: Int, block: @escaping (Int) throws -> Void) async throws {
     try await test(over: v, block: block) // expected-error {{ambiguous use of 'test'}}

--- a/test/Constraints/old_hack_related_ambiguities.swift
+++ b/test/Constraints/old_hack_related_ambiguities.swift
@@ -364,8 +364,8 @@ class TestFailableOnly {
 do {
   @_disfavoredOverload
   func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) async throws {}
-  func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, Int) -> ()'}}
-  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, Int) -> ()'}}
+  func test(over: Int, that: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, @escaping (Int) throws -> Void) throws -> ()'}}
+  func test(over: Int, other: String = "", block: @escaping (Int) throws -> Void) throws {} // expected-note {{found candidate with type '(Int, String, @escaping (Int) throws -> Void) throws -> ()'}}
 
   func performLocal(v: Int, block: @escaping (Int) throws -> Void) async throws {
     try await test(over: v, block: block) // expected-error {{ambiguous use of 'test'}}

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -343,8 +343,8 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   // CHECK: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
   _ = getF(otherV) // Ok `E` doesn't have a `where` clause
 
-  func getSelf<T: B>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '(B) -> B'}}
-  func getSelf<T: D>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '(D) -> D'}}
+  func getSelf<T: B>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '<T where T : B> (T) -> T'}}
+  func getSelf<T: D>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '<T where T : D> (T) -> T'}}
 
   // CHECK: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
   _ = getSelf(v) // Ok

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -343,8 +343,8 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   // CHECK: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
   _ = getF(otherV) // Ok `E` doesn't have a `where` clause
 
-  func getSelf<T: B>(_: T) -> T { fatalError() } // expected-note {{found this candidate}}
-  func getSelf<T: D>(_: T) -> T { fatalError() } // expected-note {{found this candidate}}
+  func getSelf<T: B>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '(B) -> B'}}
+  func getSelf<T: D>(_: T) -> T { fatalError() } // expected-note {{found candidate with type '(D) -> D'}}
 
   // CHECK: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
   _ = getSelf(v) // Ok

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -293,9 +293,8 @@ func f63834(int: Int, string: Bool) {} // expected-note 3{{found candidate with 
 func f63834_1(int: Int, string: Bool) {} // expected-note{{candidate '(Int, Bool) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
 func f63834_1(int: Int, string: String) {} // expected-note{{candidate '(Int, String) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
 
-// FIXME: We can mention candidate type.
-func f63834_2(int: Int, string: Bool) {} // expected-note {{found this candidate}}
-func f63834_2(int: Int, string: String) {} // expected-note {{found this candidate}}
+func f63834_2(int: Int, string: Bool) {} // expected-note {{found candidate with type '(Int, Bool) -> ()'}}
+func f63834_2(int: Int, string: String) {} // expected-note {{found candidate with type '(Int, String) -> ()'}}
 
 // One function argument mismatch
 let _ = f63834(int:string:) as (Int, Int) -> Void // expected-error{{no exact matches in reference to global function 'f63834'}}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -295,8 +295,8 @@ func test_init_refs_with_single_pack_expansion_param() {
   _ = Data(42, "") // Ok
 
   struct EmptyAmbiguous<each V> {
-    init(_: repeat each V) {} // expected-note {{found this candidate}}
-    init(x: repeat each V) {} // expected-note {{found this candidate}}
+    init(_: repeat each V) {} // expected-note {{found candidate with type '(repeat each V) -> EmptyAmbiguous<repeat each V>'}}
+    init(x: repeat each V) {} // expected-note {{found candidate with type '(repeat each V) -> EmptyAmbiguous<repeat each V>'}}
   }
 
   _ = EmptyAmbiguous() // expected-error {{ambiguous use of 'init'}}
@@ -630,25 +630,25 @@ do {
 // rdar://112029630 - incorrect variadic generic overload ranking
 do {
   func test1<T>(_: T...) {}
-  // expected-note@-1 {{found this candidate}}
+  // expected-note@-1 {{found candidate with type '(T...) -> ()'}}
   func test1<each T>(_: repeat each T) {}
-  // expected-note@-1 {{found this candidate}}
+  // expected-note@-1 {{found candidate with type '<each T> (repeat each T) -> ()'}}
 
   test1(1, 2, 3) // expected-error {{ambiguous use of 'test1'}}
   test1(1, "a") // Ok
 
   func test2<each T>(_: repeat each T) {}
-  // expected-note@-1 {{found this candidate}}
+  // expected-note@-1 {{found candidate with type '<each T> (repeat each T) -> ()'}}
   func test2<each T>(vals: repeat each T) {}
-  // expected-note@-1 {{found this candidate}}
+  // expected-note@-1 {{found candidate with type '<each T> (vals:repeat each T) -> ()'}}
 
   test2() // expected-error {{ambiguous use of 'test2'}}
 
   func test_different_requirements<A: BinaryInteger & StringProtocol>(_ a: A) {
     func test3<each T: BinaryInteger>(str: String, _: repeat each T) {}
-    // expected-note@-1 {{found this candidate}}
+    // expected-note@-1 {{found candidate with type '<A, each T where A : BInaryInteger, A : StringProtocol, repeat each T : StringProtocol> (str: repeat each T) -> ()'}}
     func test3<each U: StringProtocol>(str: repeat each U) {}
-    // expected-note@-1 {{found this candidate}}
+    // expected-note@-1 {{found candidate with type '<A, each U where A : BinaryInteger, A : StringProtocol, repeat each U : StringProtocol> (str: repeat each U) -> ()'}}
 
     test3(str: "", a, a)  // expected-error {{ambiguous use of 'test3'}}
   }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -630,7 +630,7 @@ do {
 // rdar://112029630 - incorrect variadic generic overload ranking
 do {
   func test1<T>(_: T...) {}
-  // expected-note@-1 {{found candidate with type '(T...) -> ()'}}
+  // expected-note@-1 {{found candidate with type '<T> (T...) -> ()'}}
   func test1<each T>(_: repeat each T) {}
   // expected-note@-1 {{found candidate with type '<each T> (repeat each T) -> ()'}}
 
@@ -640,13 +640,13 @@ do {
   func test2<each T>(_: repeat each T) {}
   // expected-note@-1 {{found candidate with type '<each T> (repeat each T) -> ()'}}
   func test2<each T>(vals: repeat each T) {}
-  // expected-note@-1 {{found candidate with type '<each T> (vals:repeat each T) -> ()'}}
+  // expected-note@-1 {{found candidate with type '<each T> (vals: repeat each T) -> ()'}}
 
   test2() // expected-error {{ambiguous use of 'test2'}}
 
   func test_different_requirements<A: BinaryInteger & StringProtocol>(_ a: A) {
     func test3<each T: BinaryInteger>(str: String, _: repeat each T) {}
-    // expected-note@-1 {{found candidate with type '<A, each T where A : BInaryInteger, A : StringProtocol, repeat each T : StringProtocol> (str: repeat each T) -> ()'}}
+    // expected-note@-1 {{found candidate with type '<A, each T where A : BinaryInteger, A : StringProtocol, repeat each T : BinaryInteger> (str: String, repeat each T) -> ()'}}
     func test3<each U: StringProtocol>(str: repeat each U) {}
     // expected-note@-1 {{found candidate with type '<A, each U where A : BinaryInteger, A : StringProtocol, repeat each U : StringProtocol> (str: repeat each U) -> ()'}}
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -392,10 +392,10 @@ func test_50875() -> String {
     func h() -> Double {
       return 3.0
     }
-    func h() -> Int? { //expected-note{{found this candidate}}
+    func h() -> Int? { //expected-note{{found candidate with type '() -> Int?'}}
       return 2
     }
-    func h() -> Float? { //expected-note{{found this candidate}}
+    func h() -> Float? { //expected-note{{found candidate with type '() -> Float?'}}
       return nil
     }
 

--- a/test/Constraints/ranking_ambiguities.swift
+++ b/test/Constraints/ranking_ambiguities.swift
@@ -9,8 +9,8 @@ protocol P {
 
 // We currently only apply the constructor ranking rule to X() and not X.init().
 struct S<T : P> {
-  init(_ x: T = .init()) {} // expected-note {{found candidate with type '(T) -> S'}}
-  init(_ x: T? = nil) {} // expected-note {{found candidate with type '(T?) -> S'}}
+  init(_ x: T = .init()) {} // expected-note {{found candidate with type '(T) -> S<T>'}}
+  init(_ x: T? = nil) {} // expected-note {{found candidate with type '(T?) -> S<T>'}}
   func testInitRanking() {
     _ = S<T>() // Okay
     _ = S<T>.init() // expected-error {{ambiguous use of 'init(_:)'}}

--- a/test/Constraints/ranking_ambiguities.swift
+++ b/test/Constraints/ranking_ambiguities.swift
@@ -9,8 +9,8 @@ protocol P {
 
 // We currently only apply the constructor ranking rule to X() and not X.init().
 struct S<T : P> {
-  init(_ x: T = .init()) {} // expected-note {{found candidate with type '(P) -> S'}}
-  init(_ x: T? = nil) {} // expected-note {{found candidate with type '(P?) -> S'}}
+  init(_ x: T = .init()) {} // expected-note {{found candidate with type '(T) -> S'}}
+  init(_ x: T? = nil) {} // expected-note {{found candidate with type '(T?) -> S'}}
   func testInitRanking() {
     _ = S<T>() // Okay
     _ = S<T>.init() // expected-error {{ambiguous use of 'init(_:)'}}
@@ -28,8 +28,8 @@ struct S1 {
 
 // Ambiguous because we don't prefer one label over the other.
 struct S2 {
-  init(x: Int...) {} // expected-note {{found this candidate}}
-  init(y: Int...) {} // expected-note {{found this candidate}}
+  init(x: Int...) {} // expected-note {{found candidate with type '(Int...) -> S2'}}
+  init(y: Int...) {} // expected-note {{found candidate with type '(Int...) -> S2'}}
 
   func testInitRanking() {
     _ = S2() // expected-error {{ambiguous use of 'init'}}
@@ -39,8 +39,8 @@ struct S2 {
 // Ambiguous because we don't apply the prefer-unlabeled rule if the types
 // aren't compatible.
 struct S3 {
-  init(x: Int...) {} // expected-note {{found this candidate}}
-  init(_: String...) {} // expected-note {{found this candidate}}
+  init(x: Int...) {} // expected-note {{found candidate with type '(Int...) -> S3'}}
+  init(_: String...) {} // expected-note {{found candidate with type '(String...) -> S3'}}
 
   func testInitRanking() {
     _ = S3() // expected-error {{ambiguous use of 'init'}}
@@ -51,8 +51,8 @@ struct S3 {
 // parameter list, and we don't have a special case for it. Ideally we would
 // align this behavior with the variadic behavior.
 struct S4 {
-  init(x: Int = 0) {} // expected-note {{found this candidate}}
-  init(_: Int = 0) {} // expected-note {{found this candidate}}
+  init(x: Int = 0) {} // expected-note {{found candidate with type '(Int) -> S4'}}
+  init(_: Int = 0) {} // expected-note {{found candidate with type '(Int) -> S4'}}
 
   func testInitRanking() {
     _ = S4() // expected-error {{ambiguous use of 'init'}}
@@ -60,8 +60,8 @@ struct S4 {
 }
 
 infix operator ^^^
-func ^^^ (lhs: (Int, Int), rhs: Int) -> Int { 0 }  // expected-note {{found this candidate}}
-func ^^^ (lhs: (Int, Int), rhs: Int) -> String { "" }  // expected-note {{found this candidate}}
+func ^^^ (lhs: (Int, Int), rhs: Int) -> Int { 0 }  // expected-note {{found candidate with type '((Int, Int), Int) -> Int'}}
+func ^^^ (lhs: (Int, Int), rhs: Int) -> String { "" }  // expected-note {{found candidate with type '((Int, Int), Int) -> String'}}
 
 // We shouldn't favor based on the type of a tuple element.
 struct S5 {

--- a/test/Constraints/ranking_ambiguities.swift
+++ b/test/Constraints/ranking_ambiguities.swift
@@ -9,16 +9,16 @@ protocol P {
 
 // We currently only apply the constructor ranking rule to X() and not X.init().
 struct S<T : P> {
-  init(_ x: T = .init()) {} // expected-note {{found this candidate}}
-  init(_ x: T? = nil) {} // expected-note {{found this candidate}}
+  init(_ x: T = .init()) {} // expected-note {{found candidate with type '(P) -> S'}}
+  init(_ x: T? = nil) {} // expected-note {{found candidate with type '(P?) -> S'}}
   func testInitRanking() {
     _ = S<T>() // Okay
     _ = S<T>.init() // expected-error {{ambiguous use of 'init(_:)'}}
   }
 }
 struct S1 {
-  init(x: Int = 0, y: Int = 0) {} // expected-note {{found this candidate}}
-  init(_ x: Int = 0, _ y: Int = 0) {} // expected-note {{found this candidate}}
+  init(x: Int = 0, y: Int = 0) {} // expected-note {{found candidate with type '(Int, Int) -> S1'}}
+  init(_ x: Int = 0, _ y: Int = 0) {} // expected-note {{found candidate with type '(Int, Int) -> S1'}}
 
   func testInitRanking() {
     _ = S1() // Okay

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -141,11 +141,11 @@ func testDiags() {
 struct A { }
 struct B { }
 
-func overloadedTuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) -> A { // expected-note {{found this candidate}}
+func overloadedTuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) -> A { // expected-note {{found candidate with type '<T> (Bool, body: (Bool) -> T) -> A'}}
   return A()
 }
 
-func overloadedTuplify<T>(_ cond: Bool, @TupleBuilderWithoutIf body: (Bool) -> T) -> B { // expected-note {{found this candidate}}
+func overloadedTuplify<T>(_ cond: Bool, @TupleBuilderWithoutIf body: (Bool) -> T) -> B { // expected-note {{found candidate with type '<T> (Bool, body: (Bool) -> T) -> B'}}
   return B()
 }
 

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -90,15 +90,15 @@ func genericSubscript<T>(_ t: T,
 
 // <rdar://problem/21364448> QoI: Poor error message for ambiguous subscript call
 extension String {
-  func number() -> Int {  }     // expected-note {{found this candidate}}
-  func number() -> Double {  }  // expected-note {{found this candidate}}
+  func number() -> Int {  }     // expected-note {{found candidate with type '() -> Int'}}
+  func number() -> Double {  }  // expected-note {{found candidate with type '() -> Double'}}
 }
 
 let _ = "a".number  // expected-error {{ambiguous use of 'number()'}}
 
 extension Int {
-  subscript(key: String) -> Int { get {} }      // expected-note {{found this candidate}}
-  subscript(key: String) -> Double {  get {} }   // expected-note {{found this candidate}}
+  subscript(key: String) -> Int { get {} }      // expected-note {{found candidate with type '(String) -> Int'}}
+  subscript(key: String) -> Double {  get {} }   // expected-note {{found candidate with type '(String) -> Double'}}
 }
 
 let _ = 1["1"]  // expected-error {{ambiguous use of 'subscript(_:)'}}

--- a/test/Constraints/type_of.swift
+++ b/test/Constraints/type_of.swift
@@ -70,10 +70,10 @@ func foo(_: Any...) {}
 // the that of type(of:) to make sure that latter is
 // picked first.
 
-func bar() -> Int {}    // expected-note {{found this candidate}}
-func bar() -> Float {}  // expected-note {{found this candidate}}
-func bar() -> String {} // expected-note {{found this candidate}}
-func bar() -> UInt {}   // expected-note {{found this candidate}}
+func bar() -> Int {}    // expected-note {{found candidate with type '() -> Int'}}
+func bar() -> Float {}  // expected-note {{found candidate with type '() -> Float'}}
+func bar() -> String {} // expected-note {{found candidate with type '() -> String'}}
+func bar() -> UInt {}   // expected-note {{found candidate with type '() -> UInt'}}
 
 foo(type(of: G.T.self)) // Ok
 let _: Any = type(of: G.T.self) // Ok

--- a/test/Generics/ambiguous_protocol_inheritance.swift
+++ b/test/Generics/ambiguous_protocol_inheritance.swift
@@ -1,12 +1,12 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol Base { // expected-note {{'Base' previously declared here}}
-// expected-note@-1 {{found this candidate}}
+// expected-note@-1 {{found candidate 'Base'}}
   associatedtype E
 }
 
 struct Base<T> {} // expected-error {{invalid redeclaration of 'Base'}}
-// expected-note@-1 {{found this candidate}}
+// expected-note@-1 {{found candidate 'Base'}}
 
 protocol Derived : Base { // expected-error {{'Base' is ambiguous for type lookup in this context}}
   associatedtype E

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -106,8 +106,8 @@ func acceptUnaryFnSameRef<T>(_ f: inout (T) -> T) { }
 
 func unaryFnIntInt(_: Int) -> Int {}
 
-func unaryFnOvl(_: Int) -> Int {} // expected-note{{found this candidate}}
-func unaryFnOvl(_: Float) -> Int {} // expected-note{{found this candidate}}
+func unaryFnOvl(_: Int) -> Int {} // expected-note{{found candidate with type '(Int) -> Int'}}
+func unaryFnOvl(_: Float) -> Int {} // expected-note{{found candidate with type '(Float) -> Int'}}
 
 // Variable forms of the above functions
 var unaryFnIntIntVar : (Int) -> Int = unaryFnIntInt
@@ -147,8 +147,8 @@ func passGeneric() {
 struct SomeType {
   func identity<T>(_ x: T) -> T { return x }
 
-  func identity2<T>(_ x: T) -> T { return x } // expected-note 2{{found this candidate}}
-  func identity2<T>(_ x: T) -> Float { } // expected-note 2{{found this candidate}}
+  func identity2<T>(_ x: T) -> T { return x } // expected-note 2{{found candidate with type '(_) -> _'}}
+  func identity2<T>(_ x: T) -> Float { } // expected-note 2{{found candidate with type '(_) -> Float'}}
 
   func returnAs<T>() -> T {}
 }

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -147,8 +147,8 @@ func passGeneric() {
 struct SomeType {
   func identity<T>(_ x: T) -> T { return x }
 
-  func identity2<T>(_ x: T) -> T { return x } // expected-note 2{{found candidate with type '(_) -> _'}}
-  func identity2<T>(_ x: T) -> Float { } // expected-note 2{{found candidate with type '(_) -> Float'}}
+  func identity2<T>(_ x: T) -> T { return x } // expected-note 2{{found candidate with type '(T) -> T'}}
+  func identity2<T>(_ x: T) -> Float { } // expected-note 2{{found candidate with type '(T) -> Float'}}
 
   func returnAs<T>() -> T {}
 }

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -68,8 +68,8 @@ protocol Overload {
   func getB() -> B
   func f1(_: A) -> A // expected-note {{candidate expects value of type 'OtherOvl.A' for parameter #1}}
   func f1(_: B) -> B // expected-note {{candidate expects value of type 'OtherOvl.B' for parameter #1}}
-  func f2(_: Int) -> A // expected-note{{found this candidate}}
-  func f2(_: Int) -> B // expected-note{{found this candidate}}
+  func f2(_: Int) -> A // expected-note{{found candidate with type '(Int) -> Self.A'}}
+  func f2(_: Int) -> B // expected-note{{found candidate with type '(Int) -> Self.B'}}
   func f3(_: Int) -> Int // expected-note {{found candidate with type '(Int) -> Int'}}
   func f3(_: Float) -> Float // expected-note {{found candidate with type '(Float) -> Float'}}
   func f3(_: Self) -> Self // expected-note {{found candidate with type '(OtherOvl) -> OtherOvl'}}

--- a/test/ImportResolution/import-specific-decl.swift
+++ b/test/ImportResolution/import-specific-decl.swift
@@ -12,8 +12,8 @@ import asdf
 
 var a : A // expected-error {{'A' is ambiguous for type lookup in this context}}
 // CHECK: error: 'A' is ambiguous for type lookup in this context
-// CHECK-DAG: abcde{{.+}}note: found this candidate
-// CHECK-DAG: asdf{{.+}}note: found this candidate
+// CHECK-DAG: abcde{{.+}}note: found candidate 'A'
+// CHECK-DAG: asdf{{.+}}note: found candidate 'A'
 
 var b : B = abcde.B()
 var e : E = aeiou.E()

--- a/test/ImportResolution/import-specific-fixits.swift
+++ b/test/ImportResolution/import-specific-fixits.swift
@@ -53,7 +53,7 @@ import struct ambiguous.funcOrVar // expected-error{{ambiguous name 'funcOrVar' 
 
 // CHECK: [[@LINE-4]]:13: error: ambiguous name 'funcOrVar' in module 'ambiguous'
 // CHECK-NEXT: Number FIXITs = 0
-// CHECK-NEXT: note: found this candidate
+// CHECK-NEXT: note: found candidate 'SomeStruct'
 // CHECK-NEXT: Number FIXITs = 0
 // CHECK-NEXT: CONTENTS OF FILE ambiguous_right.funcOrVar:
 // CHECK: public var funcOrVar: Int

--- a/test/ImportResolution/import-specific-fixits.swift
+++ b/test/ImportResolution/import-specific-fixits.swift
@@ -53,12 +53,11 @@ import struct ambiguous.funcOrVar // expected-error{{ambiguous name 'funcOrVar' 
 
 // CHECK: [[@LINE-4]]:13: error: ambiguous name 'funcOrVar' in module 'ambiguous'
 // CHECK-NEXT: Number FIXITs = 0
-// CHECK-NEXT: note: found candidate 'SomeStruct'
-// CHECK-NEXT: Number FIXITs = 0
+// CHECK: note: found candidate 'funcOrVar'
+// CHECK: note: found candidate 'SomeStruct'
 // CHECK-NEXT: CONTENTS OF FILE ambiguous_right.funcOrVar:
 // CHECK: public var funcOrVar: Int
 // CHECK: END CONTENTS OF FILE
-// CHECK-NEXT: note: found this candidate
 
 import func ambiguous.someVar // expected-error{{ambiguous name 'someVar' in module 'ambiguous'}}
 import var ambiguous.someVar // expected-error{{ambiguous name 'someVar' in module 'ambiguous'}}

--- a/test/Misc/serialized-diagnostics-prettyprint.swift
+++ b/test/Misc/serialized-diagnostics-prettyprint.swift
@@ -25,7 +25,8 @@ var x = S.init // expected-error {{ambiguous use of 'init'}}
 // keying the source file contents on the buffer identifier, so we end up
 // with duplicated 'init(b:)'.
 
-// CHECK: Lib.S.init:3:10: note: found this candidate
+// CHECK: Lib.S.init:2:8: note: found candidate with type '(String) -> S' in module 'Lib'
+// CHECK: Lib.S.init:3:10: note: found candidate with type '(Int) -> S' in module 'Lib'
 // CHECK:      CONTENTS OF FILE Lib.S.init:
 // CHECK:      struct S {
 // CHECK-NEXT:    @discardableResult

--- a/test/NameLookup/library.swift
+++ b/test/NameLookup/library.swift
@@ -23,7 +23,7 @@ var e = 3
 
 // Name lookup with imports.
 import imported_module
-func over1(_ x: UInt64) {} // expected-note{{found this candidate}}
+func over1(_ x: UInt64) {} // expected-note{{found candidate with type '(UInt64) -> ()}}
 func over2(_ x: UInt32) {}
 func over3(_ x: UInt32) {}
 typealias over4 = UInt32

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -4,8 +4,8 @@ class B {
   var foo: Int
   func bar() {}
 
-  init() {} // expected-note {{found this candidate}}
-  init(x: Int) {} // expected-note {{found this candidate}}
+  init() {} // expected-note {{found candidate with type '() -> B'}}
+  init(x: Int) {} // expected-note {{found candidate with type '(Int) -> B'}}
 
   subscript(x: Int) -> Int {
     get {}

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -154,10 +154,10 @@ private class VIPPrivateSetPropSub : VIPPrivateSetPropBase, VeryImportantProto {
 }
 
 extension Container {
-  private typealias ExtensionConflictingType = Int // expected-note {{found candidate with type}} expected-note {{previously declared here}} expected-note{{found this candidate}}
+  private typealias ExtensionConflictingType = Int // expected-note {{found candidate with type}} expected-note {{previously declared here}} expected-note{{found candidate with type 'Int'}}
 }
 extension Container {
-  private typealias ExtensionConflictingType = Double  // expected-error {{invalid redeclaration of 'ExtensionConflictingType'}} expected-note {{found candidate with type}} expected-note{{found this candidate}}
+  private typealias ExtensionConflictingType = Double  // expected-error {{invalid redeclaration of 'ExtensionConflictingType'}} expected-note {{found candidate with type}} expected-note{{found candidate with type 'Double'}}
 }
 extension Container {
   func test() {

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -154,10 +154,10 @@ private class VIPPrivateSetPropSub : VIPPrivateSetPropBase, VeryImportantProto {
 }
 
 extension Container {
-  private typealias ExtensionConflictingType = Int // expected-note {{found candidate with type}} expected-note {{previously declared here}} expected-note{{found candidate with type 'Int'}}
+  private typealias ExtensionConflictingType = Int // expected-note {{found candidate with type}} expected-note {{previously declared here}} expected-note{{found candidate 'ExtensionConflictingType'}}
 }
 extension Container {
-  private typealias ExtensionConflictingType = Double  // expected-error {{invalid redeclaration of 'ExtensionConflictingType'}} expected-note {{found candidate with type}} expected-note{{found candidate with type 'Double'}}
+  private typealias ExtensionConflictingType = Double  // expected-error {{invalid redeclaration of 'ExtensionConflictingType'}} expected-note {{found candidate with type}} expected-note{{found candidate 'ExtensionConflictingType'}}
 }
 extension Container {
   func test() {

--- a/test/Sema/call_as_function_protocol.swift
+++ b/test/Sema/call_as_function_protocol.swift
@@ -15,14 +15,14 @@ protocol P1 {
   func callAsFunction() -> Self
 }
 extension P1 {
-  // expected-note @+1 {{found this candidate}}
+  // expected-note @+1 {{found candidate with type '() -> Self'}}
   func callAsFunction() -> Self {
     return self
   }
 }
 protocol P2 {}
 extension P2 {
-  // expected-note @+1 {{found this candidate}}
+  // expected-note @+1 {{found candidate with type '(Int, Int) -> Int'}}
   func callAsFunction(x: Int, y: Int) -> Int {
     return x + y
   }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -170,11 +170,11 @@ protocol N { associatedtype D }
 infix operator ++ : AdditionPrecedence
 infix operator -- : AdditionPrecedence
 
-func ++ <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found this candidate}}
-func ++ <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found this candidate}}
+func ++ <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found candidate with type '<T where T : N> (T, T) -> T.D'}}
+func ++ <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found candidate with type '<T where T : N> (T, T) -> T'}}
 
-func -- <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found this candidate}}
-func -- <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found this candidate}}
+func -- <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found candidate with type '<T where T : N> (T, T) -> T'}}
+func -- <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found candidate with type '<T where T : N> (T, T) -> T.D'}}
 
 do {
   struct MyInt16: N { typealias D = MyInt32 }

--- a/test/Sema/diag_non_ephemeral.swift
+++ b/test/Sema/diag_non_ephemeral.swift
@@ -524,8 +524,8 @@ func testArgumentLabelReferencing() {
   // expected-note@-6 {{use the 'withUnsafeBufferPointer' method on Array in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 }
 
-func ambiguous_fn(@_nonEphemeral _ ptr: UnsafePointer<Int>) {} // expected-note {{found this candidate}}
-func ambiguous_fn(_ ptr: UnsafeRawPointer) {} // expected-note {{found this candidate}}
+func ambiguous_fn(@_nonEphemeral _ ptr: UnsafePointer<Int>) {} // expected-note {{found candidate with type '(UnsafePointer<Int>) -> ()'}}
+func ambiguous_fn(_ ptr: UnsafeRawPointer) {} // expected-note {{found candidate with type '(UnsafeRawPointer) -> ()'}}
 
 func test_ambiguity_with_function_instead_of_argument(_ x: inout Int) {
   ambiguous_fn(&x) // expected-error {{ambiguous use of 'ambiguous_fn'}}

--- a/test/Sema/diag_non_ephemeral_warning.swift
+++ b/test/Sema/diag_non_ephemeral_warning.swift
@@ -469,8 +469,8 @@ func testNonEphemeralInMemberwiseInits() {
   // expected-note@-2 {{use the 'withCString' method on String in order to explicitly convert argument to pointer valid for a defined scope}}
 }
 
-func ambiguous_fn(@_nonEphemeral _ ptr: UnsafePointer<Int>) {} // expected-note {{found this candidate}}
-func ambiguous_fn(_ ptr: UnsafeRawPointer) {} // expected-note {{found this candidate}}
+func ambiguous_fn(@_nonEphemeral _ ptr: UnsafePointer<Int>) {} // expected-note {{found candidate with type '(UnsafePointer<Int>) -> ()'}}
+func ambiguous_fn(_ ptr: UnsafeRawPointer) {} // expected-note {{found candidate with type '(UnsafeRawPointer) -> ()'}}
 
 func test_ambiguity_with_function_instead_of_argument(_ x: inout Int) {
   ambiguous_fn(&x) // expected-error {{ambiguous use of 'ambiguous_fn'}}

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -56,7 +56,7 @@ enum Color : Int {
     return nil
   }
 
-  var rawValue: Double { // expected-note {{found this candidate}}
+  var rawValue: Double { // expected-note {{found candidate with type 'Double'}}
     return 1.0
   }
 }

--- a/test/Sema/generic_specialization.swift
+++ b/test/Sema/generic_specialization.swift
@@ -77,8 +77,8 @@ do {
   func f(_: Swift<Int>) {}
 }
 
-func overloadedGenericFn<T, U>(_ x: T, _ y: U) {} // expected-note {{found this candidate}}
-func overloadedGenericFn<T, U>(_ x: T, _ y: U, z: Int = 0) {} // expected-note {{found this candidate}}
+func overloadedGenericFn<T, U>(_ x: T, _ y: U) {} // expected-note {{found candidate with type '(_, _) -> ()'}}
+func overloadedGenericFn<T, U>(_ x: T, _ y: U, z: Int = 0) {} // expected-note {{found candidate with type '(_, _, Int) -> ()'}}
 
 // Make sure we don't crash.
 func testSpecializedOverloaded() {

--- a/test/Sema/public-module-name.swift
+++ b/test/Sema/public-module-name.swift
@@ -99,17 +99,17 @@ import LibUnrelated
 ambiguous() // expected-error {{ambiguous use of 'ambiguous()'}}
 // CHECK-NOT: LibCore
 // CHECK-NOT: LibMiddle
-// CHECK: LibUnrelated.ambiguous:1:13: note: found this candidate in module 'LibUnrelated'
-// CHECK: Lib.ambiguous:1:13: note: found this candidate in module 'Lib'
-// CHECK: Lib.ambiguous:1:13: note: found this candidate in module 'Lib'
+// CHECK: LibUnrelated.ambiguous:1:13: note: found candidate with type '() -> ()' in module 'LibUnrelated'
+// CHECK: Lib.ambiguous:1:13: note: found candidate with type '() -> ()' in module 'Lib'
+// CHECK: Lib.ambiguous:1:13: note: found candidate with type '() -> ()' in module 'Lib'
 
 //--- ClientMiddle.swift
 import LibCore
 import LibMiddle
 
 ambiguous() // expected-error {{ambiguous use of 'ambiguous()'}}
-// CHECK: LibCore.ambiguous:1:13: note: found this candidate in module 'LibCore'
-// CHECK: LibMiddle.ambiguous:1:13: note: found this candidate in module 'LibMiddle'
+// CHECK: LibCore.ambiguous:1:13: note: found candidate with type '() -> ()' in module 'LibCore'
+// CHECK: LibMiddle.ambiguous:1:13: note: found candidate with type '() -> ()' in module 'LibMiddle'
 
 //--- ClientAccessLevelOnImports.swift
 internal import Lib // expected-note {{global function 'coreFunc()' imported as 'internal' from 'Lib' here}}

--- a/test/TypeCoercion/integer_literals.swift
+++ b/test/TypeCoercion/integer_literals.swift
@@ -20,8 +20,8 @@ func operators(_ x1: Int8) {
 // Check coercion failure due to overflow.
 struct X { }
 struct Y { }
-func accept_integer(_ x: Int8) -> X { } // expected-note 2{{found this candidate}}
-func accept_integer(_ x: Int16) -> Y { } // expected-note 2{{found this candidate}}
+func accept_integer(_ x: Int8) -> X { } // expected-note 2{{found candidate with type '(Int8) -> X'}}
+func accept_integer(_ x: Int16) -> Y { } // expected-note 2{{found candidate with type '(Int16) -> Y'}}
 
 func overflow_check() {
   var y : Y = accept_integer(500)

--- a/test/TypeCoercion/overload_member.swift
+++ b/test/TypeCoercion/overload_member.swift
@@ -8,14 +8,14 @@ class A {
   func f(x: X) -> X { }
   func f(y: Y) -> Y { }
 
-  func g(z: Z) -> X { } // expected-note 2{{found this candidate}}
-  func g(z: Z) -> Y { } // expected-note 2{{found this candidate}}
+  func g(z: Z) -> X { } // expected-note 2{{found candidate with type '(Z) -> X'}}
+  func g(z: Z) -> Y { } // expected-note 2{{found candidate with type '(Z) -> Y'}}
 
   class func sf(x: X) -> X { }
   class func sf(y: Y) -> Y { }
 
-  class func sg(z: Z) -> X { } // expected-note 2{{found this candidate}}
-  class func sg(z: Z) -> Y { } // expected-note 2{{found this candidate}}
+  class func sg(z: Z) -> X { } // expected-note 2{{found candidate with type '(Z) -> X'}}
+  class func sg(z: Z) -> Y { } // expected-note 2{{found candidate with type '(Z) -> Y'}}
 
   func mixed(x: X) -> X { }
   class func mixed(y: Y) -> Y { }

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -2,11 +2,11 @@
 // REQUIRES: concurrency
 
 // Concurrent attribute on a function type.
-// expected-note@+1{{found candidate with type '@Sendable (Int) -> Int'}}
+// expected-note@+1{{found candidate with type '(@Sendable (Int) -> Int) -> ()'}}
 func f(_ fn: @Sendable (Int) -> Int) { }
 
 // Okay to overload @Sendable vs. not concurrent
-// expected-note@+1{{found candidate with type '(Int) -> Int'}}
+// expected-note@+1{{found candidate with type '((Int) -> Int) -> ()'}}
 func f(_ fn: (Int) -> Int) { }
 
 // Concurrent attribute with other function attributes.

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -2,11 +2,11 @@
 // REQUIRES: concurrency
 
 // Concurrent attribute on a function type.
-// expected-note@+1{{found this candidate}}
+// expected-note@+1{{found candidate with type '@Sendable (Int) -> Int'}}
 func f(_ fn: @Sendable (Int) -> Int) { }
 
 // Okay to overload @Sendable vs. not concurrent
-// expected-note@+1{{found this candidate}}
+// expected-note@+1{{found candidate with type '(Int) -> Int'}}
 func f(_ fn: (Int) -> Int) { }
 
 // Concurrent attribute with other function attributes.

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -163,11 +163,11 @@ class InvalidDerived : InvalidBase {
 
 @dynamicCallable
 struct OverloadedCallable {
-  // expected-note @+1 {{found candidate 'dynamicallyCall'}}
+  // expected-note @+1 {{found candidate with type '([Int]) -> Int'}}
   func dynamicallyCall(withArguments arguments: [Int]) -> Int {
     return 1
   }
-  // expected-note @+1 {{found candidate with type '([Int])->Float'}}
+  // expected-note @+1 {{found candidate with type '([Int]) -> Float'}}
   func dynamicallyCall(withArguments arguments: [Int]) -> Float {
     return 1.0
   }

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -163,11 +163,11 @@ class InvalidDerived : InvalidBase {
 
 @dynamicCallable
 struct OverloadedCallable {
-  // expected-note @+1 {{found this candidate}}
+  // expected-note @+1 {{found candidate 'dynamicallyCall'}}
   func dynamicallyCall(withArguments arguments: [Int]) -> Int {
     return 1
   }
-  // expected-note @+1 {{found this candidate}}
+  // expected-note @+1 {{found candidate with type '([Int])->Float'}}
   func dynamicallyCall(withArguments arguments: [Int]) -> Float {
     return 1.0
   }

--- a/test/decl/func/local-function-overload.swift
+++ b/test/decl/func/local-function-overload.swift
@@ -35,14 +35,14 @@ func invalid1() {
 func invalid2() {
   func inner(_: Int) {}
   // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
-  // expected-note@-2 {{found this candidate}}
+  // expected-note@-2 {{found candidate with type '(Int) -> ()'}}
   // expected-note@-3 {{did you mean 'inner'?}}
   func inner(_: String) {}
   // expected-note@-1 {{candidate expects value of type 'String' for parameter #1}}
-  // expected-note@-2 {{found this candidate}}
+  // expected-note@-2 {{found candidate with type '(String) -> ()'}}
 
   func inner(label: Int) {}
-  // expected-note@-1 {{found this candidate}}
+  // expected-note@-1 {{found candidate with type '(Int) -> ()'}}
 
   inner([])
   // expected-error@-1 {{no exact matches in call to local function 'inner'}}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -131,8 +131,8 @@ infix operator +-+=
 infix func +-+ (x: Int, y: Int) -> Int {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}}
 prefix func +-+ (x: Int) -> Int {}
 
-prefix func -+- (y: inout Int) -> Int {} // expected-note 2{{found this candidate}}
-postfix func -+- (x: inout Int) -> Int {} // expected-note 2{{found this candidate}}
+prefix func -+- (y: inout Int) -> Int {} // expected-note 2{{found candidate with type '(inout Int) -> Int'}}
+postfix func -+- (x: inout Int) -> Int {} // expected-note 2{{found candidate with type '(inout Int) -> Int'}}
 
 infix func +-+= (x: inout Int, y: Int) -> Int {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}}
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -5,10 +5,10 @@ var_redecl1 = 0
 var var_redecl1: UInt // expected-error {{invalid redeclaration of 'var_redecl1'}}
 
 var var_redecl2: Int // expected-note {{previously declared here}}
-// expected-note@-1 {{found this candidate}}
+// expected-note@-1 {{found candidate with type 'Int'}}
 var_redecl2 = 0 // expected-error {{ambiguous use of 'var_redecl2'}}
 var var_redecl2: Int // expected-error {{invalid redeclaration of 'var_redecl2'}}
-// expected-note@-1 {{found this candidate}}
+// expected-note@-1 {{found candidate with type 'Int'}}
 
 var var_redecl3: (Int) -> () { get {} } // expected-note {{previously declared here}}
 var var_redecl3: () -> () { get {} } // expected-error {{invalid redeclaration of 'var_redecl3'}}
@@ -74,17 +74,17 @@ class mixed_redecl2 {} // expected-note {{previously declared here}}
 struct mixed_redecl2 {} // expected-error {{invalid redeclaration}}
 
 class mixed_redecl3 {} // expected-note {{previously declared here}}
-// expected-note @-1 2{{found this candidate}}
+// expected-note @-1 2{{found candidate with type 'mixed_redecl3'}}
 enum mixed_redecl3 {} // expected-error {{invalid redeclaration}}
-// expected-note @-1 2{{found this candidate}}
+// expected-note @-1 2{{found candidate with type 'mixed_redecl3'}}
 enum mixed_redecl3a : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 // expected-error@-1 {{an enum with no cases cannot declare a raw type}}
 class mixed_redecl3b : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 
 class mixed_redecl4 {} // expected-note {{previously declared here}}
-// expected-note@-1{{found this candidate}}
+// expected-note@-1{{found candidate with type 'mixed_redecl4'}}
 protocol mixed_redecl4 {} // expected-error {{invalid redeclaration}}
-// expected-note@-1{{found this candidate}}
+// expected-note@-1{{found candidate with type 'mixed_redecl4'}}
 protocol mixed_redecl4a : mixed_redecl4 {} // expected-error {{'mixed_redecl4' is ambiguous for type lookup in this context}}
 
 class mixed_redecl5 {} // expected-note {{previously declared here}}
@@ -579,27 +579,27 @@ enum E8_52486 {
 }
 
 enum E9_52486 {
-  case A // expected-note {{'A' previously declared here}} expected-note {{found this candidate}}
+  case A // expected-note {{'A' previously declared here}} expected-note {{found candidate with type 'E9_52486'}}
   static let A: E9_52486 = .A // expected-error {{invalid redeclaration of 'A'}}
-  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found this candidate}}
+  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found candidate with type 'E9_52486'}}
 }
 
 enum E10_52486 {
   static let A: E10_52486 = .A // expected-note {{'A' previously declared here}}
-  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found this candidate}}
-  case A // expected-error {{invalid redeclaration of 'A'}} expected-note {{found this candidate}}
+  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found candidate with type 'E10_52486'}}
+  case A // expected-error {{invalid redeclaration of 'A'}} expected-note {{found candidate with type 'E10_52486'}}
 }
 
 enum E11_52486 {
-  case A // expected-note {{'A' previously declared here}} expected-note {{found this candidate}}
+  case A // expected-note {{'A' previously declared here}} expected-note {{found candidate with type 'E11_52486'}}
   static var A: E11_52486 = .A // expected-error {{invalid redeclaration of 'A'}}
-  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found this candidate}}
+  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found candidate with type 'E11_52486'}}
 }
 
 enum E12_52486 {
   static var A: E12_52486 = .A // expected-note {{'A' previously declared here}}
-  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found this candidate}}
-  case A // expected-error {{invalid redeclaration of 'A'}} expected-note {{found this candidate}}
+  // expected-error@-1 {{ambiguous use of 'A'}} expected-note@-1 {{found candidate with type 'E12_52486'}}
+  case A // expected-error {{invalid redeclaration of 'A'}} expected-note {{found candidate with type 'E12_52486'}}
 }
 
 enum E13_52486 {

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -74,17 +74,17 @@ class mixed_redecl2 {} // expected-note {{previously declared here}}
 struct mixed_redecl2 {} // expected-error {{invalid redeclaration}}
 
 class mixed_redecl3 {} // expected-note {{previously declared here}}
-// expected-note @-1 2{{found candidate with type 'mixed_redecl3'}}
+// expected-note @-1 2{{found candidate 'mixed_redecl3'}}
 enum mixed_redecl3 {} // expected-error {{invalid redeclaration}}
-// expected-note @-1 2{{found candidate with type 'mixed_redecl3'}}
+// expected-note @-1 2{{found candidate 'mixed_redecl3'}}
 enum mixed_redecl3a : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 // expected-error@-1 {{an enum with no cases cannot declare a raw type}}
 class mixed_redecl3b : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 
 class mixed_redecl4 {} // expected-note {{previously declared here}}
-// expected-note@-1{{found candidate with type 'mixed_redecl4'}}
+// expected-note@-1{{found candidate 'mixed_redecl4'}}
 protocol mixed_redecl4 {} // expected-error {{invalid redeclaration}}
-// expected-note@-1{{found candidate with type 'mixed_redecl4'}}
+// expected-note@-1{{found candidate 'mixed_redecl4'}}
 protocol mixed_redecl4a : mixed_redecl4 {} // expected-error {{'mixed_redecl4' is ambiguous for type lookup in this context}}
 
 class mixed_redecl5 {} // expected-note {{previously declared here}}

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -12,7 +12,7 @@ extension ConformsToP
   typealias A = Double // expected-note{{type alias 'A' will not be used to satisfy the conformance to 'P1'}}
 
   func f() -> Double { return 0.0 } // expected-note{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
-       // expected-note@-1{{found this candidate}}
+       // expected-note@-1{{found candidate with type '() -> Double'}}
 }
 
 extension ConformsToP

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -327,10 +327,10 @@ protocol DuplicateSuper : Concrete, Concrete {}
 // Ambiguous name lookup situation
 protocol Amb : Concrete {}
 // expected-note@-1 {{'Amb' previously declared here}}
-// expected-note@-2 {{found candidate with type 'Amb'}}
+// expected-note@-2 {{found candidate 'Amb'}}
 protocol Amb : Concrete {}
 // expected-error@-1 {{invalid redeclaration of 'Amb'}}
-// expected-note@-2 {{found candidate with type 'Amb'}}
+// expected-note@-2 {{found candidate 'Amb'}}
 
 extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
   func extensionMethodUsesClassTypes() {

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -327,10 +327,10 @@ protocol DuplicateSuper : Concrete, Concrete {}
 // Ambiguous name lookup situation
 protocol Amb : Concrete {}
 // expected-note@-1 {{'Amb' previously declared here}}
-// expected-note@-2 {{found this candidate}}
+// expected-note@-2 {{found candidate with type 'Amb'}}
 protocol Amb : Concrete {}
 // expected-error@-1 {{invalid redeclaration of 'Amb'}}
-// expected-note@-2 {{found this candidate}}
+// expected-note@-2 {{found candidate with type 'Amb'}}
 
 extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
   func extensionMethodUsesClassTypes() {

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -329,10 +329,10 @@ protocol DuplicateSuper2 where Self : Concrete, Self : Concrete {}
 // Ambiguous name lookup situation
 protocol Amb where Self : Concrete {}
 // expected-note@-1 {{'Amb' previously declared here}}
-// expected-note@-2 {{found this candidate}}
+// expected-note@-2 {{found candidate 'Amb'}}
 protocol Amb where Self : Concrete {}
 // expected-error@-1 {{invalid redeclaration of 'Amb'}}
-// expected-note@-2 {{found this candidate}}
+// expected-note@-2 {{found candidate 'Amb'}}
 
 extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
   func extensionMethodUsesClassTypes() {

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -213,12 +213,12 @@ struct OverloadedSubscript {
 }
 
 struct RetOverloadedSubscript {
-  subscript(i: Int) -> Int {  // expected-note {{found this candidate}}
+  subscript(i: Int) -> Int {  // expected-note {{found candidate with type '(Int) -> Int'}}
     get { return i }
     set {}
   }
 
-  subscript(i: Int) -> Float {  // expected-note {{found this candidate}}
+  subscript(i: Int) -> Float {  // expected-note {{found candidate with type '(Int) -> Float'}}
     get { return Float(i) }
     set {}
   }
@@ -359,14 +359,14 @@ func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }
-  // expected-note@-1 5 {{found this candidate}} expected-note@-1 {{'subscript(_:)' produces 'Bool', not the expected contextual result type 'Int'}}
+  // expected-note@-1 5 {{found candidate 'subscript(_:)'}} expected-note@-1 {{'subscript(_:)' produces 'Bool', not the expected contextual result type 'Int'}}
   subscript(keyword:String) -> String? {return nil }
-  // expected-note@-1 5 {{found this candidate}} expected-note@-1 {{'subscript(_:)' produces 'String?', not the expected contextual result type 'Int'}}
+  // expected-note@-1 5 {{found candidate with type '(String) -> String'}} expected-note@-1 {{'subscript(_:)' produces 'String?', not the expected contextual result type 'Int'}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
-  // expected-note@-1 2 {{found this candidate}}
+  // expected-note@-1 2 {{found candidate with type '(SubClass) -> Bool'}}
   subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
-  // expected-note@-1 2 {{found this candidate}}
+  // expected-note@-1 2 {{found candidate with type '(any Protocol) -> Bool'}}
 
   subscript(arg: (foo: Bool, bar: (Int, baz: SubClass)), arg2: String) -> Bool { return true }
   // expected-note@-1 3 {{declared here}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -359,9 +359,9 @@ func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }
-  // expected-note@-1 5 {{found candidate 'subscript(_:)'}} expected-note@-1 {{'subscript(_:)' produces 'Bool', not the expected contextual result type 'Int'}}
+  // expected-note@-1 5 {{found candidate with type '(String) -> Bool'}} expected-note@-1 {{'subscript(_:)' produces 'Bool', not the expected contextual result type 'Int'}}
   subscript(keyword:String) -> String? {return nil }
-  // expected-note@-1 5 {{found candidate with type '(String) -> String'}} expected-note@-1 {{'subscript(_:)' produces 'String?', not the expected contextual result type 'Int'}}
+  // expected-note@-1 5 {{found candidate with type '(String) -> String?'}} expected-note@-1 {{'subscript(_:)' produces 'String?', not the expected contextual result type 'Int'}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
   // expected-note@-1 2 {{found candidate with type '(SubClass) -> Bool'}}

--- a/test/decl/typealias/on_constrained_protocol.swift
+++ b/test/decl/typealias/on_constrained_protocol.swift
@@ -46,10 +46,10 @@ func useDoubleOverloadedSameTypealias() -> DoubleOverloadedSameTypealias.Content
 
 protocol MarkerProtocol {}
 protocol ProtocolWithAssoctype {
-  associatedtype MyAssocType // expected-note {{found this candidate}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Self.MyAssocType'}} (from useAssocTypeOutsideExtension)
+  associatedtype MyAssocType // expected-note {{found candidate 'MyAssocType'}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Self.MyAssocType'}} (from useAssocTypeOutsideExtension)
 }
 extension ProtocolWithAssoctype where Self: MarkerProtocol {
-  typealias MyAssocType = Int // expected-note {{found this candidate}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Int'}} (from useAssocTypeOutsideExtension)
+  typealias MyAssocType = Int // expected-note {{found candidate 'MyAssocType'}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Int'}} (from useAssocTypeOutsideExtension)
   func useAssocTypeInExtension() -> MyAssocType {} // expected-error {{'MyAssocType' is ambiguous for type lookup in this context}}
 }
 func useAssocTypeOutsideExtension() -> ProtocolWithAssoctype.MyAssocType {} // expected-error {{ambiguous type name 'MyAssocType' in 'ProtocolWithAssoctype'}}

--- a/test/diagnostics/ambiguity-across-modules.swift
+++ b/test/diagnostics/ambiguity-across-modules.swift
@@ -26,23 +26,19 @@ func foo() {
   publicAmbiguity()
 // CHECK: error: ambiguous use of 'publicAmbiguity()'
 // CHECK:  publicAmbiguity()
-// CHECK: note: found this candidate in module 'A'
+// CHECK: note: found candidate with type '() -> ()' in module 'A'
 // CHECK: public func publicAmbiguity() {}
-// CHECK: note: found this candidate in module 'B'
+// CHECK: note: found candidate with type '() -> ()' in module 'B'
 // CHECK: public func publicAmbiguity() {}
 
   packageAmbiguity()
 // CHECK: error: ambiguous use of 'packageAmbiguity()'
 // CHECK-NEXT:  packageAmbiguity()
-// CHECK: note: found this candidate in module 'A'
 // CHECK: package func packageAmbiguity() {}
-// CHECK: note: found this candidate in module 'B'
 // CHECK: package func packageAmbiguity() {}
 
   internalAmbiguity()
 // CHECK: error: ambiguous use of 'internalAmbiguity()'
 // CHECK-NEXT:  internalAmbiguity()
-// CHECK: note: found this candidate in module 'A'
 // CHECK: internal func internalAmbiguity() {}
-// CHECK: note: found this candidate in module 'B'
 }

--- a/test/diagnostics/testable-printast-locations.swift
+++ b/test/diagnostics/testable-printast-locations.swift
@@ -9,5 +9,5 @@
 ambiguous()
 
 // CHECK: testable-printast-locations.swift:[[@LINE-2]]:1: error: ambiguous use of 'ambiguous()'
-// CHECK: ModuleA.ambiguous:1:15: note: found this candidate in module 'ModuleA'
-// CHECK: ModuleB.ambiguous:1:15: note: found this candidate in module 'ModuleB'
+// CHECK: ModuleA.ambiguous:1:15: note: found candidate with type '() -> ()' in module 'ModuleA'
+// CHECK: ModuleB.ambiguous:1:15: note: found candidate with type '() -> ()' in module 'ModuleB'

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -22,8 +22,8 @@ public func universally_unavailable() { }
 @_unavailableInEmbedded
 public func unused() { } // no error
 
-public struct S1 {} // expected-note 2 {{found this candidate}}
-public struct S2 {} // expected-note 2 {{found this candidate}}
+public struct S1 {} // expected-note 2 {{found candidate with type '() -> S1'}}
+public struct S2 {} // expected-note 2 {{found candidate with type '() -> S2'}}
 
 @_unavailableInEmbedded
 public func has_unavailable_in_embedded_overload(_ s1: S1) { }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -250,8 +250,8 @@ func test_test_invalid_redeclaration() {
 
 func test_pattern_ambiguity_doesnot_crash_compiler() {
   enum E {
-  case hello(result: Int) // expected-note 2 {{found this candidate}}
-  case hello(status: Int) // expected-note 2 {{found this candidate}}
+  case hello(result: Int) // expected-note 2 {{found candidate with type '(Int) -> E'}}
+  case hello(status: Int) // expected-note 2 {{found candidate with type '(Int) -> E'}}
   }
 
   let _: (E) -> Void = {

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -301,23 +301,23 @@ func overloadOnLabelDefaultArgs(x: Int = 1, b: () -> Void) {}
 func overloadOnLabelSomeDefaultArgs(_: Int, x: Int = 0, a: () -> Void) {}
 func overloadOnLabelSomeDefaultArgs(_: Int, x: Int = 1, b: () -> Void) {}
 
-func overloadOnDefaultArgsOnly(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found this candidate}}
-func overloadOnDefaultArgsOnly(y: Int = 1, a: () -> Void) {} // expected-note 2 {{found this candidate}}
+func overloadOnDefaultArgsOnly(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Int, () -> Void) -> ()'}}
+func overloadOnDefaultArgsOnly(y: Int = 1, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Int, () -> Void) -> ()'}}
 
-func overloadOnDefaultArgsOnly2(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found this candidate}}
-func overloadOnDefaultArgsOnly2(y: Bool = true, a: () -> Void) {} // expected-note 2 {{found this candidate}}
+func overloadOnDefaultArgsOnly2(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Int, () -> Void) -> ()'}}
+func overloadOnDefaultArgsOnly2(y: Bool = true, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Bool, () -> Void) -> ()'}}
 
-func overloadOnDefaultArgsOnly3(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found this candidate}}
-func overloadOnDefaultArgsOnly3(x: Bool = true, a: () -> Void) {} // expected-note 2 {{found this candidate}}
+func overloadOnDefaultArgsOnly3(x: Int = 0, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Int, () -> Void) -> ()'}}
+func overloadOnDefaultArgsOnly3(x: Bool = true, a: () -> Void) {} // expected-note 2 {{found candidate with type '(Bool, () -> Void) -> ()'}}
 
-func overloadOnSomeDefaultArgsOnly(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found this candidate}}
-func overloadOnSomeDefaultArgsOnly(_: Int, y: Int = 1, a: () -> Void) {} // expected-note {{found this candidate}}
+func overloadOnSomeDefaultArgsOnly(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Int, () -> Void) -> ()'}}
+func overloadOnSomeDefaultArgsOnly(_: Int, y: Int = 1, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Int, () -> Void) -> ()'}}
 
-func overloadOnSomeDefaultArgsOnly2(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found this candidate}}
-func overloadOnSomeDefaultArgsOnly2(_: Int, y: Bool = true, a: () -> Void) {} // expected-note {{found this candidate}}
+func overloadOnSomeDefaultArgsOnly2(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Int, () -> Void) -> ()'}}
+func overloadOnSomeDefaultArgsOnly2(_: Int, y: Bool = true, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Bool, () -> Void) -> ()'}}
 
-func overloadOnSomeDefaultArgsOnly3(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found this candidate}}
-func overloadOnSomeDefaultArgsOnly3(_: Int, x: Bool = true, a: () -> Void) {} // expected-note {{found this candidate}}
+func overloadOnSomeDefaultArgsOnly3(_: Int, x: Int = 0, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Int, () -> Void) -> ()'}}
+func overloadOnSomeDefaultArgsOnly3(_: Int, x: Bool = true, a: () -> Void) {} // expected-note {{found candidate with type '(Int, Bool, () -> Void) -> ()'}}
 
 func testOverloadAmbiguity() {
   overloadOnLabel {} // expected-error {{ambiguous use of 'overloadOnLabel'}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabel(a:)'}} {{18-19=(a: }} {{21-21=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabel(b:)'}} {{18-19=(b: }} {{21-21=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabel(c:)'}} {{18-19=(c: }} {{21-21=)}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -562,8 +562,8 @@ struct SpecialPi {} // Type with no implicit construction.
 
 var pi_s: SpecialPi
 
-func getPi() -> Float {}  // expected-note 3 {{found this candidate}}
-func getPi() -> Double {} // expected-note 3 {{found this candidate}}
+func getPi() -> Float {}  // expected-note 3 {{found candidate with type '() -> Float'}}
+func getPi() -> Double {} // expected-note 3 {{found candidate with type '() -> Double'}}
 func getPi() -> SpecialPi {}
 
 enum Empty { }

--- a/test/expr/primary/selector/selector.swift
+++ b/test/expr/primary/selector/selector.swift
@@ -12,11 +12,11 @@ class C1 {
   @objc func method1(_ a: A, b: B) { }
   @objc(someMethodWithA:B:) func method2(_ a: A, b: B) { }
 
-  @objc class func method3(_ a: A, b: B) { } // expected-note{{found this candidate}}
-  @objc class func method3(a: A, b: B) { } // expected-note{{found this candidate}}
+  @objc class func method3(_ a: A, b: B) { } // expected-note{{found candidate with type '(A, B) -> ()'}}
+  @objc class func method3(a: A, b: B) { } // expected-note{{found candidate with type '(A, B) -> ()'}}
 
-  @objc(ambiguous1:b:) class func ambiguous(a: A, b: A) { } // expected-note{{found this candidate}}
-  @objc(ambiguous2:b:) class func ambiguous(a: A, b: B) { } // expected-note{{found this candidate}}
+  @objc(ambiguous1:b:) class func ambiguous(a: A, b: A) { } // expected-note{{found candidate with type '(A, A) -> ()'}}
+  @objc(ambiguous2:b:) class func ambiguous(a: A, b: B) { } // expected-note{{found candidate with type '(A, B) -> ()'}}
 
   @objc func getC1() -> AnyObject { return self }
 

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -107,9 +107,9 @@ struct Seq<T> : Sequence {
 
 func getIntSeq() -> Seq<Int> { return Seq() }
 
-func getOvlSeq() -> Seq<Int> { return Seq() } // expected-note{{found this candidate}}
-func getOvlSeq() -> Seq<Double> { return Seq() } // expected-note{{found this candidate}}
-func getOvlSeq() -> Seq<X<Int>> { return Seq() } // expected-note{{found this candidate}}
+func getOvlSeq() -> Seq<Int> { return Seq() } // expected-note{{found candidate with type '() -> Seq<Int>'}}
+func getOvlSeq() -> Seq<Double> { return Seq() } // expected-note{{found candidate with type '() -> Seq<Double>'}}
+func getOvlSeq() -> Seq<X<Int>> { return Seq() } // expected-note{{found candidate with type '() -> Seq<X<Int>>'}}
 
 func getGenericSeq<T>() -> Seq<T> { return Seq() }
 

--- a/validation-test/Sema/Inputs/rdar84879566_invalid_decls.swift
+++ b/validation-test/Sema/Inputs/rdar84879566_invalid_decls.swift
@@ -1,10 +1,10 @@
-struct MyView: Tupled { // expected-note {{found this candidate}}
+struct MyView: Tupled { // expected-note {{found candidate 'MyView'}}
   var tuple: some Any {
     ""
   }
 }
 
-struct MyView: Tupled { // expected-note {{found this candidate}}
+struct MyView: Tupled { // expected-note {{found candidate 'MyView'}}
   var tuple: some Any {
     ""
   }

--- a/validation-test/Sema/OverridesAndOverloads.swift
+++ b/validation-test/Sema/OverridesAndOverloads.swift
@@ -165,11 +165,11 @@ Overrides.test("contravariant return type override, protocol to protocol") {
   // FIXME: https://github.com/apple/swift/issues/43348
   // Contravariant overrides on return type don't work with protocols
   class Base {
-    // expected-note@+1 {{found this candidate}}
+    // expected-note@+1 {{found candidate with type '() -> P1'}}
     func foo() -> P1 { which = "Base.foo() -> P1"; return P1ImplS1() }
   }
   class Derived : Base {
-    // expected-note@+1 {{found this candidate}}
+    // expected-note@+1 {{found candidate with type '() -> P1x'}}
     /*FIXME: override */ func foo() -> P1x {
       which = "Derived.foo() -> P1x"; return P1xImplS1()
     }
@@ -189,11 +189,11 @@ Overrides.test("contravariant return type override, protocol to struct") {
   // FIXME: https://github.com/apple/swift/issues/43348
   // Contravariant overrides on return type don't work with protocols
   class Base {
-    // expected-note@+1 {{found this candidate}}
+    // expected-note@+1 {{found candidate with type '() -> P1'}}
     func foo() -> P1 { which = "Base.foo() -> P1"; return P1ImplS1() }
   }
   class Derived : Base {
-    // expected-note@+1 {{found this candidate}}
+    // expected-note@+1 {{found candidate with type '() -> P1ImpleS1'}}
     /*FIXME: override */ func foo() -> P1ImplS1 {
       which = "Derived.foo() -> P1ImplS1"; return P1ImplS1()
     }
@@ -307,8 +307,8 @@ Overloads.test("implicit conversion to a protocol existential is better than con
 
 Overloads.test("implicit conversion to a superclass is ambiguous with conversion to a protocol existential") {
   class Base {
-    func foo(_: C1) { which = "foo(C1)" } // expected-note {{found this candidate}}
-    func foo(_: P1) { which = "foo(P1)" } // expected-note {{found this candidate}}
+    func foo(_: C1) { which = "foo(C1)" } // expected-note {{found candidate with type '(C1) -> ()'}}
+    func foo(_: P1) { which = "foo(P1)" } // expected-note {{found candidate with type '(P1) -> ()'}}
   }
 
   Base().foo(C1());       expectEqual("foo(C1)", which)

--- a/validation-test/Sema/result_builder_buildBlock_resolution.swift
+++ b/validation-test/Sema/result_builder_buildBlock_resolution.swift
@@ -12,11 +12,11 @@ struct ActionLookup<Identifier: ActionIdentifier> {
 
 @resultBuilder
 enum ActionLookupBuilder<Identifier: ActionIdentifier> { // expected-note 3{{'Identifier' previously declared here}}
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found this candidate}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found candidate with type '<Identifier: ActionIdentifier> ([ActionLookup<Identifier>]...) -> ActionLookup<Identifier>'}}
     fatalError()
   }
 
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found this candidate}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found candidate with type '<Identifier: ActionIdentifier> ([ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>]'}}
     []
   }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-57165.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-57165.swift
@@ -8,13 +8,13 @@ struct MyResultBuilder {
 }
 
 struct VariableDecl2 {
-  init( // expected-note {{found this candidate}}
+  init( // expected-note {{found candidate with type '(() -> Int?, Int, () -> Int?) -> VariableDecl2'}}
     paramClosure: () -> Int? = { nil },
     paramInt: Int,
     @MyResultBuilder paramResultBuilder: () -> Int? = { nil }
   ) { fatalError() }
 
-  init( // expected-note {{found this candidate}}
+  init( // expected-note {{found candidate with type '(() -> Int?, Int, () -> Int?) -> VariableDecl2'}}
     paramInt: Int,
     paramClosure: () -> Int? = { nil },
     @MyResultBuilder paramResultBuilder: () -> Int? = { nil }


### PR DESCRIPTION
Updates the message to use the type or ValueDecl instead of this on previous 'Found this candidate' messages Note: doees not yet change all test cases so more tests are failing

Improve Diagnostic message on overload ambiguitiy

Remove messages that say 'found this candidate' in favour of providing the type for the candidate to aid in selection when the candidates are presented in a dialogue window.

Fix more tests

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
