### PR TITLE
[WIP] Add default types to generic parameters

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2893,12 +2893,13 @@ BridgedGenericParamList BridgedGenericParamList_createParsed(
 
 SWIFT_NAME(
     "BridgedGenericTypeParamDecl.createParsed(_:declContext:specifierLoc:"
-    "name:nameLoc:inheritedType:index:paramKind:)")
+    "name:nameLoc:inheritedType:defaultType:index:paramKind:)")
 BridgedGenericTypeParamDecl BridgedGenericTypeParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     swift::SourceLoc specifierLoc, swift::Identifier name,
     swift::SourceLoc nameLoc, BridgedNullableTypeRepr opaqueInheritedType,
-    size_t index, swift::GenericTypeParamKind paramKind);
+    BridgedNullableTypeRepr defaultType, size_t index,
+    swift::GenericTypeParamKind paramKind);
 
 SWIFT_NAME(
     "BridgedTrailingWhereClause.createParsed(_:whereKeywordLoc:requirements:)")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8925,5 +8925,19 @@ ERROR(invalid_redecl_of_file_isolation,none,
 NOTE(invalid_redecl_of_file_isolation_prev,none,
      "default isolation was previously declared here", ())
 
+//===----------------------------------------------------------------------===//
+// MARK: Default generics
+//===----------------------------------------------------------------------===//
+
+ERROR(default_generic_not_trailing,none,
+      "generic parameter %0 with default type %1 must be trailing",
+      (const GenericTypeParamDecl *, Type))
+ERROR(default_generic_not_type,none,
+      "generic parameter %0 can only have a default type on type declarations",
+      (const GenericTypeParamDecl *))
+ERROR(default_generic_parameter_pack,none,
+      "declaration %0 cannot have both parameter packs and generic parameters with default types",
+      (const Decl *))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5386,6 +5386,27 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Compute the default type of a generic type param.
+class GenericTypeParamDeclDefaultTypeRequest
+    : public SimpleRequest<GenericTypeParamDeclDefaultTypeRequest,
+                           Type(GenericTypeParamDecl *decl),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, GenericTypeParamDecl *decl) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+  std::optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 class CustomDerivativesRequest
     : public SimpleRequest<CustomDerivativesRequest,
                            evaluator::SideEffect(SourceFile *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -635,6 +635,8 @@ SWIFT_REQUEST(TypeChecker, CustomDerivativesRequest,
 
 SWIFT_REQUEST(TypeChecker, GenericTypeParamDeclGetValueTypeRequest,
               Type(const GenericTypeParamDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GenericTypeParamDeclDefaultTypeRequest,
+              Type(GenericTypeParamDecl *), SeparatelyCached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, SemanticAvailableAttrRequest,
               std::optional<SemanticAvailableAttr>

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -548,6 +548,9 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 /// Enable borrow/mutate accessors
 EXPERIMENTAL_FEATURE(BorrowAndMutateAccessors, false)
 
+/// Allow generics to have a default type, e.g. `<T = Int>`.
+EXPERIMENTAL_FEATURE(DefaultGenerics, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2204,6 +2204,11 @@ namespace {
         printRec(decl->getValueType(), Label::always("value_type"));
         break;
       }
+
+      if (decl->hasDefaultType()) {
+        printRec(decl->getDefaultType(), Label::always("default_type"));
+      }
+
       printAttributes(decl);
 
       printFoot();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8388,7 +8388,28 @@ void GenericParamList::print(ASTPrinter &Printer,
   interleave(
       *this,
       [&](const GenericTypeParamDecl *P) {
-        P->print(Printer, PO);
+        Printer << P->getName();
+        if (!P->getInherited().empty()) {
+          Printer << " : ";
+
+          auto loc = P->getInherited().getEntry(0);
+          if (willUseTypeReprPrinting(loc, nullptr, PO)) {
+            loc.getTypeRepr()->print(Printer, PO);
+          } else {
+            loc.getType()->print(Printer, PO);
+          }
+
+          if (P->hasDefaultType()) {
+            Printer << " = ";
+
+            auto loc = P->getDefaultTypeRepr();
+            if (loc && willUseTypeReprPrinting(loc, nullptr, PO)) {
+              loc->print(Printer, PO);
+            } else {
+              P->getDefaultType()->print(Printer, PO);
+            }
+          }
+        }
       },
       [&] { Printer << ", "; });
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2022,6 +2022,11 @@ void PrintAST::printSingleDepthOfGenericSignature(
               printType(param->getValueType());
             }
 
+            if (GP->hasDefaultType()) {
+              Printer << " = ";
+              printType(GP->getDefaultType());
+            }
+
             Printer.printStructurePost(PrintStructureKind::GenericParameter,
                                        GP);
           } else {
@@ -3660,6 +3665,11 @@ void PrintAST::visitGenericTypeParamDecl(GenericTypeParamDecl *decl) {
   });
 
   printInherited(decl);
+
+  if (decl->hasDefaultType()) {
+    Printer << " = ";
+    decl->getDefaultType().print(Printer, Options);
+  }
 }
 
 void PrintAST::visitAssociatedTypeDecl(AssociatedTypeDecl *decl) {
@@ -8378,17 +8388,7 @@ void GenericParamList::print(ASTPrinter &Printer,
   interleave(
       *this,
       [&](const GenericTypeParamDecl *P) {
-        Printer << P->getName();
-        if (!P->getInherited().empty()) {
-          Printer << " : ";
-
-          auto loc = P->getInherited().getEntry(0);
-          if (willUseTypeReprPrinting(loc, nullptr, PO)) {
-            loc.getTypeRepr()->print(Printer, PO);
-          } else {
-            loc.getType()->print(Printer, PO);
-          }
-        }
+        P->print(Printer, PO);
       },
       [&] { Printer << ", "; });
 

--- a/lib/AST/Bridging/GenericsBridging.cpp
+++ b/lib/AST/Bridging/GenericsBridging.cpp
@@ -45,10 +45,18 @@ BridgedGenericParamList BridgedGenericParamList_createParsed(
 BridgedGenericTypeParamDecl BridgedGenericTypeParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     SourceLoc specifierLoc, Identifier name, SourceLoc nameLoc,
-    BridgedNullableTypeRepr bridgedInheritedType, size_t index,
+    BridgedNullableTypeRepr bridgedInheritedType,
+    BridgedNullableTypeRepr bridgedDefaultType, size_t index,
     swift::GenericTypeParamKind paramKind) {
+  TypeLoc defaultType;
+
+  if (auto *defaultTypeRepr = bridgedDefaultType.unbridged()) {
+    defaultType = TypeLoc(defaultTypeRepr);
+  }
+
   auto *decl = GenericTypeParamDecl::createParsed(
-      cDeclContext.unbridged(), name, nameLoc, specifierLoc, index, paramKind);
+      cDeclContext.unbridged(), name, nameLoc, specifierLoc, defaultType,
+      index, paramKind);
 
   if (auto *inheritedType = bridgedInheritedType.unbridged()) {
     auto entry = InheritedEntry(inheritedType);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -431,6 +431,22 @@ static bool usesFeatureDefaultIsolationPerFile(Decl *D) {
   return isa<UsingDecl>(D);
 }
 
+static bool usesFeatureDefaultGenerics(Decl *decl) {
+  auto genericContext = decl->getAsGenericContext();
+
+  if (!genericContext || !genericContext->getGenericParams()) {
+    return false;
+  }
+
+  for (auto arg : *genericContext->getGenericParams()) {
+    if (arg->hasDefaultType()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 UNINTERESTING_FEATURE(BuiltinSelect)
 UNINTERESTING_FEATURE(BuiltinInterleave)
 UNINTERESTING_FEATURE(BuiltinVectorsExternC)

--- a/lib/AST/GenericParamList.cpp
+++ b/lib/AST/GenericParamList.cpp
@@ -85,6 +85,10 @@ GenericParamList::clone(DeclContext *dc) const {
         GenericTypeParamDeclGetValueTypeRequest{newParam},
         param->getValueType());
 
+    ctx.evaluator.cacheOutput(
+        GenericTypeParamDeclDefaultTypeRequest{newParam},
+        param->getDefaultType());
+
     params.push_back(newParam);
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2887,3 +2887,17 @@ void IsCustomAvailabilityDomainPermanentlyEnabled::cacheResult(
   domain->flags.isPermanentlyEnabledComputed = true;
   domain->flags.isPermanentlyEnabled = isPermanentlyEnabled;
 }
+
+//----------------------------------------------------------------------------//
+// GenericTypeParamDeclDefaultTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+std::optional<Type> GenericTypeParamDeclDefaultTypeRequest::getCachedResult() const {
+  auto *decl = std::get<0>(getStorage());
+  return decl->getCachedDefaultType();
+}
+
+void GenericTypeParamDeclDefaultTypeRequest::cacheResult(Type value) const {
+  auto *decl = std::get<0>(getStorage());
+  decl->setDefaultType(value);
+}

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -57,6 +57,7 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       inheritedType: self.generate(type: node.inheritedType),
+      defaultType: self.generate(type: node.initializer?.value),
       index: genericParameterIndex,
       paramKind: paramKind
     )

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -86,6 +86,7 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
     mapFeature(.KeyPathWithMethodMembers, to: .keypathWithMethodMembers)
     mapFeature(.DefaultIsolationPerFile, to: .defaultIsolationPerFile)
+    mapFeature(.DefaultGenerics, to: .defaultGenerics)
   }
 }
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -509,6 +509,24 @@ Type GenericTypeParamDeclGetValueTypeRequest::evaluate(
   return inherited.getResolvedType(0, TypeResolutionStage::Structural);
 }
 
+Type GenericTypeParamDeclDefaultTypeRequest::evaluate(
+    Evaluator &evaluator, GenericTypeParamDecl *decl) const {
+  auto defaultTyRepr = decl->getDefaultTypeRepr();
+
+  if (!defaultTyRepr) {
+    return Type();
+  }
+
+  return TypeResolution::forInterface(decl->getDeclContext(),
+                                      std::nullopt,
+                                      // Diagnose unbound generics and
+                                      // placeholders.
+                                      /*unboundTyOpener*/ nullptr,
+                                      /*placeholderHandler*/ nullptr,
+                                      /*packElementOpener*/ nullptr)
+      .resolveType(defaultTyRepr);
+}
+
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *typeCheckerRequestFunctions[] = {
 #define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3619,9 +3619,11 @@ public:
     bool isImplicit;
     bool isOpaqueType;
     TypeID interfaceTypeID;
+    TypeID defaultTypeID;
 
     decls_block::GenericTypeParamDeclLayout::readRecord(
-        scratch, nameID, isImplicit, isOpaqueType, interfaceTypeID);
+        scratch, nameID, isImplicit, isOpaqueType, interfaceTypeID,
+        defaultTypeID);
 
     auto interfaceTy = MF.getTypeChecked(interfaceTypeID);
     if (!interfaceTy)
@@ -3647,6 +3649,15 @@ public:
       ctx.evaluator.cacheOutput(
         GenericTypeParamDeclGetValueTypeRequest{genericParam},
         paramTy->getValueType());
+    }
+
+    // If this generic parameter had a default type, inform the evaluator that
+    // this value is already computed.
+    auto defaultTy = MF.getTypeChecked(defaultTypeID);
+    if (defaultTy) {
+      ctx.evaluator.cacheOutput(
+        GenericTypeParamDeclDefaultTypeRequest{genericParam},
+        std::move(defaultTy.get()));
     }
 
     return genericParam;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 961; // borrow/mutate accessors
+const uint16_t SWIFTMODULE_VERSION_MINOR = 962; // generic parameter default types
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1589,7 +1589,8 @@ namespace decls_block {
     IdentifierIDField,     // name
     BCFixed<1>,            // implicit flag
     BCFixed<1>,            // is opaque?
-    TypeIDField            // interface type
+    TypeIDField,           // interface type,
+    TypeIDField            // default type?
   >;
 
   using AssociatedTypeDeclLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4442,7 +4442,8 @@ public:
         S.addDeclBaseNameRef(genericParam->getName()),
         genericParam->isImplicit(),
         genericParam->isOpaqueType(),
-        S.addTypeRef(genericParam->getDeclaredInterfaceType()->getCanonicalType()));
+        S.addTypeRef(genericParam->getDeclaredInterfaceType()->getCanonicalType()),
+        S.addTypeRef(genericParam->getDefaultType()));
   }
 
   void visitAssociatedTypeDecl(const AssociatedTypeDecl *assocType) {

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -13,7 +13,7 @@
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-concurrency -enable-experimental-feature CoroutineAccessors -enable-experimental-feature DefaultIsolationPerFile -enable-experimental-feature ParserASTGen)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-concurrency -enable-experimental-feature CoroutineAccessors -enable-experimental-feature DefaultIsolationPerFile -enable-experimental-feature DefaultGenerics -enable-experimental-feature ParserASTGen)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_swift_parser
@@ -370,4 +370,3 @@ struct Vec<Element, A = SystemAllocator> {}
 enum DefaultGenericEnum<T = Int> {}
 class DefaultGenericClass<T, U: Proto1, V: Proto2 = SystemAllocator> {}
 typealias DefaultGenericTypealias<T = Int> = Vec<T>
-func defaultGenericFunc<T = String>() {}

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -3,10 +3,12 @@
 // RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-concurrency -enable-experimental-feature ParserASTGen \
 // RUN:    -enable-experimental-feature CoroutineAccessors \
 // RUN:    -enable-experimental-feature DefaultIsolationPerFile \
+// RUN:    -enable-experimental-feature DefaultGenerics \
 // RUN:    | %sanitize-address > %t/astgen.ast
 // RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-concurrency \
 // RUN:    -enable-experimental-feature CoroutineAccessors \
 // RUN:    -enable-experimental-feature DefaultIsolationPerFile \
+// RUN:    -enable-experimental-feature DefaultGenerics \
 // RUN:    | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
@@ -18,6 +20,7 @@
 // REQUIRES: swift_feature_ParserASTGen
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_DefaultIsolationPerFile
+// REQUIRES: swift_feature_DefaultGenerics
 
 // rdar://116686158
 // UNSUPPORTED: asan
@@ -361,3 +364,10 @@ func testBuilder() {
 }
 
 struct ExpansionRequirementTest<each T> where repeat each T: Comparable {}
+
+struct SystemAllocator: Proto1, Proto2 {}
+struct Vec<Element, A = SystemAllocator> {}
+enum DefaultGenericEnum<T = Int> {}
+class DefaultGenericClass<T, U: Proto1, V: Proto2 = SystemAllocator> {}
+typealias DefaultGenericTypealias<T = Int> = Vec<T>
+func defaultGenericFunc<T = String>() {}

--- a/test/Sema/default_generics.swift
+++ b/test/Sema/default_generics.swift
@@ -1,0 +1,85 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature DefaultGenerics -disable-availability-checking
+
+// REQUIRES: swift_feature_DefaultGenerics
+
+struct A<T = Int> {} // expected-note{{generic struct 'A' declared here}}
+enum B<T = Int> {
+  case foo
+}
+class C<T = Int> {}
+typealias D<T = Int> = A<T>
+actor E<T = Int> {}
+
+protocol F<T = Int> {} // expected-error{{an associated type named 'T' must be declared in the protocol 'F' or a protocol it inherits}}
+                       // expected-error@-1{{expected '>' to complete primary associated type list}}
+                       // expected-note@-2{{to match this opening '<'}}
+
+protocol G<T = Int> { // expected-error{{expected '>' to complete primary associated type list}}
+                      // expected-note@-1{{to match this opening '<'}}
+  associatedtype T
+}
+
+func h<T = Int>(_: T) {} // expected-error{{generic parameter 'T' can only have a default type on type declarations}}
+
+struct I {
+  subscript<T = Int>(_: T) -> Int { 123 } // expected-error{{generic parameter 'T' can only have a default type on type declarations}}
+}
+
+struct J<each T, U = Int> {} // expected-error{{declaration 'J' cannot have both parameter packs and generic parameters with default types}}
+
+struct K<let n: Int, T = Int> {} // OK
+
+struct L<T = Int, U, V = String> {} // expected-error{{generic parameter 'T' with default type 'Int' must be trailing}}
+
+protocol Allocator {}
+
+struct SystemAllocator: Allocator {}
+struct BumpAllocator: Allocator {}
+
+struct Vec<Element: ~Copyable, Alloc: Allocator = SystemAllocator> {} // OK
+                                                                      // expected-note@-1{{arguments to generic parameter 'Alloc' ('BumpAllocator' and 'SystemAllocator') are expected to be equal}}
+// FIXME: This needs to be diagnosed somehow...
+struct Vec2<Element: ~Copyable, Alloc: Allocator = Int> {}
+
+let m = A() // OK
+let n = B.foo // OK
+let o = C() // OK
+let p = D() // OK
+let q = E() // OK
+
+struct R<T = Int> {
+  struct S<U = String> {}
+}
+
+let t = R.S() // OK
+let u = R<Bool>.S() // OK
+let v = R.S<Bool>() // OK
+
+let w = Vec<Int>() // OK
+
+// FIXME: We need to diagnose the declaration with an incorrect default type
+let x = Vec2<String>() // expected-error{{type 'Int' does not conform to protocol 'Allocator'}}
+
+func y(_: Vec<Int>) {} // OK
+
+// TODO: Perhaps we can eliminate generic arguments from being printed if they are the default?
+y(Vec<Int, BumpAllocator>()) // expected-error{{cannot convert value of type 'Vec<Int, BumpAllocator>' to expected argument type 'Vec<Int, SystemAllocator>'}}
+
+// FIXME: We need to disallow this.
+struct Z<T, U = T?> {}
+
+// FIXME: We should probably allow this.
+func aa(_: A) {} // expected-error{{reference to generic type 'A' requires arguments in <...>}}
+
+func ab(_: A< >) {} // OK
+
+struct MyArray<Element, Alloc: Allocator = SystemAllocator> {} // OK
+
+extension MyArray: ExpressibleByArrayLiteral {
+  init(arrayLiteral: Element...) {}
+}
+
+func ac<Element>(_: MyArray<Element>) {}
+
+let ad: MyArray = [1, 2, 3] // OK
+ac(ad) // OK

--- a/test/Serialization/default_generics.swift
+++ b/test/Serialization/default_generics.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature DefaultGenerics -disable-availability-checking -parse-as-library -o %t
+// RUN: %target-sil-opt -enable-sil-verify-all %t/default_generics.swiftmodule -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_DefaultGenerics
+
+// CHECK: struct A<T = Int> {
+struct A<T = Int> {}
+
+protocol Allocator {}
+struct SystemAllocator: Allocator {}
+
+// CHECK: struct Vec<Element, Alloc = SystemAllocator> where Alloc : Allocator, Element : ~Copyable {
+struct Vec<Element: ~Copyable, Alloc: Allocator = SystemAllocator> {}
+
+// CHECK: func foo(_: Vec<Int, SystemAllocator>)
+func foo(_: Vec<Int>) {}


### PR DESCRIPTION
This adds a new experimental feature `DefaultGenerics` that allows you to add default types to generic parameters on types.

```swift
struct UniqueArray<Element: ~Copyable, Alloc: Allocator = SystemAllocator> {}
```

You can explicitly specialize said types with all of their generic parameters, or just the required ones.

Rules:
* All defaulted generic parameters _must_ be trailing every other parameter
* There must not be a parameter pack and a default generic parameter present
* Currently only limited to type parameters (value parameters could be supported in the future)
* Generic parameters can only have default types when they are on generic type declarations (or extensions). I.e. generic functions cannot introduce a generic parameter and have a default type.

Corresponding swift-syntax PR here: https://github.com/swiftlang/swift-syntax/pull/3152

Resolves: rdar://160474830