### PR TITLE
Stop installing obsolete swift-build-tool executable

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2892,10 +2892,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 INSTALL_TARGETS=install-swift-components
                 ;;
             llbuild)
-                if [[ -z "${INSTALL_LLBUILD}" ]] ; then
-                    continue
-                fi
-                INSTALL_TARGETS="install-swift-build-tool"
+                # The llbuild built by build-script impl is tested and is used
+                # to bootstrap SwiftPM, but doesn't install any toolchain
+                # content
+                continue
                 ;;
             # Products from this here install themselves; they don't fall-through.
             lldb)

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -37,7 +37,6 @@
 # CHECK: --- Installing cmark ---
 # CHECK: --- Installing llvm ---
 # CHECK: --- Installing swift ---
-# CHECK: --- Installing llbuild ---
 
 # Then make sure we are installing/building SwiftPM last.
 #

--- a/validation-test/BuildSystem/infer_implies_install_all.test
+++ b/validation-test/BuildSystem/infer_implies_install_all.test
@@ -7,6 +7,5 @@
 # CHECK: --- Installing cmark ---
 # CHECK: --- Installing llvm ---
 # CHECK: --- Installing swift ---
-# CHECK: --- Installing llbuild ---
 # CHECK: --- Building swiftpm ---
 # CHECK: --- Installing swiftpm ---

--- a/validation-test/BuildSystem/install_all_linux.test
+++ b/validation-test/BuildSystem/install_all_linux.test
@@ -8,7 +8,6 @@
 # CHECK-DAG: --- Installing cmark ---
 # CHECK-DAG: --- Installing swift ---
 # CHECK-DAG: --- Installing llvm ---
-# CHECK-DAG: --- Installing llbuild ---
 # CHECK-DAG: --- Installing foundation ---
 # CHECK-DAG: --- Installing libdispatch ---
 # CHECK-DAG: --- Installing swiftpm ---


### PR DESCRIPTION
https://github.com/swiftlang/swift-llbuild/pull/1013 removes swift-build-tool from the products of llbuild, as it's no longer used during SwiftPM builds or bootstrapping. Remove the reference in build-script-impl