### PR TITLE
[build-windows-toolchain.bat] Enable passing host arch name to build.ps1 through env var

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -73,10 +73,15 @@ if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 set "WindowsSDKArchitecturesArg= "
 if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-WindowsSDKArchitectures %WINDOWS_SDKS%"
 
+:: Build the -HostArchName argument, if any.
+set "HostArchNameArg="
+if not "%HOST_ARCH_NAME%"=="" set "HostArchNameArg=-HostArchName %HOST_ARCH_NAME%"
+
 call :CloneRepositories || (exit /b 1)
 
 :: We only have write access to BuildRoot, so use that as the image root.
 powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
+  %HostArchName% ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^


### PR DESCRIPTION
This allows us to fix the `build toolchain Windows arm64` trigger, which currently builds a toolchain for x86, by setting an environment variable.