### PR TITLE
[Frontend] Print least valid pointer value in -print-target-info

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -25,6 +25,7 @@ namespace llvm {
 }
 
 namespace swift {
+  class LangOptions;
 
   enum class DarwinPlatformKind : unsigned {
     MacOS,
@@ -74,6 +75,12 @@ namespace swift {
   /// Returns true if the given triple represents a version of OpenBSD
   /// that enforces BTCFI by default.
   bool tripleBTCFIByDefaultInOpenBSD(const llvm::Triple &triple);
+
+  /// Returns the least valid pointer value for the given target triple.
+  uint64_t
+  getLeastValidPointerValueForTriple(const llvm::Triple &triple,
+                                     const LangOptions &LangOpts,
+                                     uint64_t customLeastValidPointerValue);
 
   /// Returns the platform name for a given target triple.
   ///

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/Assertions.h"
+#include "swift/ABI/System.h"
+#include "swift/Basic/Feature.h"
+#include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Pack.h"
 #include "swift/Basic/Platform.h"
 #include "llvm/ADT/StringExtras.h"
@@ -142,6 +145,33 @@ bool swift::tripleRequiresRPathForSwiftLibrariesInOS(
 
 bool swift::tripleBTCFIByDefaultInOpenBSD(const llvm::Triple &triple) {
   return triple.isOSOpenBSD() && triple.getArch() == llvm::Triple::aarch64;
+}
+
+uint64_t swift::getLeastValidPointerValueForTriple(const llvm::Triple &triple,
+                                                  const LangOptions &LangOpts,
+                                                  uint64_t customLeastValidPointerValue) {
+  if (customLeastValidPointerValue != 0)
+    return customLeastValidPointerValue;
+
+  uint64_t value = SWIFT_ABI_DEFAULT_LEAST_VALID_POINTER;
+
+  if (triple.isOSDarwin() && !LangOpts.hasFeature(Feature::Embedded)) {
+    // Non-embedded Darwin reserves the low 4GB of address space.
+    switch (triple.getArch()) {
+    case llvm::Triple::x86_64:
+      value = SWIFT_ABI_DARWIN_X86_64_LEAST_VALID_POINTER;
+      break;
+    case llvm::Triple::aarch64:
+      value = SWIFT_ABI_DARWIN_ARM64_LEAST_VALID_POINTER;
+      break;
+    default:
+      break;
+    }
+  } else if (triple.getArch() == llvm::Triple::wasm32) {
+    value = SWIFT_ABI_WASM32_LEAST_VALID_POINTER;
+  }
+
+  return value;
 }
 
 DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {

--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -157,6 +157,11 @@ void printTripleInfo(const CompilerInvocation &invocation,
   out << "    \"pointerWidthInBytes\": "
       << TI->getPointerWidth(clang::LangAS::Default) / TI->getCharWidth()
       << ",\n";
+  out << "    \"leastValidPointerValue\": "
+      << getLeastValidPointerValueForTriple(
+             triple, invocation.getLangOptions(),
+             invocation.getIRGenOptions().CustomLeastValidPointerValue)
+      << ",\n";
 
   if (runtimeVersion) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -49,14 +49,6 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
   }
   setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_ARM64_IS_OBJC_BIT);
 
-  // Non-embedded Darwin reserves the low 4GB of address space.
-  if (triple.isOSDarwin() &&
-      !IGM.getSwiftModule()->getASTContext().LangOpts.hasFeature(
-          Feature::Embedded)) {
-    target.LeastValidPointerValue =
-      SWIFT_ABI_DARWIN_ARM64_LEAST_VALID_POINTER;
-  }
-
   // arm64 has no special objc_msgSend variants, not even stret.
   target.ObjCUseStret = false;
 
@@ -105,13 +97,6 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
   } else {
     setToMask(target.ObjCPointerReservedBits, 64,
               SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK);
-  }
-
-  if (triple.isOSDarwin() &&
-      !IGM.getSwiftModule()->getASTContext().LangOpts.hasFeature(
-          Feature::Embedded)) {
-    target.LeastValidPointerValue =
-      SWIFT_ABI_DARWIN_X86_64_LEAST_VALID_POINTER;
   }
 
   // x86-64 has every objc_msgSend variant known to humankind.
@@ -184,8 +169,6 @@ static void configureSystemZ(IRGenModule &IGM, const llvm::Triple &triple,
 /// Configures target-specific information for wasm32 platforms.
 static void configureWasm32(IRGenModule &IGM, const llvm::Triple &triple,
                             SwiftTargetInfo &target) {
-  target.LeastValidPointerValue =
-    SWIFT_ABI_WASM32_LEAST_VALID_POINTER;
 }
 
 /// Configure a default target.
@@ -268,8 +251,9 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
     break;
   }
 
-  if (IGM.getOptions().CustomLeastValidPointerValue != 0)
-    target.LeastValidPointerValue = IGM.getOptions().CustomLeastValidPointerValue;
+  target.LeastValidPointerValue = getLeastValidPointerValueForTriple(
+      triple, IGM.Context.LangOpts,
+      IGM.getOptions().CustomLeastValidPointerValue);
 
   return target;
 }

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -16,6 +16,8 @@
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
+// RUN: %swift_frontend_plain -target wasm32-unknown-wasip1 -print-target-info | %FileCheck -check-prefix CHECK-WASM %s
+
 // RUN: %swift_frontend_plain -target thumbv7-unknown-windows-msvc -print-target-info | %FileCheck -check-prefix CHECK-PTR-SIZE-32 %s
 // RUN: %swift_frontend_plain -target aarch64-unknown-windows-msvc -print-target-info | %FileCheck -check-prefix CHECK-PTR-SIZE-64 %s
 
@@ -25,6 +27,7 @@
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",
 // CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
 // CHECK-IOS:     "moduleTriple": "arm64-apple-ios",
+// CHECK-IOS:     "leastValidPointerValue": 4294967296,
 // CHECK-IOS:     "swiftRuntimeCompatibilityVersion": "5.0",
 // CHECK-IOS:     "compatibilityLibraries": [
 // CHECK-IOS:       "libraryName": "swiftCompatibility50",
@@ -53,6 +56,7 @@
 // CHECK-LINUX:   "target": {
 // CHECK-LINUX:     "triple": "x86_64-unknown-linux",
 // CHECK-LINUX:     "moduleTriple": "x86_64-unknown-linux",
+// CHECK-LINUX:     "leastValidPointerValue": 4096,
 // CHECK-LINUX:     "librariesRequireRPath": false
 // CHECK-LINUX:   }
 
@@ -66,6 +70,7 @@
 // CHECK-LINUX-STATIC:   "target": {
 // CHECK-LINUX-STATIC:     "triple": "x86_64-unknown-linux",
 // CHECK-LINUX-STATIC:     "moduleTriple": "x86_64-unknown-linux",
+// CHECK-LINUX-STATIC:     "leastValidPointerValue": 4096,
 // CHECK-LINUX-STATIC:     "librariesRequireRPath": false
 // CHECK-LINUX-STATIC:   }
 
@@ -77,6 +82,7 @@
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-macosx10.15"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "unversionedTriple": "x86_64-apple-macosx"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "moduleTriple": "x86_64-apple-macos"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "leastValidPointerValue": 4294967296,
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "librariesRequireRPath": true
 // CHECK-PRE-CONCURRENCY-ZIPPERED: }
@@ -85,6 +91,7 @@
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-ios13.1-macabi"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "leastValidPointerValue": 4294967296,
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "librariesRequireRPath": true
 // CHECK-PRE-CONCURRENCY-ZIPPERED: }
@@ -110,6 +117,13 @@
 // CHECK-IOS-SIM:     "swiftRuntimeCompatibilityVersion": "5.0",
 // CHECK-IOS-SIM:     "librariesRequireRPath": true
 // CHECK-IOS-SIM:   }
+
+// CHECK-WASM: "target": {
+// CHECK-WASM:   "triple": "wasm32-unknown-wasip1",
+// CHECK-WASM:   "moduleTriple": "wasm32-unknown-wasip1",
+// CHECK-WASM:   "leastValidPointerValue": 4096,
+// CHECK-WASM:   "librariesRequireRPath": false
+// CHECK-WASM: }
 
 // CHECK-PTR-SIZE-32: "target": {
 // CHECK-PTR-SIZE-32:   "triple": "thumbv7-unknown-windows-msvc",

--- a/test/Driver/print_target_info_embedded.swift
+++ b/test/Driver/print_target_info_embedded.swift
@@ -1,0 +1,18 @@
+// RUN: %swift_frontend_plain -target arm64-apple-macos11 -enable-experimental-feature Embedded -print-target-info | %FileCheck -check-prefix CHECK-MACOS-EMBEDDED %s
+// RUN: %swift_frontend_plain -target arm64-apple-macos11 -enable-experimental-feature Embedded -print-target-info -min-valid-pointer-value=0x2000 | %FileCheck -check-prefix CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE %s
+
+// REQUIRES: swift_feature_Embedded
+
+// CHECK-MACOS-EMBEDDED: "target": {
+// CHECK-MACOS-EMBEDDED:   "triple": "arm64-apple-macos11",
+// CHECK-MACOS-EMBEDDED:   "moduleTriple": "arm64-apple-macos",
+// CHECK-MACOS-EMBEDDED:   "leastValidPointerValue": 4096,
+// CHECK-MACOS-EMBEDDED:   "librariesRequireRPath": true
+// CHECK-MACOS-EMBEDDED: }
+
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE: "target": {
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE:   "triple": "arm64-apple-macos11",
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE:   "moduleTriple": "arm64-apple-macos",
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE:   "leastValidPointerValue": 8192,
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE:   "librariesRequireRPath": true
+// CHECK-MACOS-EMBEDDED-WITH-MIN-VALID-POINTER-VALUE: }


### PR DESCRIPTION
This allows swift-driver to use the value when constructing the linker command line for platforms that need it like WebAssembly.

Addressing a review feedback from Doug: https://github.com/swiftlang/swift-driver/pull/1988#discussion_r2349545624