### PR TITLE
Core: add missing link against `log` on Android

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -136,6 +136,7 @@ target_link_libraries(swift_Concurrency PRIVATE
   swiftShims
   swiftConcurrencyInternalShims
   $<$<BOOL:${BUILD_SHARED_LIBS}>:swiftThreading>
+  $<$<PLATFORM_ID:Android>:log>
   $<$<PLATFORM_ID:Windows>:Synchronization>
   $<$<PLATFORM_ID:Windows>:mincore>
   # Link to the runtime that we are just building.

--- a/Runtimes/Core/LLVMSupport/CMakeLists.txt
+++ b/Runtimes/Core/LLVMSupport/CMakeLists.txt
@@ -5,9 +5,10 @@ add_library(swiftLLVMSupport OBJECT
   SmallPtrSet.cpp
   SmallVector.cpp
   StringRef.cpp)
-target_compile_options(swiftLLVMSupport
-  PRIVATE
-    $<$<BOOL:${SwiftCore_HAS_ASL}>:-DSWIFT_STDLIB_HAS_ASL>)
+target_compile_options(swiftLLVMSupport PRIVATE
+  $<$<BOOL:${SwiftCore_HAS_ASL}>:-DSWIFT_STDLIB_HAS_ASL>)
+target_link_libraries(swiftLLVMSupport PRIVATE
+  $<$<PLATFORM_ID:Android>:log>)
 
 if(NOT BUILD_SHARED_LIBS)
   install(TARGETS swiftLLVMSupport


### PR DESCRIPTION
The standard library and Concurrency depend on liblog from the NDK. Add the missing dependency to fully resolve symbols.