### PR TITLE
Runtimes: add support for Runtime module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ Runtimes/**/*.cpp
 Runtimes/**/*.c
 Runtimes/**/*.m
 Runtimes/**/*.mm
+Runtimes/**/*.S
+Runtimes/**/*.asm
 Runtimes/**/*.def
 Runtimes/**/*.gyb
 Runtimes/**/*.apinotes

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -56,6 +56,8 @@ function(copy_library_sources name from_prefix to_prefix)
     "${ARG_ROOT}/${from_prefix}/${name}/*.c"
     "${ARG_ROOT}/${from_prefix}/${name}/*.mm"
     "${ARG_ROOT}/${from_prefix}/${name}/*.m"
+    "${ARG_ROOT}/${from_prefix}/${name}/*.S"
+    "${ARG_ROOT}/${from_prefix}/${name}/*.asm"
     "${ARG_ROOT}/${from_prefix}/${name}/*.def"
     "${ARG_ROOT}/${from_prefix}/${name}/*.gyb"
     "${ARG_ROOT}/${from_prefix}/${name}/*.apinotes"
@@ -115,6 +117,9 @@ copy_files("" "Supplemental/Synchronization" FILES "Info.plist.in")
 
 message(STATUS "plist[${StdlibSources}/Info.plist.in] -> Supplemental/Volatile/Info.plist.in")
 copy_files("" "Supplemental/Volatile" FILES "Info.plist.in")
+
+message(STATUS "plist[${StdlibSources}/Info.plist.in] -> Supplemental/Runtime/Info.plist.in")
+copy_files("" "Supplemental/Runtime" FILES "Info.plist.in")
 
 # Platform Overlays
 
@@ -185,6 +190,7 @@ copy_library_sources(Distributed "public" "Supplemental")
 copy_library_sources(Observation "public" "Supplemental")
 copy_library_sources(Synchronization "public" "Supplemental")
 copy_library_sources(Volatile "public" "Supplemental")
+copy_library_sources("" "public/RuntimeModule" "Supplemental/Runtime")
 
 copy_library_sources(_RegexParser "Sources" "Supplemental/StringProcessing"
   ROOT "${StringProcessing_ROOT_DIR}/swift-experimental-string-processing")

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -39,6 +39,7 @@ set(COMMON_OPTIONS
   -DCMAKE_Swift_COMPILER=${CMAKE_Swift_COMPILER}
   -DCMAKE_C_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
   -DCMAKE_CXX_COMPILER_TARGET=${CMAKE_CXX_COMPILER_TARGET}
+  -DCMAKE_ASM_COMPILER_TARGET=${CMAKE_ASM_COMPILER_TARGET}
   -DCMAKE_Swift_COMPILER_TARGET=${CMAKE_Swift_COMPILER_TARGET}
   -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=${CMAKE_FIND_PACKAGE_PREFER_CONFIG}
   ${SwiftCore_DIR_FLAG}
@@ -77,6 +78,8 @@ if(SwiftRuntime_ENABLE_distributed)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Distributed"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()
@@ -89,6 +92,8 @@ if(SwiftRuntime_ENABLE_differentiation)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Differentiation"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()
@@ -100,6 +105,21 @@ if(SwiftRuntime_ENABLE_observation)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Observation"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()
+
+# Runtime
+if(SwiftRuntime_ENABLE_runtime)
+  ExternalProject_Add(Runtime
+    PREFIX "Runtime"
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtime"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -1,0 +1,174 @@
+cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
+
+if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+  cmake_policy(SET CMP0157 OLD)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH
+  "${CMAKE_SOURCE_DIR}/../cmake/modules"
+  "${CMAKE_SOURCE_DIR}/../../cmake/modules")
+
+include(SwiftProjectVersion)
+project(SwiftRuntime
+  LANGUAGES Swift CXX
+  VERSION ${SWIFT_RUNTIME_VERSION})
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift Runtime must build as a standalone project")
+endif()
+
+include(AsmSupport)
+enable_asm_language()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
+  "${PROJECT_SOURCE_DIR}/../../../"
+  CACHE FILEPATH "Path to the root source directory of the Swift compiler")
+
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
+  CACHE FILEPATH "Location for private build system extension")
+
+find_package(SwiftCore REQUIRED)
+find_package(SwiftOverlay REQUIRED)
+#find_package(SwiftDarwin)
+
+include(GNUInstallDirs)
+
+include(AvailabilityMacros)
+include(EmitSwiftInterface)
+include(InstallSwiftInterface)
+include(PlatformInfo)
+include(gyb)
+include(ResourceEmbedding)
+include(CatalystSupport)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
+
+option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${SwiftCore_ENABLE_LIBRARY_EVOLUTION})
+
+option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
+  ${SwiftCore_ENABLE_PRESPECIALIZATION})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 5>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-disable-upcoming-feature MemberImportVisibility>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-ossa-modules>"
+  "$<$<COMPILE_LANGUAGE:Swift>:-warn-implicit-overrides>"
+  "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -experimental-spi-only-imports>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
+
+# LNK4049: symbol 'symbol' defined in 'filename.obj' is imported
+# LNK4286: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj'
+# LNK4217: symbol 'symbol' defined in 'filename_1.obj' is imported by 'filename_2.obj' in function 'function'
+#
+# We cannot selectively filter the linker warnings as we do not use the MSVC
+# frontned and `clang-cl` (and `clang`) currently do not support `/WX:nnnn`. As
+# a compromise, treat all linker warnings as errors.
+add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
+# Ensure all symbols are fully resolved on Linux
+add_link_options($<$<PLATFORM_ID:Linux>:LINKER:-z,defs>)
+
+add_library(swiftRuntime
+  Address.swift
+  Backtrace.swift
+  Backtrace+Codable.swift
+  BacktraceFormatter.swift
+  Base64.swift
+  ByteSwapping.swift
+  CachingMemoryReader.swift
+  CompactBacktrace.swift
+  CompactImageMap.swift
+  Compression.swift
+  Context.swift
+  CoreSymbolication.swift
+  Dwarf.swift
+  EightByteBuffer.swift
+  Elf.swift
+  ElfImageCache.swift
+  FramePointerUnwinder.swift
+  Image.swift
+  ImageMap.swift
+  ImageMap+Darwin.swift
+  ImageMap+Linux.swift
+  ImageSource.swift
+  Libc.swift
+  LimitSequence.swift
+  MemoryReader.swift
+  OSReleaseScanner.swift
+  ProcMapsScanner.swift
+  Registers.swift
+  Runtime.swift
+  RichFrame.swift
+  SymbolicatedBacktrace.swift
+  Utils.swift
+  Win32Extras.cpp
+  get-cpu-context.${SWIFT_ASM_EXT})
+
+set_target_properties(swiftRuntime PROPERTIES
+  Swift_MODULE_NAME Runtime)
+target_compile_definitions(swiftRuntime PRIVATE
+  SWIFT_ASM_AVAILABLE)
+target_compile_options(swiftRuntime PRIVATE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/modules/module.modulemap>")
+# FIXME: We should split out the parts that are needed by the runtime to avoid
+# pulling in headers from the compiler.
+target_include_directories(swiftRuntime PRIVATE
+  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include")
+target_link_libraries(swiftRuntime PRIVATE
+  swiftShims
+  swiftCore
+  swift_Concurrency
+  swiftCxxStdlib
+  $<$<PLATFORM_ID:Android>:swiftAndroid>
+  #$<$<PLATFORM_ID:Darwin>:swiftDarwin>
+  $<$<PLATFORM_ID:Linux>:swiftGlibc>
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
+
+install(TARGETS swiftRuntime
+  EXPORT SwiftRuntimeTargets
+  COMPONENT ${PROJECT_NAME}_runtime
+  ARCHIVE DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${${PROJECT_NAME}_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swiftRuntime)
+install_swift_interface(swiftRuntime)
+
+# Configure plist creation for Darwin platforms.
+generate_plist(swiftRuntime "${CMAKE_PROJECT_VERSION}" swiftRuntime)
+embed_manifest(swiftRuntime)
+
+include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/SwiftRuntime.cmake" OPTIONAL)

--- a/Runtimes/Supplemental/cmake/modules/AsmSupport.cmake
+++ b/Runtimes/Supplemental/cmake/modules/AsmSupport.cmake
@@ -1,0 +1,15 @@
+macro(enable_asm_language)
+  # On Windows, use MASM or MARMASM
+  set(SWIFT_ASM_DIALECT ASM)
+  set(SWIFT_ASM_EXT S)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+      set(SWIFT_ASM_DIALECT ASM_MARMASM)
+    else()
+      set(SWIFT_ASM_DIALECT ASM_MASM)
+    endif()
+    set(SWIFT_ASM_EXT asm)
+  endif()
+
+  enable_language(${SWIFT_ASM_DIALECT})
+endmacro()


### PR DESCRIPTION
* take the chance to rename the containing folder, as in this context it should be clear we are talking about the Runtime module and not the Swift runtime
* this will fail to build for Apple platforms until we land #84388 -- to signal this, comment the invocations that would add the dependency on the Darwin overlay
* piggyback a fix to ensure we rebuild always all the external projects in the Supplemental superbuild used in macOS PR testing

Addresses rdar://160774902