### PR TITLE
build.ps1: add an option to control linkage

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -84,6 +84,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   %WindowsSDKArchitecturesArg% ^
   %TestArg% ^
   -SkipPackaging ^
+  -WindowsSDKLinkage dynamic ^
   -IncludeSBoM ^
   -Summary || (exit /b 1)
 


### PR DESCRIPTION
This allows us to control whether to build the static, dynamic, or both SDK linkage content. Disable the static SDK builds in PR testing.