### PR TITLE
[6.2] Mark a UTF8Span test unavailable on watchOS.

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -329,6 +329,9 @@ func testWrite(_ w: inout ArrayWrapper) {
 }
 
 // Test store_borrow extension which is required when the addressable UTF8View is extended over the Span's uses.
+//
+// UTF8Span is unavailable on watchOS as of the introduction of this test.
+@available(watchOS, unavailable)
 @available(SwiftStdlib 6.2, *)
 func testSpanOfBorrowByAddress(_ i: Int) -> Int {
     let span = String(i).utf8.span


### PR DESCRIPTION
Fixes rdar://158517336 - Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable

(cherry picked from commit 14e44a569ca032008e5630e70c5bd7033be56c85)

--- CCC ---

Explanation: [NFC] add a missing availability check in a unit test

Scope: only affects an unit test which was blocking CI

Radar/SR Issue: rdar://160430103 (🟧 Swift CI: fs-swift-6.2-tools_RA-stdlib_RA-watchos-device failed: test: SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift (exit code 2))

main PR: https://github.com/swiftlang/swift/pull/83821

Risk: Zero. This does not touch anything we ship.

Testing: Updates a test.

Reviewer: @glessard 

