### PR TITLE
Tests: Allow Interpreter/cdecl_official_run.swift to run on older OSes

### DIFF
--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -5,12 +5,16 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
 // RUN:   -emit-clang-header-path %t/cdecl.h \
+// RUN:   -disable-implicit-string-processing-module-import \
+// RUN:   -disable-implicit-concurrency-module-import \
 // RUN:   -enable-experimental-feature CDecl
 
 /// Build and run a binary from Swift and C code.
 // RUN: %clang-no-modules -c %t/Client.c -o %t/Client.o -target %target-triple \
 // RUN:   %target-pic-opt -I %t -I %clang-include-dir -Werror -isysroot %sdk
 // RUN: %target-build-swift %t/Lib.swift %t/Client.o -O -o %t/a.out \
+// RUN:   -Xfrontend -disable-implicit-string-processing-module-import \
+// RUN:   -Xfrontend -disable-implicit-concurrency-module-import \
 // RUN:   -enable-experimental-feature CDecl -parse-as-library
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out > %t/run.log


### PR DESCRIPTION
Remove the dependency on string processing to run against OSes where it's not available. Remove the unused dependency on concurrency as well.

rdar://160448792