### PR TITLE
[Caching] Allow prefix mapping for generated bridging header

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -577,9 +577,9 @@ bool extractCompilerFlagsFromInterface(
 llvm::VersionTuple extractUserModuleVersionFromInterface(StringRef moduleInterfacePath);
 
 /// Extract embedded bridging header from binary module.
-std::string
+std::unique_ptr<llvm::MemoryBuffer>
 extractEmbeddedBridgingHeaderContent(std::unique_ptr<llvm::MemoryBuffer> file,
-                                     ASTContext &Context);
+                                     StringRef headerPath, ASTContext &Context);
 } // end namespace swift
 
 #endif

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1364,12 +1364,8 @@ void ModuleDependencyScanner::resolveHeaderDependenciesForModule(
     if (!moduleBuf)
       return nullptr;
 
-    auto content = extractEmbeddedBridgingHeaderContent(std::move(*moduleBuf),
-                                                        ScanASTContext);
-    if (content.empty())
-      return nullptr;
-
-    return llvm::MemoryBuffer::getMemBufferCopy(content, header);
+    return extractEmbeddedBridgingHeaderContent(std::move(*moduleBuf), header,
+                                                ScanASTContext);
   };
 
   if (isBinaryModuleWithHeaderInput) {
@@ -1636,28 +1632,24 @@ void ModuleDependencyScanner::resolveCrossImportOverlayDependencies(
                 allModules.end(), action);
 }
 
+static void appendHeaderContent(llvm::raw_ostream &OS,
+                                llvm::MemoryBufferRef buffer,
+                                ModuleDependencyID fromModule) {
+  // Use preprocessor directives to add some clues for where the content is
+  // coming from.
+  OS << "# 1 \"<module-" << fromModule.ModuleName << ">/"
+     << llvm::sys::path::filename(buffer.getBufferIdentifier()) << "\" 1\n";
+  OS << buffer.getBuffer();
+}
+
 llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
     const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
     ModuleDependencyIDSetVector &allModules) {
   if (rootModuleID.Kind != ModuleDependencyKind::SwiftSource)
     return llvm::Error::success();
 
-  bool hasBridgingHeader = false;
-  llvm::vfs::OnDiskOutputBackend outputBackend;
-
-  SmallString<256> outputPath(
-      ScanCompilerInvocation.getFrontendOptions().ScannerOutputDir);
-
-  if (outputPath.empty())
-    outputPath = "/<compiler-generated>";
-
-  llvm::sys::path::append(
-      outputPath, ScanCompilerInvocation.getFrontendOptions().ModuleName + "-" +
-                      ScanCompilerInvocation.getModuleScanningHash() +
-                      "-ChainedBridgingHeader.h");
-
-  llvm::SmallString<256> sourceBuf;
-  llvm::raw_svector_ostream outOS(sourceBuf);
+  llvm::SmallString<256> chainedHeaderBuffer;
+  llvm::raw_svector_ostream outOS(chainedHeaderBuffer);
 
   // Iterate through all the modules and collect all the bridging header
   // and chain them into a single file. The allModules list is in the order of
@@ -1665,16 +1657,14 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   // buffer.
   auto FS = ScanASTContext.SourceMgr.getFileSystem();
   for (const auto &moduleID : allModules) {
-    if (moduleID.Kind != ModuleDependencyKind::SwiftSource &&
-        moduleID.Kind != ModuleDependencyKind::SwiftBinary)
+    if (moduleID.Kind != ModuleDependencyKind::SwiftBinary)
       continue;
 
     auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
     if (auto *binaryMod = moduleDependencyInfo.getAsSwiftBinaryModule()) {
       if (!binaryMod->headerImport.empty()) {
-        hasBridgingHeader = true;
-        if (FS->exists(binaryMod->headerImport)) {
-          outOS << "#include \"" << binaryMod->headerImport << "\"\n";
+        if (auto buffer= FS->getBufferForFile(binaryMod->headerImport)) {
+          appendHeaderContent(outOS, (*buffer)->getMemBufferRef(), moduleID);
         } else {
           // Extract the embedded bridging header
           auto moduleBuf = FS->getBufferForFile(binaryMod->compiledModulePath);
@@ -1682,39 +1672,76 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
             return llvm::errorCodeToError(moduleBuf.getError());
 
           auto content = extractEmbeddedBridgingHeaderContent(
-              std::move(*moduleBuf), ScanASTContext);
-          if (content.empty())
+              std::move(*moduleBuf), /*headerPath=*/"", ScanASTContext);
+          if (!content)
             return llvm::createStringError("can't load embedded header from " +
                                            binaryMod->compiledModulePath);
 
-          outOS << content << "\n";
+          outOS << content->getBuffer() << "\n";
         }
-      }
-    } else if (auto *srcMod = moduleDependencyInfo.getAsSwiftSourceModule()) {
-      if (srcMod->textualModuleDetails.bridgingHeaderFile) {
-        hasBridgingHeader = true;
-        outOS << "#include \""
-              << *srcMod->textualModuleDetails.bridgingHeaderFile << "\"\n";
       }
     }
   }
 
-  if (!hasBridgingHeader)
-    return llvm::Error::success();
+  // Handle bridging header in main module.
+  auto mainModuleDeps = cache.findKnownDependency(rootModuleID);
+  auto *mainModule = mainModuleDeps.getAsSwiftSourceModule();
+  assert(mainModule && "expect main module to be a swift source module");
+  std::unique_ptr<llvm::MemoryBuffer> sourceBuffer;
+  bool needChainedHeader = !chainedHeaderBuffer.empty();
+  if (!needChainedHeader) {
+    // There is no bridging header chained from dependencies.
+    // If main module also has no bridging header, ther is nothing to scan.
+    if (!mainModule->textualModuleDetails.bridgingHeaderFile)
+      return llvm::Error::success();
 
-  if (ScanCompilerInvocation.getFrontendOptions().WriteScannerOutput) {
-    auto outFile = outputBackend.createFile(outputPath);
-    if (!outFile)
-      return outFile.takeError();
-    *outFile << sourceBuf;
-    if (auto err = outFile->keep())
-      return err;
+    // Otherwise, there is no chaining needed. Just use the bridging header from
+    // main module.
+    if (auto headerBuffer = FS->getBufferForFile(
+            *mainModule->textualModuleDetails.bridgingHeaderFile))
+      sourceBuffer = std::move(*headerBuffer);
+    else
+      return llvm::errorCodeToError(headerBuffer.getError());
+  } else {
+    // There are bridging header needed to be chained. Append the bridging
+    // header from main module if needed and create use a new source buffer.
+    if (mainModule->textualModuleDetails.bridgingHeaderFile) {
+      auto srcBuf = FS->getBufferForFile(
+          *mainModule->textualModuleDetails.bridgingHeaderFile);
+      if (!srcBuf)
+        return llvm::errorCodeToError(srcBuf.getError());
+      appendHeaderContent(outOS, (*srcBuf)->getMemBufferRef(), rootModuleID);
+    }
+
+    SmallString<256> outputPath(
+        ScanCompilerInvocation.getFrontendOptions().ScannerOutputDir);
+
+    if (outputPath.empty())
+      outputPath = "/<compiler-generated>";
+
+    // Use the hash of the file content to differentiate the chained header.
+    auto fileHash =
+        llvm::toString(llvm::APInt(64, llvm::hash_value(chainedHeaderBuffer)),
+                       36, /*Signed=*/false);
+    llvm::sys::path::append(
+        outputPath, ScanCompilerInvocation.getFrontendOptions().ModuleName +
+                        "-" + fileHash + "-ChainedBridgingHeader.h");
+
+    if (ScanCompilerInvocation.getFrontendOptions().WriteScannerOutput) {
+      llvm::vfs::OnDiskOutputBackend outputBackend;
+      auto outFile = outputBackend.createFile(outputPath);
+      if (!outFile)
+        return outFile.takeError();
+      *outFile << chainedHeaderBuffer;
+      if (auto err = outFile->keep())
+        return err;
+    }
+
+    sourceBuffer =
+        llvm::MemoryBuffer::getMemBufferCopy(chainedHeaderBuffer, outputPath);
   }
 
-  auto sourceBuffer =
-      llvm::MemoryBuffer::getMemBufferCopy(sourceBuf, outputPath);
   // Scan and update the main module dependency.
-  auto mainModuleDeps = cache.findKnownDependency(rootModuleID);
   ModuleDependencyIDSetVector headerClangModuleDependencies;
   std::optional<std::string> includeTreeID;
   auto err = withDependencyScanningWorker(
@@ -1733,7 +1760,8 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
 
         if (!headerScanResult)
           return llvm::createStringError(
-              "failed to scan generated bridging header " + outputPath);
+              "failed to scan generated bridging header " +
+              sourceBuffer->getBufferIdentifier());
 
         // Record module dependencies for each new module we found.
         cache.recordClangDependencies(
@@ -1774,9 +1802,25 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
         }
         mainModuleDeps.updateBridgingHeaderCommandLine(
             bridgingHeaderCommandLine);
+        if (needChainedHeader) {
+          // As only the chained bridging header is scanned, the dependency will
+          // not include the original bridging header passed by user. Fixup the
+          // headerFileInputs to include original bridging header and not
+          // include the generated header so build system can correctly computes
+          // the dependencies.
+          auto generated =
+              llvm::find(headerFileInputs, sourceBuffer->getBufferIdentifier());
+          if (generated != headerFileInputs.end()) {
+            if (mainModule->textualModuleDetails.bridgingHeaderFile)
+              *generated = *mainModule->textualModuleDetails.bridgingHeaderFile;
+            else
+              headerFileInputs.erase(generated);
+          }
+        }
         mainModuleDeps.setHeaderSourceFiles(headerFileInputs);
-        mainModuleDeps.setChainedBridgingHeaderBuffer(
-            outputPath, sourceBuffer->getBuffer());
+        if (needChainedHeader)
+          mainModuleDeps.setChainedBridgingHeaderBuffer(
+              sourceBuffer->getBufferIdentifier(), sourceBuffer->getBuffer());
         // Update the set of visible Clang modules
         mainModuleDeps.addVisibleClangModules(headerScanResult->VisibleModules);
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -675,9 +675,9 @@ public:
   }
 
   /// Get embedded bridging header.
-  std::string getEmbeddedHeader() const {
+  StringRef getEmbeddedHeader() const {
     // Don't include the '\0' in the end.
-    return importedHeaderInfo.contents.drop_back().str();
+    return importedHeaderInfo.contents.drop_back();
   }
 
   /// If the module-defining `.swiftinterface` file is an SDK-relative path,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1478,8 +1478,9 @@ swift::extractUserModuleVersionFromInterface(StringRef moduleInterfacePath) {
   return result;
 }
 
-std::string swift::extractEmbeddedBridgingHeaderContent(
-    std::unique_ptr<llvm::MemoryBuffer> file, ASTContext &Context) {
+std::unique_ptr<llvm::MemoryBuffer> swift::extractEmbeddedBridgingHeaderContent(
+    std::unique_ptr<llvm::MemoryBuffer> file, StringRef headerPath,
+    ASTContext &Context) {
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(file), nullptr, nullptr, false,
@@ -1489,9 +1490,10 @@ std::string swift::extractEmbeddedBridgingHeaderContent(
       loadedModuleFile);
 
   if (loadInfo.status != serialization::Status::Valid)
-    return {};
+    return nullptr;;
 
-  return loadedModuleFile->getEmbeddedHeader();
+  return llvm::MemoryBuffer::getMemBufferCopy(
+      loadedModuleFile->getEmbeddedHeader(), headerPath);
 }
 
 bool SerializedModuleLoaderBase::canImportModule(

--- a/test/CAS/Inputs/BuildCommandExtractor.py
+++ b/test/CAS/Inputs/BuildCommandExtractor.py
@@ -31,7 +31,8 @@ with open(input_json, "r") as file:
         cmd = info["bridgingHeader"]["commandLine"][1:]
         printCmd(cmd)
         # print input file name.
-        print(info["chainedBridgingHeaderPath"])
+        if "chainedBridgingHeaderPath" in info:
+            print(info["chainedBridgingHeaderPath"])
     else:
         module_names = deps["modules"][::2]
         module_details = deps["modules"][1::2]

--- a/test/CAS/Inputs/SwiftDepsExtractor.py
+++ b/test/CAS/Inputs/SwiftDepsExtractor.py
@@ -10,6 +10,7 @@ module_name = sys.argv[2]
 key = sys.argv[3]
 
 mode = 'swift'
+is_bridging_header = False
 
 if module_name.startswith('clang:'):
     mode = 'clang'
@@ -17,6 +18,9 @@ if module_name.startswith('clang:'):
 elif module_name.startswith('swiftPrebuiltExternal:'):
     mode = 'swiftPrebuiltExternal'
     module_name = module_name[22:]
+elif module_name.startswith('bridgingHeader:'):
+    is_bridging_header = True
+    module_name = module_name[15:]
 
 with open(input_json, 'r') as file:
     deps = json.load(file)
@@ -28,6 +32,11 @@ with open(input_json, 'r') as file:
 
         if key in detail.keys():
             json.dump(detail[key], sys.stdout, indent=2)
+            break
+
+        if is_bridging_header:
+            json.dump(detail['details'][mode]['bridgingHeader']
+                      [key], sys.stdout, indent=2)
             break
 
         json.dump(detail['details'][mode][key], sys.stdout, indent=2)

--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -1,0 +1,88 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Test prefix mapped bridging header path will result in the same cache key.
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps-1.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
+// RUN:   -scanner-output-dir %t/header-1 -import-objc-header %t/header-1/Bridging.h
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps-2.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-2 /^header \
+// RUN:   -scanner-output-dir %t/header-2 -import-objc-header %t/header-2/Bridging.h
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-1.json bridgingHeader:Test includeTree > %t/includeTree-1.casid
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-2.json bridgingHeader:Test includeTree > %t/includeTree-2.casid
+// RUN: diff %t/includeTree-1.casid %t/includeTree-2.casid
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-1.json Test casFSRootID > %t/root-1.casid
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-2.json Test casFSRootID > %t/root-2.casid
+// RUN: diff %t/root-1.casid %t/root-2.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json bridgingHeader > %t/header.cmd
+// RUN: %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
+// RUN: echo "\"/^header/Bridging.h\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps-1.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd /^tmp/test.swift \
+// RUN:   -emit-module -o %t/Test.swiftmodule
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
+// RUN:   -scanner-output-dir %t/header-1 -I %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-4.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-2 /^header \
+// RUN:   -scanner-output-dir %t/header-2 -I %t
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-3.json bridgingHeader:Test includeTree > %t/includeTree-3.casid
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-4.json bridgingHeader:Test includeTree > %t/includeTree-4.casid
+// RUN: diff %t/includeTree-3.casid %t/includeTree-4.casid
+
+
+
+//--- test.swift
+public func test() {
+    b()
+}
+
+//--- user.swift
+import Test
+
+//--- header-1/Bridging.h
+#include "Foo.h"
+//--- header-1/Foo.h
+void b(void);
+//--- header-2/Bridging.h
+#include "Foo.h"
+//--- header-2/Foo.h
+void b(void);

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -41,9 +41,9 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -8,9 +8,9 @@
 // RUN: %swift_frontend_plain @%t/shim.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
+// RUN: %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json

--- a/test/CAS/cached_diagnostics_remap.swift
+++ b/test/CAS/cached_diagnostics_remap.swift
@@ -7,11 +7,11 @@
 // RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map-paths %t /^test -scanner-output-dir %t.noremap
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
+// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch > %t/keys.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/keys.json -- \
-// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch -cache-replay-prefix-map /^test %t 2>&1 \
+// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch -cache-replay-prefix-map /^test %t 2>&1 \
 // RUN:    | %FileCheck %s -check-prefix BRIDGE -check-prefix BRIDGE-REMAP
 
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key

--- a/test/CAS/module_deps_clang_extras.swift
+++ b/test/CAS/module_deps_clang_extras.swift
@@ -29,9 +29,9 @@
 // RUN: %swift_frontend_plain @%t/dummy.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch
+// RUN: %target-swift-frontend @%t/header.cmd %t/Bridge.h -disable-implicit-swift-modules -O -o %t/objc.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd %t/Bridge.h -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -72,7 +72,6 @@ import SubE
 // CHECK-SAME: Bridging.h
 
 // CHECK-NEXT: "sourceFiles":
-// CHECK-NEXT: ChainedBridgingHeader.h
 // CHECK-NEXT: Bridging.h
 // CHECK-NEXT: BridgingOther.h
 

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -62,7 +62,6 @@ import SubE
 // CHECK-SAME: Bridging.h
 
 // CHECK-NEXT: "sourceFiles":
-// CHECK-NEXT: ChainedBridgingHeader.h
 // CHECK-NEXT: Bridging.h
 // CHECK-NEXT: BridgingOther.h
 

--- a/test/CAS/reproducer.swift
+++ b/test/CAS/reproducer.swift
@@ -14,9 +14,9 @@
 // RUN: %swift_frontend_plain @%t/simple.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json

--- a/test/CAS/uncached-casfs.swift
+++ b/test/CAS/uncached-casfs.swift
@@ -15,9 +15,9 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd


### PR DESCRIPTION
To allow prefix mapping of the bridging header to achieve cache hit when source files are located in different location, the generated chained bridging header should not include absolute paths of the headers. Fix the problem by concat the chained bridging header together.

Fixes: https://github.com/swiftlang/swift/issues/84088

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
