### PR TITLE
[Backtracing] Add check for theoretical environment overflow issue.

### DIFF
--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -902,7 +902,11 @@ _swift_backtraceSetupEnvironment()
 
     size_t nameLen = std::strlen(name);
     size_t valueLen = std::strlen(value);
-    size_t totalLen = nameLen + 1 + valueLen + 1;
+    size_t totalLen;
+
+    if (__builtin_add_overflow(nameLen + 1, valueLen + 1, &totalLen)) {
+      break;
+    }
 
     if (remaining > totalLen) {
       std::memcpy(penv, name, nameLen);


### PR DESCRIPTION
Pretty sure this can't ever trigger because of operating system limits on the size of environment strings, but since overflow tests are cheap, there seems no reason not to add one.

rdar://160307933
