### PR TITLE
Sema: Add -solver-{enable,disable}-prepared-overloads frontend flags

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1011,6 +1011,9 @@ namespace swift {
 
     /// Disable the component splitter phase of the expression type checker.
     bool SolverDisableSplitter = false;
+
+    /// Enable the experimental "prepared overloads" optimization.
+    bool SolverEnablePreparedOverloads = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -883,6 +883,12 @@ def solver_scope_threshold_EQ : Joined<["-"], "solver-scope-threshold=">,
 def solver_trail_threshold_EQ : Joined<["-"], "solver-trail-threshold=">,
   HelpText<"Expression type checking trail change limit">;
 
+def solver_disable_prepared_overloads : Flag<["-"], "solver-disable-prepared-overloads">,
+  HelpText<"Disable experimental prepared overloads optimization">;
+
+def solver_enable_prepared_overloads : Flag<["-"], "solver-enable-prepared-overloads">,
+  HelpText<"Enable experimental prepared overloads optimization">;
+
 def solver_disable_splitter : Flag<["-"], "solver-disable-splitter">,
   HelpText<"Disable the component splitter phase of expression type checking">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2000,6 +2000,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   if (Args.getLastArg(OPT_solver_disable_splitter))
     Opts.SolverDisableSplitter = true;
 
+  if (Args.hasArg(OPT_solver_enable_prepared_overloads) ||
+      Args.hasArg(OPT_solver_disable_prepared_overloads))
+    Opts.SolverEnablePreparedOverloads = Args.hasArg(OPT_solver_enable_prepared_overloads);
+
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate)
     Opts.DeferToRuntime = true;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16737,7 +16737,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     }
 
     // FIXME: Transitional hack.
-    bool enablePreparedOverloads = false;
+    bool enablePreparedOverloads = getASTContext().TypeCheckerOpts.SolverEnablePreparedOverloads;
 
     auto *preparedOverload = constraint.getPreparedOverload();
     if (!preparedOverload) {


### PR DESCRIPTION
Off by default since a few diagnostics tests still fail.