### PR TITLE
[cxx-interop] Do not import C++23 deducing this

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1538,6 +1538,10 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   if (!swift3OrLaterName && isa<clang::CXXMethodDecl>(D)) {
     return ImportedName();
   }
+  // If this function uses C++23 deducing this, bail.
+  if (auto functionDecl = dyn_cast<clang::FunctionDecl>(D))
+    if (functionDecl->hasCXXExplicitFunctionObjectParameter())
+      return {};
 
   // Dig out the definition, if there is one.
   if (auto def = getDefinitionForClangTypeDecl(D)) {

--- a/test/Interop/Cxx/class/method/Inputs/deducing-this.h
+++ b/test/Interop/Cxx/class/method/Inputs/deducing-this.h
@@ -1,0 +1,4 @@
+struct HasDeducingThis {
+  int value;
+  int deducingRef(this HasDeducingThis &self) { return self.value; }
+};

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -1,3 +1,8 @@
+module DeducingThis {
+  header "deducing-this.h"
+  requires cplusplus23
+}
+
 module Methods {
   header "methods.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/method/deducing-this-module-interface.swift
+++ b/test/Interop/Cxx/class/method/deducing-this-module-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=DeducingThis -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++23 | %FileCheck %s
+
+// This mostly ensures that we don't import deducing this method with an incorrect signature.
+
+// CHECK: struct HasDeducingThis {
+// CHECK-NOT:   deducingRef


### PR DESCRIPTION
We don't currently support C++23 deducing this parameters. Until we do, let's not expose incorrect function signatures to Swift.

rdar://161345481

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
