### PR TITLE
[cxx-interop] Do not freeze when printing libc++ module interface

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3271,7 +3271,7 @@ namespace {
       // building with libstdc++, i.e. on most Linux distros.
       if (decl->isInStdNamespace() && decl->getIdentifier() &&
           (decl->getName() == "conditional" || decl->getName() == "__or_" ||
-           decl->getName() == "_Expr"))
+            decl->getName() == "_Expr" || decl->getName() == "__val_expr"))
         return nullptr;
 
       // `decl->getDefinition()` can return nullptr before the call to sema and


### PR DESCRIPTION
Follow-up to fed7373f.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
