### PR TITLE
Sema: Better prepared overloads

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4463,6 +4463,13 @@ public:
                           DeclContext *useDC,
                           PreparedOverloadBuilder *preparedOverload);
 
+  /// \returns the opened type, the thrown error type, and the base object type.
+  std::tuple<Type, Type, Type> getTypeOfMemberReferenceImpl(
+      Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
+      FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
+      SmallVectorImpl<OpenedType> *replacements = nullptr,
+      PreparedOverloadBuilder *preparedOverload = nullptr);
+
   /// Retrieve the type of a reference to the given value declaration,
   /// as a member with a base of the given type.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4437,8 +4437,15 @@ public:
   FunctionType *adjustFunctionTypeForConcurrency(
       FunctionType *fnType, Type baseType, ValueDecl *decl, DeclContext *dc,
       unsigned numApplies, bool isMainDispatchQueue,
-      ArrayRef<OpenedType> replacements, ConstraintLocatorBuilder locator,
-      PreparedOverloadBuilder *preparedOverload);
+      bool openGlobalActorType, ConstraintLocatorBuilder locator);
+
+  /// \returns The opened type and the thrown error type.
+  std::pair<Type, Type> getTypeOfReferenceImpl(
+                          ValueDecl *decl,
+                          FunctionRefInfo functionRefInfo,
+                          ConstraintLocatorBuilder locator,
+                          DeclContext *useDC,
+                          PreparedOverloadBuilder *preparedOverload);
 
   /// Retrieve the type of a reference to the given value declaration.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4441,8 +4441,7 @@ public:
 
   /// \returns The opened type and the thrown error type.
   std::pair<Type, Type> getTypeOfReferenceImpl(
-                          ValueDecl *decl,
-                          FunctionRefInfo functionRefInfo,
+                          OverloadChoice choice,
                           ConstraintLocatorBuilder locator,
                           DeclContext *useDC,
                           PreparedOverloadBuilder *preparedOverload);
@@ -4453,20 +4452,16 @@ public:
   /// the type by replacing each instance of an archetype with a fresh type
   /// variable.
   ///
-  /// \param decl The declarations whose type is being computed.
-  ///
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfReference(
-                          ValueDecl *decl,
-                          FunctionRefInfo functionRefInfo,
+                          OverloadChoice choice,
                           ConstraintLocatorBuilder locator,
                           DeclContext *useDC,
                           PreparedOverloadBuilder *preparedOverload);
 
   /// \returns the opened type, the thrown error type, and the base object type.
   std::tuple<Type, Type, Type> getTypeOfMemberReferenceImpl(
-      Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
-      FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
+      OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
       SmallVectorImpl<OpenedType> *replacements = nullptr,
       PreparedOverloadBuilder *preparedOverload = nullptr);
 
@@ -4477,13 +4472,9 @@ public:
   /// this routine "opens up" the type by replacing each instance of a generic
   /// parameter with a fresh type variable.
   ///
-  /// \param isDynamicLookup Indicates that this declaration was found via
-  /// dynamic lookup.
-  ///
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfMemberReference(
-      Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
-      FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
+      OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
       SmallVectorImpl<OpenedType> *replacements = nullptr,
       PreparedOverloadBuilder *preparedOverload = nullptr);
 
@@ -4497,7 +4488,7 @@ public:
   }
 
 private:
-  DeclReferenceType getTypeOfMemberTypeReference(
+  Type getTypeOfMemberTypeReference(
       Type baseObjTy, TypeDecl *typeDecl, ConstraintLocator *locator,
       PreparedOverloadBuilder *preparedOverload);
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4459,8 +4459,8 @@ public:
                           DeclContext *useDC,
                           PreparedOverloadBuilder *preparedOverload);
 
-  /// \returns the opened type, the thrown error type, and the base object type.
-  std::tuple<Type, Type, Type> getTypeOfMemberReferenceImpl(
+  /// \returns the opened type and the thrown error type.
+  std::pair<Type, Type> getTypeOfMemberReferenceImpl(
       OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
       SmallVectorImpl<OpenedType> *replacements = nullptr,
       PreparedOverloadBuilder *preparedOverload = nullptr);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4931,7 +4931,12 @@ public:
   /// Populate the prepared overload with all type variables and constraints
   /// that are to be introduced into the constraint system when this choice
   /// is taken.
-  DeclReferenceType
+  ///
+  /// Returns a pair consisting of the opened type, and the thrown error type.
+  ///
+  /// FIXME: As a transitional mechanism, if preparedOverload is nullptr, this
+  /// immediately performs all operations.
+  std::pair<Type, Type>
   prepareOverloadImpl(OverloadChoice choice,
                       DeclContext *useDC,
                       ConstraintLocator *locator,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3795,7 +3795,7 @@ public:
   /// Add a constraint that binds an overload set to a specific choice.
   void addBindOverloadConstraint(Type boundTy, OverloadChoice choice,
                                  ConstraintLocator *locator, DeclContext *useDC) {
-    resolveOverload(locator, boundTy, choice, useDC,
+    resolveOverload(choice, useDC, locator, boundTy,
                     /*preparedOverload=*/nullptr);
   }
 
@@ -4439,13 +4439,6 @@ public:
       unsigned numApplies, bool isMainDispatchQueue,
       bool openGlobalActorType, ConstraintLocatorBuilder locator);
 
-  /// \returns The opened type and the thrown error type.
-  std::pair<Type, Type> getTypeOfReferenceImpl(
-                          OverloadChoice choice,
-                          ConstraintLocatorBuilder locator,
-                          DeclContext *useDC,
-                          PreparedOverloadBuilder *preparedOverload);
-
   /// Retrieve the type of a reference to the given value declaration.
   ///
   /// For references to polymorphic function types, this routine "opens up"
@@ -4454,14 +4447,7 @@ public:
   ///
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfReference(
-                          OverloadChoice choice,
-                          ConstraintLocatorBuilder locator,
-                          DeclContext *useDC,
-                          PreparedOverloadBuilder *preparedOverload);
-
-  /// \returns the opened type and the thrown error type.
-  std::pair<Type, Type> getTypeOfMemberReferenceImpl(
-      OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
+      OverloadChoice choice, DeclContext *useDC, ConstraintLocatorBuilder locator,
       PreparedOverloadBuilder *preparedOverload);
 
   /// Retrieve the type of a reference to the given value declaration,
@@ -4486,6 +4472,24 @@ public:
   }
 
 private:
+  /// \returns The opened type and the thrown error type.
+  std::pair<Type, Type> getTypeOfReferencePre(
+       OverloadChoice choice, DeclContext *useDC, ConstraintLocatorBuilder locator,
+       PreparedOverloadBuilder *preparedOverload);
+
+  DeclReferenceType getTypeOfReferencePost(
+       OverloadChoice choice, DeclContext *useDC, ConstraintLocatorBuilder locator,
+       Type openedType, Type thrownErrorType);
+
+  /// \returns the opened type and the thrown error type.
+  std::pair<Type, Type> getTypeOfMemberReferencePre(
+      OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
+      PreparedOverloadBuilder *preparedOverload);
+
+  DeclReferenceType getTypeOfMemberReferencePost(
+      OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
+      Type openedType, Type thrownErrorType);
+
   Type getTypeOfMemberTypeReference(
       Type baseObjTy, TypeDecl *typeDecl, ConstraintLocator *locator,
       PreparedOverloadBuilder *preparedOverload);
@@ -4920,17 +4924,17 @@ public:
                               SelectedOverload choice);
 
   /// Build and allocate a prepared overload in the solver arena.
-  PreparedOverload *prepareOverload(ConstraintLocator *locator,
-                                    OverloadChoice choice,
-                                    DeclContext *useDC);
+  PreparedOverload *prepareOverload(OverloadChoice choice,
+                                    DeclContext *useDC,
+                                    ConstraintLocator *locator);
 
   /// Populate the prepared overload with all type variables and constraints
   /// that are to be introduced into the constraint system when this choice
   /// is taken.
   DeclReferenceType
-  prepareOverloadImpl(ConstraintLocator *locator,
-                      OverloadChoice choice,
+  prepareOverloadImpl(OverloadChoice choice,
                       DeclContext *useDC,
+                      ConstraintLocator *locator,
                       PreparedOverloadBuilder *preparedOverload);
 
   void replayChanges(
@@ -4938,8 +4942,8 @@ public:
       PreparedOverload *preparedOverload);
 
   /// Resolve the given overload set to the given choice.
-  void resolveOverload(ConstraintLocator *locator, Type boundType,
-                       OverloadChoice choice, DeclContext *useDC,
+  void resolveOverload(OverloadChoice choice, DeclContext *useDC,
+                       ConstraintLocator *locator, Type boundType,
                        PreparedOverload *preparedOverload);
 
   /// Simplify a type, by replacing type variables with either their

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4462,8 +4462,7 @@ public:
   /// \returns the opened type and the thrown error type.
   std::pair<Type, Type> getTypeOfMemberReferenceImpl(
       OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
-      SmallVectorImpl<OpenedType> *replacements = nullptr,
-      PreparedOverloadBuilder *preparedOverload = nullptr);
+      PreparedOverloadBuilder *preparedOverload);
 
   /// Retrieve the type of a reference to the given value declaration,
   /// as a member with a base of the given type.
@@ -4475,8 +4474,7 @@ public:
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfMemberReference(
       OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
-      SmallVectorImpl<OpenedType> *replacements = nullptr,
-      PreparedOverloadBuilder *preparedOverload = nullptr);
+      PreparedOverloadBuilder *preparedOverload);
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4520,8 +4520,7 @@ private:
   /// determine the reference type of the member reference.
   Type getMemberReferenceTypeFromOpenedType(
       Type type, Type baseObjTy, ValueDecl *value,
-      ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
-      ArrayRef<OpenedType> replacements);
+      ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup);
 
   /// Add the constraints needed to bind an overload's type variable.
   void bindOverloadType(const SelectedOverload &overload, Type boundType,

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -126,19 +126,18 @@ class OverloadChoice {
   /// FIXME: This needs three bits. Can we pack them somewhere?
   FunctionRefInfo TheFunctionRefInfo = FunctionRefInfo::unappliedBaseName();
 
-public:
-  OverloadChoice() : BaseAndDeclKind(nullptr, 0), DeclOrKind() {}
-
   OverloadChoice(Type base, ValueDecl *value,
                  FunctionRefInfo functionRefInfo)
     : BaseAndDeclKind(base, 0),
       TheFunctionRefInfo(functionRefInfo) {
-    assert(!base || !base->hasTypeParameter());
     assert((reinterpret_cast<uintptr_t>(value) & (uintptr_t)0x03) == 0 &&
            "Badly aligned decl");
     
     DeclOrKind = value;
   }
+
+public:
+  OverloadChoice() : BaseAndDeclKind(nullptr, 0), DeclOrKind() {}
 
   OverloadChoice(Type base, OverloadChoiceKind kind)
       : BaseAndDeclKind(base, 0), DeclOrKind(uint32_t(kind)) {
@@ -160,6 +159,22 @@ public:
   bool isInvalid() const {
     return BaseAndDeclKind.getPointer().isNull() &&
            BaseAndDeclKind.getInt() == 0 && DeclOrKind.isNull();
+  }
+
+  /// Retrieve an overload choice for a declaration that was found via
+  /// unqualified lookup.
+  static OverloadChoice getDecl(ValueDecl *value,
+                                FunctionRefInfo functionRefInfo) {
+    return OverloadChoice(Type(), value, functionRefInfo);
+  }
+
+
+  /// Retrieve an overload choice for a declaration that was found via
+  /// qualified lookup.
+  static OverloadChoice getDecl(Type base, ValueDecl *value,
+                                FunctionRefInfo functionRefInfo) {
+    ASSERT(!base->hasTypeParameter());
+    return OverloadChoice(base, value, functionRefInfo);
   }
 
   /// Retrieve an overload choice for a declaration that was found via

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -88,7 +88,10 @@ struct PreparedOverloadChange {
     AppliedPropertyWrapper,
 
     /// A fix was recorded because a property wrapper application failed.
-    AddedFix
+    AddedFix,
+
+    /// The type of an AST node was changed.
+    RecordedNodeType
   };
 
   /// The kind of change.
@@ -132,7 +135,17 @@ struct PreparedOverloadChange {
       ConstraintFix *TheFix;
       unsigned Impact;
     } Fix;
+
+    /// For ChangeKind::RecordedNodeType.
+    struct {
+      ASTNode Node;
+      Type TheType;
+    } Node;
   };
+
+  PreparedOverloadChange()
+      : Kind(ChangeKind::AddedTypeVariable),
+        TypeVar(nullptr) { }
 };
 
 /// A "pre-cooked" representation of all type variables and constraints
@@ -236,6 +249,14 @@ struct PreparedOverloadBuilder {
     change.Kind = PreparedOverload::Change::AddedFix;
     change.Fix.TheFix = fix;
     change.Fix.Impact = impact;
+    Changes.push_back(change);
+  }
+
+  void recordedNodeType(ASTNode node, Type type) {
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::RecordedNodeType;
+    change.Node.Node = node;
+    change.Node.TheType = type;
     Changes.push_back(change);
   }
 };

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -144,38 +144,29 @@ public:
   using Change = PreparedOverloadChange;
 
 private:
+  Type OpenedType;
+  Type ThrownErrorType;
   size_t Count;
-  DeclReferenceType DeclType;
 
   size_t numTrailingObjects(OverloadToken<Change>) const {
     return Count;
   }
 
 public:
-  PreparedOverload(const DeclReferenceType &declType, ArrayRef<Change> changes)
-    : Count(changes.size()), DeclType(declType) {
+  PreparedOverload(Type openedType, Type thrownErrorType,
+                   ArrayRef<Change> changes)
+    : OpenedType(openedType), ThrownErrorType(thrownErrorType),
+      Count(changes.size()) {
     std::uninitialized_copy(changes.begin(), changes.end(),
                             getTrailingObjects<Change>());
   }
 
   Type getOpenedType() const {
-    return DeclType.openedType;
+    return OpenedType;
   }
 
-  Type getAdjustedOpenedType() const {
-    return DeclType.adjustedOpenedType;
-  }
-
-  Type getReferenceType() const {
-    return DeclType.referenceType;
-  }
-
-  Type getAdjustedReferenceType() const {
-    return DeclType.adjustedReferenceType;
-  }
-
-  Type getThrownErrorTypeOnAccess() const {
-    return DeclType.thrownErrorTypeOnAccess;
+  Type getThrownErrorType() const {
+    return ThrownErrorType;
   }
 
   ArrayRef<Change> getChanges() const {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2465,9 +2465,10 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
       const auto &declRef = SE->getDecl();
       if (auto *subscript =
               dyn_cast_or_null<SubscriptDecl>(declRef.getDecl())) {
-        if (isImmutable(subscript))
-          return {expr, OverloadChoice(getType(SE->getBase()), subscript,
-                                       FunctionRefInfo::doubleBaseNameApply())};
+        if (isImmutable(subscript)) {
+          return {expr, OverloadChoice::getDecl(getType(SE->getBase()), subscript,
+                                                FunctionRefInfo::doubleBaseNameApply())};
+        }
       }
     }
 
@@ -2522,8 +2523,8 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     // If the member isn't settable, then it is the problem: return it.
     if (auto member = dyn_cast<AbstractStorageDecl>(MRE->getMember().getDecl()))
       if (isImmutable(member))
-        return {expr, OverloadChoice(getType(MRE->getBase()), member,
-                                     FunctionRefInfo::singleBaseNameApply())};
+        return {expr, OverloadChoice::getDecl(getType(MRE->getBase()), member,
+                                              FunctionRefInfo::singleBaseNameApply())};
 
     // If we weren't able to resolve a member or if it is mutable, then the
     // problem must be with the base, recurse.
@@ -2543,8 +2544,8 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
   }
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(expr))
-    return {expr, OverloadChoice(Type(), DRE->getDecl(),
-                                 FunctionRefInfo::unappliedBaseName())};
+    return {expr, OverloadChoice::getDecl(DRE->getDecl(),
+                                          FunctionRefInfo::unappliedBaseName())};
 
   // Look through x!
   if (auto *FVE = dyn_cast<ForceValueExpr>(expr))

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2811,6 +2811,9 @@ namespace {
           // interface type request via `var->getType()` that would
           // attempt to validate `weak` attribute, and produce a
           // diagnostic in the middle of the solver path.
+          //
+          // FIXME: getVarType() is now gone. Is the above still
+          // relevant?
 
           CS.addConstraint(ConstraintKind::OneWayEqual, oneWayVarType,
                            varType, locator);
@@ -5241,7 +5244,8 @@ ConstraintSystem::applyPropertyWrapperToParameter(
                   locator,
                   /*isFavored=*/false,
                   preparedOverload);
-    setType(param->getPropertyWrapperWrappedValueVar(), wrappedValueType);
+    setType(param->getPropertyWrapperWrappedValueVar(), wrappedValueType,
+            preparedOverload);
 
     applyPropertyWrapper(anchor,
                          { wrapperType, PropertyWrapperInitKind::WrappedValue },

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1020,7 +1020,7 @@ namespace {
                   options);
       SmallVector<OverloadChoice, 4> outerChoices;
       for (auto decl : outerAlternatives) {
-        outerChoices.push_back(OverloadChoice(Type(), decl, functionRefInfo));
+        outerChoices.push_back(OverloadChoice::getDecl(decl, functionRefInfo));
       }
       CS.addValueMemberConstraint(
           baseTy, name, tv, CurDC, functionRefInfo, outerChoices,
@@ -1044,8 +1044,8 @@ namespace {
       auto tv = CS.createTypeVariable(memberLocator,
                                       TVO_CanBindToLValue | TVO_CanBindToNoEscape);
 
-      OverloadChoice choice =
-          OverloadChoice(CS.getType(base), decl, functionRefInfo);
+      auto choice =
+          OverloadChoice::getDecl(CS.getType(base), decl, functionRefInfo);
 
       auto locator = CS.getConstraintLocator(expr, ConstraintLocator::Member);
       CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
@@ -1162,7 +1162,7 @@ namespace {
       // a known subscript here. This might be cleaner if we split off a new
       // UnresolvedSubscriptExpr from SubscriptExpr.
       if (auto decl = declOrNull) {
-        OverloadChoice choice = OverloadChoice(
+        auto choice = OverloadChoice::getDecl(
             baseTy, decl, FunctionRefInfo::doubleBaseNameApply());
         CS.addBindOverloadConstraint(memberTy, choice, memberLocator,
                                      CurDC);
@@ -1657,8 +1657,8 @@ namespace {
       // resolve it. This records the overload for use later.
       auto tv = CS.createTypeVariable(locator, options);
 
-      OverloadChoice choice =
-          OverloadChoice(Type(), E->getDecl(), E->getFunctionRefInfo());
+      auto choice =
+          OverloadChoice::getDecl(E->getDecl(), E->getFunctionRefInfo());
       CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
       return tv;
     }
@@ -1775,8 +1775,8 @@ namespace {
         if (decls[i]->isInvalid())
           continue;
 
-        OverloadChoice choice =
-            OverloadChoice(Type(), decls[i], expr->getFunctionRefInfo());
+        auto choice =
+            OverloadChoice::getDecl(decls[i], expr->getFunctionRefInfo());
         choices.push_back(choice);
       }
 
@@ -4120,7 +4120,7 @@ namespace {
         // logic.
         if (result->isInvalid())
           continue;
-        OverloadChoice choice = OverloadChoice(Type(), result, functionRefInfo);
+        auto choice = OverloadChoice::getDecl(result, functionRefInfo);
         choices.push_back(choice);
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16742,16 +16742,17 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     if (!preparedOverload) {
       if (enablePreparedOverloads &&
           constraint.getOverloadChoice().canBePrepared()) {
-        preparedOverload = prepareOverload(constraint.getLocator(),
-                                           constraint.getOverloadChoice(),
-                                           constraint.getDeclContext());
+        preparedOverload = prepareOverload(constraint.getOverloadChoice(),
+                                           constraint.getDeclContext(),
+                                           constraint.getLocator());
         const_cast<Constraint &>(constraint).setPreparedOverload(preparedOverload);
       }
     }
 
-    resolveOverload(constraint.getLocator(), constraint.getFirstType(),
-                    constraint.getOverloadChoice(),
+    resolveOverload(constraint.getOverloadChoice(),
                     constraint.getDeclContext(),
+                    constraint.getLocator(),
+                    constraint.getFirstType(),
                     preparedOverload);
     return SolutionKind::Solved;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10491,8 +10491,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         auto choice =
             instanceTy->isAnyObject()
                 ? candidate
-                : OverloadChoice(instanceTy, decl,
-                                 FunctionRefInfo::singleBaseNameApply());
+                : OverloadChoice::getDecl(instanceTy, decl,
+                                          FunctionRefInfo::singleBaseNameApply());
 
         const bool invalidMethodRef = isa<FuncDecl>(decl) && !hasInstanceMethods;
         const bool invalidMemberRef = !isa<FuncDecl>(decl) && !hasInstanceMembers;
@@ -10727,7 +10727,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       }
     }
 
-    return OverloadChoice(baseTy, cand, functionRefInfo);
+    return OverloadChoice::getDecl(baseTy, cand, functionRefInfo);
   };
 
   // Add all results from this lookup.
@@ -11866,7 +11866,8 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   if (!witness)
     return fail();
 
-  auto choice = OverloadChoice(resolvedBaseType, witness.getDecl(), functionRefInfo);
+  auto choice = OverloadChoice::getDecl(
+      resolvedBaseType, witness.getDecl(), functionRefInfo);
   addBindOverloadConstraint(memberType, choice, getConstraintLocator(locator),
                             useDC);
   return SolutionKind::Solved;
@@ -14110,8 +14111,8 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
   SmallVector<OverloadChoice, 4> choices;
   for (auto candidate : candidates) {
     if (candidate->isInvalid()) continue;
-    choices.push_back(OverloadChoice(type2, candidate,
-                                     FunctionRefInfo::singleBaseNameApply()));
+    choices.push_back(OverloadChoice::getDecl(type2, candidate,
+                                              FunctionRefInfo::singleBaseNameApply()));
   }
 
   if (choices.empty()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3508,8 +3508,10 @@ void OpenGenericTypeRequirements::operator()(GenericTypeDecl *decl,
   cs.recordOpenedTypes(locator, replacements, preparedOverload,
                        /*fixmeAllowDuplicates*/ true);
 
-  for (auto [gp, typeVar] : replacements)
-    cs.addConstraint(ConstraintKind::Bind, typeVar, subst(gp), locator);
+  for (auto [gp, typeVar] : replacements) {
+    cs.addConstraint(ConstraintKind::Bind, typeVar, subst(gp), locator,
+                     /*isFavored=*/false, preparedOverload);
+  }
 
   auto openType = [&](Type ty) -> Type {
     return cs.openType(ty, replacements, locator, preparedOverload);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4325,15 +4325,9 @@ Type constraints::getConcreteReplacementForProtocolSelfType(ValueDecl *member) {
   if (!DC->getSelfProtocolDecl())
     return Type();
 
-  GenericSignature signature;
-  if (auto *genericContext = member->getAsGenericContext()) {
-    signature = genericContext->getGenericSignature();
-  } else {
-    signature = DC->getGenericSignatureOfContext();
-  }
-
+  auto sig = member->getInnermostDeclContext()->getGenericSignatureOfContext();
   auto selfTy = DC->getSelfInterfaceType();
-  return signature->getConcreteType(selfTy);
+  return sig->getConcreteType(selfTy);
 }
 
 static bool isOperator(Expr *expr, StringRef expectedName) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4005,8 +4005,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
     if (!(access & RK_Defined))
       continue;
 
-    if (auto *caseStmt =
-            dyn_cast_or_null<CaseStmt>(var->getRecursiveParentPatternStmt())) {
+    if (isa_and_nonnull<CaseStmt>(var->getRecursiveParentPatternStmt())) {
       // Only diagnose for the parent-most VarDecl.
       if (var->getParentVarDecl())
         continue;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1172,11 +1172,9 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
     reqLocator =
         cs->getConstraintLocator(req, ConstraintLocator::ProtocolRequirement);
+    OverloadChoice reqChoice(selfTy, req, FunctionRefInfo::doubleBaseNameApply());
     auto reqTypeInfo =
-        cs->getTypeOfMemberReference(selfTy, req, dc,
-                                     /*isDynamicResult=*/false,
-                                     FunctionRefInfo::doubleBaseNameApply(),
-                                     reqLocator, &reqReplacements);
+        cs->getTypeOfMemberReference(reqChoice, dc, reqLocator, &reqReplacements);
     reqType = reqTypeInfo.adjustedReferenceType;
     reqType = reqType->getRValueType();
 
@@ -1202,23 +1200,23 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     }
 
     // Open up the witness type.
-    SmallVector<OpenedType, 4> witnessReplacements;
-
     witnessType = witness->getInterfaceType();
     witnessLocator =
         cs->getConstraintLocator(req, LocatorPathElt::Witness(witness));
     DeclReferenceType openWitnessTypeInfo;
 
     if (witness->getDeclContext()->isTypeContext()) {
+      OverloadChoice witnessChoice(selfTy, witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
-          cs->getTypeOfMemberReference(selfTy, witness, dc,
-                                       /*isDynamicResult=*/false,
-                                       FunctionRefInfo::doubleBaseNameApply(),
-                                       witnessLocator, &witnessReplacements);
+          cs->getTypeOfMemberReference(witnessChoice, dc,
+                                       witnessLocator,
+                                       /*replacements=*/nullptr,
+                                       /*preparedOverload=*/nullptr);
     } else {
+      OverloadChoice witnessChoice(Type(), witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
           cs->getTypeOfReference(
-                witness, FunctionRefInfo::doubleBaseNameApply(), witnessLocator,
+                witnessChoice, witnessLocator,
                 /*useDC=*/nullptr, /*preparedOverload=*/nullptr);
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1168,13 +1168,13 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
 
     // Open up the type of the requirement.
-    SmallVector<OpenedType, 4> reqReplacements;
-
     reqLocator =
         cs->getConstraintLocator(req, ConstraintLocator::ProtocolRequirement);
     OverloadChoice reqChoice(selfTy, req, FunctionRefInfo::doubleBaseNameApply());
     auto reqTypeInfo =
-        cs->getTypeOfMemberReference(reqChoice, dc, reqLocator, &reqReplacements);
+        cs->getTypeOfMemberReference(reqChoice, dc, reqLocator,
+                                     /*preparedOverload=*/nullptr);
+
     reqType = reqTypeInfo.adjustedReferenceType;
     reqType = reqType->getRValueType();
 
@@ -1182,7 +1182,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
     // For any type parameters we replaced in the witness, map them
     // to the corresponding archetypes in the witness's context.
-    for (const auto &replacement : reqReplacements) {
+    for (const auto &replacement : cs->getOpenedTypes(reqLocator)) {
       auto replacedInReq = Type(replacement.first).subst(reqSubMap);
 
       // If substitution failed, skip the requirement. This only occurs in
@@ -1210,7 +1210,6 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
       openWitnessTypeInfo =
           cs->getTypeOfMemberReference(witnessChoice, dc,
                                        witnessLocator,
-                                       /*replacements=*/nullptr,
                                        /*preparedOverload=*/nullptr);
     } else {
       OverloadChoice witnessChoice(Type(), witness, FunctionRefInfo::doubleBaseNameApply());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1208,15 +1208,14 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     if (witness->getDeclContext()->isTypeContext()) {
       OverloadChoice witnessChoice(selfTy, witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
-          cs->getTypeOfMemberReference(witnessChoice, dc,
-                                       witnessLocator,
+          cs->getTypeOfMemberReference(witnessChoice, dc, witnessLocator,
                                        /*preparedOverload=*/nullptr);
     } else {
       OverloadChoice witnessChoice(Type(), witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
           cs->getTypeOfReference(
-                witnessChoice, witnessLocator,
-                /*useDC=*/nullptr, /*preparedOverload=*/nullptr);
+                witnessChoice, /*useDC=*/nullptr, witnessLocator,
+                /*preparedOverload=*/nullptr);
     }
 
     openWitnessType = openWitnessTypeInfo.adjustedReferenceType;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1170,7 +1170,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     // Open up the type of the requirement.
     reqLocator =
         cs->getConstraintLocator(req, ConstraintLocator::ProtocolRequirement);
-    OverloadChoice reqChoice(selfTy, req, FunctionRefInfo::doubleBaseNameApply());
+    auto reqChoice = OverloadChoice::getDecl(
+        selfTy, req, FunctionRefInfo::doubleBaseNameApply());
     auto reqTypeInfo =
         cs->getTypeOfMemberReference(reqChoice, dc, reqLocator,
                                      /*preparedOverload=*/nullptr);
@@ -1206,12 +1207,14 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     DeclReferenceType openWitnessTypeInfo;
 
     if (witness->getDeclContext()->isTypeContext()) {
-      OverloadChoice witnessChoice(selfTy, witness, FunctionRefInfo::doubleBaseNameApply());
+      auto witnessChoice = OverloadChoice::getDecl(
+          selfTy, witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
           cs->getTypeOfMemberReference(witnessChoice, dc, witnessLocator,
                                        /*preparedOverload=*/nullptr);
     } else {
-      OverloadChoice witnessChoice(Type(), witness, FunctionRefInfo::doubleBaseNameApply());
+      auto witnessChoice = OverloadChoice::getDecl(
+          witness, FunctionRefInfo::doubleBaseNameApply());
       openWitnessTypeInfo =
           cs->getTypeOfReference(
                 witnessChoice, /*useDC=*/nullptr, witnessLocator,

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2834,6 +2834,10 @@ void ConstraintSystem::replayChanges(
     case PreparedOverload::Change::AddedFix:
       recordFix(change.Fix.TheFix, change.Fix.Impact);
       break;
+
+    case PreparedOverload::Change::RecordedNodeType:
+      setType(change.Node.Node, change.Node.TheType);
+      break;
     }
   }
 }

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1109,10 +1109,10 @@ recordFixIfNeededForPlaceholderInDecl(ConstraintSystem &cs, ValueDecl *D,
 }
 
 std::pair<Type, Type>
-ConstraintSystem::getTypeOfReferenceImpl(OverloadChoice choice,
-                                         ConstraintLocatorBuilder locator,
-                                         DeclContext *useDC,
-                                         PreparedOverloadBuilder *preparedOverload) {
+ConstraintSystem::getTypeOfReferencePre(OverloadChoice choice,
+                                        DeclContext *useDC,
+                                        ConstraintLocatorBuilder locator,
+                                        PreparedOverloadBuilder *preparedOverload) {
   auto *value = choice.getDecl();
 
   ASSERT(!!preparedOverload == PreparingOverload);
@@ -1237,16 +1237,10 @@ ConstraintSystem::getTypeOfReferenceImpl(OverloadChoice choice,
 }
 
 DeclReferenceType
-ConstraintSystem::getTypeOfReference(OverloadChoice choice,
-                                     ConstraintLocatorBuilder locator,
-                                     DeclContext *useDC,
-                                     PreparedOverloadBuilder *preparedOverload) {
-  ASSERT(!!preparedOverload == PreparingOverload);
-
-  Type openedType, thrownErrorType;
-  std::tie(openedType, thrownErrorType) = getTypeOfReferenceImpl(
-      choice, locator, useDC, preparedOverload);
-
+ConstraintSystem::getTypeOfReferencePost(OverloadChoice choice,
+                                         DeclContext *useDC,
+                                         ConstraintLocatorBuilder locator,
+                                         Type openedType, Type thrownErrorType) {
   auto *value = choice.getDecl();
 
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
@@ -1331,7 +1325,24 @@ ConstraintSystem::getTypeOfReference(OverloadChoice choice,
         ClosureIsolatedByPreconcurrency{*this});
   }
 
-  return { origOpenedType, openedType, origOpenedType, openedType, thrownErrorType };
+  return { origOpenedType, openedType,
+           origOpenedType, openedType,
+           thrownErrorType };
+}
+
+DeclReferenceType
+ConstraintSystem::getTypeOfReference(OverloadChoice choice,
+                                     DeclContext *useDC,
+                                     ConstraintLocatorBuilder locator,
+                                     PreparedOverloadBuilder *preparedOverload) {
+  ASSERT(!!preparedOverload == PreparingOverload);
+
+  Type openedType, thrownErrorType;
+  std::tie(openedType, thrownErrorType) = getTypeOfReferencePre(
+      choice, useDC, locator, preparedOverload);
+
+  return getTypeOfReferencePost(choice, useDC, locator,
+                                openedType, thrownErrorType);
 }
 
 /// Bind type variables for archetypes that are determined from
@@ -1856,7 +1867,7 @@ static FunctionType *applyOptionality(ValueDecl *value, FunctionType *fnTy) {
 }
 
 std::pair<Type, Type>
-ConstraintSystem::getTypeOfMemberReferenceImpl(
+ConstraintSystem::getTypeOfMemberReferencePre(
     OverloadChoice choice, DeclContext *useDC,
     ConstraintLocator *locator,
     PreparedOverloadBuilder *preparedOverload) {
@@ -2032,12 +2043,15 @@ ConstraintSystem::getTypeOfMemberReferenceImpl(
   return { openedType, thrownErrorType };
 }
 
-DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
+DeclReferenceType ConstraintSystem::getTypeOfMemberReferencePost(
     OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
-    PreparedOverloadBuilder *preparedOverload) {
-  ASSERT(!!preparedOverload == PreparingOverload);
-
+    Type openedType, Type thrownErrorType) {
   auto *value = choice.getDecl();
+
+  if (isa<TypeDecl>(value)) {
+    auto type = openedType->castTo<FunctionType>()->getResult();
+    return { openedType, openedType, type, type, Type() };
+  }
 
   // Figure out the instance type used for the base.
   Type baseTy = choice.getBaseType();
@@ -2047,15 +2061,6 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   // A reference to a module member is really unqualified, and should
   // be handled by the caller via getTypeOfReference().
   ASSERT(!baseObjTy->is<ModuleType>());
-
-  Type openedType, thrownErrorType;
-  std::tie(openedType, thrownErrorType)
-      = getTypeOfMemberReferenceImpl(choice, useDC, locator, preparedOverload);
-
-  if (isa<TypeDecl>(value)) {
-    auto type = openedType->castTo<FunctionType>()->getResult();
-    return { openedType, openedType, type, type, Type() };
-  }
 
   auto hasAppliedSelf = doesMemberRefApplyCurriedSelf(baseRValueTy, value);
 
@@ -2111,6 +2116,19 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   }
 
   return { origOpenedType, openedType, origType, type, thrownErrorType };
+}
+
+DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
+    OverloadChoice choice, DeclContext *useDC, ConstraintLocator *locator,
+    PreparedOverloadBuilder *preparedOverload) {
+  ASSERT(!!preparedOverload == PreparingOverload);
+
+  Type openedType, thrownErrorType;
+  std::tie(openedType, thrownErrorType)
+      = getTypeOfMemberReferencePre(choice, useDC, locator, preparedOverload);
+
+  return getTypeOfMemberReferencePost(
+      choice, useDC, locator, openedType, thrownErrorType);
 }
 
 Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
@@ -2825,9 +2843,9 @@ void ConstraintSystem::replayChanges(
 /// FIXME: As a transitional mechanism, if preparedOverload is nullptr, this
 /// immediately performs all operations.
 DeclReferenceType
-ConstraintSystem::prepareOverloadImpl(ConstraintLocator *locator,
-                                      OverloadChoice choice,
+ConstraintSystem::prepareOverloadImpl(OverloadChoice choice,
                                       DeclContext *useDC,
+                                      ConstraintLocator *locator,
                                       PreparedOverloadBuilder *preparedOverload) {
   // If we refer to a top-level decl with special type-checking semantics,
   // handle it now.
@@ -2842,23 +2860,23 @@ ConstraintSystem::prepareOverloadImpl(ConstraintLocator *locator,
 
     // If the base is a module type, it's an unqualified reference.
     if (baseTy->getMetatypeInstanceType()->is<ModuleType>()) {
-      return getTypeOfReference(choice, locator, useDC, preparedOverload);
+      return getTypeOfReference(choice, useDC, locator, preparedOverload);
     }
 
     return getTypeOfMemberReference(choice, useDC, locator, preparedOverload);
   } else {
-    return getTypeOfReference(choice, locator, useDC, preparedOverload);
+    return getTypeOfReference(choice, useDC, locator, preparedOverload);
   }
 }
 
-PreparedOverload *ConstraintSystem::prepareOverload(ConstraintLocator *locator,
-                                                    OverloadChoice choice,
-                                                    DeclContext *useDC) {
+PreparedOverload *ConstraintSystem::prepareOverload(OverloadChoice choice,
+                                                    DeclContext *useDC,
+                                                    ConstraintLocator *locator) {
   ASSERT(!PreparingOverload);
   PreparingOverload = true;
 
   PreparedOverloadBuilder builder;
-  auto declRefType = prepareOverloadImpl(locator, choice, useDC, &builder);
+  auto declRefType = prepareOverloadImpl(choice, useDC, locator, &builder);
 
   PreparingOverload = false;
 
@@ -2869,9 +2887,8 @@ PreparedOverload *ConstraintSystem::prepareOverload(ConstraintLocator *locator,
   return new (mem) PreparedOverload(declRefType, builder.Changes);
 }
 
-void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
-                                       Type boundType, OverloadChoice choice,
-                                       DeclContext *useDC,
+void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC,
+                                       ConstraintLocator *locator, Type boundType,
                                        PreparedOverload *preparedOverload) {
   // Determine the type to which we'll bind the overload set's type.
   Type openedType;
@@ -2896,7 +2913,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       adjustedRefType = preparedOverload->getAdjustedReferenceType();
       thrownErrorTypeOnAccess = preparedOverload->getThrownErrorTypeOnAccess();
     } else {
-      auto declRefType = prepareOverloadImpl(locator, choice, useDC, nullptr);
+      auto declRefType = prepareOverloadImpl(choice, useDC, locator, nullptr);
 
       openedType = declRefType.openedType;
       adjustedOpenedType = declRefType.adjustedOpenedType;

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2037,12 +2037,12 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   } else if (isa<AbstractFunctionDecl>(value) || isa<EnumElementDecl>(value)) {
     unsigned numApplies = getNumApplications(hasAppliedSelf, functionRefInfo);
     openedType = adjustFunctionTypeForConcurrency(
-        origOpenedType->castTo<FunctionType>(), baseRValueTy, value, useDC,
+        origOpenedType->castTo<FunctionType>(), baseObjTy, value, useDC,
         numApplies, isMainDispatchQueueMember(locator),
         /*openGlobalActorType=*/true, locator);
   } else if (auto subscript = dyn_cast<SubscriptDecl>(value)) {
     openedType = adjustFunctionTypeForConcurrency(
-        origOpenedType->castTo<FunctionType>(), baseRValueTy, subscript, useDC,
+        origOpenedType->castTo<FunctionType>(), baseObjTy, subscript, useDC,
         /*numApplies=*/2, /*isMainDispatchQueue=*/false,
         /*openGlobalActorType=*/true, locator);
   } else if (auto var = dyn_cast<VarDecl>(value)) {

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -303,7 +303,8 @@ public:
     // an invalid AST node.
     if (type->hasError()) {
       cs.recordFix(
-          IgnoreInvalidASTNode::create(cs, cs.getConstraintLocator(locator)));
+          IgnoreInvalidASTNode::create(cs, cs.getConstraintLocator(locator)),
+          /*impact=*/1, preparedOverload);
     }
     return type.transformRec([&](Type type) -> std::optional<Type> {
       if (!type->hasUnboundGenericType() && !type->hasPlaceholder() &&

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2625,7 +2625,7 @@ isInvalidPartialApplication(ConstraintSystem &cs,
 /// checking semantics, compute the type of the reference.  For now, follow
 /// the lead of \c getTypeOfMemberReference and return a pair of
 /// the full opened type and the reference's type.
-static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
+static Type getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     ConstraintSystem &CS, ConstraintLocator *locator,
     DeclTypeCheckingSemantics semantics,
     PreparedOverloadBuilder *preparedOverload) {
@@ -2654,8 +2654,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         /*isFavored=*/false, preparedOverload);
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     FunctionType::ExtInfo info;
-    auto refType = FunctionType::get({inputArg}, output, info);
-    return {refType, refType, refType, refType, Type()};
+    return FunctionType::get({inputArg}, output, info);
   }
   case DeclTypeCheckingSemantics::WithoutActuallyEscaping: {
     // Proceed with a "WithoutActuallyEscaping" operation. The body closure
@@ -2702,14 +2701,13 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
       withoutEscapingIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
     }
 
-    auto refType = FunctionType::get(args, result,
-                                     FunctionType::ExtInfoBuilder()
-                                         .withNoEscape(false)
-                                         .withIsolation(withoutEscapingIsolation)
-                                         .withAsync(true)
-                                         .withThrows(true, thrownError)
-                                         .build());
-    return {refType, refType, refType, refType, Type()};
+    return FunctionType::get(args, result,
+                             FunctionType::ExtInfoBuilder()
+                                 .withNoEscape(false)
+                                 .withIsolation(withoutEscapingIsolation)
+                                 .withAsync(true)
+                                 .withThrows(true, thrownError)
+                                 .build());
   }
   case DeclTypeCheckingSemantics::OpenExistential: {
     // The body closure receives a freshly-opened archetype constrained by the
@@ -2755,14 +2753,13 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
       openExistentialIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
     }
 
-    auto refType = FunctionType::get(args, result,
-                                     FunctionType::ExtInfoBuilder()
-                                         .withNoEscape(false)
-                                         .withThrows(true, thrownError)
-                                         .withIsolation(openExistentialIsolation)
-                                         .withAsync(true)
-                                         .build());
-    return {refType, refType, refType, refType, Type()};
+    return FunctionType::get(args, result,
+                             FunctionType::ExtInfoBuilder()
+                                 .withNoEscape(false)
+                                 .withThrows(true, thrownError)
+                                 .withIsolation(openExistentialIsolation)
+                                 .withAsync(true)
+                                 .build());
   }
   }
 
@@ -2840,9 +2837,11 @@ void ConstraintSystem::replayChanges(
 /// that are to be introduced into the constraint system when this choice
 /// is taken.
 ///
+/// Returns a pair consisting of the opened type, and the thrown error type.
+///
 /// FIXME: As a transitional mechanism, if preparedOverload is nullptr, this
 /// immediately performs all operations.
-DeclReferenceType
+std::pair<Type, Type>
 ConstraintSystem::prepareOverloadImpl(OverloadChoice choice,
                                       DeclContext *useDC,
                                       ConstraintLocator *locator,
@@ -2852,20 +2851,21 @@ ConstraintSystem::prepareOverloadImpl(OverloadChoice choice,
   auto semantics =
       TypeChecker::getDeclTypeCheckingSemantics(choice.getDecl());
   if (semantics != DeclTypeCheckingSemantics::Normal) {
-    return getTypeOfReferenceWithSpecialTypeCheckingSemantics(
+    auto openedType = getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         *this, locator, semantics, preparedOverload);
+    return {openedType, Type()};
   } else if (auto baseTy = choice.getBaseType()) {
     // Retrieve the type of a reference to the specific declaration choice.
     assert(!baseTy->hasTypeParameter());
 
     // If the base is a module type, it's an unqualified reference.
     if (baseTy->getMetatypeInstanceType()->is<ModuleType>()) {
-      return getTypeOfReference(choice, useDC, locator, preparedOverload);
+      return getTypeOfReferencePre(choice, useDC, locator, preparedOverload);
     }
 
-    return getTypeOfMemberReference(choice, useDC, locator, preparedOverload);
+    return getTypeOfMemberReferencePre(choice, useDC, locator, preparedOverload);
   } else {
-    return getTypeOfReference(choice, useDC, locator, preparedOverload);
+    return getTypeOfReferencePre(choice, useDC, locator, preparedOverload);
   }
 }
 
@@ -2876,7 +2876,10 @@ PreparedOverload *ConstraintSystem::prepareOverload(OverloadChoice choice,
   PreparingOverload = true;
 
   PreparedOverloadBuilder builder;
-  auto declRefType = prepareOverloadImpl(choice, useDC, locator, &builder);
+  Type openedType;
+  Type thrownErrorType;
+  std::tie(openedType, thrownErrorType) = prepareOverloadImpl(
+      choice, useDC, locator, &builder);
 
   PreparingOverload = false;
 
@@ -2884,7 +2887,7 @@ PreparedOverload *ConstraintSystem::prepareOverload(OverloadChoice choice,
   auto size = PreparedOverload::totalSizeToAlloc<PreparedOverload::Change>(count);
   auto mem = Allocator.Allocate(size, alignof(PreparedOverload));
 
-  return new (mem) PreparedOverload(declRefType, builder.Changes);
+  return new (mem) PreparedOverload(openedType, thrownErrorType, builder.Changes);
 }
 
 void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC,
@@ -2895,7 +2898,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
   Type adjustedOpenedType;
   Type refType;
   Type adjustedRefType;
-  Type thrownErrorTypeOnAccess;
+  Type thrownErrorType;
 
   switch (choice.getKind()) {
   case OverloadChoiceKind::Decl:
@@ -2908,18 +2911,40 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
       replayChanges(locator, preparedOverload);
 
       openedType = preparedOverload->getOpenedType();
-      adjustedOpenedType = preparedOverload->getAdjustedOpenedType();
-      refType = preparedOverload->getReferenceType();
-      adjustedRefType = preparedOverload->getAdjustedReferenceType();
-      thrownErrorTypeOnAccess = preparedOverload->getThrownErrorTypeOnAccess();
+      thrownErrorType = preparedOverload->getThrownErrorType();
     } else {
-      auto declRefType = prepareOverloadImpl(choice, useDC, locator, nullptr);
+      std::tie(openedType, thrownErrorType) = prepareOverloadImpl(
+          choice, useDC, locator, nullptr);
+    }
+
+    auto semantics =
+        TypeChecker::getDeclTypeCheckingSemantics(choice.getDecl());
+    if (semantics != DeclTypeCheckingSemantics::Normal) {
+      adjustedOpenedType = openedType;
+      refType = openedType;
+      adjustedRefType = openedType;
+    } else {
+      DeclReferenceType declRefType;
+
+      if (auto baseTy = choice.getBaseType()) {
+        // If the base is a module type, it's an unqualified reference.
+        if (baseTy->getMetatypeInstanceType()->is<ModuleType>()) {
+          declRefType = getTypeOfReferencePost(
+              choice, useDC, locator, openedType, thrownErrorType);
+        } else {
+          declRefType = getTypeOfMemberReferencePost(
+              choice, useDC, locator, openedType, thrownErrorType);
+        }
+      } else {
+        declRefType = getTypeOfReferencePost(
+            choice, useDC, locator, openedType, thrownErrorType);
+      }
 
       openedType = declRefType.openedType;
       adjustedOpenedType = declRefType.adjustedOpenedType;
       refType = declRefType.referenceType;
       adjustedRefType = declRefType.adjustedReferenceType;
-      thrownErrorTypeOnAccess = declRefType.thrownErrorTypeOnAccess;
+      thrownErrorType = declRefType.thrownErrorTypeOnAccess;
     }
 
     break;
@@ -3110,9 +3135,9 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
 
   // If accessing this declaration could throw an error, record this as a
   // potential throw site.
-  if (thrownErrorTypeOnAccess) {
+  if (thrownErrorType) {
     recordPotentialThrowSite(
-        PotentialThrowSite::PropertyAccess, thrownErrorTypeOnAccess, locator);
+        PotentialThrowSite::PropertyAccess, thrownErrorType, locator);
   }
 
   // Note that we have resolved this overload.

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2891,11 +2891,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
                                        ConstraintLocator *locator, Type boundType,
                                        PreparedOverload *preparedOverload) {
   // Determine the type to which we'll bind the overload set's type.
-  Type openedType;
-  Type adjustedOpenedType;
-  Type refType;
-  Type adjustedRefType;
-  Type thrownErrorType;
+  DeclReferenceType declRefType;
 
   switch (choice.getKind()) {
   case OverloadChoiceKind::Decl:
@@ -2904,6 +2900,8 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
+    Type openedType, thrownErrorType;
+
     if (preparedOverload) {
       replayChanges(locator, preparedOverload);
 
@@ -2917,12 +2915,12 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     auto semantics =
         TypeChecker::getDeclTypeCheckingSemantics(choice.getDecl());
     if (semantics != DeclTypeCheckingSemantics::Normal) {
-      adjustedOpenedType = openedType;
-      refType = openedType;
-      adjustedRefType = openedType;
+      declRefType.openedType = openedType;
+      declRefType.adjustedOpenedType = openedType;
+      declRefType.referenceType = openedType;
+      declRefType.adjustedReferenceType = openedType;
+      declRefType.thrownErrorTypeOnAccess = thrownErrorType;
     } else {
-      DeclReferenceType declRefType;
-
       if (choice.getBaseType()) {
         declRefType = getTypeOfMemberReferencePost(
             choice, useDC, locator, openedType, thrownErrorType);
@@ -2930,12 +2928,6 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
         declRefType = getTypeOfReferencePost(
             choice, useDC, locator, openedType, thrownErrorType);
       }
-
-      openedType = declRefType.openedType;
-      adjustedOpenedType = declRefType.adjustedOpenedType;
-      refType = declRefType.referenceType;
-      adjustedRefType = declRefType.adjustedReferenceType;
-      thrownErrorType = declRefType.thrownErrorTypeOnAccess;
     }
 
     break;
@@ -2945,14 +2937,16 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     if (auto lvalueTy = choice.getBaseType()->getAs<LValueType>()) {
       // When the base of a tuple lvalue, the member is always an lvalue.
       auto tuple = lvalueTy->getObjectType()->castTo<TupleType>();
-      adjustedRefType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
-      adjustedRefType = LValueType::get(adjustedRefType);
+      declRefType.adjustedReferenceType =
+          LValueType::get(
+              tuple->getElementType(choice.getTupleIndex())->getRValueType());
     } else {
       // When the base is a tuple rvalue, the member is always an rvalue.
       auto tuple = choice.getBaseType()->castTo<TupleType>();
-      adjustedRefType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
+      declRefType.adjustedReferenceType =
+          tuple->getElementType(choice.getTupleIndex())->getRValueType();
     }
-    refType = adjustedRefType;
+    declRefType.referenceType = declRefType.adjustedReferenceType;
     break;
 
   case OverloadChoiceKind::MaterializePack: {
@@ -2962,18 +2956,18 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     // In the future, _if_ the syntax allows for multiple expansions
     // this code would have to be adjusted to project l-value from the
     // base type just like TupleIndex does.
-    adjustedRefType =
+    declRefType.adjustedReferenceType =
         getPatternTypeOfSingleUnlabeledPackExpansionTuple(choice.getBaseType());
-    refType = adjustedRefType;
+    declRefType.referenceType = declRefType.adjustedReferenceType;
     break;
   }
 
   case OverloadChoiceKind::ExtractFunctionIsolation: {
     // The type of `.isolation` is `(any Actor)?`
     auto actor = getASTContext().getProtocol(KnownProtocolKind::Actor);
-    adjustedRefType =
+    declRefType.adjustedReferenceType =
         OptionalType::get(actor->getDeclaredExistentialType());
-    refType = adjustedRefType;
+    declRefType.referenceType = declRefType.adjustedReferenceType;
     break;
   }
 
@@ -3004,11 +2998,11 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     FunctionType::ExtInfo fullInfo;
     auto fullTy = FunctionType::get({baseParam}, subscriptTy, fullInfo);
-    openedType = fullTy;
-    adjustedOpenedType = fullTy;
+    declRefType.openedType = fullTy;
+    declRefType.adjustedOpenedType = fullTy;
     // FIXME: @preconcurrency
-    refType = subscriptTy;
-    adjustedRefType = subscriptTy;
+    declRefType.referenceType = subscriptTy;
+    declRefType.adjustedReferenceType = subscriptTy;
 
     // Increase the score so that actual subscripts get preference.
     // ...except if we're solving for code completion and the index expression
@@ -3021,8 +3015,9 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     break;
   }
   }
-  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");
-  assert(!adjustedRefType->hasTypeParameter() &&
+  assert(!declRefType.referenceType->hasTypeParameter() &&
+         "Cannot have a dependent type here");
+  assert(!declRefType.adjustedReferenceType->hasTypeParameter() &&
          "Cannot have a dependent type here");
 
   if (auto *decl = choice.getDeclOrNull()) {
@@ -3042,7 +3037,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
       if (locator->isResultOfKeyPathDynamicMemberLookup() ||
           locator->isKeyPathSubscriptComponent()) {
         // Subscript type has a format of (Self[.Type) -> (Arg...) -> Result
-        auto declTy = adjustedOpenedType->castTo<FunctionType>();
+        auto declTy = declRefType.adjustedOpenedType->castTo<FunctionType>();
         auto subscriptTy = declTy->getResult()->castTo<FunctionType>();
         // If we have subscript, each of the arguments has to conform to
         // Hashable, because it would be used as a component inside key path.
@@ -3114,7 +3109,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
 
       // The default type of the #isolation builtin macro is `(any Actor)?`
       if (macro->getBuiltinKind() == BuiltinMacroKind::IsolationMacro) {
-        auto *fnType = openedType->getAs<FunctionType>();
+        auto *fnType = declRefType.openedType->getAs<FunctionType>();
         auto actor = getASTContext().getProtocol(KnownProtocolKind::Actor);
         addConstraint(
             ConstraintKind::Defaultable, fnType->getResult(),
@@ -3126,14 +3121,20 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
 
   // If accessing this declaration could throw an error, record this as a
   // potential throw site.
-  if (thrownErrorType) {
+  if (declRefType.thrownErrorTypeOnAccess) {
     recordPotentialThrowSite(
-        PotentialThrowSite::PropertyAccess, thrownErrorType, locator);
+        PotentialThrowSite::PropertyAccess,
+        declRefType.thrownErrorTypeOnAccess,
+        locator);
   }
 
   // Note that we have resolved this overload.
   auto overload = SelectedOverload{
-      choice, openedType, adjustedOpenedType, refType, adjustedRefType,
+      choice,
+      declRefType.openedType,
+      declRefType.adjustedOpenedType,
+      declRefType.referenceType,
+      declRefType.adjustedReferenceType,
       boundType};
   recordResolvedOverload(locator, overload);
 
@@ -3149,7 +3150,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
     log << "(overload set choice binding ";
     boundType->print(log, PO);
     log << " := ";
-    adjustedRefType->print(log, PO);
+    declRefType.adjustedReferenceType->print(log, PO);
 
     auto openedAtLoc = getOpenedTypes(locator);
     if (!openedAtLoc.empty()) {
@@ -3181,8 +3182,9 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
                   OverloadChoiceKind::DeclViaDynamic)) {
 
         // Strip curried 'self' parameters.
-        auto fromTy = openedType->castTo<AnyFunctionType>()->getResult();
-        auto toTy = refType;
+        auto fromTy = declRefType.openedType
+            ->castTo<AnyFunctionType>()->getResult();
+        auto toTy = declRefType.referenceType;
         if (!doesMemberRefApplyCurriedSelf(baseTy, decl)) {
           toTy = toTy->castTo<AnyFunctionType>()->getResult();
         }

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -814,27 +814,24 @@ void ConstraintSystem::recordOpenedTypes(
 
   // If the last path element is an archetype or associated type, ignore it.
   SmallVector<LocatorPathElt, 2> pathElts;
-  auto anchor = locator.getLocatorParts(pathElts);
+  (void) locator.getLocatorParts(pathElts);
   if (!pathElts.empty() &&
       pathElts.back().getKind() == ConstraintLocator::GenericParameter)
-    return;
-
-  // If the locator is empty, ignore it.
-  if (!anchor && pathElts.empty())
     return;
 
   ConstraintLocator *locatorPtr = getConstraintLocator(locator);
   assert(locatorPtr && "No locator for opened types?");
 
-  OpenedType *openedTypes
-    = Allocator.Allocate<OpenedType>(replacements.size());
-  std::copy(replacements.begin(), replacements.end(), openedTypes);
-
   // FIXME: Get rid of fixmeAllowDuplicates.
-  if (!fixmeAllowDuplicates || OpenedTypes.count(locatorPtr) == 0)
+  if (!fixmeAllowDuplicates || OpenedTypes.count(locatorPtr) == 0) {
+    OpenedType *openedTypes
+      = Allocator.Allocate<OpenedType>(replacements.size());
+    std::copy(replacements.begin(), replacements.end(), openedTypes);
+
     recordOpenedType(
       locatorPtr, llvm::ArrayRef(openedTypes, replacements.size()),
       preparedOverload);
+  }
 }
 
 /// Determine how many levels of argument labels should be removed from the
@@ -1757,8 +1754,7 @@ static bool isExistentialMemberAccessWithExplicitBaseExpression(
 
 Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
     Type type, Type baseObjTy, ValueDecl *value,
-    ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup,
-    ArrayRef<OpenedType> replacements) {
+    ConstraintLocator *locator, bool hasAppliedSelf, bool isDynamicLookup) {
   auto *outerDC = value->getDeclContext();
 
   // Cope with dynamic 'Self'.
@@ -1790,8 +1786,8 @@ Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
           baseObjTy, value, locator, isDynamicLookup) &&
       // If there are no type variables, there were no references to 'Self'.
       type->hasTypeVariable()) {
-    auto selfGP = outerDC->getSelfInterfaceType();
-    ASSERT(selfGP->isEqual(replacements[0].first));
+    auto replacements = getOpenedTypes(locator);
+    ASSERT(replacements[0].first->isEqual(getASTContext().TheSelfType));
     auto openedTypeVar = replacements[0].second;
 
     type = typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar,
@@ -2072,14 +2068,14 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   // Handle DynamicSelfType and a couple of other things.
   Type type = getMemberReferenceTypeFromOpenedType(
       openedType, baseObjTy, value, locator, hasAppliedSelf,
-      isDynamicLookup, replacements);
+      isDynamicLookup);
 
   // Do the same thing for the original type, if there can be any difference.
   Type origType = type;
   if (openedType.getPointer() != origOpenedType.getPointer()) {
     origType = getMemberReferenceTypeFromOpenedType(
         origOpenedType, baseObjTy, value, locator, hasAppliedSelf,
-        isDynamicLookup, replacements);
+        isDynamicLookup);
   }
 
   return { origOpenedType, openedType, origType, type, thrownErrorType };


### PR DESCRIPTION
This PR is another intermediate step on my quest to simplify getTypeOfReference()/getTypeOfMemberReference().

These functions are used in exactly two places: when applying a disjunction choice inside the solver, and in protocol witness matching. I cleaned up the latter code path a bit to make it look more like what happens in the solver, and this allowed me to simplify the parameter lists of both functions a fair bit; both take an OverloadChoice now.

The Pre()/Post() split is transitional and I'm going to re-organize this a little bit more, but I'd like to land this separately and test source compatibility first.