### PR TITLE
OpenBSD 7.8 will require OpaquePointer for FILE.

### DIFF
--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -30,7 +30,10 @@ if(SWIFT_BUILD_SDK_OVERLAY
   endif()
   # Currently SwiftReflectionTest cannot be built on Windows, due to
   # dependencies on POSIX symbols
-  if (SWIFT_INCLUDE_TESTS AND (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows"))
+  if (SWIFT_INCLUDE_TESTS
+      AND NOT CMAKE_SYSTEM_NAME STREQUAL "Windows"
+      AND NOT (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"
+               AND CMAKE_SYSTEM_VERSION VERSION_LESS "7.8"))
     add_subdirectory(SwiftReflectionTest)
   endif()
 endif()

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -74,9 +74,9 @@ public func snprintf(ptr: UnsafeMutablePointer<Int8>, _ len: Int, _ format: Unsa
 #endif
 
 #elseif os(OpenBSD)
-public var stdin: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdin() }
-public var stdout: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdout() }
-public var stderr: UnsafeMutablePointer<FILE> { return _swift_stdlib_stderr() }
+public var stdin: OpaquePointer { return OpaquePointer(_swift_stdlib_stdin()) }
+public var stdout: OpaquePointer { return OpaquePointer(_swift_stdlib_stdout()) }
+public var stderr: OpaquePointer { return OpaquePointer(_swift_stdlib_stderr()) }
 #elseif os(Windows)
 public var stdin: UnsafeMutablePointer<FILE> {
   return unsafe __acrt_iob_func(0)

--- a/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
@@ -121,15 +121,15 @@ int static inline _swift_stdlib_openat(int fd, const char *path, int oflag,
 #endif
 
 #if defined(__OpenBSD__)
-static inline FILE *_swift_stdlib_stdin(void) {
+static inline void *_swift_stdlib_stdin(void) {
   return stdin;
 }
 
-static inline FILE *_swift_stdlib_stdout(void) {
+static inline void *_swift_stdlib_stdout(void) {
   return stdout;
 }
 
-static inline FILE *_swift_stdlib_stderr(void) {
+static inline void *_swift_stdlib_stderr(void) {
   return stderr;
 }
 #endif


### PR DESCRIPTION
OpenBSD 7.8 snapshots hide the type information for FILE. Therefore, the types for the standard stdio streams should (regrettably) be OpaquePointer, due to the well-discussed issue of losing type information for forward-declared C types.

We explicitly drop to void * in the LibcOverlayShims for backwards compatibility, since OpenBSD 7.8 is not yet released.