### PR TITLE
[6.2][cxx-interop] Handle Unowned values in implicit value ctors

### DIFF
--- a/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
+++ b/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
@@ -4,6 +4,31 @@
 
 import LoggingFrts
 
+struct SwiftStruct {
+    var frt: SharedFRT
+    var token: MyToken
+}
+
+func go() {
+    let frt = SharedFRT()
+    let token = MyToken()
+    let _ = SwiftStruct(frt: frt, token: token)
+    let _ = SwiftStruct(frt: frt, token: token)
+    let _ = SwiftStruct(frt: frt, token: token)
+}
+
+go()
+
+// CHECK:      RefCount: 1, message: Ctor
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 0, message: release
+// CHECK-NEXT: RefCount: 0, message: Dtor
+
 func takesLargeStructWithRefCountedField(_ x: LargeStructWithRefCountedField) {
     var a = x
 }


### PR DESCRIPTION
Explanation: Implicit value constructors did not account for unowned ownership resulting in unbalanced refcounts and use after free errors. This PR makes sure we +1 the unowned constructor arguments to balance out the ref counts.
Issues: rdar://160232360
Original PRs: #84203
Risk: Low, the fix is narrow to implicit value ctors taking foreign reference types and this scenario was broken before the patch.
Testing: Added a compiler test.
Reviewers: @egorzhdan, @jckarter