### PR TITLE
[IRGen] Use PrivateLinkage for `@__Swift_AST` global

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1851,8 +1851,12 @@ void swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
       llvm::ConstantDataArray::getString(IGM.getLLVMContext(),
                                          Buffer, /*AddNull=*/false);
   auto &M = *IGM.getModule();
+  // Use PrivateLinkage here. The ".swift_ast" section is specially recognized
+  // by LLVM’s object emission and classified as a "metadata" section. On
+  // WebAssembly, metadata symbols must not appear in the object file symbol
+  // table, so using PrivateLinkage avoids exposing the symbol.
   auto *ASTSym = new llvm::GlobalVariable(M, Ty, /*constant*/ true,
-                                          llvm::GlobalVariable::InternalLinkage,
+                                          llvm::GlobalValue::PrivateLinkage,
                                           Data, "__Swift_AST");
 
   std::string Section;


### PR DESCRIPTION
`.swift_ast` section is now recognized as a "metadata" section by LLVM's object emission. On WebAssembly, metadata symbols must not appear in the object file symbol table. Therefore, change the linkage of the `@__Swift_AST` global from InternalLinkage to PrivateLinkage to avoid exposing the symbol.

https://github.com/swiftlang/llvm-project/commit/555eaef3ab34108b68631411f0ec8464ee45af0a
