### PR TITLE
[cxx-interop] fix a typo in returns_retained_or_returns_unretained_for_non_cxx_frt_values

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -303,7 +303,7 @@ ERROR(redundant_conformance_protocol,none,
      "redundant conformance of %0 to protocol '%1'", (Type, StringRef))
 
 WARNING(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
-      "%0 should not be annotated with SWIFT_TURNS_RETAINED or "
+      "%0 should not be annotated with SWIFT_RETURNS_RETAINED or "
       "SWIFT_RETURNS_UNRETAINED because it is not returning "
       "a SWIFT_SHARED_REFERENCE type",
       (const clang::NamedDecl *))

--- a/test/Interop/Cxx/foreign-reference/Inputs/cxx-functions-and-methods-returning-frt.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/cxx-functions-and-methods-returning-frt.h
@@ -191,38 +191,38 @@ FRTStruct *_Nonnull global_function_returning_cxx_frt_with_annotations()
 // C++ APIs returning non-cxx-frts (for testing diagnostics)
 struct StructWithAPIsReturningNonCxxFrt {
   static NonFRTStruct *_Nonnull StaticMethodReturningNonCxxFrt();
-  static NonFRTStruct *_Nonnull StaticMethodReturningNonCxxFrtWithAnnotation() // expected-warning {{'StaticMethodReturningNonCxxFrtWithAnnotation' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+  static NonFRTStruct *_Nonnull StaticMethodReturningNonCxxFrtWithAnnotation() // expected-warning {{'StaticMethodReturningNonCxxFrtWithAnnotation' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
       __attribute__((swift_attr("returns_retained")));
 };
 
 NonFRTStruct *_Nonnull global_function_returning_non_cxx_frt();
-NonFRTStruct *_Nonnull global_function_returning_non_cxx_frt_with_annotations() // expected-warning {{'global_function_returning_non_cxx_frt_with_annotations' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+NonFRTStruct *_Nonnull global_function_returning_non_cxx_frt_with_annotations() // expected-warning {{'global_function_returning_non_cxx_frt_with_annotations' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
     __attribute__((swift_attr("returns_retained")));
 
 // C++ APIs returning SWIFT_IMMORTAL_REFERENCE types (for testing diagnostics)
 struct StructWithAPIsReturningImmortalReference {
   static ImmortalRefStruct *_Nonnull StaticMethodReturningImmortalReference();
   static ImmortalRefStruct
-      *_Nonnull StaticMethodReturningImmortalReferenceWithAnnotation() // expected-warning {{'StaticMethodReturningImmortalReferenceWithAnnotation' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+      *_Nonnull StaticMethodReturningImmortalReferenceWithAnnotation() // expected-warning {{'StaticMethodReturningImmortalReferenceWithAnnotation' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
           __attribute__((swift_attr("returns_retained")));
 };
 
 ImmortalRefStruct *_Nonnull global_function_returning_immortal_reference();
 ImmortalRefStruct
-    *_Nonnull global_function_returning_immortal_reference_with_annotations() // expected-warning {{'global_function_returning_immortal_reference_with_annotations' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+    *_Nonnull global_function_returning_immortal_reference_with_annotations() // expected-warning {{'global_function_returning_immortal_reference_with_annotations' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
         __attribute__((swift_attr("returns_retained")));
 
 // C++ APIs returning SWIFT_UNSAFE_REFERENCE types (for testing diagnostics)
 struct StructWithAPIsReturningUnsafeReference {
   static UnsafeRefStruct *_Nonnull StaticMethodReturningUnsafeReference();
   static UnsafeRefStruct
-      *_Nonnull StaticMethodReturningUnsafeReferenceWithAnnotation() // expected-warning {{'StaticMethodReturningUnsafeReferenceWithAnnotation' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+      *_Nonnull StaticMethodReturningUnsafeReferenceWithAnnotation() // expected-warning {{'StaticMethodReturningUnsafeReferenceWithAnnotation' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
           __attribute__((swift_attr("returns_retained")));
 };
 
 UnsafeRefStruct *_Nonnull global_function_returning_unsafe_reference();
 UnsafeRefStruct
-    *_Nonnull global_function_returning_unsafe_reference_with_annotations() // expected-warning {{'global_function_returning_unsafe_reference_with_annotations' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
+    *_Nonnull global_function_returning_unsafe_reference_with_annotations() // expected-warning {{'global_function_returning_unsafe_reference_with_annotations' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
         __attribute__((swift_attr("returns_retained")));
 
 // Global/free C++ functions returning non-FRT

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
@@ -24,7 +24,7 @@ void releaseCxxRefType(CxxRefType *_Nonnull b) {}
 + (struct CxxRefType *)objCMethodReturningFRTBothAnnotations // expected-error {{'objCMethodReturningFRTBothAnnotations' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED}}
     __attribute__((swift_attr("returns_unretained")))
     __attribute__((swift_attr("returns_retained")));
-+ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated // expected-warning {{'objCMethodReturningNonCxxFrtAnannotated' should not be annotated with SWIFT_TURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
++ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated // expected-warning {{'objCMethodReturningNonCxxFrtAnannotated' should not be annotated with SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
     __attribute__((swift_attr("returns_retained")));
 
 @end


### PR DESCRIPTION
[PR-84375](https://github.com/swiftlang/swift/pull/84375/) mistakenly added a typo to the message of the `returns_retained_or_returns_unretained_for_non_cxx_frt_values` diagnostic just before merging. Fixing that typo in this patch.
