### PR TITLE
[AST] Opaque read ownership is determined by root.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5908,7 +5908,7 @@ class AbstractStorageDecl : public ValueDecl {
   friend class SetterAccessLevelRequest;
   friend class IsGetterMutatingRequest;
   friend class IsSetterMutatingRequest;
-  friend class OpaqueReadOwnershipRequest;
+  friend class DirectOpaqueReadOwnershipRequest;
   friend class StorageImplInfoRequest;
   friend class RequiresOpaqueAccessorsRequest;
   friend class RequiresOpaqueModifyCoroutineRequest;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1750,10 +1750,10 @@ public:
 };
 
 /// Request whether reading the storage yields a borrowed value.
-class OpaqueReadOwnershipRequest :
-    public SimpleRequest<OpaqueReadOwnershipRequest,
-                         OpaqueReadOwnership(AbstractStorageDecl *),
-                         RequestFlags::SeparatelyCached> {
+class DirectOpaqueReadOwnershipRequest
+    : public SimpleRequest<DirectOpaqueReadOwnershipRequest,
+                           OpaqueReadOwnership(AbstractStorageDecl *),
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -255,7 +255,7 @@ SWIFT_REQUEST(TypeChecker, EnumElementExprPatternRequest,
 SWIFT_REQUEST(TypeChecker, ResolvePatternRequest,
               Pattern *(Pattern *, DeclContext *, bool),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
+SWIFT_REQUEST(TypeChecker, DirectOpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueResultTypeRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3725,7 +3725,7 @@ AbstractStorageDecl::mutabilityInSwift(
 OpaqueReadOwnership AbstractStorageDecl::getOpaqueReadOwnership() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
-    OpaqueReadOwnershipRequest{const_cast<AbstractStorageDecl *>(this)}, {});
+    DirectOpaqueReadOwnershipRequest{const_cast<AbstractStorageDecl *>(this)}, {});
 }
 
 bool ValueDecl::isInstanceMember() const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -774,18 +774,19 @@ void IsSetterMutatingRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
-// OpaqueReadOwnershipRequest computation.
+// DirectOpaqueReadOwnershipRequest computation.
 //----------------------------------------------------------------------------//
 
 std::optional<OpaqueReadOwnership>
-OpaqueReadOwnershipRequest::getCachedResult() const {
+DirectOpaqueReadOwnershipRequest::getCachedResult() const {
   auto *storage = std::get<0>(getStorage());
   if (storage->LazySemanticInfo.OpaqueReadOwnershipComputed)
     return OpaqueReadOwnership(storage->LazySemanticInfo.OpaqueReadOwnership);
   return std::nullopt;
 }
 
-void OpaqueReadOwnershipRequest::cacheResult(OpaqueReadOwnership value) const {
+void DirectOpaqueReadOwnershipRequest::cacheResult(
+    OpaqueReadOwnership value) const {
   auto *storage = std::get<0>(getStorage());
   storage->setOpaqueReadOwnership(value);
 }

--- a/test/Interpreter/borrowed_storage_override.swift
+++ b/test/Interpreter/borrowed_storage_override.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// Currently, D's opaque read ownership is ::Owned which results in not
+// producing an override for C.read.
+// XFAIL: *
+
+// REQUIRES: executable_test
+
+protocol P {
+  var i: Int { get }
+}
+
+class C : P {
+  @_borrowed
+  var i: Int
+
+  init() {
+    self.i = 5
+  }
+}
+
+class D : C {
+  override var i: Int {
+    get {42}
+    set {}
+  }
+}
+
+func getFromC(_ c: C) -> Int {
+  return c.i
+}
+
+func getFromD(_ c: D) -> Int {
+  return c.i
+}
+
+func getFromP<T : P>(_ c: T) -> Int {
+  return c.i
+}
+
+func doit() {
+  let c = D()
+  let ic = getFromC(c)
+  print("as C:", ic)
+  // CHECK: as C: 42
+  let id = getFromD(c)
+  print("as D:", id)
+  // CHECK: as D: 42
+  let ip = getFromP(c)
+  print("as P:", ip)
+  // CHECK: as P: 42
+}
+
+doit()

--- a/test/Interpreter/borrowed_storage_override.swift
+++ b/test/Interpreter/borrowed_storage_override.swift
@@ -1,9 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
-// Currently, D's opaque read ownership is ::Owned which results in not
-// producing an override for C.read.
-// XFAIL: *
-
 // REQUIRES: executable_test
 
 protocol P {


### PR DESCRIPTION
When storage overrides a supertype's storage, the storage's opaque access must be via the same mechanism as the supertype.

rdar://156627653
