### PR TITLE
build.ps1: avoid unnecessary double build of compiler runtimes

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3191,7 +3191,6 @@ function Build-SDK([Hashtable] $Platform) {
   Invoke-BuildStep Build-Runtime $Platform
   Invoke-BuildStep Build-Dispatch $Platform
   Invoke-BuildStep Build-Foundation $Platform
-  Invoke-BuildStep Build-CompilerRuntime $Platform
 }
 
 function Build-ExperimentalSDK([Hashtable] $Platform) {


### PR DESCRIPTION
These are now built as part of the toolchain build to allow the removal of the legacy SDK. While this is low cost as the build is cached, avoid the unnecessary work.