### PR TITLE
utils: remove reference to yams from unified SPM project

### DIFF
--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -21,5 +21,4 @@
    <FileRef location = "group:../../../../swift-system"></FileRef>
    <FileRef location = "group:../../../../swift-tools-support-core"></FileRef>
    <FileRef location = "group:../../../../swiftpm"></FileRef>
-   <FileRef location = "group:../../../../yams"></FileRef>
 </Workspace>


### PR DESCRIPTION
Remove the reference to Yams from the unified workspace as this dependency has been removed.