### PR TITLE
Parser: Rename the experimental attribute `@cdecl` to the shorter `@c`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4903,12 +4903,12 @@ public:
     return getAttrs().hasAttribute<IndirectAttr>();
   }
 
-  /// True if the enum is marked with `@cdecl`.
+  /// True if the enum is marked with `@c`.
   bool isCDeclEnum() const {
     return getAttrs().hasAttribute<CDeclAttr>();
   }
 
-  /// True if the enum is marked with `@cdecl` or `@objc`.
+  /// True if the enum is marked with `@c` or `@objc`.
   bool isCCompatibleEnum() const {
     return isCDeclEnum() || isObjC();
   }
@@ -8236,8 +8236,8 @@ public:
   /// instance method.
   bool isObjCInstanceMethod() const;
 
-  /// Get the foreign language targeted by a @cdecl-style attribute, if any.
-  /// Used to abstract away the change in meaning of @cdecl vs @_cdecl while
+  /// Get the foreign language targeted by a @c-style attribute, if any.
+  /// Used to abstract away the change in meaning of @c vs @_cdecl while
   /// formalizing the attribute.
   std::optional<ForeignLanguage> getCDeclKind() const;
 

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -368,11 +368,11 @@ SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
   UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | UnreachableInABIAttr,
   62)
 
-DECL_ATTR(_cdecl, CDecl,
+DECL_ATTR(c, CDecl,
   OnFunc | OnAccessor | OnEnum,
   LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   63)
-DECL_ATTR_ALIAS(cdecl, CDecl)
+DECL_ATTR_ALIAS(_cdecl, CDecl)
 
 SIMPLE_DECL_ATTR(usableFromInline, UsableFromInline,
   OnAbstractFunction | OnVar | OnSubscript | OnNominalType | OnTypeAlias,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2089,10 +2089,10 @@ ERROR(cdecl_empty_name,none,
 ERROR(cdecl_throws,none,
       "raising errors from %0 functions is not supported", (DeclAttribute))
 ERROR(cdecl_incompatible_with_objc,none,
-      "cannot apply both '@cdecl' and '@objc' to %kindonly0",
+      "cannot apply both '@c' and '@objc' to %kindonly0",
       (const Decl *))
 ERROR(cdecl_feature_required,none,
-      "'@cdecl' requires '-enable-experimental-feature CDecl'",
+      "'@c' requires '-enable-experimental-feature CDecl'",
       ())
 
 // @_used and @_section
@@ -6617,7 +6617,7 @@ ERROR(objc_cannot_infer_name_raw_identifier,none,
       (const ValueDecl *))
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked '@cdecl'|marked '@_cdecl'|marked dynamic|marked '@objc'|marked '@objcMembers'|marked '@IBOutlet'|marked '@IBAction'|marked '@IBSegueAction'|marked '@NSManaged'|a member of an '@objc' protocol|implicitly '@objc'|an '@objc' override|an implementation of an '@objc' requirement|marked '@IBInspectable'|marked '@GKInspectable'|in an '@objc' extension of a class (without '@nonobjc')|in an '@objc @implementation' extension of a class (without final or '@nonobjc')|marked '@objc' by an access note}"
+#define OBJC_ATTR_SELECT "select{marked '@c'|marked '@_cdecl'|marked dynamic|marked '@objc'|marked '@objcMembers'|marked '@IBOutlet'|marked '@IBAction'|marked '@IBSegueAction'|marked '@NSManaged'|a member of an '@objc' protocol|implicitly '@objc'|an '@objc' override|an implementation of an '@objc' requirement|marked '@IBInspectable'|marked '@GKInspectable'|in an '@objc' extension of a class (without '@nonobjc')|in an '@objc @implementation' extension of a class (without final or '@nonobjc')|marked '@objc' by an access note}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "
@@ -6671,7 +6671,7 @@ NOTE(not_objc_swift_struct,none,
 NOTE(not_objc_swift_enum,none,
       "non-'@objc' enums cannot be represented in Objective-C", ())
 NOTE(not_cdecl_or_objc_swift_enum,none,
-     "Swift enums not marked '@cdecl'%select{| or '@objc'}0 cannot be "
+     "Swift enums not marked '@c'%select{| or '@objc'}0 cannot be "
      "represented in %" FOREIGN_LANG_SELECT "0",
      (ForeignLanguage))
 NOTE(not_objc_generic_type_param,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4948,7 +4948,7 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Check @cdecl functions for compatibility with the foreign language.
+/// Check @c functions for compatibility with the foreign language.
 class TypeCheckCDeclFunctionRequest
     : public SimpleRequest<TypeCheckCDeclFunctionRequest,
                            evaluator::SideEffect(FuncDecl *FD,
@@ -4967,7 +4967,7 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Check @cdecl enums for compatibility with C.
+/// Check @c enums for compatibility with C.
 class TypeCheckCDeclEnumRequest
     : public SimpleRequest<TypeCheckCDeclEnumRequest,
                            evaluator::SideEffect(EnumDecl *ED,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -529,7 +529,7 @@ EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)
 /// Allow declarations of Swift runtime symbols using @_silgen_name.
 EXPERIMENTAL_FEATURE(AllowRuntimeSymbolDeclarations, true)
 
-/// Allow use of `@cdecl`
+/// Allow use of `@c`
 EXPERIMENTAL_FEATURE(CDecl, false)
 
 /// Allow use of `Module::name` syntax

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1825,7 +1825,7 @@ StringRef DeclAttribute::getAttrName() const {
   case DeclAttrKind::CDecl:
     if (cast<CDeclAttr>(this)->Underscored)
       return "_cdecl";
-    return "cdecl";
+    return "c";
   case DeclAttrKind::SwiftNativeObjCRuntimeBase:
     return "_swift_native_objc_runtime_base";
   case DeclAttrKind::Semantics:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1246,9 +1246,17 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
-  case DeclAttrKind::CDecl:
-    Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
+  case DeclAttrKind::CDecl: {
+    auto Attr = cast<CDeclAttr>(this);
+    if (Attr->Underscored)
+      Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
+    else {
+      Printer << "@c";
+      if (!Attr->Name.empty())
+        Printer << "(" << cast<CDeclAttr>(this)->Name << ")";
+    }
     break;
+  }
 
   case DeclAttrKind::Expose: {
     Printer.printAttrName("@_expose");

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -655,7 +655,7 @@ clang::QualType ClangTypeConverter::visitEnumType(EnumType *type) {
 
   auto ED = type->getDecl();
   if (!ED->isCCompatibleEnum())
-    // Can't translate something not marked with @objc or @cdecl.
+    // Can't translate something not marked with @objc or @c.
     return clang::QualType();
 
   // @objc enums lower to their raw types.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3166,7 +3166,7 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       if (isa<ClassDecl>(nominal) || isa<ProtocolDecl>(nominal))
         return failure();
 
-      // @objc enums are not representable in C, @cdecl ones and imported ones
+      // @objc enums are not representable in C, @c ones and imported ones
       // are ok.
       if (!nominal->hasClangNode())
         return failure();
@@ -3209,7 +3209,7 @@ getForeignRepresentable(Type type, ForeignLanguage language,
     }
   }
 
-  // @cdecl enums are representable in C and Objective-C.
+  // @c enums are representable in C and Objective-C.
   if (nominal->getAttrs().getAttribute<CDeclAttr>()) {
     return { ForeignRepresentableKind::Trivial, nullptr };
   }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6536,7 +6536,7 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
         std::move(elementsWithPayload), std::move(elementsWithNoPayload)));
   }
 
-  // Enums imported from Clang or marked with @objc or @cdecl use a
+  // Enums imported from Clang or marked with @objc or @c use a
   // C-compatible layout.
   if (theEnum->hasClangNode() || theEnum->isCCompatibleEnum()) {
     assert(elementsWithPayload.empty() && "C enum with payload?!");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3026,7 +3026,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   case DeclAttrKind::CDecl: {
     if (!AttrName.starts_with("_") &&
 
-        // Backwards support for @cdecl("stringId"). Remove before enabling in
+        // Backwards support for @c("stringId"). Remove before enabling in
         // production so we accept only the identifier format.
         lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
            return Tok.isNot(tok::string_literal);

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2418,7 +2418,7 @@ private:
     if (ED && !NTD->hasClangNode()) {
       if (ED->isCDeclEnum()) {
         // We should be able to use the tag macro for all printed enums but
-        // for now restrict it to @cdecl to guard it behind the feature flag.
+        // for now restrict it to @c to guard it behind the feature flag.
         os << "SWIFT_ENUM_TAG ";
       } else {
         os << "enum ";
@@ -3056,7 +3056,7 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
       return false;
   }
 
-  // In C output mode print only the C variant `@cdecl` (no `@_cdecl`),
+  // In C output mode print only the C variant `@c` (no `@_cdecl`),
   // while in other modes print only `@_cdecl`.
   std::optional<ForeignLanguage> cdeclKind = std::nullopt;
   if (auto *FD = dyn_cast<AbstractFunctionDecl>(VD))
@@ -3066,14 +3066,14 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
        (outputLang == OutputLanguageMode::C))
     return false;
 
-  // C output mode only prints @cdecl functions and enums.
+  // C output mode only prints @c functions and enums.
   if (outputLang == OutputLanguageMode::C &&
       !cdeclKind && !isa<EnumDecl>(VD)) {
     return false;
   }
 
-  // The C mode prints @cdecl enums and reject other enums,
-  // while other modes accept other enums and reject @cdecl ones.
+  // The C mode prints @c enums and reject other enums,
+  // while other modes accept other enums and reject @c ones.
   if (isa<EnumDecl>(VD) &&
       VD->getAttrs().hasAttribute<CDeclAttr>() !=
         (outputLang == OutputLanguageMode::C)) {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -460,7 +460,7 @@ public:
 
     if (isa<EnumDecl>(D) && !D->hasClangNode() &&
         outputLangMode != OutputLanguageMode::Cxx) {
-      // We don't want to add an import for a @cdecl or @objc enum declared
+      // We don't want to add an import for a @c or @objc enum declared
       // in Swift. We either do nothing for special enums like Optional as
       // done in the prologue here, or we forward declare them.
       return false;

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -615,7 +615,7 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
   SwiftToClangInteropContext interopContext(*M, irGenOpts);
   writePrologue(os, M->getASTContext(), computeMacroGuard(M));
 
-  // C content (@cdecl)
+  // C content (@c)
   std::string moduleContentsScratch;
   if (M->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {
     SmallPtrSet<ImportModuleTy, 8> imports;

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -170,7 +170,7 @@ void SILFunctionBuilder::addFunctionAttributes(
   for (auto *EA : Attrs.getAttributes<ExposeAttr>()) {
     bool shouldExportDecl = true;
     if (Attrs.hasAttribute<CDeclAttr>()) {
-      // If the function is marked with @cdecl, expose only C compatible
+      // If the function is marked with @c, expose only C compatible
       // thunk function.
       shouldExportDecl = constant.isNativeToForeignThunk();
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2446,12 +2446,12 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
              attr, "func");
   }
 
-  // Reject using both @cdecl and @objc on the same decl.
+  // Reject using both @c and @objc on the same decl.
   if (D->getAttrs().getAttribute<ObjCAttr>()) {
     diagnose(attr->getLocation(), diag::cdecl_incompatible_with_objc, D);
   }
 
-  // @cdecl needs to be enabled via a feature flag.
+  // @c needs to be enabled via a feature flag.
   if (!attr->Underscored &&
       !Ctx.LangOpts.hasFeature(Feature::CDecl)) {
     diagnose(attr->getLocation(), diag::cdecl_feature_required);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -223,7 +223,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
   // Special diagnostic for enums.
   if (T->is<EnumType>()) {
     if (DC->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {
-      // New dialog mentioning @cdecl.
+      // New dialog mentioning @c.
       diags.diagnose(TypeRange.Start, diag::not_cdecl_or_objc_swift_enum,
                      language)
           .highlight(TypeRange)
@@ -1782,13 +1782,13 @@ static bool isCIntegerType(Type type) {
 static bool isEnumObjC(EnumDecl *enumDecl, DeclAttribute *attr) {
   // FIXME: Use shouldMarkAsObjC once it loses it's TypeChecker argument.
 
-  // If there is no @objc or @cdecl attribute, skip it.
+  // If there is no @objc or @c attribute, skip it.
   if (!attr)
     return false;
 
   Type rawType = enumDecl->getRawType();
 
-  // @objc/@cdecl enums must have a raw type.
+  // @objc/@c enums must have a raw type.
   if (!rawType) {
     enumDecl->diagnose(diag::objc_enum_no_raw_type, attr);
     return false;
@@ -4227,7 +4227,7 @@ TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
   auto &ctx = FD->getASTContext();
 
   auto lang = FD->getCDeclKind();
-  assert(lang && "missing @cdecl?");
+  assert(lang && "missing @c?");
   auto kind = lang == ForeignLanguage::ObjectiveC
                       ? ObjCReason::ExplicitlyUnderscoreCDecl
                       : ObjCReason::ExplicitlyCDecl;

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -41,7 +41,7 @@ class ObjCReason {
 public:
   // The kind of reason.
   enum Kind {
-    /// Has the '@cdecl' attribute.
+    /// Has the '@c' attribute.
     ExplicitlyCDecl,
     /// Has the '@_cdecl' attribute.
     ExplicitlyUnderscoreCDecl,

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -99,8 +99,8 @@ func fn(_: Int) {}
 @_disallowFeatureSuppression(NoncopyableGenerics) public struct LoudlyNC<T: ~Copyable> {}
 
 @_cdecl("c_function_name") func cdeclUnderscore(x: Int) {}
-@cdecl(c_function_name_official) func cdecl(x: Int) {}
-@cdecl func cdeclDefault() {}
+@c(c_function_name_official) func cdecl(x: Int) {}
+@c func cdeclDefault() {}
 
 struct StaticProperties {
   dynamic var property: Int { return 1 }

--- a/test/IRGen/cdecl_implementation.swift
+++ b/test/IRGen/cdecl_implementation.swift
@@ -10,13 +10,13 @@
 // REQUIRES: swift_feature_CImplementation
 // REQUIRES: swift_feature_CDecl
 
-@implementation @cdecl
+@implementation @c
 public func implFunc(_ param: Int32) {}
 
-@implementation @cdecl
+@implementation @c
 public func implFuncCName(_ param: Int32) {}
 
-@implementation @cdecl(implFuncRenamed_C)
+@implementation @c(implFuncRenamed_C)
 public func implFuncRenamed_Swift(param: Int32) {}
 
 public func fn() {

--- a/test/Interpreter/cdecl_enum_run.swift
+++ b/test/Interpreter/cdecl_enum_run.swift
@@ -4,19 +4,19 @@
 // REQUIRES: swift_feature_CDecl
 // REQUIRES: executable_test
 
-@cdecl
+@c
 enum CDecl8: UInt8 {
 case a
 case b
 }
 
-@cdecl
+@c
 enum CDecl16: UInt16 {
 case a
 case b
 }
 
-@cdecl(SomeName)
+@c(SomeName)
 enum CDecl32: UInt32 {
 case a
 case b
@@ -33,12 +33,12 @@ case a
 case b
 }
 
-print("@cdecl enum 8 is \(MemoryLayout<CDecl8>.size) bytes")
-// CHECK: @cdecl enum 8 is 1 bytes
-print("@cdecl enum 16 is \(MemoryLayout<CDecl16>.size) bytes")
-// CHECK: @cdecl enum 16 is 2 bytes
-print("@cdecl enum 32 is \(MemoryLayout<CDecl32>.size) bytes")
-// CHECK: @cdecl enum 32 is 4 bytes
+print("@c enum 8 is \(MemoryLayout<CDecl8>.size) bytes")
+// CHECK: @c enum 8 is 1 bytes
+print("@c enum 16 is \(MemoryLayout<CDecl16>.size) bytes")
+// CHECK: @c enum 16 is 2 bytes
+print("@c enum 32 is \(MemoryLayout<CDecl32>.size) bytes")
+// CHECK: @c enum 32 is 4 bytes
 print("@objc enum is \(MemoryLayout<ObjCEnum>.size) bytes")
 // CHECK: @objc enum is 4 bytes
 print("Swift enum is \(MemoryLayout<SwiftEnum>.size) bytes")

--- a/test/Interpreter/cdecl_implementation_run.swift
+++ b/test/Interpreter/cdecl_implementation_run.swift
@@ -44,23 +44,23 @@ extern void renamed_clangSide(ptrdiff_t arg);
 
 //--- Lib.swift
 
-@cdecl @implementation
+@c @implementation
 public func simple(_ x: Int32, _ y: Int32) -> Int32 {
     print(x, y)
     return x
 }
 
-@implementation @cdecl
+@implementation @c
 public func primitiveTypes(_ i: Int, _ ci: CInt, _ l: CLong, _ c: CChar, _ f: Float, _ d: Double, _ b: Bool) {
     print(i, ci, l, c, f, d, b)
 }
 
-@cdecl(sameName) @implementation
+@c(sameName) @implementation
 public func sameName() {
     print("sameName")
 }
 
-@cdecl(renamed_clangSide) @implementation
+@c(renamed_clangSide) @implementation
 public func renamed_swiftSide(_ arg: Int) {
     print(arg)
 }

--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -26,22 +26,22 @@
 //--- Lib.swift
 
 /// My documentation
-@cdecl(simple) public func simpleNameSwiftSide(x: CInt, bar y: CInt) -> CInt {
+@c(simple) public func simpleNameSwiftSide(x: CInt, bar y: CInt) -> CInt {
     print(x, y)
     return x
 }
 
-@cdecl func defaultName(x: Int) {
+@c func defaultName(x: Int) {
     print(x)
 }
 
-@cdecl public func primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {
+@c public func primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {
     print(i, ci, l, c, f, d, b)
 }
 
-@cdecl enum CEnum: CInt { case A, B }
+@c enum CEnum: CInt { case A, B }
 
-@cdecl func useEnum(e: CEnum) -> CEnum {
+@c func useEnum(e: CEnum) -> CEnum {
     print(e)
     print(e.rawValue)
     return e

--- a/test/PrintAsObjC/cdecl-enum-reference.swift
+++ b/test/PrintAsObjC/cdecl-enum-reference.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// Build CoreLib defining a @cdecl enum.
+/// Build CoreLib defining a @c enum.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   %t/CoreLib.swift -emit-module -verify -o %t \
 // RUN:   -emit-clang-header-path %t/CoreLib.h \
 // RUN:   -enable-experimental-feature CDecl
 // RUN: %check-in-clang-c %t/CoreLib.h -I %t
 
-/// Build MiddleLib using the @cdecl enum in API.
+/// Build MiddleLib using the @c enum in API.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   %t/MiddleLib.swift -emit-module -verify -o %t -I %t \
 // RUN:   -emit-clang-header-path %t/MiddleLib.h \
@@ -25,13 +25,13 @@
 // REQUIRES: swift_feature_CDecl
 
 //--- CoreLib.swift
-@cdecl("CEnum")
+@c("CEnum")
 public enum CEnum: CInt { case A, B }
 
 //--- MiddleLib.swift
 import CoreLib
 
-@cdecl("CFunc")
+@c("CFunc")
 public func CFunc(e: CEnum) {}
 // CHECK: typedef SWIFT_ENUM_FWD_DECL(int, CEnum)
 // CHECK: SWIFT_EXTERN void CFunc(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT;

--- a/test/PrintAsObjC/cdecl-enums.swift
+++ b/test/PrintAsObjC/cdecl-enums.swift
@@ -1,4 +1,4 @@
-/// Variant of PrintAsObjC/enums.swift for @cdecl enums.
+/// Variant of PrintAsObjC/enums.swift for @c enums.
 
 // RUN: %empty-directory(%t)
 
@@ -31,7 +31,7 @@ import Foundation
 // CHECK-NEXT:   ObjcEnumNamedHelloDolly = 4,
 // CHECK-NEXT: };
 
-@cdecl(ObjcEnumNamed) enum EnumNamed: Int {
+@c(ObjcEnumNamed) enum EnumNamed: Int {
   case A, B, C, d, helloDolly
 }
 
@@ -42,7 +42,7 @@ import Foundation
 // CHECK-NEXT: };
 // NEGATIVE-NOT: ExplicitValuesDomain
 
-@cdecl enum ExplicitValues: CUnsignedInt {
+@c enum ExplicitValues: CUnsignedInt {
   case Zim, Zang = 219, Zung
 
   func methodNotExportedToC() {}
@@ -57,7 +57,7 @@ import Foundation
 // CHECK-NEXT: }
 
 /// Foo: A feer, a female feer.
-@cdecl("FooComments") public enum FooComments: CInt {
+@c("FooComments") public enum FooComments: CInt {
   /// Zim: A zeer, a female zeer.
   case Zim
   case Zang, Zung
@@ -67,7 +67,7 @@ import Foundation
 // CHECK-NEXT:   Zang = -219,
 // CHECK-NEXT:   Zung = -218,
 // CHECK-NEXT: };
-@cdecl("NegativeValues") enum NegativeValues: Int16 {
+@c("NegativeValues") enum NegativeValues: Int16 {
   case Zang = -219, Zung
 
   func methodNotExportedToC() {}
@@ -77,7 +77,7 @@ import Foundation
 // CHECK-NEXT:   SomeErrorBadness = 9001,
 // CHECK-NEXT:   SomeErrorWorseness = 9002,
 // CHECK-NEXT: };
-@cdecl("SomeError") enum SomeError: Int, Error {
+@c("SomeError") enum SomeError: Int, Error {
   case Badness = 9001
   case Worseness
 }
@@ -85,32 +85,32 @@ import Foundation
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, SomeOtherError, "SomeOtherError", closed) {
 // CHECK-NEXT:   SomeOtherErrorDomain = 0,
 // CHECK-NEXT: };
-@cdecl("SomeOtherError") enum SomeOtherError: Int, Error {
+@c("SomeOtherError") enum SomeOtherError: Int, Error {
   case Domain
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, ObjcErrorType, "SomeRenamedErrorType", closed) {
 // CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
 // CHECK-NEXT: };
-@cdecl("ObjcErrorType") enum SomeRenamedErrorType: Int, Error {
+@c("ObjcErrorType") enum SomeRenamedErrorType: Int, Error {
   case BadStuff
 }
 
-@cdecl("acceptMemberImported") func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+@c("acceptMemberImported") func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptMemberImported(enum MemberRaw a, enum MemberEnum b, MemberOptions c, enum MemberTypedef d, MemberAnon e, MemberAnon2 ee) SWIFT_NOEXCEPT;
 
-@cdecl("acceptPlainEnum") func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
+@c("acceptPlainEnum") func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptPlainEnum(enum NSMalformedEnumMissingTypedef) SWIFT_NOEXCEPT;
 
-@cdecl("acceptTopLevelImported") func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
+@c("acceptTopLevelImported") func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptTopLevelImported(enum TopLevelRaw a, TopLevelEnum b, TopLevelOptions c, TopLevelTypedef d, TopLevelAnon e) SWIFT_NOEXCEPT;
 
-@cdecl("takeAndReturnEnumC") func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
+@c("takeAndReturnEnumC") func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
   return .Zung
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG NegativeValues takeAndReturnEnumC(SWIFT_ENUM_TAG FooComments foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("takeAndReturnRenamedEnum") func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
+@c("takeAndReturnRenamedEnum") func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
   return .A
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG ObjcEnumNamed takeAndReturnRenamedEnum(SWIFT_ENUM_TAG ObjcEnumNamed foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;

--- a/test/PrintAsObjC/cdecl-includes-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-includes-with-objc.swift
@@ -1,4 +1,4 @@
-/// Include module for use from both C and Objective-C @cdecl variants.
+/// Include module for use from both C and Objective-C @c variants.
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t --leading-lines
@@ -53,11 +53,11 @@ import Foundation
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@cdecl("get_int_alias")
+@c("get_int_alias")
 public func getIntAlias() -> IntFromCFramework { 42 }
 // CHECK: SWIFT_EXTERN IntFromCFramework get_int_alias(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("imports_cgpoint")
+@c("imports_cgpoint")
 public func importsCGPoint(pt: CGPoint) {  }
 // CHECK: SWIFT_EXTERN void imports_cgpoint(CGPoint pt) SWIFT_NOEXCEPT;
 

--- a/test/PrintAsObjC/cdecl-includes.swift
+++ b/test/PrintAsObjC/cdecl-includes.swift
@@ -78,16 +78,16 @@ import CModule
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@cdecl("mirror_struct")
+@c("mirror_struct")
 public func a_mirrorStruct(_ a: CStruct) -> CStruct { a }
 // CHECK: SWIFT_EXTERN struct CStruct mirror_struct(struct CStruct a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("mirror_union")
+@c("mirror_union")
 public func b_mirrorStruct(_ a: CUnion) -> CUnion { a }
 // CHECK: SWIFT_EXTERN union CUnion mirror_union(union CUnion a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 
-@cdecl("TKGetDefaultToastSetting")
+@c("TKGetDefaultToastSetting")
 public func c_defaultToastSetting() -> TKTimeSetting { TKTimeSettingNormal } // It would be nice to import TKTimeSettingNormal as a member.
 // CHECK: SWIFT_EXTERN TKTimeSetting TKGetDefaultToastSetting(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 

--- a/test/PrintAsObjC/cdecl-official-visibility.swift
+++ b/test/PrintAsObjC/cdecl-official-visibility.swift
@@ -22,43 +22,43 @@
 
 //--- Lib.swift
 
-@cdecl private enum PrivateEnum: CInt { case A, B }
+@c private enum PrivateEnum: CInt { case A, B }
 // PUBLIC-AND-INTERNAL-NOT: PrivateEnum
 
-@cdecl internal enum InternalEnum: CInt { case A, B }
+@c internal enum InternalEnum: CInt { case A, B }
 // INTERNAL-ONLY: typedef SWIFT_ENUM(int, InternalEnum, closed) {
 // INTERNAL-ONLY:   InternalEnumA = 0,
 // INTERNAL-ONLY:   InternalEnumB = 1,
 // INTERNAL-ONLY: };
 
-@cdecl package enum PackageEnum: CInt { case A, B }
+@c package enum PackageEnum: CInt { case A, B }
 // INTERNAL-ONLY: typedef SWIFT_ENUM(int, PackageEnum, closed) {
 // INTERNAL-ONLY:   PackageEnumA = 0,
 // INTERNAL-ONLY:   PackageEnumB = 1,
 // INTERNAL-ONLY: };
 
-@cdecl public enum PublicEnum: CInt { case A, B }
+@c public enum PublicEnum: CInt { case A, B }
 // PUBLIC-AND-INTERNAL: typedef SWIFT_ENUM(int, PublicEnum, closed) {
 // PUBLIC-AND-INTERNAL:   PublicEnumA = 0,
 // PUBLIC-AND-INTERNAL:   PublicEnumB = 1,
 // PUBLIC-AND-INTERNAL: };
 
 /// Private documentation
-@cdecl private func a_private() {}
+@c private func a_private() {}
 // PUBLIC-AND-INTERNAL-NOT: // Private documentation
 // PUBLIC-AND-INTERNAL-NOT: a_private
 
 /// Internal documentation
-@cdecl internal func b_internal() {}
+@c internal func b_internal() {}
 // INTERNAL-ONLY: // Internal documentation
 // INTERNAL-ONLY: b_internal
 
 /// Package documentation
-@cdecl package func c_package() {}
+@c package func c_package() {}
 // INTERNAL-ONLY: // Package documentation
 // INTERNAL-ONLY: c_package
 
 /// Public documentation
-@cdecl public func d_public() {}
+@c public func d_public() {}
 // PUBLIC-AND-INTERNAL: // Public documentation
 // PUBLIC-AND-INTERNAL: d_public

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -44,31 +44,31 @@
 // CHECK: };
 
 /// My documentation
-@cdecl(simple)
+@c(simple)
 func a0_simple(x: Int, bar y: Int) -> Int { return x }
 // CHECK-LABEL: // My documentation
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t simple(ptrdiff_t x, ptrdiff_t y) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl
+@c
 func a1_defaultName(x: Int) -> Int { return x }
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t a1_defaultName(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("primitiveTypes")
+@c("primitiveTypes")
 public func b_primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {}
 // CHECK-LABEL: SWIFT_EXTERN void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b) SWIFT_NOEXCEPT;
 
-@cdecl("has_keyword_arg_names")
+@c("has_keyword_arg_names")
 func c_keywordArgNames(auto: Int, union: Int) {}
 // CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(ptrdiff_t auto_, ptrdiff_t union_) SWIFT_NOEXCEPT;
 
-@cdecl("return_never")
+@c("return_never")
 func d_returnNever() -> Never { fatalError() }
 // CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
 
 /// Pointer types
 // CHECK: /// Pointer types
 
-@cdecl("pointers")
+@c("pointers")
 func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   y: UnsafePointer<Int>,
                   z: UnsafeMutableRawPointer,
@@ -76,7 +76,7 @@ func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   u: OpaquePointer) {}
 // CHECK: SWIFT_EXTERN void pointers(ptrdiff_t * _Nonnull x, ptrdiff_t const * _Nonnull y, void * _Nonnull z, void const * _Nonnull w, void * _Nonnull u) SWIFT_NOEXCEPT;
 
-@cdecl("nullable_pointers")
+@c("nullable_pointers")
 func g_nullablePointers(_ x: UnsafeMutableRawPointer,
                           y: UnsafeMutableRawPointer?,
                           z: UnsafeMutableRawPointer!) {}
@@ -84,26 +84,26 @@ func g_nullablePointers(_ x: UnsafeMutableRawPointer,
 
 /// Enums
 
-@cdecl
+@c
 enum CEnum: CInt { case A, B }
 
-@cdecl("CEnumRenamed_CName")
+@c("CEnumRenamed_CName")
 enum CEnumRenamed: CLong { case A, B }
 
-@cdecl("use_enum")
+@c("use_enum")
 func h_useCEnum(e: CEnum) -> CEnum { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnum use_enum(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("use_enum_renamed")
+@c("use_enum_renamed")
 func i_useCEnumLong(e: CEnumRenamed) -> CEnumRenamed { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnumRenamed_CName use_enum_renamed(SWIFT_ENUM_TAG CEnumRenamed_CName e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("use_enum_late")
+@c("use_enum_late")
 func j_useCEnumChar(e: zCEnumDefinedLate) -> zCEnumDefinedLate { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG zCEnumDefinedLate use_enum_late(SWIFT_ENUM_TAG zCEnumDefinedLate e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 /// Declare this enum late in the source file and in alphabetical order.
-@cdecl("zCEnumDefinedLate")
+@c("zCEnumDefinedLate")
 enum zCEnumDefinedLate: CChar { case A, B }
 
 // CHECK:      #if defined(__cplusplus)

--- a/test/PrintAsObjC/cdecl-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-with-objc.swift
@@ -1,4 +1,4 @@
-/// Ensure we print @cdecl and @_cdecl only once.
+/// Ensure we print @c and @_cdecl only once.
 
 // RUN: %empty-directory(%t)
 
@@ -18,7 +18,7 @@
 // REQUIRES: swift_feature_CDecl
 // REQUIRES: objc_interop
 
-@cdecl("cFunc")
+@c("cFunc")
 func cFunc() { }
 // CHECK: cFunc
 // CHECK-NOT: cFunc

--- a/test/SILGen/cdecl-official.swift
+++ b/test/SILGen/cdecl-official.swift
@@ -9,7 +9,7 @@
 // CHECK-LABEL: sil hidden [thunk] [ossa] @pear : $@convention(c)
 // CHECK:         function_ref @$s5cdecl5apple{{[_0-9a-zA-Z]*}}F
 // CHECK-LABEL: sil hidden [ossa] @$s5cdecl5apple{{[_0-9a-zA-Z]*}}F
-@cdecl(pear)
+@c(pear)
 func apple(_ f: @convention(c) (Int) -> Int) { }
 
 // CHECK-LABEL: sil hidden [ossa] @$s5cdecl16forceCEntryPoint{{[_0-9a-zA-Z]*}}F
@@ -24,7 +24,7 @@ func forceCEntryPoint() {
 // CHECK-LABEL: sil hidden [thunk] [ossa] @grapefruit : $@convention(c)
 // CHECK:         function_ref @$s5cdecl6orange{{[_0-9a-zA-Z]*}}F
 // CHECK-LABEL: sil hidden [ossa] @$s5cdecl6orange{{[_0-9a-zA-Z]*}}F
-@cdecl(grapefruit)
+@c(grapefruit)
 func orange(_ x: Int) -> Int {
   return x
 }
@@ -33,7 +33,7 @@ func orange(_ x: Int) -> Int {
 // CHECK:         function_ref @$s5cdecl8broccoli{{[_0-9a-zA-Z]*}}F
 // CHECK-LABEL: sil [ossa] @$s5cdecl8broccoli{{[_0-9a-zA-Z]*}}F
 // FIXME should it be `sil hidden`?
-@cdecl(cauliflower)
+@c(cauliflower)
 public func broccoli(_ x: Int) -> Int {
   return x
 }
@@ -41,7 +41,7 @@ public func broccoli(_ x: Int) -> Int {
 // CHECK-LABEL: sil private [thunk] [ossa] @collard_greens : $@convention(c)
 // CHECK:         function_ref @$s5cdecl4kale[[PRIVATE:.*]]
 // CHECK:       sil private [ossa] @$s5cdecl4kale[[PRIVATE:.*]]
-@cdecl(collard_greens)
+@c(collard_greens)
 private func kale(_ x: Int) -> Int {
   return x
 }
@@ -49,7 +49,7 @@ private func kale(_ x: Int) -> Int {
 // CHECK-LABEL: sil private [thunk] [ossa] @defaultName : $@convention(c)
 // CHECK:         function_ref @$s5cdecl11defaultName[[PRIVATE:.*]]
 // CHECK:       sil private [ossa] @$s5cdecl11defaultName[[PRIVATE:.*]]
-@cdecl
+@c
 private func defaultName(_ x: Int) -> Int {
   return x
 }

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -1,4 +1,4 @@
-/// @cdecl attribute
+/// @c attribute
 /// This test shouldn't require the objc runtime.
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s \
@@ -6,104 +6,104 @@
 
 // REQUIRES: swift_feature_CDecl
 
-@cdecl(cdecl_foo) func foo(x: Int) -> Int { return x }
+@c(cdecl_foo) func foo(x: Int) -> Int { return x }
 
-@cdecl(not an identifier) func invalidName() {}
-// expected-error @-1 {{expected ')' in 'cdecl' attribute}}
+@c(not an identifier) func invalidName() {}
+// expected-error @-1 {{expected ')' in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}
 
-@cdecl() func emptyParen() {}
-// expected-error @-1 {{expected C identifier in 'cdecl' attribute}}
+@c() func emptyParen() {}
+// expected-error @-1 {{expected C identifier in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}
 
-@cdecl(42) func aNumber() {}
-// expected-error @-1 {{expected C identifier in 'cdecl' attribute}}
+@c(42) func aNumber() {}
+// expected-error @-1 {{expected C identifier in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}
 
-@cdecl(a:selector:) func selectordName() {}
-// expected-error @-1 {{expected ')' in 'cdecl' attribute}}
+@c(a:selector:) func selectordName() {}
+// expected-error @-1 {{expected ')' in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}
 
-@cdecl func defaultName() {}
+@c func defaultName() {}
 
-@cdecl("noBody")
+@c("noBody")
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
 
-@cdecl("property") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+@c("property") // expected-error{{'@c' attribute cannot be applied to this declaration}}
 var property: Int
 
 var computed: Int {
-  @cdecl("get_computed") get { return 0 }
-  @cdecl("set_computed") set { return }
+  @c("get_computed") get { return 0 }
+  @c("set_computed") set { return }
 }
 
-@cdecl("inout")
-func noBody(x: inout Int) { } // expected-error{{global function cannot be marked '@cdecl' because inout parameters cannot be represented in C}}
+@c("inout")
+func noBody(x: inout Int) { } // expected-error{{global function cannot be marked '@c' because inout parameters cannot be represented in C}}
 
 struct SwiftStruct { var x, y: Int }
 enum SwiftEnum { case A, B }
 
 #if os(Windows) && (arch(x86_64) || arch(arm64))
-@cdecl("CEnum") enum CEnum: Int32 { case A, B }
+@c("CEnum") enum CEnum: Int32 { case A, B }
 #else
-@cdecl("CEnum") enum CEnum: Int { case A, B }
+@c("CEnum") enum CEnum: Int { case A, B }
 #endif
 
-@cdecl enum CEnumDefaultName: CInt { case A, B }
+@c enum CEnumDefaultName: CInt { case A, B }
 
-@cdecl("CEnumNoRawType") enum CEnumNoRawType { case A, B }
-// expected-error @-1 {{'@cdecl' enum must declare an integer raw type}}
+@c("CEnumNoRawType") enum CEnumNoRawType { case A, B }
+// expected-error @-1 {{'@c' enum must declare an integer raw type}}
 
-@cdecl("CEnumStringRawType") enum CEnumStringRawType: String { case A, B }
-// expected-error @-1 {{'@cdecl' enum raw type 'String' is not an integer type}}
+@c("CEnumStringRawType") enum CEnumStringRawType: String { case A, B }
+// expected-error @-1 {{'@c' enum raw type 'String' is not an integer type}}
 
-@cdecl("swiftStruct")
+@c("swiftStruct")
 func swiftStruct(x: SwiftStruct) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
-@cdecl("swiftEnum")
+@c("swiftEnum")
 func swiftEnum(x: SwiftEnum) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
-// expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift enums not marked '@c' cannot be represented in C}}
 
-@cdecl("cEnum")
+@c("cEnum")
 func cEnum(x: CEnum) {}
 
-@cdecl("CDeclAndObjC") // expected-error {{cannot apply both '@cdecl' and '@objc' to enum}}
+@c("CDeclAndObjC") // expected-error {{cannot apply both '@c' and '@objc' to enum}}
 @objc
 enum CDeclAndObjC: CInt { case A, B }
 
-@cdecl("TwoCDecls") // expected-note {{attribute already specified here}}
+@c("TwoCDecls") // expected-note {{attribute already specified here}}
 @_cdecl("TwoCDecls") // expected-error {{duplicate attribute}}
 func TwoCDecls() {}
 
 class Foo {
-  @cdecl("Foo_foo") // expected-error{{@cdecl can only be applied to global functions}}
+  @c("Foo_foo") // expected-error{{@c can only be applied to global functions}}
   func foo(x: Int) -> Int { return x }
 
-  @cdecl("Foo_foo_2") // expected-error{{@cdecl can only be applied to global functions}}
+  @c("Foo_foo_2") // expected-error{{@c can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
-  @cdecl("Foo_init") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+  @c("Foo_init") // expected-error{{'@c' attribute cannot be applied to this declaration}}
   init() {}
 
-  @cdecl("Foo_deinit") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+  @c("Foo_deinit") // expected-error{{'@c' attribute cannot be applied to this declaration}}
   deinit {}
 }
 
-@cdecl("throwing") // expected-error{{raising errors from @cdecl functions is not supported}}
+@c("throwing") // expected-error{{raising errors from @c functions is not supported}}
 func throwing() throws { }
 
-@cdecl("acceptedPointers")
+@c("acceptedPointers")
 func acceptedPointers(_ x: UnsafeMutablePointer<Int>,
                         y: UnsafePointer<Int>,
                         z: UnsafeMutableRawPointer,
                         w: UnsafeRawPointer,
                         u: OpaquePointer) {}
 
-@cdecl("rejectedPointers")
-func rejectedPointers( // expected-error 6 {{global function cannot be marked '@cdecl' because the type of the parameter}}
+@c("rejectedPointers")
+func rejectedPointers( // expected-error 6 {{global function cannot be marked '@c' because the type of the parameter}}
     x: UnsafePointer<String>, // expected-note {{Swift structs cannot be represented in C}}
     y: CVaListPointer, // expected-note {{Swift structs cannot be represented in C}}
     z: UnsafeBufferPointer<Int>, // expected-note {{Swift structs cannot be represented in C}}
@@ -111,93 +111,93 @@ func rejectedPointers( // expected-error 6 {{global function cannot be marked '@
     v: UnsafeRawBufferPointer, // expected-note {{Swift structs cannot be represented in C}}
     t: UnsafeMutableRawBufferPointer) {} // expected-note {{Swift structs cannot be represented in C}}
 
-@cdecl("genericParam")
+@c("genericParam")
 func genericParam<I>(i: I) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because it has generic parameters}}
+// expected-error @-1 {{global function cannot be marked '@c' because it has generic parameters}}
 
-@cdecl("variadic")
+@c("variadic")
 func variadic(_: Int...) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because it has a variadic parameter}}
+// expected-error @-1 {{global function cannot be marked '@c' because it has a variadic parameter}}
 
-@cdecl("tupleParamEmpty")
+@c("tupleParamEmpty")
 func tupleParamEmpty(a: ()) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{empty tuple type cannot be represented in C}}
 
-@cdecl("tupleParam")
+@c("tupleParam")
 func tupleParam(a: (Int, Float)) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@cdecl("emptyTupleReturn")
+@c("emptyTupleReturn")
 func emptyTupleReturn() -> () {}
 
-@cdecl("tupleReturn")
+@c("tupleReturn")
 func tupleReturn() -> (Int, Float) { (1, 2.0) }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@cdecl("funcAcceptsThrowingFunc")
+@c("funcAcceptsThrowingFunc")
 func funcAcceptsThrowingFunc(fn: (String) throws -> Int) { }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@cdecl("funcAcceptsThrowingFuncReturn")
+@c("funcAcceptsThrowingFuncReturn")
 func funcAcceptsThrowingFuncReturn() -> (String) throws -> Int { fatalError() }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@cdecl("bar")
+@c("bar")
 func bar(f: (SwiftEnum) -> SwiftStruct) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("bas")
+@c("bas")
 func bas(f: (SwiftEnum) -> ()) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zim")
+@c("zim")
 func zim(f: () -> SwiftStruct) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zang")
+@c("zang")
 func zang(f: (SwiftEnum, SwiftStruct) -> ()) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zang_zang")
+@c("zang_zang")
   func zangZang(f: (Int...) -> ()) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("array")
+@c("array")
 func array(i: [Int]) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
 class SwiftClass {}
-@cdecl("swiftClass")
+@c("swiftClass")
 func swiftClass(p: SwiftClass) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
 protocol SwiftProtocol {}
-@cdecl("swiftProtocol")
+@c("swiftProtocol")
 func swiftProtocol(p: SwiftProtocol) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@cdecl("swiftErrorProtocol")
+@c("swiftErrorProtocol")
 func swiftErrorProtocol(e: Error) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@cdecl("anyParam")
+@c("anyParam")
 func anyParam(e:Any) {}
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@cdecl func swift_allocBox() {} // expected-warning {{symbol name 'swift_allocBox' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}
-@cdecl(swift_allocObject) func swift_allocObject_renamed() {} // expected-warning {{symbol name 'swift_allocObject' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}
+@c func swift_allocBox() {} // expected-warning {{symbol name 'swift_allocBox' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}
+@c(swift_allocObject) func swift_allocObject_renamed() {} // expected-warning {{symbol name 'swift_allocObject' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}

--- a/test/attr/attr_cdecl_official_async.swift
+++ b/test/attr/attr_cdecl_official_async.swift
@@ -8,10 +8,10 @@
 @_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
 func asynchronous() async { }
 
-@cdecl("async2") // expected-error{{@cdecl global function cannot be asynchronous}}
+@c("async2") // expected-error{{@c global function cannot be asynchronous}}
 func asynchronous2() async { }
 
-@cdecl("asyncParam")
+@c("asyncParam")
 func asynchronousParam(fn: (String) async -> Int) { }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{'async' function types cannot be represented in C}}

--- a/test/attr/attr_cdecl_official_rejected.swift
+++ b/test/attr/attr_cdecl_official_rejected.swift
@@ -4,9 +4,9 @@
 
 // REQUIRES: swift_feature_CDecl
 
-@cdecl("cdecl_foo") func foo() { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
+@c("cdecl_foo") func foo() { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
 
 var computed: Int {
-  @cdecl("get_computed") get { return 0 } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
-  @cdecl("set_computed") set { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
+  @c("get_computed") get { return 0 } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
+  @c("set_computed") set { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
 }

--- a/test/attr/attr_cdecl_official_with_objc.swift
+++ b/test/attr/attr_cdecl_official_with_objc.swift
@@ -9,34 +9,34 @@ import Foundation
 @objc
 class ObjCClass: NSObject { }
 
-@cdecl("objcClassReturn") func objcClassReturn() -> ObjCClass { fatalError() }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
+@c("objcClassReturn") func objcClassReturn() -> ObjCClass { fatalError() }
+// expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
-@cdecl("objcClassParams") func objcClassParams(a: ObjCClass, b: ObjCClass) { }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter 1 cannot be represented in C}}
-// expected-error @-2 {{global function cannot be marked '@cdecl' because the type of the parameter 2 cannot be represented in C}}
+@c("objcClassParams") func objcClassParams(a: ObjCClass, b: ObjCClass) { }
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
+// expected-error @-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
 // expected-note @-3 2 {{classes cannot be represented in C}}
 
 @objc
 protocol ObjCProtocol {}
 
-@cdecl("objcProtocol") func objcProtocol(a: ObjCProtocol) { }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+@c("objcProtocol") func objcProtocol(a: ObjCProtocol) { }
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
 @objc
 enum ObjCEnum: Int { case A, B }
-@cdecl("objcEnumUseInCDecl") func objcEnumUseInCDecl(a: ObjCEnum) { }
-// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
-// expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
+@c("objcEnumUseInCDecl") func objcEnumUseInCDecl(a: ObjCEnum) { }
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift enums not marked '@c' cannot be represented in C}}
 
-/// Objective-C accepts @cdecl enums.
-@cdecl("CEnum")
+/// Objective-C accepts @c enums.
+@c("CEnum")
 enum CEnum: Int { case A, B }
 @_cdecl("cdeclEnumUseInObjc") func cdeclEnumUseInObjc(a: CEnum) { }
 
 enum SwiftEnum { case A, B }
 @_cdecl("swiftEnumUseInObjc") func swiftEnumUseInObjc(a: SwiftEnum) { }
 // expected-error @-1 {{global function cannot be marked '@_cdecl' because the type of the parameter cannot be represented in Objective-C}}
-// expected-note @-2 {{Swift enums not marked '@cdecl' or '@objc' cannot be represented in Objective-C}}
+// expected-note @-2 {{Swift enums not marked '@c' or '@objc' cannot be represented in Objective-C}}

--- a/test/decl/ext/cdecl_official_implementation.swift
+++ b/test/decl/ext/cdecl_official_implementation.swift
@@ -7,60 +7,60 @@
 // REQUIRES: swift_feature_CImplementation
 // REQUIRES: swift_feature_CDecl
 
-@implementation @cdecl
+@implementation @c
 func CImplFunc1(_: Int32) {
   // OK
 }
 
-@implementation @cdecl(CImplFuncRenamed_C)
+@implementation @c(CImplFuncRenamed_C)
 func CImplFuncRenamed_Swift(arg: CInt) {
   // OK
 }
 
-@implementation(BadCategory) @cdecl
+@implementation(BadCategory) @c
 func CImplFunc2(_: Int32) {
   // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{16-29=}}
 }
 
-@implementation @cdecl
+@implementation @c
 func CImplFuncMissing(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
 }
 
-@implementation @cdecl
+@implementation @c
 func CImplFuncMismatch1(_: Float) {
   // expected-error@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @cdecl
+@implementation @c
 func CImplFuncMismatch2(_: Int32) -> Float {
   // expected-error@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @cdecl(CImplFuncNameMismatch1)
+@implementation @c(CImplFuncNameMismatch1)
 func mismatchedName1(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncNameMismatch1' matching global function 'mismatchedName1'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
 }
 
-@implementation @cdecl(mismatchedName2)
+@implementation @c(mismatchedName2)
 func CImplFuncNameMismatch2(_: Int32) {
   // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
 }
 
 //
-// TODO: @cdecl for global functions imported as computed vars
+// TODO: @c for global functions imported as computed vars
 //
 var cImplComputedGlobal1: Int32 {
-  @implementation @cdecl(CImplGetComputedGlobal1)
+  @implementation @c(CImplGetComputedGlobal1)
   get {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplGetComputedGlobal1' matching getter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
     return 0
   }
 
-  @implementation @cdecl(CImplSetComputedGlobal1)
+  @implementation @c(CImplSetComputedGlobal1)
   set {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplSetComputedGlobal1' matching setter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
@@ -69,13 +69,13 @@ var cImplComputedGlobal1: Int32 {
 }
 
 //
-// TODO: @cdecl for import-as-member functions
+// TODO: @c for import-as-member functions
 //
 extension CImplStruct {
-  @implementation @cdecl(CImplStructStaticFunc1)
+  @implementation @c(CImplStructStaticFunc1)
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
-    // expected-error@-3 {{@cdecl can only be applied to global functions}}
+    // expected-error@-3 {{@c can only be applied to global functions}}
     // FIXME: Lookup in an enclosing type is not working yet
     // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure your umbrella or bridging header imports the header that declares it}}
   }

--- a/validation-test/compiler_crashers_2/557cde75b2fa4b56.swift
+++ b/validation-test/compiler_crashers_2/557cde75b2fa4b56.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"isParamListRepresentableInLanguage(swift::AbstractFunctionDecl const*, swift::ParameterList const*, swift::ObjCReason)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->"}
 // RUN: not --crash %target-swift-frontend -typecheck %s
 // REQUIRES: objc_interop
-class a { @objc b(@c & d Int) @propertyWrapper enum c
+class a { @objc b(@e & d Int) @propertyWrapper enum e

--- a/validation-test/compiler_crashers_2/75874d2cf6f384c8.swift
+++ b/validation-test/compiler_crashers_2/75874d2cf6f384c8.swift
@@ -3,9 +3,9 @@
 @propertyWrapper struct a<b{
          wrappedValue: b
        }
-        @propertyWrapper struct c<b{
+        @propertyWrapper struct e<b{
          wrappedValue: b
        }
            {
-               @c @a var value = if true
-                 let : c<a<Bool>> = _value
+               @e @a var value = if true
+                 let : e<a<Bool>> = _value

--- a/validation-test/compiler_crashers_2/8b3bbe2fe5878590.swift
+++ b/validation-test/compiler_crashers_2/8b3bbe2fe5878590.swift
@@ -1,10 +1,10 @@
 // {"kind":"typecheck","signature":"swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*)","signatureAssert":"Assertion failed: (0 && \"Bad base type\"), function getContextSubstitutions"}
 // RUN: not --crash %target-swift-frontend -typecheck %s
 struct a< b {
-  @propertyWrapper struct c {
+  @propertyWrapper struct e {
     var wrappedValue
         projectedValue : a
                                         init(projectedValue
                                              a) {
-      func d(@c b) d($e
+      func d(@e b) d($e
                                                             : f

--- a/validation-test/compiler_crashers_2/d78fbedb0dfa9273.swift
+++ b/validation-test/compiler_crashers_2/d78fbedb0dfa9273.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::optionset::OptionSet<swift::NameLookupFlags, unsigned int>, swift::TypoCorrectionResults&, swift::GenericSignature, unsigned int)","signatureAssert":"Assertion failed: (!baseTypeOrNull || !baseTypeOrNull->hasTypeParameter() || genericSig), function performTypoCorrection"}
 // RUN: not --crash %target-swift-frontend -typecheck %s
 enum a<b {
-  @propertyWrapper class c {wrappedValue:b var projectedValue: a? {
-      @c var wrappedValue: b wrappedValue.d
+  @propertyWrapper class e {wrappedValue:b var projectedValue: a? {
+      @e var wrappedValue: b wrappedValue.d


### PR DESCRIPTION
There's no user of `@cdecl` yet so we can do a direct rename. The legacy `@_cdecl` remains unaffected.