### PR TITLE
[6.2]Update OS versions requiring stdlib OS rpaths

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -117,23 +117,32 @@ bool swift::tripleRequiresRPathForSwiftLibrariesInOS(
     // macOS versions before 10.14.4 don't have Swift in the OS
     // (the linker still uses an rpath-based install name until 10.15).
     // macOS versions before 12.0 don't have _Concurrency in the OS.
-    return triple.isMacOSXVersionLT(12, 0);
+    // macOS versions before 26.0 don't have Span in stdlib.
+    return triple.isMacOSXVersionLT(26, 0);
   }
 
   if (triple.isiOS()) {
     // iOS versions before 12.2 don't have Swift in the OS.
     // iOS versions before 15.0 don't have _Concurrency in the OS.
-    return triple.isOSVersionLT(15, 0);
+    // iOS versions before 26.0 don't have Span in stdlib.
+    return triple.isOSVersionLT(26, 0);
   }
 
   if (triple.isWatchOS()) {
     // watchOS versions before 5.2 don't have Swift in the OS.
     // watchOS versions before 8.0 don't have _Concurrency in the OS.
-    return triple.isOSVersionLT(8, 0);
+    // watchOS versions before 26.0 don't have Span in stdlib.
+    return triple.isOSVersionLT(26, 0);
+  }
+
+  if (triple.isTvOS()) {
+    // tvOS versions before 26.0 don't have Span in stdlib.
+    return triple.isOSVersionLT(26, 0);
   }
 
   if (triple.isXROS()) {
-    return triple.isOSVersionLT(1, 0);
+    // visionOS versions before 26.0 don't have Span in stdlib.
+    return triple.isOSVersionLT(26, 0);
   }
 
   // Other platforms don't have Swift installed as part of the OS by default.

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -8,32 +8,37 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx11.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx26.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios26 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13.1-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios26-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos26 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos7 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos8 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos8 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos26 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RPATH: bin/ld{{"? }}
 // RPATH-SAME: -rpath {{"?/usr/lib/swift(-.+)?"? }}
@@ -51,7 +56,7 @@
 
 // ### Test with -no-toolchain-stdlib-rpath
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx26.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // TOOLCHAIN-RPATH: bin/ld{{"? }}
 // TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -11,8 +11,8 @@
 // RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
 // RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
 
-// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
-// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx26.0 -target-variant x86_64-apple-ios26-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx26.0 -target-variant x86_64-apple-ios26-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
@@ -90,14 +90,14 @@
 // CHECK-PRE-CONCURRENCY-ZIPPERED: }
 
 // CHECK-ZIPPERED: "target": {
-// CHECK-ZIPPERED:   "triple": "x86_64-apple-macosx12.0"
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-macosx26.0"
 // CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-macosx"
 // CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-macos"
 // CHECK-ZIPPERED:   "librariesRequireRPath": false
 // CHECK-ZIPPERED: }
 
 // CHECK-ZIPPERED: "targetVariant": {
-// CHECK-ZIPPERED:   "triple": "x86_64-apple-ios15-macabi"
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-ios26-macabi"
 // CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
 // CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
 // CHECK-ZIPPERED:   "librariesRequireRPath": false

--- a/unittests/DependencyScan/PrintTarget.cpp
+++ b/unittests/DependencyScan/PrintTarget.cpp
@@ -52,7 +52,7 @@ TEST_F(ScanTest, TestTargetInfoQuery) {
 
   auto targetInfoStr = std::string(swift::c_string_utils::get_C_string(targetInfo.get()));
   EXPECT_NE(targetInfoStr.find("\"triple\": \"x86_64-apple-macosx12.0\""), std::string::npos);
-  EXPECT_NE(targetInfoStr.find("\"librariesRequireRPath\": false"), std::string::npos);
+  EXPECT_NE(targetInfoStr.find("\"librariesRequireRPath\": true"), std::string::npos);
 
   std::string expectedRuntimeResourcePath = "\"runtimeResourcePath\": \"" + relativeLibPath.str().str() + "\"";
   // On windows, need to normalize the path back to "\\" separators


### PR DESCRIPTION
**Explanation**: swift-print-target-info incorrectly reported a /usr/lib/swift rpath was not needed for targets with concurrency in the OS but requiring back deployment for Span. Binaries linked using swiftc with a deployment target in this range will have incorrect behavior on newer OS versions if the rpath isn't added manually.
- **Scope**: swiftc -print-target-info, which influences driver behavior
- **Issues**: https://github.com/swiftlang/swift-package-manager/issues/9163
- **Original PRs**: https://github.com/swiftlang/swift/pull/84420
- **Risk**: Low, this change applies existing behavior to an updated range of OS versions
- **Testing**: updated tests, manual testing on older macOS versions
- **Reviewers**: @DougGregor  @jakepetroules 