### PR TITLE
[cxx-interop] Do not consider std::span<T>::size and co unsafe

### DIFF
--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -6,9 +6,13 @@ add_custom_command_target(unused_var
     CUSTOM_TARGET_NAME CxxStdlib-apinotes
     COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}"
     COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes" "${output_dir}"
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/std_span.apinotes" "${output_dir}"
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/std_string_view.apinotes" "${output_dir}"
     COMMENT "Copying CxxStdlib API Notes to ${output_dir}"
     OUTPUT "${output_dir}/std.apinotes"
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes")
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/std_span.apinotes"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/std_string_view.apinotes")
 
 swift_install_in_component(FILES std.apinotes
     DESTINATION "lib/swift/apinotes"

--- a/stdlib/public/Cxx/std/std.apinotes
+++ b/stdlib/public/Cxx/std/std.apinotes
@@ -17,3 +17,20 @@ Namespaces:
     Methods:
     - Name: data
       SwiftName: __dataUnsafe()
+    - Name: size
+      SwiftSafety: safe
+    - Name: size_bytes
+      SwiftSafety: safe
+    - Name: empty
+      SwiftSafety: safe
+  - Name: basic_string_view
+    Methods:
+    - Name: size
+      SwiftSafety: safe
+    - Name: max_size
+      SwiftSafety: safe
+    - Name: length
+      SwiftSafety: safe
+    - Name: empty
+      SwiftSafety: safe
+ 

--- a/stdlib/public/Cxx/std/std_span.apinotes
+++ b/stdlib/public/Cxx/std/std_span.apinotes
@@ -1,0 +1,14 @@
+Name: std_span
+Namespaces:
+- Name: std
+  Tags:
+  - Name: span
+    Methods:
+    - Name: data
+      SwiftName: __dataUnsafe()
+    - Name: size
+      SwiftSafety: safe
+    - Name: size_bytes
+      SwiftSafety: safe
+    - Name: empty
+      SwiftSafety: safe

--- a/stdlib/public/Cxx/std/std_string_view.apinotes
+++ b/stdlib/public/Cxx/std/std_string_view.apinotes
@@ -1,0 +1,14 @@
+Name: std_string_view
+Namespaces:
+- Name: std
+  Tags:
+  - Name: basic_string_view
+    Methods:
+    - Name: size
+      SwiftSafety: safe
+    - Name: max_size
+      SwiftSafety: safe
+    - Name: length
+      SwiftSafety: safe
+    - Name: empty
+      SwiftSafety: safe

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -1,7 +1,7 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -strict-memory-safety -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -iapinotes-modules -Xcc %swift_src_root/stdlib/public/Cxx/std -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -strict-memory-safety -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_LifetimeDependence
@@ -134,6 +134,7 @@ func useUnsafeTuple(x: UnsafeTuple) {
 func useCppSpan(x: SpanOfInt) {
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+  _ = x.size()
 }
 
 func useCppSpan2(x: SpanOfIntAlias) {


### PR DESCRIPTION
Since these APIs operate on unsafes we consider them unsafe by default. This PR adds APINotes to override these defaults as these APIs will not touch the underlying buffer. This should slightly reduce the number of `unsafe`s in user code.

rdar://159839254