### PR TITLE
silgen: clean-up some APIs

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -55,8 +55,6 @@ ManagedValue ManagedValue::forForwardedRValue(SILGenFunction &SGF,
 /// Emit a copy of this value with independent ownership.
 ManagedValue ManagedValue::copy(SILGenFunction &SGF, SILLocation loc) const {
   auto &lowering = SGF.getTypeLowering(getType());
-  if (lowering.isTrivial())
-    return *this;
 
   if (getType().isObject()) {
     return SGF.B.createCopyValue(loc, *this, lowering);
@@ -121,18 +119,6 @@ void ManagedValue::copyInto(SILGenFunction &SGF, SILLocation loc,
                             Initialization *dest) {
   dest->copyOrInitValueInto(SGF, loc, *this, /*isInit*/ false);
   dest->finishInitialization(SGF);
-}
-
-/// This is the same operation as 'copy', but works on +0 values that don't
-/// have cleanups.  It returns a +1 value with one.
-ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &SGF, SILLocation loc) {
-  if (getType().isObject()) {
-    return SGF.B.createCopyValue(loc, *this);
-  }
-
-  SILValue result = SGF.emitTemporaryAllocation(loc, getType());
-  SGF.B.createCopyAddr(loc, getValue(), result, IsNotTake, IsInitialization);
-  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 /// This is the same operation as 'copy', but works on +0 values that don't

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -365,10 +365,6 @@ public:
   /// formal evaluation scope.
   ManagedValue formalAccessCopy(SILGenFunction &SGF, SILLocation loc);
 
-  /// This is the same operation as 'copy', but works on +0 values that don't
-  /// have cleanups.  It returns a +1 value with one.
-  ManagedValue copyUnmanaged(SILGenFunction &SGF, SILLocation loc);
-
   /// This is the same operation as 'formalAccessCopy', but works on +0 values
   /// that don't have cleanups.  It returns a +1 value with one.
   ManagedValue formalAccessCopyUnmanaged(SILGenFunction &SGF, SILLocation loc);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1049,7 +1049,7 @@ ManagedValue SILGenFunction::manageOpaqueValue(ManagedValue value,
   }
 
   // Otherwise, copy the value into a temporary.
-  return value.copyUnmanaged(*this, loc);
+  return value.copy(*this, loc);
 }
 
 ManagedValue SILGenFunction::emitAsOrig(SILLocation loc,

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -991,7 +991,7 @@ public:
       // Disable the expression cleanup of the copy, since the let value
       // initialization has a cleanup that lives for the entire scope of the
       // let declaration.
-      bindValue(value.copyUnmanaged(SGF, loc).forward(SGF), SGF, true, loc);
+      bindValue(value.copy(SGF, loc).forward(SGF), SGF, true, loc);
     }
   }
 
@@ -1298,13 +1298,13 @@ void EnumElementPatternInitialization::emitEnumMatch(
               ManagedValue borrowedVal =
                   SGF.B.createLoadBorrow(loc, mvAccessAddress);
               mv = loadScope.popPreservingValue(
-                  borrowedVal.copyUnmanaged(SGF, loc));
+                  borrowedVal.copy(SGF, loc));
             }
             access.endAccess(SGF);
           } else {
             // If we do not have a loadable value, just do a copy of the
             // boxedValue.
-            mv = boxedValue.copyUnmanaged(SGF, loc);
+            mv = boxedValue.copy(SGF, loc);
           }
         }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -7489,24 +7489,6 @@ RValue SILGenFunction::emitRValue(Expr *E, SGFContext C) {
   return RValueEmitter(*this).visit(E, C);
 }
 
-RValue SILGenFunction::emitPlusOneRValue(Expr *E, SGFContext C) {
-  Scope S(*this, SILLocation(E));
-  assert(!E->getType()->hasLValueType() &&
-         "l-values must be emitted with emitLValue");
-  return S.popPreservingValue(
-      RValueEmitter(*this).visit(E, C.withSubExprSideEffects()));
-}
-
-RValue SILGenFunction::emitPlusZeroRValue(Expr *E) {
-  // Check if E is a case that we know how to emit at plus zero. If so, handle
-  // it here.
-  //
-  // TODO: Fill this in.
-
-  // Otherwise, we go through the +1 path and borrow the result.
-  return emitPlusOneRValue(E).borrow(*this, SILLocation(E));
-}
-
 static void emitIgnoredPackExpansion(SILGenFunction &SGF,
                                      PackExpansionExpr *E) {
   auto expansionType =

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1827,21 +1827,6 @@ public:
                                             StorageReferenceOperationKind kind);
   Expr *findStorageReferenceExprForBorrowExpr(Expr *argExpr);
 
-  /// Emit the given expression as a +1 r-value.
-  ///
-  /// *NOTE* This creates the +1 r-value and then pushes that +1 r-value through
-  /// a scope. So all temporaries resulting will be cleaned up.
-  ///
-  /// *NOTE* +0 vs +1 is ignored by this function. The only reason to use the
-  /// SGFContext argument is to pass in an initialization.
-  RValue emitPlusOneRValue(Expr *E, SGFContext C = SGFContext());
-
-  /// Emit the given expression as a +0 r-value.
-  ///
-  /// *NOTE* This does not scope the creation of the +0 r-value. The reason why
-  /// this is done is that +0 r-values can not be pushed through scopes.
-  RValue emitPlusZeroRValue(Expr *E);
-
   /// Emit the given expression as an r-value with the given conversion
   /// context.  This may be more efficient --- and, in some cases,
   /// semantically different --- than emitting the expression and then

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3756,7 +3756,7 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     // This is a 'let', so we can make guarantees.
     return RValue(*this, loc, formalRValueType,
                   C.isGuaranteedPlusZeroOk()
-                    ? Result : Result.copyUnmanaged(*this, loc));
+                    ? Result : Result.ensurePlusOne(*this, loc));
   }
 
   LValue lv = emitLValueForNonMemberVarDecl(
@@ -5582,7 +5582,7 @@ RValue SILGenFunction::emitRValueForStorageLoad(
 
     // Otherwise, bring the component up to +1 so we can reabstract it.
     result = std::move(loaded).getAsSingleValue(*this, loc)
-                              .copyUnmanaged(*this, loc);
+                              .copy(*this, loc);
   } else if (!base.getType().isAddress()) {
     // For non-address-only structs, we emit a struct_extract sequence.
     result = B.createStructExtract(loc, base, field);
@@ -5601,7 +5601,7 @@ RValue SILGenFunction::emitRValueForStorageLoad(
       // guaranteed consumer. Otherwise, since we do not have enough information
       // to know if the base's lifetime last's as long as our use of the access,
       // we can only emit at +0 for immediate clients.
-      result = result.copyUnmanaged(*this, loc);
+      result = result.copy(*this, loc);
     }
   } else {
     // Create a tiny unenforced access scope around a load from local memory. No

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2109,7 +2109,7 @@ private:
 
     // If our inner is guaranteed or unowned, we need to create a copy here.
     if (inner.getOwnershipKind() != OwnershipKind::Owned)
-      inner = inner.copyUnmanaged(SGF, Loc);
+      inner = inner.copy(SGF, Loc);
 
     return inner;
   }
@@ -2190,7 +2190,7 @@ private:
     if (outer.getType() == innerParam.getType()) {
       if (isConsumedParameterInCaller(innerParam.getConvention()) &&
           !outer.isPlusOne(SGF)) {
-        outer = outer.copyUnmanaged(SGF, Loc);
+        outer = outer.copy(SGF, Loc);
       }
 
       return outer;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -498,9 +498,7 @@ public:
       } else {
         // Otherwise, we need to move or copy values into a +1 tuple.
         for (auto element : elements) {
-          SILValue value = element.hasCleanup()
-            ? element.forward(SGF)
-            : element.copyUnmanaged(SGF, loc).forward(SGF);
+          SILValue value = element.ensurePlusOne(SGF, loc).forward(SGF);
           elementValues.push_back(value);
         }
       }


### PR DESCRIPTION
1. ManagedValue had `copy`, `copyUnmanaged`, and `unmanagedCopy`, and the first two were practically the same. In some cases, I simplified callers to use `ManagedValue::ensurePlusOne` instead.
2. There's a few unused, unfinished RValue emission functions in SILGenFunction. Best to remove them to avoid confusion.