### PR TITLE
Revert "[Dependency Scanning] Re-enable querying Swift Overlays only for visible Clang modules"

### DIFF
--- a/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
+++ b/test/ScanDependencies/module_deps_swift_overlay_only_visible.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar157603647
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/clang-module-cache)
 // RUN: %empty-directory(%t/swiftDeps)


### PR DESCRIPTION
Reverts swiftlang/swift#83841