### PR TITLE
Sema: Don't diagnose isolated deinit availability in skipped function bodies

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -135,6 +135,12 @@ public:
     }
 
     if (!getActorIsolation(nominal).isMainActor() && destructor->hasBody()) {
+      // In module emission jobs, type checking the body of the destructor may
+      // be skipped which means availability in the body cannot be diagnosed
+      // accurately.
+      if (destructor->isBodySkipped())
+        return;
+
       TypeChecker::checkAvailability(
           destructor->getBodySourceRange(), C.getIsolatedDeinitAvailability(),
           D->getDeclContext(),

--- a/test/Concurrency/deinit_isolation_availability.swift
+++ b/test/Concurrency/deinit_isolation_availability.swift
@@ -2,6 +2,11 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-6.1-abi-triple
 // RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-6.1-abi-triple -target-min-inlining-version min -verify-additional-prefix inlining-
 
+// Test -emit-module configurations.
+
+// RUN: %target-swift-frontend -emit-module -verify -swift-version 5 %s -strict-concurrency=complete -target %target-swift-5.1-abi-triple -experimental-skip-non-inlinable-function-bodies -verify-additional-prefix inlining-
+// RUN: %target-swift-frontend -emit-module -verify -swift-version 5 %s -strict-concurrency=complete -target %target-swift-6.1-abi-triple -experimental-skip-non-inlinable-function-bodies -target-min-inlining-version min -verify-additional-prefix inlining-
+
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
As a follow-up fix for https://github.com/swiftlang/swift/pull/83545, avoid incorrectly diagnosing `isolated deinit` availability during module emission jobs, which skip type checking non-inlinable function bodies and therefore don't build accurate availability scopes for those bodies. It's ok to skip these diagnostics during module emission since they should still be emitted during compilation jobs.

Resolves rdar://161178785.
