### PR TITLE
[Sema] Reject placeholders in type resolution for param and result types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4863,10 +4863,6 @@ NOTE(descriptive_generic_type_declared_here,none,
 
 ERROR(placeholder_type_not_allowed,none,
       "type placeholder not allowed here", ())
-ERROR(placeholder_type_not_allowed_in_return_type,none,
-      "type placeholder may not appear in function return type", ())
-ERROR(placeholder_type_not_allowed_in_parameter,none,
-      "type placeholder may not appear in top-level parameter", ())
 ERROR(placeholder_type_not_allowed_in_pattern,none,
       "placeholder type may not appear as type of a variable", ())
 NOTE(replace_placeholder_with_inferred_type,none,

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -117,12 +117,6 @@ private:
 #define SINGLETON_TYPE(SHORT_ID, ID) TRIVIAL_CASE(ID##Type)
 #include "swift/AST/TypeNodes.def"
 
-    bool visitPlaceholderType(CanPlaceholderType firstType, Type secondType,
-                              Type sugaredFirstType) {
-      // Placeholder types never match.
-      return mismatch(firstType.getPointer(), secondType, sugaredFirstType);
-    }
-
     bool visitUnresolvedType(CanUnresolvedType firstType, Type secondType,
                              Type sugaredFirstType) {
       // Unresolved types never match.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -362,9 +362,6 @@ enum class FixKind : uint8_t {
   /// resolved.
   SpecifyTypeForPlaceholder,
 
-  /// Ignore an invalid placeholder in a decl's interface type.
-  IgnoreInvalidPlaceholderInDeclRef,
-
   /// Allow Swift -> C pointer conversion in an argument position
   /// of a Swift function.
   AllowSwiftToCPointerConversion,
@@ -3191,30 +3188,6 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::SpecifyTypeForPlaceholder;
-  }
-};
-
-class IgnoreInvalidPlaceholderInDeclRef final : public ConstraintFix {
-  IgnoreInvalidPlaceholderInDeclRef(ConstraintSystem &cs,
-                                    ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::IgnoreInvalidPlaceholderInDeclRef, locator) {}
-
-public:
-  std::string getName() const override {
-    return "ignore invalid placeholder in decl ref";
-  }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const override;
-
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
-
-  static IgnoreInvalidPlaceholderInDeclRef *create(ConstraintSystem &cs,
-                                                   ConstraintLocator *locator);
-
-  static bool classof(const ConstraintFix *fix) {
-    return fix->getKind() == FixKind::IgnoreInvalidPlaceholderInDeclRef;
   }
 };
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1227,6 +1227,11 @@ void InterfaceTypeRequest::cacheResult(Type type) const {
     ASSERT(!type->hasPrimaryArchetype() && "Archetype in interface type");
     ASSERT(decl->getDeclContext()->isLocalContext() || !type->hasLocalArchetype() &&
            "Local archetype in interface type of non-local declaration");
+    // Placeholders are only permitted in closure parameters.
+    if (!(isa<ParamDecl>(decl) &&
+          isa<AbstractClosureExpr>(decl->getDeclContext()))) {
+      ASSERT(!type->hasPlaceholder() && "Placeholder in interface type");
+    }
   }
   decl->TypeAndAccess.setPointer(type);
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1222,10 +1222,10 @@ std::optional<Type> InterfaceTypeRequest::getCachedResult() const {
 void InterfaceTypeRequest::cacheResult(Type type) const {
   auto *decl = std::get<0>(getStorage());
   if (type) {
-    assert(!type->hasTypeVariable() && "Type variable in interface type");
-    assert(!type->is<InOutType>() && "Interface type must be materializable");
-    assert(!type->hasPrimaryArchetype() && "Archetype in interface type");
-    assert(decl->getDeclContext()->isLocalContext() || !type->hasLocalArchetype() &&
+    ASSERT(!type->hasTypeVariable() && "Type variable in interface type");
+    ASSERT(!type->is<InOutType>() && "Interface type must be materializable");
+    ASSERT(!type->hasPrimaryArchetype() && "Archetype in interface type");
+    ASSERT(decl->getDeclContext()->isLocalContext() || !type->hasLocalArchetype() &&
            "Local archetype in interface type of non-local declaration");
   }
   decl->TypeAndAccess.setPointer(type);

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2317,9 +2317,9 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
     /// Deduce associated types from dependent member types in the witness.
     bool mismatch(DependentMemberType *firstDepMember,
                   TypeBase *secondType, Type sugaredFirstType) {
-      // If the second type is an error or placeholder, don't look at it
-      // further, but proceed to find other matches.
-      if (secondType->hasError() || secondType->hasPlaceholder())
+      // If the second type is an error, don't look at it further, but proceed
+      // to find other matches.
+      if (secondType->hasError())
         return true;
 
       // If the second type is a generic parameter of the witness, the match

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2264,20 +2264,6 @@ SpecifyTypeForPlaceholder::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) SpecifyTypeForPlaceholder(cs, locator);
 }
 
-IgnoreInvalidPlaceholderInDeclRef *
-IgnoreInvalidPlaceholderInDeclRef::create(ConstraintSystem &cs, ConstraintLocator *locator) {
-  return new (cs.getAllocator()) IgnoreInvalidPlaceholderInDeclRef(cs, locator);
-}
-
-bool
-IgnoreInvalidPlaceholderInDeclRef::diagnose(const Solution &solution,
-                                            bool asNote) const {
-  // These are diagnosed separately. Unfortunately we can't enforce that a
-  // diagnostic has already been emitted since their diagnosis depends on e.g
-  // type-checking a function body for a placeholder result of a function.
-  return true;
-}
-
 bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
                                      bool asNote) const {
   ReferenceToInvalidDeclaration failure(solution, getLocator());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16099,7 +16099,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowValueExpansionWithoutPackReferences:
   case FixKind::IgnoreInvalidPatternInExpr:
   case FixKind::IgnoreInvalidPlaceholder:
-  case FixKind::IgnoreInvalidPlaceholderInDeclRef:
   case FixKind::IgnoreOutOfPlaceThenStmt:
   case FixKind::IgnoreMissingEachKeyword:
   case FixKind::AllowInlineArrayLiteralCountMismatch:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1238,24 +1238,6 @@ bool diagnoseInvalidFunctionType(FunctionType *fnTy, SourceLoc loc,
                                  std::optional<FunctionTypeRepr *> repr,
                                  DeclContext *dc,
                                  std::optional<TypeResolutionStage> stage);
-
-/// Walk the parallel structure of a type with user-provided placeholders and
-/// an inferred type produced by the type checker. Where placeholders can be
-/// found, suggest the corresponding inferred type.
-///
-/// For example,
-///
-/// \code
-///  func foo(_ x: [_] = [0])
-/// \endcode
-///
-/// Has a written type of `(ArraySlice (Placeholder))` and an inferred type of
-/// `(ArraySlice Int)`, so we walk to `Placeholder` and `Int` in each type and
-/// suggest replacing `_` with `Int`.
-///
-/// \param writtenType The interface type usually derived from a user-written
-/// type repr. \param inferredType The type inferred by the type checker.
-void notePlaceholderReplacementTypes(Type writtenType, Type inferredType);
 } // namespace TypeChecker
 
 /// Returns the protocol requirement kind of the given declaration.

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1084,31 +1084,6 @@ static Type replaceParamErrorTypeByPlaceholder(Type type, ValueDecl *value, bool
                            funcType->getExtInfo());
 }
 
-/// We allow placeholder types in interface types in certain cases to allow
-/// better recovery since we can suggest the inferred type as a replacement.
-/// When referencing those decls though we need to make sure we record a fix
-/// since we cannot form a valid solution with them.
-static void
-recordFixIfNeededForPlaceholderInDecl(ConstraintSystem &cs, ValueDecl *D,
-                                      ConstraintLocatorBuilder locator) {
-  auto mayHavePlaceholder = [&]() -> bool {
-    // Parameters with types may have placeholders, since this allows us to
-    // suggest an inferred type from a default argument. Match the logic in
-    // `getUnopenedTypeOfReference` and only query the interface type if we have
-    // one already.
-    if (auto *PD = dyn_cast<ParamDecl>(D))
-      return PD->hasInterfaceType();
-
-    // Therefore decls with parameter lists may also have placeholders.
-    return D->getParameterList();
-  };
-  if (!mayHavePlaceholder() || !D->getInterfaceType()->hasPlaceholder())
-    return;
-
-  auto *loc = cs.getConstraintLocator(locator);
-  cs.recordFix(IgnoreInvalidPlaceholderInDeclRef::create(cs, loc));
-}
-
 std::pair<Type, Type>
 ConstraintSystem::getTypeOfReferencePre(OverloadChoice choice,
                                         DeclContext *useDC,
@@ -1117,8 +1092,6 @@ ConstraintSystem::getTypeOfReferencePre(OverloadChoice choice,
   auto *value = choice.getDecl();
 
   ASSERT(!!preparedOverload == PreparingOverload);
-
-  recordFixIfNeededForPlaceholderInDecl(*this, value, locator);
 
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
     // Unqualified lookup can find operator names within nominal types.
@@ -1876,8 +1849,6 @@ ConstraintSystem::getTypeOfMemberReferencePre(
 
   auto *value = choice.getDecl();
   auto functionRefInfo = choice.getFunctionRefInfo();
-
-  recordFixIfNeededForPlaceholderInDecl(*this, value, locator);
 
   // Figure out the instance type used for the base.
   auto baseTy = choice.getBaseType();

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -10,8 +10,7 @@ let dict2: [Character: _] = ["h": 0]
 
 let arr = [_](repeating: "hi", count: 3)
 
-func foo(_ arr: [_] = [0]) {} // expected-error {{type placeholder may not appear in top-level parameter}}
-// expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
+func foo(_ arr: [_] = [0]) {} // expected-error {{type placeholder not allowed here}}
 
 let foo = _.foo // expected-error {{type placeholder not allowed here}}
 let zero: _ = .zero // expected-error {{cannot infer contextual base in reference to member 'zero'}}
@@ -78,33 +77,25 @@ where T: ExpressibleByIntegerLiteral, U: ExpressibleByIntegerLiteral {
 }
 
 extension Bar {
-  func frobnicate2() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the inferred type 'T'}}
-    // expected-note@-2 {{replace the placeholder with the inferred type 'U'}}
+  func frobnicate2() -> Bar<_, _> { // expected-error {{type placeholder not allowed here}}
     return Bar(t: 42, u: 42)
   }
   func frobnicate3() -> Bar {
     return Bar<_, _>(t: 42, u: 42)
   }
-  func frobnicate4() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
-    // expected-note@-2 {{replace the placeholder with the inferred type 'Int'}}
+  func frobnicate4() -> Bar<_, _> { // expected-error {{type placeholder not allowed here}}
     return Bar<_, _>(t: 42, u: 42)
   }
-  func frobnicate5() -> Bar<_, U> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the inferred type 'T'}}
+  func frobnicate5() -> Bar<_, U> { // expected-error {{type placeholder not allowed here}}
     return Bar(t: 42, u: 42)
   }
   func frobnicate6() -> Bar {
     return Bar<_, U>(t: 42, u: 42)
   }
-  func frobnicate7() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
-    // expected-note@-2 {{replace the placeholder with the inferred type 'U'}}
+  func frobnicate7() -> Bar<_, _> { // expected-error {{type placeholder not allowed here}}
     return Bar<_, U>(t: 42, u: 42)
   }
-  func frobnicate8() -> Bar<_, U> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
+  func frobnicate8() -> Bar<_, U> { // expected-error {{type placeholder not allowed here}}
     return Bar<_, _>(t: 42, u: 42)
   }
 }
@@ -244,11 +235,11 @@ let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setF
 // diagnostic.
 func mismatchedDefault<T>(_ x: [_] = [String: T]()) {} // expected-error {{type placeholder not allowed here}}
 
-func mismatchedReturnTypes() -> _ { // expected-error {{type placeholder may not appear in function return type}}
+func mismatchedReturnTypes() -> _ { // expected-error {{type placeholder not allowed here}}
   if true {
-    return "" // expected-note@-2 {{replace the placeholder with the inferred type 'String'}}
+    return ""
   } else {
-    return 0.5 // expected-note@-4 {{replace the placeholder with the inferred type 'Double'}}
+    return 0.5
   }
 }
 
@@ -261,9 +252,8 @@ func opaque() -> some _ { // expected-error {{type placeholder not allowed here}
 }
 
 enum EnumWithPlaceholders {
-  case topLevelPlaceholder(x: _) // expected-error {{type placeholder may not appear in top-level parameter}}
-  case placeholderWithDefault(x: _ = 5) // expected-error {{type placeholder may not appear in top-level parameter}}
-  // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
+  case topLevelPlaceholder(x: _) // expected-error {{type placeholder not allowed here}}
+  case placeholderWithDefault(x: _ = 5) // expected-error {{type placeholder not allowed here}}
 }
 
 func deferredInit(_ c: Bool) {
@@ -303,30 +293,29 @@ protocol TestPlaceholderRequirement {
   subscript() -> _ { get } // expected-error {{type placeholder not allowed here}}
 }
 
-func testPlaceholderFn1(_:_) {} // expected-error {{type placeholder may not appear in top-level parameter}}
-func testPlaceholderFn2() -> _ {} // expected-error {{type placeholder may not appear in function return type}}
+func testPlaceholderFn1(_:_) {} // expected-error {{type placeholder not allowed here}}
+func testPlaceholderFn2() -> _ {} // expected-error {{type placeholder not allowed here}}
 
 var testPlaceholderComputed1: _ { 0 } // expected-error {{type placeholder not allowed here}}
 var testPlaceholderComputed2: [_] { [0] } // expected-error {{type placeholder not allowed here}}
 
 struct TestPlaceholderSubscript {
-  // FIXME: Shouldn't diagnose twice.
-  subscript(_: _) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
-  subscript(_: [_]) -> Void { () } // expected-error 2{{type placeholder may not appear in top-level parameter}}
+  subscript(_: _) -> Void { () } // expected-error {{type placeholder not allowed here}}
+  subscript(_: [_]) -> Void { () } // expected-error {{type placeholder not allowed here}}
   subscript() -> _ { () } // expected-error {{type placeholder not allowed here}}
   subscript() -> [_] { [0] } // expected-error {{type placeholder not allowed here}}
 }
 
 enum TestPlaceholderInEnumElement {
-  case a(_) // expected-error {{type placeholder may not appear in top-level parameter}}
-  case b([_]) // expected-error {{type placeholder may not appear in top-level parameter}}
+  case a(_) // expected-error {{type placeholder not allowed here}}
+  case b([_]) // expected-error {{type placeholder not allowed here}}
 }
 
 @freestanding(expression) macro testPlaceholderMacro(_ x: _) -> String = #file
-// expected-error@-1 {{type placeholder may not appear in top-level parameter}}
+// expected-error@-1 {{type placeholder not allowed here}}
 
 @freestanding(expression) macro testPlaceholderMacro(_ x: [_]) -> String = #file
-// expected-error@-1 {{type placeholder may not appear in top-level parameter}}
+// expected-error@-1 {{type placeholder not allowed here}}
 
 @freestanding(expression) macro testPlaceholderMacro() -> _ = #file
 // expected-error@-1 {{type placeholder not allowed here}}
@@ -351,8 +340,10 @@ func usePlaceholderDecls(
   _ = TestPlaceholderInEnumElement.a(0)
   _ = TestPlaceholderInEnumElement.b([])
 
-  _ = #testPlaceholderMacro(0)
-  _ = #testPlaceholderMacro([])
+  // There are marked invalid so get removed from the overload set.
+  // FIXME: We ought to turn them into holes instead
+  _ = #testPlaceholderMacro(0) // expected-error {{no macro named 'testPlaceholderMacro'}}
+  _ = #testPlaceholderMacro([]) // expected-error {{no macro named 'testPlaceholderMacro'}}
 
   _ = testPlaceholderFn1(0)
   _ = testPlaceholderFn2()

--- a/validation-test/compiler_crashers_2_fixed/b9c30d56ac83b29.swift
+++ b/validation-test/compiler_crashers_2_fixed/b9c30d56ac83b29.swift
@@ -1,0 +1,6 @@
+// {"kind":"typecheck","original":"1bb3e6fd","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: not %target-swift-frontend -typecheck %s
+@propertyWrapper struct a<b {
+  wrappedValue: b
+}
+func c(@a _ )

--- a/validation-test/compiler_crashers_2_fixed/da2c588d8b81b55b.swift
+++ b/validation-test/compiler_crashers_2_fixed/da2c588d8b81b55b.swift
@@ -1,0 +1,5 @@
+// {"kind":"typecheck","original":"a01bf256","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: not %target-swift-frontend -typecheck %s
+enum b: Codable {
+  case a(_ = encode)
+}


### PR DESCRIPTION
Not all clients can properly handle the presence of placeholders in interface types and it doesn't seem worth the complexity for the  type replacement diagnostic.