### PR TITLE
Frontend: Require explicit language mode when emitting swiftinterfaces

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1035,10 +1035,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (!isValid)
       diagnoseSwiftVersion(vers, A, Args, Diags);
   } else if (FrontendOpts.InputsAndOutputs.hasModuleInterfaceOutputPath()) {
-    Diags.diagnose({}, diag::error_module_interface_requires_language_mode)
-        .limitBehavior(DiagnosticBehavior::Warning);
-    // FIXME: Make this an error again (rdar://145168219)
-    // HadError = true;
+    Diags.diagnose({}, diag::error_module_interface_requires_language_mode);
+    HadError = true;
   }
 
   if (auto A = Args.getLastArg(OPT_package_description_version)) {

--- a/test/ModuleInterface/language_mode.swift
+++ b/test/ModuleInterface/language_mode.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
+// RUN: not %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
 // RUN:   -enable-library-evolution -module-name Test \
 // RUN:   -emit-module-interface-path %t.swiftinterface \
 // RUN:   -emit-module -o /dev/null 2>&1 | %FileCheck %s
 
-// CHECK: <unknown>:0: warning: emitting module interface files requires '-language-mode'
+// CHECK: <unknown>:0: error: emitting module interface files requires '-language-mode'
 
 // RUN: %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
 // RUN:   -enable-library-evolution -module-name Test \


### PR DESCRIPTION
If a .swiftinterface file does not include an explicit `-language-mode` option (or its predecessor `-swift-version`) and needs to be built as a dependency of a client compilation, then the invocation to build the module from interface would end up inheriting the language mode that the client code is built with. This can result in spurious type checking diagnostics or even mis-compilation. To ensure that a module interface is always built using the language mode that its source code was originally built with, require an explicit `-language-mode` option when emitting swiftinterface files.

In https://github.com/swiftlang/swift/pull/84307 this diagnostic was downgraded to a warning. The failures it caused in PR testing should now be resolved.

Resolves rdar://145168219.
