### PR TITLE
Revert "Frontend: Require explicit language mode when emitting swiftinterfaces"

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1040,8 +1040,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (!isValid)
       diagnoseSwiftVersion(vers, A, Args, Diags);
   } else if (FrontendOpts.InputsAndOutputs.hasModuleInterfaceOutputPath()) {
-    Diags.diagnose({}, diag::error_module_interface_requires_language_mode);
-    HadError = true;
+    Diags.diagnose({}, diag::error_module_interface_requires_language_mode)
+        .limitBehavior(DiagnosticBehavior::Warning);
+    // FIXME: Make this an error again (rdar://145168219)
+    // HadError = true;
   }
 
   if (auto A = Args.getLastArg(OPT_package_description_version)) {

--- a/test/ModuleInterface/language_mode.swift
+++ b/test/ModuleInterface/language_mode.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
-// RUN: not %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
+// RUN: %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
 // RUN:   -enable-library-evolution -module-name Test \
 // RUN:   -emit-module-interface-path %t.swiftinterface \
 // RUN:   -emit-module -o /dev/null 2>&1 | %FileCheck %s
 
-// CHECK: <unknown>:0: error: emitting module interface files requires '-language-mode'
+// CHECK: <unknown>:0: warning: emitting module interface files requires '-language-mode'
 
 // RUN: %swift_frontend_plain -target %target-swift-5.1-abi-triple %s \
 // RUN:   -enable-library-evolution -module-name Test \


### PR DESCRIPTION
This reverts https://github.com/swiftlang/swift/pull/84327.

Resolves rdar://161078613.
