### PR TITLE
[6.2] Build foundation tests in release

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2414,12 +2414,16 @@ function Build-Foundation {
 }
 
 function Test-Foundation {
+  $ScratchPath = "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests"
+
   # Foundation tests build via swiftpm rather than CMake
   Build-SPMProject `
     -Action Test `
     -Src $SourceCache\swift-foundation `
-    -Bin "$BinaryCache\$($BuildPlatform.Triple)\CoreFoundationTests" `
-    -Platform $BuildPlatform
+    -Bin "$ScratchPath" `
+    -Platform $BuildPlatform `
+    --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+    --test-product swift-foundationPackageTests
 
   Invoke-IsolatingEnvVars {
     $env:DISPATCH_INCLUDE_PATH="$(Get-SwiftSDK Windows)/usr/include"
@@ -2431,9 +2435,10 @@ function Test-Foundation {
     Build-SPMProject `
       -Action Test `
       -Src $SourceCache\swift-corelibs-foundation `
-      -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
+      -Bin "$ScratchPath" `
       -Platform $BuildPlatform `
-      -Configuration $FoundationTestConfiguration
+      --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+      --test-product swift-corelibs-foundationPackageTests
   }
 }
 

--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -6,10 +6,13 @@
    <FileRef location = "group:../../../../sourcekit-lsp"></FileRef>
    <FileRef location = "group:../../../../swift-argument-parser"></FileRef>
    <FileRef location = "group:../../../../swift-collections"></FileRef>
+   <FileRef location = "group:../../../../swift-corelibs-foundation"></FileRef>
    <FileRef location = "group:../../../../swift-crypto"></FileRef>
    <FileRef location = "group:../../../../swift-docc"></FileRef>
    <FileRef location = "group:../../../../swift-driver"></FileRef>
    <FileRef location = "group:../../../../swift-format"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation-icu"></FileRef>
    <FileRef location = "group:../../../../swift-stress-tester/SourceKitStressTester"></FileRef>
    <FileRef location = "group:../../../../swift-syntax"></FileRef>
    <FileRef location = "group:../../../../swift-syntax/CodeGeneration"></FileRef>


### PR DESCRIPTION
- **Explanation**: Updates foundation tests to build in release to avoid a race in swift-driver on Windows (tracked by https://github.com/swiftlang/swift/issues/83606). We have a swift-driver (https://github.com/swiftlang/swift-driver/pull/1989) and swift-build (https://github.com/swiftlang/swift-build/pull/809) change up for this, but this keeps blocking release/6.2 PRs until that's in.
- **Scope**: PR testing
- **Issues**: https://github.com/swiftlang/swift/issues/83606 is the underlying issue
- **Original PRs**: https://github.com/swiftlang/swift/pull/83764
- **Risk**: None (this is just PR testing)
- **Testing**: CI either passes or it doesn't
- **Reviewers**: @compnerd