### PR TITLE
Parser: Reject `@c` attributes using the string format

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3027,14 +3027,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   case DeclAttrKind::CDecl: {
-    if (!AttrName.starts_with("_") &&
-
-        // Backwards support for @c("stringId"). Remove before enabling in
-        // production so we accept only the identifier format.
-        lookahead(1, [&](CancellableBacktrackingScope &) {
-           return Tok.isNot(tok::string_literal);
-        })) {
-
+    if (AttrName == "c") {
       std::optional<StringRef> CName;
       if (consumeIfAttributeLParen()) {
         // Custom C name.

--- a/test/PrintAsObjC/cdecl-enum-reference.swift
+++ b/test/PrintAsObjC/cdecl-enum-reference.swift
@@ -25,13 +25,13 @@
 // REQUIRES: swift_feature_CDecl
 
 //--- CoreLib.swift
-@c("CEnum")
+@c(CEnum)
 public enum CEnum: CInt { case A, B }
 
 //--- MiddleLib.swift
 import CoreLib
 
-@c("CFunc")
+@c(CFunc)
 public func CFunc(e: CEnum) {}
 // CHECK: typedef SWIFT_ENUM_FWD_DECL(int, CEnum)
 // CHECK: SWIFT_EXTERN void CFunc(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT;

--- a/test/PrintAsObjC/cdecl-enums.swift
+++ b/test/PrintAsObjC/cdecl-enums.swift
@@ -57,7 +57,7 @@ import Foundation
 // CHECK-NEXT: }
 
 /// Foo: A feer, a female feer.
-@c("FooComments") public enum FooComments: CInt {
+@c(FooComments) public enum FooComments: CInt {
   /// Zim: A zeer, a female zeer.
   case Zim
   case Zang, Zung
@@ -67,7 +67,7 @@ import Foundation
 // CHECK-NEXT:   Zang = -219,
 // CHECK-NEXT:   Zung = -218,
 // CHECK-NEXT: };
-@c("NegativeValues") enum NegativeValues: Int16 {
+@c(NegativeValues) enum NegativeValues: Int16 {
   case Zang = -219, Zung
 
   func methodNotExportedToC() {}
@@ -77,7 +77,7 @@ import Foundation
 // CHECK-NEXT:   SomeErrorBadness = 9001,
 // CHECK-NEXT:   SomeErrorWorseness = 9002,
 // CHECK-NEXT: };
-@c("SomeError") enum SomeError: Int, Error {
+@c(SomeError) enum SomeError: Int, Error {
   case Badness = 9001
   case Worseness
 }
@@ -85,32 +85,32 @@ import Foundation
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, SomeOtherError, "SomeOtherError", closed) {
 // CHECK-NEXT:   SomeOtherErrorDomain = 0,
 // CHECK-NEXT: };
-@c("SomeOtherError") enum SomeOtherError: Int, Error {
+@c(SomeOtherError) enum SomeOtherError: Int, Error {
   case Domain
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, ObjcErrorType, "SomeRenamedErrorType", closed) {
 // CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
 // CHECK-NEXT: };
-@c("ObjcErrorType") enum SomeRenamedErrorType: Int, Error {
+@c(ObjcErrorType) enum SomeRenamedErrorType: Int, Error {
   case BadStuff
 }
 
-@c("acceptMemberImported") func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+@c(acceptMemberImported) func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptMemberImported(enum MemberRaw a, enum MemberEnum b, MemberOptions c, enum MemberTypedef d, MemberAnon e, MemberAnon2 ee) SWIFT_NOEXCEPT;
 
-@c("acceptPlainEnum") func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
+@c(acceptPlainEnum) func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptPlainEnum(enum NSMalformedEnumMissingTypedef) SWIFT_NOEXCEPT;
 
-@c("acceptTopLevelImported") func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
+@c(acceptTopLevelImported) func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptTopLevelImported(enum TopLevelRaw a, TopLevelEnum b, TopLevelOptions c, TopLevelTypedef d, TopLevelAnon e) SWIFT_NOEXCEPT;
 
-@c("takeAndReturnEnumC") func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
+@c(takeAndReturnEnumC) func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
   return .Zung
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG NegativeValues takeAndReturnEnumC(SWIFT_ENUM_TAG FooComments foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("takeAndReturnRenamedEnum") func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
+@c(takeAndReturnRenamedEnum) func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
   return .A
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG ObjcEnumNamed takeAndReturnRenamedEnum(SWIFT_ENUM_TAG ObjcEnumNamed foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;

--- a/test/PrintAsObjC/cdecl-includes-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-includes-with-objc.swift
@@ -53,11 +53,11 @@ import Foundation
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@c("get_int_alias")
+@c(get_int_alias)
 public func getIntAlias() -> IntFromCFramework { 42 }
 // CHECK: SWIFT_EXTERN IntFromCFramework get_int_alias(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("imports_cgpoint")
+@c(imports_cgpoint)
 public func importsCGPoint(pt: CGPoint) {  }
 // CHECK: SWIFT_EXTERN void imports_cgpoint(CGPoint pt) SWIFT_NOEXCEPT;
 

--- a/test/PrintAsObjC/cdecl-includes.swift
+++ b/test/PrintAsObjC/cdecl-includes.swift
@@ -78,16 +78,16 @@ import CModule
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@c("mirror_struct")
+@c(mirror_struct)
 public func a_mirrorStruct(_ a: CStruct) -> CStruct { a }
 // CHECK: SWIFT_EXTERN struct CStruct mirror_struct(struct CStruct a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("mirror_union")
+@c(mirror_union)
 public func b_mirrorStruct(_ a: CUnion) -> CUnion { a }
 // CHECK: SWIFT_EXTERN union CUnion mirror_union(union CUnion a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 
-@c("TKGetDefaultToastSetting")
+@c(TKGetDefaultToastSetting)
 public func c_defaultToastSetting() -> TKTimeSetting { TKTimeSettingNormal } // It would be nice to import TKTimeSettingNormal as a member.
 // CHECK: SWIFT_EXTERN TKTimeSetting TKGetDefaultToastSetting(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -53,22 +53,22 @@ func a0_simple(x: Int, bar y: Int) -> Int { return x }
 func a1_defaultName(x: Int) -> Int { return x }
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t a1_defaultName(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("primitiveTypes")
+@c(primitiveTypes)
 public func b_primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {}
 // CHECK-LABEL: SWIFT_EXTERN void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b) SWIFT_NOEXCEPT;
 
-@c("has_keyword_arg_names")
+@c(has_keyword_arg_names)
 func c_keywordArgNames(auto: Int, union: Int) {}
 // CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(ptrdiff_t auto_, ptrdiff_t union_) SWIFT_NOEXCEPT;
 
-@c("return_never")
+@c(return_never)
 func d_returnNever() -> Never { fatalError() }
 // CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
 
 /// Pointer types
 // CHECK: /// Pointer types
 
-@c("pointers")
+@c(pointers)
 func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   y: UnsafePointer<Int>,
                   z: UnsafeMutableRawPointer,
@@ -76,7 +76,7 @@ func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   u: OpaquePointer) {}
 // CHECK: SWIFT_EXTERN void pointers(ptrdiff_t * _Nonnull x, ptrdiff_t const * _Nonnull y, void * _Nonnull z, void const * _Nonnull w, void * _Nonnull u) SWIFT_NOEXCEPT;
 
-@c("nullable_pointers")
+@c(nullable_pointers)
 func g_nullablePointers(_ x: UnsafeMutableRawPointer,
                           y: UnsafeMutableRawPointer?,
                           z: UnsafeMutableRawPointer!) {}
@@ -87,23 +87,23 @@ func g_nullablePointers(_ x: UnsafeMutableRawPointer,
 @c
 enum CEnum: CInt { case A, B }
 
-@c("CEnumRenamed_CName")
+@c(CEnumRenamed_CName)
 enum CEnumRenamed: CLong { case A, B }
 
-@c("use_enum")
+@c(use_enum)
 func h_useCEnum(e: CEnum) -> CEnum { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnum use_enum(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("use_enum_renamed")
+@c(use_enum_renamed)
 func i_useCEnumLong(e: CEnumRenamed) -> CEnumRenamed { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnumRenamed_CName use_enum_renamed(SWIFT_ENUM_TAG CEnumRenamed_CName e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@c("use_enum_late")
+@c(use_enum_late)
 func j_useCEnumChar(e: zCEnumDefinedLate) -> zCEnumDefinedLate { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG zCEnumDefinedLate use_enum_late(SWIFT_ENUM_TAG zCEnumDefinedLate e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 /// Declare this enum late in the source file and in alphabetical order.
-@c("zCEnumDefinedLate")
+@c(zCEnumDefinedLate)
 enum zCEnumDefinedLate: CChar { case A, B }
 
 // CHECK:      #if defined(__cplusplus)

--- a/test/PrintAsObjC/cdecl-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-with-objc.swift
@@ -18,7 +18,7 @@
 // REQUIRES: swift_feature_CDecl
 // REQUIRES: objc_interop
 
-@c("cFunc")
+@c(cFunc)
 func cFunc() { }
 // CHECK: cFunc
 // CHECK-NOT: cFunc

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -26,83 +26,83 @@
 
 @c func defaultName() {}
 
-@c("noBody")
+@c(noBody)
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
 
-@c("property") // expected-error{{'@c' attribute cannot be applied to this declaration}}
+@c(property) // expected-error{{'@c' attribute cannot be applied to this declaration}}
 var property: Int
 
 var computed: Int {
-  @c("get_computed") get { return 0 }
-  @c("set_computed") set { return }
+  @c(get_computed) get { return 0 }
+  @c(set_computed) set { return }
 }
 
-@c("inout")
+@c(`inout`)
 func noBody(x: inout Int) { } // expected-error{{global function cannot be marked '@c' because inout parameters cannot be represented in C}}
 
 struct SwiftStruct { var x, y: Int }
 enum SwiftEnum { case A, B }
 
 #if os(Windows) && (arch(x86_64) || arch(arm64))
-@c("CEnum") enum CEnum: Int32 { case A, B }
+@c(CEnum) enum CEnum: Int32 { case A, B }
 #else
-@c("CEnum") enum CEnum: Int { case A, B }
+@c(CEnum) enum CEnum: Int { case A, B }
 #endif
 
 @c enum CEnumDefaultName: CInt { case A, B }
 
-@c("CEnumNoRawType") enum CEnumNoRawType { case A, B }
+@c(CEnumNoRawType) enum CEnumNoRawType { case A, B }
 // expected-error @-1 {{'@c' enum must declare an integer raw type}}
 
-@c("CEnumStringRawType") enum CEnumStringRawType: String { case A, B }
+@c(CEnumStringRawType) enum CEnumStringRawType: String { case A, B }
 // expected-error @-1 {{'@c' enum raw type 'String' is not an integer type}}
 
-@c("swiftStruct")
+@c(swiftStruct)
 func swiftStruct(x: SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
-@c("swiftEnum")
+@c(swiftEnum)
 func swiftEnum(x: SwiftEnum) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift enums not marked '@c' cannot be represented in C}}
 
-@c("cEnum")
+@c(cEnum)
 func cEnum(x: CEnum) {}
 
-@c("CDeclAndObjC") // expected-error {{cannot apply both '@c' and '@objc' to enum}}
+@c(CDeclAndObjC) // expected-error {{cannot apply both '@c' and '@objc' to enum}}
 @objc
 enum CDeclAndObjC: CInt { case A, B }
 
-@c("TwoCDecls") // expected-note {{attribute already specified here}}
+@c(TwoCDecls) // expected-note {{attribute already specified here}}
 @_cdecl("TwoCDecls") // expected-error {{duplicate attribute}}
 func TwoCDecls() {}
 
 class Foo {
-  @c("Foo_foo") // expected-error{{@c can only be applied to global functions}}
+  @c(Foo_foo) // expected-error{{@c can only be applied to global functions}}
   func foo(x: Int) -> Int { return x }
 
-  @c("Foo_foo_2") // expected-error{{@c can only be applied to global functions}}
+  @c(Foo_foo_2) // expected-error{{@c can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
-  @c("Foo_init") // expected-error{{'@c' attribute cannot be applied to this declaration}}
+  @c(Foo_init) // expected-error{{'@c' attribute cannot be applied to this declaration}}
   init() {}
 
-  @c("Foo_deinit") // expected-error{{'@c' attribute cannot be applied to this declaration}}
+  @c(Foo_deinit) // expected-error{{'@c' attribute cannot be applied to this declaration}}
   deinit {}
 }
 
-@c("throwing") // expected-error{{raising errors from @c functions is not supported}}
+@c(throwing) // expected-error{{raising errors from @c functions is not supported}}
 func throwing() throws { }
 
-@c("acceptedPointers")
+@c(acceptedPointers)
 func acceptedPointers(_ x: UnsafeMutablePointer<Int>,
                         y: UnsafePointer<Int>,
                         z: UnsafeMutableRawPointer,
                         w: UnsafeRawPointer,
                         u: OpaquePointer) {}
 
-@c("rejectedPointers")
+@c(rejectedPointers)
 func rejectedPointers( // expected-error 6 {{global function cannot be marked '@c' because the type of the parameter}}
     x: UnsafePointer<String>, // expected-note {{Swift structs cannot be represented in C}}
     y: CVaListPointer, // expected-note {{Swift structs cannot be represented in C}}
@@ -111,90 +111,90 @@ func rejectedPointers( // expected-error 6 {{global function cannot be marked '@
     v: UnsafeRawBufferPointer, // expected-note {{Swift structs cannot be represented in C}}
     t: UnsafeMutableRawBufferPointer) {} // expected-note {{Swift structs cannot be represented in C}}
 
-@c("genericParam")
+@c(genericParam)
 func genericParam<I>(i: I) {}
 // expected-error @-1 {{global function cannot be marked '@c' because it has generic parameters}}
 
-@c("variadic")
+@c(variadic)
 func variadic(_: Int...) {}
 // expected-error @-1 {{global function cannot be marked '@c' because it has a variadic parameter}}
 
-@c("tupleParamEmpty")
+@c(tupleParamEmpty)
 func tupleParamEmpty(a: ()) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{empty tuple type cannot be represented in C}}
 
-@c("tupleParam")
+@c(tupleParam)
 func tupleParam(a: (Int, Float)) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@c("emptyTupleReturn")
+@c(emptyTupleReturn)
 func emptyTupleReturn() -> () {}
 
-@c("tupleReturn")
+@c(tupleReturn)
 func tupleReturn() -> (Int, Float) { (1, 2.0) }
 // expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@c("funcAcceptsThrowingFunc")
+@c(funcAcceptsThrowingFunc)
 func funcAcceptsThrowingFunc(fn: (String) throws -> Int) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@c("funcAcceptsThrowingFuncReturn")
+@c(funcAcceptsThrowingFuncReturn)
 func funcAcceptsThrowingFuncReturn() -> (String) throws -> Int { fatalError() }
 // expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@c("bar")
+@c(bar)
 func bar(f: (SwiftEnum) -> SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@c("bas")
+@c(bas)
 func bas(f: (SwiftEnum) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@c("zim")
+@c(zim)
 func zim(f: () -> SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@c("zang")
+@c(zang)
 func zang(f: (SwiftEnum, SwiftStruct) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@c("zang_zang")
+@c(zang_zang)
   func zangZang(f: (Int...) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@c("array")
+@c(array)
 func array(i: [Int]) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
 class SwiftClass {}
-@c("swiftClass")
+@c(swiftClass)
 func swiftClass(p: SwiftClass) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
 protocol SwiftProtocol {}
-@c("swiftProtocol")
+@c(swiftProtocol)
 func swiftProtocol(p: SwiftProtocol) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@c("swiftErrorProtocol")
+@c(swiftErrorProtocol)
 func swiftErrorProtocol(e: Error) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@c("anyParam")
+@c(anyParam)
 func anyParam(e:Any) {}
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -12,6 +12,10 @@
 // expected-error @-1 {{expected ')' in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}
 
+@c("old string syntax") func stringSyntax() {}
+// expected-error @-1 {{expected C identifier in 'c' attribute}}
+// expected-error @-2 {{expected declaration}}
+
 @c() func emptyParen() {}
 // expected-error @-1 {{expected C identifier in 'c' attribute}}
 // expected-error @-2 {{expected declaration}}

--- a/test/attr/attr_cdecl_official_async.swift
+++ b/test/attr/attr_cdecl_official_async.swift
@@ -8,10 +8,10 @@
 @_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
 func asynchronous() async { }
 
-@c("async2") // expected-error{{@c global function cannot be asynchronous}}
+@c(async2) // expected-error{{@c global function cannot be asynchronous}}
 func asynchronous2() async { }
 
-@c("asyncParam")
+@c(asyncParam)
 func asynchronousParam(fn: (String) async -> Int) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{'async' function types cannot be represented in C}}

--- a/test/attr/attr_cdecl_official_rejected.swift
+++ b/test/attr/attr_cdecl_official_rejected.swift
@@ -4,9 +4,9 @@
 
 // REQUIRES: swift_feature_CDecl
 
-@c("cdecl_foo") func foo() { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
+@c(cdecl_foo) func foo() { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
 
 var computed: Int {
-  @c("get_computed") get { return 0 } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
-  @c("set_computed") set { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
+  @c(get_computed) get { return 0 } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
+  @c(set_computed) set { } // expected-error {{'@c' requires '-enable-experimental-feature CDecl'}}
 }

--- a/test/attr/attr_cdecl_official_with_objc.swift
+++ b/test/attr/attr_cdecl_official_with_objc.swift
@@ -9,11 +9,11 @@ import Foundation
 @objc
 class ObjCClass: NSObject { }
 
-@c("objcClassReturn") func objcClassReturn() -> ObjCClass { fatalError() }
+@c(objcClassReturn) func objcClassReturn() -> ObjCClass { fatalError() }
 // expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
-@c("objcClassParams") func objcClassParams(a: ObjCClass, b: ObjCClass) { }
+@c(objcClassParams) func objcClassParams(a: ObjCClass, b: ObjCClass) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
 // expected-error @-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
 // expected-note @-3 2 {{classes cannot be represented in C}}
@@ -21,18 +21,18 @@ class ObjCClass: NSObject { }
 @objc
 protocol ObjCProtocol {}
 
-@c("objcProtocol") func objcProtocol(a: ObjCProtocol) { }
+@c(objcProtocol) func objcProtocol(a: ObjCProtocol) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
 @objc
 enum ObjCEnum: Int { case A, B }
-@c("objcEnumUseInCDecl") func objcEnumUseInCDecl(a: ObjCEnum) { }
+@c(objcEnumUseInCDecl) func objcEnumUseInCDecl(a: ObjCEnum) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift enums not marked '@c' cannot be represented in C}}
 
 /// Objective-C accepts @c enums.
-@c("CEnum")
+@c(CEnum)
 enum CEnum: Int { case A, B }
 @_cdecl("cdeclEnumUseInObjc") func cdeclEnumUseInObjc(a: CEnum) { }
 

--- a/test/embedded/linkage/c.swift
+++ b/test/embedded/linkage/c.swift
@@ -29,7 +29,7 @@ package func f2() { }
 internal func f3() { }
 
 // CHECK: define hidden void @lib_publicCDeclFunc4
-@c("lib_publicCDeclFunc4")
+@c(lib_publicCDeclFunc4)
 internal func f4() { }
 
 // CHECK-NOT: lib_publicCDeclFunc5
@@ -37,7 +37,7 @@ internal func f4() { }
 private func f5() { }
 
 // CHECK-NOT: lib_publicCDeclFunc6
-@c("lib_publicCDeclFunc6")
+@c(lib_publicCDeclFunc6)
 private func f6() { }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Reject `@c` attributes using strings, in the style of `@c("customName")`, and accept only `@c(customName)` and the bare `@c`.  Update all tests along with it.