### PR TITLE
[cxx-interop] Avoid trying to generate module interfaces twice

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_clang_cxx_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_cxx_module.swift
@@ -1,7 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %sourcekitd-test -req=interface-gen -module CxxModule -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t/Inputs -target %target-triple %clang-importer-sdk-nosource | %FileCheck %s
+// The interface should fail to generate with C++ interop disabled:
+// RUN: not %sourcekitd-test -req=interface-gen -module CxxModule -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t/Inputs -target %target-triple %clang-importer-sdk-nosource
+
+// With C++ interop enabled, it should succeed:
 // RUN: %sourcekitd-test -req=interface-gen -module CxxModule -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -cxx-interoperability-mode=default -I %t/Inputs -target %target-triple %clang-importer-sdk-nosource | %FileCheck %s
 
 

--- a/test/SourceKit/InterfaceGen/gen_clang_mixed_lang_fmwk_cxx_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_mixed_lang_fmwk_cxx_module.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -emit-module %t/TestFmSwift.swift -module-name TestFm -enable-experimental-cxx-interop -F %t -o %t/TestFm.swiftmodule -import-underlying-module
 
-// RUN: %sourcekitd-test -req=interface-gen -module TestFm -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck %s
+// RUN: %sourcekitd-test -req=interface-gen -module TestFm -- -cxx-interoperability-mode=default -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck %s
 
 //--- TestFm.framework/Headers/TestFm.h
 #pragma once

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -790,26 +790,8 @@ void SwiftLangSupport::editorOpenInterface(
                                                       SynthesizedExtensions,
                                                       InterestedUSR);
   if (!IFaceGenRef) {
-      // Retry to generate a module interface with C++ interop enabled,
-      // if the first attempt failed.
-      bool retryWithCxxEnabled = true;
-      for (const auto &arg: Args) {
-          if (StringRef(arg).starts_with("-cxx-interoperability-mode=") ||
-              StringRef(arg).starts_with("-enable-experimental-cxx-interop")) {
-              retryWithCxxEnabled = false;
-              break;
-          }
-      }
-      if (retryWithCxxEnabled) {
-          std::vector<const char *> AdjustedArgs(Args.begin(), Args.end());
-          AdjustedArgs.push_back("-cxx-interoperability-mode=default");
-          return editorOpenInterface(Consumer, Name, ModuleName, Group, AdjustedArgs,
-                                     SynthesizedExtensions, InterestedUSR);
-      }
-      else {
-          Consumer.handleRequestError(ErrMsg.c_str());
-          return;
-      }
+    Consumer.handleRequestError(ErrMsg.c_str());
+    return;
   }
 
   IFaceGenRef->reportEditorInfo(Consumer);


### PR DESCRIPTION
This reverts most of 72050c5385e7a93643399e2daca006f445e778d1, which led to decreased performance of jump-to-definition.

Instead of re-attempting to generate a module interface with C++ interop enabled, Swift should rely on the IDE to pass the correct `-cxx-interoperability-mode=` value to SourceKit.

rdar://149061322

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
