### PR TITLE
lit.cfg: Use raw strings for regex patterns.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2938,26 +2938,26 @@ config.substitutions.append(('%target-pic-opt', config.target_pic_opt))
 config.substitutions.append(('%target-msvc-runtime-opt',
                              config.target_msvc_runtime_opt))
 
-config.substitutions.append(('%target-swift-emit-module-interfaces\(([^)]+),\w*([^)]+)\)',
+config.substitutions.append((r'%target-swift-emit-module-interfaces\(([^)]+),\w*([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-emit-module-interface(\1) -emit-private-module-interface-path \2')))
-config.substitutions.append(('%target-swift-emit-module-interface\(([^)]+)\)',
+config.substitutions.append((r'%target-swift-emit-module-interface\(([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -parse-as-library -typecheck -emit-module-interface-path \1')))
 
-config.substitutions.append(('%target-swift-typecheck-module-from-interface\(([^)]+)\)',
+config.substitutions.append((r'%target-swift-typecheck-module-from-interface\(([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck-module-from-interface \1')))
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
-config.substitutions.append(('%target-swift-emit-silgen\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-swift-emit-silgen\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-silgen')))
 config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen'))
-config.substitutions.append(('%target-swift-emit-sil\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-swift-emit-sil\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-sil')))
 config.substitutions.append(('%target-swift-emit-sil', '%target-swift-frontend -emit-sil'))
-config.substitutions.append(('%target-swift-emit-ir\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-swift-emit-ir\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend(mock-sdk:\1) -emit-ir')))
 config.substitutions.append(('%target-swift-emit-ir', '%target-swift-frontend -emit-ir'))
-config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-swift-frontend\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk),
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk_after)))))
@@ -2965,14 +2965,14 @@ config.substitutions.append(('%target-swift-frontend-plain', config.target_swift
 config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
 
 
-config.substitutions.append(('%target-run-simple-swiftgyb\(([^)]+)\)',
+config.substitutions.append((r'%target-run-simple-swiftgyb\(([^)]+)\)',
                             config.target_run_simple_swiftgyb_parameterized))
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
-config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)',
+config.substitutions.append((r'%target-run-simple-swift\(([^)]+)\)',
                             config.target_run_simple_swift_parameterized))
-config.substitutions.append(('%target-fail-simple-swift\(([^)]+)\)',
+config.substitutions.append((r'%target-fail-simple-swift\(([^)]+)\)',
                             config.target_fail_simple_swift_parameterized))
-config.substitutions.append(('%target-run-stdlib-swift\(([^)]+)\)',
+config.substitutions.append((r'%target-run-stdlib-swift\(([^)]+)\)',
                             config.target_run_stdlib_swift_parameterized))
 
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
@@ -2984,7 +2984,7 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 # Capture groups:
 # \1 = path before the file name (non-greedy)
 # \2 = file name (last component, no slashes or parentheses)
-config.substitutions.append(('%target-build-swift-dylib\(([^)]+?)([^/\\()]+)\)', config.target_build_swift_dylib))
+config.substitutions.append((r'%target-build-swift-dylib\(([^)]+?)([^/\\()]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
 config.substitutions.append(('%target-clang', config.target_clang))
@@ -3034,7 +3034,7 @@ config.substitutions.append(('%scale-test',
                                  shell_quote(sys.executable), config.scale_test,
                                  config.swiftc)))
 config.substitutions.append(('%abi-symbol-checker', '%s %s' % (shell_quote(sys.executable), config.abi_symbol_checker)))
-config.substitutions.append(('%target-sil-opt\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-sil-opt\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (
                                  escape_for_substitute_captures(subst_target_sil_opt_mock_sdk),
                                  escape_for_substitute_captures(subst_target_sil_opt_mock_sdk_after)))))
@@ -3048,7 +3048,7 @@ config.substitutions.append(('%target-sil-nm', config.target_sil_nm))
 
 config.substitutions.append(('%batch-code-completion', '%empty-directory(%t/batch-code-completion) && %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t/batch-code-completion'))
 
-config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
+config.substitutions.append((r'%target-swift-ide-test\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s %s' % (
                                  escape_for_substitute_captures(subst_target_swift_ide_test_mock_sdk),
                                  escape_for_substitute_captures(subst_target_swift_ide_test_mock_sdk_after),
@@ -3061,7 +3061,7 @@ config.substitutions.append(('%target-swift-ide-test',
 config.substitutions.append(('%target-swift-symbolgraph-extract', config.target_swift_symbolgraph_extract))
 config.substitutions.append(('%target-swift-synthesize-interface', config.target_swift_synthesize_interface))
 
-config.substitutions.append(('%empty-directory\(([^)]+)\)',
+config.substitutions.append((r'%empty-directory\(([^)]+)\)',
                              SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
 
 if not hasattr(config, 'target_swift_reflection_test'):
@@ -3115,15 +3115,15 @@ config.substitutions.append(('%target-package-swiftinterface-name', target_speci
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))
 config.substitutions.append(('%{target-shared-library-suffix}', config.target_shared_library_suffix))
-config.substitutions.insert(0, ('%target-library-name\(([^)]+)\)',
+config.substitutions.insert(0, (r'%target-library-name\(([^)]+)\)',
                                 SubstituteCaptures(r'%s\1%s' % (
                                     escape_for_substitute_captures(config.target_shared_library_prefix),
                                     escape_for_substitute_captures(config.target_shared_library_suffix)))))
-config.substitutions.insert(0, ('%target-static-library-name\(([^)]+)\)',
+config.substitutions.insert(0, (r'%target-static-library-name\(([^)]+)\)',
                                 SubstituteCaptures(r'%s\1%s' % (
                                     escape_for_substitute_captures(config.target_static_library_prefix),
                                     escape_for_substitute_captures(config.target_static_library_suffix)))))
-config.substitutions.append(('%target-rpath\(([^)]+)\)', config.target_add_rpath))
+config.substitutions.append((r'%target-rpath\(([^)]+)\)', config.target_add_rpath))
 
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 


### PR DESCRIPTION
This avoid deprecated/syntax warnings about invalid escape sequences. The deprecation warnings were off by default but made into SyntaxWarnings in python 3.12+.

For example,

swift/test/lit.cfg:2899: SyntaxWarning: invalid escape sequence '\('
  config.substitutions.append(('%target-swift-emit-module-interfaces\(([^)]+),\w*([^)]+)\)',
swift/test/lit.cfg:2901: SyntaxWarning: invalid escape sequence '\('
  config.substitutions.append(('%target-swift-emit-module-interface\(([^)]+)\)',
