### PR TITLE
Use condfail_message in _debugPrecondition and make it more transparent

### DIFF
--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -91,7 +91,7 @@ internal func _fatalErrorFlags() -> UInt32 {
 #if !$Embedded
 @inline(never)
 #else
-@inline(__always)
+@inline(__always) @_transparent
 #endif
 @_semantics("programtermination_point")
 internal func _assertionFailure(
@@ -121,6 +121,7 @@ internal func _assertionFailure(
       file: file, line: line)
   }
 #endif
+  Builtin.condfail_message(false._value, message.unsafeRawPointer)
   Builtin.int_trap()
 }
 
@@ -216,6 +217,7 @@ internal func _assertionFailure(
     _embeddedReportFatalError(prefix: prefix, message: message)
   }
 
+  Builtin.condfail_message(false._value, message.unsafeRawPointer)
   Builtin.int_trap()
 }
 #endif
@@ -230,7 +232,7 @@ internal func _assertionFailure(
 #if !$Embedded
 @inline(never)
 #else
-@inline(__always)
+@inline(__always) @_transparent
 #endif
 @_semantics("programtermination_point")
 internal func _fatalErrorMessage(

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -731,6 +731,7 @@ func _embeddedReportFatalError(prefix: StaticString, message: UnsafeBufferPointe
 }
 
 @inline(never)
+@usableFromInline
 func _embeddedReportFatalErrorInFile(prefix: StaticString, message: StaticString, file: StaticString, line: UInt) {
   print(file, terminator: ":")
   print(line, terminator: ": ")
@@ -740,6 +741,7 @@ func _embeddedReportFatalErrorInFile(prefix: StaticString, message: StaticString
 }
 
 @inline(never)
+@usableFromInline
 func _embeddedReportFatalErrorInFile(prefix: StaticString, message: UnsafeBufferPointer<UInt8>, file: StaticString, line: UInt) {
   print(file, terminator: ":")
   print(line, terminator: ": ")

--- a/test/embedded/debug-precondition-condfail.swift
+++ b/test/embedded/debug-precondition-condfail.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -g -emit-sil %s -enable-experimental-feature Embedded -module-name trap -wmo -o - | %FileCheck %s
+
+// RUN: %target-swift-frontend -g -emit-ir %s -enable-experimental-feature Embedded -module-name trap -wmo -o - | %FileCheck -check-prefix IR %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
+
+// CHECK-LABEL: sil @$e4trap11rebindCheck3ptr8capacityySpySuG_SitFySpys5Int64VGXEfU_
+public func rebindCheck(ptr: UnsafeMutablePointer<UInt>, capacity: Int) {
+  // CHECK-NOT: _assertionFa
+  // CHECK: cond_fail
+  // CHECK-NOT: _assertionFa
+  // CHECK: return
+  ptr.withMemoryRebound(to: Int64.self, capacity: capacity) {
+    $0.pointee.negate()
+  }
+}
+
+// IR: distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow"


### PR DESCRIPTION
Improve debugging from core dumps for Embedded Swift by using condfail rather than trap within _debugPrecondition, and make the call stack transparent enough that we promote these out to callers.

Fixes rdar://159471659.
