### PR TITLE
AST: Give `CustomAvailabilityDomain` 8 byte alignment

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -22,6 +22,7 @@
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/PlatformKindUtils.h"
+#include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
@@ -334,7 +335,8 @@ struct StableAvailabilityDomainComparator {
 };
 
 /// Represents an availability domain that has been defined in a module.
-class CustomAvailabilityDomain : public llvm::FoldingSetNode {
+class alignas(1 << CustomAvailabilityDomainAlignInBits) CustomAvailabilityDomain
+    : public llvm::FoldingSetNode {
 public:
   enum class Kind : uint8_t {
     /// A domain that is known to be enabled at compile time.

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -34,6 +34,7 @@ namespace swift {
   class AttributeBase;
   class BraceStmt;
   class CaptureListExpr;
+  class CustomAvailabilityDomain;
   class Decl;
   class DeclContext;
   class DifferentiableAttr;
@@ -80,6 +81,7 @@ namespace swift {
   constexpr size_t ASTContextAlignInBits = 2;
   constexpr size_t TypeVariableAlignInBits = 4;
   constexpr size_t StoredDefaultArgumentAlignInBits = 3;
+  constexpr size_t CustomAvailabilityDomainAlignInBits = 3;
 
   // Well, this is the *minimum* pointer alignment; it's going to be 3 on
   // 64-bit targets, but that doesn't matter.
@@ -164,6 +166,9 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::CaseLabelItem, swift::PatternAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::StmtConditionElement,
                             swift::PatternAlignInBits)
+
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::CustomAvailabilityDomain,
+                            swift::CustomAvailabilityDomainAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 


### PR DESCRIPTION
`AvailabilityDomain` is a pointer union over `CustomAvailabilityDomain` and an opaque pointer-like 24-bit value, which means the number of spare bits in an `AvailabilityDomain` representation is one fewer than a `CustomAvailabilityDomain` pointer. Other structures in the compiler rely on there being at least 2 spare bits in `AvailabilityDomain`, though, which was not the case when building for a 32 bit architecture. To ensure there are enough spare bits, always align `CustomAvailabilityDomain` to 8 bytes, the same as many AST data structures.
