### PR TITLE
[Dependency Scanning] Avoid querying Swift Overlay for underlying module 

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4144,6 +4144,7 @@ bool CompilerInvocation::parseArgs(
     IRGenOpts.ReflectionMetadata = ReflectionMetadataMode::None;
     IRGenOpts.EnableReflectionNames = false;
     FrontendOpts.DisableBuildingInterface = true;
+    SearchPathOpts.ModuleLoadMode = ModuleLoadingMode::OnlySerialized;
     TypeCheckerOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;

--- a/test/ScanDependencies/embedded_no_textual.swift
+++ b/test/ScanDependencies/embedded_no_textual.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -enable-library-evolution
+
+// RUN: %target-swift-frontend -scan-dependencies \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/main.swift -I %t -enable-experimental-feature Embedded -o - | %FileCheck %s --check-prefix=SERIALIZED
+
+// SERIALIZED: "swiftPrebuiltExternal": "Foo"
+
+//--- main.swift
+import Foo
+
+//--- Foo.swift
+public func foo() {}
+

--- a/test/ScanDependencies/embedded_no_textual.swift
+++ b/test/ScanDependencies/embedded_no_textual.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_feature_Embedded
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
This can lead to bizarre interactions where the source module under scan is queried as a dependency of itself.

On top of that, properly restrict embedded compilation mode to load serialized binary modules, only.

Resolves rdar://159706486