### PR TITLE
[cxx-interop] SWIFT_NONCOPYABLE overlooked in some cases

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8237,17 +8237,15 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
 }
 
 static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {
-  if (llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-        return ctor->isMoveConstructor() &&
-               (ctor->isDeleted() || ctor->isIneligibleOrNotSelected() ||
-                ctor->getAccess() != clang::AS_public);
-      }))
-    return false;
+  if (decl->hasSimpleMoveConstructor())
+    return true;
 
   return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-    return ctor->isMoveConstructor() &&
+    return ctor->isMoveConstructor() && !ctor->isDeleted() &&
+           !ctor->isIneligibleOrNotSelected() &&
            // FIXME: Support default arguments (rdar://142414553)
-           ctor->getNumParams() == 1;
+           ctor->getNumParams() == 1 &&
+           ctor->getAccess() == clang::AS_public;
   });
 }
 
@@ -8379,46 +8377,48 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       return CxxValueSemanticsKind::Copyable;
   }
 
-  auto injectedStlAnnotation =
-      recordDecl->isInStdNamespace()
-          ? STLConditionalParams.find(recordDecl->getName())
-          : STLConditionalParams.end();
-  auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
-                       ? injectedStlAnnotation->second
-                       : std::vector<int>();
-  auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
+  if (!hasNonCopyableAttr(recordDecl)) {
+    auto injectedStlAnnotation =
+        recordDecl->isInStdNamespace()
+            ? STLConditionalParams.find(recordDecl->getName())
+            : STLConditionalParams.end();
+    auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
+                         ? injectedStlAnnotation->second
+                         : std::vector<int>();
+    auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
 
-  if (!STLParams.empty() || !conditionalParams.empty()) {
-    HeaderLoc loc{recordDecl->getLocation()};
-    std::function checkArgValueSemantics =
-        [&](clang::TemplateArgument &arg,
-            StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
-      if (arg.getKind() != clang::TemplateArgument::Type && importerImpl) {
-        importerImpl->diagnose(loc, diag::type_template_parameter_expected,
-                               argToCheck);
-        return CxxValueSemanticsKind::Unknown;
-      }
+    if (!STLParams.empty() || !conditionalParams.empty()) {
+      HeaderLoc loc{recordDecl->getLocation()};
+      std::function checkArgValueSemantics =
+          [&](clang::TemplateArgument &arg,
+              StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
+        if (arg.getKind() != clang::TemplateArgument::Type && importerImpl) {
+          importerImpl->diagnose(loc, diag::type_template_parameter_expected,
+                                 argToCheck);
+          return CxxValueSemanticsKind::Unknown;
+        }
 
-      auto argValueSemantics = evaluateOrDefault(
-          evaluator,
-          CxxValueSemantics(
-              {arg.getAsType()->getUnqualifiedDesugaredType(), importerImpl}),
-          {});
-      if (argValueSemantics != CxxValueSemanticsKind::Copyable)
-        return argValueSemantics;
-      return std::nullopt;
-    };
+        auto argValueSemantics = evaluateOrDefault(
+            evaluator,
+            CxxValueSemantics(
+                {arg.getAsType()->getUnqualifiedDesugaredType(), importerImpl}),
+            {});
+        if (argValueSemantics != CxxValueSemanticsKind::Copyable)
+          return argValueSemantics;
+        return std::nullopt;
+      };
 
-    auto result = checkConditionalParams<CxxValueSemanticsKind>(
-        recordDecl, STLParams, conditionalParams, checkArgValueSemantics);
-    if (result.has_value())
-      return result.value();
+      auto result = checkConditionalParams<CxxValueSemanticsKind>(
+          recordDecl, STLParams, conditionalParams, checkArgValueSemantics);
+      if (result.has_value())
+        return result.value();
 
-    if (importerImpl)
-      for (auto name : conditionalParams)
-        importerImpl->diagnose(loc, diag::unknown_template_parameter, name);
+      if (importerImpl)
+        for (auto name : conditionalParams)
+          importerImpl->diagnose(loc, diag::unknown_template_parameter, name);
 
-    return CxxValueSemanticsKind::Copyable;
+      return CxxValueSemanticsKind::Copyable;
+    }
   }
 
   const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
@@ -8428,7 +8428,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     return CxxValueSemanticsKind::Copyable;
   }
 
-  bool isCopyable = hasCopyTypeOperations(cxxRecordDecl);
+  bool isCopyable = !hasNonCopyableAttr(cxxRecordDecl) && 
+                    hasCopyTypeOperations(cxxRecordDecl);
   bool isMovable = hasMoveTypeOperations(cxxRecordDecl);
 
   if (!hasDestroyTypeOperations(cxxRecordDecl) || (!isCopyable && !isMovable)) {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3011,10 +3011,8 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
       ctx.evaluator, 
       CxxValueSemantics({clangType->getTypeForDecl(), &ImporterImpl}), {});
 
-  if (valueSemanticsKind == CxxValueSemanticsKind::MoveOnly)
-    return destroyFunc;
-
-  if (valueSemanticsKind != CxxValueSemanticsKind::Copyable)
+  if (valueSemanticsKind != CxxValueSemanticsKind::Copyable &&
+      valueSemanticsKind != CxxValueSemanticsKind::MoveOnly)
     return nullptr;
 
   auto cxxRecordSemanticsKind = evaluateOrDefault(
@@ -3032,6 +3030,9 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
         return nullptr;
       }
     }
+
+    if (valueSemanticsKind == CxxValueSemanticsKind::MoveOnly)
+      return destroyFunc;
 
     markDeprecated(
         nominal,

--- a/test/Interop/C/struct/Inputs/noncopyable-struct.h
+++ b/test/Interop/C/struct/Inputs/noncopyable-struct.h
@@ -47,7 +47,7 @@ void badDestroy2(BadDestroyNonCopyableType2 *ptr);
 
 struct __attribute__((swift_attr("~Copyable"))) __attribute__((swift_attr("destroy:extraDestroy"))) ExtraDestroy {
   void *storage;
-
+  ExtraDestroy(ExtraDestroy&&) = default;
   ~ExtraDestroy() { }
 };
 

--- a/test/Interop/C/struct/noncopyable_structs_nontrivial.swift
+++ b/test/Interop/C/struct/noncopyable_structs_nontrivial.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-frontend -emit-sil -I %S/Inputs/ -I %swift_src_root/lib/ClangImporter/SwiftBridging %s -verify -DERRORS -verify-additional-prefix conly-
 // RUN: %target-swift-frontend -emit-sil -I %S/Inputs/ -I %swift_src_root/lib/ClangImporter/SwiftBridging %s -verify -DERRORS -DCPLUSPLUS -verify-additional-prefix cplusplus- -cxx-interoperability-mode=default
 
-// XFAIL: OS=windows-msvc
 import NoncopyableStructs
 
 #if CPLUSPLUS


### PR DESCRIPTION
In some cases, the use of `SWIFT_NONCOPYABLE` was being overlooked. 
Also, if this attribute is present, there's no need to evaluate the conditional parameters. We currently accept that the user adds both `SWIFT_NONCOPYABLE` and `SWIFT_COPYABLE_IF` attributes to the same record, but if the first is present, we don't need to evaluate the second one. 
