### PR TITLE
[cxx-interop] Allow SWIFT_RETURNS_(UN)RETAINED on template class member functions returning T*

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -299,8 +299,8 @@ ERROR(both_returns_retained_returns_unretained, none,
 ERROR(redundant_conformance_protocol,none,
      "redundant conformance of %0 to protocol '%1'", (Type, StringRef))
 
-ERROR(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
-      "%0 cannot be annotated with either SWIFT_RETURNS_RETAINED or "
+WARNING(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
+      "%0 should not be annotated with SWIFT_TURNS_RETAINED or "
       "SWIFT_RETURNS_UNRETAINED because it is not returning "
       "a SWIFT_SHARED_REFERENCE type",
       (const clang::NamedDecl *))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3615,10 +3615,17 @@ namespace {
       } else {
         if (attrInfo.hasRetainAttr()) {
           if (const auto *functionDecl = dyn_cast<clang::FunctionDecl>(decl)) {
-            if (functionDecl->isTemplateInstantiation()) {
+            // Skip diagnostics for template instantiations and template-dependent
+            // return types. We cannot determine at import time whether T or T* will
+            // be instantiated as a SWIFT_SHARED_REFERENCE type or not, so we avoid
+            // emitting potentially incorrect warnings for these cases.
+            if (functionDecl->isTemplateInstantiation() ||
+                functionDecl->getReturnType()->isInstantiationDependentType() ||
+                functionDecl->getReturnType()->isDependentType()) {
               return;
             }
           }
+
           Impl.diagnose(
               loc,
               diag::

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
@@ -47,3 +47,8 @@ let _ = DefaultOwnershipInheritance.createDerivedTypeNonDefault() // expected-wa
 let _ = DefaultOwnershipInheritance.createDerivedTypeNonDefaultUnretained()
 let  _ = SourceLocationCaching.FactoryA.make() // expected-warning {{cannot infer the ownership of the returned value, annotate 'make()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
 let  _ = SourceLocationCaching.FactoryB.make() // expected-warning {{cannot infer the ownership of the returned value, annotate 'make()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
+
+let refTemplate = FRTStructRef()
+let templatePtr = refTemplate.ptr()
+let templateGet = refTemplate.get()
+let templateValue = refTemplate.value()  // expected-warning {{cannot infer the ownership of the returned value, annotate 'value()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
@@ -276,3 +276,16 @@ func testDefaultOwnershipAnnotation() {
   let _ = DefaultOwnershipInheritance.createDerivedTypeNonDefaultUnretained()
   // CHECK: function_ref {{.*}}createDerivedTypeNonDefaultUnretained{{.*}} : $@convention(c) () -> DefaultOwnershipInheritance.DerivedTypeNonDefault
 }
+
+func testTemplateMemberFunctions() {
+  let refTemplate = FRTStructRef()
+
+  let ptr = refTemplate.ptr()
+  // CHECK: function_ref {{.*}}ptr{{.*}} : $@convention(cxx_method) (@in_guaranteed RefTemplate<FRTStruct>) -> @owned FRTStruct
+
+  let get = refTemplate.get()
+  // CHECK: function_ref {{.*}}get{{.*}} : $@convention(cxx_method) (@in_guaranteed RefTemplate<FRTStruct>) -> FRTStruct
+
+  let value = refTemplate.value()
+  // CHECK: function_ref {{.*}}value{{.*}} : $@convention(cxx_method) (@in_guaranteed RefTemplate<FRTStruct>) -> FRTStruct
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
@@ -24,7 +24,7 @@ void releaseCxxRefType(CxxRefType *_Nonnull b) {}
 + (struct CxxRefType *)objCMethodReturningFRTBothAnnotations // expected-error {{'objCMethodReturningFRTBothAnnotations' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED}}
     __attribute__((swift_attr("returns_unretained")))
     __attribute__((swift_attr("returns_retained")));
-+ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated // expected-error {{'objCMethodReturningNonCxxFrtAnannotated' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
++ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated // expected-warning {{'objCMethodReturningNonCxxFrtAnannotated' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
     __attribute__((swift_attr("returns_retained")));
 
 @end


### PR DESCRIPTION
When importing C++ template classes like`Ref<T>` that have methods returning `T*`, we face the following situation when `T` is a `SWIFT_SHARED_REFERENCE` type:

  1. Without `SWIFT_RETURNS_(UN)RETAINED` annotation: Swift  compiler would emit a warning (currently under experimental-feature flag `WarnUnannotatedReturnOfCxxFrt`) _"cannot infer the ownership of the returned value" when T is a SWIFT_SHARED_REFERENCE type_ 
  2. With annotation: Compiler rejects it with this error: _"cannot be annotated... not returning a SWIFT_SHARED_REFERENCE type"_

This affects WebGPU's smart pointer types (`WTF::Ref<T>, WTF::RefPtr<T>`) and similar patterns in other C++ codebases.

In this patch I am fixing the logic for diagnostic `returns_retained_or_returns_unretained_for_non_cxx_frt_values`. I'm also making it a warning instead of an error to minimize the risk, as this diagnostic has been a hindrance to the adoption of these annotations in real codebases when templated functions and types are involved. (Refer to [PR-78968](https://github.com/swiftlang/swift/pull/78968))

rdar://160862498