### PR TITLE
[test] Require concurrency runtime for `macro_expand_body.swift`

### DIFF
--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test, asserts, concurrency
+// REQUIRES: swift_swift_parser, executable_test, asserts, concurrency, concurrency_runtime
 // REQUIRES: swift_feature_PreambleMacros
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
@@ -46,7 +46,6 @@ func log(_ message: String) {
   print(message)
 }
 
-@available(SwiftStdlib 5.1, *)
 func remoteCall<Result: ConjureRemoteValue>(function: String, arguments: [String: Any]) async throws -> Result {
   let printedArgs = arguments.keys.sorted().map { key in
     "\(key): \(arguments[key]!)"
@@ -55,7 +54,6 @@ func remoteCall<Result: ConjureRemoteValue>(function: String, arguments: [String
   return Result.conjureValue()
 }
 
-@available(SwiftStdlib 5.1, *)
 @Remote
 func f(a: Int, b: String) async throws -> String
 
@@ -71,7 +69,6 @@ func useLogger() {
   print(x)
 }
 
-@available(SwiftStdlib 5.1, *)
 @Remote
 @Traced
 @Logged
@@ -80,7 +77,6 @@ func g(a: Int, b: String) async throws -> String {
 }
 
 #if compiler(>=6.0) && TEST_DIAGNOSTICS
-@available(SwiftStdlib 5.1, *)
 @Remote
 func h(a: Int, b: String) async throws -> String {
   does not
@@ -93,17 +89,15 @@ func h(a: Int, b: String) async throws -> String {
 // CHECK-NEXT: Exiting doubleTheValue(value:)
 _ = doubleTheValue(value: 7)
 
-if #available(SwiftStdlib 5.1, *) {
-  // CHECK: Remote call f(a: 5, b: Hello)
-  print(try await f(a: 5, b: "Hello"))
+// CHECK: Remote call f(a: 5, b: Hello)
+print(try await f(a: 5, b: "Hello"))
 
-  // CHECK: Entering g(a: 5, b: World)
-  // CHECK: Logger entering g(a: 5, b: World)
-  // CHECK: Remote call g(a: 5, b: World)
-  // CHECK: Logger exiting g(a:b:)
-  // CHECK: Exiting g(a:b:)
-  print(try await g(a: 5, b: "World"))
-}
+// CHECK: Entering g(a: 5, b: World)
+// CHECK: Logger entering g(a: 5, b: World)
+// CHECK: Remote call g(a: 5, b: World)
+// CHECK: Logger exiting g(a:b:)
+// CHECK: Exiting g(a:b:)
+print(try await g(a: 5, b: "World"))
 
 // CHECK: Logger entering useLogger()
 // CHECK: --- use it


### PR DESCRIPTION
The test is implicitly using `async` main so the `SwiftStdlib 5.1` checks weren't actually preventing it from exercising the concurrency runtime. Just require the runtime to be present.