### PR TITLE
[swift-inspect] Add a mode to search for and dump generic metadata without metadata iteration enabled.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -3215,6 +3215,23 @@ private:
     if (!descriptor)
       return BuiltType();
 
+    // Make sure the kinds match, to catch bad data from not reading an actual
+    // metadata.
+    auto metadataKind = metadata.getLocalBuffer()->getKind();
+    auto descriptorKind = descriptor.getLocalBuffer()->getKind();
+    if (metadataKind == MetadataKind::Class &&
+        descriptorKind != ContextDescriptorKind::Class)
+      return BuiltType();
+    if (metadataKind == MetadataKind::Struct &&
+        descriptorKind != ContextDescriptorKind::Struct)
+      return BuiltType();
+    if (metadataKind == MetadataKind::Enum &&
+        descriptorKind != ContextDescriptorKind::Enum)
+      return BuiltType();
+    if (metadataKind == MetadataKind::Optional &&
+        descriptorKind != ContextDescriptorKind::Enum)
+      return BuiltType();
+
     // From that, attempt to resolve a nominal type.
     BuiltTypeDecl typeDecl = buildNominalTypeDecl(descriptor);
     if (!typeDecl)

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -267,6 +267,14 @@ SWIFT_RUNTIME_STDLIB_SPI
 const void * const _swift_debug_allocationPoolPointer;
 
 SWIFT_RUNTIME_STDLIB_SPI
+const size_t _swift_debug_allocationPoolSize;
+
+// The size of the pages the metadata allocator allocates on the heap. May be
+// used to filter out possible metadata pages when examining the heap.
+SWIFT_RUNTIME_STDLIB_SPI
+const size_t _swift_debug_metadataAllocatorPageSize;
+
+SWIFT_RUNTIME_STDLIB_SPI
 std::atomic<const void *> _swift_debug_metadataAllocationBacktraceList;
 
 SWIFT_RUNTIME_STDLIB_SPI

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2324,8 +2324,9 @@ class LowerType
     if (auto N = dyn_cast<NominalTypeRef>(TR)) {
       Demangler Dem;
       auto Node = N->getDemangling(Dem);
-      if (Node->getKind() == Node::Kind::Type && Node->getNumChildren() == 1) {
-	auto Alias = Node->getChild(0);
+      if (Node && Node->getKind() == Node::Kind::Type &&
+          Node->getNumChildren() == 1) {
+        auto Alias = Node->getChild(0);
 	if (Alias->getKind() == Node::Kind::TypeAlias && Alias->getNumChildren() == 2) {
 	  auto Module = Alias->getChild(0);
 	  auto Name = Alias->getChild(1);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -7903,6 +7903,8 @@ std::tuple<const void *, size_t> MetadataAllocator::InitialPoolLocation() {
 
 bool swift::_swift_debug_metadataAllocationIterationEnabled = false;
 const void * const swift::_swift_debug_allocationPoolPointer = &AllocationPool;
+const size_t swift::_swift_debug_allocationPoolSize = InitialPoolSize;
+const size_t swift::_swift_debug_metadataAllocatorPageSize = PoolRange::PageSize;
 std::atomic<const void *> swift::_swift_debug_metadataAllocationBacktraceList;
 
 static void recordBacktrace(void *allocation) {

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1139,3 +1139,7 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 // Obsolete/broken SPIs removed in 6.3
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
+
+// Internal info exposed for swift-inspect.
+Added: __swift_debug_allocationPoolSize
+Added: __swift_debug_metadataAllocatorPageSize

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1139,3 +1139,7 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 // Obsolete/broken SPIs removed in 6.3
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
+
+// Internal info exposed for swift-inspect.
+Added: __swift_debug_allocationPoolSize
+Added: __swift_debug_metadataAllocatorPageSize

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -154,5 +154,9 @@
     internal func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {
       fatalError("heap iteration is not supported on Linux")
     }
+
+    internal func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void) {
+      fatalError("metadata page iteration is not supported on Linux")
+    }
   }
 #endif  // os(Linux)

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -92,8 +92,8 @@ fileprivate class ConcurrencyDumper {
     self.process = process
 
     func getMetadata(symbolName: String) -> swift_reflection_ptr_t? {
-      let addr = process.getAddr(symbolName: symbolName)
-      if let ptr = process.read(address: addr, size: MemoryLayout<UInt>.size) {
+      if let addr = process.getAddr(symbolName: symbolName),
+         let ptr = process.read(address: addr, size: MemoryLayout<UInt>.size) {
         return swift_reflection_ptr_t(ptr.load(as: UInt.self))
       }
       return nil

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -79,6 +79,18 @@ extension SwiftReflectionContextRef {
     let typeref = swift_reflection_typeRefForMetadata(self, UInt(type))
     if typeref == 0 { return nil }
 
+    let info = swift_reflection_infoForTypeRef(self, typeref)
+    let nominalKinds = [
+      SWIFT_STRUCT,
+      SWIFT_TUPLE,
+      SWIFT_NO_PAYLOAD_ENUM,
+      SWIFT_SINGLE_PAYLOAD_ENUM,
+      SWIFT_MULTI_PAYLOAD_ENUM,
+      SWIFT_CLASS_INSTANCE,
+      SWIFT_ARRAY
+    ]
+    guard nominalKinds.contains(info.Kind) else { return nil }
+
     guard let name = swift_reflection_copyNameForTypeRef(self, typeref, mangled) else {
       return nil
     }

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -43,6 +43,7 @@ internal protocol RemoteProcess: AnyObject {
 
   func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?)
   func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void)
+  func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void)
 }
 
 extension RemoteProcess {

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -397,6 +397,10 @@ internal final class WindowsRemoteProcess: RemoteProcess {
     }
   }
 
+  internal func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void) {
+    fatalError("metadata page iteration is not supported on Windows")
+  }
+
   private func allocateDllPathRemote() -> UnsafeMutableRawPointer? {
     URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
       .deletingLastPathComponent()


### PR DESCRIPTION
We scan the target's initial allocation pool, and all 16kB heap allocations. We check each pointer-aligned offset within those areas, and try to read it as Swift metadata and get a name from it. If that fails, quietly move on. It's very unlikely for some random memory to look enough like Swift metadata for this to produce a name, so this works very well to print the generic metadata instantiated in the remote process without requiring `SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION`.

rdar://161120936