### PR TITLE
[cxx-interop] Add SWIFT_COPYABLE_IF macro

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -576,6 +576,7 @@ SourceLoc extractNearestSourceLoc(EscapabilityLookupDescriptor desc);
 // the object’s storage. This means reference types can be imported as
 // copyable to Swift, even when they are non-copyable in C++.
 enum class CxxValueSemanticsKind {
+  Unknown,
   Copyable,
   MoveOnly,
   // A record that is either not copyable/movable or not destructible.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5303,16 +5303,66 @@ static const llvm::StringMap<std::vector<int>> STLConditionalParams{
     {"unordered_multimap", {0, 1}},
 };
 
+template <typename Kind>
+static std::optional<Kind> checkConditionalParams(
+    clang::RecordDecl *recordDecl, const std::vector<int> &STLParams,
+    std::set<StringRef> &conditionalParams,
+    std::function<std::optional<Kind>(clang::TemplateArgument &, StringRef)>
+        &checkArg) {
+  auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
+  SmallVector<std::pair<unsigned, StringRef>, 4> argumentsToCheck;
+  bool hasInjectedSTLAnnotation = !STLParams.empty();
+  while (specDecl) {
+    auto templateDecl = specDecl->getSpecializedTemplate();
+    if (hasInjectedSTLAnnotation) {
+      auto params = templateDecl->getTemplateParameters();
+      for (auto idx : STLParams)
+        argumentsToCheck.push_back(
+            std::make_pair(idx, params->getParam(idx)->getName()));
+    } else {
+      for (auto [idx, param] :
+           llvm::enumerate(*templateDecl->getTemplateParameters())) {
+        if (conditionalParams.erase(param->getName()))
+          argumentsToCheck.push_back(std::make_pair(idx, param->getName()));
+      }
+    }
+    auto &argList = specDecl->getTemplateArgs();
+    for (auto argToCheck : argumentsToCheck) {
+      auto arg = argList[argToCheck.first];
+      llvm::SmallVector<clang::TemplateArgument, 1> nonPackArgs;
+      if (arg.getKind() == clang::TemplateArgument::Pack) {
+        auto pack = arg.getPackAsArray();
+        nonPackArgs.assign(pack.begin(), pack.end());
+      } else
+        nonPackArgs.push_back(arg);
+      for (auto nonPackArg : nonPackArgs) {
+        auto result = checkArg(nonPackArg, argToCheck.second);
+        if (result.has_value())
+          return result.value();
+      }
+    }
+    if (hasInjectedSTLAnnotation)
+      break;
+    clang::DeclContext *dc = specDecl;
+    specDecl = nullptr;
+    while ((dc = dc->getParent())) {
+      specDecl = dyn_cast<clang::ClassTemplateSpecializationDecl>(dc);
+      if (specDecl)
+        break;
+    }
+  }
+  return std::nullopt;
+}
+
 static std::set<StringRef>
-getConditionalEscapableAttrParams(const clang::RecordDecl *decl) {
+getConditionalAttrParams(const clang::RecordDecl *decl, StringRef attrName) {
   std::set<StringRef> result;
   if (!decl->hasAttrs())
     return result;
   for (auto attr : decl->getAttrs()) {
-    if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-      if (swiftAttr->getAttribute().starts_with("escapable_if:")) {
-        StringRef params = swiftAttr->getAttribute().drop_front(
-            StringRef("escapable_if:").size());
+    if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+      StringRef params = swiftAttr->getAttribute();
+      if (params.consume_front(attrName)) {
         auto commaPos = params.find(',');
         StringRef nextParam = params.take_front(commaPos);
         while (!nextParam.empty() && commaPos != StringRef::npos) {
@@ -5322,8 +5372,19 @@ getConditionalEscapableAttrParams(const clang::RecordDecl *decl) {
           nextParam = params.take_front(commaPos);
         }
       }
+    }
   }
   return result;
+}
+
+static std::set<StringRef>
+getConditionalEscapableAttrParams(const clang::RecordDecl *decl) {
+  return getConditionalAttrParams(decl, "escapable_if:");
+}
+
+static std::set<StringRef>
+getConditionalCopyableAttrParams(const clang::RecordDecl *decl) {
+  return getConditionalAttrParams(decl, "copyable_if:");
 }
 
 CxxEscapability
@@ -5351,60 +5412,33 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         recordDecl->isInStdNamespace()
             ? STLConditionalParams.find(recordDecl->getName())
             : STLConditionalParams.end();
-    bool hasInjectedSTLAnnotation =
-        injectedStlAnnotation != STLConditionalParams.end();
+    auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
+                         ? injectedStlAnnotation->second
+                         : std::vector<int>();
     auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
-    if (!conditionalParams.empty() || hasInjectedSTLAnnotation) {
-      auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
-      SmallVector<std::pair<unsigned, StringRef>, 4> argumentsToCheck;
-      HeaderLoc loc{recordDecl->getLocation()};
-      while (specDecl) {
-        auto templateDecl = specDecl->getSpecializedTemplate();
-        if (hasInjectedSTLAnnotation) {
-          auto params = templateDecl->getTemplateParameters();
-          for (auto idx : injectedStlAnnotation->second)
-            argumentsToCheck.push_back(
-                std::make_pair(idx, params->getParam(idx)->getName()));
-        } else {
-          for (auto [idx, param] :
-               llvm::enumerate(*templateDecl->getTemplateParameters())) {
-            if (conditionalParams.erase(param->getName()))
-              argumentsToCheck.push_back(std::make_pair(idx, param->getName()));
-          }
-        }
-        auto &argList = specDecl->getTemplateArgs();
-        for (auto argToCheck : argumentsToCheck) {
-          auto arg = argList[argToCheck.first];
-          llvm::SmallVector<clang::TemplateArgument, 1> nonPackArgs;
-          if (arg.getKind() == clang::TemplateArgument::Pack) {
-            auto pack = arg.getPackAsArray();
-            nonPackArgs.assign(pack.begin(), pack.end());
-          } else
-            nonPackArgs.push_back(arg);
-          for (auto nonPackArg : nonPackArgs) {
-            if (nonPackArg.getKind() != clang::TemplateArgument::Type &&
-                desc.impl) {
-              desc.impl->diagnose(loc, diag::type_template_parameter_expected,
-                                  argToCheck.second);
-              return CxxEscapability::Unknown;
-            }
 
-            auto argEscapability = evaluateEscapability(
-                nonPackArg.getAsType()->getUnqualifiedDesugaredType());
-            if (argEscapability == CxxEscapability::NonEscapable)
-              return CxxEscapability::NonEscapable;
-          }
+    if (!STLParams.empty() || !conditionalParams.empty()) {
+      HeaderLoc loc{recordDecl->getLocation()};
+      std::function checkArgEscapability =
+          [&](clang::TemplateArgument &arg,
+              StringRef argToCheck) -> std::optional<CxxEscapability> {
+        if (arg.getKind() != clang::TemplateArgument::Type && desc.impl) {
+          desc.impl->diagnose(loc, diag::type_template_parameter_expected,
+                              argToCheck);
+          return CxxEscapability::Unknown;
         }
-        if (hasInjectedSTLAnnotation)
-          break;
-        clang::DeclContext *dc = specDecl;
-        specDecl = nullptr;
-        while ((dc = dc->getParent())) {
-          specDecl = dyn_cast<clang::ClassTemplateSpecializationDecl>(dc);
-          if (specDecl)
-            break;
-        }
-      }
+
+        auto argEscapability = evaluateEscapability(
+            arg.getAsType()->getUnqualifiedDesugaredType());
+        if (argEscapability == CxxEscapability::NonEscapable)
+          return CxxEscapability::NonEscapable;
+        return std::nullopt;
+      };
+
+      auto result = checkConditionalParams<CxxEscapability>(
+          recordDecl, STLParams, conditionalParams, checkArgEscapability);
+      if (result.has_value())
+        return result.value();
 
       if (desc.impl)
         for (auto name : conditionalParams)
@@ -8343,36 +8377,48 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     if (recordDecl->getIdentifier() &&
         recordDecl->getName() == "_Optional_construct_base")
       return CxxValueSemanticsKind::Copyable;
+  }
 
-    auto injectedStlAnnotation =
-        STLConditionalParams.find(recordDecl->getName());
+  auto injectedStlAnnotation =
+      recordDecl->isInStdNamespace()
+          ? STLConditionalParams.find(recordDecl->getName())
+          : STLConditionalParams.end();
+  auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
+                       ? injectedStlAnnotation->second
+                       : std::vector<int>();
+  auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
 
-    if (injectedStlAnnotation != STLConditionalParams.end()) {
-      auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
-      auto &argList = specDecl->getTemplateArgs();
-      for (auto argToCheck : injectedStlAnnotation->second) {
-        auto arg = argList[argToCheck];
-        llvm::SmallVector<clang::TemplateArgument, 1> nonPackArgs;
-        if (arg.getKind() == clang::TemplateArgument::Pack) {
-          auto pack = arg.getPackAsArray();
-          nonPackArgs.assign(pack.begin(), pack.end());
-        } else
-          nonPackArgs.push_back(arg);
-        for (auto nonPackArg : nonPackArgs) {
-
-          auto argValueSemantics = evaluateOrDefault(
-              evaluator,
-              CxxValueSemantics(
-                  {nonPackArg.getAsType()->getUnqualifiedDesugaredType(),
-                   desc.importerImpl}),
-              {});
-          if (argValueSemantics != CxxValueSemanticsKind::Copyable)
-            return argValueSemantics;
-        }
+  if (!STLParams.empty() || !conditionalParams.empty()) {
+    HeaderLoc loc{recordDecl->getLocation()};
+    std::function checkArgValueSemantics =
+        [&](clang::TemplateArgument &arg,
+            StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
+      if (arg.getKind() != clang::TemplateArgument::Type && importerImpl) {
+        importerImpl->diagnose(loc, diag::type_template_parameter_expected,
+                               argToCheck);
+        return CxxValueSemanticsKind::Unknown;
       }
 
-      return CxxValueSemanticsKind::Copyable;
-    }
+      auto argValueSemantics = evaluateOrDefault(
+          evaluator,
+          CxxValueSemantics(
+              {arg.getAsType()->getUnqualifiedDesugaredType(), importerImpl}),
+          {});
+      if (argValueSemantics != CxxValueSemanticsKind::Copyable)
+        return argValueSemantics;
+      return std::nullopt;
+    };
+
+    auto result = checkConditionalParams<CxxValueSemanticsKind>(
+        recordDecl, STLParams, conditionalParams, checkArgValueSemantics);
+    if (result.has_value())
+      return result.value();
+
+    if (importerImpl)
+      for (auto name : conditionalParams)
+        importerImpl->diagnose(loc, diag::unknown_template_parameter, name);
+
+    return CxxValueSemanticsKind::Copyable;
   }
 
   const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -190,6 +190,11 @@
   __attribute__((swift_attr("~Copyable"))) \
   __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(destroy:_destroy))))
 
+/// Specifies that a C++ `class` or `struct` should be imported as a copyable
+/// Swift value if all of the specified template arguments are copyable.
+#define SWIFT_COPYABLE_IF(...) \
+  __attribute__((swift_attr("copyable_if:" _CXX_INTEROP_CONCAT(__VA_ARGS__))))
+
 /// Specifies that a specific class or struct should be imported
 /// as a non-escapable Swift value type.
 #define SWIFT_NONESCAPABLE \
@@ -283,6 +288,7 @@
 #define SWIFT_UNCHECKED_SENDABLE
 #define SWIFT_NONCOPYABLE
 #define SWIDT_NONCOPYABLE_WITH_DESTROY(_destroy)
+#define SWIFT_COPYABLE_IF(...)
 #define SWIFT_NONESCAPABLE
 #define SWIFT_ESCAPABLE
 #define SWIFT_ESCAPABLE_IF(...)

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %t/Inputs %t/test.swift
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %t/Inputs %t/test.swift
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t/Inputs %t/test.swift
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t/Inputs %t/test.swift
 
 //--- Inputs/module.modulemap
 module Test {
@@ -10,6 +10,7 @@ module Test {
 }
 
 //--- Inputs/noncopyable.h
+#include "swift/bridging"
 #include <string>
 
 struct NonCopyable {
@@ -28,6 +29,29 @@ struct OwnsT {
 
 using OwnsNonCopyable = OwnsT<NonCopyable>;
 
+template <typename T>
+struct SWIFT_COPYABLE_IF(T) AnnotatedOwnsT {
+    T element;
+    AnnotatedOwnsT() {}
+    AnnotatedOwnsT(const AnnotatedOwnsT &other) : element(other.element) {}
+    AnnotatedOwnsT(AnnotatedOwnsT&& other) {}
+};
+
+using AnnotatedOwnsNonCopyable = AnnotatedOwnsT<NonCopyable>;
+
+template <typename F, typename S>
+struct SWIFT_COPYABLE_IF(F, S) MyPair {
+    F first;
+    S second;
+};
+
+MyPair<int, NonCopyable> p1();
+MyPair<int, NonCopyable*> p2();
+MyPair<int, OwnsNonCopyable> p3();
+MyPair<int, AnnotatedOwnsNonCopyable> p4();
+MyPair<int, MyPair<int, NonCopyable>> p5();
+MyPair<NonCopyable, int> p6();
+
 #if __cplusplus >= 202002L
 template <typename T>
 struct RequiresCopyableT {
@@ -38,6 +62,9 @@ struct RequiresCopyableT {
 };
 
 using NonCopyableRequires = RequiresCopyableT<NonCopyable>;
+using CopyableIfRequires = RequiresCopyableT<MyPair<int, NonCopyable>>;
+
+MyPair<int, NonCopyableRequires> p7();
 
 #endif
 
@@ -55,9 +82,28 @@ func userDefinedTypes() {
     takeCopyable(ownsT) // no error, OwnsNonCopyable imported as Copyable
 }
 
+func useCopyableIf() {
+    takeCopyable(p1()) // expected-error {{global function 'takeCopyable' requires that 'MyPair<CInt, NonCopyable>' conform to 'Copyable'}}
+    takeCopyable(p2())
+
+    // p3() -> MyPair<int, OwnsNonCopyable> is imported as Copyable and will cause an error during IRGen.
+    // During typecheck we don't produce an error because we're missing an annotation in OwnsT.
+    takeCopyable(p3())
+    // p4() -> (MyPair<int, AnnotatedOwnsNonCopyable>) is imported as NonCopyable because AnnotatedOwnsT is correctly annotated.
+    takeCopyable(p4()) // expected-error {{global function 'takeCopyable' requires that 'MyPair<CInt, AnnotatedOwnsT<NonCopyable>>' conform to 'Copyable'}}
+
+    takeCopyable(p5()) // expected-error {{global function 'takeCopyable' requires that 'MyPair<CInt, MyPair<CInt, NonCopyable>>' conform to 'Copyable'}}
+    takeCopyable(p6()) // expected-error {{global function 'takeCopyable' requires that 'MyPair<NonCopyable, CInt>' conform to 'Copyable'}}
+}
+
 #if CPP20
 func useOfRequires() {
-    let nCop = NonCopyableRequires()
-    takeCopyable(nCop) // expected-cpp20-error {{global function 'takeCopyable' requires that 'NonCopyableRequires' (aka 'RequiresCopyableT<NonCopyable>') conform to 'Copyable'}}
+    let a = NonCopyableRequires()
+    takeCopyable(a) // expected-cpp20-error {{global function 'takeCopyable' requires that 'NonCopyableRequires' (aka 'RequiresCopyableT<NonCopyable>') conform to 'Copyable'}}
+
+    let b = CopyableIfRequires()
+    takeCopyable(b) // expected-cpp20-error {{global function 'takeCopyable' requires that 'CopyableIfRequires' (aka 'RequiresCopyableT<MyPair<CInt, NonCopyable>>') conform to 'Copyable'}}
+
+    takeCopyable(p7()) // expected-cpp20-error {{global function 'takeCopyable' requires that 'MyPair<CInt, RequiresCopyableT<NonCopyable>>' conform to 'Copyable'}}
 }
 #endif


### PR DESCRIPTION
`SWIFT_COPYABLE_IF` is similar to `SWIFT_ESCAPABLE_IF`, allowing us to import a C++ type as copyable/non-copyable depending on some other types.

rdar://158852663
