### PR TITLE
ModuleInterface: Don't print `@c @implementation` functions

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -353,6 +353,13 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
         }
       }
 
+      // Skip @c @implementation functions along with the attribute.
+      if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+        if (options.excludeAttrKind(DeclAttrKind::ObjCImplementation) &&
+            AFD->isObjCImplementation() && AFD->getCDeclKind())
+          return false;
+      }
+
       // Skip extensions that extend things we wouldn't print.
       if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
         if (!shouldPrint(ED->getExtendedNominal(), options))

--- a/test/ModuleInterface/cdecl-swiftinterface.swift
+++ b/test/ModuleInterface/cdecl-swiftinterface.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -emit-module %t/Lib.swift -o %t -I %t \
+// RUN:   -swift-version 6 -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -enable-experimental-feature CDecl \
+// RUN:   -enable-experimental-feature CImplementation
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t \
+// RUN:   -typecheck-module-from-interface %t/Lib.swiftinterface
+
+// RUN: %FileCheck %s --input-file %t/Lib.swiftinterface
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: swift_feature_CImplementation
+
+//--- module.modulemap
+module Lib {
+    header "Lib.h"
+}
+
+//--- Lib.h
+extern void cImplFunc();
+extern void objcImplFunc();
+
+//--- Lib.swift
+@_exported import Lib
+import Foundation
+
+/// Don't print the implementation functions.
+// CHECK-NOT: @implementation
+// CHECK-NOT: ImplFunc
+
+@c @implementation
+public func cImplFunc() { }
+
+@_cdecl("objcImplFunc") @implementation
+public func objcImplFunc() { }
+
+/// Print other @c functions.
+@c
+public func bareCDecl() {}
+// CHECK: @c
+// CHECK-NEXT: public func bareCDecl
+
+@c(c_name)
+public func namedCDecl() {}
+// CHECK: @c(c_name)
+// CHECK-NEXT: public func namedCDecl
+
+@_cdecl("objc_name")
+public func namedLegacyCDecl() {}
+// CHECK: @_cdecl("objc_name")
+// CHECK-NEXT: public func namedLegacyCDecl


### PR DESCRIPTION
We don't need to print `@c @implementation` functions in swiftinterfaces as clients should only see the original declaration in the C header. Ensure we don't print `@c @implementation` and `@objc @implementation` functions, but still print simple `@c` and `@objc` functions.