### PR TITLE
[6.2][wasm] Fix `@_expose(wasm)` serialization crash

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2526,7 +2526,7 @@ namespace decls_block {
   >;
 
   using ExposeDeclAttrLayout = BCRecordLayout<Expose_DECL_ATTR,
-                                              BCFixed<1>, // exposure kind
+                                              BCFixed<2>, // exposure kind
                                               BCFixed<1>, // implicit flag
                                               BCBlob      // declaration name
                                               >;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 947; // @preEnumExtensibility attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 948; // @_expose kind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/Serialization/attr-expose.swift
+++ b/test/Serialization/attr-expose.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend  -module-name attr_expose -emit-module -parse-as-library -o %t %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/attr_expose.swiftmodule | %FileCheck %s
+
+// @_expose
+// -----------------------------------------------------------------------------
+
+// CHECK:      @_expose(Cxx)
+// CHECK-NEXT: func exposeToCxx()
+@_expose(Cxx)
+func exposeToCxx() -> Int { return 42 }
+
+// CHECK:      @_expose(Cxx, "custom_name")
+// CHECK-NEXT: func exposeToCxxWithName()
+@_expose(Cxx, "custom_name")
+func exposeToCxxWithName() -> Int { return 24 }
+
+// CHECK:      @_expose(!Cxx)
+// CHECK-NEXT: func dontExposeToCxx()
+@_expose(!Cxx)
+func dontExposeToCxx() -> Int { return 13 }
+
+// CHECK:      @_expose(wasm)
+// CHECK-NEXT: func exposeToWasm()
+@_expose(wasm)
+func exposeToWasm() -> Int { return 99 }
+
+// CHECK:     @_expose(wasm, "wasm_custom")
+// CHECK-NEXT func exposeToWasmWithName()
+@_expose(wasm, "wasm_custom")
+func exposeToWasmWithName() -> Int { return 88 }


### PR DESCRIPTION
Explanation: https://github.com/swiftlang/swift/pull/82616 added a new exposure kind for the `@_expose` attribute, but did not update the serialization format to account for the new kind. This caused a crash when serializing a module that used `@_expose(wasm)`.
Issues: https://github.com/swiftlang/swift/issues/84196 https://github.com/swiftlang/swift/issues/84140
Original PRs: https://github.com/swiftlang/swift/pull/84215
Risk: Low, it only affects when using `@_expose(wasm)`
Testing: Added a test.
Reviewers: @bnbarham, @MaxDesiatov 
