### PR TITLE
[Distributed] Avoid redundant conformance to DistributedActor in interfaces

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1267,7 +1267,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
     }
   }
 
-  // Actor classes conform to the actor protocol.
+  // Actor classes conform to the appropriate actor protocol.
   if (auto classDecl = dyn_cast<ClassDecl>(mutableThis)) {
     if (classDecl->isDistributedActor()) {
       addSynthesized(ctx.getProtocol(KnownProtocolKind::DistributedActor));

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -688,10 +688,13 @@ public:
     if (!printOptions.shouldPrint(nominal))
       return;
 
-    /// is this nominal specifically an 'actor'?
+    /// is this nominal specifically an 'actor' or 'distributed actor'?
     bool actorClass = false;
-    if (auto klass = dyn_cast<ClassDecl>(nominal))
+    bool distributedActorClass = false;
+    if (auto klass = dyn_cast<ClassDecl>(nominal)) {
       actorClass = klass->isActor();
+      distributedActorClass = klass->isDistributedActor();
+    }
 
     SmallPtrSet<ProtocolDecl *, 16> handledProtocols;
 
@@ -727,7 +730,10 @@ public:
         // it is only valid to conform to Actor on an 'actor' decl,
         // not extensions of that 'actor'.
         if (actorClass &&
-            inherited->isSpecificProtocol(KnownProtocolKind::Actor))
+          inherited->isSpecificProtocol(KnownProtocolKind::Actor))
+          return TypeWalker::Action::SkipNode;
+        if (distributedActorClass &&
+          inherited->isSpecificProtocol(KnownProtocolKind::DistributedActor))
           return TypeWalker::Action::SkipNode;
 
         // Do not synthesize an extension to print a conformance to an

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -689,11 +689,9 @@ public:
       return;
 
     /// is this nominal specifically an 'actor' or 'distributed actor'?
-    bool actorClass = false;
-    bool distributedActorClass = false;
+    bool anyActorClass = false;
     if (auto klass = dyn_cast<ClassDecl>(nominal)) {
-      actorClass = klass->isActor();
-      distributedActorClass = klass->isDistributedActor();
+      anyActorClass = klass->isAnyActor();
     }
 
     SmallPtrSet<ProtocolDecl *, 16> handledProtocols;
@@ -729,12 +727,11 @@ public:
         // There is a special restriction on the Actor protocol in that
         // it is only valid to conform to Actor on an 'actor' decl,
         // not extensions of that 'actor'.
-        if (actorClass &&
-          inherited->isSpecificProtocol(KnownProtocolKind::Actor))
-          return TypeWalker::Action::SkipNode;
-        if (distributedActorClass &&
-          inherited->isSpecificProtocol(KnownProtocolKind::DistributedActor))
-          return TypeWalker::Action::SkipNode;
+        if (anyActorClass) {
+          if (inherited->isSpecificProtocol(KnownProtocolKind::Actor) ||
+              inherited->isSpecificProtocol(KnownProtocolKind::DistributedActor))
+            return TypeWalker::Action::SkipNode;
+        }
 
         // Do not synthesize an extension to print a conformance to an
         // invertible protocol, as their conformances are always re-inferred

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -75,17 +75,10 @@ public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSys
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Distributed.DistributedActor {}
-// CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT:extension Library.DA : Swift.Encodable {}
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT:extension Library.DA : Swift.Decodable {}
-
-// CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-// CHECK-NEXT: extension Library.DAG : Distributed.DistributedActor {}
 
 //--- Client.swift
 

--- a/test/ModuleInterface/distributed_no_redundant_conformance.swift
+++ b/test/ModuleInterface/distributed_no_redundant_conformance.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/TestResilient.swiftinterface) %s -module-name TestResilient
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestResilient.swiftinterface) -module-name TestResilient
+// RUN: %FileCheck %s --dump-input=always < %t/TestResilient.swiftinterface
+
+// RUN: %target-swift-frontend -compile-module-from-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
+
+import Distributed
+
+// Note that tat while an actor is implicitly conforming to Actor, we don't need to print this in interfaces
+// as it would cause 'redundant conformance of ... to (Distributed)Actor' issues.
+
+public actor Example {}
+
+// CHECK-NOT: extension TestResilient.Example : _Concurrency.Actor {}
+
+public distributed actor DistributedExample {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+  distributed func example() {}
+}
+
+// CHECK: distributed public actor DistributedExample {
+
+// CHECK-NOT: extension TestResilient.DistributedExample : Distributed.DistributedActor {}

--- a/test/ModuleInterface/distributed_no_redundant_conformance.swift
+++ b/test/ModuleInterface/distributed_no_redundant_conformance.swift
@@ -2,10 +2,7 @@
 
 // RUN: %target-swift-emit-module-interface(%t/TestResilient.swiftinterface) %s -module-name TestResilient
 // RUN: %target-swift-typecheck-module-from-interface(%t/TestResilient.swiftinterface) -module-name TestResilient
-// RUN: %FileCheck %s --dump-input=always < %t/TestResilient.swiftinterface
-
-// RUN: %target-swift-frontend -compile-module-from-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
 
 import Distributed
 


### PR DESCRIPTION
Forgetting to handle DistributedActor next to Actor strikes again:
Actors are special that their conformance is implicit and needs not be
printed in swift interface files.

an actor's Actor conformance was filtered out, however the same logic
needs to be applied to DistributedActor, as otherwise there can be
redundant conformance errors when validating module interface files.

Resolves rdar://160252579