### PR TITLE
A few fixes for placeholder types in interface types

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7101,6 +7101,14 @@ public:
       Identifier parameterName, Expr *defaultValue,
       DefaultArgumentInitializer *defaultValueInitContext, DeclContext *dc);
 
+  SourceLoc getLocFromSource() const {
+    // If we have a name loc, use it, otherwise fallback to the start loc for
+    // e.g enum elements without parameter names.
+    if (auto nameLoc = getNameLoc())
+      return nameLoc;
+    return getStartLoc();
+  }
+
   /// Retrieve the argument (API) name for this function parameter.
   Identifier getArgumentName() const {
     return ArgumentNameAndFlags.getPointer();

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -117,6 +117,12 @@ private:
 #define SINGLETON_TYPE(SHORT_ID, ID) TRIVIAL_CASE(ID##Type)
 #include "swift/AST/TypeNodes.def"
 
+    bool visitPlaceholderType(CanPlaceholderType firstType, Type secondType,
+                              Type sugaredFirstType) {
+      // Placeholder types never match.
+      return mismatch(firstType.getPointer(), secondType, sugaredFirstType);
+    }
+
     bool visitUnresolvedType(CanUnresolvedType firstType, Type secondType,
                              Type sugaredFirstType) {
       // Unresolved types never match.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -362,6 +362,9 @@ enum class FixKind : uint8_t {
   /// resolved.
   SpecifyTypeForPlaceholder,
 
+  /// Ignore an invalid placeholder in a decl's interface type.
+  IgnoreInvalidPlaceholderInDeclRef,
+
   /// Allow Swift -> C pointer conversion in an argument position
   /// of a Swift function.
   AllowSwiftToCPointerConversion,
@@ -3188,6 +3191,30 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::SpecifyTypeForPlaceholder;
+  }
+};
+
+class IgnoreInvalidPlaceholderInDeclRef final : public ConstraintFix {
+  IgnoreInvalidPlaceholderInDeclRef(ConstraintSystem &cs,
+                                    ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreInvalidPlaceholderInDeclRef, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore invalid placeholder in decl ref";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreInvalidPlaceholderInDeclRef *create(ConstraintSystem &cs,
+                                                   ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreInvalidPlaceholderInDeclRef;
   }
 };
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2317,9 +2317,9 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
     /// Deduce associated types from dependent member types in the witness.
     bool mismatch(DependentMemberType *firstDepMember,
                   TypeBase *secondType, Type sugaredFirstType) {
-      // If the second type is an error, don't look at it further, but proceed
-      // to find other matches.
-      if (secondType->hasError())
+      // If the second type is an error or placeholder, don't look at it
+      // further, but proceed to find other matches.
+      if (secondType->hasError() || secondType->hasPlaceholder())
         return true;
 
       // If the second type is a generic parameter of the witness, the match

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2264,6 +2264,20 @@ SpecifyTypeForPlaceholder::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) SpecifyTypeForPlaceholder(cs, locator);
 }
 
+IgnoreInvalidPlaceholderInDeclRef *
+IgnoreInvalidPlaceholderInDeclRef::create(ConstraintSystem &cs, ConstraintLocator *locator) {
+  return new (cs.getAllocator()) IgnoreInvalidPlaceholderInDeclRef(cs, locator);
+}
+
+bool
+IgnoreInvalidPlaceholderInDeclRef::diagnose(const Solution &solution,
+                                            bool asNote) const {
+  // These are diagnosed separately. Unfortunately we can't enforce that a
+  // diagnostic has already been emitted since their diagnosis depends on e.g
+  // type-checking a function body for a placeholder result of a function.
+  return true;
+}
+
 bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
                                      bool asNote) const {
   ReferenceToInvalidDeclaration failure(solution, getLocator());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2542,8 +2542,11 @@ namespace {
       Type thrownErrorTy = [&] {
         // Explicitly-specified thrown type.
         if (closure->getExplicitThrownTypeRepr()) {
-          if (Type explicitType = closure->getExplicitThrownType())
-            return explicitType;
+          if (Type explicitType = closure->getExplicitThrownType()) {
+            // The thrown type may have errors, open as placeholders if needed.
+            return CS.replaceInferableTypesWithTypeVars(explicitType,
+                                                        thrownErrorLocator);
+          }
         }
 
         // Explicitly-specified 'throws' without a type is untyped throws.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16109,6 +16109,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowValueExpansionWithoutPackReferences:
   case FixKind::IgnoreInvalidPatternInExpr:
   case FixKind::IgnoreInvalidPlaceholder:
+  case FixKind::IgnoreInvalidPlaceholderInDeclRef:
   case FixKind::IgnoreOutOfPlaceThenStmt:
   case FixKind::IgnoreMissingEachKeyword:
   case FixKind::AllowInlineArrayLiteralCountMismatch:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2317,9 +2317,17 @@ static Type validateParameterType(ParamDecl *decl) {
                      : TypeResolverContext::FunctionInput);
   options |= TypeResolutionFlags::Direct;
 
+  // We allow placeholders in parameter types to improve recovery since if a
+  // default argument is present we can suggest the inferred type. Avoid doing
+  // this for protocol requirements though since those can't ever have default
+  // arguments anyway.
+  HandlePlaceholderTypeReprFn placeholderOpener;
+  if (!isa<ProtocolDecl>(dc->getParent()))
+    placeholderOpener = PlaceholderType::get;
+
   const auto resolution =
       TypeResolution::forInterface(dc, options, unboundTyOpener,
-                                   PlaceholderType::get,
+                                   placeholderOpener,
                                    /*packElementOpener*/ nullptr);
 
   if (isa<VarargTypeRepr>(nestedRepr)) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2121,10 +2121,17 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   if (decl->preconcurrency())
     options |= TypeResolutionFlags::Preconcurrency;
 
+  // Placeholders are only currently allowed for FuncDecls with bodies, which
+  // we diagnose in ReturnTypePlaceholderReplacer.
+  HandlePlaceholderTypeReprFn placeholderOpener;
+  if (auto *FD = dyn_cast<FuncDecl>(decl)) {
+    if (FD->hasBody() && !FD->isBodySkipped())
+      placeholderOpener = PlaceholderType::get;
+  }
   auto *const dc = decl->getInnermostDeclContext();
   return TypeResolution::forInterface(dc, options,
                                       /*unboundTyOpener*/ nullptr,
-                                      PlaceholderType::get,
+                                      placeholderOpener,
                                       /*packElementOpener*/ nullptr)
       .resolveType(resultTyRepr);
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6999,7 +6999,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
     return TypeResolution::forInterface(func, options,
                                         /*unboundTyOpener*/ nullptr,
-                                        PlaceholderType::get,
+                                        /*placeholderOpener*/ nullptr,
                                         /*packElementOpener*/ nullptr)
         .resolveType(thrownTypeRepr);
   }
@@ -7011,7 +7011,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
       return TypeResolution::resolveContextualType(
                thrownTypeRepr, closure,
                TypeResolutionOptions(TypeResolverContext::None),
-               /*unboundTyOpener*/ nullptr, PlaceholderType::get,
+               /*unboundTyOpener*/ nullptr, /*placeholderOpener*/ nullptr,
                /*packElementOpener*/ nullptr);
     }
 
@@ -7045,7 +7045,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
     return TypeResolution::resolveContextualType(
         typeRepr, doCatch->getDeclContext(),
         TypeResolutionOptions(TypeResolverContext::None),
-        /*unboundTyOpener*/ nullptr, PlaceholderType::get,
+        /*unboundTyOpener*/ nullptr, /*placeholderOpener*/ nullptr,
         /*packElementOpener*/ nullptr);
   }
 

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -294,13 +294,12 @@ do {
 
 // Make sure we reject placeholders here.
 protocol TestPlaceholderRequirement {
-  func foo(_:_) // expected-error {{type placeholder may not appear in top-level parameter}}
+  func foo(_:_) // expected-error {{type placeholder not allowed here}}
   func bar() -> _ // expected-error {{type placeholder not allowed here}}
   func baz() -> [_] // expected-error {{type placeholder not allowed here}}
-  func qux(_: [_]) // expected-error {{type placeholder may not appear in top-level parameter}}
+  func qux(_: [_]) // expected-error {{type placeholder not allowed here}}
 
-  // FIXME: Shouldn't diagnose twice
-  subscript(_: _) -> Void { get } // expected-error 2{{type placeholder may not appear in top-level parameter}}
+  subscript(_: _) -> Void { get } // expected-error {{type placeholder not allowed here}}
   subscript() -> _ { get } // expected-error {{type placeholder not allowed here}}
 }
 
@@ -311,6 +310,7 @@ var testPlaceholderComputed1: _ { 0 } // expected-error {{type placeholder not a
 var testPlaceholderComputed2: [_] { [0] } // expected-error {{type placeholder not allowed here}}
 
 struct TestPlaceholderSubscript {
+  // FIXME: Shouldn't diagnose twice.
   subscript(_: _) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
   subscript(_: [_]) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
   subscript() -> _ { () } // expected-error {{type placeholder not allowed here}}

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -330,3 +330,30 @@ enum TestPlaceholderInEnumElement {
 
 @freestanding(expression) macro testPlaceholderMacro() -> _ = #file
 // expected-error@-1 {{type placeholder not allowed here}}
+
+// Make sure we can use decls with placeholders in their interface type.
+func usePlaceholderDecls(
+  _ fromProto: some TestPlaceholderRequirement, _ hasSubscript: TestPlaceholderSubscript
+) {
+  _ = optInt
+
+  _ = testPlaceholderComputed1
+  _ = testPlaceholderComputed2
+
+  fromProto.foo(0)
+  _ = fromProto.bar()
+  _ = fromProto.baz()
+  fromProto.qux([])
+  fromProto[0]
+
+  _ = hasSubscript[0]
+
+  _ = TestPlaceholderInEnumElement.a(0)
+  _ = TestPlaceholderInEnumElement.b([])
+
+  _ = #testPlaceholderMacro(0)
+  _ = #testPlaceholderMacro([])
+
+  _ = testPlaceholderFn1(0)
+  _ = testPlaceholderFn2()
+}

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -291,3 +291,42 @@ do {
     _ = X(content: <#T##() -> _#>) // expected-error {{editor placeholder in source file}}
   }
 }
+
+// Make sure we reject placeholders here.
+protocol TestPlaceholderRequirement {
+  func foo(_:_) // expected-error {{type placeholder may not appear in top-level parameter}}
+  func bar() -> _ // expected-error {{type placeholder not allowed here}}
+  func baz() -> [_] // expected-error {{type placeholder not allowed here}}
+  func qux(_: [_]) // expected-error {{type placeholder may not appear in top-level parameter}}
+
+  // FIXME: Shouldn't diagnose twice
+  subscript(_: _) -> Void { get } // expected-error 2{{type placeholder may not appear in top-level parameter}}
+  subscript() -> _ { get } // expected-error {{type placeholder not allowed here}}
+}
+
+func testPlaceholderFn1(_:_) {} // expected-error {{type placeholder may not appear in top-level parameter}}
+func testPlaceholderFn2() -> _ {} // expected-error {{type placeholder may not appear in function return type}}
+
+var testPlaceholderComputed1: _ { 0 } // expected-error {{type placeholder not allowed here}}
+var testPlaceholderComputed2: [_] { [0] } // expected-error {{type placeholder not allowed here}}
+
+struct TestPlaceholderSubscript {
+  subscript(_: _) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
+  subscript(_: [_]) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
+  subscript() -> _ { () } // expected-error {{type placeholder not allowed here}}
+  subscript() -> [_] { [0] } // expected-error {{type placeholder not allowed here}}
+}
+
+enum TestPlaceholderInEnumElement {
+  case a(_) // expected-error {{type placeholder may not appear in top-level parameter}}
+  case b([_]) // expected-error {{type placeholder may not appear in top-level parameter}}
+}
+
+@freestanding(expression) macro testPlaceholderMacro(_ x: _) -> String = #file
+// expected-error@-1 {{type placeholder may not appear in top-level parameter}}
+
+@freestanding(expression) macro testPlaceholderMacro(_ x: [_]) -> String = #file
+// expected-error@-1 {{type placeholder may not appear in top-level parameter}}
+
+@freestanding(expression) macro testPlaceholderMacro() -> _ = #file
+// expected-error@-1 {{type placeholder not allowed here}}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -402,3 +402,5 @@ extension BitwiseCopyable {} // expected-error {{cannot extend protocol 'Bitwise
 
 @_marker protocol MyMarkerProto {}
 extension MyMarkerProto {} // OK
+
+extension _ {} // expected-error {{cannot extend a type that contains placeholders}}

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -216,3 +216,8 @@ struct NotAnError<T> {}
 
 func badThrowingFunctionType<T>(_: () throws(NotAnError<T>) -> ()) {}
 // expected-error@-1 {{thrown type 'NotAnError<T>' does not conform to the 'Error' protocol}}
+
+struct GenericError<T>: Error {}
+
+func placeholderThrowing1() throws(_) {} // expected-error {{type placeholder not allowed here}}
+func placeholderThrowing2() throws(GenericError<_>) {} // expected-error {{type placeholder not allowed here}}

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -8,6 +8,8 @@ enum MyBadError {
   case fail
 }
 
+struct GenericError<T>: Error {}
+
 func testClosures() {
   let c1 = { () throws(MyError) in
     throw .fail
@@ -36,5 +38,8 @@ func testClosures() {
   let c2 = { throw MyError.fail }
   let _: Int = c2
   // expected-error@-1{{cannot convert value of type '() throws -> ()'}}
+
+  _ = { () throws(_) in } // expected-error {{type placeholder not allowed here}}
+  _ = { () throws(GenericError<_>) in } // expected-error {{type placeholder not allowed here}}
 }
 

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -12,6 +12,8 @@ case dogAteIt
 case forgot
 }
 
+struct GenericError<T>: Error {}
+
 func processMyError(_: MyError) { }
 
 func doSomething() throws(MyError) { }
@@ -417,4 +419,13 @@ func testSequenceExpr() async throws(Never) {
 
   try true ? 0 : try! getInt() ~~~ getInt()
   // expected-error@-1 {{'try!' following conditional operator does not cover everything to its right}}
+}
+
+func testPlaceholder() {
+  do throws(_) {} catch {}
+  // expected-error@-1 {{type placeholder not allowed here}}
+  // expected-warning@-2 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  do throws(GenericError<_>) {} catch {}
+  // expected-error@-1 {{type placeholder not allowed here}}
+  // expected-warning@-2 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
 }

--- a/validation-test/compiler_crashers_2_fixed/1b94fce977ad935d.swift
+++ b/validation-test/compiler_crashers_2_fixed/1b94fce977ad935d.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"printDifferentiableAttrArguments(swift::DifferentiableAttr const*, swift::ASTPrinter&, swift::PrintOptions const&, swift::Decl const*, bool)","signatureAssert":"Assertion failed: (original && \"Must resolve original declaration\"), function printDifferentiableAttrArguments"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a(@differentiable _ =

--- a/validation-test/compiler_crashers_2_fixed/88ba80199b702649.swift
+++ b/validation-test/compiler_crashers_2_fixed/88ba80199b702649.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a(b : ()->Void c : _->Void) { withoutActuallyEscaping(b do : c

--- a/validation-test/compiler_crashers_2_fixed/89acda2815351ec6.swift
+++ b/validation-test/compiler_crashers_2_fixed/89acda2815351ec6.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)::$_3::operator()(swift::Type, swift::Type) const","signatureAssert":"Assertion failed: (restriction == ConversionRestrictionKind::DeepEquality), function operator()"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a(inout _ )
 var b = String
 a(b

--- a/validation-test/compiler_crashers_2_fixed/ac7123f2338b128.swift
+++ b/validation-test/compiler_crashers_2_fixed/ac7123f2338b128.swift
@@ -1,5 +1,5 @@
 // {"signature":"swift::TypeChecker::typeCheckTarget(swift::constraints::SyntacticElementTarget&, swift::optionset::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::DiagnosticTransaction*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a
   protocol b {
     associatedtype c

--- a/validation-test/compiler_crashers_2_fixed/c8563a4a60b27cf3.swift
+++ b/validation-test/compiler_crashers_2_fixed/c8563a4a60b27cf3.swift
@@ -1,5 +1,5 @@
 // {"signature":"swift::CanTypeVisitor<swift::TypeMatcher<desugarSameTypeRequirement(swift::Requirement, swift::SourceLoc, llvm::SmallVectorImpl<swift::Requirement>&, llvm::SmallVectorImpl<swift::InverseRequirement>&, llvm::SmallVectorImpl<swift::rewriting::RequirementError>&)::Matcher>::MatchVisitor, bool, swift::Type, swift::Type>::visit(swift::CanType, swift::Type, swift::Type)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b associatedtype c associatedtype d func e(b, c) -> d
 }

--- a/validation-test/compiler_crashers_2_fixed/ce57354c94ae5aad.swift
+++ b/validation-test/compiler_crashers_2_fixed/ce57354c94ae5aad.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","signature":"swift::CanTypeVisitor<swift::Lowering::TypeConverter::computeLoweredRValueType(swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanType)::LoweredRValueTypeVisitor, swift::CanType>::visit(swift::CanType)"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: not %target-swift-frontend -emit-silgen %s
 protocol a {
   func b() -> _
 }

--- a/validation-test/compiler_crashers_2_fixed/e1f8b6a26663e9b5.swift
+++ b/validation-test/compiler_crashers_2_fixed/e1f8b6a26663e9b5.swift
@@ -1,4 +1,4 @@
 // {"signature":"swift::CanTypeVisitor<swift::TypeMatcher<(anonymous namespace)::AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(swift::ValueDecl*, swift::ValueDecl*)::MatchVisitor>::MatchVisitor, bool, swift::Type, swift::Type>::visit(swift::CanType, swift::Type, swift::Type)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a { associatedtype b func c(_ : _ d: b }
                          extension a { c(_ : _ d: b struct e : a

--- a/validation-test/compiler_crashers_2_fixed/edb1d98948183f4c.swift
+++ b/validation-test/compiler_crashers_2_fixed/edb1d98948183f4c.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","signature":"emitRawApply(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::ManagedValue, swift::SubstitutionMap, llvm::ArrayRef<swift::Lowering::ManagedValue>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::optionset::OptionSet<swift::ApplyFlags, unsigned char>, llvm::ArrayRef<swift::SILValue>, swift::SILValue, llvm::SmallVectorImpl<swift::SILValue>&, swift::Lowering::ExecutorBreadcrumb)"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: not %target-swift-frontend -emit-silgen %s
 protocol a {
   func b() -> [(_) -> Self]
 }

--- a/validation-test/compiler_crashers_2_fixed/f6ae9d69266e6b1c.swift
+++ b/validation-test/compiler_crashers_2_fixed/f6ae9d69266e6b1c.swift
@@ -1,0 +1,6 @@
+// {"kind":"typecheck","original":"0e81571d","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: not %target-swift-frontend -typecheck %s
+subscript(a: _) -> <#type#> {
+  a
+  0
+}


### PR DESCRIPTION
- Improve the diagnostic for `extension _ {}`
- Ban placeholders for typed throws
- Only allow placeholder return types for FuncDecls with bodies
- Ban placeholder param types in protocol requirements
- Ensure we record a fix when referencing a decl with a placeholder interface type to ensure we don't attempt to apply the solution
- Avoid matching placeholder types in associated type inference