### PR TITLE
sil: provide ability to run CopyPropagation in -Onone

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -49,10 +49,14 @@ enum class CopyPropagationOption : uint8_t {
   // just -enable-ossa-modules.
   RequestedPassesOnly,
 
-  // Add all relevant copy propagation passes.  If a setting, e.g.
-  // -enable-ossa-modules, requests to add copy propagation to the pipeline, do
-  // so.
-  On
+  // Run copy propagation during optimized builds only.
+  //
+  // If a setting, e.g. -enable-ossa-modules, requests to add copy propagation
+  // to the performance pipeline, do so.
+  Optimizing,
+
+  // Run copy propagation during all builds and whenever requested.
+  Always
 };
 
 enum class DestroyHoistingOption : uint8_t {
@@ -90,11 +94,8 @@ public:
   /// observable end of lexical scope.
   LexicalLifetimesOption LexicalLifetimes = LexicalLifetimesOption::On;
 
-  /// Whether to run SIL copy propagation to shorten object lifetime in whatever
-  /// optimization pipeline is currently used.
-  ///
-  /// When this is 'On' the pipeline has default behavior.
-  CopyPropagationOption CopyPropagation = CopyPropagationOption::On;
+  /// Controls when to run SIL copy propagation, which shortens object lifetimes
+  CopyPropagationOption CopyPropagation = CopyPropagationOption::Optimizing;
 
   /// Whether to run the DestroyAddrHoisting pass.
   ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -282,12 +282,12 @@ def no_parallel_scan : Flag<["-"], "no-parallel-scan">,
    HelpText<"Perform dependency scanning in a single-threaded fashion.">;
 
 def enable_copy_propagation : Flag<["-"], "enable-copy-propagation">,
-  HelpText<"Run SIL copy propagation with lexical lifetimes to shorten object "
+  HelpText<"Always run SIL copy propagation with lexical lifetimes to shorten object "
            "lifetimes while preserving variable lifetimes.">;
 def copy_propagation_state_EQ :
   Joined<["-"], "enable-copy-propagation=">,
   HelpText<"Whether to enable copy propagation">,
-  MetaVarName<"true|requested-passes-only|false">;
+  MetaVarName<"always|optimizing|requested-passes-only|false">;
 
 def disable_infer_public_concurrent_value : Flag<["-"], "disable-infer-public-sendable">,
     HelpText<"Disable inference of Sendable conformances for public structs and enums">;

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -115,8 +115,11 @@ operator<<(raw_ostream &os, const std::optional<CopyPropagationOption> option) {
     case CopyPropagationOption::RequestedPassesOnly:
       os << "requested-passes-only";
       break;
-    case CopyPropagationOption::On:
-      os << "on";
+    case CopyPropagationOption::Optimizing:
+      os << "optimizing";
+      break;
+    case CopyPropagationOption::Always:
+      os << "always";
       break;
     }
   } else {
@@ -135,24 +138,27 @@ public:
   // parse - Return true on error.
   bool parse(Option &O, StringRef ArgName, StringRef Arg,
              std::optional<CopyPropagationOption> &Value) {
-    if (Arg == "" || Arg == "true" || Arg == "TRUE" || Arg == "True" ||
-        Arg == "1") {
-      Value = CopyPropagationOption::On;
+    if (Arg.compare_insensitive("always")) {
+      Value = CopyPropagationOption::Always;
       return false;
     }
-    if (Arg == "false" || Arg == "FALSE" || Arg == "False" || Arg == "0") {
+    if (Arg.compare_insensitive("optimizing")) {
+      Value = CopyPropagationOption::Optimizing;
+      return false;
+    }
+    if (Arg.compare_insensitive("false") || Arg.compare_insensitive("off") ||
+        Arg == "0") {
       Value = CopyPropagationOption::Off;
       return false;
     }
-    if (Arg == "requested-passes-only" || Arg == "REQUESTED-PASSES-ONLY" ||
-        Arg == "Requested-Passes-Only") {
+    if (Arg.compare_insensitive("requested-passes-only")) {
       Value = CopyPropagationOption::RequestedPassesOnly;
       return false;
     }
 
     return O.error("'" + Arg +
-                   "' is invalid for CopyPropagationOption! Try true, false, "
-                   "or requested-passes-only.");
+                   "' is invalid for CopyPropagationOption!"
+                   " Try always, optimizing, or requested-passes-only.");
   }
 
   void initialize() {}
@@ -908,7 +914,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   // Unless overridden below, enabling copy propagation means enabling lexical
   // lifetimes.
-  if (SILOpts.CopyPropagation == CopyPropagationOption::On)
+  if (SILOpts.CopyPropagation >= CopyPropagationOption::Optimizing)
     SILOpts.LexicalLifetimes = LexicalLifetimesOption::On;
 
   // Unless overridden below, disable copy propagation means disabling lexical

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2878,33 +2878,22 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Arg *A = Args.getLastArg(OPT_copy_propagation_state_EQ)) {
     specifiedCopyPropagationOption =
         llvm::StringSwitch<std::optional<CopyPropagationOption>>(A->getValue())
-            .Case("true", CopyPropagationOption::On)
+            .Case("always", CopyPropagationOption::Always)
+            .Case("optimizing", CopyPropagationOption::Optimizing)
             .Case("false", CopyPropagationOption::Off)
             .Case("requested-passes-only",
                   CopyPropagationOption::RequestedPassesOnly)
             .Default(std::nullopt);
+
+    // Error if copy propagation has been set via the flag at the same time.
+    if (auto *Flag = Args.getLastArg(OPT_enable_copy_propagation)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
+                       Flag->getAsString(Args),
+                       A->getAsString(Args));
+    }
   }
   if (Args.hasArg(OPT_enable_copy_propagation)) {
-    if (specifiedCopyPropagationOption) {
-      if (*specifiedCopyPropagationOption == CopyPropagationOption::Off) {
-        // Error if copy propagation has been set to ::Off via the meta-var form
-        // and enabled via the flag.
-        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
-                       "enable-copy-propagation",
-                       "enable-copy-propagation=false");
-        return true;
-      } else if (*specifiedCopyPropagationOption ==
-                 CopyPropagationOption::RequestedPassesOnly) {
-        // Error if copy propagation has been set to ::RequestedPassesOnly via
-        // the meta-var form and enabled via the flag.
-        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
-                       "enable-copy-propagation",
-                       "enable-copy-propagation=requested-passes-only");
-        return true;
-      }
-    } else {
-      specifiedCopyPropagationOption = CopyPropagationOption::On;
-    }
+    specifiedCopyPropagationOption = CopyPropagationOption::Always;
   }
   if (specifiedCopyPropagationOption) {
     Opts.CopyPropagation = *specifiedCopyPropagationOption;
@@ -2936,7 +2925,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   // Unless overridden below, enabling copy propagation means enabling lexical
   // lifetimes.
-  if (Opts.CopyPropagation == CopyPropagationOption::On) {
+  if (Opts.CopyPropagation >= CopyPropagationOption::Optimizing) {
     Opts.LexicalLifetimes = LexicalLifetimesOption::On;
     Opts.DestroyHoisting = DestroyHoistingOption::On;
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -668,7 +668,7 @@ class SILCombine : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     bool enableCopyPropagation =
-        getOptions().CopyPropagation == CopyPropagationOption::On;
+        getOptions().CopyPropagation >= CopyPropagationOption::Optimizing;
     if (getOptions().EnableOSSAModules) {
       enableCopyPropagation =
           getOptions().CopyPropagation != CopyPropagationOption::Off;

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -688,10 +688,10 @@ void CopyPropagation::verifyOwnership() {
                          : deBlocksAnalysis->get(f));
 }
 
-// MandatoryCopyPropagation is not currently enabled in the -Onone pipeline
-// because it may negatively affect the debugging experience.
+// MandatoryCopyPropagation runs in the -Onone pipeline and needs to be more
+// conservative, preserving debug information.
 SILTransform *swift::createMandatoryCopyPropagation() {
-  return new CopyPropagation(PruneDebugInsts, /*canonicalizeAll*/ true,
+  return new CopyPropagation(DontPruneDebugInsts, /*canonicalizeAll*/ true,
                              /*canonicalizeBorrows*/ false);
 }
 

--- a/test/SILOptimizer/copy_propagation.swift
+++ b/test/SILOptimizer/copy_propagation.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O \
+// RUN:   -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+
+// RUN: %target-swift-frontend -primary-file %s -Onone -enable-copy-propagation \
+// RUN:    -sil-verify-all -module-name=test -emit-sil | %FileCheck %s --check-prefix ONONE
 
 // REQUIRES: swift_in_compiler
 
@@ -21,10 +25,88 @@ func borrow(_ c: C)
 // CHECK:         [[NON_BARRIER:%[^,]+]] = function_ref @non_barrier
 // CHECK:         apply [[NON_BARRIER]]()
 // CHECK-LABEL: } // end sil function 'test_hoist_over_non_barrier'
+
+
+/////
+// NOTE: in -Onone, the release is NOT hoisted, to preserve debugging.
+
+// ONONE-LABEL: sil {{.*}}@test_hoist_over_non_barrier : {{.*}} {
+// ONONE:         [[INSTANCE:%[^,]+]] = apply {{.*}} -> @owned C
+// ONONE:         debug_value [[INSTANCE]], let, name "c"
+// ONONE:         [[BORROW:%[^,]+]] = function_ref @borrow
+// ONONE:         apply [[BORROW]]([[INSTANCE]])
+// ONONE:         [[NON_BARRIER:%[^,]+]] = function_ref @non_barrier
+// ONONE:         apply [[NON_BARRIER]]()
+// ONONE:         strong_release [[INSTANCE]]
+// ONONE-LABEL: } // end sil function 'test_hoist_over_non_barrier'
 @_silgen_name("test_hoist_over_non_barrier")
 func test_hoist_over_non_barrier() {
   let c = C()
   borrow(c)
   non_barrier()
+}
+
+// CHECK-LABEL: sil {{.*}}@reassign_with_lets : {{.*}} {
+// CHECK:           [[INSTANCE:%[^,]+]] = alloc_ref $C
+// CHECK:           [[EI:%.*]] = end_init_let_ref [[INSTANCE]]
+// CHECK-NEXT:      debug_value [[EI]], let, name "x"
+// CHECK-NEXT:      debug_value [[EI]], let, name "y"
+// CHECK-NEXT:      debug_value [[EI]], let, name "z"
+// CHECK-NEXT:      return [[EI]]
+// CHECK-LABEL: } // end sil function 'reassign_with_lets'
+
+// ONONE-LABEL: sil {{.*}}@reassign_with_lets : {{.*}} {
+// ONONE:           [[INSTANCE:%[^,]+]] = apply {{.*}} -> @owned C
+// ONONE-NEXT:      debug_value [[INSTANCE]], let, name "x"
+// ONONE-NEXT:      debug_value [[INSTANCE]], let, name "y"
+// ONONE-NEXT:      debug_value [[INSTANCE]], let, name "z"
+// ONONE-NEXT:      return [[INSTANCE]]
+// ONONE-LABEL: } // end sil function 'reassign_with_lets'
+@_silgen_name("reassign_with_lets")
+func reassign_with_lets() -> C {
+  let x = C()
+  let y = x
+  let z = y
+  return z
+}
+
+// CHECK-LABEL: sil {{.*}}@renamed_return : {{.*}} {
+// CHECK-NOT:       strong_retain
+// CHECK:           debug_value %1, let, name "a"
+// CHECK-NEXT:      debug_value %1, let, name "b"
+// CHECK-NEXT:      debug_value %1, let, name "c"
+// CHECK-NEXT:      strong_retain %1
+// CHECK-NEXT:      return %1
+// CHECK-LABEL: } // end sil function 'renamed_return'
+
+
+/////
+// Slightly different control-flow in -Onone, but still one
+// retain dynamically executed on the object.
+
+// ONONE-LABEL: sil {{.*}}@renamed_return : {{.*}} {
+// ONONE-NOT:       strong_retain
+// ONONE:           debug_value %1, let, name "a"
+// ONONE-NEXT:      debug_value %1, let, name "b"
+// ONONE-NEXT:      debug_value %1, let, name "c"
+// ONONE: cond_br {{.*}} bb1, bb2
+
+// ONONE: bb1
+// ONONE:           strong_retain %1
+// ONONE:           br bb3
+
+// ONONE: bb2
+// ONONE:           strong_retain %1
+// ONONE:           br bb3
+
+// ONONE: bb3
+// ONONE-NEXT:      return
+// ONONE-LABEL: } // end sil function 'renamed_return'
+@_silgen_name("renamed_return")
+func renamed_return(_ cond: Bool, _ a: C) -> C {
+  let b = a
+  let c = b
+  if cond { return b }
+  return c
 }
 

--- a/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
+++ b/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
@@ -49,7 +49,7 @@
 
 // RUN: %target-swift-frontend %s \
 // RUN:     -O \
-// RUN:     -enable-copy-propagation=true \
+// RUN:     -enable-copy-propagation=optimizing \
 // RUN:     -Xllvm -sil-print-pass-name \
 // RUN:     -emit-ir \
 // RUN:     -o /dev/null \
@@ -57,7 +57,7 @@
 
 // RUN: %target-swift-frontend %s \
 // RUN:     -O \
-// RUN:     -enable-copy-propagation=true \
+// RUN:     -enable-copy-propagation=optimizing \
 // RUN:     -enable-destroy-hoisting=false \
 // RUN:     -Xllvm -sil-print-pass-name \
 // RUN:     -emit-ir \
@@ -66,7 +66,7 @@
 
 // RUN: %target-swift-frontend %s \
 // RUN:     -O \
-// RUN:     -enable-copy-propagation=true \
+// RUN:     -enable-copy-propagation=optimizing \
 // RUN:     -enable-destroy-hoisting=true \
 // RUN:     -Xllvm -sil-print-pass-name \
 // RUN:     -emit-ir \

--- a/test/SILOptimizer/shrink_borrow_scope.swift
+++ b/test/SILOptimizer/shrink_borrow_scope.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -c -O -enable-copy-propagation=true -enable-lexical-lifetimes=true -sil-verify-all -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -c -O -enable-copy-propagation=optimizing -enable-lexical-lifetimes=true -sil-verify-all -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
 // =============================================================================
 // = DECLARATIONS                                                             {{


### PR DESCRIPTION
This does not enable it by default. Use either of the flags:

```
-enable-copy-propagation
-enable-copy-propagation=always
```

to enable it in -Onone. The previous frontend flag `-enable-copy-propagation=true` has been renamed to `-enable-copy-propagation=optimizing`, which is currently default.

rdar://107610971