### PR TITLE
[DiagnoseStaticExclusivity] Fix this assertion.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -336,7 +336,7 @@ static StringRef extractExprText(const Expr *E, SourceManager &SM) {
 /// it is in the ifndef.
 #ifndef NDEBUG
 static bool isCallToStandardLibrarySwap(CallExpr *CE, ASTContext &Ctx) {
-  if (CE->getCalledValue() == Ctx.getSwap())
+  if (CE->getCalledValue(/*skipFunctionConversions=*/true) == Ctx.getSwap())
     return true;
 
   // Is the call module qualified, i.e. Swift.swap(&a[i], &[j)?

--- a/validation-test/SILOptimizer/rdar160692694.swift
+++ b/validation-test/SILOptimizer/rdar160692694.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend \
+// RUN:     -c \
+// RUN:     -verify \
+// RUN:     -disable-availability-checking \
+// RUN:     -swift-version 6 \
+// RUN:     %s
+
+typealias A = InlineArray<2, UInt64>
+func mix(_ a: inout A) {
+    swap(&a[0], &a[1]) // expected-error{{overlapping accesses}}
+                       // expected-note@-1{{conflicting access}}
+}


### PR DESCRIPTION
This function is called in one place in an assertion.  It asserts that the function in question is the stdlib's swap.  In language mode 6, the called value may be wrapped in a `function_conversion_expr` for `@Sendable`.  That's irrelevant for the purposes of this assertion, so look through such conversions.

rdar://160692694
