### PR TITLE
[stdlib] Fix typo in doc comment: change "One" to "Once"

### DIFF
--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -137,7 +137,7 @@ extension Unicode {
     /// consuming elements from the given source as necessary.
     ///
     /// If the normalizer returns `nil`, the source was exhausted.
-    /// One a source is exhausted, you may:
+    /// Once a source is exhausted, you may:
     ///
     /// - Call `resume` again some time later with a different source
     ///   to continue processing the same logical text stream, or


### PR DESCRIPTION
I noticed a small typo in the documentation while reading through the comments.  
This PR corrects "<mark>One</mark> a source is exhausted" => "<mark>Once</mark> a source is exhausted."