### PR TITLE
[IDE] Ignore unresolved types in WithSolutionSpecificVarTypesRAII

### DIFF
--- a/include/swift/IDE/TypeCheckCompletionCallback.h
+++ b/include/swift/IDE/TypeCheckCompletionCallback.h
@@ -86,19 +86,16 @@ struct WithSolutionSpecificVarTypesRAII {
 
   WithSolutionSpecificVarTypesRAII(
       llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes) {
-    for (auto SolutionVarType : SolutionSpecificVarTypes) {
-      if (SolutionVarType.first->hasInterfaceType()) {
-        RestoreVarTypes[SolutionVarType.first] =
-            SolutionVarType.first->getInterfaceType();
+    for (auto &[var, ty] : SolutionSpecificVarTypes) {
+      if (var->hasInterfaceType()) {
+        RestoreVarTypes[var] = var->getInterfaceType();
       } else {
-        RestoreVarTypes[SolutionVarType.first] = Type();
+        RestoreVarTypes[var] = Type();
       }
-      if (!SolutionVarType.second->hasArchetype()) {
-        setInterfaceType(const_cast<VarDecl *>(SolutionVarType.first),
-                         SolutionVarType.second);
+      if (!ty->hasArchetype() && !ty->hasUnresolvedType()) {
+        setInterfaceType(const_cast<VarDecl *>(var), ty);
       } else {
-        setInterfaceType(const_cast<VarDecl *>(SolutionVarType.first),
-                         ErrorType::get(SolutionVarType.second));
+        setInterfaceType(const_cast<VarDecl *>(var), ErrorType::get(ty));
       }
     }
   }

--- a/validation-test/IDE/crashers_fixed/bfc920b5867dcc4c.swift
+++ b/validation-test/IDE/crashers_fixed/bfc920b5867dcc4c.swift
@@ -1,0 +1,7 @@
+// {"kind":"complete","original":"03137cdb","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+@propertyWrapper struct a<b {
+  wrappedValue: b
+}
+{
+  @a var c #^^#

--- a/validation-test/IDE/crashers_fixed/c9b7522368139eb7.swift
+++ b/validation-test/IDE/crashers_fixed/c9b7522368139eb7.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"ad5b343d","signature":"swift::InterfaceTypeRequest::cacheResult(swift::Type) const","signatureAssert":"Assertion failed: (!type->is<InOutType>() && \"Interface type must be materializable\"), function cacheResult"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 [
   #^^#
 ].reduce?(


### PR DESCRIPTION
Make sure we don't try to set an UnresolvedType as a VarDecl interface type in WithSolutionSpecificVarTypesRAII.