### PR TITLE
Build and install .swiftsourceinfo files for the standard library + friends

### DIFF
--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -28,10 +28,18 @@ function(emit_swift_interface target)
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>")
+  set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>"
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-source-info-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo>")
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
   endif()
 
   add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -39,6 +39,11 @@ function(emit_swift_interface target)
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
   endif()
+
+  # Swift source info file.
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>")
+
   add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})
   target_sources(${target}

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -26,25 +26,11 @@ function(emit_swift_interface target)
     file(REMOVE "${module_directory}")
   endif()
   target_compile_options(${target} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
-  set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
-    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
-    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"
-    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
-  if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
-    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
-      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
-      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
-  endif()
-
-  # Swift source info file.
-  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>")
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>"
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-source-info-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo>")
   endif()
 

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -43,6 +43,10 @@ function(emit_swift_interface target)
   # Swift source info file.
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>")
+  if(SwiftCore_VARIANT_MODULE_TRIPLE)
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-source-info-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo>")
+  endif()
 
   add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -759,7 +759,7 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
   auto &req = getRequirement();
   auto *reqDC = getRequirementDC();
   auto *genericCtx = getGenericContext();
-  auto noteLocation = reqDC->getAsDecl()->getLoc();
+  auto noteLocation = reqDC->getAsDecl()->getLoc(/*SerializedOK=*/false);
 
   if (!noteLocation.isValid())
     noteLocation = getLoc();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2686,7 +2686,7 @@ static bool diagnoseAmbiguity(
 
       auto emitGeneralFoundCandidateNote = [&]() {
         // Emit a general "found candidate" note
-        if (decl->getLoc().isInvalid()) {
+        if (decl->getLoc(/*SerializedOK=*/false).isInvalid()) {
           if (candidateTypes.insert(type->getCanonicalType()).second)
             DE.diagnose(getLoc(commonAnchor), diag::found_candidate_type, type);
         } else {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6256,7 +6256,7 @@ NeverNullType TypeResolver::resolvePackElement(PackElementTypeRepr *repr,
     if (auto *packIdent =
             dyn_cast<UnqualifiedIdentTypeRepr>(repr->getPackType())) {
       if (auto *packIdentBinding = packIdent->getBoundDecl()) {
-        if (packIdentBinding->getLoc().isValid()) {
+        if (packIdentBinding->getLoc(/*SerializedOK=*/false).isValid()) {
           diag.fixItInsert(packIdentBinding->getLoc(), "each ");
           addEachFixitApplied = true;
         }

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -1096,7 +1096,7 @@ function(_compile_swift_files
   # 6. *.O.sib
   # 7. *.sibgen
   #
-  # Only 1,2,4,3 are built by default. 5,6,7 are utility targets for use by
+  # Only 1,2,3,4 are built by default. 5,6,7 are utility targets for use by
   # engineers and thus even though the targets are generated, the targets are
   # not built by default.
   #

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -695,6 +695,8 @@ function(_compile_swift_files
   set(module_file_static)
   set(module_doc_file)
   set(module_doc_file_static)
+  set(module_location_file)
+  set(module_location_file_static)
   set(interface_file)
   set(interface_file_static)
 
@@ -726,9 +728,11 @@ function(_compile_swift_files
     set(module_base_static "${module_base_static}.swiftmodule/${module_triple}")
     set(module_file "${module_base}.swiftmodule")
     set(module_doc_file "${module_base}.swiftdoc")
+    set(module_location_file "${module_base}.swiftsourceinfo")
 
     set(module_file_static "${module_base_static}.swiftmodule")
     set(module_doc_file_static "${module_base_static}.swiftdoc")
+    set(module_location_file_static "${module_base_static}.swiftsourceinfo")
 
     # FIXME: These don't really belong inside the swiftmodule, but there's not
     # an obvious alternate place to put them.
@@ -759,7 +763,7 @@ function(_compile_swift_files
            "-Xfrontend" "-experimental-skip-non-inlinable-function-bodies")
     endif()
 
-    set(module_outputs "${module_file}" "${module_doc_file}")
+    set(module_outputs "${module_file}" "${module_doc_file}" "${module_location_file}")
 
     if(interface_file)
       list(APPEND module_outputs "${interface_file}" "${private_interface_file}")
@@ -855,8 +859,8 @@ function(_compile_swift_files
     endif()
   endif()
 
-  set(module_outputs "${module_file}" "${module_doc_file}")
-  set(module_outputs_static "${module_file_static}" "${module_doc_file_static}")
+  set(module_outputs "${module_file}" "${module_doc_file}" "${module_location_file}")
+  set(module_outputs_static "${module_file_static}" "${module_doc_file_static}" "${module_location_file_static}")
   if(interface_file)
     list(APPEND module_outputs "${interface_file}" "${private_interface_file}")
     list(APPEND module_outputs_static "${interface_file_static}" "${private_interface_file_static}")
@@ -1087,11 +1091,12 @@ function(_compile_swift_files
   # 1. *.swiftmodule
   # 2. *.swiftdoc
   # 3. *.swiftinterface
-  # 4. *.Onone.sib
-  # 5. *.O.sib
-  # 6. *.sibgen
+  # 4. *.swiftsourceinfo
+  # 5. *.Onone.sib
+  # 6. *.O.sib
+  # 7. *.sibgen
   #
-  # Only 1,2,3 are built by default. 4,5,6 are utility targets for use by
+  # Only 1,2,4,3 are built by default. 5,6,7 are utility targets for use by
   # engineers and thus even though the targets are generated, the targets are
   # not built by default.
   #
@@ -1111,7 +1116,7 @@ function(_compile_swift_files
           ${set_environment_args}
           "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
-          "-avoid-emit-module-source-info"
+          "-emit-module-source-info-path" "${module_location_file}"
           ${swift_flags} ${swift_module_flags} "@${file_path}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}
@@ -1141,6 +1146,8 @@ function(_compile_swift_files
           "${CMAKE_COMMAND}" "-E" "copy" ${module_file} ${module_file_static}
         COMMAND
           "${CMAKE_COMMAND}" "-E" "copy" ${module_doc_file} ${module_doc_file_static}
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "copy" ${module_location_file} ${module_location_file_static}
         ${command_copy_interface_file}
         OUTPUT ${module_outputs_static}
         DEPENDS

--- a/test/Concurrency/isolation_macro.swift
+++ b/test/Concurrency/isolation_macro.swift
@@ -62,7 +62,7 @@ func mainActorIsolated() {
   // CHECK: rewritten=current_context_isolation_expr
   // CHECK-NEXT: inject_into_optional
   // CHECK-NEXT: erasure_expr
-  // CHECK: member_ref_expr type="MainActor" location=@__swiftmacro_{{.*}} decl="_Concurrency.(file).MainActor.shared"
+  // CHECK: member_ref_expr type="MainActor" location=@__swiftmacro_{{.*}} decl="_Concurrency.(file).MainActor.shared{{.*}}"
   // CHECK-NEXT: type_expr implicit type="MainActor.Type"
   _ = #isolation
 }

--- a/test/Frontend/DiagnosticVerifier/Inputs/ArrayLib.swift
+++ b/test/Frontend/DiagnosticVerifier/Inputs/ArrayLib.swift
@@ -1,0 +1,1 @@
+public struct MyArray<Element>  { }

--- a/test/Frontend/DiagnosticVerifier/Inputs/BoolLib.swift
+++ b/test/Frontend/DiagnosticVerifier/Inputs/BoolLib.swift
@@ -1,0 +1,4 @@
+public enum MyBool {
+case `false`
+case `true`
+}

--- a/test/Frontend/DiagnosticVerifier/verify.swift
+++ b/test/Frontend/DiagnosticVerifier/verify.swift
@@ -1,6 +1,10 @@
 // Tests for the Swift frontends `-verify` mode.
 
-// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ArrayLib.swiftmodule -parse-as-library %S/Inputs/ArrayLib.swift
+// RUN: not %target-typecheck-verify-swift -I %t 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+
+import ArrayLib
 
 // CHECK: [[@LINE+1]]:1: error: unexpected error produced: cannot find 'undefinedFunc' in scope
 undefinedFunc()
@@ -30,7 +34,7 @@ fn(())    // expected-error {{argument passed to call that takes no arguments}} 
 // CHECK: [[@LINE+1]]:81: error: expected no fix-its; actual fix-it seen: {{[{][{]4-6=[}][}]}}
 fn(())    // expected-error {{argument passed to call that takes no arguments}} {{none}}
 
-// CHECK: [[@LINE+1]]:8: error: unexpected error produced: generic type 'Array' specialized with too many type parameters
-let x: Array<Int, Int>
-// CHECK: error: unexpected note produced: generic struct 'Array' declared here
-// CHECK: note: file 'Swift.Array' is not parsed for 'expected' statements. Use '-verify-additional-file Swift.Array' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
+// CHECK: [[@LINE+1]]:8: error: unexpected error produced: generic type 'MyArray' specialized with too many type parameters
+let x: MyArray<Int, Int>
+// CHECK: error: unexpected note produced: generic struct 'MyArray' declared here
+// CHECK: note: file 'ArrayLib.MyArray' is not parsed for 'expected' statements. Use '-verify-additional-file ArrayLib.MyArray' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file

--- a/test/Frontend/DiagnosticVerifier/verify2.swift
+++ b/test/Frontend/DiagnosticVerifier/verify2.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck -verify -serialize-diagnostics-path %t/serialized.dia %s 2>&1 | %FileCheck %s --check-prefixes CHECK,CHECK-WARNINGS-AS-WARNINGS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
-// RUN: not %target-swift-frontend -typecheck -verify -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefixes CHECK,CHECK-WARNINGS-AS-ERRORS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/BoolLib.swiftmodule -parse-as-library %S/Inputs/BoolLib.swift
+
+// RUN: not %target-swift-frontend -typecheck -verify -serialize-diagnostics-path %t/serialized.dia %s -I %t 2>&1 | %FileCheck %s --check-prefixes CHECK,CHECK-WARNINGS-AS-WARNINGS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+// RUN: not %target-swift-frontend -typecheck -verify -warnings-as-errors %s -I %t 2>&1 | %FileCheck %s -check-prefixes CHECK,CHECK-WARNINGS-AS-ERRORS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 // RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/serialized.dia
+
+import BoolLib
 
 // Wrong message
 let x: Int = "hello, world!" // expected-error {{foo bar baz}}
@@ -18,13 +23,13 @@ let z: Int = "hello, world!" as Any
 // CHECK: error: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36-36= as! Int{{[}][}]}}
 
 // Expected no fix-it
-let a: Bool = "hello, world!" as Any
+let a: MyBool = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{none}}
-// CHECK: error: expected no fix-its; actual fix-it seen: {{[{][{]}}37-37= as! Bool{{[}][}]}}
+// CHECK: error: expected no fix-its; actual fix-it seen: {{[{][{]}}39-39= as! MyBool{{[}][}]}}
 
 // Unexpected error
-_ = foo()
-// CHECK: error: unexpected error produced: cannot find 'foo' in scope
+_ = Myfoo()
+// CHECK: error: unexpected error produced: cannot find 'Myfoo' in scope
 
 func b() {
   let c = 2
@@ -42,8 +47,8 @@ extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') c
 extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{documentation-file=nominal-types,foo-bar-baz}}
 // CHECK: error: expected documentation file not seen; actual documentation file: {{[{][{]}}documentation-file=nominal-types{{[}][}]}}
 
-// CHECK: error: unexpected note produced: 'Bool' declared here
-// CHECK: note: file 'Swift.Bool' is not parsed for 'expected' statements. Use '-verify-additional-file Swift.Bool' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
+// CHECK: error: unexpected note produced: 'MyBool' declared here
+// CHECK: note: file 'BoolLib.MyBool' is not parsed for 'expected' statements. Use '-verify-additional-file BoolLib.MyBool' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 
 // Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA

--- a/test/LiteralExpressions/EnumRawValue.swift
+++ b/test/LiteralExpressions/EnumRawValue.swift
@@ -9,13 +9,13 @@ enum E1: Int {
 }
 // CHECK-LABEL: (enum_element_decl {{.*}} "a" interface_type="(E1.Type) -> E1"
 // CHECK: (original_raw_value_expr=binary_expr type="Int" {{.*}} nothrow isolation_crossing="none"
-// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="4" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="4" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"
 
 // CHECK-LABEL: (enum_element_decl {{.*}} "b" interface_type="(E1.Type) -> E1"
-// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="5" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="5" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"
 
 // CHECK-LABEL: (enum_element_decl {{.*}} "c" interface_type="(E1.Type) -> E1"
-// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="6" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="6" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"
 
 @section("mysection") let sectionInt = 42
 let someOtherInt = 42
@@ -26,11 +26,11 @@ enum E2: Int {
 }
 // CHECK-LABEL: (enum_element_decl {{.*}} "life" interface_type="(E2.Type) -> E2"
 // CHECK: (original_raw_value_expr=declref_expr type="Int" {{.*}} decl="EnumRawValue.(file).sectionInt@{{.*}}EnumRawValue.swift:{{[0-9]+}}:{{[0-9]+}}" function_ref=unapplied)
-// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="42" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="42" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"
 
 // CHECK-LABEL: (enum_element_decl {{.*}} "universe" interface_type="(E2.Type) -> E2"
 // CHECK: (original_raw_value_expr=binary_expr type="Int" {{.*}} nothrow isolation_crossing="none"
-// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="84" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="84" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"
 
 // CHECK-LABEL: (enum_element_decl {{.*}} "everything" interface_type="(E2.Type) -> E2"
-// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="85" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="85" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:){{.*}}"

--- a/test/SourceKit/CursorInfo/cursor_in_stdlib_module.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_stdlib_module.swift
@@ -3,7 +3,7 @@ func test() {
   Swift.min(1, 2)
 }
 
-// CHECK: source.lang.swift.ref.function.free ()
+// CHECK: source.lang.swift.ref.function.free ({{.*}})
 // CHECK-NEXT: min(_:_:)
 // CHECK-NEXT: s:s3minyxx_xtSLRzlF
 // CHECK-NEXT: source.lang.swift

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -835,8 +835,8 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 
 // RUN: %sourcekitd-test -req=cursor -pos=227:14 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK94 %s
 // CHECK94: source.lang.swift.ref.struct
-// CHECK94-NEXT: String
-// CHECK94-NEXT: s:SS
+// CHECK94: String
+// CHECK94: s:SS
 // CHECK94-NEXT: source.lang.swift
 // CHECK94-NEXT: String.Type
 // CHECK94-NEXT: $sSSmD
@@ -851,8 +851,8 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 
 // RUN: %sourcekitd-test -req=cursor -pos=23:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK96 %s
 // CHECK96: source.lang.swift.ref.struct
-// CHECK96-NEXT: String
-// CHECK96-NEXT: s:SS
+// CHECK96: String
+// CHECK96: s:SS
 // CHECK96-NEXT: source.lang.swift
 // CHECK96-NEXT: String.Type
 // CHECK96-NEXT: $sSSmD
@@ -863,8 +863,8 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 
 // RUN: %sourcekitd-test -req=cursor -pos=233:19 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK97 %s
 // CHECK97: source.lang.swift.ref.struct
-// CHECK97-NEXT: Int
-// CHECK97-NEXT: s:Si
+// CHECK97: Int
+// CHECK97: s:Si
 // CHECK97-NEXT: source.lang.swift
 // CHECK97-NEXT: Int.Type
 // CHECK97-NEXT: $sSimD
@@ -882,7 +882,7 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 // CHECK98-NEXT: cursor_info
 
 // RUN: %sourcekitd-test -req=cursor -pos=244:51 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK99 %s
-// CHECK99: source.lang.swift.ref.struct ()
+  // CHECK99: source.lang.swift.ref.struct ({{.*}})
 // CHECK99-NEXT: String
 // CHECK99-NEXT: s:SS
 // CHECK99-NEXT: source.lang.swift
@@ -893,7 +893,7 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 // CHECK99-NEXT: SYSTEM
 
 // RUN: %sourcekitd-test -req=cursor -pos=244:61 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK100 %s
-// CHECK100: source.lang.swift.ref.function.constructor ()
+  // CHECK100: source.lang.swift.ref.function.constructor ({{.*}})
 // CHECK100-NEXT: init(stringInterpolation:)
 // CHECK100-NEXT: s:SS19stringInterpolationSSs013DefaultStringB0V_tcfc
 // CHECK100-NEXT: source.lang.swift

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
@@ -51,7 +51,7 @@ extension Parent {
 // GLOBAL:      SYMBOL GRAPH END
 //
 // GLOBAL:      REFERENCED DECLS BEGIN
-// GLOBAL-NEXT: [[Int_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// GLOBAL-NEXT: [[Int_USR]] | public | {{.*}} | Swift | System | NonSPI | source.lang.swift
 // GLOBAL-NEXT:   Int swift.struct [[Int_USR]]
 // GLOBAL-NEXT: REFERENCED DECLS END
 
@@ -127,7 +127,7 @@ extension Parent {
 // GENERIC:      SYMBOL GRAPH END
 //
 // GENERIC:      REFERENCED DECLS BEGIN
-// GENERIC-NEXT: [[Equatable_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// GENERIC-NEXT: [[Equatable_USR]] | public | {{.*}} | Swift | System | NonSPI | source.lang.swift
 // GENERIC-NEXT:   Equatable swift.protocol [[Equatable_USR]]
 // GENERIC-NEXT: REFERENCED DECLS END
 
@@ -220,7 +220,7 @@ extension Parent {
 // NESTED-NEXT: [[Inner_USR]] | internal | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
 // NESTED-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
 // NESTED-NEXT:   Inner swift.struct [[Inner_USR]]
-// NESTED-NEXT: [[Array_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// NESTED-NEXT: [[Array_USR]] | public | {{.*}} | Swift | System | NonSPI | source.lang.swift
 // NESTED-NEXT:   Array swift.struct [[Array_USR]]
 // NESTED-NEXT: [[ExtInner_USR]] | internal | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
 // NESTED-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV

--- a/test/SourceKit/CursorInfo/cursor_synthesized.swift
+++ b/test/SourceKit/CursorInfo/cursor_synthesized.swift
@@ -2,7 +2,7 @@ struct Synthesized: Hashable {
   let a: Int
   // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):10 %s -- %s -target %target-triple | %FileCheck -check-prefix=INT %s
   // INT: Int
-  // INT-NEXT: s:Si
+  // INT: s:Si
   // INT-NOT: SYNTHESIZED
 }
 

--- a/test/SourceKit/CursorInfo/missing_module_map.swift
+++ b/test/SourceKit/CursorInfo/missing_module_map.swift
@@ -4,6 +4,6 @@
 // We used to fail to load the stdlib if there is a `-fmodule-map-file` option pointing to a missing file
 
 let x: String = "abc"
-// CHECK: source.lang.swift.ref.struct ()
+// CHECK: source.lang.swift.ref.struct ({{.*}})
 // CHECK: String
 // CHECK: s:SS

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -8,8 +8,10 @@
 
 // RUN: %sourcekitd-test -req=doc-info -module Foo -- -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
-// RUN: %diff -u %s.response %t.response
+// RUN: sed -e 's/ file=[^*.]*.swift[^>]*>/>/g' %t.response > %t.response.cleaned
+// RUN: %diff -u %s.response %t.response.cleaned
 
 // RUN: %sourcekitd-test -req=doc-info -module Foo.FooSub -- -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
-// RUN: %diff -u %s.sub.response %t.response
+// RUN: sed -e 's/ file=[^*.]*.swift[^>]*>/>/g' %t.response > %t.response.cleaned
+// RUN: %diff -u %s.sub.response %t.response.cleaned

--- a/test/SourceKit/DocSupport/doc_swift_module.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library  -enable-objc-interop -emit-module-doc-path %t.mod/cake.swiftdoc -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 // RUN: %sourcekitd-test -req=doc-info -module cake -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t.mod > %t.response
-// RUN: %diff -u %s.response %t.response
+// RUN: sed -e 's/ file=[^>]*>/>/g' %t.response > %t.response.cleaned
+// RUN: %diff -u %s.response %t.response.cleaned
 

--- a/test/SourceKit/InterfaceGen/gen_stdlib.swift
+++ b/test/SourceKit/InterfaceGen/gen_stdlib.swift
@@ -29,7 +29,7 @@ var x: Int
 // RUN: %sourcekitd-test -req=interface-gen-open -module Swift \
 // RUN:   == -req=cursor -pos=2:8 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 
-// CHECK1:      source.lang.swift.ref.struct ()
+// CHECK1:      source.lang.swift.ref.struct ({{.*}})
 // CHECK1-NEXT: Int
 // CHECK1-NEXT: s:Si
 // CHECK1-NEXT: source.lang.swift

--- a/test/SourceKit/Session/info_after_open.swift
+++ b/test/SourceKit/Session/info_after_open.swift
@@ -1,5 +1,5 @@
 print("a")
 
 // RUN: %sourcekitd-test -req=syntax-map %s == -req=cursor -pos=1:2 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
-// CHECK1: source.lang.swift.ref.function.free ()
+// CHECK1: source.lang.swift.ref.function.free ({{.*}})
 // CHECK1-NEXT: print

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/SourceModule.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/SourceModule.swift
@@ -49,7 +49,7 @@ public struct Override: Hashable, P {
 
 // NO-OVERRIDE-OTHER-LABEL: "precise": "s:12SourceModule13NoDocOverrideV4hash4intoys6HasherVz_tF"
 // NO-OVERRIDE-OTHER:      "docComment": {
-// NO-OVERRIDE-OTHER-NEXT:        "module": "Swift",
+// NO-OVERRIDE-OTHER:        "module": "Swift",
 // NO-OVERRIDE-OTHER-NEXT:        "lines": [
 // actual doc comment lines skipped because they're from the stdlib
 


### PR DESCRIPTION
These are useful for debug backtraces when building against the binary Swift modules. For Embedded Swift, it's even more important because everything gets inlined. rdar://159398310