### PR TITLE
SILGen: few small fixes

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -829,8 +829,8 @@ bool RValue::isPlusOneOrTrivial(SILGenFunction &SGF) const & {
       });
 }
 
-bool RValue::isPlusZero(SILGenFunction &SGF) const & {
-  return llvm::none_of(values,
+bool RValue::isPlusZero() const & {
+  return llvm::all_of(values,
                        [](ManagedValue mv) -> bool { return mv.isPlusZero(); });
 }
 

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -273,15 +273,8 @@ public:
 
   /// Returns true if this is an rvalue that can be used safely as a +0 rvalue.
   ///
-  /// Specifically, we return true if:
-  ///
-  /// 1. All sub-values are trivially typed.
-  /// 2. At least 1 subvalue is non-trivial and all such non-trivial values do
-  /// not have a cleanup.
-  ///
-  /// *NOTE* Due to 1. isPlusOne and isPlusZero both return true for rvalues
-  /// consisting of only trivial values.
-  bool isPlusZero(SILGenFunction &SGF) const &;
+  /// Specifically, we return true if all sub-values are +0
+  bool isPlusZero() const &;
 
   /// Use this rvalue to initialize an Initialization.
   void forwardInto(SILGenFunction &SGF, SILLocation loc, Initialization *I) &&;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -7633,7 +7633,15 @@ void SILGenFunction::emitIgnoredExpr(Expr *E) {
 /// Emit the given expression as an r-value, then (if it is a tuple), combine
 /// it together into a single ManagedValue.
 ManagedValue SILGenFunction::emitRValueAsSingleValue(Expr *E, SGFContext C) {
-  return emitRValue(E, C).getAsSingleValue(*this, E);
+  RValue rv = emitRValue(E, C);
+
+  // If there's an Initialization destination, emit into that.
+  if (auto *init = C.getEmitInto()) {
+    std::move(rv).ensurePlusOne(*this, E).forwardInto(*this, E, init);
+    return ManagedValue::forInContext();
+  }
+
+  return std::move(rv).getAsSingleValue(*this, E);
 }
 
 RValue SILGenFunction::emitUndefRValue(SILLocation loc, Type type) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3689,7 +3689,7 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
       // fix the rvalue to begin_access operand. The end_access cleanup
       // doesn't change. FIXME: this can't happen with sil-opaque-values.
       if (accessAddr != destAddr && rvalue.isComplete()
-          && rvalue.isPlusZero(*this) && !isa<TupleType>(rvalue.getType())) {
+          && rvalue.isPlusZero() && !isa<TupleType>(rvalue.getType())) {
         auto mv = std::move(rvalue).getScalarValue();
         if (mv.getValue() == accessAddr)
           mv = std::move(mv).transform(


### PR DESCRIPTION
1. [RValue::isPlusZero](https://github.com/swiftlang/swift/commit/ec0ee1eddb9879747dba9c30bc993cec0aac2079) was returning true if none of the ManagedValues are +0, rather than all of them.
2. [`SGF::emitRValueAsSingleValue`](https://github.com/swiftlang/swift/pull/84382/commits/73ac602934b5140e8d5861a23ec6746b3f11ec80) doesn't handle the case where SGFContext has an `Initialization*`. I noticed that `ArgumentSource::getAsSingleValue` [_does_ handle that case](https://github.com/swiftlang/swift/blob/22e85b0a8b0917eb6b54289d7563f7b606a899e6/lib/SILGen/ArgumentSource.cpp#L55), so I copied the implementation over so people don't trip over this.