### PR TITLE
Add IRPGO and CSIRPGO options to Swift

### DIFF
--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -41,6 +41,11 @@ ERROR(too_few_output_filenames,none,
 ERROR(no_input_files_for_mt,none,
       "no swift input files for multi-threaded compilation", ())
 
+ERROR(ir_profile_read_failed, none,
+      "error reading profile '%0': %1", (StringRef, StringRef))
+ERROR(ir_profile_invalid, none,
+      "invalid ir profile '%0'", (StringRef))
+
 ERROR(alignment_dynamic_type_layout_unsupported,none,
       "'@_alignment' is not supported on types with dynamic layout", ())
 ERROR(alignment_less_than_natural,none,

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -552,6 +552,16 @@ public:
   /// or the empty string.
   std::string UseSampleProfile = "";
 
+  /// Path to the context-sensitive profile file to be used for CS-IR PGO,
+  /// or the default string.
+  std::string CSProfileGenFile = "default_%m.profraw";
+
+  /// Whether to enable context-sensitive IR PGO generation.
+  bool EnableCSIRProfileGen = false;
+
+  /// Whether to enable IR level instrumentation.
+  bool EnableIRProfileGen = false;
+
   /// Controls whether DWARF discriminators are added to the IR.
   unsigned DebugInfoForProfiling : 1;
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -552,9 +552,9 @@ public:
   /// or the empty string.
   std::string UseSampleProfile = "";
 
-  /// Path to the context-sensitive profile file to be used for CS-IR PGO,
-  /// or the default string.
-  std::string CSProfileGenFile = "default_%m.profraw";
+  /// Name of the profile file to use as output for -ir-profile-generate,
+  /// and -cs-profile-generate, or the default string.
+  std::string InstrProfileOutput = "default_%m.profraw";
 
   /// Whether to enable context-sensitive IR PGO generation.
   bool EnableCSIRProfileGen = false;

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -548,6 +548,9 @@ public:
   /// Path to the profdata file to be used for PGO, or the empty string.
   std::string UseProfile = "";
 
+  /// Path to the profdata file to be used for IR/CS-IR PGO, or the empty string.
+  std::string UseIRProfile = "";
+
   /// Path to the data file to be used for sampling-based PGO,
   /// or the empty string.
   std::string UseSampleProfile = "";

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1608,6 +1608,19 @@ def profile_sample_use : Joined<["-"], "profile-sample-use=">,
   MetaVarName<"<profile data>">,
   HelpText<"Supply sampling-based profiling data from llvm-profdata to enable profile-guided optimization">;
 
+def cs_profile_generate : Flag<["-"], "cs-profile-generate">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Generate instrumented code to collect context sensitive execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
+
+def cs_profile_generate_EQ : Joined<["-"], "cs-profile-generate=">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  MetaVarName<"<directory>">,
+  HelpText<"Generate instrumented code to collect context sensitive execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
+
+def ir_profile_generate: Flag<["-"], "ir-profile-generate">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
+
 def embed_bitcode : Flag<["-"], "embed-bitcode">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Embed LLVM IR bitcode as data">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1621,6 +1621,11 @@ def ir_profile_generate: Flag<["-"], "ir-profile-generate">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
 
+def ir_profile_use : CommaJoined<["-"], "ir-profile-use=">,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  MetaVarName<"<profdata>">,
+  HelpText<"Supply an IR-level PGO profdata file to enable profile-guided optimization">;
+
 def embed_bitcode : Flag<["-"], "embed-bitcode">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Embed LLVM IR bitcode as data">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1621,6 +1621,11 @@ def ir_profile_generate: Flag<["-"], "ir-profile-generate">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
 
+def ir_profile_generate_EQ : Joined<["-"], "ir-profile-generate=">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  MetaVarName<"<directory>">,
+  HelpText<"Generate instrumented code to collect execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
+
 def ir_profile_use : CommaJoined<["-"], "ir-profile-use=">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
   MetaVarName<"<profdata>">,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -42,6 +42,7 @@
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
+using namespace swift::driver::toolchains;
 
 std::string
 toolchains::Darwin::findProgramRelativeToSwiftImpl(StringRef name) const {
@@ -470,7 +471,7 @@ void
 toolchains::Darwin::addProfileGenerationArgs(ArgStringList &Arguments,
                                              const JobContext &context) const {
   const llvm::Triple &Triple = getTriple();
-  if (context.Args.hasArg(options::OPT_profile_generate)) {
+  if (needsInstrProfileRuntime(context.Args)) {
     SmallString<128> LibProfile;
     getClangLibraryPath(context.Args, LibProfile);
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -219,19 +219,28 @@ static void validateProfilingArgs(DiagnosticEngine &diags,
   const Arg *ProfileUse = args.getLastArg(options::OPT_profile_use);
   const Arg *IRProfileGenerate =
       args.getLastArg(options::OPT_ir_profile_generate);
+  const Arg *IRProfileUse = args.getLastArg(options::OPT_ir_profile_use);
   if (ProfileGenerate && ProfileUse) {
     diags.diagnose(SourceLoc(), diag::error_conflicting_options,
                    "-profile-generate", "-profile-use");
+  }
+  if (ProfileGenerate && IRProfileUse) {
+    diags.diagnose(SourceLoc(), diag::error_conflicting_options,
+                   "-profile-generate", "-ir-profile-use");
   }
   if (IRProfileGenerate && ProfileUse) {
     diags.diagnose(SourceLoc(), diag::error_conflicting_options,
                    "-ir-profile-generate", "-profile-use");
   }
-
+  if (IRProfileGenerate && IRProfileUse) {
+    diags.diagnose(SourceLoc(), diag::error_conflicting_options,
+                   "-ir-profile-generate", "-ir-profile-use");
+  }
   // Check if the profdata is missing
-  if (ProfileUse && !llvm::sys::fs::exists(ProfileUse->getValue())) {
-    diags.diagnose(SourceLoc(), diag::error_profile_missing,
-                   ProfileUse->getValue());
+  for (const Arg *use : {ProfileUse, IRProfileUse}) {
+    if (use && !llvm::sys::fs::exists(use->getValue())) {
+      diags.diagnose(SourceLoc(), diag::error_profile_missing, use->getValue());
+    }
   }
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -175,13 +175,57 @@ static void validateWarningControlArgs(DiagnosticEngine &diags,
   }
 }
 
+/// Validates only *generate* profiling flags and their mutual conflicts.
+static void validateProfilingGenerateArgs(DiagnosticEngine &diags,
+                                          const ArgList &args) {
+  const Arg *ProfileGenerate = args.getLastArg(options::OPT_profile_generate);
+  const Arg *IRProfileGenerate =
+      args.getLastArg(options::OPT_ir_profile_generate);
+  const Arg *CSProfileGenerate =
+      args.getLastArg(options::OPT_cs_profile_generate);
+  const Arg *CSProfileGenerateEQ =
+      args.getLastArg(options::OPT_cs_profile_generate_EQ);
+
+  // If both CS Profile forms were specified, report a clear conflict.
+  if (CSProfileGenerate && CSProfileGenerateEQ) {
+    diags.diagnose(SourceLoc(), diag::error_conflicting_options,
+                   "-cs-profile-generate", "-cs-profile-generate=");
+    CSProfileGenerateEQ = nullptr;
+  }
+
+  llvm::SmallVector<std::pair<const Arg *, const char *>, 3> gens;
+  if (ProfileGenerate)
+    gens.push_back({ProfileGenerate, "-profile-generate"});
+  if (IRProfileGenerate)
+    gens.push_back({IRProfileGenerate, "-ir-profile-generate"});
+  if (CSProfileGenerate)
+    gens.push_back({CSProfileGenerate, "-cs-profile-generate"});
+  else if (CSProfileGenerateEQ)
+    gens.push_back({CSProfileGenerateEQ, "-cs-profile-generate="});
+
+  // Emit pairwise conflicts if more than one generate-mode was selected
+  for (size_t i = 0; i + 1 < gens.size(); ++i) {
+    for (size_t j = i + 1; j < gens.size(); ++j) {
+      diags.diagnose(SourceLoc(), diag::error_conflicting_options,
+                     gens[i].second, gens[j].second);
+    }
+  }
+}
+
 static void validateProfilingArgs(DiagnosticEngine &diags,
                                   const ArgList &args) {
+  validateProfilingGenerateArgs(diags, args);
   const Arg *ProfileGenerate = args.getLastArg(options::OPT_profile_generate);
   const Arg *ProfileUse = args.getLastArg(options::OPT_profile_use);
+  const Arg *IRProfileGenerate =
+      args.getLastArg(options::OPT_ir_profile_generate);
   if (ProfileGenerate && ProfileUse) {
     diags.diagnose(SourceLoc(), diag::error_conflicting_options,
                    "-profile-generate", "-profile-use");
+  }
+  if (IRProfileGenerate && ProfileUse) {
+    diags.diagnose(SourceLoc(), diag::error_conflicting_options,
+                   "-ir-profile-generate", "-profile-use");
   }
 
   // Check if the profdata is missing

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -160,6 +160,15 @@ bool containsValue(
 
 }
 
+namespace swift::driver::toolchains {
+bool needsInstrProfileRuntime(const llvm::opt::ArgList &Args) {
+  return Args.hasArg(options::OPT_profile_generate) ||
+         Args.hasArg(options::OPT_cs_profile_generate) ||
+         Args.hasArg(options::OPT_cs_profile_generate_EQ) ||
+         Args.hasArg(options::OPT_ir_profile_generate);
+}
+} // namespace swift::driver::toolchains
+
 void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                                       const CommandOutput &output,
                                       const ArgList &inputArgs,
@@ -323,6 +332,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_PackageCMO);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
+  inputArgs.AddLastArg(arguments, options::OPT_ir_profile_generate);
+  inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);
   inputArgs.AddAllArgs(arguments, options::OPT_warning_treating_Group);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -333,6 +333,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_ir_profile_generate);
+  inputArgs.AddLastArg(arguments, options::OPT_ir_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -334,6 +334,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_ir_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate);
+  inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);
   inputArgs.AddAllArgs(arguments, options::OPT_warning_treating_Group);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -165,7 +165,8 @@ bool needsInstrProfileRuntime(const llvm::opt::ArgList &Args) {
   return Args.hasArg(options::OPT_profile_generate) ||
          Args.hasArg(options::OPT_cs_profile_generate) ||
          Args.hasArg(options::OPT_cs_profile_generate_EQ) ||
-         Args.hasArg(options::OPT_ir_profile_generate);
+         Args.hasArg(options::OPT_ir_profile_generate) ||
+         Args.hasArg(options::OPT_ir_profile_generate_EQ);
 }
 } // namespace swift::driver::toolchains
 
@@ -333,6 +334,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_ir_profile_generate);
+  inputArgs.AddLastArg(arguments, options::OPT_ir_profile_generate_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_ir_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_cs_profile_generate_EQ);

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -25,6 +25,11 @@ class DiagnosticEngine;
 namespace driver {
 namespace toolchains {
 
+/// True if any *generation* mode of instrumentation-based profile is enabled.
+///
+/// This is used to determine if the profiler runtime should be linked.
+bool needsInstrProfileRuntime(const llvm::opt::ArgList &Args);
+
 class LLVM_LIBRARY_VISIBILITY Darwin : public ToolChain {
 protected:
 

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -40,6 +40,7 @@
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
+using namespace swift::driver::toolchains;
 
 std::string
 toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
@@ -330,7 +331,7 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     }
   }
 
-  if (context.Args.hasArg(options::OPT_profile_generate)) {
+  if (needsInstrProfileRuntime(context.Args)) {
     SmallString<128> LibProfile(SharedResourceDirPath);
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -38,6 +38,7 @@
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
+using namespace swift::driver::toolchains;
 
 std::string
 toolchains::WebAssembly::sanitizerRuntimeLibName(StringRef Sanitizer,
@@ -168,7 +169,7 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
         "-fsanitize=" + getSanitizerList(context.OI.SelectedSanitizers)));
   }
 
-  if (context.Args.hasArg(options::OPT_profile_generate)) {
+  if (needsInstrProfileRuntime(context.Args)) {
     SmallString<128> LibProfile(SharedResourceDirPath);
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -36,6 +36,7 @@
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
+using namespace swift::driver::toolchains;
 
 std::string toolchains::Windows::sanitizerRuntimeLibName(StringRef Sanitizer,
                                                          bool shared) const {
@@ -89,7 +90,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
     // for now, which supports the behavior via a flag.
     // TODO: Once we've changed coverage to no longer rely on emitting
     // duplicate weak symbols (rdar://131295678), we can remove this.
-    if (context.Args.getLastArg(options::OPT_profile_generate)) {
+    if (swift::driver::toolchains::needsInstrProfileRuntime(context.Args)) {
       return true;
     }
     return false;
@@ -186,7 +187,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
                         sanitizerRuntimeLibName("ubsan"));
   }
 
-  if (context.Args.hasArg(options::OPT_profile_generate)) {
+  if (needsInstrProfileRuntime(context.Args)) {
     Arguments.push_back(context.Args.MakeArgString("-Xlinker"));
     Arguments.push_back(context.Args.MakeArgString(
         Twine({"-include:", llvm::getInstrProfRuntimeHookVarName()})));

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3497,6 +3497,12 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   const Arg *ProfileSampleUse = Args.getLastArg(OPT_profile_sample_use);
   Opts.UseSampleProfile = ProfileSampleUse ? ProfileSampleUse->getValue() : "";
 
+  Opts.EnableIRProfileGen = Args.hasArg(OPT_ir_profile_generate);
+  Opts.EnableCSIRProfileGen = Args.hasArg(OPT_cs_profile_generate) ||
+                              Args.hasArg(OPT_cs_profile_generate_EQ);
+  if (auto V = Args.getLastArgValue(OPT_cs_profile_generate_EQ); !V.empty())
+    Opts.CSProfileGenFile = V.str();
+
   Opts.DebugInfoForProfiling |= Args.hasArg(OPT_debug_info_for_profiling);
 
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3501,7 +3501,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.EnableCSIRProfileGen = Args.hasArg(OPT_cs_profile_generate) ||
                               Args.hasArg(OPT_cs_profile_generate_EQ);
   if (auto V = Args.getLastArgValue(OPT_cs_profile_generate_EQ); !V.empty())
-    Opts.CSProfileGenFile = V.str();
+    Opts.InstrProfileOutput = V.str();
 
   Opts.DebugInfoForProfiling |= Args.hasArg(OPT_debug_info_for_profiling);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3502,6 +3502,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                               Args.hasArg(OPT_cs_profile_generate_EQ);
   if (auto V = Args.getLastArgValue(OPT_cs_profile_generate_EQ); !V.empty())
     Opts.InstrProfileOutput = V.str();
+  const Arg *IRProfileUse = Args.getLastArg(OPT_ir_profile_use);
+  Opts.UseIRProfile = IRProfileUse ? IRProfileUse->getValue() : "";
 
   Opts.DebugInfoForProfiling |= Args.hasArg(OPT_debug_info_for_profiling);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3497,7 +3497,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   const Arg *ProfileSampleUse = Args.getLastArg(OPT_profile_sample_use);
   Opts.UseSampleProfile = ProfileSampleUse ? ProfileSampleUse->getValue() : "";
 
-  Opts.EnableIRProfileGen = Args.hasArg(OPT_ir_profile_generate);
+  Opts.EnableIRProfileGen = Args.hasArg(OPT_ir_profile_generate) ||
+                            Args.hasArg(OPT_ir_profile_generate_EQ);
+  if (auto V = Args.getLastArgValue(OPT_ir_profile_generate_EQ); !V.empty())
+    Opts.InstrProfileOutput = V.str();
   Opts.EnableCSIRProfileGen = Args.hasArg(OPT_cs_profile_generate) ||
                               Args.hasArg(OPT_cs_profile_generate_EQ);
   if (auto V = Args.getLastArgValue(OPT_cs_profile_generate_EQ); !V.empty())

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -232,9 +232,9 @@ static void populatePGOOptions(std::optional<PGOOptions> &Out,
   }
 
   if (Opts.EnableCSIRProfileGen) {
-    const bool hasUse = !Opts.UseProfile.empty();
+    const bool hasUse = !Opts.UseIRProfile.empty();
     Out = PGOOptions(
-      /*ProfileFile=*/ Opts.UseProfile,
+      /*ProfileFile=*/ Opts.UseIRProfile,
       /*CSProfileGenFile=*/ Opts.InstrProfileOutput,
       /*ProfileRemappingFile=*/ "",
       /*MemoryProfile=*/ "",

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -231,6 +231,37 @@ static void populatePGOOptions(std::optional<PGOOptions> &Out,
     return;
   }
 
+  if (Opts.EnableCSIRProfileGen) {
+    const bool hasUse = !Opts.UseProfile.empty();
+    Out = PGOOptions(
+      /*ProfileFile=*/ hasUse ? Opts.UseProfile : "",
+      /*CSProfileGenFile=*/ Opts.CSProfileGenFile,
+      /*ProfileRemappingFile=*/ "",
+      /*MemoryProfile=*/ "",
+      /*FS=*/ llvm::vfs::getRealFileSystem(),
+      /*Action=*/ hasUse ? PGOOptions::IRUse : PGOOptions::NoAction,
+      /*CSPGOAction=*/ PGOOptions::CSIRInstr,
+      /*ColdType=*/ PGOOptions::ColdFuncOpt::Default,
+      /*DebugInfoForProfiling=*/ Opts.DebugInfoForProfiling
+    );
+    return;
+  }
+
+  if (Opts.EnableIRProfileGen) {
+    Out = PGOOptions(
+      /*ProfileFile=*/ "",
+      /*CSProfileGenFile=*/ "",
+      /*ProfileRemappingFile=*/ "",
+      /*MemoryProfile=*/ "",
+      /*FS=*/ llvm::vfs::getRealFileSystem(),
+      /*Action=*/ PGOOptions::IRInstr,
+      /*CSPGOAction=*/ PGOOptions::NoCSAction,
+      /*ColdType=*/ PGOOptions::ColdFuncOpt::Default,
+      /*DebugInfoForProfiling=*/ Opts.DebugInfoForProfiling
+    );
+    return;
+  }
+
   if (Opts.DebugInfoForProfiling) {
     Out = PGOOptions(
         /*ProfileFile=*/ "",

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -234,8 +234,8 @@ static void populatePGOOptions(std::optional<PGOOptions> &Out,
   if (Opts.EnableCSIRProfileGen) {
     const bool hasUse = !Opts.UseProfile.empty();
     Out = PGOOptions(
-      /*ProfileFile=*/ hasUse ? Opts.UseProfile : "",
-      /*CSProfileGenFile=*/ Opts.CSProfileGenFile,
+      /*ProfileFile=*/ Opts.UseProfile,
+      /*CSProfileGenFile=*/ Opts.InstrProfileOutput,
       /*ProfileRemappingFile=*/ "",
       /*MemoryProfile=*/ "",
       /*FS=*/ llvm::vfs::getRealFileSystem(),
@@ -249,7 +249,7 @@ static void populatePGOOptions(std::optional<PGOOptions> &Out,
 
   if (Opts.EnableIRProfileGen) {
     Out = PGOOptions(
-      /*ProfileFile=*/ "",
+      /*ProfileFile=*/ Opts.InstrProfileOutput,
       /*CSProfileGenFile=*/ "",
       /*ProfileRemappingFile=*/ "",
       /*MemoryProfile=*/ "",

--- a/test/IRGen/cs_profile_generate.sil
+++ b/test/IRGen/cs_profile_generate.sil
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -cs-profile-generate -O -emit-ir %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+sil @b : $@convention(thin) () -> ()
+
+sil @c : $@convention(thin) () -> ()
+
+
+// CHECK: @__llvm_profile_runtime = external hidden global
+
+// counter array (2 counters for the then/else)
+// CHECK: @__profc_a = {{.*}} global [2 x i64]
+// data record pointing at the counter array and the function
+// CHECK: @__profd_a = {{.*}} global {{.*}} ptr @a.local
+
+
+// CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
+// THEN: increment counter[0] and call b()
+// CHECK: [[THEN]]:
+// CHECK:   %[[L0:.*]] = load i64, ptr @__profc_a, align 8
+// CHECK:   %[[A0:.*]] = add i64 %[[L0]], 1
+// CHECK:   store i64 %[[A0]], ptr @__profc_a, align 8
+// CHECK:   call swiftcc void @b()
+// CHECK:   br label %[[MERGE:[0-9]+]]
+
+// ELSE: increment counter[1] and call c()
+// CHECK: [[ELSE]]:
+// CHECK:   %[[L1:.*]] = load i64, ptr getelementptr inbounds (i8, ptr @__profc_a, i64 8), align 8
+// CHECK:   %[[A1:.*]] = add i64 %[[L1]], 1
+// CHECK:   store i64 %[[A1]], ptr getelementptr inbounds (i8, ptr @__profc_a, i64 8), align 8
+// CHECK:   call swiftcc void @c()
+// CHECK:   br label %[[MERGE]]
+
+// CHECK: [[MERGE]]:
+// CHECK:   ret void
+
+// CHECK: declare swiftcc void @c()
+// CHECK: declare swiftcc void @b()
+
+sil @a : $@convention(thin) (Bool) -> () {
+bb0(%0 : $Bool):
+  %2 = struct_extract %0, #Bool._value
+  cond_br %2, bb1, bb2
+
+bb1:
+  // function_ref b()
+  %4 = function_ref @b : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  br bb3 
+
+bb2:
+  // function_ref c()
+  %7 = function_ref @c: $@convention(thin) () -> ()
+  %8 = apply %7() : $@convention(thin) () -> ()
+  br bb3 
+
+bb3:
+  %10 = tuple ()
+  return %10
+}

--- a/test/IRGen/cs_profile_generate.sil
+++ b/test/IRGen/cs_profile_generate.sil
@@ -6,9 +6,9 @@
 // RUN: %target-swift-frontend -O -cs-profile-generate=%t.dir -emit-ir %s | %FileCheck %s
 
 // Ensure Passes: PGOInstrumentationGenPass and InstrProfilingLoweringPass are invoked.
-// RUN: %target-swift-frontend  -O -cs-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PGOGENPASS-INVOKED-INSTR-GEN --check-prefix=CHECK-INSTRPROF %s
-// CHECK-PGOGENPASS-INVOKED-INSTR-GEN: PGOInstrumentationGen
-// CHECK-INSTRPROF: InstrProfilingLoweringPass
+// RUN: %target-swift-frontend  -O -cs-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PASSES %s
+// CHECK-PASSES-DAG: PGOInstrumentationGen
+// CHECK-PASSES-DAG: InstrProfilingLoweringPass
 
 sil_stage canonical
 

--- a/test/IRGen/cs_profile_generate.sil
+++ b/test/IRGen/cs_profile_generate.sil
@@ -21,8 +21,6 @@ sil @b : $@convention(thin) () -> ()
 sil @c : $@convention(thin) () -> ()
 
 
-// CHECK: @__llvm_profile_runtime = external hidden global
-
 // counter array (2 counters for the then/else)
 // CHECK: @__profc_a = {{.*}} global {{.*}}
 // data record pointing at the counter array and the function
@@ -32,23 +30,23 @@ sil @c : $@convention(thin) () -> ()
 // CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
 // THEN: increment counter[0] and call b()
 // CHECK: [[THEN]]:
-// CHECK:   {{.*}} = load {{.*}}@__profc_a{{.*}}
-// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
-// CHECK:   call swiftcc void @b()
+// CHECK:   {{.*}}load{{.*}}@__profc_a
+// CHECK:   {{.*}}store{{.*}}@__profc_a
+// CHECK:   {{.*}}call{{.*}}@b(
 // CHECK:   br label %[[MERGE:[0-9]+]]
 
 // ELSE: increment counter[1] and call c()
 // CHECK: [[ELSE]]:
-// CHECK:   {{.*}} = load {{.*}}, {{.*}} getelementptr{{.*}}@__profc_a{{.*}}
-// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
-// CHECK:   call swiftcc void @c()
+// CHECK:   {{.*}} = {{.*}}@__profc_a{{.*}}
+// CHECK:   store{{.*}}@__profc_a
+// CHECK:   {{.*}}call{{.*}}@c(
 // CHECK:   br label %[[MERGE]]
 
 // CHECK: [[MERGE]]:
 // CHECK:   ret void
 
-// CHECK: declare swiftcc void @c()
-// CHECK: declare swiftcc void @b()
+// CHECK: declare {{.*}}@c(
+// CHECK: declare {{.*}}@b(
 
 sil @a : $@convention(thin) (Bool) -> () {
 bb0(%0 : $Bool):

--- a/test/IRGen/cs_profile_generate.sil
+++ b/test/IRGen/cs_profile_generate.sil
@@ -1,4 +1,9 @@
-// RUN: %target-swift-frontend -cs-profile-generate -O -emit-ir %s | %FileCheck %s
+// Without directory
+// RUN: %target-swift-frontend -O -cs-profile-generate -emit-ir %s | %FileCheck %s
+
+// With directory
+// RUN: %empty-directory(%t.dir)
+// RUN: %target-swift-frontend -O -cs-profile-generate=%t.dir -emit-ir %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/cs_profile_generate.sil
+++ b/test/IRGen/cs_profile_generate.sil
@@ -5,6 +5,11 @@
 // RUN: %empty-directory(%t.dir)
 // RUN: %target-swift-frontend -O -cs-profile-generate=%t.dir -emit-ir %s | %FileCheck %s
 
+// Ensure Passes: PGOInstrumentationGenPass and InstrProfilingLoweringPass are invoked.
+// RUN: %target-swift-frontend  -O -cs-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PGOGENPASS-INVOKED-INSTR-GEN --check-prefix=CHECK-INSTRPROF %s
+// CHECK-PGOGENPASS-INVOKED-INSTR-GEN: PGOInstrumentationGen
+// CHECK-INSTRPROF: InstrProfilingLoweringPass
+
 sil_stage canonical
 
 import Builtin
@@ -19,7 +24,7 @@ sil @c : $@convention(thin) () -> ()
 // CHECK: @__llvm_profile_runtime = external hidden global
 
 // counter array (2 counters for the then/else)
-// CHECK: @__profc_a = {{.*}} global [2 x i64]
+// CHECK: @__profc_a = {{.*}} global {{.*}}
 // data record pointing at the counter array and the function
 // CHECK: @__profd_a = {{.*}} global {{.*}} ptr @a.local
 
@@ -27,17 +32,15 @@ sil @c : $@convention(thin) () -> ()
 // CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
 // THEN: increment counter[0] and call b()
 // CHECK: [[THEN]]:
-// CHECK:   %[[L0:.*]] = load i64, ptr @__profc_a, align 8
-// CHECK:   %[[A0:.*]] = add i64 %[[L0]], 1
-// CHECK:   store i64 %[[A0]], ptr @__profc_a, align 8
+// CHECK:   {{.*}} = load {{.*}}@__profc_a{{.*}}
+// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[MERGE:[0-9]+]]
 
 // ELSE: increment counter[1] and call c()
 // CHECK: [[ELSE]]:
-// CHECK:   %[[L1:.*]] = load i64, ptr getelementptr inbounds (i8, ptr @__profc_a, i64 8), align 8
-// CHECK:   %[[A1:.*]] = add i64 %[[L1]], 1
-// CHECK:   store i64 %[[A1]], ptr getelementptr inbounds (i8, ptr @__profc_a, i64 8), align 8
+// CHECK:   {{.*}} = load {{.*}}, {{.*}} getelementptr{{.*}}@__profc_a{{.*}}
+// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[MERGE]]
 

--- a/test/IRGen/ir_profile_generate.sil
+++ b/test/IRGen/ir_profile_generate.sil
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -ir-profile-generate -emit-ir %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+sil @b : $@convention(thin) () -> ()
+
+sil @c : $@convention(thin) () -> ()
+
+// CHECK: @__llvm_profile_runtime = external hidden global
+
+// counter array (2 counters for the then/else)
+// CHECK: @__profc_a = {{.*}} global [2 x i64]
+// data record pointing at the counter array and the function
+// CHECK: @__profd_a = {{.*}} global {{.*}} ptr @a.local
+
+// CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
+
+// THEN: increment counter[0] and call b()
+// CHECK: [[THEN]]:
+// CHECK:   %[[L0:.*]] = load i64, ptr @__profc_a, align 8
+// CHECK:   %[[A0:.*]] = add i64 %[[L0]], 1
+// CHECK:   store i64 %[[A0]], ptr @__profc_a, align 8
+// CHECK:   call swiftcc void @b()
+// CHECK:   br label %[[MERGE:[0-9]+]]
+
+// ELSE: increment counter[1] and call c()
+// CHECK: [[ELSE]]:
+// CHECK:   %[[L1:.*]] = load i64, ptr getelementptr inbounds ([2 x i64], ptr @__profc_a, i32 0, i32 1), align 8
+// CHECK:   %[[A1:.*]] = add i64 %[[L1]], 1
+// CHECK:   store i64 %[[A1]], ptr getelementptr inbounds ([2 x i64], ptr @__profc_a, i32 0, i32 1), align 8
+// CHECK:   call swiftcc void @c()
+// CHECK:   br label %[[MERGE]]
+
+// CHECK: [[MERGE]]:
+// CHECK:   ret void
+
+// CHECK: declare swiftcc void @c()
+// CHECK: declare swiftcc void @b()
+// CHECK: declare void @llvm.instrprof.increment
+
+sil @a : $@convention(thin) (Bool) -> () {
+bb0(%0 : $Bool):
+  %2 = struct_extract %0, #Bool._value
+  cond_br %2, bb1, bb2
+
+bb1:
+  // function_ref b()
+  %4 = function_ref @b : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  br bb3 
+
+bb2:
+  // function_ref c()
+  %7 = function_ref @c: $@convention(thin) () -> ()
+  %8 = apply %7() : $@convention(thin) () -> ()
+  br bb3 
+
+bb3:
+  %10 = tuple ()
+  return %10
+}

--- a/test/IRGen/ir_profile_generate.sil
+++ b/test/IRGen/ir_profile_generate.sil
@@ -1,4 +1,15 @@
+// Without directory
 // RUN: %target-swift-frontend -ir-profile-generate -emit-ir %s | %FileCheck %s
+
+// With directory
+// RUN: %empty-directory(%t.dir)
+// RUN: %target-swift-frontend -ir-profile-generate=%t.dir -emit-ir %s | %FileCheck %s
+
+// Ensure Passes: PGOInstrumentationGenPass and InstrProfilingLoweringPass are invoked.
+// RUN: %target-swift-frontend -ir-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PGOGENPASS-INVOKED-INSTR-GEN --check-prefix=CHECK-INSTRPROF %s
+// CHECK-PGOGENPASS-INVOKED-INSTR-GEN: PGOInstrumentationGen
+// CHECK-INSTRPROF: InstrProfilingLoweringPass
+
 
 sil_stage canonical
 
@@ -13,25 +24,23 @@ sil @c : $@convention(thin) () -> ()
 // CHECK: @__llvm_profile_runtime = external hidden global
 
 // counter array (2 counters for the then/else)
-// CHECK: @__profc_a = {{.*}} global [2 x i64]
+// CHECK: @__profc_a = {{.*}} global {{.*}}
 // data record pointing at the counter array and the function
 // CHECK: @__profd_a = {{.*}} global {{.*}} ptr @a.local
 
-// CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
 
+// CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
 // THEN: increment counter[0] and call b()
 // CHECK: [[THEN]]:
-// CHECK:   %[[L0:.*]] = load i64, ptr @__profc_a, align 8
-// CHECK:   %[[A0:.*]] = add i64 %[[L0]], 1
-// CHECK:   store i64 %[[A0]], ptr @__profc_a, align 8
+// CHECK:   {{.*}} = load {{.*}}@__profc_a{{.*}}
+// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
 // CHECK:   call swiftcc void @b()
 // CHECK:   br label %[[MERGE:[0-9]+]]
 
 // ELSE: increment counter[1] and call c()
 // CHECK: [[ELSE]]:
-// CHECK:   %[[L1:.*]] = load i64, ptr getelementptr inbounds ([2 x i64], ptr @__profc_a, i32 0, i32 1), align 8
-// CHECK:   %[[A1:.*]] = add i64 %[[L1]], 1
-// CHECK:   store i64 %[[A1]], ptr getelementptr inbounds ([2 x i64], ptr @__profc_a, i32 0, i32 1), align 8
+// CHECK:   {{.*}} = load {{.*}}, {{.*}} getelementptr{{.*}}@__profc_a{{.*}}
+// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
 // CHECK:   call swiftcc void @c()
 // CHECK:   br label %[[MERGE]]
 

--- a/test/IRGen/ir_profile_generate.sil
+++ b/test/IRGen/ir_profile_generate.sil
@@ -6,10 +6,9 @@
 // RUN: %target-swift-frontend -ir-profile-generate=%t.dir -emit-ir %s | %FileCheck %s
 
 // Ensure Passes: PGOInstrumentationGenPass and InstrProfilingLoweringPass are invoked.
-// RUN: %target-swift-frontend -ir-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PGOGENPASS-INVOKED-INSTR-GEN --check-prefix=CHECK-INSTRPROF %s
-// CHECK-PGOGENPASS-INVOKED-INSTR-GEN: PGOInstrumentationGen
-// CHECK-INSTRPROF: InstrProfilingLoweringPass
-
+// RUN: %target-swift-frontend -ir-profile-generate -emit-ir %s -Xllvm -debug-pass=Structure -Xllvm --time-passes -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-PASSES %s
+// CHECK-PASSES-DAG: PGOInstrumentationGen
+// CHECK-PASSES-DAG: InstrProfilingLoweringPass
 
 sil_stage canonical
 

--- a/test/IRGen/ir_profile_generate.sil
+++ b/test/IRGen/ir_profile_generate.sil
@@ -21,8 +21,6 @@ sil @b : $@convention(thin) () -> ()
 
 sil @c : $@convention(thin) () -> ()
 
-// CHECK: @__llvm_profile_runtime = external hidden global
-
 // counter array (2 counters for the then/else)
 // CHECK: @__profc_a = {{.*}} global {{.*}}
 // data record pointing at the counter array and the function
@@ -32,24 +30,24 @@ sil @c : $@convention(thin) () -> ()
 // CHECK: br i1 {{.*}}, label %[[THEN:[0-9]+]], label %[[ELSE:[0-9]+]]
 // THEN: increment counter[0] and call b()
 // CHECK: [[THEN]]:
-// CHECK:   {{.*}} = load {{.*}}@__profc_a{{.*}}
-// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
-// CHECK:   call swiftcc void @b()
+// CHECK:   {{.*}}load{{.*}}@__profc_a
+// CHECK:   {{.*}}store{{.*}}@__profc_a
+// CHECK:   {{.*}}call{{.*}}@b(
 // CHECK:   br label %[[MERGE:[0-9]+]]
 
 // ELSE: increment counter[1] and call c()
 // CHECK: [[ELSE]]:
-// CHECK:   {{.*}} = load {{.*}}, {{.*}} getelementptr{{.*}}@__profc_a{{.*}}
-// CHECK:   store {{.*}} %{{.*}}, ptr @__profc_a
-// CHECK:   call swiftcc void @c()
+/// CHECK:   {{.*}} = {{.*}}@__profc_a{{.*}}
+// CHECK:   store{{.*}}@__profc_a
+// CHECK:   {{.*}}call{{.*}}@c(
 // CHECK:   br label %[[MERGE]]
 
 // CHECK: [[MERGE]]:
 // CHECK:   ret void
 
-// CHECK: declare swiftcc void @c()
-// CHECK: declare swiftcc void @b()
-// CHECK: declare void @llvm.instrprof.increment
+// CHECK: declare {{.*}}@c(
+// CHECK: declare {{.*}}@b(
+// CHECK: declare {{.*}}@llvm.instrprof.increment
 
 sil @a : $@convention(thin) (Bool) -> () {
 bb0(%0 : $Bool):

--- a/test/IRGen/ir_profile_use.sil
+++ b/test/IRGen/ir_profile_use.sil
@@ -1,0 +1,23 @@
+// Missing file
+// RUN: %target-swift-frontend -ir-profile-use=missing.profdata -emit-ir %s 2>&1 | %FileCheck --check-prefix=CHECK-NOFILE %s
+// CHECK-NOFILE: error reading profile
+// CHECK-NOFILE: .profdata
+// CHECK-NOFILE: No such file or directory
+
+
+// Invalid IR file
+// RUN: %empty-directory(%t)
+// RUN: echo "" > %t.invalid.profdata
+// RUN: %target-swift-frontend -ir-profile-use=%t.invalid.profdata -emit-ir %s 2>&1 | %FileCheck --check-prefix=CHECK-INVALIDFILE %s
+// CHECK-INVALIDFILE: error reading profile
+// CHECK-INVALIDFILE: invalid.profdata
+// CHECK-INVALIDFILE: invalid instrumentation profile data (bad magic)
+
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public func foo() {}

--- a/test/IRGen/ir_profile_use.sil
+++ b/test/IRGen/ir_profile_use.sil
@@ -1,5 +1,5 @@
 // Missing file
-// RUN: %target-swift-frontend -ir-profile-use=missing.profdata -emit-ir %s 2>&1 | %FileCheck --check-prefix=CHECK-NOFILE %s
+// RUN: %target-swift-frontend -ir-profile-use=missing.profdata -emit-ir %s 2>&1 | %FileCheck --ignore-case --check-prefix=CHECK-NOFILE %s
 // CHECK-NOFILE: error reading profile
 // CHECK-NOFILE: .profdata
 // CHECK-NOFILE: No such file or directory
@@ -8,10 +8,10 @@
 // Invalid IR file
 // RUN: %empty-directory(%t)
 // RUN: echo "" > %t.invalid.profdata
-// RUN: %target-swift-frontend -ir-profile-use=%t.invalid.profdata -emit-ir %s 2>&1 | %FileCheck --check-prefix=CHECK-INVALIDFILE %s
+// RUN: %target-swift-frontend -ir-profile-use=%t.invalid.profdata -emit-ir %s 2>&1 | %FileCheck --ignore-case --check-prefix=CHECK-INVALIDFILE %s
 // CHECK-INVALIDFILE: error reading profile
 // CHECK-INVALIDFILE: invalid.profdata
-// CHECK-INVALIDFILE: invalid instrumentation profile data (bad magic)
+// CHECK-INVALIDFILE: invalid instrumentation profile data
 
 
 sil_stage canonical


### PR DESCRIPTION
This PR introduces three new instrumentation flags and plumbs them through to IRGen:

1. `-ir-profile-generate` - enable IR-level instrumentation.
2. `-cs-profile-generate` - enable context-sensitive IR-level instrumentation.
3. `-ir-profile-use` - IR-level PGO input profdata file to enable profile-guided optimization (both IRPGO and CSIRPGO)

**Context:** https://forums.swift.org/t/ir-level-pgo-instrumentation-in-swift/82123

**Swift-driver PR:** https://github.com/swiftlang/swift-driver/pull/1992

**Tests and validation:**
This PR includes ir level verification tests, also checks few edge-cases when `-ir-profile-use` supplied profile is either missing or is an invalid IR profile. 

However, for argument validation, linking, and generating IR profiles that can later be consumed by -cs-profile-generate, I’ll need corresponding swift-driver changes. Those changes are being tracked in https://github.com/swiftlang/swift-driver/pull/1992

The plan is:

1. Land this PR first.
2. Then update swift-driver with the required changes.
4. Then add the remaining set of test cases in this repo.


~~**Open Questions (Reviewer Input Requested)**~~

~~1. **Naming:**~~
~~Is `-ir-profile-generate` a good flag name?
`-cs-profile-generate` pairs nicely with Clang’s `-fcs-profile-generate`. However, `-ir-profile-generate` feels closer to Clang's `-fprofile-generate` but `-profile-generate` already exists in Swift as a frontend level and not IR level. Should it stay as is, or is there a clearer alternative?~~

~~2. **Missing LLVM runtime + Blocked on tests**~~

~~At the moment, I haven’t added tests because they currently fail locally due to missing LLVM runtime symbols. This is expected, since the required runtime linking through libclang APIs will be handled in swift-driver(https://github.com/swiftlang/swift-driver/pull/1992). However, swift-driver itself depends on these new options being available in Swift.~~

~~Does that mean the correct order of the PRs should be the following?~~

~~1. Create a PR in Swift that introduces just the new options, and land that PR first.
2. Land the corresponding swift-driver PR to handle runtime linking,
3. Then follow up with a Swift PR adding the full functionality and tests?~~
~~