### PR TITLE
Provide an implementation of `swift_stdlib_random()` derived from `std::random_device`.

### DIFF
--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -46,6 +46,15 @@
 
 #include <stdlib.h>
 
+#if !defined(__APPLE__)
+#warning For testing only
+#define SWIFT_USE_STD_RANDOM_DEVICE 1
+#endif
+
+#if defined(SWIFT_USE_STD_RANDOM_DEVICE)
+#include <random>
+#endif
+
 #include "swift/shims/Random.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Threading/Mutex.h"
@@ -54,7 +63,27 @@
 
 using namespace swift;
 
-#if defined(__APPLE__)
+#if defined(SWIFT_USE_STD_RANDOM_DEVICE)
+SWIFT_RUNTIME_STDLIB_API
+void swift_stdlib_random_fallback(void *buf, __swift_size_t nbytes) {
+  auto buffer = reinterpret_cast<char *>(buf); // for arithmetic
+  std::random_device rd;
+
+  // We must assign each generated value to a temporary local integer because we
+  // do not know if the buffer is well-aligned or not.
+  for (size_t i = 0; i < nbytes; i += sizeof(std::random_device::result_type)) {
+    auto value = rd();
+    std::memcpy(buffer + i, &value, sizeof(value));
+  }
+
+  auto trailingCount = (nbytes % sizeof(std::random_device::result_type));
+  if (trailingCount > 0) {
+    auto value = rd();
+    std::memcpy(buffer + (nbytes - trailingCount), &value, trailingCount);
+  }
+}
+
+#elseif defined(__APPLE__)
 
 SWIFT_RUNTIME_STDLIB_API
 void swift_stdlib_random(void *buf, __swift_size_t nbytes) {

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -72,12 +72,15 @@ void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
 
   // We must assign each generated value to a temporary local integer because we
   // do not know if the buffer is well-aligned or not.
-  for (size_t i = 0; i < nbytes; i += sizeof(std::random_device::result_type)) {
-    auto value = rd();
-    std::memcpy(buffer + i, &value, sizeof(value));
+  constexpr size_t byteCountPerWord = sizeof(std::random_device::result_type);
+  if (nbytes >= byteCountPerWord) {
+    for (size_t i = 0; i < nbytes; i += byteCountPerWord) {
+      auto value = rd();
+      std::memcpy(buffer + i, &value, byteCountPerWord);
+    }
   }
 
-  auto trailingCount = (nbytes % sizeof(std::random_device::result_type));
+  auto trailingCount = (nbytes % byteCountPerWord);
   if (trailingCount > 0) {
     auto value = rd();
     std::memcpy(buffer + (nbytes - trailingCount), &value, trailingCount);

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -52,6 +52,7 @@
 #endif
 
 #if defined(SWIFT_USE_STD_RANDOM_DEVICE)
+#include <cstring>
 #include <random>
 #endif
 
@@ -83,7 +84,7 @@ void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   }
 }
 
-#elseif defined(__APPLE__)
+#elif defined(__APPLE__)
 
 SWIFT_RUNTIME_STDLIB_API
 void swift_stdlib_random(void *buf, __swift_size_t nbytes) {

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -65,7 +65,7 @@ using namespace swift;
 
 #if defined(SWIFT_USE_STD_RANDOM_DEVICE)
 SWIFT_RUNTIME_STDLIB_API
-void swift_stdlib_random_fallback(void *buf, __swift_size_t nbytes) {
+void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   auto buffer = reinterpret_cast<char *>(buf); // for arithmetic
   std::random_device rd;
 


### PR DESCRIPTION
This PR provides an alternate platform-agnostic implementation of `swift_stdlib_random()` based on C++11's `std::random_device`. This implementation should be portable even to Embedded Swift, with the significant caveat that there is no way to know at compile time if the random numbers produced are _actually_ non-deterministic. (They _should_ be, but if the current implementation has no suitable RNG, the API doesn't provide a way to detect that statically.)