### PR TITLE
Embedded swift restrictions

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -378,32 +378,48 @@ ERROR(bad_attr_on_non_const_global,none,
       "global variable must be a compile-time constant to use %0 attribute", (StringRef))
 ERROR(global_must_be_compile_time_const,none,
       "global variable must be a compile-time constant", ())
-ERROR(embedded_cannot_specialize_class_method,none,
-      "classes cannot have a non-final, generic method %0 in embedded Swift", (DeclName))
-ERROR(embedded_cannot_specialize_witness_method,none,
-      "a protocol type cannot contain a generic method %0 in embedded Swift", (DeclName))
-ERROR(cannot_specialize_class,none,
-      "cannot specialize %0 because class definition is not available (make sure to build with -wmo)", (Type))
-ERROR(embedded_swift_existential_type,none,
-      "cannot use a value of protocol type %0 in embedded Swift", (Type))
-ERROR(embedded_swift_existential_protocol,none,
-      "cannot use a value of protocol type 'any %0' in embedded Swift", (StringRef))
-ERROR(embedded_swift_existential,none,
-      "cannot use a value of protocol type in embedded Swift", ())
 ERROR(perf_diag_existential_type,none,
       "cannot use a value of protocol type %0 in '@_noExistential' function", (Type))
 ERROR(perf_diag_existential,none,
       "cannot use a value of protocol type in '@_noExistential' function", ())
-ERROR(embedded_swift_value_deinit,none,
+
+// Embedded Swift diagnostics
+GROUPED_ERROR(embedded_cannot_specialize_class_method,EmbeddedRestrictions,none,
+      "classes cannot have a non-final, generic method %0 in embedded Swift", (DeclName))
+GROUPED_ERROR(embedded_cannot_specialize_witness_method,EmbeddedRestrictions,none,
+      "a protocol type cannot contain a generic method %0 in embedded Swift", (DeclName))
+GROUPED_ERROR(cannot_specialize_class,EmbeddedRestrictions,none,
+      "cannot specialize %0 because class definition is not available (make sure to build with -wmo)", (Type))
+GROUPED_ERROR(embedded_swift_existential_type,EmbeddedRestrictions,none,
+      "cannot use a value of protocol type %0 in embedded Swift", (Type))
+GROUPED_ERROR(embedded_swift_existential_protocol,EmbeddedRestrictions,none,
+      "cannot use a value of protocol type 'any %0' in embedded Swift", (StringRef))
+GROUPED_ERROR(embedded_swift_existential,EmbeddedRestrictions,none,
+      "cannot use a value of protocol type in embedded Swift", ())
+GROUPED_ERROR(embedded_swift_value_deinit,EmbeddedRestrictions,none,
       "cannot de-virtualize deinit of type %0", (Type))
-ERROR(embedded_swift_metatype_type,none,
+GROUPED_ERROR(embedded_swift_metatype_type,EmbeddedRestrictions,none,
       "cannot use metatype of type %0 in embedded Swift", (Type))
-ERROR(embedded_swift_metatype,none,
+GROUPED_ERROR(embedded_swift_metatype,EmbeddedRestrictions,none,
       "cannot use metatype in embedded Swift", ())
-ERROR(embedded_swift_keypath,none,
+GROUPED_ERROR(embedded_swift_keypath,EmbeddedRestrictions,none,
       "cannot use key path in embedded Swift", ())
-ERROR(embedded_swift_dynamic_cast,none,
+GROUPED_ERROR(embedded_swift_dynamic_cast,EmbeddedRestrictions,none,
       "cannot do dynamic casting in embedded Swift", ())
+GROUPED_ERROR(embedded_capture_of_generic_value_with_deinit,EmbeddedRestrictions,none,
+      "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
+GROUPED_ERROR(embedded_call_generic_function,EmbeddedRestrictions,none,
+      "cannot specialize generic function or default protocol method in this context", ())
+GROUPED_ERROR(embedded_call_generic_function_with_dynamic_self,EmbeddedRestrictions,none,
+      "cannot call an initializer or static method, which is defined as default protocol method, from a class method or initializer", ())
+NOTE(embedded_specialization_called_from,none,
+      "generic specialization called here", ())
+NOTE(embedded_existential_created,none,
+      "protocol type value created here", ())
+NOTE(embedded_constructor_called,none,
+      "instance of type created here", ())
+
+// no-allocations diagnostics
 ERROR(embedded_swift_allocating_type,none,
       "cannot use allocating type %0 in -no-allocations mode", (Type))
 ERROR(embedded_swift_allocating_coroutine,none,
@@ -412,18 +428,7 @@ ERROR(embedded_swift_allocating_closure,none,
       "cannot use escaping closures in -no-allocations mode", ())
 ERROR(embedded_swift_allocating,none,
       "cannot use allocating operation in -no-allocations mode", ())
-ERROR(embedded_capture_of_generic_value_with_deinit,none,
-      "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
-ERROR(embedded_call_generic_function,none,
-      "cannot specialize generic function or default protocol method in this context", ())
-ERROR(embedded_call_generic_function_with_dynamic_self,none,
-      "cannot call an initializer or static method, which is defined as default protocol method, from a class method or initializer", ())
-NOTE(embedded_specialization_called_from,none,
-      "generic specialization called here", ())
-NOTE(embedded_existential_created,none,
-      "protocol type value created here", ())
-NOTE(embedded_constructor_called,none,
-      "instance of type created here", ())
+
 ERROR(wrong_linkage_for_serialized_function,none,
       "function has wrong linkage to be called from %0", (StringRef))
 NOTE(performance_called_from,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8612,6 +8612,9 @@ GROUPED_ERROR(weak_unowned_in_embedded_swift, EmbeddedRestrictions, none,
 GROUPED_WARNING(untyped_throws_in_embedded_swift, EmbeddedRestrictions,
                 DefaultIgnore,
                 "untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'", ())
+GROUPED_ERROR(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions, none,
+              "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",
+              (const Decl *, bool))
 
 //===----------------------------------------------------------------------===//
 // MARK: @abi Attribute

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8612,9 +8612,10 @@ GROUPED_ERROR(weak_unowned_in_embedded_swift, EmbeddedRestrictions, none,
 GROUPED_WARNING(untyped_throws_in_embedded_swift, EmbeddedRestrictions,
                 DefaultIgnore,
                 "untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'", ())
-GROUPED_ERROR(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions, none,
-              "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",
-              (const Decl *, bool))
+GROUPED_WARNING(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions,
+                DefaultIgnore,
+                "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",
+                (const Decl *, bool))
 GROUPED_WARNING(use_generic_member_of_existential_in_embedded_swift,
                 EmbeddedRestrictions, DefaultIgnore,
                 "cannot use generic %kind0 on a value of type %1 in Embedded Swift",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8615,6 +8615,10 @@ GROUPED_WARNING(untyped_throws_in_embedded_swift, EmbeddedRestrictions,
 GROUPED_ERROR(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions, none,
               "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",
               (const Decl *, bool))
+GROUPED_WARNING(use_generic_member_of_existential_in_embedded_swift,
+                EmbeddedRestrictions, DefaultIgnore,
+                "cannot use generic %kind0 on a value of type %1 in Embedded Swift",
+                (const Decl *, Type))
 
 //===----------------------------------------------------------------------===//
 // MARK: @abi Attribute

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8620,6 +8620,10 @@ GROUPED_WARNING(use_generic_member_of_existential_in_embedded_swift,
                 EmbeddedRestrictions, DefaultIgnore,
                 "cannot use generic %kind0 on a value of type %1 in Embedded Swift",
                 (const Decl *, Type))
+GROUPED_WARNING(dynamic_cast_involving_protocol_in_embedded_swift,
+                EmbeddedRestrictions, DefaultIgnore,
+                "cannot perform a dynamic cast to a type involving %kind0 in Embedded Swift",
+                (const Decl *))
 
 //===----------------------------------------------------------------------===//
 // MARK: @abi Attribute

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -21,6 +21,7 @@
 #include "MiscDiagnostics.h"
 #include "OpenedExistentials.h"
 #include "TypeCheckConcurrency.h"
+#include "TypeCheckEmbedded.h"
 #include "TypeCheckMacros.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
@@ -924,8 +925,9 @@ namespace {
     /// \returns An OpaqueValueExpr that provides a reference to the value
     /// stored within the expression or its metatype (if the base was a
     /// metatype).
-    Expr *openExistentialReference(Expr *base, ExistentialArchetypeType *archetype,
-                                   ValueDecl *member) {
+    Expr *openExistentialReference(Expr *base,
+                                   ExistentialArchetypeType *archetype,
+                                   ValueDecl *member, SourceLoc memberLoc) {
       assert(archetype && "archetype not already opened?");
 
       // Dig out the base type.
@@ -954,6 +956,11 @@ namespace {
       }
 
       assert(baseTy->isAnyExistentialType() && "Type must be existential");
+
+      // Embedded Swift has limitations on the use of generic members of
+      // existentials. Diagnose them here.
+      diagnoseGenericMemberOfExistentialInEmbedded(
+          dc, memberLoc, baseTy, member);
 
       // If the base was an lvalue but it will only be treated as an
       // rvalue, turn the base into an rvalue now. This results in
@@ -1983,7 +1990,8 @@ namespace {
             (!member->getDeclContext()->getSelfProtocolDecl() &&
              baseIsInstance && member->isInstanceMember())) {
           // Open the existential before performing the member reference.
-          base = openExistentialReference(base, knownOpened->second, member);
+          base = openExistentialReference(base, knownOpened->second, member,
+                                          memberLoc.getBaseNameLoc());
           baseTy = baseOpenedTy;
           selfTy = baseTy;
           openedExistential = true;
@@ -2490,7 +2498,8 @@ namespace {
       auto memberLoc = cs.getCalleeLocator(cs.getConstraintLocator(locator));
       auto knownOpened = solution.OpenedExistentialTypes.find(memberLoc);
       if (knownOpened != solution.OpenedExistentialTypes.end()) {
-        base = openExistentialReference(base, knownOpened->second, subscript);
+        base = openExistentialReference(base, knownOpened->second, subscript,
+                                        args->getLoc());
         baseTy = knownOpened->second;
       }
 
@@ -6551,7 +6560,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
           cs.getConstraintLocator(argLoc));
       if (knownOpened != solution.OpenedExistentialTypes.end()) {
         argExpr = openExistentialReference(
-            argExpr, knownOpened->second, callee.getDecl());
+            argExpr, knownOpened->second, callee.getDecl(), apply->getLoc());
         argType = cs.getType(argExpr);
       }
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6560,7 +6560,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
           cs.getConstraintLocator(argLoc));
       if (knownOpened != solution.OpenedExistentialTypes.end()) {
         argExpr = openExistentialReference(
-            argExpr, knownOpened->second, callee.getDecl(), apply->getLoc());
+            argExpr, knownOpened->second, callee.getDecl(),
+            apply ? apply->getLoc() : argExpr->getLoc());
         argType = cs.getType(argExpr);
       }
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -17,6 +17,7 @@
 #include "MiscDiagnostics.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
+#include "TypeCheckEmbedded.h"
 #include "TypeCheckInvertible.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTBridging.h"
@@ -389,6 +390,9 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           return;
         }
       }
+
+      // Embedded Swift places restrictions on dynamic casting.
+      diagnoseDynamicCastInEmbedded(DC, cast);
 
       // now, look for conditional casts to marker protocols.
 

--- a/lib/Sema/TypeCheckEmbedded.cpp
+++ b/lib/Sema/TypeCheckEmbedded.cpp
@@ -152,3 +152,20 @@ void swift::diagnoseUntypedThrowsInEmbedded(
     .limitBehavior(*behavior)
     .fixItInsertAfter(throwsLoc, "(<#thrown error type#>)");
 }
+
+void swift::diagnoseGenericMemberOfExistentialInEmbedded(
+    const DeclContext *dc, SourceLoc loc,
+    Type baseType, const ValueDecl *member) {
+  // If we are not supposed to diagnose Embedded Swift limitations, do nothing.
+  auto behavior = shouldDiagnoseEmbeddedLimitations(dc, loc, true);
+  if (!behavior)
+    return;
+
+  if (isABIMoreGenericThan(
+          member->getInnermostDeclContext()->getGenericSignatureOfContext(),
+          member->getDeclContext()->getGenericSignatureOfContext())) {
+    dc->getASTContext().Diags.diagnose(loc, diag::use_generic_member_of_existential_in_embedded_swift, member,
+        baseType)
+      .limitBehavior(*behavior);
+  }
+}

--- a/lib/Sema/TypeCheckEmbedded.h
+++ b/lib/Sema/TypeCheckEmbedded.h
@@ -25,7 +25,9 @@ class AbstractFunctionDecl;
 class DeclContext;
 struct DiagnosticBehavior;
 class SourceLoc;
-  
+class Type;
+class ValueDecl;
+
 /// Whether we should diagnose language-level limitations of Embedded Swift
 /// at the given source location, and how.
 ///
@@ -46,5 +48,10 @@ void checkEmbeddedRestrictionsInSignature(const AbstractFunctionDecl *func);
 /// Diagnose a declaration of typed throws at the given location.
 void diagnoseUntypedThrowsInEmbedded(const DeclContext *dc, SourceLoc throwsLoc);
 
+/// Diagnose references to a generic member via an existential type, which are
+/// not available in Embedded Swift.
+void diagnoseGenericMemberOfExistentialInEmbedded(
+    const DeclContext *dc, SourceLoc loc,
+    Type baseType, const ValueDecl *member);
 }
 #endif // SWIFT_SEMA_TYPECHECKEMBEDDED_H

--- a/lib/Sema/TypeCheckEmbedded.h
+++ b/lib/Sema/TypeCheckEmbedded.h
@@ -24,6 +24,7 @@ namespace swift {
 class AbstractFunctionDecl;
 class DeclContext;
 struct DiagnosticBehavior;
+class CheckedCastExpr;
 class SourceLoc;
 class Type;
 class ValueDecl;
@@ -53,5 +54,11 @@ void diagnoseUntypedThrowsInEmbedded(const DeclContext *dc, SourceLoc throwsLoc)
 void diagnoseGenericMemberOfExistentialInEmbedded(
     const DeclContext *dc, SourceLoc loc,
     Type baseType, const ValueDecl *member);
+
+/// Diagnose dynamic casts (is/as?/as!) to a type, which is not always available
+/// in Embedded Swift.
+void diagnoseDynamicCastInEmbedded(
+    const DeclContext *dc, const CheckedCastExpr *cast);
+
 }
 #endif // SWIFT_SEMA_TYPECHECKEMBEDDED_H

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -181,12 +181,14 @@ internal class _AnySequenceBox<Element> {
   @inlinable
   internal var _underestimatedCount: Int { _abstract() }
 
+#if !$Embedded
   @inlinable
   internal func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
     _abstract()
   }
+#endif
 
   @inlinable
   internal func _filter(
@@ -534,12 +536,16 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
+
+#if !$Embedded
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
     try _base.map(transform)
   }
+#endif
+
   @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
@@ -627,12 +633,14 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
+#if !$Embedded
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
     try _base.map(transform)
   }
+#endif
   @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
@@ -822,12 +830,14 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
+#if !$Embedded
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
     try _base.map(transform)
   }
+#endif
   @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
@@ -1035,12 +1045,14 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
+#if !$Embedded
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
     try _base.map(transform)
   }
+#endif
   @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
@@ -1322,6 +1334,7 @@ extension AnySequence {
     return _box._underestimatedCount
   }
 
+#if !$Embedded
   @inlinable
   @_alwaysEmitIntoClient
   public func map<T, E>(
@@ -1334,7 +1347,6 @@ extension AnySequence {
     }
   }
 
-#if !$Embedded
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
@@ -1428,6 +1440,7 @@ extension AnyCollection {
     return _box._underestimatedCount
   }
 
+#if !$Embedded
   @inlinable
   @_alwaysEmitIntoClient
   public func map<T, E>(
@@ -1440,7 +1453,6 @@ extension AnyCollection {
     }
   }
 
-#if !$Embedded
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
@@ -1540,6 +1552,7 @@ extension AnyBidirectionalCollection {
     return _box._underestimatedCount
   }
 
+#if !$Embedded
   @inlinable
   @_alwaysEmitIntoClient
   public func map<T, E>(
@@ -1552,7 +1565,6 @@ extension AnyBidirectionalCollection {
     }
   }
 
-#if !$Embedded
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
@@ -1654,6 +1666,7 @@ extension AnyRandomAccessCollection {
     return _box._underestimatedCount
   }
 
+#if !$Embedded
   @inlinable
   @_alwaysEmitIntoClient
   public func map<T, E>(
@@ -1666,7 +1679,6 @@ extension AnyRandomAccessCollection {
     }
   }
 
-#if !$Embedded
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".

--- a/test/embedded/classes-non-final-method-no-stdlib.swift
+++ b/test/embedded/classes-non-final-method-no-stdlib.swift
@@ -4,7 +4,7 @@
 // REQUIRES: swift_feature_Embedded
 
 public class MyClass {
-  public func foo<T>(t: T) { } // expected-error {{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
+  public func foo<T>(t: T) { } // expected-error {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
   public func bar() { }
 }
 
@@ -24,7 +24,7 @@ func testit2() -> C2<S> {
 }
 
 open class C3<X> {
-  public func foo<T>(t: T) {} // expected-error {{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
+  public func foo<T>(t: T) {} // expected-error {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
 }
 
 func testit3() -> C3<S> {

--- a/test/embedded/classes-non-final-method-no-stdlib.swift
+++ b/test/embedded/classes-non-final-method-no-stdlib.swift
@@ -4,7 +4,8 @@
 // REQUIRES: swift_feature_Embedded
 
 public class MyClass {
-  public func foo<T>(t: T) { } // expected-error {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
+  public func foo<T>(t: T) { } // expected-warning {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
+  // expected-error@-1{{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
   public func bar() { }
 }
 
@@ -24,7 +25,8 @@ func testit2() -> C2<S> {
 }
 
 open class C3<X> {
-  public func foo<T>(t: T) {} // expected-error {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
+  public func foo<T>(t: T) {} // expected-warning {{generic instance method 'foo(t:)' in a class must be 'final' in Embedded Swift}}
+  // expected-error@-1{{classes cannot have a non-final, generic method 'foo(t:)' in embedded Swift}}
 }
 
 func testit3() -> C3<S> {

--- a/test/embedded/existential-generic-error.swift
+++ b/test/embedded/existential-generic-error.swift
@@ -9,9 +9,10 @@ public protocol MyProtocol: AnyObject {
 }
 
 func test_some(p: some MyProtocol) {
-    p.foo(ptr: nil, value: 0) // expected-error {{a protocol type cannot contain a generic method 'foo(ptr:value:)' in embedded Swift}}
+  p.foo(ptr: nil, value: 0) // expected-error {{a protocol type cannot contain a generic method 'foo(ptr:value:)' in embedded Swift}}
 }
 
 public func test_any(p: any MyProtocol) {
-    test_some(p: p)
+  test_some(p: p)
+  // expected-warning@-1{{cannot use generic global function 'test_some(p:)' on a value of type 'any MyProtocol' in Embedded Swift}}
 }

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -14,6 +14,7 @@ public func test() -> Int {
 
 func castToExistential<T>(x: T) {
   if x is any FixedWidthInteger {    // expected-error {{cannot do dynamic casting in embedded Swift}}
+    // expected-warning@-1{{cannot perform a dynamic cast to a type involving protocol 'FixedWidthInteger' in Embedded Swift}}
   }
 }
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -86,6 +86,35 @@ class MyGenericClass<T> {
 }
 
 // ---------------------------------------------------------------------------
+// generic functions on existentials
+// ---------------------------------------------------------------------------
+
+public protocol Q {
+  func f<T>(_ value: T)
+  func okay()
+}
+
+extension Q {
+  public func g<T>(_ value: T) {
+    f(value)
+  }
+
+  public mutating func h<T>(_ value: T) {
+    f(value)
+  }
+}
+
+public func existentials(q: any AnyObject & Q, i: Int) {
+  q.okay()
+  q.f(i) // expected-warning{{cannot use generic instance method 'f' on a value of type 'any AnyObject & Q' in Embedded Swift}}
+
+  q.g(i) // expected-warning{{cannot use generic instance method 'g' on a value of type 'any AnyObject & Q' in Embedded Swift}}
+
+  var qm = q
+  qm.h(i) // expected-warning{{cannot use generic instance method 'h' on a value of type 'any AnyObject & Q' in Embedded Swift}}
+}
+
+// ---------------------------------------------------------------------------
 // #if handling to suppress diagnostics for non-Embedded-only code
 // ---------------------------------------------------------------------------
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -112,6 +112,30 @@ public func existentials(q: any AnyObject & Q, i: Int) {
 }
 
 // ---------------------------------------------------------------------------
+// Dynamic casting restrictions
+// ---------------------------------------------------------------------------
+
+class ConformsToQ: Q {
+  final func f<T>(_ value: T) { }
+  func okay() { }
+}
+
+func dynamicCasting(object: AnyObject, cq: ConformsToQ) {
+  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  if let q = object as? any AnyObject & Q {
+    _ = q
+  }
+
+  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  if object is any AnyObject & Q { }
+
+  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  _ = object as! AnyObject & Q
+
+  _ = cq as AnyObject & Q
+}
+
+// ---------------------------------------------------------------------------
 // #if handling to suppress diagnostics for non-Embedded-only code
 // ---------------------------------------------------------------------------
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -65,6 +65,27 @@ public struct MyStruct {
 }
 
 // ---------------------------------------------------------------------------
+// generic, non-final functions
+// ---------------------------------------------------------------------------
+
+protocol P { }
+
+class MyGenericClass<T> {
+  func f<U>(value: U) { } // expected-nonembedded-warning{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
+  // expected-embedded-error@-1{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
+  func g() { }
+  class func h() where T: P { } // expected-nonembedded-warning{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
+  // expected-embedded-error@-1{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
+
+  init<U>(value: U) { } // okay, can be directly called
+
+  required init() { } // non-generic is okay
+
+  required init<V>(something: V) { } // expected-nonembedded-warning{{generic initializer 'init(something:)' in a class cannot be 'required' in Embedded Swift}}
+  // expected-embedded-error@-1{{generic initializer 'init(something:)' in a class cannot be 'required' in Embedded Swift}}
+}
+
+// ---------------------------------------------------------------------------
 // #if handling to suppress diagnostics for non-Embedded-only code
 // ---------------------------------------------------------------------------
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -71,18 +71,15 @@ public struct MyStruct {
 protocol P { }
 
 class MyGenericClass<T> {
-  func f<U>(value: U) { } // expected-nonembedded-warning{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
-  // expected-embedded-error@-1{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
+  func f<U>(value: U) { } // expected-warning{{generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift}}
   func g() { }
-  class func h() where T: P { } // expected-nonembedded-warning{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
-  // expected-embedded-error@-1{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
+  class func h() where T: P { } // expected-warning{{generic class method 'h()' in a class must be 'final' in Embedded Swift}}
 
   init<U>(value: U) { } // okay, can be directly called
 
   required init() { } // non-generic is okay
 
-  required init<V>(something: V) { } // expected-nonembedded-warning{{generic initializer 'init(something:)' in a class cannot be 'required' in Embedded Swift}}
-  // expected-embedded-error@-1{{generic initializer 'init(something:)' in a class cannot be 'required' in Embedded Swift}}
+  required init<V>(something: V) { } // expected-warning{{generic initializer 'init(something:)' in a class cannot be 'required' in Embedded Swift}}
 }
 
 // ---------------------------------------------------------------------------

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -1,11 +1,25 @@
 # Embedded Swift language restrictions (EmbeddedRestrictions)
 
-Embedded Swift is a compilation model of Swift that can produce extremely small binaries without external dependencies, suitable for restricted environments including embedded (microcontrollers) and baremetal setups (no operating system at all), and low-level environments (firmware, kernels, device drivers, low-level components of userspace OS runtimes). While the vast majority of Swift language features are available in Embedded Swift, there are some language features that require the full Swift standard library and runtime, which are not available in Embedded Swift.
+Embedded Swift is a subset of the Swift language that compiles to smaller binaries that do not rely on the Swift runtime. Embedded Swift produces some restrictions on the use of the Swift language to eliminate the runtime dependency, which are captured by the `EmbeddedRestrictions` diagnostic group.
 
-Diagnostics in the `EmbeddedRestrictions` group describe those language features that cannot be used in Embedded Swift. For example, Embedded Swift uses a simplified reference-counting model that does not support `weak` or `unowned` references. The following will produce a diagnostic in Embedded Swift:
+The Embedded Swift compilation model can produce extremely small binaries without external dependencies, suitable for restricted environments including embedded (microcontrollers) and baremetal setups (no operating system at all), and low-level environments (firmware, kernels, device drivers, low-level components of userspace OS runtimes). While the vast majority of Swift language features are available in Embedded Swift, there are some language features that require the full Swift standard library and runtime, which are not available in Embedded Swift.
+
+Diagnostics in the `EmbeddedRestrictions` group describe those language features that cannot be used in Embedded Swift. These include:
+
+* `weak` and `unowned` references, because Embedded Swift uses a simplified reference-counting model that cannot support them. For example:
 
     class Node {
       weak var parent: Node?    // error: attribute 'weak' cannot be used in Embedded Swift
+    }
+
+* Non-final generic methods in a class, which are prohibited because they cannot be specialized for every possible call site. For example:
+
+    class MyGenericClass<T> {
+      func f<U>(value: U) { } // warning: generic instance method 'f(value:)' in a class must be 'final' in Embedded Swift
+
+      func g() { } // okay, not generic relative to the class itself
+
+      class func h() where T: P { } // warning: generic class method 'h()' in a class must be 'final' in Embedded Swift
     }
 
 ## See Also

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -1,6 +1,6 @@
 # Embedded Swift language restrictions (EmbeddedRestrictions)
 
-Embedded Swift is a subset of the Swift language that compiles to smaller binaries that do not rely on the Swift runtime. Embedded Swift produces some restrictions on the use of the Swift language to eliminate the runtime dependency, which are captured by the `EmbeddedRestrictions` diagnostic group.
+Embedded Swift is a subset of the Swift language that that introduces some restrictions on the use of language features to eliminate the need for the Swift runtime. These restrictions are captured by the `EmbeddedRestrictions` diagnostic group.
 
 The Embedded Swift compilation model can produce extremely small binaries without external dependencies, suitable for restricted environments including embedded (microcontrollers) and baremetal setups (no operating system at all), and low-level environments (firmware, kernels, device drivers, low-level components of userspace OS runtimes). While the vast majority of Swift language features are available in Embedded Swift, there are some language features that require the full Swift standard library and runtime, which are not available in Embedded Swift.
 
@@ -20,6 +20,23 @@ Diagnostics in the `EmbeddedRestrictions` group describe those language features
       func g() { } // okay, not generic relative to the class itself
 
       class func h() where T: P { } // warning: generic class method 'h()' in a class must be 'final' in Embedded Swift
+    }
+
+* Generic methods used on values of protocol type, which are prohibited because they cannot be specialized for every possible call site. For example:
+
+    protocol P: AnyObject {
+      func doNothing()
+      func doSomething<T>(on value: T)
+    }
+
+    func testGenerics<Value: P>(value: value, i: Int) {
+      value.doNothing()        // okay
+      value.doSomething(on: i) // okay, always specialized
+    }
+
+    func testValuesOfProtocolType(value: any P, i: Int) {
+      value.doNothing()        // okay
+      value.doSomething(on: i) // warning: cannot use generic instance method 'doSomething(on:)' on a value of type 'any P' in Embedded Swift
     }
 
 ## See Also

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -48,6 +48,11 @@ Diagnostics in the `EmbeddedRestrictions` group describe those language features
       value.doSomething(on: i) // warning: cannot use generic instance method 'doSomething(on:)' on a value of type 'any P' in Embedded Swift
     }
 
+* Use of untyped throws, which depends on `any Error` and is not available in Embedded Swift. Use typed throws instead:
+
+    func mayFail() throws { } // error: untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'
+    func mayFail() throws(MyError) // okay
+
 ## See Also
 
 - [A Vision for Embedded Swift](https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md)

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -12,6 +12,15 @@ Diagnostics in the `EmbeddedRestrictions` group describe those language features
       weak var parent: Node?    // error: attribute 'weak' cannot be used in Embedded Swift
     }
 
+* Dynamic casts to a type involving a protocol are not supported, because Embedded Swift does not include runtime metadata about protocol conformances. For example:
+
+    protocol P: AnyObject { }
+    func casting(object: AnyObject) {
+      if let p = object as? P { // error: cannot perform a dynamic cast to a type involving protocol 'P' in Embedded Swift
+        // ...
+      }
+    }
+
 * Non-final generic methods in a class, which are prohibited because they cannot be specialized for every possible call site. For example:
 
     class MyGenericClass<T> {


### PR DESCRIPTION
Implement diagnostics in the type checker for more of the Embedded Swift language restrictions in the type checker. They are all introduced as warnings in the same diagnostic group (`EmbeddedRestrictions`), which also documents the restrictions. Take existing diagnostics in SIL and put them in the same diagnostic group. Diagnostics introduced include:

* Casting to an existential
* Defining non-final generic functions in a class
* Calling generic functions on an existential

This is tracked by rdar://119383905