### PR TITLE
[ObjC][Gen] Emit ObjC strings to respective sections

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1401,8 +1401,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     auto clangTy = IGF.IGM.getClangType(valueTy->getCanonicalType());
     std::string encoding;
     IGF.IGM.getClangASTContext().getObjCEncodingForType(clangTy, encoding);
-    
-    auto globalString = IGF.IGM.getAddrOfGlobalString(encoding);
+
+    auto globalString = IGF.IGM.getAddrOfGlobalString(
+        encoding, /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
     out.add(globalString);
     return;
   }

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1403,7 +1403,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     IGF.IGM.getClangASTContext().getObjCEncodingForType(clangTy, encoding);
 
     auto globalString = IGF.IGM.getAddrOfGlobalString(
-        encoding, IRGenModule::ObjCMethodTypeSectionName);
+        encoding, CStringSectionType::ObjCMethodType);
     out.add(globalString);
     return;
   }

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1403,7 +1403,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     IGF.IGM.getClangASTContext().getObjCEncodingForType(clangTy, encoding);
 
     auto globalString = IGF.IGM.getAddrOfGlobalString(
-        encoding, /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
+        encoding, IRGenModule::ObjCMethodTypeSectionName);
     out.add(globalString);
     return;
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1464,7 +1464,7 @@ namespace {
 
       // struct category_t {
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(CategoryName));
+      fields.add(IGM.getAddrOfGlobalString(CategoryName, /*sectionName=*/"__TEXT,__objc_classname,cstring_literals")));
       //   const class_t *theClass;
       fields.add(getClassMetadataRef());
       //   const method_list_t *instanceMethods;
@@ -1503,7 +1503,7 @@ namespace {
       //   Class super;
       fields.addNullPointer(IGM.Int8PtrTy);
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(getEntityName(nameBuffer)));
+      fields.add(IGM.getAddrOfGlobalString(getEntityName(nameBuffer), /*sectionName=*/"__TEXT,__objc_classname,cstring_literals")));
       //   const protocol_list_t *baseProtocols;
       fields.add(buildProtocolList(weakLinkage));
       //   const method_list_t *requiredInstanceMethods;
@@ -1724,7 +1724,7 @@ namespace {
       }
       
       llvm::SmallString<64> buffer;
-      Name = IGM.getAddrOfGlobalString(getClass()->getObjCRuntimeName(buffer));
+      Name = IGM.getAddrOfGlobalString(getClass()->getObjCRuntimeName(buffer), /*sectionName=*/"__TEXT,__objc_classname,cstring_literals"));
       return Name;
     }
 
@@ -2088,11 +2088,8 @@ namespace {
       else
         fields.addNullPointer(IGM.PtrTy);
 
-      // TODO: clang puts this in __TEXT,__objc_methname,cstring_literals
-      fields.add(IGM.getAddrOfGlobalString(name));
-
-      // TODO: clang puts this in __TEXT,__objc_methtype,cstring_literals
-      fields.add(IGM.getAddrOfGlobalString(typeEnc));
+      fields.add(IGM.getAddrOfGlobalString(name), /*sectionName=*/"__TEXT,__objc_methname,cstring_literals"));
+      fields.add(IGM.getAddrOfGlobalString(typeEnc), /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals"));
 
       Size size;
       Alignment alignment;
@@ -2228,8 +2225,8 @@ namespace {
       buildPropertyAttributes(prop, propertyAttributes);
       
       auto fields = properties.beginStruct();
-      fields.add(IGM.getAddrOfGlobalString(prop->getObjCPropertyName().str()));
-      fields.add(IGM.getAddrOfGlobalString(propertyAttributes));
+      fields.add(IGM.getAddrOfGlobalString(prop->getObjCPropertyName().str(), /*sectionName=*/"__TEXT,__objc_methname,cstring_literals")));
+      fields.add(IGM.getAddrOfGlobalString(propertyAttributes, /*sectionName=*/"__TEXT,__objc_methname,cstring_literals")));
       fields.finishAndAddTo(properties);
     }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1464,8 +1464,8 @@ namespace {
 
       // struct category_t {
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(
-          CategoryName, IRGenModule::ObjCClassNameSectionName));
+      fields.add(IGM.getAddrOfGlobalString(CategoryName,
+                                           CStringSectionType::ObjCClassName));
       //   const class_t *theClass;
       fields.add(getClassMetadataRef());
       //   const method_list_t *instanceMethods;
@@ -1504,8 +1504,8 @@ namespace {
       //   Class super;
       fields.addNullPointer(IGM.Int8PtrTy);
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(
-          getEntityName(nameBuffer), IRGenModule::ObjCClassNameSectionName));
+      fields.add(IGM.getAddrOfGlobalString(getEntityName(nameBuffer),
+                                           CStringSectionType::ObjCClassName));
       //   const protocol_list_t *baseProtocols;
       fields.add(buildProtocolList(weakLinkage));
       //   const method_list_t *requiredInstanceMethods;
@@ -1727,7 +1727,7 @@ namespace {
       
       llvm::SmallString<64> buffer;
       Name = IGM.getAddrOfGlobalString(getClass()->getObjCRuntimeName(buffer),
-                                       IRGenModule::ObjCClassNameSectionName);
+                                       CStringSectionType::ObjCClassName);
       return Name;
     }
 
@@ -2091,10 +2091,10 @@ namespace {
       else
         fields.addNullPointer(IGM.PtrTy);
 
-      fields.add(IGM.getAddrOfGlobalString(
-          name, IRGenModule::ObjCMethodNameSectionName));
-      fields.add(IGM.getAddrOfGlobalString(
-          typeEnc, IRGenModule::ObjCMethodTypeSectionName));
+      fields.add(
+          IGM.getAddrOfGlobalString(name, CStringSectionType::ObjCMethodName));
+      fields.add(IGM.getAddrOfGlobalString(typeEnc,
+                                           CStringSectionType::ObjCMethodType));
 
       Size size;
       Alignment alignment;
@@ -2232,9 +2232,9 @@ namespace {
       auto fields = properties.beginStruct();
       fields.add(
           IGM.getAddrOfGlobalString(prop->getObjCPropertyName().str(),
-                                    IRGenModule::ObjCPropertyNameSectionName));
+                                    CStringSectionType::ObjCPropertyName));
       fields.add(IGM.getAddrOfGlobalString(
-          propertyAttributes, IRGenModule::ObjCPropertyNameSectionName));
+          propertyAttributes, CStringSectionType::ObjCPropertyName));
       fields.finishAndAddTo(properties);
     }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1464,7 +1464,8 @@ namespace {
 
       // struct category_t {
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(CategoryName, /*sectionName=*/"__TEXT,__objc_classname,cstring_literals")));
+      fields.add(IGM.getAddrOfGlobalString(
+          CategoryName, IRGenModule::ObjCClassNameSectionName));
       //   const class_t *theClass;
       fields.add(getClassMetadataRef());
       //   const method_list_t *instanceMethods;
@@ -1503,7 +1504,8 @@ namespace {
       //   Class super;
       fields.addNullPointer(IGM.Int8PtrTy);
       //   char const *name;
-      fields.add(IGM.getAddrOfGlobalString(getEntityName(nameBuffer), /*sectionName=*/"__TEXT,__objc_classname,cstring_literals")));
+      fields.add(IGM.getAddrOfGlobalString(
+          getEntityName(nameBuffer), IRGenModule::ObjCClassNameSectionName));
       //   const protocol_list_t *baseProtocols;
       fields.add(buildProtocolList(weakLinkage));
       //   const method_list_t *requiredInstanceMethods;
@@ -1724,7 +1726,8 @@ namespace {
       }
       
       llvm::SmallString<64> buffer;
-      Name = IGM.getAddrOfGlobalString(getClass()->getObjCRuntimeName(buffer), /*sectionName=*/"__TEXT,__objc_classname,cstring_literals"));
+      Name = IGM.getAddrOfGlobalString(getClass()->getObjCRuntimeName(buffer),
+                                       IRGenModule::ObjCClassNameSectionName);
       return Name;
     }
 
@@ -2088,8 +2091,10 @@ namespace {
       else
         fields.addNullPointer(IGM.PtrTy);
 
-      fields.add(IGM.getAddrOfGlobalString(name), /*sectionName=*/"__TEXT,__objc_methname,cstring_literals"));
-      fields.add(IGM.getAddrOfGlobalString(typeEnc), /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals"));
+      fields.add(IGM.getAddrOfGlobalString(
+          name, IRGenModule::ObjCMethodNameSectionName));
+      fields.add(IGM.getAddrOfGlobalString(
+          typeEnc, IRGenModule::ObjCMethodTypeSectionName));
 
       Size size;
       Alignment alignment;
@@ -2225,8 +2230,11 @@ namespace {
       buildPropertyAttributes(prop, propertyAttributes);
       
       auto fields = properties.beginStruct();
-      fields.add(IGM.getAddrOfGlobalString(prop->getObjCPropertyName().str(), /*sectionName=*/"__TEXT,__objc_methname,cstring_literals")));
-      fields.add(IGM.getAddrOfGlobalString(propertyAttributes, /*sectionName=*/"__TEXT,__objc_methname,cstring_literals")));
+      fields.add(
+          IGM.getAddrOfGlobalString(prop->getObjCPropertyName().str(),
+                                    IRGenModule::ObjCPropertyNameSectionName));
+      fields.add(IGM.getAddrOfGlobalString(
+          propertyAttributes, IRGenModule::ObjCPropertyNameSectionName));
       fields.finishAndAddTo(properties);
     }
 

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -79,7 +79,9 @@ llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
   case StringLiteralInst::Encoding::Bytes:
   case StringLiteralInst::Encoding::UTF8:
   case StringLiteralInst::Encoding::UTF8_OSLOG:
-    return IGM.getAddrOfGlobalString(SLI->getValue(), false, useOSLogEncoding);
+    return IGM.getAddrOfGlobalString(
+        SLI->getValue(), useOSLogEncoding ? CStringSectionType::OSLogString
+                                          : CStringSectionType::Default);
 
   case StringLiteralInst::Encoding::ObjCSelector:
     llvm_unreachable("cannot get the address of an Objective-C selector");

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -79,8 +79,7 @@ llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
   case StringLiteralInst::Encoding::Bytes:
   case StringLiteralInst::Encoding::UTF8:
   case StringLiteralInst::Encoding::UTF8_OSLOG:
-    return IGM.getAddrOfGlobalString(SLI->getValue(), /*sectionName=*/"", false,
-                                     useOSLogEncoding);
+    return IGM.getAddrOfGlobalString(SLI->getValue(), false, useOSLogEncoding);
 
   case StringLiteralInst::Encoding::ObjCSelector:
     llvm_unreachable("cannot get the address of an Objective-C selector");

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -79,7 +79,8 @@ llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
   case StringLiteralInst::Encoding::Bytes:
   case StringLiteralInst::Encoding::UTF8:
   case StringLiteralInst::Encoding::UTF8_OSLOG:
-    return IGM.getAddrOfGlobalString(SLI->getValue(), false, useOSLogEncoding);
+    return IGM.getAddrOfGlobalString(SLI->getValue(), /*sectionName=*/"", false,
+                                     useOSLogEncoding);
 
   case StringLiteralInst::Encoding::ObjCSelector:
     llvm_unreachable("cannot get the address of an Objective-C selector");

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -297,8 +297,7 @@ public:
     // protocol. If so, use it.
     SmallString<32> buf;
     auto protocolName = IGM.getAddrOfGlobalString(
-        proto->getObjCRuntimeName(buf),
-        /*sectionName=*/"__TEXT,__objc_classname,cstring_literals");
+        proto->getObjCRuntimeName(buf), IRGenModule::ObjCClassNameSectionName);
 
     auto existing = Builder.CreateCall(objc_getProtocol, protocolName);
     auto isNull = Builder.CreateICmpEQ(existing,
@@ -1057,16 +1056,16 @@ void IRGenModule::SetCStringLiteralSection(llvm::GlobalVariable *GV,
   case llvm::Triple::MachO:
     switch (Type) {
     case ObjCLabelType::ClassName:
-      GV->setSection("__TEXT,__objc_classname,cstring_literals");
+      GV->setSection(IRGenModule::ObjCClassNameSectionName);
       return;
     case ObjCLabelType::MethodVarName:
-      GV->setSection("__TEXT,__objc_methname,cstring_literals");
+      GV->setSection(IRGenModule::ObjCMethodNameSectionName);
       return;
     case ObjCLabelType::MethodVarType:
-      GV->setSection("__TEXT,__objc_methtype,cstring_literals");
+      GV->setSection(IRGenModule::ObjCMethodTypeSectionName);
       return;
     case ObjCLabelType::PropertyName:
-      GV->setSection("__TEXT,__objc_methname,cstring_literals");
+      GV->setSection(IRGenModule::ObjCPropertyNameSectionName);
       return;
     }
   case llvm::Triple::ELF:
@@ -4241,10 +4240,10 @@ static TypeEntityReference
 getObjCClassByNameReference(IRGenModule &IGM, ClassDecl *cls) {
   auto kind = TypeReferenceKind::DirectObjCClassName;
   SmallString<64> objcRuntimeNameBuffer;
-  auto ref = IGM.getAddrOfGlobalString(
-      cls->getObjCRuntimeName(objcRuntimeNameBuffer),
-      /*sectionName=*/"__TEXT,__objc_classname,cstring_literals",
-      /*willBeRelativelyAddressed=*/true);
+  auto ref =
+      IGM.getAddrOfGlobalString(cls->getObjCRuntimeName(objcRuntimeNameBuffer),
+                                IRGenModule::ObjCClassNameSectionName,
+                                /*willBeRelativelyAddressed=*/true);
 
   return TypeEntityReference(kind, ref);
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1065,7 +1065,7 @@ void IRGenModule::SetCStringLiteralSection(llvm::GlobalVariable *GV,
       GV->setSection(IRGenModule::ObjCMethodTypeSectionName);
       return;
     case ObjCLabelType::PropertyName:
-      GV->setSection(IRGenModule::ObjCPropertyNameSectionName);
+      GV->setSection(IRGenModule::ObjCMethodNameSectionName);
       return;
     }
   case llvm::Triple::ELF:
@@ -6043,16 +6043,15 @@ IRGenModule::getAddrOfGlobalString(StringRef data, CStringSectionType type,
   case CStringSectionType::ObjCMethodType:
     sectionName = ObjCMethodTypeSectionName;
     break;
-  case CStringSectionType::ObjCPropertyName:
-    sectionName = ObjCPropertyNameSectionName;
-    break;
   case CStringSectionType::OSLogString:
     sectionName = OSLogStringSectionName;
     break;
+  case CStringSectionType::NumTypes:
+    llvm_unreachable("invalid type");
   }
 
   // Check whether this string already exists.
-  auto &entry = GlobalStrings[sectionName][data];
+  auto &entry = GlobalStrings[static_cast<size_t>(type)][data];
 
   if (entry.second) {
     // FIXME: Clear unnamed_addr if the global will be relative referenced

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -6052,7 +6052,7 @@ IRGenModule::getAddrOfGlobalString(StringRef data, CStringSectionType type,
   }
 
   // Check whether this string already exists.
-  auto &entry = GlobalStrings[type][data];
+  auto &entry = GlobalStrings[sectionName][data];
 
   if (entry.second) {
     // FIXME: Clear unnamed_addr if the global will be relative referenced

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1059,13 +1059,11 @@ void IRGenModule::SetCStringLiteralSection(llvm::GlobalVariable *GV,
       GV->setSection(IRGenModule::ObjCClassNameSectionName);
       return;
     case ObjCLabelType::MethodVarName:
+    case ObjCLabelType::PropertyName:
       GV->setSection(IRGenModule::ObjCMethodNameSectionName);
       return;
     case ObjCLabelType::MethodVarType:
       GV->setSection(IRGenModule::ObjCMethodTypeSectionName);
-      return;
-    case ObjCLabelType::PropertyName:
-      GV->setSection(IRGenModule::ObjCMethodNameSectionName);
       return;
     }
   case llvm::Triple::ELF:

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1143,6 +1143,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   // null otherwise.
   if (!pattern->getObjCString().empty()) {
     auto objcString = getAddrOfGlobalString(pattern->getObjCString(),
+                                            CStringSectionType::Default,
                                             /*relatively addressed*/ true);
     fields.addRelativeAddress(objcString);
   } else {

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1143,6 +1143,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   // null otherwise.
   if (!pattern->getObjCString().empty()) {
     auto objcString = getAddrOfGlobalString(pattern->getObjCString(),
+                                            /*sectionName=*/"",
                                             /*relatively addressed*/ true);
     fields.addRelativeAddress(objcString);
   } else {

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1143,7 +1143,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   // null otherwise.
   if (!pattern->getObjCString().empty()) {
     auto objcString = getAddrOfGlobalString(pattern->getObjCString(),
-                                            /*sectionName=*/"",
                                             /*relatively addressed*/ true);
     fields.addRelativeAddress(objcString);
   } else {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -845,8 +845,8 @@ namespace {
       IRGenMangler mangler(IGM.Context);
       auto mangledName = mangler.mangleAnonymousDescriptorName(Name);
       auto mangledNameConstant =
-        IGM.getAddrOfGlobalString(mangledName,
-                                  /*willBeRelativelyAddressed*/ true);
+          IGM.getAddrOfGlobalString(mangledName, CStringSectionType::Default,
+                                    /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(mangledNameConstant);
     }
 
@@ -1277,6 +1277,7 @@ namespace {
       llvm::Constant *global = nullptr;
       if (!AssociatedTypeNames.empty()) {
         global = IGM.getAddrOfGlobalString(AssociatedTypeNames,
+                                           CStringSectionType::Default,
                                            /*willBeRelativelyAddressed=*/true);
       }
       B.addRelativeAddressOrNull(global);
@@ -1515,9 +1516,10 @@ namespace {
         name.pop_back();
         assert(name.back() == '\0');
       }
-      
-      auto nameStr = IGM.getAddrOfGlobalString(name,
-                                               /*willBeRelativelyAddressed*/ true);
+
+      auto nameStr =
+          IGM.getAddrOfGlobalString(name, CStringSectionType::Default,
+                                    /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(nameStr);
     }
       

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -845,8 +845,9 @@ namespace {
       IRGenMangler mangler(IGM.Context);
       auto mangledName = mangler.mangleAnonymousDescriptorName(Name);
       auto mangledNameConstant =
-        IGM.getAddrOfGlobalString(mangledName,
-                                  /*willBeRelativelyAddressed*/ true);
+          IGM.getAddrOfGlobalString(mangledName,
+                                    /*sectionName=*/"",
+                                    /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(mangledNameConstant);
     }
 
@@ -1277,6 +1278,7 @@ namespace {
       llvm::Constant *global = nullptr;
       if (!AssociatedTypeNames.empty()) {
         global = IGM.getAddrOfGlobalString(AssociatedTypeNames,
+                                           /*sectionName=*/"",
                                            /*willBeRelativelyAddressed=*/true);
       }
       B.addRelativeAddressOrNull(global);
@@ -1515,9 +1517,11 @@ namespace {
         name.pop_back();
         assert(name.back() == '\0');
       }
-      
-      auto nameStr = IGM.getAddrOfGlobalString(name,
-                                               /*willBeRelativelyAddressed*/ true);
+
+      auto nameStr =
+          IGM.getAddrOfGlobalString(name,
+                                    /*sectionName=*/"",
+                                    /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(nameStr);
     }
       

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -845,9 +845,8 @@ namespace {
       IRGenMangler mangler(IGM.Context);
       auto mangledName = mangler.mangleAnonymousDescriptorName(Name);
       auto mangledNameConstant =
-          IGM.getAddrOfGlobalString(mangledName,
-                                    /*sectionName=*/"",
-                                    /*willBeRelativelyAddressed*/ true);
+        IGM.getAddrOfGlobalString(mangledName,
+                                  /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(mangledNameConstant);
     }
 
@@ -1278,7 +1277,6 @@ namespace {
       llvm::Constant *global = nullptr;
       if (!AssociatedTypeNames.empty()) {
         global = IGM.getAddrOfGlobalString(AssociatedTypeNames,
-                                           /*sectionName=*/"",
                                            /*willBeRelativelyAddressed=*/true);
       }
       B.addRelativeAddressOrNull(global);
@@ -1517,11 +1515,9 @@ namespace {
         name.pop_back();
         assert(name.back() == '\0');
       }
-
-      auto nameStr =
-          IGM.getAddrOfGlobalString(name,
-                                    /*sectionName=*/"",
-                                    /*willBeRelativelyAddressed*/ true);
+      
+      auto nameStr = IGM.getAddrOfGlobalString(name,
+                                               /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(nameStr);
     }
       

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1330,7 +1330,7 @@ getObjectEncodingFromClangNode(IRGenModule &IGM, Decl *d,
     auto clangDecl = d->getClangNode().castAsDecl();
     auto &clangASTContext = IGM.getClangASTContext();
     std::string typeStr;
-    std::string sectionName;
+    const char *sectionName;
     if (auto objcMethodDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
       typeStr = clangASTContext.getObjCEncodingForMethodDecl(
           objcMethodDecl, useExtendedEncoding /*extended*/);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1318,9 +1318,8 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   encodingString += llvm::itostr(parmOffset);
   encodingString += fixedParamsString;
   encodingString += paramsString;
-  return IGM.getAddrOfGlobalString(
-      encodingString,
-      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
+  return IGM.getAddrOfGlobalString(encodingString,
+                                   IRGenModule::ObjCMethodTypeSectionName);
 }
 
 static llvm::Constant *
@@ -1335,12 +1334,12 @@ getObjectEncodingFromClangNode(IRGenModule &IGM, Decl *d,
     if (auto objcMethodDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
       typeStr = clangASTContext.getObjCEncodingForMethodDecl(
           objcMethodDecl, useExtendedEncoding /*extended*/);
-      sectionName = "__TEXT,__objc_methtype,cstring_literals";
+      sectionName = IRGenModule::ObjCMethodTypeSectionName;
     }
     if (auto objcPropertyDecl = dyn_cast<clang::ObjCPropertyDecl>(clangDecl)) {
       typeStr = clangASTContext.getObjCEncodingForPropertyDecl(objcPropertyDecl,
                                                                nullptr);
-      sectionName = "__TEXT,__objc_methname,cstring_literals";
+      sectionName = IRGenModule::ObjCPropertyNameSectionName;
     }
     if (!typeStr.empty()) {
       return IGM.getAddrOfGlobalString(typeStr.c_str(), sectionName);
@@ -1440,8 +1439,7 @@ irgen::emitObjCGetterDescriptorParts(IRGenModule &IGM, VarDecl *property) {
   TypeStr += "@0:";
   TypeStr += llvm::itostr(PtrSize.getValue());
   descriptor.typeEncoding = IGM.getAddrOfGlobalString(
-      TypeStr.c_str(),
-      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
+      TypeStr.c_str(), IRGenModule::ObjCMethodTypeSectionName);
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCGetterPointer(IGM, property, descriptor.silFunction);
   return descriptor;
@@ -1519,8 +1517,7 @@ irgen::emitObjCSetterDescriptorParts(IRGenModule &IGM,
   clangASTContext.getObjCEncodingForType(clangType, TypeStr);
   TypeStr += llvm::itostr(ParmOffset);
   descriptor.typeEncoding = IGM.getAddrOfGlobalString(
-      TypeStr.c_str(),
-      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
+      TypeStr.c_str(), IRGenModule::ObjCMethodTypeSectionName);
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCSetterPointer(IGM, property, descriptor.silFunction);
   return descriptor;
@@ -1627,7 +1624,7 @@ void irgen::emitObjCIVarInitDestroyDescriptor(IRGenModule &IGM,
   llvm::SmallString<8> signature;
   signature = "v" + llvm::itostr(ptrSize * 2) + "@0:" + llvm::itostr(ptrSize);
   descriptor.typeEncoding = IGM.getAddrOfGlobalString(
-      signature, /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
+      signature, IRGenModule::ObjCMethodTypeSectionName);
 
   /// The third element is the method implementation pointer.
   descriptor.impl = llvm::ConstantExpr::getBitCast(objcImpl, IGM.Int8PtrTy);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1318,7 +1318,9 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   encodingString += llvm::itostr(parmOffset);
   encodingString += fixedParamsString;
   encodingString += paramsString;
-  return IGM.getAddrOfGlobalString(encodingString);
+  return IGM.getAddrOfGlobalString(
+      encodingString,
+      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
 }
 
 static llvm::Constant *
@@ -1329,16 +1331,19 @@ getObjectEncodingFromClangNode(IRGenModule &IGM, Decl *d,
     auto clangDecl = d->getClangNode().castAsDecl();
     auto &clangASTContext = IGM.getClangASTContext();
     std::string typeStr;
+    std::string sectionName;
     if (auto objcMethodDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
       typeStr = clangASTContext.getObjCEncodingForMethodDecl(
           objcMethodDecl, useExtendedEncoding /*extended*/);
+      sectionName = "__TEXT,__objc_methtype,cstring_literals";
     }
     if (auto objcPropertyDecl = dyn_cast<clang::ObjCPropertyDecl>(clangDecl)) {
       typeStr = clangASTContext.getObjCEncodingForPropertyDecl(objcPropertyDecl,
                                                                nullptr);
+      sectionName = "__TEXT,__objc_methname,cstring_literals";
     }
     if (!typeStr.empty()) {
-      return IGM.getAddrOfGlobalString(typeStr.c_str());
+      return IGM.getAddrOfGlobalString(typeStr.c_str(), sectionName);
     }
   }
   return nullptr;
@@ -1434,7 +1439,9 @@ irgen::emitObjCGetterDescriptorParts(IRGenModule &IGM, VarDecl *property) {
   TypeStr += llvm::itostr(ParmOffset);
   TypeStr += "@0:";
   TypeStr += llvm::itostr(PtrSize.getValue());
-  descriptor.typeEncoding = IGM.getAddrOfGlobalString(TypeStr.c_str());
+  descriptor.typeEncoding = IGM.getAddrOfGlobalString(
+      TypeStr.c_str(),
+      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCGetterPointer(IGM, property, descriptor.silFunction);
   return descriptor;
@@ -1511,7 +1518,9 @@ irgen::emitObjCSetterDescriptorParts(IRGenModule &IGM,
   ParmOffset = 2 * PtrSize.getValue();
   clangASTContext.getObjCEncodingForType(clangType, TypeStr);
   TypeStr += llvm::itostr(ParmOffset);
-  descriptor.typeEncoding = IGM.getAddrOfGlobalString(TypeStr.c_str());
+  descriptor.typeEncoding = IGM.getAddrOfGlobalString(
+      TypeStr.c_str(),
+      /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCSetterPointer(IGM, property, descriptor.silFunction);
   return descriptor;
@@ -1617,7 +1626,8 @@ void irgen::emitObjCIVarInitDestroyDescriptor(IRGenModule &IGM,
   auto ptrSize = IGM.getPointerSize().getValue();
   llvm::SmallString<8> signature;
   signature = "v" + llvm::itostr(ptrSize * 2) + "@0:" + llvm::itostr(ptrSize);
-  descriptor.typeEncoding = IGM.getAddrOfGlobalString(signature);
+  descriptor.typeEncoding = IGM.getAddrOfGlobalString(
+      signature, /*sectionName=*/"__TEXT,__objc_methtype,cstring_literals");
 
   /// The third element is the method implementation pointer.
   descriptor.impl = llvm::ConstantExpr::getBitCast(objcImpl, IGM.Int8PtrTy);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1339,8 +1339,8 @@ private:
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;
   llvm::DenseSet<const clang::Decl *> GlobalClangDecls;
-  llvm::DenseMap<
-      CStringSectionType,
+  // Maps sectionName -> string data -> constant
+  llvm::StringMap<
       llvm::StringMap<std::pair<llvm::GlobalVariable *, llvm::Constant *>>>
       GlobalStrings;
   llvm::StringMap<llvm::Constant*> GlobalUTF16Strings;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1204,6 +1204,7 @@ public:
       StringRef Str, bool willBeRelativelyAddressed = false,
       StringRef sectionName = "", StringRef name = "");
   llvm::Constant *getAddrOfGlobalString(StringRef utf8,
+                                        StringRef sectionName = "",
                                         bool willBeRelativelyAddressed = false,
                                         bool useOSLogSection = false);
   llvm::Constant *getAddrOfGlobalUTF16String(StringRef utf8);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -674,8 +674,11 @@ enum class CStringSectionType {
   ObjCClassName,
   ObjCMethodName,
   ObjCMethodType,
-  ObjCPropertyName,
   OSLogString,
+  // Place all new section types above this line
+  NumTypes,
+  // Place all alias below this line
+  ObjCPropertyName = ObjCMethodName,
 };
 
 /// IRGenModule - Primary class for emitting IR for global declarations.
@@ -1340,8 +1343,9 @@ private:
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;
   llvm::DenseSet<const clang::Decl *> GlobalClangDecls;
   // Maps sectionName -> string data -> constant
-  llvm::StringMap<
-      llvm::StringMap<std::pair<llvm::GlobalVariable *, llvm::Constant *>>>
+  std::array<
+      llvm::StringMap<std::pair<llvm::GlobalVariable *, llvm::Constant *>>,
+      static_cast<size_t>(CStringSectionType::NumTypes)>
       GlobalStrings;
   llvm::StringMap<llvm::Constant*> GlobalUTF16Strings;
   llvm::StringMap<std::pair<llvm::GlobalVariable*, llvm::Constant*>>
@@ -1559,8 +1563,6 @@ public:
       "__TEXT,__objc_methname,cstring_literals";
   static constexpr const char ObjCMethodTypeSectionName[] =
       "__TEXT,__objc_methtype,cstring_literals";
-  static constexpr const char ObjCPropertyNameSectionName[] =
-      "__TEXT,__objc_methname,cstring_literals";
   static constexpr const char OSLogStringSectionName[] =
       "__TEXT,__oslogstring,cstring_literals";
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1204,9 +1204,11 @@ public:
       StringRef Str, bool willBeRelativelyAddressed = false,
       StringRef sectionName = "", StringRef name = "");
   llvm::Constant *getAddrOfGlobalString(StringRef utf8,
-                                        StringRef sectionName = "",
                                         bool willBeRelativelyAddressed = false,
-                                        bool useOSLogSection = false);
+                                        bool useOSLogSection = false,
+                                        StringRef sectionName = "");
+  llvm::Constant *getAddrOfGlobalString(StringRef utf8,
+                                        const char *sectionName);
   llvm::Constant *getAddrOfGlobalUTF16String(StringRef utf8);
   llvm::Constant *
   getAddrOfGlobalIdentifierString(StringRef utf8,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1544,6 +1544,15 @@ public:
   const char *getReflectionTypeRefSectionName();
   const char *getMultiPayloadEnumDescriptorSectionName();
 
+  static constexpr const char ObjCClassNameSectionName[] =
+      "__TEXT,__objc_classname,cstring_literals";
+  static constexpr const char ObjCMethodNameSectionName[] =
+      "__TEXT,__objc_methname,cstring_literals";
+  static constexpr const char ObjCMethodTypeSectionName[] =
+      "__TEXT,__objc_methtype,cstring_literals";
+  static constexpr const char ObjCPropertyNameSectionName[] =
+      "__TEXT,__objc_methname,cstring_literals";
+
   /// Returns the special builtin types that should be emitted in the stdlib
   /// module.
   llvm::ArrayRef<CanType> getOrCreateSpecialStlibBuiltinTypes();

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -39,16 +39,16 @@ public struct NonCopyable: ~Copyable { }
 // 'MF' constant as a separator that precedes each field descriptor.
 
 // NEW: @"$s4test8CC_TestsCMF" =
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.3"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.{{[0-9]+}}"
 // NEW-SAME: @"symbolic _____yq_G 4test21ConditionallyCopyableOAARi_zrlE"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.4"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.{{[0-9]+}}"
 // NEW-SAME: @"symbolic _____ySSG 4test21ConditionallyCopyableOAARi_zrlE"
 
 // OLD: @"$s4test8CC_TestsCMF" =
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.3"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyq_G.4"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.5"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOySSG.6"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyq_G.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOySSG.{{[0-9]+}}"
 public class CC_Tests<NCG: ~Copyable, T> {
   var ccNCG: ConditionallyCopyable<NCG> = .none
   var ccT: ConditionallyCopyable<T> = .none
@@ -62,16 +62,16 @@ public class CC_Tests<NCG: ~Copyable, T> {
 /// fields until a future runtime says they're safe to reflect.
 
 // NEW: @"$s4test8NC_TestsCMF" =
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.5"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.6"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.7"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.8"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.{{[0-9]+}}"
 
 // OLD: @"$s4test8NC_TestsCMF" =
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.7"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.8"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.9"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.10"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.{{[0-9]+}}"
 public class NC_Tests<NCG: ~Copyable, T> {
   var ncNCG: NeverCopyable<NCG> = .none
   var ncT: NeverCopyable<T> = .none
@@ -83,7 +83,7 @@ public class NC_Tests<NCG: ~Copyable, T> {
 // NEW: @"$s4test17StdlibTypes_TestsCMF" =
 // NEW-SAME: @"symbolic xSg"
 // NEW-SAME: @"symbolic q_Sg"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.9"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.{{[0-9]+}}"
 // NEW-SAME: @"symbolic SSSg"
 // NEW-SAME: @"symbolic SPyxG"
 // NEW-SAME: @"symbolic SPyq_G"
@@ -93,7 +93,7 @@ public class NC_Tests<NCG: ~Copyable, T> {
 // OLD: @"$s4test17StdlibTypes_TestsCMF" =
 // OLD-SAME: @"symbolic xSg"
 // OLD-SAME: @"symbolic q_Sg"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.11"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.{{[0-9]+}}"
 // OLD-SAME: @"symbolic SSSg"
 // OLD-SAME: @"symbolic SPyxG"
 // OLD-SAME: @"symbolic SPyq_G"
@@ -115,13 +115,13 @@ public class StdlibTypes_Tests<NCG: ~Copyable, T> {
 // NEW: @"$s4test19PlainlyStored_TestsCMF" =
 // NEW-SAME: @"symbolic x"
 // NEW-SAME: @"symbolic q_"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.10"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.{{[0-9]+}}"
 // NEW-SAME: @"symbolic SS"
 
 // OLD: @"$s4test19PlainlyStored_TestsCMF" =
 // OLD-SAME: @"symbolic x"
 // OLD-SAME: @"symbolic q_"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.12"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.{{[0-9]+}}"
 // OLD-SAME: @"symbolic SS"
 public class PlainlyStored_Tests<NCG: ~Copyable, T> {
   var ncg: NCG

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -39,16 +39,16 @@ public struct NonCopyable: ~Copyable { }
 // 'MF' constant as a separator that precedes each field descriptor.
 
 // NEW: @"$s4test8CC_TestsCMF" =
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.3"
 // NEW-SAME: @"symbolic _____yq_G 4test21ConditionallyCopyableOAARi_zrlE"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.4"
 // NEW-SAME: @"symbolic _____ySSG 4test21ConditionallyCopyableOAARi_zrlE"
 
 // OLD: @"$s4test8CC_TestsCMF" =
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyq_G.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOySSG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG.3"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyq_G.4"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyAA03NonC0VG.5"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOySSG.6"
 public class CC_Tests<NCG: ~Copyable, T> {
   var ccNCG: ConditionallyCopyable<NCG> = .none
   var ccT: ConditionallyCopyable<T> = .none
@@ -62,16 +62,16 @@ public class CC_Tests<NCG: ~Copyable, T> {
 /// fields until a future runtime says they're safe to reflect.
 
 // NEW: @"$s4test8NC_TestsCMF" =
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.{{[0-9]+}}"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.{{[0-9]+}}"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.{{[0-9]+}}"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.5"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.6"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.7"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.8"
 
 // OLD: @"$s4test8NC_TestsCMF" =
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.{{[0-9]+}}"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyxG.7"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyq_G.8"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOyAA03NonC0VG.9"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test13NeverCopyableOySSG.10"
 public class NC_Tests<NCG: ~Copyable, T> {
   var ncNCG: NeverCopyable<NCG> = .none
   var ncT: NeverCopyable<T> = .none
@@ -83,7 +83,7 @@ public class NC_Tests<NCG: ~Copyable, T> {
 // NEW: @"$s4test17StdlibTypes_TestsCMF" =
 // NEW-SAME: @"symbolic xSg"
 // NEW-SAME: @"symbolic q_Sg"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.9"
 // NEW-SAME: @"symbolic SSSg"
 // NEW-SAME: @"symbolic SPyxG"
 // NEW-SAME: @"symbolic SPyq_G"
@@ -93,7 +93,7 @@ public class NC_Tests<NCG: ~Copyable, T> {
 // OLD: @"$s4test17StdlibTypes_TestsCMF" =
 // OLD-SAME: @"symbolic xSg"
 // OLD-SAME: @"symbolic q_Sg"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableVSg.11"
 // OLD-SAME: @"symbolic SSSg"
 // OLD-SAME: @"symbolic SPyxG"
 // OLD-SAME: @"symbolic SPyq_G"
@@ -115,13 +115,13 @@ public class StdlibTypes_Tests<NCG: ~Copyable, T> {
 // NEW: @"$s4test19PlainlyStored_TestsCMF" =
 // NEW-SAME: @"symbolic x"
 // NEW-SAME: @"symbolic q_"
-// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.{{[0-9]+}}"
+// NEW-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.10"
 // NEW-SAME: @"symbolic SS"
 
 // OLD: @"$s4test19PlainlyStored_TestsCMF" =
 // OLD-SAME: @"symbolic x"
 // OLD-SAME: @"symbolic q_"
-// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.{{[0-9]+}}"
+// OLD-SAME: @"get_type_metadata Ri_zr0_l4test11NonCopyableV.12"
 // OLD-SAME: @"symbolic SS"
 public class PlainlyStored_Tests<NCG: ~Copyable, T> {
   var ncg: NCG

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -13,7 +13,7 @@ import objc_extension_base
 // Check that metadata for nested enums added in extensions to imported classes
 // gets emitted concretely.
 
-// CHECK: [[CATEGORY_NAME:@.*]] = private constant [16 x i8] c"objc_extensions\00"
+// CHECK: [[CATEGORY_NAME:@.*]] = private unnamed_addr constant [16 x i8] c"objc_extensions\00"
 // CHECK: [[METHOD_TYPE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 
 // CHECK-LABEL: @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions" = internal constant

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -15,4 +15,4 @@ extension A : YourProtocol {}
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       @.str.21.MyRuntimeVisibleClass = private constant [22 x i8] c"MyRuntimeVisibleClass\00"
+// CHECK:       @.str.21.MyRuntimeVisibleClass = {{.*}} [22 x i8] c"MyRuntimeVisibleClass\00"

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -15,4 +15,4 @@ extension A : YourProtocol {}
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       @.str.21.MyRuntimeVisibleClass = {{.*}} [22 x i8] c"MyRuntimeVisibleClass\00"
+// CHECK:       @.str.21.MyRuntimeVisibleClass = private constant [22 x i8] c"MyRuntimeVisibleClass\00"


### PR DESCRIPTION
Clang emits ObjC strings into special sections
https://github.com/llvm/llvm-project/blob/d5e7c27d53887e6ae490d8e26193a54987728458/clang/lib/CodeGen/CGObjCMac.cpp#L4056-L4072

As far as I can tell from `CGObjCMac.cpp`:
* types go into `__objc_methtype`
* class, category, and protocol names go into `__objc_classname`
* method names, property names, and property types go into `__objc_methname`

See also https://github.com/swiftlang/swift/pull/84236.