### PR TITLE
[Utils] Add support for lit's --update-tests to run-test

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -186,8 +186,10 @@ kIsAndroid = 'ANDROID_DATA' in os.environ
 
 # Choose between lit's internal shell pipeline runner and a real shell.  If
 # LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
-use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows)
+use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows or lit_config.update_tests)
 if not use_lit_shell:
+    if lit_config.update_tests:
+        lit_config.fatal('--update-tests cannot be combined with LIT_USE_INTERNAL_SHELL=0')
     config.available_features.add('shell')
 
 config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode,

--- a/utils/run-test
+++ b/utils/run-test
@@ -160,6 +160,9 @@ def main():
     parser.add_argument("--unified", action="store_true",
                         help="The build directory is an unified LLVM build, "
                              "not a standalone Swift build")
+    parser.add_argument("--update-tests", action="store_true",
+                        help="Invoke lit with --update-tests to auto-repair failing tests "
+                             "(when possible)")
 
     args = parser.parse_args()
 
@@ -279,6 +282,9 @@ def main():
 
     if args.filter:
         test_args += ['--filter', args.filter]
+
+    if args.update_tests:
+        test_args.append('--update-tests')
 
     test_cmd = [sys.executable, args.lit] + test_args + paths
 


### PR DESCRIPTION
This flag checks for known test patterns in failed tests, and tries to automatically update the test to pass. Relies on https://github.com/swiftlang/llvm-project/pull/11400