### PR TITLE
[cxx-interop] Make imported enum members inherit the access of their parent

### DIFF
--- a/test/Interop/Cxx/class/access/access-inversion-executable.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-executable.swift
@@ -28,7 +28,7 @@ AccessInversionTestSuite.test("usePrivateRec") {
 }
 
 AccessInversionTestSuite.test("usePrivateEnum") {
-    let e = Leaky.AliasToPrivateEnum(rawValue: 0)!
+    let e = Leaky.AliasToPrivateEnum(rawValue: 0)
     expectEqual(e.rawValue, 0)
 }
 

--- a/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
@@ -282,9 +282,7 @@ func usePrivateEnumClass(a: inout Leaky.AliasToPrivateEnumClass) -> Leaky.AliasT
     let _ = Leaky.AliasToPrivateEnumClass.privateEnumClassMember
     let _ = Leaky.PrivateEnumClass.privateEnumClassMember
     // expected-error@-1 {{'PrivateEnumClass' is inaccessible due to 'private' protection level}}
-    let _: Leaky.AliasToPrivateEnum = .privateEnumClassMember
-    // expected-error@-1 {{type 'Leaky.AliasToPrivateEnum' (aka 'Leaky.PrivateEnum') has no member 'privateEnumClassMember'}}
-    // FIXME: ^this should be accessible
+    let _: Leaky.AliasToPrivateEnumClass = .privateEnumClassMember
 
     let rv0 = Leaky.AliasToPrivateEnumClass(rawValue: 0)!
     let _ = Leaky.PrivateEnumClass(rawValue: 0)!

--- a/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
@@ -208,10 +208,10 @@ func usePrivateEnum(a: inout Leaky.AliasToPrivateEnum) -> Leaky.AliasToPrivateEn
     // Constructing and reading PrivateEnum
     //
 
-    // TODO: nested enum members are not being imported (#54905)
-    // let _ = Leaky.privateEnumMember
-    let rv0 = Leaky.AliasToPrivateEnum(rawValue: 0)!
-    let _ = Leaky.PrivateEnum(rawValue: 0)!
+    let _ = Leaky.privateEnumMember // FIXME: nested enum members are not being imported (#54905)
+    // expected-error@-1 {{type 'Leaky' has no member 'privateEnumMember'}}
+    let rv0 = Leaky.AliasToPrivateEnum(rawValue: 0)
+    let _ = Leaky.PrivateEnum(rawValue: 0)
     // expected-error@-1 {{'PrivateEnum' is inaccessible due to 'private' protection level}}
 
     let _ = rv0.rawValue
@@ -276,16 +276,15 @@ func usePrivateEnumClass(a: inout Leaky.AliasToPrivateEnumClass) -> Leaky.AliasT
     // Constructing and reading PrivateEnumClass
     //
 
-    // NOTE: private enum class members are not accessible even if we can access
-    // instances of the private enum class via
+    // NOTE: private enum class members are accessible if we can access
+    // their parent enum class decl
 
     let _ = Leaky.AliasToPrivateEnumClass.privateEnumClassMember
-    // expected-error@-1 {{'privateEnumClassMember' is inaccessible due to 'private' protection level}}
     let _ = Leaky.PrivateEnumClass.privateEnumClassMember
     // expected-error@-1 {{'PrivateEnumClass' is inaccessible due to 'private' protection level}}
     let _: Leaky.AliasToPrivateEnum = .privateEnumClassMember
     // expected-error@-1 {{type 'Leaky.AliasToPrivateEnum' (aka 'Leaky.PrivateEnum') has no member 'privateEnumClassMember'}}
-    // TODO: ^this is not really the right error message
+    // FIXME: ^this should be accessible
 
     let rv0 = Leaky.AliasToPrivateEnumClass(rawValue: 0)!
     let _ = Leaky.PrivateEnumClass(rawValue: 0)!
@@ -298,7 +297,6 @@ func usePrivateEnumClass(a: inout Leaky.AliasToPrivateEnumClass) -> Leaky.AliasT
 
     switch rv0 {
     case .privateEnumClassMember:
-    // expected-error@-1 {{'privateEnumClassMember' is inaccessible due to 'private' protection level}}
       doSomething()
     default:
       doSomething()

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
@@ -1,0 +1,111 @@
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -module-name main %t/base.swift -I %t/Inputs -o %t/base -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// RUN: %target-codesign %t/base
+// RUN: %target-run %t/base
+
+// RUN: %target-build-swift -module-name main %t/not-base.swift -I %t/Inputs -o %t/not-base -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// RUN: %target-codesign %t/not-base
+// RUN: %target-run %t/not-base
+
+// RUN: %target-build-swift -module-name main %t/derived.swift -I %t/Inputs -o %t/derived -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// RUN: %target-codesign %t/derived
+// RUN: %target-run %t/derived
+
+// RUN: %target-build-swift -module-name main %t/not-derived.swift -I %t/Inputs -o %t/not-derived -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// RUN: %target-codesign %t/not-derived
+// RUN: %target-run %t/not-derived
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "cxx-header.h"
+}
+
+//--- Inputs/cxx-header.h
+#pragma once
+
+class __attribute__((__swift_attr__("private_fileid:main/base.swift")))
+Base {
+protected:
+  enum class Enum { Foo, Bar };
+public:
+  Enum makeEnum(void) const { return Enum::Bar; }
+};
+
+class __attribute__((__swift_attr__("private_fileid:main/derived.swift")))
+Derived : public Base {};
+
+//--- base.swift
+import StdlibUnittest
+import CxxModule
+
+var Suite = TestSuite("BlessedForBase")
+extension Base {
+  static func makeEnums() {
+    let e1: Enum = Enum.Bar
+    let e2: Enum = Enum.Foo
+    expectEqual(e1, Enum.Bar)
+    expectNotEqual(e1, e2)
+    switch e2 {
+    case .Bar:
+      expectTrue(false, "foo is bar")
+    case .Foo:
+      expectTrue(true, "foo is foo")
+    }
+  }
+}
+Suite.test("Use private nested enum in base class") { Base.makeEnums() }
+runAllTests()
+
+//--- not-base.swift
+import StdlibUnittest
+import CxxModule
+
+var Suite = TestSuite("NotBlessedForBase")
+Suite.test("Use private nested enum in base class") {
+  let b = Base()
+  let e1 = b.makeEnum()
+  let e2 = b.makeEnum()
+  expectEqual(e1, e2)
+}
+runAllTests()
+
+
+//--- derived.swift
+import StdlibUnittest
+import CxxModule
+
+var Suite = TestSuite("BlessedForDerived")
+extension Derived {
+  static func makeEnums() {
+    let e1: Enum = Enum.Bar
+    let e2: Enum = Enum.Foo
+    expectEqual(e1, Enum.Bar)
+    expectNotEqual(e1, e2)
+    switch e2 {
+    case .Bar:
+      expectTrue(false, "foo is bar")
+    case .Foo:
+      expectTrue(true, "foo is foo")
+    }
+  }
+}
+Suite.test("Use private nested enum inherited from base class") { Derived.makeEnums() }
+runAllTests()
+
+//--- not-derived.swift
+import StdlibUnittest
+import CxxModule
+
+var Suite = TestSuite("NotBlessedForDerive")
+Suite.test("Use private nested enum inherited from base class") {
+  let d = Derived()
+  let e1 = d.makeEnum()
+  let e2 = d.makeEnum()
+  expectEqual(e1, e2)
+}
+runAllTests()

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-module-interface.swift
@@ -1,0 +1,43 @@
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -print-access -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "cxx-header.h"
+}
+
+//--- Inputs/cxx-header.h
+#pragma once
+
+class __attribute__((__swift_attr__("private_fileid:main/base.swift")))
+Base {
+protected:
+  enum class Enum { Foo, Bar };
+public:
+  Enum makeEnum(void) const { return Enum::Bar; }
+};
+
+class __attribute__((__swift_attr__("private_fileid:main/derived.swift")))
+Derived : public Base {};
+
+// CHECK:      public struct Base {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private enum Enum : [[ENUM_UNDERLYING_TYPE:Int32|UInt32]] {
+// CHECK-NEXT:     private init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
+// CHECK-NEXT:     private var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
+// CHECK-NEXT:     private typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
+// CHECK-NEXT:     case Foo
+// CHECK-NEXT:     case Bar
+// CHECK-NEXT:   }
+// CHECK-NEXT:   public func makeEnum() -> Base.Enum
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct Derived {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private typealias Enum = Base.Enum
+// CHECK-NEXT:   public func makeEnum() -> Base.Enum
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
@@ -1,7 +1,7 @@
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -module-name main %t/base.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -module-name main %t/derived.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/base.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/derived.swift
 
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers
 

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
@@ -1,0 +1,107 @@
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -module-name main %t/base.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -module-name main %t/derived.swift
+
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "cxx-header.h"
+}
+
+//--- Inputs/cxx-header.h
+#pragma once
+
+class __attribute__((__swift_attr__("private_fileid:main/base.swift")))
+Base {
+protected:
+  enum class Enum { Foo, Bar };
+public:
+  Enum makeEnum(void) const { return Enum::Bar; }
+};
+
+class __attribute__((__swift_attr__("private_fileid:main/derived.swift")))
+Derived : public Base {};
+
+//--- base.swift
+import CxxModule
+
+extension Base {
+  private static func inside(e: Enum) {
+    let _: Enum = Enum.Bar
+    let _: Base.Enum = Base.Enum.Bar
+    let _: Enum = Base.Enum.Foo
+    let _: Base.Enum = Enum.Foo
+
+    switch e {
+      case .Bar: return
+      case .Foo: return
+    }
+  }
+}
+
+func switches() {
+  let b = Base()
+  let d = Derived()
+  switch b.makeEnum() {
+    default: return   // this is OK
+  }
+  switch d.makeEnum() {
+    default: return   // this is OK
+  }
+  switch b.makeEnum() {
+    case .Bar: return // somehow this is OK
+    case .Foo: return // somehow this is OK
+  }
+  switch d.makeEnum() {
+    case .Bar: return // somehow this is OK
+    case .Foo: return // somehow this is OK
+  }
+}
+
+func outside() {
+  let b = Base()
+  let d = Derived()
+  let _ = b.makeEnum()  // This is OK as long as we don't name the type
+  let _ = d.makeEnum()  // This is OK as long as we don't name the type
+
+  let _: Derived.Enum = b.makeEnum() // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+  let _: Derived.Enum = d.makeEnum() // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+
+  // The types in the base and derived types should be considered the same type
+  var x = b.makeEnum()
+  x = d.makeEnum()
+  var y = d.makeEnum()
+  y = b.makeEnum()
+}
+
+//--- derived.swift
+import CxxModule
+
+extension Base {
+  private static func inside(e: Enum) { // expected-error    {{'Enum' is inaccessible due to 'private' protection level}}
+    let _: Enum = Enum.Bar              // expected-error    {{'Enum' is inaccessible due to 'private' protection level}}
+                                        // expected-error@-1 {{'Enum' is inaccessible due to 'private' protection level}}
+  }
+}
+
+extension Derived {
+  private static func inside(e: Enum) {
+    let b = Base()
+    let _: Enum = Enum.Bar
+    let _: Enum = b.makeEnum()
+
+    // It would be nice to make these work but they do not
+    let _: Base.Enum = Base.Enum.Bar // expected-error    {{'Enum' is inaccessible due to 'private' protection level}}
+                                     // expected-error@-1 {{'Enum' is inaccessible due to 'private' protection level}}
+    let _: Enum = Base.Enum.Foo      // expected-error    {{'Enum' is inaccessible due to 'private' protection level}}
+    let _: Base.Enum = Enum.Foo      // expected-error    {{'Enum' is inaccessible due to 'private' protection level}}
+
+    switch e {
+      case .Bar: return
+      case .Foo: return
+    }
+  }
+}

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-typecheck.swift
@@ -52,12 +52,20 @@ func switches() {
     default: return   // this is OK
   }
   switch b.makeEnum() {
-    case .Bar: return // somehow this is OK
-    case .Foo: return // somehow this is OK
+    case Base.Enum.Bar: return // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+    case Base.Enum.Foo: return // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+  }
+  switch b.makeEnum() {
+    case .Bar: return // OK as long as the user does not refer to Enum itself
+    case .Foo: return // (NOTE: arguably this should not be allowed)
   }
   switch d.makeEnum() {
-    case .Bar: return // somehow this is OK
-    case .Foo: return // somehow this is OK
+    case Derived.Enum.Bar: return // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+    case Derived.Enum.Foo: return // expected-error {{'Enum' is inaccessible due to 'private' protection level}}
+  }
+  switch d.makeEnum() {
+    case .Bar: return // OK as long as the user does not refer to Enum itself
+    case .Foo: return // (NOTE: arguably this should not be allowed)
   }
 }
 
@@ -91,6 +99,7 @@ extension Derived {
   private static func inside(e: Enum) {
     let b = Base()
     let _: Enum = Enum.Bar
+    let _: Derived.Enum = Derived.Enum.Bar
     let _: Enum = b.makeEnum()
 
     // It would be nice to make these work but they do not


### PR DESCRIPTION
This patch relaxes the access check for members of imported inherited nested enums. Without it, those members become impossible to inherit, which largely defeats the purpose of importing them in the first place.

rdar://160803362