### PR TITLE
Windows: disable the static standard library build

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -72,7 +72,7 @@ if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 
 :: Build the -WindowsSDKArchitectures argument, if any, otherwise build all the SDKs.
 set "WindowsSDKArchitecturesArg= "
-if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-Windows -WindowsSDKArchitectures %WINDOWS_SDKS%"
+if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-Windows -WindowsSDKArchitectures %WINDOWS_SDKS% -WindowsSDKLinkModes dynamic"
 
 :: Build the -HostArchName argument, if any.
 set "HostArchNameArg="


### PR DESCRIPTION
We now build the experimental SDK statically and dynamically. For now, remove the static variant build for PR testing, the release builds will build both the static and dynamic variant. This will prevent packaging from being run on PR testing, and fortunately, the swift toolchain builds are going to build both already.
