### PR TITLE
[cxx-interop] Import STL types as copyable, conditionally

### DIFF
--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify - -I %t/Inputs %t/test.swift
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %t/Inputs %t/test.swift
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %t/Inputs %t/test.swift
 
 //--- Inputs/module.modulemap
@@ -45,9 +45,7 @@ using NonCopyableRequires = RequiresCopyableT<NonCopyable>;
 import Test
 import CxxStdlib
 
-func takeCopyable<T: Copyable>(_ x: T) {} 
-// expected-note@-1 {{'where T: Copyable' is implicit here}}
-// expected-cpp20-note@-2 {{'where T: Copyable' is implicit here}}
+func takeCopyable<T: Copyable>(_ x: T) {} // expected-note * {{'where T: Copyable' is implicit here}}
 
 func userDefinedTypes() {
     let nCop = NonCopyable()
@@ -55,7 +53,6 @@ func userDefinedTypes() {
 
     let ownsT = OwnsNonCopyable()
     takeCopyable(ownsT) // no error, OwnsNonCopyable imported as Copyable
-
 }
 
 #if CPP20
@@ -64,4 +61,3 @@ func useOfRequires() {
     takeCopyable(nCop) // expected-cpp20-error {{global function 'takeCopyable' requires that 'NonCopyableRequires' (aka 'RequiresCopyableT<NonCopyable>') conform to 'Copyable'}}
 }
 #endif
-

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -17,4 +17,14 @@ inline UnorderedMap initUnorderedMap() { return {{1, 3}, {3, 3}, {2, 2}}; }
 inline Map initEmptyMap() { return {}; }
 inline UnorderedMap initEmptyUnorderedMap() { return {}; }
 
+struct NonCopyable {
+  NonCopyable() = default;
+  NonCopyable(const NonCopyable &other) = delete;
+  NonCopyable(NonCopyable &&other) = default;
+  ~NonCopyable() {}
+};
+
+using MapNonCopyableKey = std::map<NonCopyable, int>;
+using MapNonCopyableValue = std::map<int, NonCopyable>;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-set.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-set.h
@@ -12,4 +12,13 @@ inline SetOfCInt initSetOfCInt() { return {1, 5, 3}; }
 inline UnorderedSetOfCInt initUnorderedSetOfCInt() { return {2, 4, 6}; }
 inline MultisetOfCInt initMultisetOfCInt() { return {2, 2, 4, 6}; }
 
+struct NonCopyable {
+  NonCopyable() = default;
+  NonCopyable(const NonCopyable &other) = delete;
+  NonCopyable(NonCopyable &&other) = default;
+  ~NonCopyable() {}
+};
+
+using SetOfNonCopyable = std::set<NonCopyable>;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SET_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 struct NonCopyable {
     NonCopyable(int x) : x(x) {}
@@ -25,6 +26,13 @@ struct NonCopyableDerived: public NonCopyable {
 
 inline std::shared_ptr<NonCopyable> getNonCopyableSharedPtr() { return std::make_shared<NonCopyableDerived>(42); }
 inline std::unique_ptr<NonCopyable> getNonCopyableUniquePtr() { return std::make_unique<NonCopyableDerived>(42); }
+
+inline std::vector<std::unique_ptr<NonCopyable>>
+getVectorNonCopyableUniquePtr() {
+  std::vector<std::unique_ptr<NonCopyable>> vec;
+  vec.emplace_back();
+  return vec;
+}
 
 std::unique_ptr<int> makeInt() {
   return std::make_unique<int>(42);

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -1,8 +1,8 @@
 #ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H
 
-#include <vector>
 #include <string>
+#include <vector>
 
 using Vector = std::vector<int>;
 using VectorOfString = std::vector<std::string>;
@@ -29,5 +29,15 @@ __attribute__((swift_attr("release:immortal"))) ImmortalRef {
   static ImmortalRef *create(int value) { return new ImmortalRef({value}); }
 };
 using VectorOfImmortalRefPtr = std::vector<ImmortalRef *>;
+
+struct NonCopyable {
+  NonCopyable() = default;
+  NonCopyable(const NonCopyable &other) = delete;
+  NonCopyable(NonCopyable &&other) = default;
+  ~NonCopyable() {}
+};
+
+using VectorOfNonCopyable = std::vector<NonCopyable>;
+using VectorOfPointer = std::vector<NonCopyable *>;
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H

--- a/test/Interop/Cxx/stdlib/use-std-map-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map-typechecker.swift
@@ -1,0 +1,16 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import StdMap
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let mapNonCopyableKey = MapNonCopyableKey() 
+takeCopyable(mapNonCopyableKey) 
+// CHECK: error: global function 'takeCopyable' requires that 'MapNonCopyableKey' {{.*}} conform to 'Copyable'
+// CHECK: note: 'where T: Copyable' is implicit here
+
+let mapNonCopyableValue = MapNonCopyableValue() 
+takeCopyable(mapNonCopyableValue) 
+// CHECK: error: global function 'takeCopyable' requires that 'MapNonCopyableValue' {{.*}} conform to 'Copyable'
+// CHECK: note: 'where T: Copyable' is implicit here

--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import StdOptional
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
+takeCopyable(nonNilOptNonCopyable)
+// CHECK: error: global function 'takeCopyable' requires that 'StdOptionalHasDeletedCopyCtor' {{.*}} conform to 'Copyable'
+// CHECK: note: 'where T: Copyable' is implicit here

--- a/test/Interop/Cxx/stdlib/use-std-set-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set-typechecker.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import StdSet
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let setNonCopyable = SetOfNonCopyable() 
+takeCopyable(setNonCopyable) 
+// CHECK: error: global function 'takeCopyable' requires that 'SetOfNonCopyable' {{.*}} conform to 'Copyable'
+// CHECK: note: 'where T: Copyable' is implicit here

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+import StdUniquePtr
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let vecUniquePtr = getVectorNonCopyableUniquePtr()
+takeCopyable(vecUniquePtr)
+// CHECK: error: global function 'takeCopyable' requires that 'std{{.*}}vector{{.*}}unique_ptr{{.*}}NonCopyable{{.*}}' conform to 'Copyable'

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -1,0 +1,21 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import StdVector
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+func takeCxxVector<V: CxxVector>(_ v: V) {} 
+
+let vecNC = VectorOfNonCopyable()
+takeCopyable(vecNC)
+// CHECK: error: global function 'takeCopyable' requires that 'VectorOfNonCopyable' {{.*}} conform to 'Copyable'
+// CHECK: note: 'where T: Copyable' is implicit here
+
+takeCxxVector(vecNC) 
+// CHECK: error: global function 'takeCxxVector' requires that 'VectorOfNonCopyable' {{.*}} conform to 'CxxVector'
+// CHECK: note: where 'V' = 'VectorOfNonCopyable' {{.*}}
+
+let vecPointer = VectorOfPointer()
+takeCopyable(vecPointer)
+takeCxxVector(vecPointer)
+// CHECK-NOT: error


### PR DESCRIPTION
Import STL containers as non-copyable if the elements they hold are also non-copyable. 

Unfortunately, there isn't a straightforward way to automatically check if an instantiation of a copy constructor is valid, so we reuse escapability's logic that hardcodes, for each STL container, the parameters it depends on. 

rdar://148130050
