### PR TITLE
[irgen] Make HasAArch64TBI an IRGen option instead of a LangOpts.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -605,6 +605,9 @@ public:
   /// Paths to the pass plugins registered via -load-pass-plugin.
   std::vector<std::string> LLVMPassPlugins;
 
+  /// Set to true if we support AArch64TBI.
+  bool HasAArch64TBI = false;
+
   IRGenOptions()
       : OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
         Verify(true), VerifyEach(false), OptMode(OptimizationMode::NotSet),
@@ -641,22 +644,20 @@ public:
         DisableStandardSubstitutionsInReflectionMangling(false),
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
-        AnnotateCondFailMessage(false),
-        InternalizeAtLink(false), InternalizeSymbols(false),
-        EmitGenericRODatas(true),
+        AnnotateCondFailMessage(false), InternalizeAtLink(false),
+        InternalizeSymbols(false), EmitGenericRODatas(true),
         NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false), EnableHotColdSplit(false),
         EmitAsyncFramePushPopMetadata(true), EmitTypeMallocForCoroFrame(true),
         AsyncFramePointerAll(false), UseProfilingMarkerThunks(false),
-        UseCoroCCX8664(false), UseCoroCCArm64(false),
-        MergeableTraps(false),
+        UseCoroCCX8664(false), UseCoroCCArm64(false), MergeableTraps(false),
         DebugInfoForProfiling(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),
-        CASObjMode(llvm::CASBackendMode::Native) {
+        CASObjMode(llvm::CASBackendMode::Native), HasAArch64TBI(false) {
     DisableRoundTripDebugTypes = !CONDITIONAL_ASSERT_enabled();
   }
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -674,9 +674,6 @@ namespace swift {
     bool RestrictNonProductionExperimentalFeatures = false;
 #endif
 
-    /// Set to true if we support AArch64TBI.
-    bool HasAArch64TBI = false;
-
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }

--- a/lib/DriverTool/sil_llvm_gen_main.cpp
+++ b/lib/DriverTool/sil_llvm_gen_main.cpp
@@ -167,6 +167,7 @@ int sil_llvm_gen_main(ArrayRef<const char *> argv, void *MainAddr) {
   IRGenOptions &Opts = Invocation.getIRGenOptions();
   Opts.OutputKind = options.OutputKind;
   Opts.DisableLegacyTypeInfo = options.DisableLegacyTypeInfo;
+  Invocation.computeAArch64TBIOptions();
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -375,7 +375,7 @@ void CompilerInvocation::computeAArch64TBIOptions() {
   auto &LLVMArgs = getFrontendOptions().LLVMArgs;
   auto aarch64_use_tbi =
       std::find(LLVMArgs.begin(), LLVMArgs.end(), "-aarch64-use-tbi");
-  LangOpts.HasAArch64TBI = aarch64_use_tbi != LLVMArgs.end();
+  IRGenOpts.HasAArch64TBI = aarch64_use_tbi != LLVMArgs.end();
 }
 
 void CompilerInvocation::computeCXXStdlibOptions() {


### PR DESCRIPTION
With some changes that I am making, we will no longer need this flag at the SIL level, so we can just make it an IRGen flag (which it really should have been in the first place).

----

The specific changes is that I am going to emit all of the special IRGen behavior for the special TBI optimization for nonisolated(nonsending) only in IRGen. So we do not need this logic earlier.