### PR TITLE
silgen: use isSelfParameter instead of custom check

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3701,8 +3701,7 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     // If we have self, see if we are in an 'init' delegation sequence. If so,
     // call out to the special delegation init routine. Otherwise, use the
     // normal RValue emission logic.
-    if (var->getName() == getASTContext().Id_self &&
-        SelfInitDelegationState != NormalSelf) {
+    if (var->isSelfParameter() && SelfInitDelegationState != NormalSelf) {
       auto rvalue =
         emitRValueForSelfInDelegationInit(loc, formalRValueType, accessAddr, C);
       return propagateRValuePastAccess(std::move(rvalue));


### PR DESCRIPTION
This is an NFC that makes a check for the self parameter more robust.