### PR TITLE
[AllocBoxToStack] Fix missing [nothrow] of apply.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -261,7 +261,7 @@ private struct FunctionSpecializations {
 
     switch apply {
     case let applyInst as ApplyInst:
-      let newApply = builder.createApply(function: specializedCallee, applyInst.substitutionMap, arguments: newArgs)
+      let newApply = builder.createApply(function: specializedCallee, applyInst.substitutionMap, arguments: newArgs, isNonThrowing: applyInst.isNonThrowing)
       applyInst.replace(with: newApply, context)
     case let partialAp as PartialApplyInst:
       let newApply = builder.createPartialApply(function: specializedCallee, substitutionMap:

--- a/validation-test/SILOptimizer/gh84337.swift
+++ b/validation-test/SILOptimizer/gh84337.swift
@@ -1,0 +1,38 @@
+// RUN: %target-build-swift -O %s
+
+@propertyWrapper
+public struct Dependency2<Value> {
+  public init(
+    _ keyPath: KeyPath<DependencyValues, Value>
+  ) {
+
+  }
+  public var wrappedValue: Value {
+      let any: Any = "somestring"
+      return any as! Value
+  }
+}
+
+struct Client {
+    var get: (_ id: String) -> Bool
+}
+
+public struct DependencyValues {
+    var client3: Client
+}
+
+public protocol WindowData2 {
+    var id :String {get set}
+}
+
+extension WindowData2 {
+    func didSetProfileForSpaceIDs(
+        spaceIDs: [String]
+    ) -> Void {
+        @Dependency2(\.client3) var client: Client
+        spaceIDs.forEach { _ in
+            spaceIDs
+                .map { _ in return client.get(id) }
+        }
+    }
+}


### PR DESCRIPTION
When specializing an apply which is annotated `[nothrow]`, the resulting function's apply must still be annotated `[nothrow]`.

rdar://160742150
