### PR TITLE
SwiftCompilerSources/SIL: More robust `IntegerLiteralInst` construction

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -75,7 +75,7 @@ extension LoadInst : OnoneSimplifiable, SILCombineSimplifiable {
        index < stringLiteral.value.count {
 
       let builder = Builder(before: self, context)
-      let charLiteral = builder.createIntegerLiteral(Int(stringLiteral.value[index]), type: type)
+      let charLiteral = builder.createIntegerLiteral(stringLiteral.value[index], type: type)
       uses.replaceAll(with: charLiteral, context)
       context.erase(instruction: self)
       return true


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/84052.

ac619010e32ce7d6bccba544950833227e4e1df3 backfired when building the stdlib on rebranch. This time the problem is reversed: we should be interpreting an integer as unsigned where we no longer do, here: https://github.com/swiftlang/swift/blob/8f7af45115e373e05d3419ab272f02700bd8a48c/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift#L78

Rather than treating integers as signed by default, make `Builder.createIntegerLiteral` accept a generic `FixedWidthInteger`, and manipulate the value based on the generic type argument's signedness.

This doesn't entirely define away unintentional sign extensions, but makes this mistake of humouring the parameter type less likely.