### PR TITLE
Optimize Specializations of Variadic Generics by Eliminating Parameter Packs

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -146,6 +146,8 @@ extension TypeProperties {
   public var isExistentialMetatype: Bool { rawType.bridged.isExistentialMetatypeType() }
   public var isDynamicSelf: Bool { rawType.bridged.isDynamicSelf()}
   public var isBox: Bool { rawType.bridged.isBox() }
+  public var isPack: Bool { rawType.bridged.isPack() }
+  public var isSILPack: Bool { rawType.bridged.isSILPack() }
 
   public var canBeClass: Type.TraitResult { rawType.bridged.canBeClass().result }
 
@@ -262,6 +264,14 @@ extension TypeProperties {
   /// abstract, concrete or pack conformance, depending on the lookup type.
   public func checkConformance(to protocol: ProtocolDecl) -> Conformance {
     return Conformance(bridged: rawType.bridged.checkConformance(`protocol`.bridged))
+  }
+
+  public var containsSILPackExpansionType: Bool {
+    return rawType.bridged.containsSILPackExpansionType()
+  }
+
+  public var isSILPackElementAddress: Bool {
+    return rawType.bridged.isSILPackElementAddress()
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -38,4 +38,5 @@ swift_compiler_sources(Optimizer
   StripObjectHeaders.swift
   TempLValueElimination.swift
   TempRValueElimination.swift
+  PackSpecialization.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -152,8 +152,8 @@ private func specializeClosure(specializedName: String,
   newParams.append(contentsOf: nonConstantArguments.map { partialApply.parameter(for: $0)! })
 
   let isGeneric = newParams.contains { $0.type.hasTypeParameter } ||
-                  callee.convention.results.contains { $0.type.hasTypeParameter() } ||
-                  callee.convention.errorResult?.type.hasTypeParameter() ?? false
+                  callee.convention.results.contains { $0.type.hasTypeParameter } ||
+                  callee.convention.errorResult?.type.hasTypeParameter ?? false
 
   let specializedClosure = context.createSpecializedFunctionDeclaration(from: callee,
                                                                         withName: specializedName,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
@@ -1,0 +1,1035 @@
+//===--- PackSpecialization.swift - Eliminate packs in function arguments -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AST
+import SIL
+
+/// Splits pack arguments (parameters & indirect results) into separate
+/// arguments for each member of the pack. The argument conventions of the new
+/// parameters and results are determined based on whether their types are
+/// trivial or loadable.
+///
+/// A new function is created, with a name generated using the exploded argument
+/// mangling. This will be a modified version of the original, with local pack
+/// allocations introduced as substitutes for the exploded pack arguments of the
+/// original function. Call sites are also modified to extract the elements of
+/// each pack argument that are passed to (or returned from) the new function
+/// separately.
+///
+/// See below for SIL examples.
+let packSpecialization = FunctionPass(name: "pack-specialization") {
+  (function: Function, context: FunctionPassContext) in
+
+  // This pass requires both the caller and callee to be in OSSA.
+  if !function.hasOwnership {
+    return
+  }
+
+  // TODO: Support pack specialization for any FullApplySite, not just ApplyInst.
+  for case let apply as ApplyInst in function.instructions {
+    // Only support normal apply instructions for now.
+    guard let callee = apply.referencedFunction,
+      // Only specialize calls to OSSA functions
+      callee.hasOwnership,
+      let specialized = specializeCallee(apply: apply, context: context)
+    else {
+      continue
+    }
+
+    let callSiteSpecializer = CallSiteSpecializer(
+      apply: apply, specialized: specialized, context: context)
+    callSiteSpecializer.specialize()
+  }
+
+}
+
+//===----------------------------------------------------------------------===//
+// Call Site Specialization
+//===----------------------------------------------------------------------===//
+
+/// A context in which to modify call sites during pack specialization.
+private struct CallSiteSpecializer {
+  let apply: ApplyInst
+  let callee: PackExplodedFunction
+  let context: FunctionPassContext
+
+  /// Mapping from the indices of the indirect pack arguments of the original
+  /// function to an array of scalar pack indices, used to access their elements
+  typealias PackArgumentIndices = [Int: [ScalarPackIndexInst]]
+
+  init(apply: ApplyInst, specialized: PackExplodedFunction, context: FunctionPassContext) {
+    self.apply = apply
+    self.callee = specialized
+    self.context = context
+  }
+
+  /// Perform call-site specialization.
+  func specialize() {
+    let packArgumentIndices = self.createScalarPackIndices()
+
+    // Populate the arguments list with the appropriate set of indirect results and parameters
+    let results = self.collectNewIndirectResults(using: packArgumentIndices)
+    let parameters = self.collectNewParameters(
+      using: packArgumentIndices)
+
+    // Emit a call to the specialized function
+    let specializedApply = self.createSpecializedApply(arguments: results + parameters.arguments)
+
+    self.substituteNewDirectResults(from: specializedApply, using: packArgumentIndices)
+
+    // Both substituteNewDirectResults and createEndBorrows insert instructions
+    // immediately after specializedApply. We create the end_borrows last to
+    // minimise their borrow scopes.
+    self.createEndBorrows(for: parameters.borrows, after: specializedApply)
+
+    self.context.erase(instruction: self.apply)
+  }
+
+  /// Create indices to access elements of the pack arguments that will explode.
+  private func createScalarPackIndices() -> PackArgumentIndices {
+    let builder = Builder(before: self.apply, self.context)
+    // Create scalar pack indices for each pack argument's elements
+    var packArgumentIndices = PackArgumentIndices()
+    for (idx, argument) in self.apply.arguments.enumerated()
+        where argument.type.shouldExplode
+    {
+      var indices = [ScalarPackIndexInst]()
+      let packType = self.callee.packASTTypes[idx]!
+      for elementIdx in argument.type.packElements.indices {
+        indices.append(
+          builder.createScalarPackIndex(componentIndex: elementIdx, indexedPackType: packType))
+      }
+      packArgumentIndices[idx] = indices
+
+    }
+
+    return packArgumentIndices
+  }
+
+  /// Collect addresses to pass as indirect result arguments to the new function from
+  /// the original call site.
+  ///
+  /// Indirect results must be processed before generating the specialized call,
+  /// since they are passed as operands to the apply, while direct results must
+  /// be processed after generating the specialized call, since they are
+  /// extracted from its result value. See substituteNewDirectResults.
+  ///
+  /// Before: %fn : () -> (@pack_out Pack{C1, T2}, NP)
+  ///
+  /// %non_pack = apply %fn(%pack)
+  ///
+  /// After: %specialized_fn : () -> (@out C1, T2, NP)
+  ///
+  /// %c1_addr = pack_element_get 0 %pack
+  /// (%non_pack, %t2) = apply %specialized_fn(%c1_addr)
+  ///
+  private func collectNewIndirectResults(using packArgumentIndices: PackArgumentIndices)
+    -> [any Value]
+  {
+    let builder = Builder(before: self.apply, self.context)
+    var resultIterator = self.callee.resultMap.makeIterator()
+    var newResults = [any Value]()
+
+    for (index, resultOperand) in self.apply.indirectResultOperands.enumerated() {
+      let argument = resultOperand.value
+      if !argument.type.shouldExplode {
+        newResults.append(argument)
+        continue
+      }
+
+      let packIndices = packArgumentIndices[index]!
+      let mapped = resultIterator.next()!
+      assert(
+        mapped.argumentIndex == index,
+        "Iteration over mapped and apply-site indirect result packs is misaligned.")
+
+      for (packElementIdx, (resultInfo, packIdx)) in zip(mapped.expandedElements, packIndices).enumerated()
+          where resultInfo.isSILIndirect
+      {
+        let indirectResultAddress = builder.createPackElementGet(
+          packIndex: packIdx, pack: argument,
+          elementType: argument.type.packElements[packElementIdx])
+        newResults.append(indirectResultAddress)
+      }
+
+    }
+    return newResults
+  }
+
+  /// Collect values to pass as parameters to the new function from the original
+  /// call site. Also collect any borrows for @guaranteed parameters that need to
+  /// be released after the call.
+  ///
+  /// Non-pack parameters, and pack elements that map to indirect parameters,
+  /// are passed as addresses. Pack elements that map to direct parameters must
+  /// be loaded, if the original pack's elements were stored indirectly
+  /// (isPackElementAddress). We currently only attempt to eliminate indirect
+  /// packs (see TypeProperties.shouldExplode below), so these loads are always
+  /// generated.
+  ///
+  /// TODO: Update this pass to handle direct packs if they are ever generated
+  /// often enough to have a performance impact.
+  ///
+  /// Before: %fn : (@pack_owned Pack{C1, T2}, NP, @pack_guaranteed Pack{C3, T4}) -> ()
+  ///
+  /// %result = apply %fn(%pack1, %non_pack, %pack2)
+  ///
+  /// After: %specialized_fn : (@in C1, @owned T2, NP, @in_guaranteed C3, @guaranteed T4) -> ()
+  ///
+  /// %arg1addr = pack_element_get 0 %pack1
+  /// %arg2addr = pack_element_get 1 %pack1
+  /// %arg2 = load %arg2addr                 - arg2 is passed @owned or unowned
+  /// %arg3addr = pack_element_get 0 %pack2
+  /// %arg4addr = pack_element_get 1 %pack2
+  /// %arg4 = load_borrow %arg4addr          - arg4 is passed @guaranteed
+  ///
+  /// %new_result = apply %specialized_fn(%arg1addr, %arg2, %non_pack, %arg3addr, %arg4)
+  ///
+  private func collectNewParameters(using packArgumentIndices: PackArgumentIndices) -> (
+    arguments: [any Value], borrows: [LoadBorrowInst]
+  ) {
+    let builder = Builder(before: self.apply, self.context)
+
+    var parameterIterator = self.callee.parameterMap.makeIterator()
+    var newParameters = [any Value]()
+    var parameterBorrows = [LoadBorrowInst]()
+    for (index, argument) in self.apply.arguments.enumerated().dropFirst(
+      self.callee.original.argumentConventions.firstParameterIndex)
+    {
+
+      if !argument.type.shouldExplode {
+        newParameters.append(argument)
+        continue
+      }
+
+      let packIndices = packArgumentIndices[index]!
+      let mapped = parameterIterator.next()!
+      assert(
+        mapped.argumentIndex == index,
+        "Iteration over mapped and apply-site indirect parameter packs is misaligned.")
+
+      for (packElementIdx, (parameterInfo, packIdx)) in zip(mapped.expandedElements, packIndices)
+        .enumerated()
+      {
+        let indirectParameterAddress = builder.createPackElementGet(
+          packIndex: packIdx, pack: argument,
+          elementType: argument.type.packElements[packElementIdx])
+
+        switch parameterInfo.convention {
+        case .directUnowned:
+          newParameters.append(
+            builder.createLoad(
+              fromAddress: indirectParameterAddress,
+              ownership: loadOwnership(for: indirectParameterAddress, normal: .trivial)))
+        case .directGuaranteed:
+          let borrow = builder.createLoadBorrow(fromAddress: indirectParameterAddress)
+          newParameters.append(borrow)
+          parameterBorrows.append(borrow)
+        case .directOwned:
+          newParameters.append(
+            builder.createLoad(
+              fromAddress: indirectParameterAddress,
+              ownership: loadOwnership(for: indirectParameterAddress, normal: .take)))
+        case .indirectIn, .indirectInCXX, .indirectInGuaranteed, .indirectInout,
+          .indirectInoutAliasable:
+          newParameters.append(indirectParameterAddress)
+        case .packOut, .packInout, .packOwned, .packGuaranteed, .indirectOut:
+          preconditionFailure("Unsupported exploded parameter pack element convention.")
+        }
+      }
+
+    }
+
+    return (newParameters, parameterBorrows)
+  }
+
+  /// Create an application of the specialized function to the supplied arguments.
+  private func createSpecializedApply(arguments: [any Value]) -> ApplyInst {
+    let builder = Builder(before: self.apply, self.context)
+
+    // Emit a call to the specialized function
+    let specializedFunctionRef = builder.createFunctionRef(self.callee.specialized)
+    let specializedApply = builder.createApply(
+      function: specializedFunctionRef, self.apply.substitutionMap, arguments: arguments)
+    return specializedApply
+  }
+
+  /// Map the direct results of the specialized function back to the
+  /// corresponding indirect pack or direct results of the original function.
+  ///
+  /// If an element of an indirect result pack was mapped to a direct return
+  /// value, writeBack is used to write the value back to that original pack
+  /// element.
+  ///
+  /// Also collect the direct return values that correspond to those of the
+  /// original function, and use them to replace all uses of the original
+  /// result.
+  ///
+  /// The stack allocations and accesses for results can then be easily
+  /// eliminated by other passes.
+  private func substituteNewDirectResults(
+    from specializedApply: ApplyInst, using packArgumentIndices: PackArgumentIndices
+  ) {
+    if specializedApply.type == self.apply.type {
+      // No direct return values were added: we just need to replace the original result:
+      //
+      // Before: %fn : (...) -> Int
+      // %1 = apply %fn(...)
+      //
+      // After: %specialized_fn : (...) -> Int
+      // %1 = apply %specialized_fn(...)
+
+      self.apply.uses.replaceAll(with: specializedApply, self.context)
+
+    } else if !specializedApply.type.isTuple {
+      assert(
+        self.apply.type.isVoid,
+        "Pack specialized function has fewer direct return values than original function.")
+
+      // Write back the single direct result:
+      //
+      // Before: %fn : (...) -> @pack_out Pack{Int}
+      // %1 = apply %fn(%pack_addr, ...)
+      //
+      // After: %specialized_fn : (...) -> Int
+      // %result = apply %specialized_fn(...)
+      // %result_addr = pack_element_get 1 %pack_addr
+      // store %result to %result_addr
+
+      self.replaceOriginalResults(withResultsOf: specializedApply, using: packArgumentIndices)
+
+    } else {
+      // Write back multiple direct results:
+      //
+      // Before: %fn : () -> (Int, Int, @pack_out Pack{Int, Double})
+      //
+      // pack_element_set %addr to 0 of %result_pack
+      // ...
+      // %original_result = apply %fn(%result_pack)
+      //
+      // %value = load %addr
+      // operate %original_result
+      //
+      // After: %specialized_fn : () -> (Int, Int, Double)
+      //
+      // pack_element_set %addr to 0 of %result_pack
+      // ...
+      // %result = apply %specialized_fn()
+      // (%original1, %original2, %pack1, %pack2) = destructure_tuple %result  ╶┬──╴code inserted by substituteNewDirectResults
+      // %reconstructed_result = tuple (%original1, %original2)                ╶┘
+      // %addr = pack_element_get 0 of %result_pack                            ╶┬──╴code inserted by replaceOriginalResults
+      // store %result_value to %addr                                           │
+      // ... etc. for other pack elements                                      ╶┘
+      //
+      // %value = load %addr
+      // operate %reconstructed_result
+
+      let builder = Builder(after: specializedApply, self.context)
+      let destructuredTuple = builder.createDestructureTuple(tuple: specializedApply)
+
+      self.replaceOriginalResults(withResultsOf: destructuredTuple, using: packArgumentIndices)
+    }
+  }
+
+  /// Replace the results of the original callee that were mapped to direct
+  /// result values with the results of resultInstruction.
+  ///
+  /// See substituteNewDirectResults for code examples.
+  private func replaceOriginalResults(
+    withResultsOf resultInstruction: Instruction,
+    using packArgumentIndices: PackArgumentIndices
+  ) {
+    let builder = Builder(after: resultInstruction, self.context)
+
+    var directResults = resultInstruction.results.makeIterator()
+    var substitutedResultTupleElements = [any Value]()
+    var mappedResultPacks = self.callee.resultMap.makeIterator()
+
+    for resultInfo in self.apply.functionConvention.results {
+      // We only need to handle direct and pack results, since indirect results are handled above
+      if !resultInfo.isSILIndirect {
+        // Direct results of the original function are mapped to direct results of the specialized function.
+        substitutedResultTupleElements.append(directResults.next()!)
+
+      } else if resultInfo.type.shouldExplode {
+        // Some elements of pack results may get mapped to direct results of the specialized function.
+        // We handle those here.
+        let mapped = mappedResultPacks.next()!
+
+        let originalPackArgument = self.apply.arguments[mapped.argumentIndex]
+        let packIndices = packArgumentIndices[mapped.argumentIndex]!
+
+        for (mappedDirectResult, (packIndex, elementType)) in zip(
+          mapped.expandedElements, zip(packIndices, originalPackArgument.type.packElements)
+        )
+            where !mappedDirectResult.isSILIndirect
+        {
+
+          let result = directResults.next()!
+          let outputResultAddress = builder.createPackElementGet(
+            packIndex: packIndex, pack: originalPackArgument,
+            elementType: elementType)
+
+          builder.createStore(
+            source: result, destination: outputResultAddress,
+            // The callee is responsible for initializing return pack elements
+            ownership: storeOwnership(for: result, normal: .initialize))
+        }
+      }
+    }
+
+    // Replace all uses of the original apply's result, if necessary.
+    if !self.apply.uses.isEmpty {
+      // Since there could be many uses of the original apply's result tuple, we
+      // construct a new one with the corresponding values from specializedApply.
+      // If exactly one direct result was mapped, don't generate a tuple.
+      if substitutedResultTupleElements.count == 1 {
+        self.apply.uses.replaceAll(with: substitutedResultTupleElements[0], self.context)
+      } else {
+        let substitutedResultTuple = builder.createTuple(
+          type: self.apply.type, elements: substitutedResultTupleElements)
+        self.apply.uses.replaceAll(with: substitutedResultTuple, self.context)
+      }
+    }
+  }
+
+  /// Release borrows of parameters that were passed as @guaranteed.
+  private func createEndBorrows(for borrows: [LoadBorrowInst], after: Instruction) {
+    let builder = Builder(after: after, self.context)
+
+    // Release any borrows that were created to pass parameters
+    for borrow in borrows {
+      builder.createEndBorrow(of: borrow)
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Callee Specialization
+//===----------------------------------------------------------------------===//
+
+private func specializeCallee(apply: ApplySite, context: FunctionPassContext)
+  -> PackExplodedFunction?
+{
+  // Only perform pack specialization when the callee has pack arguments
+  guard let callee = apply.referencedFunction,
+    callee.isDefinition,
+    callee.argumentTypes.contains(where: { $0.shouldExplode })
+  else {
+    return nil
+  }
+
+  let exploded = PackExplodedFunction(from: callee, context)
+
+  return exploded
+}
+
+/// Given a function with parameter pack arguments that can be eliminated (or
+/// "exploded"), this struct constructs a specialized version of that function,
+/// with each such argument split into individual parameters or results for each
+/// member of each pack.
+///
+/// It also produces a mapping between the results and parameters of the
+/// original and specialized functions, allowing calls to one to be replaced
+/// with calls to the other, while retaining the same behaviour.
+///
+/// Whether a pack argument can be eliminated is determined using the
+/// TypeProperties.shouldExplode computed property (see below).
+///
+/// For each pack argument of the original function, a corresponding pack is
+/// allocated on the stack at the start of the specialized function. Each
+/// parameter of the specialized function is stored at its corresponding element
+/// of the appropriate local pack.
+///
+/// Most packs store the addresses of their elements. For pack elements that are
+/// mapped to direct arguments, we allocate a stack location, store the value in
+/// it, and store its address in the appropriate local pack.
+///
+/// For result pack elements that are mapped to direct result values, we
+/// similarly store the address of a dedicated stack location in the
+/// corresponding local pack. We can then load the value from that stack
+/// location at the end of the function to return it.
+///
+/// Original:
+///
+/// sil [ossa] @double_up : $@convention(thin) (@pack_guaranteed Pack{Int, String}) -> (@pack_out Pack{Int, String}, @pack_out Pack{Int, String}) {
+/// bb0(%0 : $*Pack{Int, String}, %1 : $*Pack{Int, String}, %2 : $*Pack{Int, String}):
+///   debug_value %2, let, name "xs", argno 1, expr op_deref
+///   ...
+///
+/// Modified:
+///
+/// sil shared [ossa] @double_upTf8xxx_n : $@convention(thin) (Int, @guaranteed String) -> (Int, @owned String, Int, @owned String) {
+/// bb0(%0 : $Int, %1 : @guaranteed $String):
+///   %2 = alloc_pack $Pack{Int, String}
+///   %3 = scalar_pack_index 0 of $Pack{Int, String}
+///   %4 = alloc_stack $Int
+///   store %0 to [trivial] %4
+///   pack_element_set %4 into %3 of %2
+///   %7 = scalar_pack_index 1 of $Pack{Int, String}
+///   %8 = alloc_stack $String
+///   %9 = copy_value %1
+///   store %9 to [init] %8
+///   pack_element_set %8 into %7 of %2
+///
+///   ... etc. for indirect result arguments of original function (%0 and %1)
+///
+///   debug_value %2, let, name "xs", argno 1, expr op_deref
+///   ...
+///
+private struct PackExplodedFunction {
+  public let original: Function
+  public let specialized: Function
+
+  /// Represents the set of results of the new function corresponding to the
+  /// pack argument of the original function at the given index, in ascending
+  /// order.
+  struct MappedResult {
+    /// Index of the indirect pack argument of the original function for this result.
+    let argumentIndex: Int
+    /// Index of this pack in the function's result type tuple.
+    /// For a non-tuple result, this is 0.
+    let resultIndex: Int
+    let expandedElements: [ResultInfo]
+  }
+
+  typealias ResultMap = [MappedResult]
+  public let resultMap: ResultMap
+
+  /// Represents the set of parameters of the new function corresponding to the
+  /// pack argument of the original function at the given index, in ascending
+  /// order.
+  struct MappedParameter {
+    let argumentIndex: Int
+    let expandedElements: [ParameterInfo]
+  }
+
+  typealias ParameterMap = [MappedParameter]
+  public let parameterMap: ParameterMap
+
+  /// Maps indices of pack arguments of the original function to its
+  /// `approximateFormalPackType` (a Canonical AST PackType).
+  /// Saves recomputing these types every time they are needed,
+  /// which would be unnecessarily expensive.
+  public let packASTTypes: [Int: CanonicalType]
+
+  init(from original: Function, _ context: FunctionPassContext) {
+
+    self.original = original
+
+    var packASTTypes = [Int: CanonicalType]()
+    for (i, argument) in original.arguments.enumerated()
+        where argument.type.shouldExplode
+    {
+      packASTTypes[i] = argument.type.approximateFormalPackType
+    }
+    self.packASTTypes = packASTTypes
+
+    let (newParameters, parameterMap) = PackExplodedFunction.computeParameters(for: original)
+
+    self.parameterMap = parameterMap
+
+    let (newResults, resultMap) = PackExplodedFunction.computeResults(for: original)
+    self.resultMap = resultMap
+
+    let packArgIndices: [Int] = original.arguments.filter { $0.type.shouldExplode }.map { $0.index }
+    let specializedName = context.mangle(withExplodedPackArguments: packArgIndices, from: original)
+    if let existingFunction = context.lookupFunction(name: specializedName) {
+      specialized = existingFunction
+    } else {
+
+      specialized = context.createSpecializedFunctionDeclaration(
+        from: original,
+        withName: specializedName,
+        withParams: newParameters,
+        withResults: newResults,
+        // If a method has a dynamic self parameter, it cannot be converted into a thin function (non-method).
+        makeThin: !original.mayBindDynamicSelf)
+
+      self.buildSpecializedFunction(context)
+    }
+  }
+
+  // Internal data structures used while building the specialized function.
+
+  /// A collection of local values used to associate an argument of the
+  /// specialized function with its corresponding pack element.
+  private struct ExplodedArgument {
+    /// The index of this element within its original pack.
+    public let packIdx: ScalarPackIndexInst
+
+    enum ConventionResources {
+      case indirect
+      case direct(AllocStackInst)
+      case directGuaranteed(AllocStackInst, StoreBorrowInst)
+    }
+
+    /// The local resources associated with the argument that must be cleaned
+    /// up, determined by its argument convention.
+    public let resources: ConventionResources
+  }
+
+  /// Information about the local pack created to replace a pack parameter in
+  /// the specialized function.
+  private struct ArgumentMapping {
+    public let allocPack: AllocPackInst
+    public let arguments: [ExplodedArgument]
+  }
+
+  /// A mapping from the indices of pack arguments of the original function to
+  /// their corresponding local packs in the specialized function.
+  private typealias ArgumentMap = [Int: ArgumentMapping]
+
+  /// Compute the parameter types for the pack-exploded version of a function,
+  /// and the mapping between the original function's pack parameters, and the
+  /// corresponding exploded parameters of the new function.
+  fileprivate static func computeParameters(for function: Function) -> (
+    parameters: [ParameterInfo], mapping: ParameterMap
+  ) {
+    var newParameters = [ParameterInfo]()
+    var parameterMap = ParameterMap()
+
+    for (argument, parameterInfo) in zip(function.parameters, function.convention.parameters) {
+      if argument.type.shouldExplode {
+
+        let mappedParameterInfos = argument.type.packElements.map { element in
+          ParameterInfo(
+            type: element.canonicalType,
+            convention: explodedPackElementArgumentConvention(
+              pack: parameterInfo, type: element, in: function),
+            options: parameterInfo.options,
+            hasLoweredAddresses: parameterInfo.hasLoweredAddresses)
+        }
+
+        parameterMap.append(MappedParameter(argumentIndex: argument.index, expandedElements: mappedParameterInfos))
+        newParameters += mappedParameterInfos
+
+      } else {
+        // Leave the original argument unchanged
+        newParameters.append(parameterInfo)
+      }
+    }
+
+    return (newParameters, parameterMap)
+  }
+
+  /// Compute the result types for the pack-exploded version of a function, and
+  /// the mapping between the original function's pack results, and the
+  /// corresponding exploded results of the new function.
+  private static func computeResults(for function: Function) -> (
+    results: [ResultInfo], mapping: ResultMap
+  ) {
+    var resultMap = ResultMap()
+    var newResults = [ResultInfo]()
+
+    var indirectResultIdx = 0
+    for (resultIndex, resultInfo) in function.convention.results.enumerated() {
+      let silType = resultInfo.type.loweredType(in: function)
+      if silType.shouldExplode {
+        let mappedResultInfos = silType.packElements.map { elem in
+          // TODO: Determine correct values for options and hasLoweredAddress
+          ResultInfo(
+            type: elem.canonicalType,
+            convention: explodedPackElementResultConvention(in: function, type: elem),
+            options: resultInfo.options,
+            hasLoweredAddresses: resultInfo.hasLoweredAddresses)
+        }
+
+        resultMap.append(
+          MappedResult(
+            argumentIndex: indirectResultIdx, resultIndex: resultIndex,
+            expandedElements: mappedResultInfos))
+        newResults += mappedResultInfos
+      } else {
+        // Leave the original result unchanged
+        newResults.append(resultInfo)
+      }
+
+      if resultInfo.isSILIndirect {
+        indirectResultIdx += 1
+      }
+    }
+
+    assert(
+      indirectResultIdx == function.argumentConventions.firstParameterIndex,
+      "We should have walked through all the indirect results, and no further.")
+
+    return (newResults, resultMap)
+  }
+
+  /// Build the body of the pack-specialized function.
+  private func buildSpecializedFunction(_ context: FunctionPassContext) {
+
+    context.buildSpecializedFunction(specializedFunction: specialized) {
+      (specialized, specContext) in
+      cloneFunction(from: original, toEmpty: specialized, specContext)
+
+      let argumentMap = explodePackArguments(from: original, to: specialized, specContext)
+
+      // Modify the return block to extract and return the necessary direct
+      // return values from their local stack allocations, if necessary. This is
+      // only necessary if any pack result elements were mapped to direct
+      // results, and the function contains at least one return statement.
+      if resultMap.contains(where: {
+        $0.expandedElements.contains(where: { !$0.isSILIndirect })
+      }) {
+        if let originalReturnStatement = specialized.returnInstruction {
+          self.createExplodedReturn(
+            replacing: originalReturnStatement, argumentMap: argumentMap, specContext)
+        }
+      }
+
+      // Emit cleanup code at all exit points of the function.
+      for bb in specialized.blocks
+          where bb.terminator.isFunctionExiting
+      {
+        self.createCleanup(before: bb.terminator, argumentMap: argumentMap, specContext)
+      }
+    }
+
+    context.notifyNewFunction(function: specialized, derivedFrom: original)
+  }
+
+  /// Replace the original return statement with one that returns all the
+  /// original result values, as well as the direct results corresponding to
+  /// indirect pack results in the original function.
+  ///
+  /// Care is taken to thread the original and new results together in an order
+  /// that matches the original function:
+  ///
+  /// Before: () -> (Int, @pack_out Pack{Double, Int}, Double)
+  ///
+  /// pack_element_set 0 of %out_pack to %pack_double
+  /// pack_element_set 1 of %out_pack to %pack_int
+  ///
+  /// return (%int, %double)
+  ///
+  /// After: () -> (Int, Double, Int, Double)
+  ///
+  /// return (%int, %pack_double, %pack_int, %double)
+  ///
+  private func createExplodedReturn(
+    replacing originalReturn: ReturnInst, argumentMap: ArgumentMap, _ context: FunctionPassContext
+  ) {
+    let builder = Builder(
+      before: originalReturn, location: originalReturn.location.asCleanup, context)
+
+    let originalValue = originalReturn.returnedValue
+
+    let originalReturnTupleElements: [Value]
+    if originalValue.type.isTuple {
+      originalReturnTupleElements = [Value](
+        builder.createDestructureTuple(tuple: originalValue).results)
+    } else {
+      originalReturnTupleElements = [originalValue]
+    }
+
+    var returnValues = [any Value]()
+
+    // Thread together the original and exploded direct return values.
+    var resultMapIndex = 0
+    var originalReturnIndex = 0
+    for (i, originalResult) in self.original.convention.results.enumerated()
+        where originalResult.type.shouldExplode
+                || !originalResult.isSILIndirect
+    {
+      if !resultMap.indices.contains(resultMapIndex) || resultMap[resultMapIndex].resultIndex != i {
+        returnValues.append(originalReturnTupleElements[originalReturnIndex])
+        originalReturnIndex += 1
+
+      } else {
+
+        let mapped = resultMap[resultMapIndex]
+
+        let argumentMapping = argumentMap[mapped.argumentIndex]!
+        for argument in argumentMapping.arguments {
+
+          switch argument.resources {
+          case .indirect:
+            break
+          case .direct(let allocStack):
+            returnValues.append(
+              builder.createLoad(
+                fromAddress: allocStack,
+                ownership: loadOwnership(for: allocStack, normal: .take))
+            )
+          case .directGuaranteed(_, _):
+            preconditionFailure(
+              "A pack-exploded result value has an associated store_borrow, but there should be no initial value to borrow."
+            )
+          }
+        }
+
+        resultMapIndex += 1
+      }
+    }
+
+    // Return the single value directly, rather than constructing a single-element tuple for it.
+    if returnValues.count == 1 {
+      builder.createReturn(of: returnValues[0])
+    } else {
+      let tupleElementTypes = returnValues.map { $0.type }
+      let tupleType = context.getTupleType(elements: tupleElementTypes).loweredType(
+        in: specialized)
+      let tuple = builder.createTuple(type: tupleType, elements: returnValues)
+      builder.createReturn(of: tuple)
+    }
+
+    context.erase(instruction: originalReturn)
+  }
+
+  /// Create a local stack-allocated pack to replace the argument at the given
+  /// index. We pass the builder so the order of inserted instructions (notably
+  /// stack allocations) is more predictable.
+  private func prepareExplosion(
+    in function: Function, at index: Int, builder: Builder, _ context: FunctionPassContext
+  ) -> (AllocPackInst, Type) {
+    let entryBlock = function.entryBlock
+
+    let originalPackArg = entryBlock.arguments[index]
+    let packType = originalPackArg.type.objectType
+
+    let localPack = builder.createAllocPack(packType)
+    originalPackArg.uses.replaceAll(with: localPack, context)
+
+    entryBlock.eraseArgument(at: index, context)
+
+    return (localPack, packType)
+  }
+
+  /// Explode the types of the entry block's pack arguments, and track the
+  /// correspondence between exploded arguments and local packs.
+  private func explodePackArguments(
+    from original: Function, to specialized: Function, _ context: FunctionPassContext
+  ) -> ArgumentMap {
+
+    let entryBlock = specialized.entryBlock
+    let builder = Builder(atBeginOf: entryBlock, context)
+
+    var argumentMap = ArgumentMap()
+
+    // Explode the arguments in reverse order. This ensures that the index of
+    // each argument is not affected by other arguments exploding before it has
+    // been processed. Parameters come after results, so we explode them first.
+
+    // Explode parameters.
+    for mapped in parameterMap.reversed() {
+
+      let (localPack, packType) = prepareExplosion(
+        in: specialized, at: mapped.argumentIndex, builder: builder, context)
+
+      var mappings = [ExplodedArgument]()
+      for (i, (type, parameterInfo)) in zip(packType.packElements, mapped.expandedElements)
+        .enumerated()
+      {
+        let packIdx = builder.createScalarPackIndex(
+          componentIndex: i, indexedPackType: self.packASTTypes[mapped.argumentIndex]!)
+        let argument = entryBlock.insertFunctionArgument(
+          atPosition: mapped.argumentIndex + i,
+          type: parameterInfo.isSILIndirect ? type.addressType : type,
+          ownership: Ownership(in: specialized, of: type, with: parameterInfo.convention),
+          context)
+
+        let address: Value
+        let resources: ExplodedArgument.ConventionResources
+        if parameterInfo.isSILIndirect {
+          builder.createPackElementSet(elementValue: argument, packIndex: packIdx, pack: localPack)
+          resources = .indirect
+        } else {
+          let alloc = builder.createAllocStack(type)
+
+          if parameterInfo.convention == .directGuaranteed {
+            // We do not own @guaranteed arguments, so we must use store_borrow instead of store.
+            let storeBorrow = builder.createStoreBorrow(source: argument, destination: alloc)
+            address = storeBorrow
+            resources = .directGuaranteed(alloc, storeBorrow)
+          } else {
+            let ownership = storeOwnership(for: argument, normal: .initialize)
+            builder.createStore(
+              source: argument, destination: alloc,
+              ownership: ownership)
+            address = alloc
+            resources = .direct(alloc)
+          }
+          builder.createPackElementSet(elementValue: address, packIndex: packIdx, pack: localPack)
+        }
+
+        mappings.append(
+          ExplodedArgument(packIdx: packIdx, resources: resources))
+
+      }
+      argumentMap[mapped.argumentIndex] = ArgumentMapping(allocPack: localPack, arguments: mappings)
+    }
+
+    // Explode results.
+    for mapped in resultMap.reversed() {
+
+      let (localPack, packType) = prepareExplosion(
+        in: specialized, at: mapped.argumentIndex, builder: builder, context)
+
+      var mappings = [ExplodedArgument]()
+      var insertArgumentPosition = mapped.argumentIndex
+      for (i, (type, resultInfo)) in zip(packType.packElements, mapped.expandedElements)
+        .enumerated()
+      {
+        let packIdx = builder.createScalarPackIndex(
+          componentIndex: i, indexedPackType: self.packASTTypes[mapped.argumentIndex]!)
+
+        let resources: ExplodedArgument.ConventionResources
+        if resultInfo.isSILIndirect {
+          // We only insert arguments for results that must be returned indirectly, so always use the addressType.
+          let argument = entryBlock.insertFunctionArgument(
+            atPosition: insertArgumentPosition, type: type.addressType,
+            ownership: Ownership(
+              in: specialized,
+              of: type, with: ArgumentConvention(result: resultInfo.convention)),
+            context)
+          builder.createPackElementSet(elementValue: argument, packIndex: packIdx, pack: localPack)
+          resources = .indirect
+          insertArgumentPosition += 1
+        } else {
+          // It is the callee's responsibility to initialize indirect results,
+          // so the original function body already does this.
+          // We do not need to initialize here.
+          let alloc = builder.createAllocStack(type)
+          builder.createPackElementSet(elementValue: alloc, packIndex: packIdx, pack: localPack)
+          resources = .direct(alloc)
+        }
+
+        // Results have no initial value that could need to be borrowed.
+        mappings.append(
+          ExplodedArgument(packIdx: packIdx, resources: resources))
+
+      }
+      argumentMap[mapped.argumentIndex] = ArgumentMapping(allocPack: localPack, arguments: mappings)
+
+    }
+
+    return argumentMap
+  }
+
+  /// Clean up locals, most notably alloc_packs, created as part of pack specialization.
+  private func createCleanup(
+    before terminator: TermInst, argumentMap: ArgumentMap, _ context: FunctionPassContext
+  ) {
+
+    let builder = Builder(before: terminator, location: terminator.location.asCleanup, context)
+
+    let createDeallocations = { (idx: Int) in
+      let mapped = argumentMap[idx]!
+      for argument in mapped.arguments.reversed() {
+        switch argument.resources {
+        case .indirect:
+          break
+        case .direct(let allocStack):
+          builder.createDeallocStack(allocStack)
+        case .directGuaranteed(let allocStack, let storeBorrow):
+          builder.createEndBorrow(of: storeBorrow)
+          builder.createDeallocStack(allocStack)
+        }
+      }
+      builder.createDeallocPack(argumentMap[idx]!.allocPack)
+    }
+
+    // Emit dealloc_packs in the opposite order to the alloc_packs. Since
+    // alloc_packs are created while iterating backwards over the arguments,
+    // iterate forwards.
+    for mapped in resultMap {
+      createDeallocations(mapped.argumentIndex)
+    }
+    for mapped in parameterMap {
+      createDeallocations(mapped.argumentIndex)
+    }
+  }
+}
+
+/// Compute the appropriate argument convention for an exploded member of the given pack parameter with the given type, in the given function
+private func explodedPackElementArgumentConvention(
+  pack: ParameterInfo, type: Type, in function: Function
+)
+  -> ArgumentConvention
+{
+  // If the pack element type is loadable, then we can pass it directly in the generated function.
+  // TODO: Account for pack.type.isPackElementAddress with packOwned and packGuaranteed packs
+  let trivial = type.isTrivial(in: function)
+  let loadable = type.isLoadable(in: function)
+
+  switch pack.convention {
+  case .packGuaranteed:
+    if trivial {
+      return .directUnowned
+    } else if loadable {
+      return .directGuaranteed
+    } else {
+      return .indirectInGuaranteed
+    }
+  case .packOwned:
+    if trivial {
+      return .directUnowned
+    } else if loadable {
+      return .directOwned
+    } else {
+      return .indirectIn
+    }
+  case .packInout:
+    return .indirectInout
+  default:
+    preconditionFailure()
+  }
+}
+
+/// Compute the appropriate argument convention for an exploded member of the
+/// given indirect result pack argument with the given result pack. For a
+/// return, the convention has to be packOut, so we know its elements are passed
+/// indirectly.
+private func explodedPackElementResultConvention(in function: Function, type: Type)
+  -> ResultConvention
+{
+  // If the pack element type is loadable, then we can return it directly
+  if type.isTrivial(in: function) {
+    return .unowned
+  } else if type.isLoadable(in: function) {
+    return .owned
+  } else {
+    return .indirect
+  }
+}
+
+private func storeOwnership(for value: any Value, normal: StoreInst.StoreOwnership)
+  -> StoreInst.StoreOwnership
+{
+  let function = value.parentFunction
+  if value.type.isTrivial(in: function) {
+    return .trivial
+  } else {
+    return normal
+  }
+}
+
+private func loadOwnership(for value: any Value, normal: LoadInst.LoadOwnership)
+  -> LoadInst.LoadOwnership
+{
+  let function = value.parentFunction
+  if value.type.isTrivial(in: function) {
+    return .trivial
+  } else {
+    return normal
+  }
+}
+
+extension TypeProperties {
+  /// A pack argument can explode if it contains no pack expansion types
+  fileprivate var shouldExplode: Bool {
+    // For now, we only attempt to explode indirect packs, since these are the most common and inefficient.
+    return isSILPack && !containsSILPackExpansionType && isSILPackElementAddress
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -108,6 +108,7 @@ private func registerSwiftPasses() {
   registerPass(closureSpecialization, { closureSpecialization.run($0) })
   registerPass(autodiffClosureSpecialization, { autodiffClosureSpecialization.run($0) })
   registerPass(loopInvariantCodeMotionPass, { loopInvariantCodeMotionPass.run($0) })
+  registerPass(packSpecialization, { packSpecialization.run($0) })
 
   // Instruction passes
   registerForSILCombine(BeginBorrowInst.self,      { run(BeginBorrowInst.self, $0) })

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -248,10 +248,31 @@ public struct Builder {
     return notifyNew(allocStack.getAs(AllocStackInst.self))
   }
 
+  public func createAllocPack(_ packType: Type) -> AllocPackInst {
+    let allocPack = bridged.createAllocPack(packType.bridged)
+    return notifyNew(allocPack.getAs(AllocPackInst.self))
+  }
+
+  public func createAllocPackMetadata() -> AllocPackMetadataInst {
+    let allocPackMetadata = bridged.createAllocPackMetadata()
+    return notifyNew(allocPackMetadata.getAs(AllocPackMetadataInst.self))
+  }
+
+  public func createAllocPackMetadata(_ packType: Type) -> AllocPackMetadataInst {
+    let allocPackMetadata = bridged.createAllocPackMetadata(packType.bridged)
+    return notifyNew(allocPackMetadata.getAs(AllocPackMetadataInst.self))
+  }
+
   @discardableResult
   public func createDeallocStack(_ operand: Value) -> DeallocStackInst {
     let dr = bridged.createDeallocStack(operand.bridged)
     return notifyNew(dr.getAs(DeallocStackInst.self))
+  }
+
+  @discardableResult
+  public func createDeallocPack(_ operand: Value) -> DeallocPackInst {
+    let dr = bridged.createDeallocPack(operand.bridged)
+    return notifyNew(dr.getAs(DeallocPackInst.self))
   }
 
   @discardableResult
@@ -689,6 +710,11 @@ public struct Builder {
     return notifyNew(store.getAs(StoreInst.self))
   }
 
+  public func createStoreBorrow(source: Value, destination: Value) -> StoreBorrowInst {
+    let storeBorrow = bridged.createStoreBorrow(source.bridged, destination.bridged)
+    return notifyNew(storeBorrow.getAs(StoreBorrowInst.self))
+  }
+
   public func createInitExistentialRef(instance: Value,
                                        existentialType: Type,
                                        formalConcreteType: CanonicalType,
@@ -711,6 +737,22 @@ public struct Builder {
                                                    BridgedConformanceArray(pcArray: $0))
     }
     return notifyNew(initExistential.getAs(InitExistentialMetatypeInst.self))
+  }
+
+  public func createScalarPackIndex(componentIndex: Int, indexedPackType: CanonicalType) -> ScalarPackIndexInst {
+    let scalarPackIndex = bridged.createScalarPackIndex(SwiftInt(componentIndex), indexedPackType.bridged)
+    return notifyNew(scalarPackIndex.getAs(ScalarPackIndexInst.self))
+  }
+
+  public func createPackElementGet(packIndex: Value, pack: Value, elementType: Type) -> PackElementGetInst {
+    let packElementGet = bridged.createPackElementGet(packIndex.bridged, pack.bridged, elementType.bridged)
+    return notifyNew(packElementGet.getAs(PackElementGetInst.self))
+  }
+
+  @discardableResult
+  public func createPackElementSet(elementValue: Value, packIndex: Value, pack: Value) -> PackElementSetInst {
+    let packElementSet = bridged.createPackElementSet(elementValue.bridged, packIndex.bridged, pack.bridged)
+    return notifyNew(packElementSet.getAs(PackElementSetInst.self))
   }
 
   public func createMetatype(

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -140,9 +140,23 @@ public struct ResultInfo : CustomStringConvertible {
   /// calling convention of the parameter.
   ///
   /// TODO: For most purposes, you probably want \c returnValueType.
-  public let type: BridgedASTType
+  public let type: CanonicalType
   public let convention: ResultConvention
+  public let options: UInt8
   public let hasLoweredAddresses: Bool
+
+  // Must be kept consistent with 'SILResultInfo::Flag'
+  public enum Flag : UInt8 {
+    case notDifferentiable = 0x1
+    case isSending = 0x2
+  };
+
+  public init(type: CanonicalType, convention: ResultConvention, options: UInt8, hasLoweredAddresses: Bool) {
+    self.type = type
+    self.convention = convention
+    self.options = options
+    self.hasLoweredAddresses = hasLoweredAddresses
+  }
 
   /// Is this result returned indirectly in SIL? Most formally
   /// indirect results can be returned directly in SIL. This depends
@@ -150,7 +164,7 @@ public struct ResultInfo : CustomStringConvertible {
   public var isSILIndirect: Bool {
     switch convention {
     case .indirect:
-      return hasLoweredAddresses || type.isExistentialArchetypeWithError()
+      return hasLoweredAddresses || type.isExistentialArchetypeWithError
     case .pack:
       return true
     case .owned, .unowned, .unownedInnerPointer, .autoreleased, .guaranteed, .guaranteedAddress, .inout:
@@ -159,8 +173,11 @@ public struct ResultInfo : CustomStringConvertible {
   }
 
   public var description: String {
-    convention.description + ": "
-    + String(taking: type.getDebugDescription())
+    convention.description + ": " + type.description
+  }
+
+  public func getReturnValueType(function: Function) -> CanonicalType {
+    CanonicalType(bridged: self._bridged.getReturnValueType(function.bridged))
   }
 }
 
@@ -233,6 +250,10 @@ public struct ParameterInfo : CustomStringConvertible {
   
   public func hasOption(_ flag: Flag) -> Bool {
     return options & flag.rawValue != 0
+  }
+
+  public func getArgumentType(function: Function) -> CanonicalType {
+    CanonicalType(bridged: self._bridged.getArgumentType(function.bridged))
   }
 }
 
@@ -443,17 +464,22 @@ public enum ResultConvention : CustomStringConvertible {
 
 extension ResultInfo {
   init(bridged: BridgedResultInfo, hasLoweredAddresses: Bool) {
-    self.type = BridgedASTType(type: bridged.type)
+    self.type = CanonicalType(bridged: bridged.type)
     self.convention = ResultConvention(bridged: bridged.convention)
     self.hasLoweredAddresses = hasLoweredAddresses
+    self.options = bridged.options
   }
   init?(bridged: OptionalBridgedResultInfo, hasLoweredAddresses: Bool) {
-    guard let t = bridged.type else {
+    if bridged.type.getRawType().type == nil {
       return nil
     }
-    self.type = BridgedASTType(type: t)
+    self.type = CanonicalType(bridged: bridged.type)
     self.convention = ResultConvention(bridged: bridged.convention)
     self.hasLoweredAddresses = hasLoweredAddresses
+    self.options = bridged.options
+  }
+  public var _bridged: BridgedResultInfo {
+    BridgedResultInfo(type.bridged, convention.bridged, options)
   }
 }
 
@@ -471,6 +497,20 @@ extension ResultConvention {
       case .Inout:               self = .inout
       default:
         fatalError("unsupported result convention")
+    }
+  }
+
+  var bridged: BridgedResultConvention {
+    switch self {
+    case .indirect:            return .Indirect
+    case .owned:               return .Owned
+    case .unowned:             return .Unowned
+    case .unownedInnerPointer: return .UnownedInnerPointer
+    case .autoreleased:        return .Autoreleased
+    case .pack:                return .Pack
+    case .guaranteed:          return .Guaranteed
+    case .guaranteedAddress:   return .GuaranteedAddress
+    case .inout:               return .Inout
     }
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -113,6 +113,11 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     .init(bridgedOrNil: bridged.getRawLayoutSubstitutedCountType())
   }
 
+  public var approximateFormalPackType: CanonicalType {
+    precondition(isSILPack);
+    return CanonicalType(bridged: bridged.getApproximateFormalPackType());
+  }
+
   //===--------------------------------------------------------------------===//
   //                Properties of lowered `SILFunctionType`s
   //===--------------------------------------------------------------------===//
@@ -159,6 +164,11 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
   public func getBoxFields(in function: Function) -> BoxFieldsArray {
     precondition(isBox)
     return BoxFieldsArray(boxType: canonicalType, function: function)
+  }
+
+  public var packElements: PackElementArray {
+    precondition(isSILPack)
+    return PackElementArray(type: self)
   }
 
   /// Returns nil if the nominal is a resilient type because in this case the complete list
@@ -319,6 +329,17 @@ public struct BoxFieldsArray : RandomAccessCollection, FormattedLikeArray {
 
   public func isMutable(fieldIndex: Int) -> Bool {
     BridgedType.getBoxFieldIsMutable(boxType.bridged, fieldIndex)
+  }
+}
+
+public struct PackElementArray : RandomAccessCollection, FormattedLikeArray {
+  fileprivate let type: Type
+
+  public var startIndex: Int { return 0 }
+  public var endIndex: Int { Int(type.bridged.getNumPackElements()) }
+
+  public subscript(_ index: Int) -> Type {
+    type.bridged.getPackElementType(index).type
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -101,6 +101,10 @@ public enum Ownership {
     }
   }
 
+  public init(in function: Function, of type: Type, with convention: ArgumentConvention) {
+    self = Ownership(bridged: BridgedValueOwnership_init(function.bridged, type.bridged, convention.bridged))
+  }
+
   public var _bridged: BridgedValue.Ownership {
     switch self {
       case .unowned:    return BridgedValue.Ownership.Unowned

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -139,6 +139,7 @@ set(SWIFT_BENCH_MODULES
     single-source/ObserverUnappliedMethod
     single-source/OpaqueConsumingUsers
     single-source/OpenClose
+    single-source/ParameterPacks
     single-source/Phonebook
     single-source/PointerArithmetics
     single-source/PolymorphicCalls

--- a/benchmark/single-source/ParameterPacks.swift
+++ b/benchmark/single-source/ParameterPacks.swift
@@ -1,0 +1,53 @@
+//===--- ParameterPacks.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This benchmark serves to test the overhead of
+
+import TestsUtils
+
+public let benchmarks = [
+  BenchmarkInfo(
+    name: "ParameterPacks.VariadicFibonacci",
+    runFunction: run_ParameterPacksVariadicFibonacci,
+    tags: [.validation])
+]
+
+@inline(never)
+func numericLoop<each T: BinaryInteger>(xs: repeat each T) -> (repeat each T) {
+  return
+    (repeat { x in
+      // Recursive "Fibonacci" function prevents inlining
+      if x <= 1 {
+        return x
+      } else {
+        let (a, b) = numericLoop(xs: x - 1, x - 2)
+        return a + b
+      }
+    }(each xs)
+
+  )
+}
+
+let expectedResult = (610, 987, 1597)
+
+@inline(never)
+public func run_ParameterPacksVariadicFibonacci(_ n: Int) {
+  var result = (0, 0, 0)
+  for _ in 1...n {
+    result = numericLoop(xs: 15, 16, 17)
+    if result != expectedResult {
+      break
+    }
+  }
+
+  check(result == expectedResult)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -143,6 +143,7 @@ import ObserverPartiallyAppliedMethod
 import ObserverUnappliedMethod
 import OpaqueConsumingUsers
 import OpenClose
+import ParameterPacks
 import Phonebook
 import PointerArithmetics
 import PolymorphicCalls
@@ -343,6 +344,7 @@ register(ObserverPartiallyAppliedMethod.benchmarks)
 register(ObserverUnappliedMethod.benchmarks)
 register(OpaqueConsumingUsers.benchmarks)
 register(OpenClose.benchmarks)
+register(ParameterPacks.benchmarks)
 register(Phonebook.benchmarks)
 register(PointerArithmetics.benchmarks)
 register(PolymorphicCalls.benchmarks)

--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -1360,6 +1360,7 @@ Some kinds need arguments, which precede ``Tf``.
   PASSID ::= '5'                             // GenericSpecializer,
   PASSID ::= '6'                             // MoveDiagnosticInOutToOut,
   PASSID ::= '7'                             // AsyncDemotion,
+  PASSID ::= '8'                             // PackSpecialization,
 
   FRAGILE ::= 'q'
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2959,6 +2959,8 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isBuiltinVector() const;
   BRIDGED_INLINE bool isBuiltinFixedArray() const;
   BRIDGED_INLINE bool isBox() const;
+  BRIDGED_INLINE bool isPack() const;
+  BRIDGED_INLINE bool isSILPack() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getBuiltinVectorElementType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getBuiltinFixedArrayElementType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getBuiltinFixedArraySizeType() const;
@@ -2982,7 +2984,9 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getInvocationGenericSignatureOfFunctionType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedSubstitutionMap substMap) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;  
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;
+  BRIDGED_INLINE bool containsSILPackExpansionType() const;
+  BRIDGED_INLINE bool isSILPackElementAddress() const;
 };
 
 class BridgedCanType {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -536,6 +536,14 @@ bool BridgedASTType::isBox() const {
   return unbridged()->is<swift::SILBoxType>();
 }
 
+bool BridgedASTType::isPack() const {
+  return unbridged()->is<swift::PackType>();
+}
+
+bool BridgedASTType::isSILPack() const {
+  return unbridged()->is<swift::SILPackType>();
+}
+
 BridgedASTType BridgedASTType::getBuiltinVectorElementType() const {
   return {unbridged()->castTo<swift::BuiltinVectorType>()->getElementType().getPointer()};
 }
@@ -636,7 +644,15 @@ BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
 
 BridgedConformance BridgedASTType::checkConformance(BridgedDeclObj proto) const {
   return swift::checkConformance(unbridged(), proto.getAs<swift::ProtocolDecl>(), /*allowMissing=*/ false);
-}  
+}
+
+bool BridgedASTType::containsSILPackExpansionType() const {
+  return unbridged()->castTo<swift::SILPackType>()->containsPackExpansionType();
+}
+
+bool BridgedASTType::isSILPackElementAddress() const {
+  return unbridged()->castTo<swift::SILPackType>()->isElementAddress();
+}
 
 static_assert((int)BridgedASTType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);
 static_assert((int)BridgedASTType::TraitResult::CanBe == (int)swift::TypeTraitResult::CanBe);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4835,6 +4835,7 @@ inline bool isIndirectFormalResult(ResultConvention convention) {
 /// A result type and the rules for returning it.
 class SILResultInfo {
 public:
+  // Must be kept consistent with `ResultInfo.Flag` in `FunctionConvention.swift`
   enum Flag : uint8_t {
     /// Not differentiable: a `@noDerivative` result.
     ///

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -164,7 +164,8 @@ enum class SpecializationPass : uint8_t {
   GenericSpecializer,
   MoveDiagnosticInOutToOut,
   AsyncDemotion,
-  LAST = AsyncDemotion
+  PackSpecialization,
+  LAST = PackSpecialization
 };
 
 constexpr uint8_t MAX_SPECIALIZATION_PASS = 10;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -85,16 +85,16 @@ class FixedSizeSlab;
 
 struct BridgedLoop {
   swift::SILLoop * _Nonnull l;
-  
+
   BRIDGED_INLINE SwiftInt getInnerLoopCount() const;
   BRIDGED_INLINE BridgedLoop getInnerLoop(SwiftInt index) const;
-  
+
   BRIDGED_INLINE SwiftInt getBasicBlockCount() const;
   BRIDGED_INLINE BridgedBasicBlock getBasicBlock(SwiftInt index) const;
-  
+
   BRIDGED_INLINE OptionalBridgedBasicBlock getPreheader() const;
   BRIDGED_INLINE BridgedBasicBlock getHeader() const;
-  
+
   BRIDGED_INLINE bool contains(BridgedBasicBlock block) const;
 };
 
@@ -114,16 +114,23 @@ enum class BridgedResultConvention {
 };
 
 struct BridgedResultInfo {
-  swift::TypeBase * _Nonnull type;
+  BridgedCanType type;
   BridgedResultConvention convention;
+  uint8_t options;
 
   BRIDGED_INLINE static BridgedResultConvention castToResultConvention(swift::ResultConvention convention);
   BRIDGED_INLINE BridgedResultInfo(swift::SILResultInfo resultInfo);
+  BridgedResultInfo(BridgedCanType type, BridgedResultConvention conv, uint8_t options)
+    : type(type), convention(conv), options(options) {}
+  BRIDGED_INLINE swift::SILResultInfo unbridged() const;
+
+  BRIDGED_INLINE BridgedCanType getReturnValueType(BridgedFunction f) const;
 };
 
 struct OptionalBridgedResultInfo {
-  swift::TypeBase * _Nullable type;
+  BridgedCanType type;
   BridgedResultConvention convention;
+  uint8_t options;
 };
 
 struct BridgedResultInfoArray {
@@ -164,6 +171,7 @@ struct BridgedParameterInfo {
 
   BRIDGED_INLINE BridgedParameterInfo(swift::SILParameterInfo parameterInfo);
   BRIDGED_INLINE swift::SILParameterInfo unbridged() const;
+  BRIDGED_INLINE BridgedCanType getArgumentType(BridgedFunction f) const;
 };
 
 struct BridgedParameterInfoArray {
@@ -301,6 +309,10 @@ struct BridgedType {
   getTupleElementType(SwiftInt idx) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getFunctionTypeWithNoEscape(bool withNoEscape) const;
   BRIDGED_INLINE BridgedArgumentConvention getCalleeConvention() const;
+
+  BRIDGED_INLINE SwiftInt getNumPackElements() const;
+  BRIDGED_INLINE BridgedType getPackElementType(SwiftInt idx) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getApproximateFormalPackType() const;
 };
 
 // SIL Bridging
@@ -337,6 +349,11 @@ struct BridgedValue {
 
   bool findPointerEscape() const;
 };
+
+BRIDGED_INLINE BridgedValue::Ownership
+BridgedValueOwnership_init(BridgedFunction f, BridgedType type,
+                           BridgedArgumentConvention convention);
+
 
 struct OptionalBridgedValue {
   OptionalSwiftObject obj;
@@ -713,7 +730,7 @@ struct BridgedInstruction {
   // =========================================================================//
   //                   Generalized instruction subclasses
   // =========================================================================//
-  
+
   BRIDGED_INLINE SwiftInt MultipleValueInstruction_getNumResults() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedMultiValueResult MultipleValueInstruction_getResult(SwiftInt index) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSuccessorArray TermInst_getSuccessors() const;
@@ -844,6 +861,8 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool BeginApplyInst_isCalleeAllocated() const;
   BRIDGED_INLINE SwiftInt TryApplyInst_numArguments() const;
   BRIDGED_INLINE BridgedArgumentConvention YieldInst_getConvention(BridgedOperand forOperand) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock YieldInst_getResumeBB() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock YieldInst_getUnwindBB() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock BranchInst_getTargetBlock() const;
   BRIDGED_INLINE SwiftInt SwitchEnumInst_getNumCases() const;
   BRIDGED_INLINE SwiftInt SwitchEnumInst_getCaseIndex(SwiftInt idx) const;
@@ -911,6 +930,9 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt FullApplySite_numIndirectResultArguments() const;
   BRIDGED_INLINE bool ConvertFunctionInst_withoutActuallyEscaping() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType TypeValueInst_getParamType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType PackLengthInst_getPackType() const;
+  BRIDGED_INLINE SwiftInt ScalarPackIndexInst_getComponentIndex() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType AnyPackIndexInst_getIndexedPackType() const;
 
   // =========================================================================//
   //                   VarDeclInst and DebugVariableInst
@@ -1094,13 +1116,13 @@ struct BridgedConstExprFunctionState {
   swift::SymbolicValueBumpAllocator * _Nonnull allocator;
   swift::ConstExprEvaluator * _Nonnull constantEvaluator;
   unsigned int * _Nonnull numEvaluatedSILInstructions;
-  
+
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   static BridgedConstExprFunctionState create();
-  
+
   BRIDGED_INLINE
   bool isConstantValue(BridgedValue value);
-  
+
   BRIDGED_INLINE
   void deinitialize();
 };
@@ -1215,10 +1237,14 @@ struct BridgedBuilder{
                    bool hasDynamicLifetime, bool isLexical, bool isFromVarDecl, bool wasMoved) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
   createAllocStack(BridgedType type, bool hasDynamicLifetime, bool isLexical, bool isFromVarDecl, bool wasMoved) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPack(BridgedType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocVector(BridgedValue capacity,
                                                                           BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDeallocStack(BridgedValue operand) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDeallocStackRef(BridgedValue operand) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDeallocPack(BridgedValue operand) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAddressToPointer(BridgedValue address,
                                                                                BridgedType pointerTy,
                                                                                bool needsStackProtection) const;
@@ -1352,6 +1378,7 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createProjectBox(BridgedValue box, SwiftInt fieldIdx) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createStore(BridgedValue src, BridgedValue dst,
                                           SwiftInt ownership) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createStoreBorrow(BridgedValue src, BridgedValue dst) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createInitExistentialRef(BridgedValue instance,
                                           BridgedType type,
                                           BridgedCanType formalConcreteType,
@@ -1359,6 +1386,13 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createInitExistentialMetatype(BridgedValue metatype,
                                           BridgedType existentialType,
                                           BridgedConformanceArray conformances) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createScalarPackIndex(
+      SwiftInt componentIndex, BridgedCanType indexedPackType) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createPackElementGet(
+      BridgedValue packIndex, BridgedValue pack, BridgedType elementType) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createPackElementSet(BridgedValue elementValue, BridgedValue packIndex,
+                       BridgedValue pack) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMetatype(BridgedCanType instanceType,
                                           BridgedASTType::MetatypeRepresentation representation) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndCOWMutation(BridgedValue instance,
@@ -1369,7 +1403,7 @@ struct BridgedBuilder{
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependenceAddr(
     BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind dependenceKind) const;
-    
+
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkUninitialized(
     BridgedValue value, SwiftInt kind) const;
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -56,10 +56,24 @@ BridgedResultConvention BridgedResultInfo::castToResultConvention(swift::ResultC
   return static_cast<BridgedResultConvention>(convention);
 }
 
-BridgedResultInfo::BridgedResultInfo(swift::SILResultInfo resultInfo):
-  type(resultInfo.getInterfaceType().getPointer()),
-  convention(castToResultConvention(resultInfo.getConvention()))
+BridgedResultInfo::BridgedResultInfo(swift::SILResultInfo resultInfo)
+    : type(resultInfo.getInterfaceType()),
+      convention(castToResultConvention(resultInfo.getConvention())),
+      options(resultInfo.getOptions().toRaw())
 {}
+
+swift::SILResultInfo BridgedResultInfo::unbridged() const {
+  return swift::SILResultInfo(type.unbridged(),
+                              static_cast<swift::ResultConvention>(convention),
+                              swift::SILResultInfo::Options(options));
+}
+
+BridgedCanType BridgedResultInfo::getReturnValueType(BridgedFunction f) const {
+  const auto function = f.getFunction();
+  return BridgedCanType(unbridged().getReturnValueType(
+      function->getModule(), function->getLoweredFunctionType().getPointer(),
+      function->getTypeExpansionContext()));
+}
 
 SwiftInt BridgedResultInfoArray::count() const {
   return resultInfoArray.unbridged<swift::SILResultInfo>().size();
@@ -125,6 +139,10 @@ inline BridgedArgumentConvention castToArgumentConvention(swift::SILArgumentConv
   return static_cast<BridgedArgumentConvention>(convention.Value);
 }
 
+inline swift::SILArgumentConvention unbridge(BridgedArgumentConvention convention) {
+  return swift::SILArgumentConvention(static_cast<swift::SILArgumentConvention::ConventionType>(convention));
+}
+
 BridgedParameterInfo::BridgedParameterInfo(swift::SILParameterInfo parameterInfo):
   type(parameterInfo.getInterfaceType()),
   convention(getArgumentConvention(parameterInfo.getConvention())),
@@ -134,6 +152,10 @@ BridgedParameterInfo::BridgedParameterInfo(swift::SILParameterInfo parameterInfo
 swift::SILParameterInfo BridgedParameterInfo::unbridged() const {
   return swift::SILParameterInfo(type.unbridged(), getParameterConvention(convention),
                                  swift::SILParameterInfo::Options(options));
+}
+
+BridgedCanType BridgedParameterInfo::getArgumentType(BridgedFunction f) const {
+  return {unbridged().getArgumentType(f.getFunction())};
 }
 
 SwiftInt BridgedParameterInfoArray::count() const {
@@ -245,10 +267,13 @@ OptionalBridgedResultInfo SILFunctionType_getErrorResult(BridgedCanType funcTy) 
   auto fnTy = funcTy.unbridged()->castTo<swift::SILFunctionType>();
   auto resultInfo = fnTy->getOptionalErrorResult();
   if (resultInfo) {
-    return {resultInfo->getInterfaceType().getPointer(),
-            BridgedResultInfo::castToResultConvention(resultInfo->getConvention())};
+    return {
+      resultInfo->getInterfaceType(),
+      BridgedResultInfo::castToResultConvention(resultInfo->getConvention()),
+      resultInfo->getOptions().toRaw(),
+    };
   }
-  return {nullptr, BridgedResultConvention::Indirect};
+  return {BridgedCanType(), BridgedResultConvention::Indirect, 0};
 
 }
 
@@ -452,6 +477,18 @@ BridgedArgumentConvention BridgedType::getCalleeConvention() const {
   return getArgumentConvention(fnType->getCalleeConvention());
 }
 
+SwiftInt BridgedType::getNumPackElements() const {
+  return unbridged().getNumPackElements();
+}
+
+BridgedType BridgedType::getPackElementType(SwiftInt idx) const {
+  return unbridged().getPackElementType((unsigned) idx);
+}
+
+BridgedCanType BridgedType::getApproximateFormalPackType() const {
+  return unbridged().castTo<swift::SILPackType>()->getApproximateFormalPackType();
+}
+
 //===----------------------------------------------------------------------===//
 //                                BridgedValue
 //===----------------------------------------------------------------------===//
@@ -504,6 +541,14 @@ BridgedFunction BridgedValue::SILUndef_getParentFunction() const {
 
 BridgedFunction BridgedValue::PlaceholderValue_getParentFunction() const {
   return {llvm::cast<swift::PlaceholderValue>(getSILValue())->getParent()};
+}
+
+BridgedValue::Ownership
+BridgedValueOwnership_init(BridgedFunction f, BridgedType type,
+                           BridgedArgumentConvention convention) {
+  swift::ValueOwnershipKind ownership(*f.getFunction(), type.unbridged(),
+                                      unbridge(convention));
+  return bridge(ownership);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1461,6 +1506,14 @@ BridgedArgumentConvention BridgedInstruction::YieldInst_getConvention(BridgedOpe
   return castToArgumentConvention(getAs<swift::YieldInst>()->getArgumentConventionForOperand(*forOperand.op));
 }
 
+BridgedBasicBlock BridgedInstruction::YieldInst_getResumeBB() const {
+  return {getAs<swift::YieldInst>()->getResumeBB()};
+}
+
+BridgedBasicBlock BridgedInstruction::YieldInst_getUnwindBB() const {
+  return {getAs<swift::YieldInst>()->getUnwindBB()};
+}
+
 BridgedBasicBlock BridgedInstruction::BranchInst_getTargetBlock() const {
   return {getAs<swift::BranchInst>()->getDestBB()};
 }
@@ -1758,6 +1811,18 @@ bool BridgedInstruction::ConvertFunctionInst_withoutActuallyEscaping() const {
 
 BridgedCanType BridgedInstruction::TypeValueInst_getParamType() const {
   return getAs<swift::TypeValueInst>()->getParamType();
+}
+
+BridgedCanType BridgedInstruction::PackLengthInst_getPackType() const {
+  return getAs<swift::PackLengthInst>()->getPackType();
+}
+
+SwiftInt BridgedInstruction::ScalarPackIndexInst_getComponentIndex() const {
+  return getAs<swift::ScalarPackIndexInst>()->getComponentIndex();
+}
+
+BridgedCanType BridgedInstruction::AnyPackIndexInst_getIndexedPackType() const {
+  return getAs<swift::AnyPackIndexInst>()->getIndexedPackType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -2281,6 +2346,18 @@ BridgedInstruction BridgedBuilder::createAllocStack(BridgedType type,
       swift::UsesMoveableValueDebugInfo_t(wasMoved), /*skipVarDeclAssert=*/ true)};
 }
 
+BridgedInstruction BridgedBuilder::createAllocPack(BridgedType type) const {
+  return {unbridged().createAllocPack(regularLoc(), type.unbridged())};
+}
+
+BridgedInstruction BridgedBuilder::createAllocPackMetadata() const {
+  return {unbridged().createAllocPackMetadata(regularLoc())};
+}
+
+BridgedInstruction BridgedBuilder::createAllocPackMetadata(BridgedType type) const {
+  return {unbridged().createAllocPackMetadata(regularLoc(), type.unbridged())};
+}
+
 BridgedInstruction BridgedBuilder::createDeallocStack(BridgedValue operand) const {
   return {unbridged().createDeallocStack(regularLoc(), operand.getSILValue())};
 }
@@ -2288,6 +2365,10 @@ BridgedInstruction BridgedBuilder::createDeallocStack(BridgedValue operand) cons
 BridgedInstruction BridgedBuilder::createDeallocStackRef(BridgedValue operand) const {
   return {
       unbridged().createDeallocStackRef(regularLoc(), operand.getSILValue())};
+}
+
+BridgedInstruction BridgedBuilder::createDeallocPack(BridgedValue operand) const {
+  return {unbridged().createDeallocPack(regularLoc(), operand.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createAddressToPointer(BridgedValue address, BridgedType pointerTy,
@@ -2678,6 +2759,11 @@ BridgedInstruction BridgedBuilder::createStore(BridgedValue src, BridgedValue ds
                                   (swift::StoreOwnershipQualifier)ownership)};
 }
 
+BridgedInstruction BridgedBuilder::createStoreBorrow(BridgedValue src, BridgedValue dst) const {
+  return {unbridged().createStoreBorrow(regularLoc(), src.getSILValue(),
+                                        dst.getSILValue())};
+}
+
 BridgedInstruction BridgedBuilder::createInitExistentialRef(BridgedValue instance,
                                             BridgedType type,
                                             BridgedCanType formalConcreteType,
@@ -2693,6 +2779,31 @@ BridgedInstruction BridgedBuilder::createInitExistentialMetatype(BridgedValue me
   return {unbridged().createInitExistentialMetatype(
       regularLoc(), metatype.getSILValue(), existentialType.unbridged(),
       conformances.pcArray.unbridged<swift::ProtocolConformanceRef>())};
+}
+
+BridgedInstruction
+BridgedBuilder::createScalarPackIndex(SwiftInt componentIndex,
+                                      BridgedCanType indexedPackType) const {
+  auto *pt = indexedPackType.unbridged()->castTo<swift::PackType>();
+  return {unbridged().createScalarPackIndex(regularLoc(), componentIndex,
+                                            swift::CanPackType(pt))};
+}
+
+BridgedInstruction
+BridgedBuilder::createPackElementGet(BridgedValue packIndex, BridgedValue pack,
+                                     BridgedType elementType) const {
+  return {unbridged().createPackElementGet(
+      regularLoc(), packIndex.getSILValue(), pack.getSILValue(),
+      elementType.unbridged())};
+}
+
+BridgedInstruction
+BridgedBuilder::createPackElementSet(BridgedValue elementValue,
+                                     BridgedValue packIndex,
+                                     BridgedValue pack) const {
+  return {unbridged().createPackElementSet(
+      regularLoc(), elementValue.getSILValue(), packIndex.getSILValue(),
+      pack.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createMetatype(BridgedCanType instanceType,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -382,6 +382,10 @@ public:
   /// Whether the type's layout is known to include some flavor of pack.
   bool isOrContainsPack(const SILFunction &F) const;
 
+  /// Whether the elements of a @pack_owned or @pack_guaranteed pack type are
+  /// direct values or addresses.
+  bool isPackElementAddress() const;
+
   /// True if the type is an empty tuple or an empty struct or a tuple or
   /// struct containing only empty types.
   bool isEmpty(const SILFunction &F) const;
@@ -664,6 +668,11 @@ public:
   /// category as the base type.
   SILType getTupleElementType(intptr_t index) const {
     return SILType(castTo<TupleType>().getElementType(index), getCategory());
+  }
+
+  unsigned getNumPackElements() const {
+    SILPackType *packTy = castTo<SILPackType>();
+    return packTy->getNumElements();
   }
 
   /// Given that this is a pack type, return the lowered type of the

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -200,6 +200,8 @@ struct BridgedPassContext {
                                                 BridgedFunction applySiteCallee) const;
   BridgedOwnedString mangleWithBoxToStackPromotedArgs(BridgedArrayRef bridgedPromotedArgIndices,
                                                       BridgedFunction bridgedOriginalFunction) const;
+  BridgedOwnedString mangleWithExplodedPackArgs(BridgedArrayRef bridgedPackArgs,
+                                                BridgedFunction applySiteCallee) const;
 
   void inlineFunction(BridgedInstruction apply, bool mandatoryInline) const;
   BRIDGED_INLINE bool eliminateDeadAllocations(BridgedFunction f) const;
@@ -269,6 +271,8 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BridgedFunction createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
                                                         const BridgedParameterInfo * _Nullable specializedBridgedParams,
                                                         SwiftInt paramCount,
+                                                        const BridgedResultInfo *_Nullable specializedBridgedResults,
+                                                        SwiftInt resultCount,
                                                         BridgedFunction bridgedOriginal,
                                                         bool makeThin,
                                                         bool makeBare,

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -152,6 +152,8 @@ PASS(TempLValueElimination, "temp-lvalue-elimination",
      "Remove short-lived immutable temporary l-values")
 PASS(LoopInvariantCodeMotion, "loop-invariant-code-motion",
      "New Loop Invariant Code Motion")
+PASS(PackSpecialization, "pack-specialization",
+     "Specialize uses of parameter packs")
 
 PASS(ClosureSpecialization, "closure-specialization",
      "Specialize functions with closure arguments")

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -161,6 +161,11 @@ bool SILType::isOrContainsPack(const SILFunction &F) const {
   return F.getTypeProperties(contextType).isOrContainsPack();
 }
 
+bool SILType::isPackElementAddress() const {
+  SILPackType *packTy = castTo<SILPackType>();
+  return packTy->isElementAddress();
+}
+
 bool SILType::isEmpty(const SILFunction &F) const {
   // Infinite types are never empty.
   if (F.getTypeProperties(*this).isInfinite()) {

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -525,6 +525,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // of embedded Swift.
   if (!P.getOptions().EmbeddedSwift) {
     P.addGenericSpecializer();
+    P.addPackSpecialization();
     // Run devirtualizer after the specializer, because many
     // class_method/witness_method instructions may use concrete types now.
     P.addDevirtualizer();

--- a/test/SILOptimizer/pack_specialization.sil
+++ b/test/SILOptimizer/pack_specialization.sil
@@ -1,0 +1,791 @@
+// RUN: %target-sil-opt %s -pack-specialization | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+protocol P {}
+
+class C : P {}
+
+// INDIVIDUAL PARAMETER TRANSFORMATION TESTS:
+//
+// There are currently 3 conventions for pack parameters: @pack_guaranteed,
+// @pack_owned and @pack_inout. Each member of an exploded pack parameter will
+// be mapped to a parameter that has a "direct" (@owned or unowned), @guaranteed
+// or indirect convention. We rely on the existing code to handle the ownership
+// and lifetimes of any indirect or @owned parameters, so there are only 3
+// different ways the pass needs to handle exploded pack elements. Accordingly,
+// this leads to 9 different cases for how a pack parameter may be transformed,
+// for which we have written 9 test cases.
+
+// Check that name mangling, parameter & result pack explosion, local pack allocation, cleanup and use work as expected.
+// CHECK-LABEL: sil shared [ossa] @$s24copy_pack_int_guaranteedTf8xx_n : $@convention(thin) (Int) -> Int {
+// CHECK:       bb0(%0 : $Int):
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ADDR:%[0-9]+]] = alloc_stack $Int
+// CHECK-NEXT:    store %0 to [trivial] [[ADDR]]
+// CHECK-NEXT:    pack_element_set [[ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[OUT_ADDR:%[0-9]+]] = alloc_stack $Int
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[RESULT:%[0-9]+]] = load [trivial] [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_stack [[ADDR]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s24copy_pack_int_guaranteedTf8xx_n'
+sil [ossa] @copy_pack_int_guaranteed : $@convention(thin) (@pack_guaranteed Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  copy_addr %1 to [init] %0
+  %9 = tuple ()
+  return %9
+}
+
+// Check that parameters and results are correctly extracted from and written back to the former argument packs,
+// including any borrows of indirect parameters.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_int_guaranteed : $@convention(thin) (@pack_guaranteed Pack{Int}) -> @pack_out Pack{Int} {
+// CHECK:       bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+// CHECK:         [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[IN_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ARG_ADDR:%[0-9]+]] = pack_element_get [[IN_IDX]] of %1 as $*Int
+// CHECK-NEXT:    [[ARG:%[0-9]+]] = load [trivial] [[ARG_ADDR]]
+// CHECK:         [[FN_REF:%[0-9]+]] = function_ref @$s24copy_pack_int_guaranteedTf8xx_n : $@convention(thin) (Int) -> Int
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[FN_REF]]([[ARG]]) : $@convention(thin) (Int) -> Int
+// CHECK-NEXT:    [[RESULT_ADDR:%[0-9]+]] = pack_element_get [[OUT_IDX]] of %0
+// CHECK-NEXT:    store [[RESULT]] to [trivial] [[RESULT_ADDR]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_int_guaranteed'
+sil [ossa] @call_copy_pack_int_guaranteed : $@convention(thin) (@pack_guaranteed Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1: $*Pack{Int}):
+  %10 = function_ref @copy_pack_int_guaranteed : $@convention(thin) (@pack_guaranteed Pack{Int}) -> @pack_out Pack{Int}
+  %11 = apply %10(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{Int}) -> @pack_out Pack{Int}
+  return %11
+}
+
+// As above, for an owned pack.
+// CHECK-LABEL: sil shared [ossa] @$s19copy_pack_int_ownedTf8xx_n : $@convention(thin) (Int) -> Int {
+// CHECK:       bb0(%0 : $Int):
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ADDR:%[0-9]+]] = alloc_stack $Int
+// CHECK-NEXT:    store %0 to [trivial] [[ADDR]]
+// CHECK-NEXT:    pack_element_set [[ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[OUT_ADDR:%[0-9]+]] = alloc_stack $Int
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[RESULT:%[0-9]+]] = load [trivial] [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_stack [[ADDR]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s19copy_pack_int_ownedTf8xx_n'
+sil [ossa] @copy_pack_int_owned : $@convention(thin) (@pack_owned Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  copy_addr %1 to [init] %0
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_pack_int_owned : $@convention(thin) (@pack_owned Pack{Int}) -> @pack_out Pack{Int} {
+// CHECK:       bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+// CHECK:         [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[IN_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ARG_ADDR:%[0-9]+]] = pack_element_get [[IN_IDX]] of %1 as $*Int
+// CHECK-NEXT:    [[ARG:%[0-9]+]] = load [trivial] [[ARG_ADDR]]
+// CHECK:         [[FN_REF:%[0-9]+]] = function_ref @$s19copy_pack_int_ownedTf8xx_n : $@convention(thin) (Int) -> Int
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[FN_REF]]([[ARG]]) : $@convention(thin) (Int) -> Int
+// CHECK-NEXT:    [[RESULT_ADDR:%[0-9]+]] = pack_element_get [[OUT_IDX]] of %0
+// CHECK-NEXT:    store [[RESULT]] to [trivial] [[RESULT_ADDR]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_int_owned'
+sil [ossa] @call_copy_pack_int_owned : $@convention(thin) (@pack_owned Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  %10 = function_ref @copy_pack_int_owned : $@convention(thin) (@pack_owned Pack{Int}) -> @pack_out Pack{Int}
+  %11 = apply %10(%0, %1) : $@convention(thin) (@pack_owned Pack{Int}) -> @pack_out Pack{Int}
+  return %11
+}
+
+// As above, for an inout pack.
+// CHECK-LABEL: sil shared [ossa] @$s19copy_pack_int_inoutTf8xx_n : $@convention(thin) (@inout Int) -> Int {
+// CHECK:       bb0([[ADDR:%[0-9]+]] : $*Int):
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    pack_element_set [[ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Int}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[OUT_ADDR:%[0-9]+]] = alloc_stack $Int
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[RESULT:%[0-9]+]] = load [trivial] [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s19copy_pack_int_inoutTf8xx_n'
+sil [ossa] @copy_pack_int_inout : $@convention(thin) (@pack_inout Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  copy_addr %1 to [init] %0
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_pack_int_inout : $@convention(thin) (@pack_inout Pack{Int}) -> @pack_out Pack{Int} {
+// CHECK:       bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+// CHECK:         [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[IN_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ARG_ADDR:%[0-9]+]] = pack_element_get [[IN_IDX]] of %1 as $*Int
+// CHECK:         [[FN_REF:%[0-9]+]] = function_ref @$s19copy_pack_int_inoutTf8xx_n : $@convention(thin) (@inout Int) -> Int
+// CHECK-NEXT:    [[CALL_RESULT:%[0-9]+]] = apply [[FN_REF]]([[ARG_ADDR]]) : $@convention(thin) (@inout Int) -> Int
+// CHECK-NEXT:    [[RESULT_ADDR:%[0-9]+]] = pack_element_get [[OUT_IDX]] of %0
+// CHECK-NEXT:    store [[CALL_RESULT]] to [trivial] [[RESULT_ADDR]]
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_int_inout'
+sil [ossa] @call_copy_pack_int_inout : $@convention(thin) (@pack_inout Pack{Int}) -> @pack_out Pack{Int} {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  %10 = function_ref @copy_pack_int_inout : $@convention(thin) (@pack_inout Pack{Int}) -> @pack_out Pack{Int}
+  %11 = apply %10(%0, %1) : $@convention(thin) (@pack_inout Pack{Int}) -> @pack_out Pack{Int}
+  %12 = tuple ()
+  return %12
+}
+
+
+// Check that borrowed lifetimes are managed correctly for guaranteed pack-exploded arguments.
+// CHECK-LABEL: sil shared [ossa] @$s28copy_pack_class_c_guaranteedTf8xx_n : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK:       bb0(%0 : @guaranteed $C):
+// CHECK:         [[IN_ADDR:%[0-9]+]] = alloc_stack $C
+// CHECK:         [[BORROW:%[0-9]+]] = store_borrow %0 to [[IN_ADDR]]
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = alloc_stack $C
+// CHECK:         [[RESULT:%[0-9]+]] = load [take] [[OUT_ADDR]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s28copy_pack_class_c_guaranteedTf8xx_n'
+sil [ossa] @copy_pack_class_c_guaranteed : $@convention(thin) (@pack_guaranteed Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  copy_addr %1 to [init] %0
+  %8 = tuple ()
+  return %8
+}
+
+// Check that non-trivial guaranteed parameters are correctly borrowed
+// CHECK-LABEL: sil [ossa] @call_copy_pack_class_c_guaranteed : $@convention(thin) (@pack_guaranteed Pack{C}) -> @pack_out Pack{C} {
+// CHECK:       bb0(%0 : $*Pack{C}, %1 : $*Pack{C})
+// CHECK:         [[IN_C_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*C
+// CHECK-NEXT:    [[BORROW:%[0-9]+]] = load_borrow [[IN_C_PACK_ADDR]]
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s28copy_pack_class_c_guaranteedTf8xx_n : $@convention(thin) (@guaranteed C) -> @owned C
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[BORROW]]) : $@convention(thin) (@guaranteed C) -> @owned C
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*C
+// CHECK:         store [[RESULT]] to [init] [[OUT_ADDR]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_class_c_guaranteed'
+sil [ossa] @call_copy_pack_class_c_guaranteed : $@convention(thin) (@pack_guaranteed Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  %16 = function_ref @copy_pack_class_c_guaranteed : $@convention(thin) (@pack_guaranteed Pack{C}) -> @pack_out Pack{C}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{C}) -> @pack_out Pack{C}
+  return %17
+}
+
+
+// Check that lifetimes are managed correctly for owned pack-exploded arguments.
+// The original code already manages lifetimes sufficiently, so no additional retains, releases, borrows etc. are necessary.
+// CHECK-LABEL: sil shared [ossa] @$s23copy_pack_class_c_ownedTf8xx_n : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       bb0(%0 : @owned $C):
+// CHECK:         [[IN_ADDR:%[0-9]+]] = alloc_stack $C
+// CHECK:         store %0 to [init] [[IN_ADDR]]
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = alloc_stack $C
+// CHECK:         [[RESULT:%[0-9]+]] = load [take] [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OUT_ADDR]]
+// CHECK:         dealloc_stack [[IN_ADDR]]
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s23copy_pack_class_c_ownedTf8xx_n'
+sil [ossa] @copy_pack_class_c_owned : $@convention(thin) (@pack_owned Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  copy_addr %1 to [init] %0
+  %8 = tuple ()
+  return %8
+}
+
+// Check that non-trivial owned pack-exploded parameters are loaded and passed correctly.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_class_c_owned : $@convention(thin) (@pack_owned Pack{C}) -> @pack_out Pack{C} {
+// CHECK:       bb0(%0 : $*Pack{C}, %1 : $*Pack{C})
+// CHECK:         [[IN_C_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*C
+// CHECK-NEXT:    [[ARGUMENT:%[0-9]+]] = load [take] [[IN_C_PACK_ADDR]]
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s23copy_pack_class_c_ownedTf8xx_n : $@convention(thin) (@owned C) -> @owned C
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[ARGUMENT]]) : $@convention(thin) (@owned C) -> @owned C
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*C
+// CHECK:         store [[RESULT]] to [init] [[OUT_ADDR]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_class_c_owned'
+sil [ossa] @call_copy_pack_class_c_owned : $@convention(thin) (@pack_owned Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  %16 = function_ref @copy_pack_class_c_owned : $@convention(thin) (@pack_owned Pack{C}) -> @pack_out Pack{C}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_owned Pack{C}) -> @pack_out Pack{C}
+  return %17
+}
+
+// As above, for an inout Pack{C}. The code in this function should be almost identical to the @pack_inout Pack{Int} one.
+// CHECK-LABEL: sil shared [ossa] @$s23copy_pack_class_c_inoutTf8xx_n : $@convention(thin) (@inout C) -> @owned C {
+// CHECK:       bb0([[ADDR:%[0-9]+]] : $*C):
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{C}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{C}
+// CHECK-NEXT:    pack_element_set [[ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{C}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{C}
+// CHECK-NEXT:    [[OUT_ADDR:%[0-9]+]] = alloc_stack $C
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[RESULT:%[0-9]+]] = load [take] [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OUT_ADDR]]
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s23copy_pack_class_c_inoutTf8xx_n'
+sil [ossa] @copy_pack_class_c_inout : $@convention(thin) (@pack_inout Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  copy_addr %1 to [init] %0
+  %9 = tuple ()
+  return %9
+}
+
+// Check that non-trivial inout pack-exploded parameters are passed correctly.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_class_c_inout : $@convention(thin) (@pack_inout Pack{C}) -> @pack_out Pack{C} {
+// CHECK:       bb0(%0 : $*Pack{C}, %1 : $*Pack{C})
+// CHECK:         [[IN_C_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*C
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s23copy_pack_class_c_inoutTf8xx_n : $@convention(thin) (@inout C) -> @owned C
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[IN_C_PACK_ADDR]]) : $@convention(thin) (@inout C) -> @owned C
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*C
+// CHECK:         store [[RESULT]] to [init] [[OUT_ADDR]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_class_c_inout'
+sil [ossa] @call_copy_pack_class_c_inout : $@convention(thin) (@pack_inout Pack{C}) -> @pack_out Pack{C} {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  %16 = function_ref @copy_pack_class_c_inout : $@convention(thin) (@pack_inout Pack{C}) -> @pack_out Pack{C}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_inout Pack{C}) -> @pack_out Pack{C}
+  return %17
+}
+
+// Check that pack explosion procedure is correct for non-loadable pack element types like any P.
+// CHECK-LABEL: sil shared [ossa] @$s31copy_pack_protocol_p_guaranteedTf8xx_n : $@convention(thin) (@in_guaranteed any P) -> @out any P {
+// CHECK:       bb0([[OUT_ADDR:%[0-9]+]] : $*any P, [[IN_ADDR:%[0-9]+]] : $*any P)
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[IN_ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[OUT_ADDR]] into [[OUT_IDX]] of [[OUT_PACK]]
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s31copy_pack_protocol_p_guaranteedTf8xx_n'
+sil [ossa] @copy_pack_protocol_p_guaranteed : $@convention(thin) (@pack_guaranteed Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  copy_addr %1 to [init] %0
+  %7 = tuple ()
+  return %7
+}
+
+// Check that indirect result and parameter pack members are correctly extracted and passed to the callee.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_protocol_p_guaranteed : $@convention(thin) (@pack_guaranteed Pack{any P}) -> @pack_out Pack{any P} {
+// CHECK:       bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P})
+// CHECK:         [[OUT_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*any P
+// CHECK:         [[IN_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*any P
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s31copy_pack_protocol_p_guaranteedTf8xx_n : $@convention(thin) (@in_guaranteed any P) -> @out any P
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[OUT_P_PACK_ADDR]], [[IN_P_PACK_ADDR]]) : $@convention(thin) (@in_guaranteed any P) -> @out any P
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_protocol_p_guaranteed'
+sil [ossa] @call_copy_pack_protocol_p_guaranteed : $@convention(thin) (@pack_guaranteed Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  %16 = function_ref @copy_pack_protocol_p_guaranteed : $@convention(thin) (@pack_guaranteed Pack{any P}) -> @pack_out Pack{any P}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{any P}) -> @pack_out Pack{any P}
+  return %17
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s26copy_pack_protocol_p_ownedTf8xx_n : $@convention(thin) (@in any P) -> @out any P {
+// CHECK:       bb0([[OUT_ADDR:%[0-9]+]] : $*any P, [[IN_ADDR:%[0-9]+]] : $*any P)
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[IN_ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[OUT_ADDR]] into [[OUT_IDX]] of [[OUT_PACK]]
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s26copy_pack_protocol_p_ownedTf8xx_n'
+sil [ossa] @copy_pack_protocol_p_owned : $@convention(thin) (@pack_owned Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  copy_addr %1 to [init] %0
+  %7 = tuple ()
+  return %7
+}
+
+// As above for non-loadable types in owned packs.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_protocol_p_owned : $@convention(thin) (@pack_owned Pack{any P}) -> @pack_out Pack{any P} {
+// CHECK:       bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P})
+// CHECK:         [[OUT_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*any P
+// CHECK:         [[IN_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*any P
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s26copy_pack_protocol_p_ownedTf8xx_n : $@convention(thin) (@in any P) -> @out any P
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[OUT_P_PACK_ADDR]], [[IN_P_PACK_ADDR]]) : $@convention(thin) (@in any P) -> @out any P
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_protocol_p_owned'
+sil [ossa] @call_copy_pack_protocol_p_owned : $@convention(thin) (@pack_owned Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  %16 = function_ref @copy_pack_protocol_p_owned : $@convention(thin) (@pack_owned Pack{any P}) -> @pack_out Pack{any P}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_owned Pack{any P}) -> @pack_out Pack{any P}
+  return %17
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s26copy_pack_protocol_p_inoutTf8xx_n : $@convention(thin) (@inout any P) -> @out any P {
+// CHECK:       bb0([[OUT_ADDR:%[0-9]+]] : $*any P, [[IN_ADDR:%[0-9]+]] : $*any P)
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[IN_ADDR]] into [[IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{any P}
+// CHECK-NEXT:    [[OUT_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P}
+// CHECK-NEXT:    pack_element_set [[OUT_ADDR]] into [[OUT_IDX]] of [[OUT_PACK]]
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    dealloc_pack [[OUT_PACK]]
+// CHECK-NEXT:    dealloc_pack [[IN_PACK]]
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s26copy_pack_protocol_p_inoutTf8xx_n'
+sil [ossa] @copy_pack_protocol_p_inout : $@convention(thin) (@pack_inout Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  copy_addr %1 to [init] %0
+  %7 = tuple ()
+  return %7
+}
+
+// As above for non-loadable types in inout packs.
+// CHECK-LABEL: sil [ossa] @call_copy_pack_protocol_p_inout : $@convention(thin) (@pack_inout Pack{any P}) -> @pack_out Pack{any P} {
+// CHECK:       bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P})
+// CHECK:         [[OUT_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[OUT_PACK_GET_IDX:%[0-9]+]] of %0 as $*any P
+// CHECK:         [[IN_P_PACK_ADDR:%[0-9]+]] = pack_element_get [[PACK_GET_IDX:%[0-9]+]] of %1 as $*any P
+// CHECK:         [[SPECIALIZED:%[0-9]+]] = function_ref @$s26copy_pack_protocol_p_inoutTf8xx_n : $@convention(thin) (@inout any P) -> @out any P
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[SPECIALIZED]]([[OUT_P_PACK_ADDR]], [[IN_P_PACK_ADDR]]) : $@convention(thin) (@inout any P) -> @out any P
+// CHECK-NEXT:    return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'call_copy_pack_protocol_p_inout'
+sil [ossa] @call_copy_pack_protocol_p_inout : $@convention(thin) (@pack_inout Pack{any P}) -> @pack_out Pack{any P} {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  %16 = function_ref @copy_pack_protocol_p_inout : $@convention(thin) (@pack_inout Pack{any P}) -> @pack_out Pack{any P}
+  %17 = apply %16(%0, %1) : $@convention(thin) (@pack_inout Pack{any P}) -> @pack_out Pack{any P}
+  return %17
+}
+
+// INTERLEAVING PACK AND NON-PACK ARGUMENTS TESTS:
+//
+// The new function arguments and return values corresponding to pack parameters
+// are inserted into the parameter and results lists in the same order as they
+// are passed in the original pack.
+//
+// Other tests cover the callee and call-site modifications necessary to extract
+// elements from packs. These tests focus primarily on the positions of the
+// mapped arguments and result values.
+
+// CHECK-LABEL: sil shared [ossa] @$s18interleave_unownedTf8xnxn_n : $@convention(thin) (Builtin.Int64, Builtin.Int32, Builtin.Int64) -> (Builtin.Int64, Builtin.Int32, Builtin.Int64) {
+// CHECK:       bb0([[A1:%[0-9]+]] : $Builtin.Int64, [[A2:%[0-9]+]] : $Builtin.Int32, [[A3:%[0-9]+]] : $Builtin.Int64):
+// CHECK:         [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int32}
+// CHECK:         store [[A2]] to [trivial] [[IN_STACK:%[0-9]+]]
+// CHECK:         pack_element_set [[IN_STACK]] into [[IN_IDX:%[0-9]+]] of [[IN_PACK]]
+// CHECK:         [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int32}
+// CHECK:         [[OUT_ADDR:%[0-9]+]] = alloc_stack $Builtin.Int32
+// CHECK:         [[ORIGINAL_RESULT:%[0-9]+]] = tuple ([[A1]], [[A3]])
+// CHECK:         ([[R1:%[0-9]+]], [[R3:%[0-9]+]]) = destructure_tuple [[ORIGINAL_RESULT]]
+// CHECK:         [[R2:%[0-9]+]] = load [trivial] [[OUT_ADDR]]
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ([[R1]], [[R2]], [[R3]])
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s18interleave_unownedTf8xnxn_n'
+sil [ossa] @interleave_unowned : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{Builtin.Int32}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{Builtin.Int32}, Builtin.Int64) {
+bb0(%0 : $*Pack{Builtin.Int32}, %1 : $Builtin.Int64, %2 : $*Pack{Builtin.Int32}, %3 : $Builtin.Int64):
+  %7 = scalar_pack_index 0 of $Pack{Builtin.Int32}
+  %8 = pack_element_get %7 of %0 as $*Builtin.Int32
+  %9 = pack_element_get %7 of %2 as $*Builtin.Int32
+  copy_addr %9 to [init] %8
+  %12 = tuple (%1, %3)
+  return %12
+}
+
+// CHECK-LABEL: sil [ossa] @call_interleave_unowned  : $@convention(thin) (@pack_owned Pack{Builtin.Int32}) -> (Builtin.Int64, @pack_out Pack{Builtin.Int32}, Builtin.Int64) {
+// CHECK:       bb0(%0 : $*Pack{Builtin.Int32}, %1 : $*Pack{Builtin.Int32}):
+// CHECK:         [[FNREF:%[0-9]+]] = function_ref @$s18interleave_unownedTf8xnxn_n
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[FNREF]]
+// CHECK:         ([[R1:%[0-9]+]], [[R2:%[0-9]+]], [[R3:%[0-9]+]]) = destructure_tuple [[RESULT]]
+// CHECK:         store [[R2]] to
+// CHECK-NEXT:    [[ORIGINAL_RESULT:%[0-9]+]] = tuple ([[R1:%[0-9]+]], [[R3:%[0-9]+]])
+// CHECK-NEXT:    return [[ORIGINAL_RESULT]]
+// CHECK-LABEL: } // end sil function 'call_interleave_unowned'
+sil [ossa] @call_interleave_unowned : $@convention(thin) (@pack_owned Pack{Builtin.Int32}) -> (Builtin.Int64, @pack_out Pack{Builtin.Int32}, Builtin.Int64) {
+bb0(%0 : $*Pack{Builtin.Int32}, %1 : $*Pack{Builtin.Int32}):
+  %6 = integer_literal $Builtin.Int64, 1
+  %12 = integer_literal $Builtin.Int64, 3
+  %14 = function_ref @interleave_unowned : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{Builtin.Int32}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{Builtin.Int32}, Builtin.Int64)
+  %15 = apply %14(%0, %6, %1, %12) : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{Builtin.Int32}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{Builtin.Int32}, Builtin.Int64)
+  return %15
+}
+
+
+// CHECK-LABEL: sil shared [ossa] @$s17interleave_directTf8xnxn_n : $@convention(thin) (Builtin.Int64, @guaranteed C, Builtin.Int64) -> (Builtin.Int64, @owned C, Builtin.Int64) {
+// CHECK:       bb0(%0 : $Builtin.Int64, %1 : @guaranteed $C, %2 : $Builtin.Int64):
+// CHECK:         ([[R1:%[0-9]+]], [[R3:%[0-9]+]]) = destructure_tuple
+// CHECK:         [[R2:%[0-9]+]] = load [take]
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = tuple ([[R1]], [[R2]], [[R3]])
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s17interleave_directTf8xnxn_n'
+sil [ossa] @interleave_direct : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{C}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{C}, Builtin.Int64) {
+bb0(%0 : $*Pack{C}, %1 : $Builtin.Int64, %2 : $*Pack{C}, %3 : $Builtin.Int64):
+  %7 = scalar_pack_index 0 of $Pack{C}
+  %8 = pack_element_get %7 of %0 as $*C
+  %9 = pack_element_get %7 of %2 as $*C
+  copy_addr %9 to [init] %8
+  %12 = tuple (%1, %3)
+  return %12
+}
+
+// CHECK-LABEL: sil [ossa] @call_interleave_direct  : $@convention(thin) (@pack_owned Pack{C}) -> (Builtin.Int64, @pack_out Pack{C}, Builtin.Int64) {
+// CHECK:       bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+// CHECK:         [[FNREF:%[0-9]+]] = function_ref @$s17interleave_directTf8xnxn_n
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[FNREF]]
+// CHECK:         ([[R1:%[0-9]+]], [[R2:%[0-9]+]], [[R3:%[0-9]+]]) = destructure_tuple [[RESULT]]
+// CHECK:         store [[R2]] to
+// CHECK-NEXT:    [[ORIGINAL_RESULT:%[0-9]+]] = tuple ([[R1:%[0-9]+]], [[R3:%[0-9]+]])
+// CHECK:         return [[ORIGINAL_RESULT]]
+// CHECK-LABEL: } // end sil function 'call_interleave_direct'
+sil [ossa] @call_interleave_direct : $@convention(thin) (@pack_owned Pack{C}) -> (Builtin.Int64, @pack_out Pack{C}, Builtin.Int64) {
+bb0(%0 : $*Pack{C}, %1 : $*Pack{C}):
+  %6 = integer_literal $Builtin.Int64, 1
+  %12 = integer_literal $Builtin.Int64, 3
+  %14 = function_ref @interleave_direct : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{C}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{C}, Builtin.Int64)
+  %15 = apply %14(%0, %6, %1, %12) : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{C}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{C}, Builtin.Int64)
+  return %15
+}
+
+
+// CHECK-LABEL: sil shared [ossa] @$s19interleave_indirectTf8xnxn_n : $@convention(thin) (Builtin.Int64, @in_guaranteed any P, Builtin.Int64) -> (Builtin.Int64, @out any P, Builtin.Int64) {
+// CHECK:       bb0(%0 : $*any P, %1 : $Builtin.Int64, %2 : $*any P, %3 : $Builtin.Int64):
+// CHECK:         pack_element_set %2 into
+// CHECK:         pack_element_set %0 into
+// CHECK:         pack_element_get [[INDEX:%[0-9]+]] of [[OUT_PACK:%[0-9]+]]
+// CHECK:         pack_element_get [[INDEX]] of [[IN_PACK:%[0-9]+]]
+// CHECK:         [[RESULT:%[0-9]+]] = tuple ([[R1:%[0-9]+]], [[R3:%[0-9]+]])
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s19interleave_indirectTf8xnxn_n'
+sil [ossa] @interleave_indirect : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{any P}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{any P}, Builtin.Int64) {
+bb0(%0 : $*Pack{any P}, %1 : $Builtin.Int64, %2 : $*Pack{any P}, %3 : $Builtin.Int64):
+  %7 = scalar_pack_index 0 of $Pack{any P}
+  %8 = pack_element_get %7 of %0 as $*any P
+  %9 = pack_element_get %7 of %2 as $*any P
+  copy_addr %9 to [init] %8
+  %11 = tuple (%1, %3)
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @call_interleave_indirect  : $@convention(thin) (@pack_owned Pack{any P}) -> (Builtin.Int64, @pack_out Pack{any P}, Builtin.Int64) {
+// CHECK:       bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+// CHECK:         [[FNREF:%[0-9]+]] = function_ref @$s19interleave_indirectTf8xnxn_n
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = apply [[FNREF]]
+// CHECK:         return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'call_interleave_indirect'
+sil [ossa] @call_interleave_indirect : $@convention(thin) (@pack_owned Pack{any P}) -> (Builtin.Int64, @pack_out Pack{any P}, Builtin.Int64) {
+bb0(%0 : $*Pack{any P}, %1 : $*Pack{any P}):
+  %6 = integer_literal $Builtin.Int64, 1
+  %12 = integer_literal $Builtin.Int64, 3
+  %14 = function_ref @interleave_indirect : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{any P}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{any P}, Builtin.Int64)
+  %15 = apply %14(%0, %6, %1, %12) : $@convention(thin) (Builtin.Int64, @pack_guaranteed Pack{any P}, Builtin.Int64) -> (Builtin.Int64, @pack_out Pack{any P}, Builtin.Int64)
+  return %15
+}
+
+// MULTI-ELEMENT PACK TESTS:
+
+// Since the pack elements are the same type, ensure they are inserted in the correct order.
+// CHECK-LABEL: sil shared [ossa] @$s09copy_int_B0Tf8xx_n : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> (Builtin.Int64, Builtin.Int64) {
+// CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
+// CHECK: [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int64, Builtin.Int64}
+// CHECK: [[IN_IDX_0:%[0-9]+]] = scalar_pack_index 0 of $Pack{Builtin.Int64, Builtin.Int64}
+// CHECK: [[IN_ADDR_0:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: store %0 to [trivial] [[IN_ADDR_0]]
+// CHECK: pack_element_set [[IN_ADDR_0]] into [[IN_IDX_0]] of [[IN_PACK]]
+// CHECK: [[IN_IDX_1:%[0-9]+]] = scalar_pack_index 1 of $Pack{Builtin.Int64, Builtin.Int64}
+// CHECK: [[IN_ADDR_1:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: store %1 to [trivial] [[IN_ADDR_1]]
+// CHECK: pack_element_set [[IN_ADDR_1]] into [[IN_IDX_1]] of [[IN_PACK]]
+// CHECK: [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int64, Builtin.Int64}
+// CHECK: [[OUT_ADDR_0:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: [[OUT_ADDR_1:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK: [[ORIGINAL_RESULT:%[0-9]+]] = tuple ()
+// CHECK: [[OUT_0:%[0-9]+]] = load [trivial] [[OUT_ADDR_0]]
+// CHECK: [[OUT_1:%[0-9]+]] = load [trivial] [[OUT_ADDR_1]]
+// CHECK: [[RESULT:%[0-9]+]] = tuple ([[OUT_0]], [[OUT_1]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s09copy_int_B0Tf8xx_n'
+sil [ossa] @copy_int_int : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, Builtin.Int64}) -> @pack_out Pack{Builtin.Int64, Builtin.Int64} {
+bb0(%0 : $*Pack{Builtin.Int64, Builtin.Int64}, %1 : $*Pack{Builtin.Int64, Builtin.Int64}):
+  copy_addr %1 to [init] %0
+  %13 = tuple ()
+  return %13
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_int_int : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, Builtin.Int64}) ->  @pack_out Pack{Builtin.Int64, Builtin.Int64} {
+// CHECK-LABEL: } // end sil function 'call_copy_int_int'
+sil [ossa] @call_copy_int_int : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, Builtin.Int64}) -> @pack_out Pack{Builtin.Int64, Builtin.Int64} {
+bb0(%0 : $*Pack{Builtin.Int64, Builtin.Int64}, %1: $*Pack{Builtin.Int64, Builtin.Int64}):
+  %2 = function_ref @copy_int_int : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, Builtin.Int64}) -> @pack_out Pack{Builtin.Int64, Builtin.Int64}
+  %3 = apply %2(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, Builtin.Int64}) -> @pack_out Pack{Builtin.Int64, Builtin.Int64}
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s10copy_int_pTf8xx_n : $@convention(thin) (Builtin.Int64, @in_guaranteed any P) -> (Builtin.Int64, @out any P) {
+// CHECK:       bb0(%0 : $*any P, %1 : $Builtin.Int64, %2 : $*any P):
+// CHECK:         [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int64, any P}
+// CHECK:         [[IN_ADDR_0:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK:         store %1 to [trivial] [[IN_ADDR_0]]
+// CHECK:         [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int64, any P}
+// CHECK:         [[OUT_ADDR_0:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[ORIGINAL_RESULT:%[0-9]+]] = tuple ()
+// CHECK:         [[OUT_0:%[0-9]+]] = load [trivial] [[OUT_ADDR_0]]
+// CHECK:         return [[OUT_0]]
+// CHECK-LABEL: } // end sil function '$s10copy_int_pTf8xx_n'
+sil [ossa] @copy_int_p : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, any P}) -> @pack_out Pack{Builtin.Int64, any P} {
+bb0(%0 : $*Pack{Builtin.Int64, any P}, %1 : $*Pack{Builtin.Int64, any P}):
+  copy_addr %1 to [init] %0
+  %12 = tuple ()
+  return %12
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_int_p : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, any P}) ->  @pack_out Pack{Builtin.Int64, any P} {
+// CHECK-LABEL: } // end sil function 'call_copy_int_p'
+sil [ossa] @call_copy_int_p : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, any P}) -> @pack_out Pack{Builtin.Int64, any P} {
+bb0(%0 : $*Pack{Builtin.Int64, any P}, %1: $*Pack{Builtin.Int64, any P}):
+  %2 = function_ref @copy_int_p : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, any P}) -> @pack_out Pack{Builtin.Int64, any P}
+  %3 = apply %2(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64, any P}) -> @pack_out Pack{Builtin.Int64, any P}
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s10copy_p_intTf8xx_n : $@convention(thin) (@in_guaranteed any P, Builtin.Int64) -> (@out any P, Builtin.Int64) {
+// CHECK:       bb0(%0 : $*any P, %1 : $*any P, %2 : $Builtin.Int64):
+// CHECK:         [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{any P, Builtin.Int64}
+// CHECK:         [[IN_ADDR_1:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK:         store %2 to [trivial] [[IN_ADDR_1]]
+// CHECK:         [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{any P, Builtin.Int64}
+// CHECK:         [[OUT_ADDR_0:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[ORIGINAL_RESULT:%[0-9]+]] = tuple ()
+// CHECK:         [[OUT_0:%[0-9]+]] = load [trivial] [[OUT_ADDR_0]]
+// CHECK:         return [[OUT_0]]
+// CHECK-LABEL: } // end sil function '$s10copy_p_intTf8xx_n'
+sil [ossa] @copy_p_int : $@convention(thin) (@pack_guaranteed Pack{any P, Builtin.Int64}) -> @pack_out Pack{any P, Builtin.Int64} {
+bb0(%0 : $*Pack{any P, Builtin.Int64}, %1 : $*Pack{any P, Builtin.Int64}):
+  copy_addr %1 to [init] %0
+  %12 = tuple ()
+  return %12
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_p_int : $@convention(thin) (@pack_guaranteed Pack{any P, Builtin.Int64}) ->  @pack_out Pack{any P, Builtin.Int64} {
+// CHECK-LABEL: } // end sil function 'call_copy_p_int'
+sil [ossa] @call_copy_p_int : $@convention(thin) (@pack_guaranteed Pack{any P, Builtin.Int64}) -> @pack_out Pack{any P, Builtin.Int64} {
+bb0(%0 : $*Pack{any P, Builtin.Int64}, %1: $*Pack{any P, Builtin.Int64}):
+  %2 = function_ref @copy_p_int : $@convention(thin) (@pack_guaranteed Pack{any P, Builtin.Int64}) -> @pack_out Pack{any P, Builtin.Int64}
+  %3 = apply %2(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{any P, Builtin.Int64}) -> @pack_out Pack{any P, Builtin.Int64}
+  %4 = tuple ()
+  return %4
+}
+
+// Since the pack elements are the same type, ensure they are inserted in the correct order.
+// CHECK-LABEL: sil shared [ossa] @$s8copy_p_pTf8xx_n : $@convention(thin) (@in_guaranteed any P, @in_guaranteed any P) -> (@out any P, @out any P) {
+// CHECK:       bb0(%0 : $*any P, %1 : $*any P, %2 : $*any P, %3 : $*any P):
+// CHECK:         [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{any P, any P}
+// CHECK-NEXT:    [[IN_IDX_0:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P, any P}
+// CHECK-NEXT:    pack_element_set %2 into [[IN_IDX_0]] of [[IN_PACK]]
+// CHECK-NEXT:    [[IN_IDX_1:%[0-9]+]] = scalar_pack_index 1 of $Pack{any P, any P}
+// CHECK-NEXT:    pack_element_set %3 into [[IN_IDX_1]] of [[IN_PACK]]
+// CHECK:         [[OUT_PACK:%[0-9]+]] = alloc_pack $Pack{any P, any P}
+// CHECK-NEXT:    [[OUT_IDX_0:%[0-9]+]] = scalar_pack_index 0 of $Pack{any P, any P}
+// CHECK-NEXT:    pack_element_set %0 into [[OUT_IDX_0]] of [[OUT_PACK]]
+// CHECK-NEXT:    [[OUT_IDX_1:%[0-9]+]] = scalar_pack_index 1 of $Pack{any P, any P}
+// CHECK-NEXT:    pack_element_set %1 into [[OUT_IDX_1]] of [[OUT_PACK]]
+// CHECK:         copy_addr [[IN_PACK]] to [init] [[OUT_PACK]]
+// CHECK:         [[ORIGINAL_RESULT:%[0-9]+]] = tuple ()
+// CHECK:         return [[ORIGINAL_RESULT]]
+// CHECK-LABEL: } // end sil function '$s8copy_p_pTf8xx_n'
+sil [ossa] @copy_p_p : $@convention(thin) (@pack_guaranteed Pack{any P, any P}) -> @pack_out Pack{any P, any P} {
+bb0(%0 : $*Pack{any P, any P}, %1 : $*Pack{any P, any P}):
+  copy_addr %1 to [init] %0
+  %11 = tuple ()
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @call_copy_p_p : $@convention(thin) (@pack_guaranteed Pack{any P, any P}) ->  @pack_out Pack{any P, any P} {
+// CHECK-LABEL: } // end sil function 'call_copy_p_p'
+sil [ossa] @call_copy_p_p : $@convention(thin) (@pack_guaranteed Pack{any P, any P}) -> @pack_out Pack{any P, any P} {
+bb0(%0 : $*Pack{any P, any P}, %1: $*Pack{any P, any P}):
+  %2 = function_ref @copy_p_p : $@convention(thin) (@pack_guaranteed Pack{any P, any P}) -> @pack_out Pack{any P, any P}
+  %3 = apply %2(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{any P, any P}) -> @pack_out Pack{any P, any P}
+  %4 = tuple ()
+  return %4
+}
+
+// EDGE CASE TESTS:
+
+// Deallocation code should not be emitted at the end of a non-exiting terminator block.
+// CHECK-LABEL: sil shared [ossa] @$s9crashableTf8x_n : $@convention(thin) (Builtin.Int64) -> () {
+// CHECK:       bb0(%0 : $Builtin.Int64):
+// CHECK-NEXT:    [[IN_PACK:%[0-9]+]] = alloc_pack $Pack{Builtin.Int64}
+// CHECK-NEXT:    [[IN_IDX:%[0-9]+]] = scalar_pack_index 0 of $Pack{Builtin.Int64}
+// CHECK-NEXT:    [[IN_ADDR:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK-NEXT:    store %0 to [trivial] [[IN_ADDR]]
+// CHECK-NEXT:    pack_element_set [[IN_ADDR]] into [[IN_IDX]] of [[IN_PACK]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function '$s9crashableTf8x_n'
+sil [ossa] @crashable : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64}) -> () {
+bb0(%0 : $*Pack{Builtin.Int64}):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @call_crashable : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64}) -> () {
+// CHECK-LABEL: } // end sil function 'call_crashable'
+sil [ossa] @call_crashable : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64}) -> () {
+bb0(%0 : $*Pack{Builtin.Int64}):
+  %1 = function_ref @crashable : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64}) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@pack_guaranteed Pack{Builtin.Int64}) -> ()
+  unreachable
+}
+
+// Pack-specialized functions should be converted to have a thin convention,
+// unless they have a dynamic self parameter.
+
+// CHECK-LABEL: sil shared [ossa] @$s27pack_method_no_dynamic_selfTf8x_n : $@convention(thin) (Int) -> () {
+// CHECK-LABEL: } // end sil function '$s27pack_method_no_dynamic_selfTf8x_n'
+sil [ossa] @pack_method_no_dynamic_self : $@convention(method) (@pack_guaranteed Pack{Int}) -> () {
+bb0(%0 : $*Pack{Int}):
+  %1 = tuple ()
+  return %1
+}
+
+// If the function does have a dynamic self parameter, it must still be the last
+// after pack specialization.
+// CHECK-LABEL: sil shared [ossa] @$s29pack_method_with_dynamic_selfTf8xn_n : $@convention(method) (Int, @thick C.Type) -> () {
+// CHECK-LABEL: } // end sil function '$s29pack_method_with_dynamic_selfTf8xn_n'
+sil [ossa] @pack_method_with_dynamic_self : $@convention(method) (@pack_guaranteed Pack{Int}, @thick C.Type) -> () {
+bb0(%0 : $*Pack{Int}, %1 : $@thick C.Type):
+  %2 = metatype $@thick @dynamic_self C.Type
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @call_pack_methods : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+// CHECK:       bb0(%0 : $*Pack{Int}):
+// CHECK:         function_ref @$s27pack_method_no_dynamic_selfTf8x_n : $@convention(thin) (Int) -> ()
+// CHECK:         function_ref @$s29pack_method_with_dynamic_selfTf8xn_n : $@convention(method) (Int, @thick C.Type) -> ()
+// CHECK-LABEL: } // end sil function 'call_pack_methods'
+sil [ossa] @call_pack_methods : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+bb0(%0 : $*Pack{Int}):
+  %1 = function_ref @pack_method_no_dynamic_self : $@convention(method) (@pack_guaranteed Pack{Int}) -> ()
+  %2 = apply %1(%0) : $@convention(method) (@pack_guaranteed Pack{Int}) -> ()
+
+  %3 = metatype $@thick C.Type
+  %4 = function_ref @pack_method_with_dynamic_self : $@convention(method) (@pack_guaranteed Pack{Int}, @thick C.Type) -> ()
+  %5 = apply %4(%0, %3) : $@convention(method) (@pack_guaranteed Pack{Int}, @thick C.Type) -> ()
+  return %2
+}
+
+// BAIL OUT CONDITION TESTS:
+//
+// Only perform pack specialization on functions that have indirect pack
+// parameters that contain no pack expansions.
+//
+// 2025-10-15: We currently only explode packs with address elements
+// (SILPackType::isElementAddress), because these are the most common (since
+// they are created after generic specialization of most variadic generic
+// functions), and expensive (since they introduce two layers of indirection).
+// See the shouldExplode computed property in PackSpecialization.swift.
+//
+// This is an OSSA-only pass, so caller and callee must both be OSSA.
+
+
+sil [ossa] @no_packs : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = tuple ()
+  return %1
+}
+
+sil [ossa] @indirect_pack : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+bb0(%0 : $*Pack{Int}):
+  %1 = tuple ()
+  return %1
+}
+
+sil [ossa] @direct_pack : $@convention(thin) (@pack_guaranteed @direct Pack{Int}) -> () {
+bb0(%0 : $*@direct Pack{Int}):
+  %1 = tuple ()
+  return %1
+}
+
+sil [ossa] @pack_expansion : $@convention(thin) <each A> (@pack_guaranteed Pack{repeat each A}) -> () {
+bb0(%0 : $*Pack{repeat each A}):
+  %1 = tuple ()
+  return %1
+}
+
+sil [ossa] @mixed_packs : $@convention(thin) <each A> (@pack_guaranteed Pack{Int}, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each A}) -> () {
+bb0(%0 : $*Pack{Int}, %1 : $*@direct Pack{Int}, %2 : $*Pack{repeat each A}):
+  %3 = tuple ()
+  return %3
+}
+
+sil @non_ossa_callee : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+bb0(%0 : $*Pack{Int}):
+  %1 = tuple ()
+  return %1
+}
+
+// CHECK-LABEL: sil [ossa] @call_eligibility_tests : $@convention(thin) <each A> (Int, @pack_guaranteed Pack{Int}, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each A}) -> () {
+// CHECK: bb0(%0 : $Int, %1 : $*Pack{Int}, %2 : $*@direct Pack{Int}, %3 : $*Pack{repeat each A}):
+// CHECK: function_ref @no_packs : $@convention(thin) (Int) -> ()
+// CHECK: function_ref @$s13indirect_packTf8x_n : $@convention(thin) (Int) -> ()
+// CHECK: function_ref @direct_pack : $@convention(thin) (@pack_guaranteed @direct Pack{Int}) -> ()
+// CHECK: function_ref @pack_expansion : $@convention(thin) <each τ_0_0> (@pack_guaranteed Pack{repeat each τ_0_0}) -> ()
+// CHECK: function_ref @$s11mixed_packsTf8xnn_n : $@convention(thin) <each τ_0_0> (Int, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each τ_0_0}) -> ()
+// CHECK: function_ref @non_ossa_callee : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+// CHECK-LABEL: } // end sil function 'call_eligibility_tests'
+sil [ossa] @call_eligibility_tests : $@convention(thin) <each A> (Int, @pack_guaranteed Pack{Int}, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each A}) -> () {
+bb0(%0 : $Int, %1 : $*Pack{Int}, %2 : $*@direct Pack{Int}, %3 : $*Pack{repeat each A}):
+  %4 = function_ref @no_packs : $@convention(thin) (Int) -> ()
+  %5 = apply %4(%0) : $@convention(thin) (Int) -> ()
+
+  %6 = function_ref @indirect_pack : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+  %7 = apply %6(%1) : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+
+  %8 = function_ref @direct_pack : $@convention(thin) (@pack_guaranteed @direct Pack{Int}) -> ()
+  %9 = apply %8(%2) : $@convention(thin) (@pack_guaranteed @direct Pack{Int}) -> ()
+
+  %10 = function_ref @pack_expansion : $@convention(thin) <each A> (@pack_guaranteed Pack{repeat each A}) -> ()
+  %11 = apply %10<Pack{repeat each A}>(%3) : $@convention(thin) <each A> (@pack_guaranteed Pack{repeat each A}) -> ()
+
+  %12 = function_ref @mixed_packs : $@convention(thin) <each A> (@pack_guaranteed Pack{Int}, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each A}) -> ()
+  %13 = apply %12<Pack{repeat each A}>(%1, %2, %3) : $@convention(thin) <each A> (@pack_guaranteed Pack{Int}, @pack_guaranteed @direct Pack{Int}, @pack_guaranteed Pack{repeat each A}) -> ()
+
+
+  %14 = function_ref @non_ossa_callee : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+  %15 = apply %14(%1) : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+
+  %99 = tuple ()
+  return %99
+}
+
+// CHECK-LABEL: sil @non_ossa_caller : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+// CHECK: function_ref @indirect_pack : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+// CHECK-LABEL: } // end sil function 'non_ossa_caller'
+sil @non_ossa_caller : $@convention(thin) (@pack_guaranteed Pack{Int}) -> () {
+bb0(%0 : $*Pack{Int}):
+  %1 = function_ref @indirect_pack : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@pack_guaranteed Pack{Int}) -> ()
+  return %2
+}

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend %s -emit-ir -O | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// When no witness methods are called on pack elements, all pack code can be fully eliminated.
+// CHECK: define {{.*}} { i64, i64, ptr, double } @"$s19pack_specialization8copyPack2xsxxQp_txxQp_tRvzlFSi_SSSdQP_Tg5Tf8xx_n"(i64 %0, i64 %1, ptr %2, double %3)
+// CHECK-NEXT: entry:
+// CHECK-NEXT: insertvalue
+// CHECK-NEXT: insertvalue
+// CHECK-NEXT: insertvalue
+// CHECK-NEXT: insertvalue
+// CHECK-NEXT: @swift_bridgeObjectRetain
+// CHECK-NEXT: ret { i64, i64, ptr, double }
+@inline(never)
+func copyPack<each A>(xs: repeat each A) -> (repeat each A) {
+  return (repeat each xs);
+}
+
+public func copyPackCaller() -> (Int, String, Double) {
+  return copyPack(xs: 1, "two", 3.0)
+}
+
+// The pack specialization pass alone is not enough to eliminate packs when witness methods are called.
+// CHECK: define {{.*}} i64 @"$s19pack_specialization11addTogether2xsxxQp_txxQp_tRvzSjRzlFSi_QP_Tg5Tf8xx_n"(i64 %0)
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[IN_STACK:%[0-9]+]] = alloca %TSi, align 8
+// CHECK-NEXT:    [[OUT_STACK:%[0-9]+]] = alloca %TSi, align 8
+// CHECK:         store i64 %0, ptr [[IN_STACK]], align 8
+// CHECK:         call swiftcc void @"$ss18AdditiveArithmeticP1poiyxx_xtFZTj"
+// CHECK:         [[RESULT:%[0-9]+]] = load i64, ptr [[OUT_STACK]]
+// CHECK:         ret i64 [[RESULT]]
+@inline(never)
+func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
+  return (repeat (each xs + each xs))
+}
+
+public func addTogetherCaller() -> Int {
+  return addTogether(xs: 1)
+}


### PR DESCRIPTION
rdar://161182876

There are two key barriers that prevent variadic generic specialisations from being optimised in most cases:

* Indirect packs in the calling convention: These force the caller to make a large number of stack allocations, since the pack is passed indirectly, and pack elements are currently always pointers, so every element must be stack-allocated separately from the pack.
* Pack loops and open_pack_element: These perform one iteration per pack element, so the loop body must be generic, with witness_method instructions that cannot be eliminated, since the type they are called on is not known.

Targeted modifications to eliminate these barriers will allow other passes to fully optimise variadic generic specialisations.

**This PR only addresses the first barrier, indirect packs as function arguments.**

The simplest way to eliminate indirect packs from the calling convention is effectively to move the stack allocations for the packs and pack elements inside the callee, and use the addresses of these local allocations in the main body, which is otherwise unchanged. These allocations can be eliminated by other passes once dynamic pack loops are optimised.

This transformation is performed by a function pass (currently called pack-specialization). For example, it would transform the following specialisation like so:
```
sil shared @$s11addTogether8doubleUp2xsxxQp_xxQptxxQp_tRvzlFSi_SdSSSJQP_Tg5 : $@convention(thin) (@pack_guaranteed Pack{Int, Double, String, Character}) -> (@pack_out Pack{Int, Double, String, Character}, @pack_out Pack{Int, Double, String, Character}) {
bb0(%0 : $*Pack{Int, Double, String, Character}, %1 : $*Pack{Int, Double, String, Character}, %2 : $*Pack{Int, Double, String, Character}):
  debug_value %2, let, name "xs", argno 1, expr op_deref
  …

sil shared @$s11addTogether8doubleUp2xsxxQp_xxQptxxQp_tRvzlFSi_SdSSSJQP_Tg5Tf8xxx_n : $@convention(thin) (Int, Double, @guaranteed String, @guaranteed Character) -> (Int, Double, @owned String, @owned Character, Int, Double, @owned String, @owned Character) {
bb0(%0 : $Int, %1 : $Double, %2 : $String, %3 : $Character):
  %4 = alloc_pack $Pack{Int, Double, String, Character}
  %5 = scalar_pack_index 0 of $Pack{Int, Double, String, Character}
  %6 = alloc_stack $Int
  store %0 to %6
  …
  debug_value %4, let, name "xs", argno 1, expr op_deref
  …
```
Note that the return values are all now direct, so bb0 only needs arguments corresponding to the xs parameter pack.

To optimise a pack loop, it must be unrolled. The pack element type is then statically known in each unrolled instance of the body. The existing loop unrolling pass can consistently do this in variadic generic specialisations, since the (known constant) pack length is used as the number of iterations. This still leaves constructs like the following:
```
  %5 = integer_literal $Builtin.Word, 0
  %6 = dynamic_pack_index %5 of $Pack{Int, Double}
  %7 = open_pack_element %6 of <each A where repeat each A : Numeric> at <Pack{Int, Double}>, shape $each A, uuid "063BDCF4-98A3-11F0-B2E8-929C59BC796C"
  %20 = witness_method $@pack_element("063BDCF4-98A3-11F0-B2E8-929C59BC796C") each A, #Numeric."*" …
  %21 = apply %20<@pack_element("063BDCF4-98A3-11F0-B2E8-929C59BC796C") each A>(%10, %14, %18, %11) … // type-defs: %7
```
In this context, we could easily replace all instances of the @pack_element type with Int. This would allow the appropriate witness method to be inlined. We will perform this in an instruction simplification for open_pack_element.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
