### PR TITLE
[cxx-interop] Fix over-releasing reference members of trival C++ types

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -41,3 +41,24 @@ inline void releaseSharedFRT(SharedFRT *_Nonnull x) {
   if (x->_refCount == 0)
     delete x;
 }
+
+struct LargeStructWithRefCountedField {
+  void const *a;
+  void const *b;
+  unsigned long c;
+  unsigned d;
+  SharedFRT *e;
+};
+
+struct LargeStructWithRefCountedFieldNested {
+  int a;
+  LargeStructWithRefCountedField b;
+};
+
+inline LargeStructWithRefCountedField getStruct() {
+  return {0, 0, 0, 0, new SharedFRT()};
+}
+
+inline LargeStructWithRefCountedFieldNested getNestedStruct() {
+  return {0, {0, 0, 0, 0, new SharedFRT()}};
+}

--- a/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
+++ b/test/Interop/Cxx/foreign-reference/frts-as-fields.swift
@@ -28,3 +28,25 @@ go()
 // CHECK-NEXT: RefCount: 1, message: release
 // CHECK-NEXT: RefCount: 0, message: release
 // CHECK-NEXT: RefCount: 0, message: Dtor
+
+func takesLargeStructWithRefCountedField(_ x: LargeStructWithRefCountedField) {
+    var a = x
+}
+
+takesLargeStructWithRefCountedField(getStruct())
+// CHECK:      RefCount: 1, message: Ctor
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 0, message: release
+// CHECK-NEXT: RefCount: 0, message: Dtor
+
+func takesLargeStructWithRefCountedFieldNested(_ x: LargeStructWithRefCountedFieldNested) {
+    var a = x
+}
+
+takesLargeStructWithRefCountedFieldNested(getNestedStruct())
+// CHECK:      RefCount: 1, message: Ctor
+// CHECK-NEXT: RefCount: 2, message: retain
+// CHECK-NEXT: RefCount: 1, message: release
+// CHECK-NEXT: RefCount: 0, message: release
+// CHECK-NEXT: RefCount: 0, message: Dtor


### PR DESCRIPTION
Large trivial types were copied via memcpy instead of doing a field-wise copy. This is incorrect for types with reference fields where we also need to bump the corresponding refcounts.

rdar://160315343
