### PR TITLE
ModuleInterface: Print imports with @preconcurrency in swiftinterface files

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -126,6 +126,13 @@ public:
                             const ModuleDecl *importedModule,
                             llvm::SmallSetVector<Identifier, 4> &spiGroups) const {};
 
+  /// Returns true if any import of \p importedModule has the `@preconcurrency`
+  /// attribute.
+  virtual bool
+  isModuleImportedPreconcurrency(const ModuleDecl *importedModule) const {
+    return false;
+  };
+
   /// Find all availability domains defined in this module with the given
   /// identifier.
   ///

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -965,6 +965,10 @@ public:
                          const ModuleDecl *importedModule,
                          llvm::SmallSetVector<Identifier, 4> &spiGroups) const;
 
+  /// Returns true if any import of \p importedModule has the `@preconcurrency`
+  /// attribute.
+  bool isModuleImportedPreconcurrency(const ModuleDecl *importedModule) const;
+
   /// Finds the custom availability domain defined by this module with the
   /// given identifier and if one exists adds it to results.
   void

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -471,6 +471,11 @@ public:
                 const ModuleDecl *importedModule,
                 llvm::SmallSetVector<Identifier, 4> &spiGroups) const override;
 
+  /// Returns true if any import of \p importedModule has the `@preconcurrency`
+  /// attribute.
+  virtual bool isModuleImportedPreconcurrency(
+      const ModuleDecl *importedModule) const override;
+
   // Is \p targetDecl accessible as an explicitly imported SPI from this file?
   bool isImportedAsSPI(const ValueDecl *targetDecl) const;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -466,6 +466,9 @@ public:
                 const ModuleDecl *importedModule,
                 llvm::SmallSetVector<Identifier, 4> &spiGroups) const override;
 
+  virtual bool isModuleImportedPreconcurrency(
+      const ModuleDecl *importedModule) const override;
+
   std::optional<CommentInfo> getCommentForDecl(const Decl *D) const override;
 
   bool hasLoadedSwiftDoc() const override;

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -271,6 +271,9 @@ static void printImports(raw_ostream &out,
       ModuleDecl::ImportFilterKind::Default,
       ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay};
 
+  // FIXME: Scan over all imports in the module once to build up the attribute
+  // set for printed imports, instead of repeatedly doing linear scans for each
+  // kind of attribute.
   using ImportSet = llvm::SmallSet<ImportedModule, 8, ImportedModule::Order>;
   auto getImports = [M](ModuleDecl::ImportFilter filter) -> ImportSet {
     SmallVector<ImportedModule, 8> matchingImports;
@@ -354,6 +357,9 @@ static void printImports(raw_ostream &out,
       for (auto spiName : spis)
         out << "@_spi(" << spiName << ") ";
     }
+
+    if (M->isModuleImportedPreconcurrency(importedModule))
+      out << "@preconcurrency ";
 
     if (Opts.printPackageInterface() &&
         !publicImportSet.count(import) &&

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1915,6 +1915,14 @@ void SerializedASTFile::lookupImportedSPIGroups(
   }
 }
 
+bool SerializedASTFile::isModuleImportedPreconcurrency(
+    const ModuleDecl *importedModule) const {
+  // This method should only be queried during `-merge-modules` jobs, which are
+  // deprecated, and thus no effort has been made to answer this query correctly
+  // (@preconcurrency is not encoded on imports in serialized modules).
+  return false;
+}
+
 std::optional<CommentInfo>
 SerializedASTFile::getCommentForDecl(const Decl *D) const {
   return File.getCommentForDecl(D);

--- a/test/ModuleInterface/preconcurrency_imports.swift
+++ b/test/ModuleInterface/preconcurrency_imports.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/PreconcurrencyLib.swift -module-name PreconcurrencyLib -swift-version 5 -enable-library-evolution -emit-module-path %t/PreconcurrencyLib.swiftmodule -emit-module-interface-path %t/PreconcurrencyLib.swiftinterface
+// RUN: %target-swift-frontend -emit-module %t/OtherLib.swift -module-name OtherLib -swift-version 5 -enable-library-evolution -emit-module-path %t/OtherLib.swiftmodule -emit-module-interface-path %t/OtherLib.swiftinterface
+
+// RUN: %target-swift-emit-module-interface(%t/ClientLib.swiftinterface) -swift-version 6 %t/ClientLib_file1.swift %t/ClientLib_file2.swift -module-name ClientLib -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.swiftinterface) -module-name ClientLib -I %t
+// RUN: %FileCheck %s < %t/ClientLib.swiftinterface
+
+// CHECK: {{^}}@preconcurrency import OtherLib
+// CHECK: {{^}}@preconcurrency import PreconcurrencyLib
+// CHECK: public struct Struct1 : Swift.Sendable
+// CHECK: public struct Struct2
+
+//--- PreconcurrencyLib.swift
+
+public class C {}
+
+//--- OtherLib.swift
+// Intentionally empty
+
+//--- ClientLib_file1.swift
+
+@preconcurrency public import PreconcurrencyLib
+public import OtherLib
+
+public struct Struct1: Sendable {
+  public var c: C
+}
+
+//--- ClientLib_file2.swift
+
+internal import PreconcurrencyLib
+@preconcurrency internal import OtherLib
+
+public struct Struct2 {}


### PR DESCRIPTION
When a module has been imported `@preconcurrency` in source, when it is printed in a `swiftinterface` file it should be printed along with the attribute to ensure that type checking of the module's public declarations behaves consistently.

This fix is a little unsatisfying because it adds another linear scan over all imports in the source for each printed import. This should be improved, but it can be done later.

Resolves rdar://136857313.
