### PR TITLE
Sema: Limit errors on LE importing non-LE modules to SDK modules 

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -68,22 +68,24 @@ namespace swift {
     Complete,
   };
 
-  /// Access or distribution level of a library.
+  /// Intended distribution level of a module.
+  ///
+  /// Ordered from more private to more public.
   enum class LibraryLevel : uint8_t {
-    /// Application Programming Interface that is publicly distributed so
-    /// public decls are really public and only @_spi decls are SPI.
-    API,
+    /// This isn't a library or the library distribution intent is unknown.
+    Other,
 
-    /// System Programming Interface that has restricted distribution
-    /// all decls in the module are considered to be SPI including public ones.
-    SPI,
-
-    /// Internal Programming Interface that is not distributed and only usable
-    /// from within a project.
+    /// Internal Programming Interface: the module is not distributed and
+    /// only usable from within its project.
     IPI,
 
-    /// The library has some other undefined distribution.
-    Other
+    /// System Programming Interface: the module has restricted distribution,
+    /// all public decls in the module are considered to be SPI.
+    SPI,
+
+    /// Application Programming Interface: the module is distributed publicly,
+    /// public decls are really public and only @_spi decls are SPI.
+    API,
   };
 
   enum class AccessNoteDiagnosticBehavior : uint8_t {

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -13,24 +13,25 @@
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
 
 /// A resilient client will error on public imports.
-/// Keep AccessLevelOnImport to get the error from Swift 6 in Swift 5.
+/// Use AccessLevelOnImport or InternalImportsByDefault to get the error
+/// from Swift 7 in Swift 5.
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name pkg
-// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
+// RUN:   -package-name pkg -library-level api
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift7.swift -I %t \
 // RUN:   -enable-library-evolution \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
-// RUN:   -verify -package-name pkg
+// RUN:   -verify -package-name pkg -library-level api
 
 /// A non-resilient client doesn't complain.
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -swift-version 5 \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
-// RUN:   -package-name pkg
-// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
+// RUN:   -package-name pkg -library-level api
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift7.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
-// RUN:   -package-name pkg
+// RUN:   -package-name pkg -library-level api
 
 // REQUIRES: swift_feature_AccessLevelOnImport
 // REQUIRES: swift_feature_InternalImportsByDefault
@@ -53,10 +54,10 @@ internal import InternalLib
 fileprivate import FileprivateLib
 private import PrivateLib
 
-//--- Client_Swift6.swift
+//--- Client_Swift7.swift
 
 import DefaultLib
-public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift6' can't be guaranteed}} {{1-8=}}
+public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift7' can't be guaranteed}} {{1-8=}}
 // expected-warning @-1 {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
 package import PackageLib
 // expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}


### PR DESCRIPTION
Limit reporting as an error imports of a non-library-evolution module from a library-evolution enabled module to sources that are part of the SDK. The error also requires having enabled `InternalImportsByDefault`. This should help prevent SDK breaking regressions while loosening the restriction elsewhere.

Framework owners can enable `-library-level api` or `spi` to get this check as an error, along with more sanity checks.

Other cases remain as a warning. We should look to silence it in some cases or offer a flag to do so.

Resolves: #84241
rdar://160414667