### PR TITLE
[6.2.1] Embedded Wasm: enable `import WASILibc`

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -504,6 +504,7 @@ if("WASI" IN_LIST SWIFT_SDKS)
     set(arch_subdir "${SWIFT_SDK_WASI_LIB_SUBDIR}/${arch}")
     set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
     set(module_dir_static "${SWIFTSTATICLIB_DIR}/${arch_subdir}")
+    set(module_dir_embedded "${SWIFTLIB_DIR}/embedded/${arch}")
 
     add_custom_command_target(
       copy_wasilibc_modulemap_resource
@@ -526,6 +527,24 @@ if("WASI" IN_LIST SWIFT_SDKS)
     if(SWIFT_BUILD_STATIC_STDLIB)
       swift_install_in_component(FILES "${wasilibc_modulemap_source}"
                                  DESTINATION "lib/swift_static/${arch_subdir}"
+                                 COMPONENT sdk-overlay)
+    endif()
+
+    if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+      add_custom_command_target(
+        copy_wasilibc_modulemap_embedded_resource
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir} ${module_dir_embedded}
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "copy_if_different"
+            "${CMAKE_CURRENT_SOURCE_DIR}/${wasilibc_modulemap_source}" ${module_dir_embedded}
+        OUTPUT "${module_dir_embedded}/${wasilibc_modulemap_source}"
+        COMMENT "Copying WASILibc modulemap to resource directories")
+      add_dependencies(sdk-overlay ${copy_wasilibc_modulemap_embedded_resource})
+      list(APPEND wasilibc_modulemap_target_list ${copy_wasilibc_modulemap_embedded_resource})
+
+      swift_install_in_component(FILES "${wasilibc_modulemap_source}"
+                                 DESTINATION "lib/swift/embedded/${arch}"
                                  COMPONENT sdk-overlay)
     endif()
 
@@ -570,4 +589,42 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
       winsdk.modulemap
     DESTINATION "share"
     COMPONENT sdk-overlay)
+endif()
+
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  add_custom_target(embedded-stdlib-platform)
+  add_dependencies(embedded-libraries embedded-stdlib-platform)
+
+  if(SWIFT_WASI_SYSROOT_PATH)
+    set(arch "wasm32")
+    set(triple "wasm32-unknown-wasip1")
+
+    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${triple}")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    add_swift_target_library_single(
+      embedded-stdlib-platform-${triple}
+      swiftWASILibc
+      ONLY_SWIFTMODULE
+      IS_STDLIB IS_FRAGILE
+        ${swift_platform_sources}
+        POSIXError.swift
+
+      GYB_SOURCES
+        ${swift_platform_gyb_sources}
+        WASILibc.swift.gyb
+
+      SWIFT_COMPILE_FLAGS
+        -enable-experimental-feature Embedded
+        -Xfrontend -emit-empty-object-file
+
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${arch}"
+      ARCHITECTURE_SUBDIR_NAME "${triple}"
+      DEPENDS embedded-stdlib-${triple} wasilibc_modulemap
+      INSTALL_IN_COMPONENT sdk-overlay
+    )
+    add_dependencies(embedded-stdlib-platform embedded-stdlib-platform-${triple})
+  endif()
 endif()

--- a/test/embedded/wasm/wasilibc_functions.swift
+++ b/test/embedded/wasm/wasilibc_functions.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+import WASILibc
+@main struct Main {
+  static func main() {
+    puts("Hello")
+    // CHECK: Hello
+    let div_result = div(5,2)
+    print(div_result.quot)
+    // CHECK: 2
+    print(div_result.rem)
+    // CHECK: 1
+  }
+}


### PR DESCRIPTION
**Explanation**: Cherry-pick of #83792 (#83846 for `release/6.2`), merged as 450cb145971cd9c39dbad802f012d8cc06efc2a7
WASILibc wasn't built for the embedded stdlib in `stdlib/public/Platform/CMakeLists.txt`. New `copy_wasilibc_modulemap_embedded_resource` and `embedded-stdlib-platform-${triple}` targets are added, the latter for `wasm32-unknown-wasip1` only for now. Also added a `wasilibc_functions.swift` test to verify the result.
**Scope**: limited to Embedded Swift for Wasm;
**Risk**: low due to limited scope;
**Testing**: added new lit test to the existing Embedded Swift test suite;
**Issue**: rdar://157467412
**Reviewer**: @bnbarham