### PR TITLE
[AST] Print ErrorType as `_`

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -694,6 +694,13 @@ public:
     return result;
   }
 
+  /// Print options suitable for debug printing.
+  static PrintOptions forDebugging() {
+    PrintOptions result;
+    result.PrintTypesForDebugging = true;
+    return result;
+  }
+
   /// Retrieve the set of options suitable for diagnostics printing.
   static PrintOptions printForDiagnostics(AccessLevel accessFilter,
                                           bool printFullConvention) {

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -402,7 +402,8 @@ struct ResolvedRangeInfo {
                     /*Single entry*/true, /*UnhandledEffects*/{},
                     OrphanKind::None, {}, {}, {}) {}
   ResolvedRangeInfo(): ResolvedRangeInfo(ArrayRef<Token>()) {}
-  void print(llvm::raw_ostream &OS) const;
+  void print(llvm::raw_ostream &OS,
+             const PrintOptions &PO = PrintOptions()) const;
   ExitState exit() const { return ExitInfo.Exit; }
   Type getType() const { return ExitInfo.ReturnType; }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6223,8 +6223,7 @@ public:
   fixForHole(ConstraintSystem &cs) const;
 
   void print(llvm::raw_ostream &Out, SourceManager *, unsigned indent) const {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
+    PrintOptions PO = PrintOptions::forDebugging();
     Out << "type variable binding " << TypeVar->getString(PO)
         << " := " << Binding.BindingType->getString(PO);
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -6820,7 +6820,7 @@ void RequirementRepr::dump() const {
 }
 
 void GenericParamList::dump() const {
-  print(llvm::errs());
+  print(llvm::errs(), PrintOptions::forDebugging());
   llvm::errs() << '\n';
 }
 
@@ -6829,11 +6829,11 @@ void LayoutConstraint::dump() const {
     llvm::errs() << "(null)\n";
     return;
   }
-  getPointer()->print(llvm::errs());
+  getPointer()->print(llvm::errs(), PrintOptions::forDebugging());
 }
 
 void GenericSignature::dump() const {
-  print(llvm::errs());
+  print(llvm::errs(), PrintOptions::forDebugging());
   llvm::errs() << '\n';
 }
 
@@ -6868,7 +6868,7 @@ void InheritedEntry::dump(llvm::raw_ostream &os) const {
     os << '@' << getDumpString(getExplicitSafety()) << ' ';
   if (isSuppressed())
     os << "~";
-  getType().print(os);
+  getType().print(os, PrintOptions::forDebugging());
 }
 
 void InheritedEntry::dump() const { dump(llvm::errs()); }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3398,13 +3398,11 @@ public:
   /// FIXME: This should use ExprWalker to print children.
 
   void printCommon(Expr *E, const char *C, Label label) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-
     printHead(C, ExprColor, label);
 
     printFlag(E->isImplicit(), "implicit", ExprModifierColor);
-    printTypeField(GetTypeOfExpr(E), Label::always("type"), PO, TypeColor);
+    printTypeField(GetTypeOfExpr(E), Label::always("type"),
+                   PrintOptions::forDebugging(), TypeColor);
 
     // If we have a source range and an ASTContext, print the source range.
     if (auto Ty = GetTypeOfExpr(E)) {
@@ -4054,10 +4052,8 @@ public:
   void visitForceTryExpr(ForceTryExpr *E, Label label) {
     printCommon(E, "force_try_expr", label);
 
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    printTypeField(E->getThrownError(), Label::always("thrown_error"), PO,
-                   TypeColor);
+    printTypeField(E->getThrownError(), Label::always("thrown_error"),
+                   PrintOptions::forDebugging(), TypeColor);
 
     printRec(E->getSubExpr(), Label::optional("sub_expr"));
     printFoot();
@@ -4066,10 +4062,8 @@ public:
   void visitOptionalTryExpr(OptionalTryExpr *E, Label label) {
     printCommon(E, "optional_try_expr", label);
 
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    printTypeField(E->getThrownError(), Label::always("thrown_error"), PO,
-                   TypeColor);
+    printTypeField(E->getThrownError(), Label::always("thrown_error"),
+                   PrintOptions::forDebugging(), TypeColor);
 
     printRec(E->getSubExpr(), Label::optional("sub_expr"));
     printFoot();
@@ -4553,10 +4547,8 @@ public:
   void visitTypeValueExpr(TypeValueExpr *E, Label label) {
     printCommon(E, "type_value_expr", label);
 
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    printTypeField(E->getParamType(), Label::always("param_type"), PO,
-                   TypeColor);
+    printTypeField(E->getParamType(), Label::always("param_type"),
+                   PrintOptions::forDebugging(), TypeColor);
 
     printFoot();
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6198,9 +6198,11 @@ public:
       if (Options.PrintTypesForDebugging || Options.PrintInSILBody)
         Printer << "@error_type ";
       visit(originalType);
-    }
-    else
+    } else if (Options.PrintTypesForDebugging) {
       Printer << "<<error type>>";
+    } else {
+      Printer << "_";
+    }
   }
 
   void visitUnresolvedType(UnresolvedType *T,

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -70,7 +70,8 @@ void XMLEscapingPrinter::printXML(StringRef Text) {
   OS << Text;
 }
 
-void ResolvedRangeInfo::print(llvm::raw_ostream &OS) const {
+void ResolvedRangeInfo::print(llvm::raw_ostream &OS,
+                              const PrintOptions &PO) const {
   OS << "<Kind>";
   switch (Kind) {
   case RangeKind::SingleExpression: OS << "SingleExpression"; break;
@@ -87,7 +88,7 @@ void ResolvedRangeInfo::print(llvm::raw_ostream &OS) const {
 
   if (auto Ty = getType()) {
     OS << "<Type>";
-    Ty->print(OS);
+    Ty->print(OS, PO);
     OS << "</Type>";
     switch(exit()) {
     case ExitState::Positive: OS << "<Exit>true</Exit>"; break;
@@ -147,7 +148,7 @@ void ResolvedRangeInfo::print(llvm::raw_ostream &OS) const {
   for (auto &RD : ReferencedDecls) {
     OS << "<Referenced>" << RD.VD->getBaseName() << "</Referenced>";
     OS << "<Type>";
-    RD.Ty->print(OS);
+    RD.Ty->print(OS, PO);
     OS << "</Type>\n";
   }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2174,13 +2174,8 @@ void PotentialBindings::reset() {
   AssociatedCodeCompletionToken = ASTNode();
 }
 
-void PotentialBindings::dump(ConstraintSystem &cs,
-                             TypeVariableType *typeVar,
-                             llvm::raw_ostream &out,
-                             unsigned indent) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-
+void PotentialBindings::dump(ConstraintSystem &cs, TypeVariableType *typeVar,
+                             llvm::raw_ostream &out, unsigned indent) const {
   out << "Potential bindings for ";
   typeVar->getImpl().print(out);
   out << "\n";
@@ -2202,16 +2197,17 @@ void PotentialBindings::dump(ConstraintSystem &cs,
                [](auto lhs, auto rhs) {
                    return lhs.first->getID() < rhs.first->getID();
                });
-    interleave(adjacentVars,
-               [&](std::pair<TypeVariableType *, Constraint *> pair) {
-                 out << pair.first->getString(PO);
-                 if (pair.first->getImpl().getFixedType(/*record=*/nullptr))
-                   out << " (fixed)";
-                 out << " via ";
-                 pair.second->print(out, &cs.getASTContext().SourceMgr, indent,
-                                    /*skipLocator=*/true);
-               },
-               [&out]() { out << ", "; });
+    interleave(
+        adjacentVars,
+        [&](std::pair<TypeVariableType *, Constraint *> pair) {
+          out << pair.first->getString(PrintOptions::forDebugging());
+          if (pair.first->getImpl().getFixedType(/*record=*/nullptr))
+            out << " (fixed)";
+          out << " via ";
+          pair.second->print(out, &cs.getASTContext().SourceMgr, indent,
+                             /*skipLocator=*/true);
+        },
+        [&out]() { out << ", "; });
     out << "] ";
   }
 }
@@ -2295,8 +2291,7 @@ static std::string getCollectionLiteralAsString(KnownProtocolKind KPK) {
 }
 
 void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   if (auto typeVar = getTypeVariable()) {
     typeVar->getImpl().print(out);
@@ -2991,8 +2986,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
   if (result.isFailure()) {
     if (cs.isDebugMode()) {
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
+      PrintOptions PO = PrintOptions::forDebugging();
 
       llvm::errs().indent(cs.solverState->getCurrentIndent())
           << "(failed to establish binding " << TypeVar->getString(PO)

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1738,13 +1738,11 @@ static void determineBestChoicesInContext(
         });
 
     if (cs.isDebugMode()) {
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
 
       llvm::errs().indent(cs.solverState->getCurrentIndent())
           << "<<< Disjunction "
           << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-                 PO)
+                 PrintOptions::forDebugging())
           << " with score " << bestScore << "\n";
     }
 
@@ -1774,8 +1772,7 @@ static void determineBestChoicesInContext(
   }
 
   if (cs.isDebugMode() && bestOverallScore > 0) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
+    PrintOptions PO = PrintOptions::forDebugging();
 
     auto getLogger = [&](unsigned extraIndent = 0) -> llvm::raw_ostream & {
       return llvm::errs().indent(cs.solverState->getCurrentIndent() +

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13439,12 +13439,9 @@ retry_after_fail:
   // If we have a common result type, bind the expected result type to it.
   if (commonResultType && !commonResultType->is<ErrorType>()) {
     if (isDebugMode()) {
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
       llvm::errs().indent(solverState ? solverState->getCurrentIndent() : 0)
-        << "(common result type for $T" << fnTypeVar->getID() << " is "
-        << commonResultType.getString(PO)
-        << ")\n";
+          << "(common result type for $T" << fnTypeVar->getID() << " is "
+          << commonResultType.getString(PrintOptions::forDebugging()) << ")\n";
     }
 
     // Introduction of a `Bind` constraint here could result in the disconnect

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -280,13 +280,11 @@ StepResult ComponentStep::take(bool prevFailed) {
     CS.collectDisjunctions(disjunctions);
     std::vector<std::string> overloadDisjunctions;
     for (const auto &disjunction : disjunctions) {
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
-
       auto constraints = disjunction->getNestedConstraints();
       if (constraints[0]->getKind() == ConstraintKind::BindOverload)
         overloadDisjunctions.push_back(
-            constraints[0]->getFirstType()->getString(PO));
+            constraints[0]->getFirstType()->getString(
+                PrintOptions::forDebugging()));
     }
 
     if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
@@ -357,14 +355,11 @@ StepResult ComponentStep::take(bool prevFailed) {
     // we can't solve this system unless we have free type variables
     // allowed in the solution.
     if (CS.isDebugMode()) {
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
-
       auto &log = getDebugLogger();
       log << "(failed due to free variables:";
       for (auto *typeVar : CS.getTypeVariables()) {
         if (!typeVar->getImpl().hasRepresentativeOrFixed()) {
-          log << " " << typeVar->getString(PO);
+          log << " " << typeVar->getString(PrintOptions::forDebugging());
         }
       }
       log << ")\n";

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -407,15 +407,12 @@ private:
       auto &log = getDebugLogger();
       log << "Type variables in scope = "
           << "[";
-      auto typeVars = CS.getTypeVariables();
-      PrintOptions PO;
-      PO.PrintTypesForDebugging = true;
-      interleave(typeVars, [&](TypeVariableType *typeVar) {
-                   Type(typeVar).print(log, PO);
-                 },
-                 [&] {
-                   log << ", ";
-                 });
+      interleave(
+          CS.getTypeVariables(),
+          [&](TypeVariableType *typeVar) {
+            Type(typeVar).print(log, PrintOptions::forDebugging());
+          },
+          [&] { log << ", "; });
       log << "]" << '\n';
     }
 
@@ -553,9 +550,8 @@ public:
   StepResult resume(bool prevFailed) override;
 
   void print(llvm::raw_ostream &Out) override {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    Out << "TypeVariableStep for " << TypeVar->getString(PO) << '\n';
+    Out << "TypeVariableStep for ";
+    Out << TypeVar->getString(PrintOptions::forDebugging()) << '\n';
   }
 
 protected:

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -577,8 +577,7 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 void SolverTrail::Change::dump(llvm::raw_ostream &out,
                                ConstraintSystem &cs,
                                unsigned indent) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   out.indent(indent);
 
@@ -887,8 +886,7 @@ void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,
   llvm::set_subtract(removedConstraints, intersects);
 
   // Print out Changes.
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
   out.indent(indent);
   out << "(Changes:\n";
   if (!addedTypeVars.empty()) {

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -338,8 +338,7 @@ ProtocolDecl *Constraint::getProtocol() const {
 void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
                        unsigned indent, bool skipLocator) const {
   // Print all type variables as $T0 instead of _ here.
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   if (Kind == ConstraintKind::Disjunction ||
       Kind == ConstraintKind::Conjunction) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1048,19 +1048,14 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,
 }
 
 void ConstraintGraphNode::dump() const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-  print(llvm::dbgs(), 0, PO);
+  print(llvm::dbgs(), 0, PrintOptions::forDebugging());
 }
 
 void ConstraintGraph::print(ArrayRef<TypeVariableType *> typeVars,
                             llvm::raw_ostream &out) {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-
   for (auto typeVar : typeVars) {
-    (*this)[typeVar].print(
-        out, (CS.solverState ? CS.solverState->getCurrentIndent() : 0) + 2, PO);
+    auto indent = (CS.solverState ? CS.solverState->getCurrentIndent() : 0) + 2;
+    (*this)[typeVar].print(out, indent, PrintOptions::forDebugging());
     out << "\n";
   }
 }
@@ -1077,8 +1072,7 @@ void ConstraintGraph::printConnectedComponents(
     ArrayRef<TypeVariableType *> typeVars,
     llvm::raw_ostream &out) {
   auto components = computeConnectedComponents(typeVars);
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+
   for (const auto& component : components) {
     out.indent((CS.solverState ? CS.solverState->getCurrentIndent() : 0) + 2);
     out << component.solutionIndex << ": ";
@@ -1087,13 +1081,12 @@ void ConstraintGraph::printConnectedComponents(
     };
 
     // Print all of the type variables in this connected component.
-    interleave(component.typeVars,
-               [&](TypeVariableType *typeVar) {
-                 Type(typeVar).print(out, PO);
-               },
-               [&] {
-                 out << ' ';
-               });
+    interleave(
+        component.typeVars,
+        [&](TypeVariableType *typeVar) {
+          Type(typeVar).print(out, PrintOptions::forDebugging());
+        },
+        [&] { out << ' '; });
   }
 }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -129,8 +129,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
 }
 
 void LocatorPathElt::dump(raw_ostream &out) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   auto dumpReqKind = [&out](RequirementKind kind) {
     out << " (";
@@ -811,9 +810,6 @@ void ConstraintLocator::dump(ConstraintSystem *CS) const {
 
 
 void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-  
   out << "locator@" << (void*) this << " [";
 
   constraints::dumpAnchor(anchor, sm, out);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -57,10 +57,8 @@ using namespace constraints;
 #pragma mark Type variable implementation
 
 void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-  getTypeVariable()->print(OS, PO);
-  
+  getTypeVariable()->print(OS, PrintOptions::forDebugging());
+
   SmallVector<TypeVariableOptions, 4> bindingOptions;
   if (canBindToLValue())
     bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToLValue);
@@ -1271,8 +1269,7 @@ TypeChecker::coerceToRValue(ASTContext &Context, Expr *expr,
 
 void OverloadChoice::dump(Type adjustedOpenedType, SourceManager *sm,
                           raw_ostream &out) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
   out << " with ";
 
   switch (getKind()) {
@@ -1317,8 +1314,7 @@ void OverloadChoice::dump(Type adjustedOpenedType, SourceManager *sm,
 void Solution::dump() const { dump(llvm::errs(), 0); }
 
 void Solution::dump(raw_ostream &out, unsigned indent) const {
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   SourceManager *sm = &getConstraintSystem().getASTContext().SourceMgr;
 
@@ -1493,8 +1489,7 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) const {
 
 void ConstraintSystem::print(raw_ostream &out) const {
   // Print all type variables as $T0 instead of _ here.
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
+  PrintOptions PO = PrintOptions::forDebugging();
 
   auto indent = solverState ? solverState->getCurrentIndent() : 0;
   out.indent(indent) << "Score:";

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2055,7 +2055,7 @@ static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
         GC->printContext(llvm::errs());
       }
       llvm::errs() << "Generic signature: ";
-      PrintOptions Opts;
+      PrintOptions Opts = PrintOptions::forDebugging();
       Opts.ProtocolQualifiedDependentMemberTypes = true;
       Opts.PrintInverseRequirements =
           !ctx.TypeCheckerOpts.DebugInverseRequirements;
@@ -3427,7 +3427,7 @@ public:
       PD->dumpRef(llvm::errs());
       llvm::errs() << "\n";
       llvm::errs() << "Requirement signature: ";
-      PrintOptions Opts;
+      PrintOptions Opts = PrintOptions::forDebugging();
       Opts.ProtocolQualifiedDependentMemberTypes = true;
       Opts.PrintInverseRequirements =
           !Ctx.TypeCheckerOpts.DebugInverseRequirements;

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -3118,8 +3118,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
   bindOverloadType(overload, boundType, locator, useDC);
 
   if (isDebugMode()) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
+    PrintOptions PO = PrintOptions::forDebugging();
 
     auto &log = llvm::errs();
     log.indent(solverState ? solverState->getCurrentIndent() : 2);

--- a/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
+++ b/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
@@ -54,7 +54,7 @@ final class System: DistributedActorSystem {
     fatalError()
   }
 
-  // expected-note@+1 {{candidate has non-matching type '<Act, Err, Res> (on: Act, target: RemoteCallTarget, invocation: inout System.InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res' (aka '<Act, Err, Res> (on: Act, target: RemoteCallTarget, invocation: inout ClassInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res') [with ResultHandler = <<error type>>]}}
+  // expected-note@+1 {{candidate has non-matching type '<Act, Err, Res> (on: Act, target: RemoteCallTarget, invocation: inout System.InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res' (aka '<Act, Err, Res> (on: Act, target: RemoteCallTarget, invocation: inout ClassInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res') [with ResultHandler = _]}}
   func remoteCall<Act, Err, Res>(
     on actor: Act,
     target: RemoteCallTarget,

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -117,7 +117,7 @@ protocol PP {
 struct G<each T> {}
 
 // CHECK-LABEL: sameTypeMatch1
-// CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, repeat each V : PP, T.[PP]A == G<repeat (each U).[PP]A>, repeat (each U).[PP]A == (each V).[PP]A>
+// CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, repeat each V : PP, T.[PP]A == G<Pack{repeat (each U).[PP]A}>, repeat (each U).[PP]A == (each V).[PP]A>
 func sameTypeMatch1<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: repeat each V)
   where T.A == G<repeat (each U).A>, T.A == G<repeat (each V).A>,
         (repeat (each U, each V)) : Any {}

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -213,7 +213,7 @@ func resyncParserB5() {}
 
 for var i = 0; ; {
   #^TOP_LEVEL_STMT_5?check=PLAIN_TOP_LEVEL;check=TOP_LEVEL_STMT_5^#
-// TOP_LEVEL_STMT_5: Decl[LocalVar]/Local: i[#<<error type>>#]{{; name=.+$}}
+// TOP_LEVEL_STMT_5: Decl[LocalVar]/Local: i[#_#]{{; name=.+$}}
 }
 
 func resyncParserB6() {}
@@ -234,7 +234,7 @@ func resyncParserB8() {}
 
 for i in unknown_var {
   #^TOP_LEVEL_STMT_8?check=PLAIN_TOP_LEVEL;check=TOP_LEVEL_STMT_8^#
-// TOP_LEVEL_STMT_8: Decl[LocalVar]/Local: i[#<<error type>>#]{{; name=.+$}}
+// TOP_LEVEL_STMT_8: Decl[LocalVar]/Local: i[#_#]{{; name=.+$}}
 }
 
 func resyncParserB9() {}

--- a/test/IDE/complete_doc_member.swift
+++ b/test/IDE/complete_doc_member.swift
@@ -129,7 +129,7 @@ func testWithNoDot() {
 
 // MEMBER_NO_DOT:      Begin completions, 12 items
 
-// MEMBER_NO_DOT-NEXT: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#<<error type>>#]; name=[:];
+// MEMBER_NO_DOT-NEXT: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#_#]; name=[:];
 // MEMBER_NO_DOT-SAME: briefcomment=subscript on struct S;
 // MEMBER_NO_DOT-SAME: xmlcomment=<Other file="{{.*}}" line="44" column="3"><Name>subscript(_:)</Name><USR>s:15CompleteDocTest2S1VyXeXecip</USR><Declaration>subscript(index: Int) -&gt; &lt;&lt;error type&gt;&gt; { get }</Declaration><CommentParts><Abstract><Para>subscript on struct S</Para></Abstract><Parameters><Parameter><Name>index</Name><Direction isExplicit="0">in</Direction><Discussion><Para>an index into S1</Para></Discussion></Parameter></Parameters></CommentParts></Other>;
 // MEMBER_NO_DOT-SAME: rawcomment=subscript on struct S

--- a/test/IDE/complete_sequence_invalid.swift
+++ b/test/IDE/complete_sequence_invalid.swift
@@ -1,10 +1,10 @@
 // RUN: %batch-code-completion
 
-// GLOBAL: Decl[GlobalVar]/CurrModule:         invalidDecl[#<<error type>>#];
+// GLOBAL: Decl[GlobalVar]/CurrModule:         invalidDecl[#_#];
 let invalidDecl = INVALID
 
 struct S {
-  // MEMBER: Decl[InstanceMethod]/CurrNominal:   invalidMethod()[#<<error type>>#];
+  // MEMBER: Decl[InstanceMethod]/CurrNominal:   invalidMethod()[#_#];
   func invalidMethod() -> INVALID
 }
 

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -413,7 +413,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 
 // WITH_I_INT_LOCAL: Decl[LocalVar]/Local: i[#Int#]{{; name=.+$}}
 
-// WITH_I_ERROR_LOCAL: Decl[LocalVar]/Local: i[#<<error type>>#]{{; name=.+$}}
+// WITH_I_ERROR_LOCAL: Decl[LocalVar]/Local: i[#_#]{{; name=.+$}}
 
 // WITH_J_INT: Decl[LocalVar]/Local: j[#Int#]{{; name=.+$}}
 

--- a/test/IDE/complete_uninferred_generic.swift
+++ b/test/IDE/complete_uninferred_generic.swift
@@ -14,5 +14,5 @@ struct S2<T> : P1 {
 _ = S2()#^UNINFERRED^#
 
 // UNINFERRED-DAG: Decl[Subscript]/Super:     [{#(v0): T#}][#Int#]; name=[:]
-// UNINFERRED-DAG: Decl[Subscript]/Super:     [{#(v0): T#}][#<<error type>>#]; name=[:]
+// UNINFERRED-DAG: Decl[Subscript]/Super:     [{#(v0): T#}][#_#]; name=[:]
 // UNINFERRED-DAG: Keyword[self]/CurrNominal: .self[#S2<_>#]; name=self

--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -497,7 +497,7 @@ func testPropertyWrapper() {
 // CHECK27-NEXT:     foo9(1, 2)</Content>
 // CHECK27-NEXT: <Type>Void</Type>
 // CHECK27-NEXT: <Context>swift_ide_test.(file).foo9(_:_:)</Context>
-// CHECK27-NEXT: <Referenced>foo9</Referenced><Type>(Int, Int) -> Int</Type>
+// CHECK27-NEXT: <Referenced>foo9</Referenced><Type>(_ a: Int, _ b: Int) -> Int</Type>
 // CHECK27-NEXT: <ASTNodes>2</ASTNodes>
 // CHECK27-NEXT: <end>
 

--- a/test/IDE/range_info_expr.swift
+++ b/test/IDE/range_info_expr.swift
@@ -109,7 +109,7 @@ func bar(x: C2 = .main) {}
 // CHECK-MTEE-EXPR-3-NEXT: <Content>{ escapable in
 // CHECK-MTEE-EXPR-3-NEXT:     _ = escapable
 // CHECK-MTEE-EXPR-3-NEXT:   }</Content>
-// CHECK-MTEE-EXPR-3-NEXT: <Type>(@escaping (Int) -> Void) -> ()</Type><Exit>false</Exit>
+// CHECK-MTEE-EXPR-3-NEXT: <Type>(_ escapable: @escaping (Int) -> Void) -> ()</Type><Exit>false</Exit>
 // CHECK-MTEE-EXPR-3-NEXT: <Context>swift_ide_test.(file).testWithoutActuallyEscaping(closure:)</Context>
 // CHECK-MTEE-EXPR-3-NEXT: <Declared>escapable</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK-MTEE-EXPR-3-NEXT: <Referenced>escapable</Referenced><Type>(Int) -> Void</Type>

--- a/test/SourceKit/CursorInfo/cursor_infer_nonmutating_from_property_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_infer_nonmutating_from_property_wrapper.swift
@@ -14,4 +14,4 @@ func test() {
     }
 }
 
-// CHECK: <Declaration>@<Type usr="s:46cursor_infer_nonmutating_from_property_wrapper5StateV">State</Type> var myState: &lt;&lt;error type&gt;&gt; { get nonmutating set }</Declaration>
+// CHECK: <Declaration>@<Type usr="s:46cursor_infer_nonmutating_from_property_wrapper5StateV">State</Type> var myState: _ { get nonmutating set }</Declaration>

--- a/test/SourceKit/Misc/load-module-with-errors.swift
+++ b/test/SourceKit/Misc/load-module-with-errors.swift
@@ -17,11 +17,11 @@ func testInvalidStructMemberCompletion() {
   let foo: InvalidStruct
   foo.#^INVALID-MEMBER^#
   // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberA[#Int#];
-  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberB[#<<error type>>#];
-  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberC[#<<error type>>#];
-  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberD[#<<error type>>#];
-  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberE[#<<error type>>#];
-  // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         add({#<<error type>>#})[#Void#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberB[#_#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberC[#_#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberD[#_#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberE[#_#];
+  // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         add({#_#})[#Void#];
   // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         get()[#InvalidStruct.Item#];
   // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         set({#item: InvalidStruct.Item#})[#Void#];
 }
@@ -45,21 +45,21 @@ func testInvalidTopLevelCompletion() {
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidGenericFuncBody({#param: T#})[#T#];
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidPartialFunc()[#Void#];
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncBody()[#Void#];
-  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureBody[#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureBody[#_#];
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncSignature()[#Void#];
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalMissingInit[#String#];
   // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct<T, U>#];
   // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidStruct[#InvalidStruct#];
-  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: typeUsesFunc({#pe: InvalidEnum#}, {#pa: <<error type>>#}, {#pp: any InvalidProtocol#}, {#ps: InvalidStruct#}, {#pg: <<error type>>#}, {#pc: InvalidClass#})[#Int#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: typeUsesFunc({#pe: InvalidEnum#}, {#pa: _#}, {#pp: any InvalidProtocol#}, {#ps: InvalidStruct#}, {#pg: _#}, {#pc: InvalidClass#})[#Int#];
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalKeypath[#InvalidStruct.Type#];
   // INVALID-TOP-DAG: Decl[TypeAlias]/OtherModule[errors]: InvalidAlias[#InvalidAlias#];
-  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidGenericFuncType({#param: T#})[#<<error type>>#];
-  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncType()[#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidGenericFuncType({#param: T#})[#_#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncType()[#_#];
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureType[#() -> ()#];
   // INVALID-TOP-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub1[#InvalidClassSub1#];
   // INVALID-TOP-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub2[#InvalidClassSub2#];
   // INVALID-TOP-DAG: Decl[Protocol]/OtherModule[errors]/Flair[RareType]: InvalidProtocol[#InvalidProtocol#];
-  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncThrows()[' throws'][#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncThrows()[' throws'][#_#];
 }
 
 // RUN: %empty-directory(%t)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1186,14 +1186,15 @@ printResult(CancellableResult<ResultType> Result,
   }
 }
 
-static int printTypeContextInfo(
-    CancellableResult<TypeContextInfoResult> CancellableResult) {
+static int
+printTypeContextInfo(CancellableResult<TypeContextInfoResult> CancellableResult,
+                     const PrintOptions &PO) {
   return printResult<TypeContextInfoResult>(
-      CancellableResult, [](const TypeContextInfoResult &Result) {
+      CancellableResult, [&](const TypeContextInfoResult &Result) {
         llvm::outs() << "-----BEGIN TYPE CONTEXT INFO-----\n";
         for (auto resultItem : Result.Results) {
           llvm::outs() << "- TypeName: ";
-          resultItem.ExpectedTy.print(llvm::outs());
+          resultItem.ExpectedTy.print(llvm::outs(), PO);
           llvm::outs() << "\n";
 
           llvm::outs() << "  TypeUSR: ";
@@ -1224,11 +1225,10 @@ static int printTypeContextInfo(
       });
 }
 
-static int doTypeContextInfo(const CompilerInvocation &InitInvok,
-                             StringRef SourceFilename,
-                             StringRef SecondSourceFileName,
-                             StringRef CodeCompletionToken,
-                             bool CodeCompletionDiagnostics) {
+static int
+doTypeContextInfo(const CompilerInvocation &InitInvok, StringRef SourceFilename,
+                  StringRef SecondSourceFileName, StringRef CodeCompletionToken,
+                  bool CodeCompletionDiagnostics, const PrintOptions &PO) {
   return performWithCompletionLikeOperationParams(
       InitInvok, SourceFilename, SecondSourceFileName, CodeCompletionToken,
       CodeCompletionDiagnostics,
@@ -1241,16 +1241,17 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
             Params.CompletionBuffer, Params.Offset, Params.DiagC,
             /*CancellationFlag=*/nullptr,
             [&](CancellableResult<TypeContextInfoResult> Result) {
-              ExitCode = printTypeContextInfo(Result);
+              ExitCode = printTypeContextInfo(Result, PO);
             });
         return ExitCode;
       });
 }
 
 static int printConformingMethodList(
-    CancellableResult<ConformingMethodListResults> CancellableResult) {
+    CancellableResult<ConformingMethodListResults> CancellableResult,
+    const PrintOptions &PO) {
   return printResult<ConformingMethodListResults>(
-      CancellableResult, [](const ConformingMethodListResults &Results) {
+      CancellableResult, [&](const ConformingMethodListResults &Results) {
         auto Result = Results.Result;
         if (!Result) {
           return 0;
@@ -1258,7 +1259,7 @@ static int printConformingMethodList(
         llvm::outs() << "-----BEGIN CONFORMING METHOD LIST-----\n";
 
         llvm::outs() << "- TypeName: ";
-        Result->ExprType.print(llvm::outs());
+        Result->ExprType.print(llvm::outs(), PO);
         llvm::outs() << "\n";
 
         llvm::outs() << "- Members: ";
@@ -1275,7 +1276,7 @@ static int printConformingMethodList(
           llvm::outs() << "\n";
 
           llvm::outs() << "     TypeName: ";
-          resultTy.print(llvm::outs());
+          resultTy.print(llvm::outs(), PO);
           llvm::outs() << "\n";
 
           StringRef BriefDoc = VD->getSemanticBriefComment();
@@ -1291,12 +1292,11 @@ static int printConformingMethodList(
       });
 }
 
-static int
-doConformingMethodList(const CompilerInvocation &InitInvok,
-                       StringRef SourceFilename, StringRef SecondSourceFileName,
-                       StringRef CodeCompletionToken,
-                       bool CodeCompletionDiagnostics,
-                       const std::vector<std::string> expectedTypeNames) {
+static int doConformingMethodList(
+    const CompilerInvocation &InitInvok, StringRef SourceFilename,
+    StringRef SecondSourceFileName, StringRef CodeCompletionToken,
+    bool CodeCompletionDiagnostics,
+    const std::vector<std::string> expectedTypeNames, const PrintOptions &PO) {
   SmallVector<const char *, 4> typeNames;
   for (auto &name : expectedTypeNames)
     typeNames.push_back(name.c_str());
@@ -1313,7 +1313,7 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
             Params.CompletionBuffer, Params.Offset, Params.DiagC, typeNames,
             /*CancellationFlag=*/nullptr,
             [&](CancellableResult<ConformingMethodListResults> Result) {
-              ExitCode = printConformingMethodList(Result);
+              ExitCode = printConformingMethodList(Result, PO);
             });
         return ExitCode;
       });
@@ -2754,7 +2754,8 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
 }
 
 static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
-                             const std::vector<std::string> ModulesToPrint) {
+                             const std::vector<std::string> ModulesToPrint,
+                             const PrintOptions &PO) {
   using NodeKind = Demangle::Node::Kind;
 
   CompilerInvocation Invocation(InitInvok);
@@ -2774,8 +2775,6 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
     return 1;
 
   int ExitCode = 0;
-
-  PrintOptions Options = PrintOptions::printDeclarations();
 
   for (StringRef ModuleName : ModulesToPrint) {
     auto *M = getModuleByFullName(Context, ModuleName);
@@ -2867,9 +2866,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
 
       llvm::outs() << remangled << "\n";
 
-      auto Options = PrintOptions::printDeclarations();
-      Options.PrintAccess = false;
-      LTD->print(llvm::outs(), Options);
+      LTD->print(llvm::outs(), PO);
       llvm::outs() << "\n";
     }
   }
@@ -3410,8 +3407,7 @@ public:
 } // unnamed namespace
 
 static int doPrintTypes(const CompilerInvocation &InitInvok,
-                        StringRef SourceFilename,
-                        bool FullyQualifiedTypes) {
+                        StringRef SourceFilename, const PrintOptions &PO) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
@@ -3427,9 +3423,7 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
-  PrintOptions Options = PrintOptions::printDeclarations();
-  Options.FullyQualifiedTypes = FullyQualifiedTypes;
-  ASTTypePrinter Printer(CI.getSourceMgr(), Options);
+  ASTTypePrinter Printer(CI.getSourceMgr(), PO);
 
   CI.getMainModule()->walk(Printer);
 
@@ -3971,10 +3965,12 @@ class TypeReconstructWalker : public SourceEntityWalker {
   llvm::raw_ostream &Stream;
   llvm::DenseSet<ValueDecl *> SeenDecls;
   llvm::SmallVector<DeclContext *, 2> NestedDCs;
+  const PrintOptions &PO;
 
 public:
-  TypeReconstructWalker(ASTContext &Ctx, llvm::raw_ostream &Stream)
-      : Ctx(Ctx), Stream(Stream) {}
+  TypeReconstructWalker(ASTContext &Ctx, llvm::raw_ostream &Stream,
+                        const PrintOptions &PO)
+      : Ctx(Ctx), Stream(Stream), PO(PO) {}
 
   bool walkToDeclPre(Decl *D, CharSourceRange range) override {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
@@ -4019,7 +4015,7 @@ private:
         Demangle::getTypeForMangling(Ctx, mangledName));
     Stream << "type: ";
     if (ReconstructedType) {
-      ReconstructedType->print(Stream);
+      ReconstructedType->print(Stream, PO);
     } else {
       Stream << "FAILURE";
     }
@@ -4044,7 +4040,11 @@ private:
     }
 
     if (TypeDecl *reDecl = Demangle::getTypeDeclForUSR(Ctx, USR)) {
-      PrintOptions POpts;
+      PrintOptions POpts = PO.clone();
+      POpts.TypeDefinitions = false;
+      POpts.VarInitializers = false;
+      POpts.FunctionDefinitions = false;
+      POpts.PrintExprs = false;
       POpts.PreferTypeRepr = false;
       POpts.PrintParameterSpecifiers = true;
       reDecl->print(Stream, POpts);
@@ -4056,7 +4056,7 @@ private:
 };
 
 static int doReconstructType(const CompilerInvocation &InitInvok,
-                             StringRef SourceFilename) {
+                             StringRef SourceFilename, const PrintOptions &PO) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
@@ -4080,15 +4080,14 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
       break;
   }
   assert(SF && "no source file?");
-  TypeReconstructWalker Walker(SF->getASTContext(), llvm::outs());
+  TypeReconstructWalker Walker(SF->getASTContext(), llvm::outs(), PO);
   Walker.walk(SF);
   return 0;
 }
 
 static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
-                            StringRef SourceFileName,
-                            StringRef StartPos,
-                            StringRef EndPos) {
+                            StringRef SourceFileName, StringRef StartPos,
+                            StringRef EndPos, const PrintOptions &PO) {
   auto StartOp = parseLineCol(StartPos);
   auto EndOp = parseLineCol(EndPos);
   if (!StartOp.has_value() || !EndOp.has_value())
@@ -4127,7 +4126,7 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
                                          EndLineCol.second);
   ResolvedRangeInfo Result = evaluateOrDefault(SF->getASTContext().evaluator,
     RangeInfoRequest(RangeInfoOwner({SF, StartLoc, EndLoc})), ResolvedRangeInfo());
-  Result.print(llvm::outs());
+  Result.print(llvm::outs(), PO);
   return 0;
 }
 
@@ -4828,11 +4827,10 @@ int main(int argc, char *argv[]) {
       llvm::errs() << "token name required\n";
       return 1;
     }
-    ExitCode = doTypeContextInfo(InitInvok,
-                                  options::SourceFilename,
-                                  options::SecondSourceFilename,
-                                  options::CodeCompletionToken,
-                                  options::CodeCompletionDiagnostics);
+    ExitCode = doTypeContextInfo(InitInvok, options::SourceFilename,
+                                 options::SecondSourceFilename,
+                                 options::CodeCompletionToken,
+                                 options::CodeCompletionDiagnostics, PrintOpts);
     break;
 
   case ActionType::PrintExpressionTypes:
@@ -4846,12 +4844,10 @@ int main(int argc, char *argv[]) {
       llvm::errs() << "token name required\n";
       return 1;
     }
-    ExitCode = doConformingMethodList(InitInvok,
-                                      options::SourceFilename,
-                                      options::SecondSourceFilename,
-                                      options::CodeCompletionToken,
-                                      options::CodeCompletionDiagnostics,
-                                      options::ConformingMethodListExpectedTypes);
+    ExitCode = doConformingMethodList(
+        InitInvok, options::SourceFilename, options::SecondSourceFilename,
+        options::CodeCompletionToken, options::CodeCompletionDiagnostics,
+        options::ConformingMethodListExpectedTypes, PrintOpts);
     break;
 
   case ActionType::SyntaxColoring:
@@ -4892,7 +4888,7 @@ int main(int argc, char *argv[]) {
     break;
   }
   case ActionType::PrintLocalTypes:
-    ExitCode = doPrintLocalTypes(InitInvok, options::ModuleToPrint);
+    ExitCode = doPrintLocalTypes(InitInvok, options::ModuleToPrint, PrintOpts);
     break;
 
   case ActionType::PrintModuleGroups:
@@ -4943,8 +4939,7 @@ int main(int argc, char *argv[]) {
   }
 
   case ActionType::PrintTypes:
-    ExitCode = doPrintTypes(InitInvok, options::SourceFilename,
-                            options::FullyQualifiedTypes);
+    ExitCode = doPrintTypes(InitInvok, options::SourceFilename, PrintOpts);
     break;
 
   case ActionType::PrintComments:
@@ -4979,12 +4974,12 @@ int main(int argc, char *argv[]) {
                                                 options::USR);
     break;
   case ActionType::ReconstructType:
-    ExitCode = doReconstructType(InitInvok, options::SourceFilename);
+    ExitCode = doReconstructType(InitInvok, options::SourceFilename, PrintOpts);
     break;
   case ActionType::Range:
     ExitCode = doPrintRangeInfo(InitInvok, options::SourceFilename,
                                 options::LineColumnPair,
-                                options::EndLineColumnPair);
+                                options::EndLineColumnPair, PrintOpts);
     break;
   case ActionType::PrintIndexedSymbols:
       if (options::ModuleToPrint.empty()) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -585,6 +585,11 @@ PreferTypeRepr("prefer-type-repr",
                llvm::cl::cat(Category),
                llvm::cl::init(true));
 
+static llvm::cl::opt<bool> PrintForDebugging(
+    "debug-print",
+    llvm::cl::desc("Print using the debug representation for types"),
+    llvm::cl::cat(Category), llvm::cl::init(true));
+
 static llvm::cl::opt<bool>
 FullyQualifiedTypes("fully-qualified-types",
                     llvm::cl::desc("Print fully qualified types"),
@@ -4735,6 +4740,7 @@ int main(int argc, char *argv[]) {
       return PrintOptions::printDocInterface();
     } else {
       auto PrintOpts = PrintOptions::printEverything();
+      PrintOpts.PrintTypesForDebugging = options::PrintForDebugging;
       PrintOpts.FullyQualifiedTypes = options::FullyQualifiedTypes;
       PrintOpts.FullyQualifiedTypesIfAmbiguous =
         options::FullyQualifiedTypesIfAmbiguous;

--- a/validation-test/IDE/issues_fixed/rdar63063279.swift
+++ b/validation-test/IDE/issues_fixed/rdar63063279.swift
@@ -61,4 +61,4 @@ D().b(b: .#^B_5?check=B^#)
 // B: Begin completions, 3 items
 // B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#(value): T#})[#B<T>#]; name=init(:)
 // B-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: void()[#B<Void>#]; name=void()
-// B-DAG: Decl[StaticMethod]/CurrNominal:     data({#(data): <<error type>>#})[#<<error type>>#]; name=data(:)
+// B-DAG: Decl[StaticMethod]/CurrNominal:     data({#(data): _#})[#_#]; name=data(:)

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
@@ -14,9 +14,9 @@ struct Test {
 
   mutating func test<T>(v: Value<T>) {
     _ = {
-      // FIXME(diagnostics): We need to figure out how to avoid mentioning <<error type>> in the second diagnostic
+      // FIXME(diagnostics): This isn't a useful error message
       self.tuple = (v, 42)
-      // expected-error@-1 {{generic struct 'Value' requires the types 'T' and '<<error type>>' be equivalent}}
+      // expected-error@-1 {{generic struct 'Value' requires the types 'T' and '_' be equivalent}}
       return 0
     }
   }


### PR DESCRIPTION
In preparation for removing UnresolvedType in favor of ErrorType, start printing ErrorType as `_` unless we've enabled debug printing. `<<error type>>` should never be presented to the user, instead `_` now just consistently means "unknown type".