### PR TITLE
[SymbolGraphGen/Tests] require StringProcessing in the Macros test

### DIFF
--- a/test/SymbolGraph/Symbols/Macro.swift
+++ b/test/SymbolGraph/Symbols/Macro.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test
+// REQUIRES: swift_swift_parser, executable_test, string_processing
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
This test implicitly loads `_StringProcessing`; add that to the requirements of this test so that is correctly reflected.

Resolves rdar://158821486