### PR TITLE
Usability improvements for ManualOwnership (part 2)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2148,6 +2148,8 @@ ERROR(attr_static_exclusive_no_setters,none,
 // @_manualOwnership
 ERROR(attr_manual_ownership_experimental,none,
       "'@_manualOwnership' requires '-enable-experimental-feature ManualOwnership'", ())
+ERROR(attr_manual_ownership_noimplicitcopy,none,
+      "'@_noImplicitCopy' cannot be used with ManualOwnership", ())
 
 // @extractConstantsFromMembers
 ERROR(attr_extractConstantsFromMembers_experimental,none,

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -537,6 +537,10 @@ static ManagedValue createInputFunctionArgument(
       isNoImplicitCopy |= pd->getSpecifier() == ParamSpecifier::Borrowing;
       isNoImplicitCopy |= pd->getSpecifier() == ParamSpecifier::Consuming;
     }
+
+    // ManualOwnership checks everything for implicit copies already.
+    if (B.hasManualOwnershipAttr())
+      isNoImplicitCopy = false;
   }
   if (isNoImplicitCopy)
     arg->setNoImplicitCopy(isNoImplicitCopy);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -561,7 +561,11 @@ public:
 
     // If our instance type is not already @moveOnly wrapped, and it's a
     // no-implicit-copy parameter, wrap it.
-    if (!isNoImplicitCopy && instanceType->isCopyable()) {
+    //
+    // Unless the function is using ManualOwnership, which checks for
+    // no-implicit-copies using a different mechanism.
+    if (!isNoImplicitCopy && instanceType->isCopyable() &&
+        !SGF.B.hasManualOwnershipAttr()) {
       if (auto *pd = dyn_cast<ParamDecl>(decl)) {
         isNoImplicitCopy = pd->isNoImplicitCopy();
         isNoImplicitCopy |= pd->getSpecifier() == ParamSpecifier::Consuming;

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1405,7 +1405,10 @@ void PatternMatchEmission::bindBorrow(Pattern *pattern, VarDecl *var,
   auto bindValue = value.asBorrowedOperand2(SGF, pattern).getFinalManagedValue();
 
   // Borrow bindings of copyable type should still be no-implicit-copy.
-  if (!bindValue.getType().isMoveOnly()) {
+  //
+  // If we're relying on ManualOwnership for explicit-copies enforcement,
+  // we don't need the MoveOnlyWrapper.
+  if (!bindValue.getType().isMoveOnly() && !SGF.B.hasManualOwnershipAttr()) {
     if (bindValue.getType().isAddress()) {
       bindValue = ManagedValue::forBorrowedAddressRValue(
         SGF.B.createCopyableToMoveOnlyWrapperAddr(pattern, bindValue.getValue()));

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -793,6 +793,10 @@ private:
         }
       }
     }
+    // If we're relying on ManualOwnership for explicit-copies enforcement,
+    // we don't need @noImplicitCopy / MoveOnlyWrapper.
+    if (SGF.B.hasManualOwnershipAttr())
+      isNoImplicitCopy = false;
 
     // If we have a no implicit copy argument and the argument is trivial,
     // we need to use copyable to move only to convert it to its move only
@@ -1216,8 +1220,9 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   SILType ty = lowering.getLoweredType();
 
   bool isNoImplicitCopy;
-  
-  if (ty.isTrivial(SGF.F) || ty.isMoveOnly()) {
+
+  if (ty.isTrivial(SGF.F) || ty.isMoveOnly() ||
+      SGF.B.hasManualOwnershipAttr()) {
     isNoImplicitCopy = false;
   } else if (VD->isNoImplicitCopy()) {
     isNoImplicitCopy = true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -491,6 +491,11 @@ void AttributeChecker::visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr) {
     return;
   }
 
+  // Don't allow it to be combined with ManualOwnership.
+  if (D->getASTContext().LangOpts.hasFeature(Feature::ManualOwnership)) {
+    diagnoseAndRemoveAttr(attr, diag::attr_manual_ownership_noimplicitcopy);
+  }
+
   if (auto *funcDecl = dyn_cast<FuncDecl>(D)) {
     if (visitOwnershipAttr(attr))
       return;

--- a/test/SIL/manual_ownership.swift
+++ b/test/SIL/manual_ownership.swift
@@ -64,6 +64,26 @@ public func basic_return3() -> Triangle {
 }
 
 @_manualOwnership
+func return_borrowed(_ t: borrowing Triangle) -> Triangle {
+  return t // expected-error {{ownership of 't' is demanded and cannot not be consumed}}
+}
+@_manualOwnership
+func return_borrowed_fixed(_ t: borrowing Triangle) -> Triangle {
+  return copy t
+}
+
+// FIXME: copy propagation isn't able to simplify this. No copy should be required.
+@_manualOwnership
+func return_consumingParam(_ t: consuming Triangle) -> Triangle { // expected-error {{accessing 't' produces a copy of it}}
+  return t
+}
+
+@_manualOwnership
+func return_owned(_ t: __owned Triangle) -> Triangle {
+  return t
+}
+
+@_manualOwnership
 func reassign_with_lets() -> Triangle {
   let x = Triangle()
   let y = x

--- a/test/SILGen/manual_ownership.swift
+++ b/test/SILGen/manual_ownership.swift
@@ -26,3 +26,49 @@ class TriangleClass {
 func basic_access_of_loadable(_ t: TriangleClass) -> ShapeClass {
   return copy t.shape
 }
+
+// CHECK-LABEL: sil {{.*}} [manual_ownership] [ossa] @return_borrowed
+// CHECK:       bb0(%0 : @guaranteed $TriangleClass):
+// CHECK-NEXT:     debug_value %0
+// CHECK-NEXT:     [[IMPL_COPY:%.*]] = copy_value %0
+// CHECK-NEXT:     return [[IMPL_COPY]]
+// CHECK-NEXT:  } // end sil function 'return_borrowed'
+@_manualOwnership
+@_silgen_name("return_borrowed")
+func return_borrowed(_ t: borrowing TriangleClass) -> TriangleClass {
+  return t
+}
+
+// CHECK-LABEL: sil {{.*}} [manual_ownership] [ossa] @return_consumingParam
+// CHECK:       bb0(%0 : @_eagerMove @owned $TriangleClass):
+// CHECK-NEXT:     alloc_box ${ var TriangleClass }, var, name "t"
+// CHECK-NEXT:     begin_borrow [var_decl]
+// CHECK-NEXT:     [[ADDR:%.*]] = project_box {{.*}}, 0
+// CHECK-NEXT:     store %0 to [init] [[ADDR]]
+// CHECK-NEXT:     [[ACCESS:%.*]] = begin_access [read] [unknown] [[ADDR]]
+// CHECK-NEXT:     [[IMPL_COPY:%.*]] = load [copy] [[ACCESS]]
+// CHECK-NEXT:     end_access [[ACCESS]]
+// CHECK-NEXT:     end_borrow
+// CHECK-NEXT:     destroy_value
+// CHECK-NEXT:     return [[IMPL_COPY]]
+// CHECK-NEXT:  } // end sil function 'return_consumingParam'
+@_manualOwnership
+@_silgen_name("return_consumingParam")
+func return_consumingParam(_ t: consuming TriangleClass) -> TriangleClass {
+  return t
+}
+
+// CHECK-LABEL: sil {{.*}} [manual_ownership] [ossa] @return_owned
+// CHECK:       bb0(%0 : @owned $TriangleClass):
+// CHECK-NEXT:     debug_value %0
+// CHECK-NEXT:     [[BORROW:%.*]] = begin_borrow %0
+// CHECK-NEXT:     [[IMPL_COPY:%.*]] = copy_value [[BORROW]]
+// CHECK-NEXT:     end_borrow [[BORROW]]
+// CHECK-NEXT:     destroy_value %0
+// CHECK-NEXT:     return [[IMPL_COPY]]
+// CHECK-NEXT:  } // end sil function 'return_owned'
+@_manualOwnership
+@_silgen_name("return_owned")
+func return_owned(_ t: __owned TriangleClass) -> TriangleClass {
+  return t
+}

--- a/test/SILGen/manual_ownership.swift
+++ b/test/SILGen/manual_ownership.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend %s -emit-silgen -verify \
+// RUN:   -enable-experimental-feature ManualOwnership -o %t.silgen
+
+// RUN: %FileCheck %s --input-file %t.silgen
+
+// REQUIRES: swift_feature_ManualOwnership
+
+class ShapeClass {}
+class TriangleClass {
+  var shape = ShapeClass()
+}
+
+// CHECK-LABEL: sil {{.*}} @basic_access_of_loadable
+// CHECK:       bb0(%0 : @guaranteed $TriangleClass):
+// CHECK-NEXT:    debug_value %0
+// CHECK-NEXT:    [[M:%.*]] = class_method %0, #TriangleClass.shape!getter
+// CHECK-NEXT:    [[SHAPE:%.*]] = apply [[M]](%0)
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[SHAPE]]
+// CHECK-NEXT:    [[COPY:%.*]] = explicit_copy_value [[B]]
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK-NEXT:    destroy_value [[SHAPE]]
+// CHECK-NEXT:    return [[COPY]]
+// CHECK-NEXT:  } // end sil function 'basic_access_of_loadable'
+@_manualOwnership
+@_silgen_name("basic_access_of_loadable")
+func basic_access_of_loadable(_ t: TriangleClass) -> ShapeClass {
+  return copy t.shape
+}

--- a/test/Sema/manualownership_attr.swift
+++ b/test/Sema/manualownership_attr.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:    -enable-experimental-feature NoImplicitCopy \
+// RUN:    -enable-experimental-feature ManualOwnership
+
+// REQUIRES: swift_feature_ManualOwnership
+// REQUIRES: swift_feature_NoImplicitCopy
+
+class C {}
+
+@_manualOwnership
+func hello() -> (C, C) {
+  @_noImplicitCopy let x = C() // expected-error {{'@_noImplicitCopy' cannot be used with ManualOwnership}}
+  return (x, x)
+}


### PR DESCRIPTION
Includes fixes for:

- `copy class.member` types of expressions
- `borrowing` parameters