### PR TITLE
build.ps1: make windows SDKs optional

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -71,7 +71,7 @@ if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 
 :: Build the -WindowsSDKArchitectures argument, if any, otherwise build all the SDKs.
 set "WindowsSDKArchitecturesArg= "
-if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-WindowsSDKArchitectures %WINDOWS_SDKS%"
+if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-Windows -WindowsSDKArchitectures %WINDOWS_SDKS%"
 
 call :CloneRepositories || (exit /b 1)
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3922,7 +3922,7 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-Compilers $HostPlatform -Variant "Asserts"
   $KnownPlatforms.Values | Where-Object {
     switch ($_.OS) {
-      Windows { $true }
+      Windows { $Windows }
       Android { $Android }
       default { $false }
     }


### PR DESCRIPTION
This treats Windows similarly to Android and introduces a new `-Windows` option to build the Windows SDKs.