### PR TITLE
Speculative hoisting in licm pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/LoopTree.swift
@@ -80,7 +80,7 @@ struct Loop {
     return loopBlock.successors.contains { !contains(block: $0) }
   }
   
-  func getBlocksThatDominateAllExitingAndLatchBlocks(_ context: FunctionPassContext) -> [BasicBlock] {
+  func getBlocksThatDominateAllExitingAndLatchBlocks(excludeColdExits: Bool = false, _ context: FunctionPassContext) -> [BasicBlock] {
     var result: [BasicBlock] = []
     var cachedExitingAndLatchBlocks = Stack<BasicBlock>(context)
     var workList = BasicBlockWorklist(context)
@@ -89,7 +89,7 @@ struct Loop {
       workList.deinitialize()
     }
     
-    cachedExitingAndLatchBlocks.append(contentsOf: exitingAndLatchBlocks)
+    cachedExitingAndLatchBlocks.append(contentsOf: exitingAndLatchBlocks.filter({ !excludeColdExits || !$0.isCold(context) }))
     workList.pushIfNotVisited(header)
     
     while let block = workList.pop() {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -57,7 +57,7 @@ private func getWorkList(forLoop loop: Loop, workList: inout Stack<Loop>) {
 private struct MovableInstructions {
   var loadAndStoreAccessPaths: [AccessPath] = []
   
-  var speculativelyHoistable: [Instruction] = []
+  var immediatelyHoistable: [Instruction] = []
   var loadsAndStores: [Instruction] = []
   var hoistUp: [Instruction] = []
   var sinkDown: [Instruction] = []
@@ -138,8 +138,6 @@ private func analyzeLoopAndSplitLoads(loop: Loop, _ context: FunctionPassContext
 
   analyzeInstructions(in: loop, &analyzedInstructions, &movableInstructions, context)
 
-  collectHoistableGlobalInitCalls(in: loop, analyzedInstructions, &movableInstructions, context)
-
   collectProjectableAccessPathsAndSplitLoads(in: loop, &analyzedInstructions, &movableInstructions, context)
   
   collectMovableInstructions(in: loop, &analyzedInstructions, &movableInstructions, context)
@@ -160,6 +158,11 @@ private func analyzeInstructions(
     analyzedInstructions.markBeginOfBlock()
     
     for inst in bb.instructions {
+      if inst.isImmediatelyHoistable {
+        movableInstructions.immediatelyHoistable.append(inst)
+        continue
+      }
+      
       switch inst {
       case is FixLifetimeInst:
         break // We can ignore the side effects of FixLifetimes
@@ -175,8 +178,6 @@ private func analyzeInstructions(
         analyzedInstructions.analyzeSideEffects(ofInst: beginAccessInst)
       case let beginBorrowInst as BeginBorrowInstruction:
         analyzedInstructions.analyzeSideEffects(ofInst: beginBorrowInst)
-      case let refElementAddrInst as RefElementAddrInst:
-        movableInstructions.speculativelyHoistable.append(refElementAddrInst)
       case let condFailInst as CondFailInst:
         analyzedInstructions.analyzeSideEffects(ofInst: condFailInst)
       case let fullApply as FullApplySite:
@@ -196,53 +197,23 @@ private func analyzeInstructions(
         
         analyzedInstructions.fullApplies.append(fullApply)
         
-        // Check for array semantics and side effects - same as default
-        fallthrough
-      default:
-        switch inst {
-        case let builtinInst as BuiltinInst:
-          switch builtinInst.id {
-          case .Once, .OnceWithContext:
-            if !builtinInst.globalInitMayConflictWith(
-              blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
-              context.aliasAnalysis
-            ) {
-              analyzedInstructions.globalInitCalls.append(builtinInst)
-            }
-          default: break
+        analyzedInstructions.analyzeSideEffects(ofInst: inst)
+      case let builtinInst as BuiltinInst:
+        switch builtinInst.id {
+        case .Once, .OnceWithContext:
+          if !builtinInst.globalInitMayConflictWith(
+            blockSideEffectSegment: analyzedInstructions.sideEffectsOfCurrentBlock,
+            context.aliasAnalysis
+          ) {
+            analyzedInstructions.globalInitCalls.append(builtinInst)
           }
         default: break
         }
         
         analyzedInstructions.analyzeSideEffects(ofInst: inst)
-        
-        if inst.canBeHoisted(outOf: loop, context) {
-          movableInstructions.hoistUp.append(inst)
-        }
+      default:
+        analyzedInstructions.analyzeSideEffects(ofInst: inst)
       }
-    }
-  }
-}
-
-/// Process collected global init calls. Moves them to `hoistUp` if they don't conflict with any side effects.
-private func collectHoistableGlobalInitCalls(
-  in loop: Loop,
-  _ analyzedInstructions: AnalyzedInstructions,
-  _ movableInstructions: inout MovableInstructions,
-  _ context: FunctionPassContext
-) {
-  for globalInitCall in analyzedInstructions.globalInitCalls {
-    // Check against side effects which are "before" (i.e. post-dominated by) the global initializer call.
-    //
-    // The effects in the same block have already been checked before
-    // adding this global init call to `analyzedInstructions.globalInitCalls` in `analyzeInstructions`.
-    if globalInitCall.parentBlock.postDominates(loop.preheader!, context.postDominatorTree),
-       !globalInitCall.globalInitMayConflictWith(
-         loopSideEffects: analyzedInstructions.loopSideEffects,
-         context.aliasAnalysis,
-         context.postDominatorTree
-       ) {
-      movableInstructions.hoistUp.append(globalInitCall)
     }
   }
 }
@@ -289,7 +260,43 @@ private func collectMovableInstructions(
   var loadInstCounter = 0
   var readOnlyApplyCounter = 0
   for bb in loop.loopBlocks {
-    for inst in bb.instructions {
+    for inst in bb.instructions where !inst.isImmediatelyHoistable {
+      // Check against side effects which are "before" (i.e. post-dominated by) the global initializer call.
+      //
+      // The effects in the same block have already been checked before
+      // adding this global init call to `analyzedInstructions.globalInitCalls` in `analyzeInstructions`.
+      // TODO: Use stack for this check.
+      if analyzedInstructions.globalInitCalls.contains(inst),
+         inst.parentBlock.postDominates(loop.preheader!, context.postDominatorTree),
+         !inst.globalInitMayConflictWith(
+           loopSideEffects: analyzedInstructions.loopSideEffects,
+           context.aliasAnalysis,
+           context.postDominatorTree
+         ) {
+        movableInstructions.hoistUp.append(inst)
+        continue
+      }
+      
+      // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
+      // TODO: Use stack for this check.
+      if let fullApplySite = inst as? FullApplySite,
+         analyzedInstructions.readOnlyApplies.contains(where: { $0 == fullApplySite }),
+         readOnlyApplyCounter * analyzedInstructions.loopSideEffects.count < 8000,
+         fullApplySite.isSafeReadOnlyApply(
+           for: analyzedInstructions.loopSideEffects,
+           context.aliasAnalysis,
+           context.calleeAnalysis
+         ) {
+        if let beginApplyInst = fullApplySite as? BeginApplyInst {
+          movableInstructions.scopedInsts.append(beginApplyInst)
+        } else {
+          movableInstructions.hoistUp.append(fullApplySite)
+        }
+        
+        readOnlyApplyCounter += 1
+        continue
+      }
+      
       switch inst {
       case let fixLifetimeInst as FixLifetimeInst:
         guard fixLifetimeInst.parentBlock.dominates(loop.preheader!, context.dominatorTree) else {
@@ -354,7 +361,9 @@ private func collectMovableInstructions(
           readOnlyApplyCounter += 1
         }
       default:
-        break
+        if inst.canBeHoisted(outOf: loop, context) {
+          movableInstructions.hoistUp.append(inst)
+        }
       }
     }
   }
@@ -373,8 +382,8 @@ private func optimizeLoop(
 ) -> Bool {
   var changed = false
   
-  // TODO: If we hoist tuple_element_addr and struct_element_addr instructions here, hoistAndSinkLoadsAndStores could converge after just one execution!
-  changed = movableInstructions.speculativelyHoistInstructions(outOf: loop, context)  || changed
+  // By hoisting `tuple_element_addr` and `struct_element_addr` here, `hoistAndSinkLoadsAndStores` could converge faster.
+  changed = movableInstructions.immediatelyHoistInstructions(outOf: loop, context)    || changed
   changed = movableInstructions.hoistAndSinkLoadsAndStores(outOf: loop, context)      || changed
   changed = movableInstructions.hoistInstructions(outOf: loop, context)               || changed
   changed = movableInstructions.sinkInstructions(outOf: loop, context)                || changed
@@ -593,10 +602,10 @@ private extension MovableInstructions {
   /// Hoist instructions speculatively.
   ///
   /// Contrary to `hoistInstructions`, it doesn't only go through instructions in blocks that dominate all exits.
-  mutating func speculativelyHoistInstructions(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
+  mutating func immediatelyHoistInstructions(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {
     var changed = false
     
-    for inst in speculativelyHoistable {
+    for inst in immediatelyHoistable {
       changed = inst.hoist(outOf: loop, context) || changed
     }
     
@@ -620,10 +629,8 @@ private extension MovableInstructions {
     let dominatingBlocks = loop.getBlocksThatDominateAllExitingAndLatchBlocks(context)
     var changed = false
 
-    for bb in dominatingBlocks {
-      for inst in bb.instructions where hoistUp.contains(inst) {
-        changed = inst.hoist(outOf: loop, context) || changed
-      }
+    for inst in hoistUp where dominatingBlocks.contains(inst.parentBlock) {
+      changed = inst.hoist(outOf: loop, context) || changed
     }
 
     return changed
@@ -831,6 +838,20 @@ private extension MovableInstructions {
 }
 
 private extension Instruction {
+  /// Returns `true` if this instruction is a simple instruction that
+  /// doesn't have any side effects and can be (speculatively) hoisted.
+  var isImmediatelyHoistable: Bool {
+    switch self {
+    case is RefElementAddrInst, is IntegerLiteralInst, is StringLiteralInst,
+         is BaseAddrForOffsetInst, is FloatLiteralInst, is FunctionRefInst,
+         is GlobalAddrInst, is StructElementAddrInst, is TupleElementAddrInst,
+         is VectorBaseAddrInst, is RefTailAddrInst, is PointerToAddressInst:
+      return true
+    default:
+      return false
+    }
+  }
+  
   /// Returns `true` if this instruction follows the default hoisting heuristic which means it
   /// is not a terminator, allocation or deallocation and either a hoistable array semantics call or doesn't have memory effects.
   func canBeHoisted(outOf loop: Loop, _ context: FunctionPassContext) -> Bool {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -163,3 +163,9 @@ extension Instruction {
     context.notifyInstructionsChanged()
   }
 }
+
+extension BasicBlock {
+  func isCold(_ context: FunctionPassContext) -> Bool {
+    return context.bridgedPassContext.isBlockCold(self.bridged)
+  }
+}

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -154,6 +154,9 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLoopTree getLoopTree() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLoop getLoop() const;
   
+  // TODO: Make ColdBlockInfo a proper SILAnalysis. This function is way too expensive.
+  BRIDGED_INLINE bool isBlockCold(BridgedBasicBlock bb) const;
+  
   // Array semantics call
   
   static BRIDGED_INLINE ArrayCallKind getArraySemanticsCallKind(BridgedInstruction inst);

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -26,6 +26,7 @@
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ColdBlockInfo.h"
 #include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -203,6 +204,12 @@ BridgedDeclObj BridgedPassContext::getSwiftArrayDecl() const {
 BridgedDeclObj BridgedPassContext::getSwiftMutableSpanDecl() const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
   return {mod->getASTContext().getMutableSpanDecl()};
+}
+
+bool BridgedPassContext::isBlockCold(BridgedBasicBlock bb) const {
+  swift::ColdBlockInfo coldBlockInfo(invocation->getPassManager()->getAnalysis<swift::DominanceAnalysis>(), invocation->getPassManager()->getAnalysis<swift::PostDominanceAnalysis>());
+  coldBlockInfo.analyze(invocation->getFunction());
+  return coldBlockInfo.isCold(bb.unbridged());
 }
 
 // Array semantics call

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -749,8 +749,7 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
         requireNoStoreBorrowLocation(IEAI->getOperand(), &I);
         break;
       }
-      case SILInstructionKind::InitExistentialAddrInst:
-      case SILInstructionKind::InitEnumDataAddrInst: {
+      case SILInstructionKind::InitExistentialAddrInst: {
         SILValue addr = I.getOperand(0);
         requireBitsClear(bits & nonTrivialLocations, addr, &I);
         requireNoStoreBorrowLocation(addr, &I);

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -355,7 +355,7 @@ sil [ossa] @test_store_borrow_init_enum : $@convention(thin) (@guaranteed Option
 bb0(%0 :  @guaranteed $Optional<T>):
   %s = alloc_stack $Optional<T>
   %sb = store_borrow %0 to %s : $*Optional<T>
-  %ie = init_enum_data_addr %sb : $*Optional<T>, #Optional.some!enumelt
+  inject_enum_addr %sb : $*Optional<T>, #Optional.some!enumelt
   end_borrow %sb : $*Optional<T>
   dealloc_stack %s : $*Optional<T>
   %res = tuple ()

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -117,8 +117,8 @@ bb2(%48 : $Builtin.Word):
 
 // CHECK-LABEL: sil @hoist_outer_loop
 // CHECK: bb0([[ADDR:%.*]] : $*Builtin.Int1
-// CHECK:  load [[ADDR]]
 // CHECK:  integer_literal $Builtin.Word, 101
+// CHECK:  load [[ADDR]]
 // CHECK: br bb1
 // CHECK: return
 
@@ -1051,9 +1051,9 @@ struct State {
 // CHECK:     [[HOISTVAL:%.*]] = struct_extract [[ELT0]] : $Int64, #Int64._value
 // ...Split element 2
 // CHECK:     [[SPLIT2:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 2
+// CHECK:     [[SINGLEADR:%.*]] = struct_element_addr %{{.*}} : $*State, #State.singleValue
 // CHECK:     [[ELT2:%.*]] = load [[SPLIT2]] : $*Int64
 // ...Split State.singlevalue
-// CHECK:     [[SINGLEADR:%.*]] = struct_element_addr %{{.*}} : $*State, #State.singleValue
 // CHECK:     [[SINGLEVAL:%.*]] = load [[SINGLEADR]] : $*Int64
 // ...Hoisted element 0
 // CHECK:     br bb1([[PRELOAD]] : $Int64)
@@ -1110,8 +1110,8 @@ bb3:
 // CHECK-LABEL: sil shared @testCommonSplitLoad : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, Int64, Int64) {
 // CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
 // CHECK:   [[ELT0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 0
-// CHECK:   [[V0:%.*]] = load [[ELT0]] : $*Int64
 // CHECK:   [[ELT2:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 2
+// CHECK:   [[V0:%.*]] = load [[ELT0]] : $*Int64
 // CHECK:   [[V2:%.*]] = load [[ELT2]] : $*Int64
 // CHECK:   [[ELT1:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 1
 // CHECK:   [[V1:%.*]] = load [[ELT1]] : $*Int64
@@ -1194,9 +1194,9 @@ bb3:
 // CHECK-LABEL: sil shared @testResplit : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
 // CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
 // CHECK:   [[ELT_0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, (Int64, Int64)), 0
-// CHECK:   [[V0:%.*]] = load [[ELT_0]] : $*Int64
 // CHECK:   [[ELT_1a:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, (Int64, Int64)), 1
 // CHECK:   [[ELT_1_0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64), 0
+// CHECK:   [[V0:%.*]] = load [[ELT_0]] : $*Int64
 // CHECK:   [[V_1_0:%.*]] = load [[ELT_1_0]] : $*Int64
 // CHECK:   [[ELT_1_1:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64), 1
 // CHECK:   [[V_1_1:%.*]] = load [[ELT_1_1]] : $*Int64

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -236,9 +236,9 @@ bb5:
 
 // CHECK-LABEL: sil @dont_licm_ginit_dependency1
 // CHECK: bb0:
+// CHECK:   [[U:%[0-9]+]] = function_ref @unknown
 // CHECK:   [[I:%[0-9]+]] = function_ref @$s4test10testGlobalSivau
 // CHECK: bb2:
-// CHECK:   [[U:%[0-9]+]] = function_ref @unknown
 // CHECK:   apply [[U]]
 // CHECK: bb4:
 // CHECK:   apply [[I]]


### PR DESCRIPTION
This PR introduces unconditional hoisting of simple instructions without side effects such as `function_ref`, `integer_literal `, or `struct_element_addr`. It also adds licm support for `ColdBlockInfo` to speculatively hoist instructions that dominate all **non-cold** exits.