### PR TITLE
Fix Bootstrap: diffing

### DIFF
--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -388,6 +388,7 @@ fileprivate struct LinearMyers: ~Copyable {
       // Save the right side of the snake for later
       stack.append(tailBox)
     }
+    fatalError("Unreachable")
   }
   
   fileprivate mutating func middleSnake<T>(


### PR DESCRIPTION
The pass that tracks which control-flow positions are unreachable after infinite loops was migrated to pure Swift in PR #79186. As a result, the C++-only compiler used to bootstrap is unable to determine that the code-location after loops is unreachable. Placing a fatalError after the infinite while loop.

Fixes: rdar://160956325