### PR TITLE
Fix running tests when host tools are a customized installation of Swiftly

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -196,7 +196,7 @@ function(add_swift_compiler_modules_library name)
     # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
     list(APPEND swift_compile_options "-Xcc" "-Xclang" "-Xcc" "-fmodule-format=raw")
 
-  elseif(swift_exec_bin_dir MATCHES ".*/swiftly/bin")
+  elseif(swift_exec_bin_dir MATCHES ".*/swiftly/bin" OR swift_exec_bin_dir STREQUAL "$ENV{SWIFTLY_BIN_DIR}")
     # Detect and handle swiftly-managed hosts.
     execute_process(COMMAND swiftly use --print-location
       OUTPUT_VARIABLE swiftly_dir

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -552,7 +552,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
           get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
 
           # Detect and handle swiftly-managed hosts.
-          if(swift_bin_dir MATCHES ".*/swiftly/bin")
+          if(swift_bin_dir MATCHES ".*/swiftly/bin" OR swift_bin_dir STREQUAL "$ENV{SWIFTLY_BIN_DIR}")
             execute_process(COMMAND swiftly use --print-location
               OUTPUT_VARIABLE swiftly_dir
               ERROR_VARIABLE err)
@@ -626,7 +626,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
           get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
 
           # Detect and handle swiftly-managed hosts.
-          if(swift_bin_dir MATCHES ".*/swiftly/bin")
+          if(swift_bin_dir MATCHES ".*/swiftly/bin" OR swift_bin_dir STREQUAL "$ENV{SWIFTLY_BIN_DIR}")
             execute_process(COMMAND swiftly use --print-location
               OUTPUT_VARIABLE swiftly_dir
               ERROR_VARIABLE err)

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -117,7 +117,7 @@ function(get_bootstrapping_swift_lib_dir bs_lib_dir bootstrapping)
       get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
 
       # Detect and handle swiftly-managed hosts.
-      if(swift_bin_dir MATCHES ".*/swiftly/bin")
+      if(swift_bin_dir MATCHES ".*/swiftly/bin" OR swift_bin_dir STREQUAL "$ENV{SWIFTLY_BIN_DIR}")
         execute_process(COMMAND swiftly use --print-location
           OUTPUT_VARIABLE swiftly_dir
           ERROR_VARIABLE err)

--- a/test/Driver/linker-arclite.swift
+++ b/test/Driver/linker-arclite.swift
@@ -9,7 +9,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 
-// NO_ARCLITE: bin/ld{{"? }}
+// NO_ARCLITE: /ld{{"? }}
 // NO_ARCLITE-NOT: arclite
 // NO_ARCLITE-NOT: CoreFoundation
 // NO_ARCLITE: -o {{[^ ]+}}

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -35,7 +35,7 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos7 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos8 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
-// RPATH: bin/ld{{"? }}
+// RPATH: /ld{{"? }}
 // RPATH-SAME: -rpath {{"?/usr/lib/swift(-.+)?"? }}
 // RPATH-SAME: -o {{[^ ]+}}
 
@@ -53,6 +53,6 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
-// TOOLCHAIN-RPATH: bin/ld{{"? }}
+// TOOLCHAIN-RPATH: /ld{{"? }}
 // TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}
 // TOOLCHAIN-RPATH-SAME: -o {{[^ ]+}}

--- a/test/Driver/linker-tbd.swift
+++ b/test/Driver/linker-tbd.swift
@@ -5,5 +5,5 @@
 // RUN: touch %t/foo.tbd
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift %t/foo.tbd | %FileCheck %s
 
-// CHECK: bin/ld{{"? }}
+// CHECK: /ld{{"? }}
 // CHECK-SAME: foo.tbd

--- a/test/Driver/macabi-environment.swift
+++ b/test/Driver/macabi-environment.swift
@@ -3,10 +3,10 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.1-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS13-MACABI %s
-// IOS13-MACABI: bin/swift
+// IOS13-MACABI: /swift
 // IOS13-MACABI: -target x86_64-apple-ios13.1-macabi
 
-// IOS13-MACABI: bin/ld
+// IOS13-MACABI: /ld
 // IOS13-MACABI-DAG: -L [[MACCATALYST_STDLIB_PATH:[^ ]+/lib/swift/maccatalyst]]
 // IOS13-MACABI-DAG: -L [[MACOSX_STDLIB_PATH:[^ ]+/lib/swift/macosx]]
 // IOS13-MACABI-DAG: -L [[MACCATALYST_SDK_STDLIB_PATH:[^ ]+/clang-importer-sdk/System/iOSSupport/usr/lib/swift]]
@@ -23,7 +23,7 @@
 // IOS12-MACABI: bin/swift
 // IOS12-MACABI: -target x86_64-apple-ios12.0-macabi
 
-// IOS12-MACABI: bin/ld
+// IOS12-MACABI: /ld
 // IOS12-MACABI-DAG: -L [[MACCATALYST_STDLIB_PATH:[^ ]+/lib/swift/maccatalyst]]
 // IOS12-MACABI-DAG: -L [[MACOSX_STDLIB_PATH:[^ ]+/lib/swift/macosx]]
 // IOS12-MACABI-DAG: -L [[MACCATALYST_SDK_STDLIB_PATH:[^ ]+/clang-importer-sdk/System/iOSSupport/usr/lib/swift]]
@@ -47,7 +47,7 @@
 // ZIPPERED-VARIANT-LIBRARY: bin/swift
 // ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
 
-// ZIPPERED-VARIANT-LIBRARY: bin/ld
+// ZIPPERED-VARIANT-LIBRARY: /ld
 // ZIPPERED-VARIANT-LIBRARY: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.1.0 0.0.0
 
 // Make sure we pass the -target-variant when creating the pre-compiled header.
@@ -57,7 +57,7 @@
 // ZIPPERED_VARIANT-PCH:  -emit-pch
 // ZIPPERED-VARIANT-PCH: bin/swift
 // ZIPPERED-VARIANT-PCH: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
-// ZIPPERED-VARIANT-PCH: bin/ld
+// ZIPPERED-VARIANT-PCH: /ld
 // ZIPPERED-VARIANT-PCH: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.1.0 0.0.0
 
 // Test using 'reverse' target-variant to build zippered outputs when the primary
@@ -71,7 +71,7 @@
 // REVERSE-ZIPPERED-VARIANT-LIBRARY: bin/swift
 // REVERSE-ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
 
-// REVERSE-ZIPPERED-VARIANT-LIBRARY: bin/ld
+// REVERSE-ZIPPERED-VARIANT-LIBRARY: /ld
 // REVERSE-ZIPPERED-VARIANT-LIBRARY: -platform_version mac-catalyst 13.1.0 0.0.0 -platform_version macos 10.14.0
 
 // Make sure we pass the -target-variant when creating the pre-compiled header.
@@ -81,7 +81,7 @@
 // REVERSE-ZIPPERED_VARIANT-PCH:  -emit-pch
 // REVERSE-ZIPPERED-VARIANT-PCH: bin/swift
 // REVERSE-ZIPPERED-VARIANT-PCH: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
-// REVERSE-ZIPPERED-VARIANT-PCH: bin/ld
+// REVERSE-ZIPPERED-VARIANT-PCH: /ld
 // REVERSE-ZIPPERED-VARIANT-PCH: -platform_version mac-catalyst 13.1.0 0.0.0 -platform_version macos 10.14.0 0.0.0
 
 // RUN: not %swiftc_driver -sdk "" -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0 %s 2>&1 | %FileCheck --check-prefix=UNSUPPORTED-TARGET-VARIANT %s
@@ -96,7 +96,7 @@
 // IOS13-NO-MACABI: bin/swift
 // IOS13-NO-MACABI: -target arm64-apple-ios13.0
 
-// IOS13-NO-MACABI: bin/ld
+// IOS13-NO-MACABI: /ld
 // IOS13-NO-MACABI-DAG: -L {{[^ ]+/lib/swift/iphoneos}}
 // IOS13-NO-MACABI-DAG: -L {{[^ ]+/clang-importer-sdk/usr/lib/swift}}
 // IOS13-NO-MACABI-DAG: -platform_version ios 13.0.0
@@ -121,4 +121,3 @@
 // MACOS_10_15_4_REVERSE_ZIPPERED: -target-variant-sdk-version 10.15.4
 // MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version mac-catalyst 13.1.0 13.4.0
 // MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version macos 10.14.0 10.15.4
-

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -175,6 +175,17 @@ if platform.system() == 'Darwin':
     config.environment['TOOLCHAINS'] = \
         os.environ.get('TOOLCHAINS', config.darwin_xcrun_toolchain)
 
+# Pass along swiftly environment variables to let tests run correctly with
+# swiftly installed. Without this, an installed swiftly assumes its default
+# configuration which may be incorrect and lead to missing tools.
+
+if 'SWIFTLY_HOME_DIR' in os.environ:
+  config.environment['SWIFTLY_HOME_DIR'] = os.environ['SWIFTLY_HOME_DIR']
+if 'SWIFTLY_BIN_DIR' in os.environ:
+  config.environment['SWIFTLY_BIN_DIR'] = os.environ['SWIFTLY_BIN_DIR']
+if 'SWIFTLY_TOOLCHAINS_DIR' in os.environ:
+  config.environment['SWIFTLY_TOOLCHAINS_DIR'] = os.environ['SWIFTLY_TOOLCHAINS_DIR']
+
 # NOTE: this mirrors the kIsWindows from lit.lit.TestRunner in LLVM
 kIsWindows = platform.system() == 'Windows'
 

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -113,7 +113,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
         get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
 
         # Detect and handle swiftly-managed hosts.
-        if(swift_bin_dir MATCHES ".*/swiftly/bin")
+        if(swift_bin_dir MATCHES ".*/swiftly/bin" OR swift_bin_dir STREQUAL "$ENV{SWIFTLY_BIN_DIR}")
           execute_process(COMMAND swiftly use --print-location
             OUTPUT_VARIABLE swiftly_dir
             ERROR_VARIABLE err)


### PR DESCRIPTION
Several pieces of the test system assume no Swiftly or assume that Swiftly is installed in the default configuration.
I adjusted the Swiftly settings to install it differently to avoid cluttering my home directory, and ran into some failures.
This adjusts 3 places to resolve those failures:
1. Forward swiftly environment variables through the lit environment, otherwise swiftly's proxy around the linker fails in 1000+ tests
2. Fix a handful of tests that assume that the linker is installed to a directory named `bin`, my own setup puts it in `bin/swiftly` and the test should probably tolerate that.
3. Fix CMake logic that explicitly handles Swiftly but only recognizes the default swiftly location.