### PR TITLE
Update getBaseMachOPlatformID to use llvm::MachO::PLATFORM_UNKNOWN.

### DIFF
--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -299,7 +299,7 @@ static unsigned getBaseMachOPlatformID(const llvm::Triple &TT) {
   case llvm::Triple::XROS:
     return llvm::MachO::PLATFORM_XROS;
   default:
-    return /*Unknown platform*/ 0;
+    return llvm::MachO::PLATFORM_UNKNOWN;
   }
 }
 


### PR DESCRIPTION
getBaseMachOPlatformID was lifted from clang which has been 
subsequently updated to use PLATFORM_UNKNOWN.

