### PR TITLE
Fix support for trailing commas in tuples within generic arguments

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1967,7 +1967,7 @@ bool Parser::canParseTypeTupleBody() {
           skipSingle();
         }
       }
-    } while (consumeIf(tok::comma));
+    } while (consumeIf(tok::comma) && Tok.isNot(tok::r_paren));
   }
   
   return consumeIf(tok::r_paren);

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -234,3 +234,19 @@ let closureTypeWithTrailingCommas: (
   bar: String,
   quux: String,
 )
+
+let _ = Array<(
+  foo: Int,
+  bar: String,
+)>()
+
+let _ = Dictionary<
+  String,
+  Dictionary<
+    String,
+    Array<(
+      foo: Int,
+      bar: String,
+    )>,
+  >,
+>()


### PR DESCRIPTION
This PR fixes support for trailing commas in tuples within generic arguments.

This currently fails to compile in Swift 6.2 due to being parsed incorrectly. The type lookahead returns `false` so it confuses the `<` for a less-than operator.

```swift
// error: binary operator '<' cannot be applied to operands of type 'Array<_>.Type' and '(bar: String, baaz: String).Type'
let _ = Array<(
  bar: String,
  baaz: String,
)>()
```

Corresponding Swift Syntax PR: https://github.com/swiftlang/swift-syntax/pull/3153