### PR TITLE
Add frontend option -verbose-asm to emit verbose assembly.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -608,6 +608,9 @@ public:
   /// Set to true if we support AArch64TBI.
   bool HasAArch64TBI = false;
 
+  /// Generate verbose assembly output with comments.
+  bool VerboseAsm = true;
+
   IRGenOptions()
       : OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
         Verify(true), VerifyEach(false), OptMode(OptimizationMode::NotSet),
@@ -657,7 +660,8 @@ public:
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),
-        CASObjMode(llvm::CASBackendMode::Native), HasAArch64TBI(false) {
+        CASObjMode(llvm::CASBackendMode::Native), HasAArch64TBI(false),
+        VerboseAsm(true) {
     DisableRoundTripDebugTypes = !CONDITIONAL_ASSERT_enabled();
   }
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -689,6 +689,12 @@ def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-valid
 def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
   HelpText<"Emit locations during SIL emission">;
 
+def verbose_asm : Flag<["-"], "verbose-asm">,
+  HelpText<"Generate verbose assembly output with comments">;
+
+def no_verbose_asm : Flag<["-"], "no-verbose-asm">,
+  HelpText<"Disable verbose assembly output (default is enabled)">;
+
 def emit_pch : Flag<["-"], "emit-pch">,
   HelpText<"Emit PCH for imported Objective-C header file">, ModeOpt;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3497,6 +3497,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.FunctionSections = Args.hasArg(OPT_function_sections);
 
+  Opts.VerboseAsm = Args.hasFlag(OPT_verbose_asm, OPT_no_verbose_asm,
+                                 /*default*/ true);
+
   if (Args.hasArg(OPT_autolink_force_load))
     Opts.ForceLoadSymbolName = Args.getLastArgValue(OPT_module_link_name).str();
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -159,6 +159,8 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // command-line flags.
   TargetOpts.EmulatedTLS = Clang->getCodeGenOpts().EmulatedTLS;
 
+  TargetOpts.MCOptions.AsmVerbose = Opts.VerboseAsm;
+
   // WebAssembly doesn't support atomics yet, see
   // https://github.com/apple/swift/issues/54533 for more details.
   if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm())

--- a/test/IRGen/verbose_asm.swift
+++ b/test/IRGen/verbose_asm.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-assembly %s | %FileCheck %s --check-prefix=VERBOSE
+// RUN: %target-swift-frontend -emit-assembly -verbose-asm %s | %FileCheck %s --check-prefix=VERBOSE
+// RUN: %target-swift-frontend -emit-assembly -no-verbose-asm %s | %FileCheck %s --check-prefix=NO-VERBOSE
+
+// Test that verbose assembly is enabled by default and can be disabled
+
+func simpleFunction() -> Int {
+    return 42
+}
+
+// VERBOSE: {{;|#}} -- {{Begin|End}} function
+// NO-VERBOSE-NOT: {{;|#}} -- {{Begin|End}} function

--- a/test/Misc/tbi.sil
+++ b/test/Misc/tbi.sil
@@ -3,12 +3,12 @@
 // respects this option and that we get the proper tbi behavior.
 
 // RUN: %swiftc_driver -sdk "" -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios8.0 -target-cpu cyclone \
-// RUN:   -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
+// RUN:   -O -S %s -parse-as-library -parse-stdlib -module-name Swift -Xfrontend -no-verbose-asm \
 // RUN:    | \
 // RUN:   %FileCheck --check-prefix=TBI %s
 
 // RUN: %swiftc_driver -sdk "" -parse-sil -Xfrontend -disable-legacy-type-info -target arm64-apple-ios7.0 -target-cpu cyclone \
-// RUN:     -O -S %s -parse-as-library -parse-stdlib -module-name Swift \
+// RUN:     -O -S %s -parse-as-library -parse-stdlib -module-name Swift -Xfrontend -no-verbose-asm \
 // RUN:      | \
 // RUN:   %FileCheck --check-prefix=NO_TBI %s
 

--- a/test/stdlib/Span/BoundsCheckOptimization.swift
+++ b/test/stdlib/Span/BoundsCheckOptimization.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-swift-frontend -primary-file %s -O -emit-assembly | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu
+// RUN: %target-swift-frontend -primary-file %s -O -emit-assembly -no-verbose-asm | \
+// RUN:   %FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu
 // REQUIRES: swift_stdlib_no_asserts
 
 import Swift


### PR DESCRIPTION
This enables the option by default to improve readability with -emit-assembly.
