### PR TITLE
Sema: Workaround for broken existential opening behavior

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13394,8 +13394,12 @@ retry_after_fail:
             choiceType = objectType;
         }
 
+        // FIXME: The !getSelfProtocolDecl() check is load-bearing, because
+        // this optimization interacts poorly with existential opening
+        // somehow. It should all be removed.
         if (auto *choiceFnType = choiceType->getAs<FunctionType>()) {
-          if (isa<ConstructorDecl>(choice.getDecl())) {
+          if (isa<ConstructorDecl>(choice.getDecl()) &&
+              !choice.getDecl()->getDeclContext()->getSelfProtocolDecl()) {
             auto choiceResultType = choice.getBaseType()
                                         ->getRValueType()
                                         ->getMetatypeInstanceType();

--- a/test/Constraints/opened_existentials_overload.swift
+++ b/test/Constraints/opened_existentials_overload.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+func g(_: some P) {}
+// expected-note@-1 {{required by global function 'g' where 'some P' = 'any P'}}
+
+// rdar://problem/160389221
+func good(_ x: Array<any P>) {
+  Array(x).forEach { y in g(y) }
+}
+
+extension Array {
+  var ffirst: Element? { fatalError() }
+  func ffirst(wwhere: (Element) -> Bool) -> Element { fatalError() }
+}
+
+func bad(_ x: Array<any P>) {
+  let y = x.ffirst!
+  g(y) // ok
+
+  let yy = x.ffirst
+  g(yy!) // ok
+
+  // FIXME: This is broken
+
+  g(x.ffirst!)
+  // expected-error@-1 {{type 'any P' cannot conform to 'P'}}
+  // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+}


### PR DESCRIPTION
This is a narrow workaround for a regression from
9e3d0e0a8c78076a70a9869d10acc6189cb7bb6b.

There is no reason to skip this logic for protocol extension members, except that doing so happens to break existential opening in an expression that involves a call to Array.init elsewhere.

However there is an underlying issue here with existential opening, which doesn't seem to work right in the presence of overloading.

The test case demonstrates the fixed problem, together with an existing bug that points to the underlying problem.

Fixes rdar://160389221.