### PR TITLE
[6.2] XFAIL `Interop/cxx/stdlib/use-std-function.swift` on Amazon Linux 2023

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -19,6 +19,7 @@
 // XFAIL: LinuxDistribution=fedora-39
 // XFAIL: LinuxDistribution=fedora-41
 // XFAIL: LinuxDistribution=debian-12
+// XFAIL: LinuxDistribution=amzn-2023
 
 import StdlibUnittest
 import StdFunction


### PR DESCRIPTION
(cherry picked from commit 1a144932a7ac0e6a5bdafe08b3ec1483a115817a)

Unblock CI: https://ci.swift.org/view/Swift%206.2/job/oss-swift-6.2-bootstrap-amazonlinux-2023-x86_64/8/console