### PR TITLE
🍒[cxx-interop] Allow retain/release operations to be methods

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -265,6 +265,9 @@ ERROR(foreign_reference_types_release_non_void_return_type, none,
 ERROR(foreign_reference_types_retain_release_not_a_function_decl, none,
       "specified %select{retain|release}0 function '%1' is not a function",
       (bool, StringRef))
+ERROR(foreign_reference_types_retain_release_not_an_instance_function, none,
+      "specified %select{retain|release}0 function '%1' is a static function; expected an instance function",
+      (bool, StringRef))
 ERROR(conforms_to_missing_dot, none,
       "expected module name and protocol name separated by '.' in protocol "
       "conformance; '%0' is invalid",

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7876,10 +7876,27 @@ getRefParentDecls(const clang::RecordDecl *decl, ASTContext &ctx,
 }
 
 llvm::SmallVector<ValueDecl *, 1>
-importer::getValueDeclsForName(
-    const clang::Decl *decl, ASTContext &ctx, StringRef name) {
+importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
+  // If the name is empty, don't try to find any decls.
+  if (name.empty())
+    return {};
+
+  auto &ctx = decl->getASTContext();
+  auto clangDecl = decl->getClangDecl();
   llvm::SmallVector<ValueDecl *, 1> results;
-  auto *clangMod = decl->getOwningModule();
+
+  if (name.starts_with(".")) {
+    // Look for a member of decl instead of a global.
+    StringRef memberName = name.drop_front(1);
+    if (memberName.empty())
+      return {};
+    auto declName = DeclName(ctx.getIdentifier(memberName));
+    auto allResults = evaluateOrDefault(
+        ctx.evaluator, ClangRecordMemberLookup({decl, declName}), {});
+    return SmallVector<ValueDecl *, 1>(allResults.begin(), allResults.end());
+  }
+
+  auto *clangMod = clangDecl->getOwningModule();
   if (clangMod && clangMod->isSubModule())
     clangMod = clangMod->getTopLevelModule();
   if (clangMod) {
@@ -8487,7 +8504,7 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     return {CustomRefCountingOperationResult::immortal, nullptr, name};
 
   llvm::SmallVector<ValueDecl *, 1> results =
-      getValueDeclsForName(swiftDecl->getClangDecl(), ctx, name);
+      getValueDeclsForName(const_cast<ClassDecl*>(swiftDecl), name);
   if (results.size() == 1)
     return {CustomRefCountingOperationResult::foundOperation, results.front(),
             name};

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2151,7 +2151,7 @@ ImportedType findOptionSetEnum(clang::QualType type,
 ///
 /// The name we're looking for is the Swift name.
 llvm::SmallVector<ValueDecl *, 1>
-getValueDeclsForName(const clang::Decl *decl, ASTContext &ctx, StringRef name);
+getValueDeclsForName(NominalTypeDecl* decl, StringRef name);
 
 } // end namespace importer
 } // end namespace swift

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2767,8 +2767,7 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
     if (!destroyFuncName.consume_front("destroy:"))
       continue;
 
-    auto decls = getValueDeclsForName(
-        clangType, nominal->getASTContext(), destroyFuncName);
+    auto decls = getValueDeclsForName(nominal, destroyFuncName);
     for (auto decl : decls) {
       auto func = dyn_cast<FuncDecl>(decl);
       if (!func)

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1722,6 +1722,11 @@ void IRGenFunction::emitBlockRelease(llvm::Value *value) {
 
 void IRGenFunction::emitForeignReferenceTypeLifetimeOperation(
     ValueDecl *fn, llvm::Value *value, bool needsNullCheck) {
+  if (auto originalDecl = fn->getASTContext()
+                              .getClangModuleLoader()
+                              ->getOriginalForClonedMember(fn))
+    fn = originalDecl;
+
   assert(fn->getClangDecl() && isa<clang::FunctionDecl>(fn->getClangDecl()));
 
   auto clangFn = cast<clang::FunctionDecl>(fn->getClangDecl());

--- a/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
@@ -1,0 +1,121 @@
+#include <swift/bridging>
+
+struct RefCountedBox {
+  int value;
+  int refCount = 1;
+
+  RefCountedBox(int value) : value(value) {}
+
+  void doRetain() { refCount++; }
+  void doRelease() { refCount--; }
+} SWIFT_SHARED_REFERENCE(.doRetain, .doRelease);
+
+struct DerivedRefCountedBox : RefCountedBox {
+  int secondValue = 1;
+  DerivedRefCountedBox(int value, int secondValue)
+      : RefCountedBox(value), secondValue(secondValue) {}
+};
+
+// MARK: Retain in a base type, release in derived
+
+struct BaseHasRetain {
+  mutable int refCount = 1;
+  void doRetainInBase() const { refCount++; }
+};
+
+struct DerivedHasRelease : BaseHasRetain {
+  int value;
+  DerivedHasRelease(int value) : value(value) {}
+
+  void doRelease() const { refCount--; }
+} SWIFT_SHARED_REFERENCE(.doRetainInBase, .doRelease);
+
+// MARK: Retain in a base type, release in templated derived
+
+template <typename T>
+struct TemplatedDerivedHasRelease : BaseHasRetain {
+  T value;
+  TemplatedDerivedHasRelease(T value) : value(value) {}
+
+  void doReleaseTemplated() const { refCount--; }
+} SWIFT_SHARED_REFERENCE(.doRetainInBase, .doReleaseTemplated);
+
+using TemplatedDerivedHasReleaseFloat = TemplatedDerivedHasRelease<float>;
+using TemplatedDerivedHasReleaseInt = TemplatedDerivedHasRelease<int>;
+
+// MARK: Retain/release in CRTP base type
+
+template <typename Derived>
+struct CRTPBase {
+  mutable int refCount = 1;
+  void crtpRetain() const { refCount++; }
+  void crtpRelease() const { refCount--; }
+} SWIFT_SHARED_REFERENCE(.crtpRetain, .crtpRelease);
+
+struct CRTPDerived : CRTPBase<CRTPDerived> {
+  int value;
+  CRTPDerived(int value) : value(value) {}
+};
+
+// MARK: Virtual retain and release
+
+struct VirtualRetainRelease {
+  int value;
+  mutable int refCount = 1;
+  VirtualRetainRelease(int value) : value(value) {}
+
+  virtual void doRetainVirtual() const { refCount++; }
+  virtual void doReleaseVirtual() const { refCount--; }
+  virtual ~VirtualRetainRelease() = default;
+} SWIFT_SHARED_REFERENCE(.doRetainVirtual, .doReleaseVirtual);
+
+struct DerivedVirtualRetainRelease : VirtualRetainRelease {
+  DerivedVirtualRetainRelease(int value) : VirtualRetainRelease(value) {}
+
+  mutable bool calledDerived = false;
+  void doRetainVirtual() const override { refCount++; calledDerived = true; }
+  void doReleaseVirtual() const override { refCount--; }
+};
+
+// MARK: Pure virtual retain and release
+
+struct PureVirtualRetainRelease {
+  int value;
+  mutable int refCount = 1;
+  PureVirtualRetainRelease(int value) : value(value) {}
+
+  virtual void doRetainPure() const = 0;
+  virtual void doReleasePure() const = 0;
+  virtual ~PureVirtualRetainRelease() = default;
+} SWIFT_SHARED_REFERENCE(.doRetainPure, .doReleasePure);
+
+struct DerivedPureVirtualRetainRelease : PureVirtualRetainRelease {
+  mutable int refCount = 1;
+
+  DerivedPureVirtualRetainRelease(int value) : PureVirtualRetainRelease(value) {}
+  void doRetainPure() const override { refCount++; }
+  void doReleasePure() const override { refCount--; }
+};
+
+// MARK: Static retain/release
+#ifdef INCORRECT
+struct StaticRetainRelease {
+// expected-error@-1 {{specified retain function '.staticRetain' is a static function; expected an instance function}}
+// expected-error@-2 {{specified release function '.staticRelease' is a static function; expected an instance function}}
+  int value;
+  int refCount = 1;
+
+  StaticRetainRelease(int value) : value(value) {}
+
+  static void staticRetain(StaticRetainRelease* o) { o->refCount++; }
+  static void staticRelease(StaticRetainRelease* o) { o->refCount--; }
+} SWIFT_SHARED_REFERENCE(.staticRetain, .staticRelease);
+
+struct DerivedStaticRetainRelease : StaticRetainRelease {
+// expected-error@-1 {{cannot find retain function '.staticRetain' for reference type 'DerivedStaticRetainRelease'}}
+// expected-error@-2 {{cannot find release function '.staticRelease' for reference type 'DerivedStaticRetainRelease'}}
+  int secondValue = 1;
+  DerivedStaticRetainRelease(int value, int secondValue)
+      : StaticRetainRelease(value), secondValue(secondValue) {}
+};
+#endif

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -44,6 +44,11 @@ module ReferenceCountedObjCProperty {
   export *
 }
 
+module LifetimeOperationMethods {
+  header "lifetime-operation-methods.h"
+  requires cplusplus
+}
+
 module MemberLayout {
   header "member-layout.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-module-interface.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -module-to-print=LifetimeOperationMethods -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// CHECK: class RefCountedBox {
+// CHECK:   func doRetain() 
+// CHECK:   func doRelease()
+// CHECK: }
+// CHECK: class DerivedRefCountedBox {
+// CHECK:   func doRetain()
+// CHECK:   func doRelease()
+// CHECK: }
+
+// CHECK: class DerivedHasRelease {
+// CHECK:   func doRelease()
+// CHECK:   func doRetainInBase()
+// CHECK: }
+
+// CHECK: class TemplatedDerivedHasRelease<CFloat> {
+// CHECK:   var value: Float
+// CHECK:   func doReleaseTemplated()
+// CHECK:   func doRetainInBase()
+// CHECK: }
+// CHECK: class TemplatedDerivedHasRelease<CInt> {
+// CHECK:   var value: Int32
+// CHECK:   func doReleaseTemplated()
+// CHECK:   func doRetainInBase()
+// CHECK: }
+
+// CHECK: class CRTPDerived {
+// CHECK:   var value: Int32
+// CHECK: }
+
+// CHECK: class VirtualRetainRelease {
+// CHECK:   func doRetainVirtual()
+// CHECK:   func doReleaseVirtual()
+// CHECK: }
+// CHECK: class DerivedVirtualRetainRelease {
+// CHECK:   func doRetainVirtual()
+// CHECK:   func doReleaseVirtual()
+// CHECK: }
+
+// CHECK: class PureVirtualRetainRelease {
+// CHECK:   func doRetainPure()
+// CHECK:   func doReleasePure()
+// CHECK: }
+// CHECK: class DerivedPureVirtualRetainRelease {
+// CHECK:   func doRetainPure()
+// CHECK:   func doReleasePure()
+// CHECK:   var refCount: Int32
+// CHECK: }

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -Xcc -DINCORRECT -I %S%{fs-sep}Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}lifetime-operation-methods.h -cxx-interoperability-mode=upcoming-swift -disable-availability-checking
+
+import LifetimeOperationMethods
+
+let _ = StaticRetainRelease(123)
+let _ = DerivedStaticRetainRelease(123, 456)

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
@@ -1,0 +1,76 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xfrontend -disable-availability-checking)
+
+// Temporarily disable when running with an older runtime (rdar://128681137)
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+import LifetimeOperationMethods
+
+var LifetimeMethodsTestSuite = TestSuite("Lifetime operations that are instance methods")
+
+LifetimeMethodsTestSuite.test("retain/release methods") {
+  let a = RefCountedBox(123)
+  expectEqual(a.value, 123)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+LifetimeMethodsTestSuite.test("retain/release methods from base type") {
+  let a = DerivedRefCountedBox(321, 456)
+  expectEqual(a.value, 321)
+  expectEqual(a.secondValue, 456)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+
+  a.secondValue = 789
+  expectEqual(a.secondValue, 789)
+}
+
+LifetimeMethodsTestSuite.test("retain in base type, release in derived type") {
+  let a = DerivedHasRelease(321)
+  expectEqual(a.value, 321)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+LifetimeMethodsTestSuite.test("retain in base type, release in derived templated type") {
+  let a = TemplatedDerivedHasReleaseInt(456)
+  expectEqual(a.value, 456)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+
+  let b = TemplatedDerivedHasReleaseFloat(5.66)
+  expectEqual(b.value, 5.66)
+}
+
+LifetimeMethodsTestSuite.test("CRTP") {
+  let a = CRTPDerived(789)
+  expectEqual(a.value, 789)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+LifetimeMethodsTestSuite.test("virtual retain/release") {
+  let a = VirtualRetainRelease(456)
+  expectEqual(a.value, 456)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+LifetimeMethodsTestSuite.test("overridden virtual retain/release") {
+  let a = DerivedVirtualRetainRelease(456)
+  expectEqual(a.value, 456)
+  expectTrue(a.calledDerived)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+LifetimeMethodsTestSuite.test("overridden pure virtual retain/release") {
+  let a = DerivedPureVirtualRetainRelease(789)
+  expectEqual(a.value, 789)
+  expectTrue(a.refCount > 0)
+  expectTrue(a.refCount < 10) // optimizations would affect the exact number
+}
+
+runAllTests()


### PR DESCRIPTION
  - **Explanation**: Some foreign reference types such as IUnknown or WebKit's RefCounted define retain/release operations as methods of the type.
Previously Swift only supported retain/release operations as standalone functions.
The syntax for member functions would be `SWIFT_SHARED_REFERENCE(.doRetain, .doRelease)`.
  - **Scope**: This extends ClangImporter and IRGen to accept retain/release functions which are instance functions.
  - **Issues**: rdar://160696723
  - **Original PRs**: https://github.com/swiftlang/swift/pull/84343
  - **Risk**: Low, this is a purely additive change. It accepts syntax that would previously not compile.
  - **Testing**: Added a compiler test.
  - **Reviewers**: @Xazax-hun @fahadnayyar 
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
