### PR TITLE
[Concurrency] Allow getting unsafe task from Job and name as well

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1098,6 +1098,10 @@ void swift_task_reportUnexpectedExecutor(
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
 
+// Runtime availability: Swift 6.4
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+const char *swift_task_getTaskName(AsyncTask* job);
+
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 const char *swift_task_getCurrentTaskName(void);
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -351,7 +351,7 @@ JobPriority swift::swift_task_getCurrentThreadPriority() {
 #endif
 }
 
-const char *swift_task_getTaskName(AsyncTask *task) {
+const char *swift::swift_task_getTaskName(AsyncTask *task) {
   if (!task) {
     return nullptr;
   }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1176,6 +1176,16 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
 #endif
   }
 
+  // Task name -- this record MUST be FIRST task record.
+  // All other records pushed after it, will be dropped when the task completes;
+  //
+  // The task name record will be kept until we destroy the task, and therefore
+  // must be pushed onto the stack earlier than records which we intended to pop
+  // during task completion.
+  if (jobFlags.task_hasInitialTaskName()) {
+    task->pushInitialTaskName(taskName);
+  }
+
   // If we're supposed to copy task locals, do so now.
   if (taskCreateFlags.copyTaskLocals()) {
     swift_task_localsCopyTo(task);
@@ -1186,28 +1196,16 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     asyncLet_addImpl(task, asyncLet, !hasAsyncLetResultBuffer);
   }
 
-  // ==== Initial Task records
-  {
-
-    // Task name
-    // This record MUST be pushed before other initial records that should be dropped when the
-    // task completes; The task name record will be kept until we destroy the task, and therefore
-    // must be pushed onto the stack earlier than records which we intended to pop during task completion.
-    if (jobFlags.task_hasInitialTaskName()) {
-      task->pushInitialTaskName(taskName);
-    }
-
-    // Task executor preference
-    // If the task does not have a specific executor set already via create
-    // options, and there is a task executor preference set in the parent, we
-    // inherit it by deep-copying the preference record. if
-    // (shouldPushTaskExecutorPreferenceRecord || taskExecutor.isDefined()) {
-    if (jobFlags.task_hasInitialTaskExecutorPreference()) {
-      // Implementation note: we must do this AFTER `swift_taskGroup_attachChild`
-      // because the group takes a fast-path when attaching the child record.
-      task->pushInitialTaskExecutorPreference(taskExecutor,
-                                              /*owned=*/taskExecutorIsOwned);
-    }
+  // Task executor preference
+  // If the task does not have a specific executor set already via create
+  // options, and there is a task executor preference set in the parent, we
+  // inherit it by deep-copying the preference record. if
+  // (shouldPushTaskExecutorPreferenceRecord || taskExecutor.isDefined()) {
+  if (jobFlags.task_hasInitialTaskExecutorPreference()) {
+    // Implementation note: we must do this AFTER `swift_taskGroup_attachChild`
+    // because the group takes a fast-path when attaching the child record.
+    task->pushInitialTaskExecutorPreference(taskExecutor,
+                                            /*owned=*/taskExecutorIsOwned);
   }
 
   // If we're supposed to enqueue the task, do so now.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1122,6 +1122,16 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     task->Private.initialize(basePriority);
   }
 
+  // Task name
+  // This record MUST be the FIRST allocation on the task allocator stack.
+  //
+  // The task name is the only initial record we keep alive after the task completes,
+  // until it is destroyed, because `task.name` can be read off a completed task.
+  // All other records are released early, during task completion.
+  if (jobFlags.task_hasInitialTaskName()) {
+    task->pushInitialTaskName(taskName);
+  }
+
   // Perform additional linking between parent and child task.
   if (parent) {
     // If the parent was already cancelled, we carry this flag forward to the child.
@@ -1174,16 +1184,6 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     // creation
     swift_retain(task);
 #endif
-  }
-
-  // Task name -- this record MUST be FIRST task record.
-  // All other records pushed after it, will be dropped when the task completes;
-  //
-  // The task name record will be kept until we destroy the task, and therefore
-  // must be pushed onto the stack earlier than records which we intended to pop
-  // during task completion.
-  if (jobFlags.task_hasInitialTaskName()) {
-    task->pushInitialTaskName(taskName);
   }
 
   // If we're supposed to copy task locals, do so now.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -630,6 +630,21 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
+extension Task {
+
+  /// Return the task's name, if it was set during its creation.
+  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  public var name: String? {
+    if let name = unsafe _getTaskName(self._task) {
+      unsafe String(cString: name)
+    } else {
+      nil
+    }
+  }
+}
+
 // ==== Voluntary Suspension -----------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
@@ -771,11 +786,11 @@ public struct UnsafeCurrentTask {
   ///
   /// ### Instance property isCancelled ignores Task Cancellation Shields
   ///
-  /// Instance properties `task.isCancelled` and `unsafeCurrentTask.isCancelled`
-  /// are not contextual and therefore do not respect cancellation shields. If a task
+  /// The instance property `task.isCancelled`
+  /// is not contextual and therefore does not respect cancellation shields. If a task
   /// was cancelled and is executing
-  /// with an active cancellation shield, these properties will return the _actual_
-  /// cancellation status of the task.
+  /// with an active cancellation shield, this property will return the _actual_
+  /// cancellation status of the specific task.
   ///
   /// It is possible to determine if a shield is active and then actively determine
   /// that the cancelled status should be temporarily ignored by using this pair of APIs:
@@ -874,6 +889,17 @@ public struct UnsafeCurrentTask {
     @_alwaysEmitIntoClient
     get {
       unsafe _taskHasActiveCancellationShield(_task)
+    }
+  }
+
+  /// Return the task's name, if it was set during its creation.
+  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  public var name: String? {
+    if let name = unsafe _getTaskName(self._task) {
+      unsafe String(cString: name)
+    } else {
+      nil
     }
   }
 }
@@ -1081,6 +1107,11 @@ func _getCurrentThreadPriority() -> Int
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getCurrentTaskName")
 internal func _getCurrentTaskName() -> UnsafePointer<UInt8>?
+
+@available(StdlibDeploymentTarget 6.4, *)
+@usableFromInline
+@_silgen_name("swift_task_getTaskName")
+internal func _getTaskName(_ job: Builtin.NativeObject) -> UnsafePointer<UInt8>?
 
 @available(SwiftStdlib 6.2, *)
 internal func _getCurrentTaskNameString() -> String? {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -208,10 +208,10 @@ extension Task {
   ///
   /// ### Instance property isCancelled ignores Task Cancellation Shields
   ///
-  /// Instance properties `task.isCancelled` and `unsafeCurrentTask.isCancelled`
-  /// are not contextual and therefore do not respect cancellation shields.
+  /// The instance property `task.isCancelled`
+  /// is not contextual and therefore does not respect cancellation shields.
   /// If a task was cancelled and is executing with an active cancellation shield,
-  /// these properties will return the _actual_ cancellation status of the task.
+  /// these properties will return the _actual_ cancellation status of the specific task.
   ///
   /// Prefer using `Task.isCancelled` (the static property) in most situations when checking
   /// the cancellation status from inside the task.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -892,20 +892,29 @@ struct AsyncTask::PrivateStorage {
     // here, before the task-local storage elements are destroyed; in order to
     // respect stack-discipline of the task-local allocator.
     {
-      if (task->hasInitialTaskNameRecord()) {
-        task->dropInitialTaskNameRecord();
-      }
       if (task->hasInitialTaskExecutorPreferenceRecord()) {
         task->dropInitialTaskExecutorPreferenceRecord();
       }
+      // We specifically DO NOT drop the task name record here, even if present,
+      // as it is possible to read it off a task handle (`task.name`).
     }
 
     // Drain unlock the task and remove any overrides on thread as a
     // result of the task
     auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
     while (true) {
-      assert(oldStatus.getInnermostRecord() == NULL &&
+      #ifndef NDEBUG
+      if (task->hasInitialTaskNameRecord()) {
+        // While we generally drop all task records during complete, the task name record is allowed to
+        // stay until destruction, because we allow reading the name from a task handle: `task.name`.
+        assert((oldStatus.getInnermostRecord() &&
+               (oldStatus.getInnermostRecord()->getKind() == TaskStatusRecordKind::TaskName)) &&
+          "The only remaining task record allowed after complete() is a task name, but was different!");
+      } else {
+        assert(oldStatus.getInnermostRecord() == NULL &&
              "Status records should have been removed by this time!");
+      }
+      #endif
       assert(oldStatus.isRunning());
 
       // Remove drainer, enqueued and override bit if any

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -733,12 +733,19 @@ void swift::updateNewChildWithParentAndGroupState(AsyncTask *child,
                                                   ActiveTaskStatus parentStatus,
                                                   TaskGroup *group) {
   // We can take the fast path of just modifying the ActiveTaskStatus in the
-  // child task since we know that it won't have any task status records and
-  // cannot be accessed by anyone else since it hasn't been linked in yet.
+  // child task since we know it cannot be accessed by anyone else yet -- it
+  // hasn't been linked in. The only record that may already be present is the
+  // initial task name (pushed first during task creation so it can outlive
+  // `complete()`); that's harmless here because we only mutate status flags,
+  // not the records list.
   // Avoids the extra logic in `swift_task_cancel` and `swift_task_escalate`
   auto oldChildTaskStatus =
       child->_private()._status().load(std::memory_order_relaxed);
-  assert(oldChildTaskStatus.getInnermostRecord() == NULL);
+  assert((oldChildTaskStatus.getInnermostRecord() == NULL ||
+          (oldChildTaskStatus.getInnermostRecord()->getKind() ==
+               TaskStatusRecordKind::TaskName &&
+           oldChildTaskStatus.getInnermostRecord()->getParent() == NULL)) &&
+         "child task should have no records, or only the initial task name");
 
   auto newChildTaskStatus = oldChildTaskStatus;
 

--- a/test/Concurrency/Runtime/async_task_naming.swift
+++ b/test/Concurrency/Runtime/async_task_naming.swift
@@ -20,6 +20,13 @@ func test() async {
     return 12
   }.value
 
+  let task = Task(name: "Caplin the Task Handle") {
+    return 12
+  }
+  _ = await task.value
+  // CHECK: task.name = Caplin the Task Handle
+  print("task.name = \(task.name ?? "NONE")")
+
   _ = try? await Task(name: "Caplin the Throwing Task") {
     // CHECK: Task.name = Caplin the Throwing Task
     print("Task.name = \(Task.name ?? "NONE")")
@@ -112,6 +119,27 @@ func test() async {
       print("Task.name = \(Task.name ?? "NONE")")
     }
   }
+
+  // Task name must remain accessible after the task completes and is awaited.
+  let completedTask = Task(name: "Caplin the Completed Task") {
+    return 42
+  }
+  _ = await completedTask.value
+  // CHECK: completed task.name = Caplin the Completed Task
+  print("completed task.name = \(completedTask.name ?? "NONE")")
+  // Access it again to make sure it's stable
+  // CHECK: completed task.name (again) = Caplin the Completed Task
+  print("completed task.name (again) = \(completedTask.name ?? "NONE")")
+
+  // Task without a name should return nil, both during and after completion
+  let unnamedTask = Task {
+    // CHECK: unnamed Task.name = NONE OK
+    print("unnamed Task.name = \(Task.name ?? "NONE OK")")
+    return 1
+  }
+  _ = await unnamedTask.value
+  // CHECK: unnamed task.name (after) = NONE OK
+  print("unnamed task.name (after) = \(unnamedTask.name ?? "NONE OK")")
 }
 
 await test()

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -418,3 +418,10 @@ Added: _swift_task_dealloc_through
 // Clock systemEpochs
 Added: _$ss15ContinuousClockV11systemEpochAB7InstantVvpMV
 Added: _$ss15SuspendingClockV11systemEpochAB7InstantVvpMV
+
+// Getting task names off a task handle (task.name)
+Added: _swift_task_getTaskName
+Added: _$sScT4nameSSSgvg
+Added: _$sScT4nameSSSgvpMV
+Added: _$sSct4nameSSSgvg
+Added: _$sSct4nameSSSgvpMV

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -418,3 +418,10 @@ Added: _swift_task_dealloc_through
 // Clock systemEpochs
 Added: _$ss15ContinuousClockV11systemEpochAB7InstantVvpMV
 Added: _$ss15SuspendingClockV11systemEpochAB7InstantVvpMV
+
+// Getting task names off a task handle (task.name)
+Added: _swift_task_getTaskName
+Added: _$sScT4nameSSSgvg
+Added: _$sScT4nameSSSgvpMV
+Added: _$sSct4nameSSSgvg
+Added: _$sSct4nameSSSgvpMV


### PR DESCRIPTION
**Explanation**: 
This was discussed in https://github.com/swiftlang/swift-evolution/blob/main/proposals/0469-task-names.md#unsafecurrenttask-access-from-unownedjob which was accepted however this part wasn't actually implemented it seems.


This change required some changes in how we handle records, since the
name must be FIRST on the stack right now, since it can outlive the task
executor preference. Added some tests

**Scope**: Narrow, adds member `task.name` and `unsafeCurrentTask` to `ExecutorJob` which were previously approved in SE, but missing from implementation.

**Risk**: Low, adds new APIs, all 6.4 gated, without backdeployment as we cannot backdeploy the runtime function.

**Testing**: 
Added CI tests reading the names using the new APIs

**Issues**: 
Resolves rdar://157558738