### PR TITLE
[stdlib] fix MutableSpan’s Sendable conformance

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -57,7 +57,7 @@ public struct MutableSpan<Element: ~Copyable>
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension MutableSpan: @unchecked Sendable where Element: Sendable {}
+extension MutableSpan: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -554,3 +554,14 @@ suite.test("MutableRawSpan from UnsafeMutableRawBufferPointer")
   let v = b.load(fromByteOffset: 8, as: Int64.self)
   expectNotEqual(v, 1)
 }
+
+private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
+
+suite.test("MutableRawSpan Sendability")
+.require(.stdlib_6_2).code {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 1, alignment: 2)
+  defer { buffer.deallocate() }
+
+  let span = MutableRawSpan(_unsafeBytes: buffer)
+  send(span)
+}

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -630,3 +630,18 @@ suite.test("MutableSpan from UnsafeMutableBufferPointer")
 
   expectTrue(b.elementsEqual((0..<capacity).reversed()))
 }
+
+private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
+
+private struct NCSendable: ~Copyable, Sendable {}
+
+suite.test("MutableSpan Sendability")
+.require(.stdlib_6_2).code {
+  let buffer = UnsafeMutableBufferPointer<NCSendable>.allocate(capacity: 1)
+  defer { buffer.deallocate() }
+  buffer.initializeElement(at: 0, to: NCSendable())
+  defer { buffer.deinitialize() }
+
+  let span = MutableSpan(_unsafeElements: buffer)
+  send(span)
+}

--- a/test/stdlib/Span/OutputRawSpanTests.swift
+++ b/test/stdlib/Span/OutputRawSpanTests.swift
@@ -153,3 +153,14 @@ suite.test("deinitialize buffer")
     expectTrue(false)
   }
 }
+
+private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
+
+suite.test("OutputRawSpan Sendability")
+.require(.stdlib_6_2).code {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 1, alignment: 2)
+  defer { buffer.deallocate() }
+
+  let span = OutputRawSpan(buffer: buffer, initializedCount: 0)
+  send(span)
+}

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -262,3 +262,16 @@ suite.test("InlineArray initialization throws")
     expectEqual(I.count, 0)
   }
 }
+
+private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
+
+private struct NCSendable: ~Copyable, Sendable {}
+
+suite.test("OutputSpan Sendability")
+.require(.stdlib_6_2).code {
+  let buffer = UnsafeMutableBufferPointer<NCSendable>.allocate(capacity: 1)
+  defer { buffer.deallocate() }
+
+  let span = OutputSpan(buffer: buffer, initializedCount: 0)
+  send(span)
+}

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -331,3 +331,14 @@ suite.test("byteOffsets(of:)")
   bounds = nilSpan.byteOffsets(of: nilSpan)
   expectEqual(bounds, 0..<0)
 }
+
+private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
+
+suite.test("RawSpan Sendability")
+.require(.stdlib_6_2).code {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 1, alignment: 2)
+  defer { buffer.deallocate() }
+
+  let span = RawSpan(_unsafeBytes: buffer)
+  send(span)
+}

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -599,8 +599,6 @@ private struct NCSendable: ~Copyable, Sendable {}
 
 suite.test("Span Sendability")
 .require(.stdlib_6_2).code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let buffer = UnsafeMutableBufferPointer<NCSendable>.allocate(capacity: 1)
   defer { buffer.deallocate() }
   buffer.initializeElement(at: 0, to: NCSendable())


### PR DESCRIPTION
The Sendable conformance mistakenly restricted what kind of elements were allowed, even though it had been correctly defined in the proposal. The conformances of `Span` and `OutputSpan` were already correct.

Addresses rdar://160885820