### PR TITLE
[SILGen]: emit default arguments after all other 'delayed' arguments

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3055,33 +3055,36 @@ static void emitDelayedArguments(SILGenFunction &SGF,
                          MutableArrayRef<SmallVector<ManagedValue, 4>> args) {
   assert(!delayedArgs.empty());
 
-  // If any of the delayed arguments are isolated default arguments,
-  // argument evaluation happens in the following order:
+  // Argument evaluation happens in the following order*:
   //
-  //   1. Left-to-right evalution of explicit r-value arguments
+  //   1. Left-to-right evaluation of explicit r-value arguments
   //   2. Left-to-right evaluation of formal access arguments
-  //   3. Hop to the callee's isolation domain
+  //   3. Hop to the callee's isolation domain (if needed)
   //   4. Left-to-right evaluation of default arguments
+  //
+  //  * One known exception to this is that implicitly-opened r-value existentials
+  //  will 'jump the queue' and be evaluated before 'regular' r-value arguments.
+  //  https://github.com/swiftlang/swift/issues/84678
+  //
+  // Default arguments are collected during the first pass over the delayed
+  // arguments, and emitted separately after a potential hop to the callee's
+  // isolation domain, which is needed for isolated default arguments.
 
-  // So, if any delayed arguments are isolated, all default arguments
-  // are collected during the first pass over the delayed arguments,
-  // and emitted separately after a hop to the callee's isolation domain.
-
+  // The isolation to use if the default arguments require it. This will be
+  // calculated as the `delayedArgs` are processed.
   std::optional<ActorIsolation> defaultArgIsolation;
-  for (auto &arg : delayedArgs) {
-    if (auto isolation = arg.getIsolation()) {
-      defaultArgIsolation = isolation;
-      break;
-    }
-  }
 
+  // The default arguments to be emitted after other kinds of delayed arguments.
   SmallVector<std::tuple<
-      /*delayedArgIt*/decltype(delayedArgs)::iterator,
-      /*siteArgsIt*/decltype(args)::iterator,
-      /*index*/size_t>, 2> isolatedArgs;
+                  /*delayedArgIt*/ decltype(delayedArgs)::iterator,
+                  /*siteArgsIt*/ decltype(args)::iterator,
+                  /*index*/ size_t>,
+              2>
+      defaultArgs;
 
+  // Holds inout arguments that were emitted. Currently used to detect 'simple'
+  // cases of storage aliasing.
   SmallVector<std::pair<SILValue, SILLocation>, 4> emittedInoutArgs;
-  auto delayedNext = delayedArgs.begin();
 
   // The assumption we make is that 'args' and 'delayedArgs' were built
   // up in parallel, with empty spots being dropped into 'args'
@@ -3093,7 +3096,9 @@ static void emitDelayedArguments(SILGenFunction &SGF,
   // remove or add elements to fill in the actual argument values.
   //
   // Note that this also begins the formal accesses in evaluation order.
-  for (auto argsIt = args.begin(); argsIt != args.end(); ++argsIt) {
+  for (auto [delayedNext, argsIt] =
+           std::tuple{delayedArgs.begin(), args.begin()};
+       argsIt != args.end(); ++argsIt) {
     auto &siteArgs = *argsIt;
     // NB: siteArgs.size() may change during iteration
     for (size_t i = 0; i < siteArgs.size(); ) {
@@ -3111,11 +3116,31 @@ static void emitDelayedArguments(SILGenFunction &SGF,
       assert(delayedNext != delayedArgs.end());
       auto &delayedArg = *delayedNext;
 
-      if (defaultArgIsolation && delayedArg.isDefaultArg()) {
-        isolatedArgs.push_back(std::make_tuple(delayedNext, argsIt, i));
+      // If we found a default argument, further delay it so it is emitted only
+      // after we've finished with formal accesses. This is done so that it is
+      // possible to make a call in which an implicitly opened existential is
+      // passed as a formal access parameter and the call contains default args
+      // that precede said parameter. e.g.
+      //
+      //  ```swift
+      //  let stream: any TextOuptputStream = ""
+      //  print("Hello, inout-implicitly-opened-existential!", to: &stream)
+      //  ```
+      //
+      // Additionally, this is done so that isolated default arguments will be
+      // evaluated in the correct isolation – an executor hop will be inserted
+      // before their emission if appropriate.
+      if (delayedArg.isDefaultArg()) {
+        // Record the argument for future emission.
+        defaultArgs.push_back(std::make_tuple(delayedNext, argsIt, i));
+
+        // Update our default argument isolation if necessary.
+        if (!defaultArgIsolation)
+          defaultArgIsolation = delayedArg.getIsolation();
+
         ++i;
         if (++delayedNext == delayedArgs.end()) {
-          goto done;
+          goto EmitDefaultArgs;
         } else {
           continue;
         }
@@ -3133,16 +3158,16 @@ static void emitDelayedArguments(SILGenFunction &SGF,
       }
 
       if (++delayedNext == delayedArgs.end())
-        goto done;
+        goto EmitDefaultArgs;
     }
   }
 
   llvm_unreachable("ran out of null arguments before we ran out of inouts");
 
-done:
+EmitDefaultArgs:
 
-  if (defaultArgIsolation) {
-    assert(!isolatedArgs.empty());
+  // TODO: verify the logic we want here
+  if (!defaultArgs.empty()) {
 
     // Only hop to the default arg isolation if the callee is async.
     // If we're in a synchronous function, the isolation has to match,
@@ -3155,8 +3180,8 @@ done:
     // do end up here for default argument generators and stored property
     // initializers. An alternative (and better) approach is to formally model
     // those generator functions as isolated.
-    if (SGF.F.isAsync()) {
-      auto &firstArg = *std::get<0>(isolatedArgs[0]);
+    if (defaultArgIsolation && SGF.F.isAsync()) {
+      auto &firstArg = *std::get<0>(defaultArgs[0]);
       auto loc = firstArg.getDefaultArgLoc();
 
       SILValue executor;
@@ -3184,7 +3209,7 @@ done:
       SGF.emitHopToTargetExecutor(loc, executor);
     }
 
-    // The index saved in isolatedArgs is the index where we're
+    // The index saved in deferredDefaultArgs is the index where we're
     // supposed to fill in the argument in siteArgs. It should point
     // to a single null element, which we will replace with zero or
     // more actual argument values. This replacement can invalidate
@@ -3196,11 +3221,11 @@ done:
     size_t indexAdjustment = 0;
     auto indexAdjustmentSite = args.begin();
 
-    for (auto &isolatedArg : isolatedArgs) {
-      auto &delayedArg = *std::get<0>(isolatedArg);
-      auto site = std::get<1>(isolatedArg);
+    for (auto &defaultArg : defaultArgs) {
+      auto &delayedArg = *std::get<0>(defaultArg);
+      auto site = std::get<1>(defaultArg);
       auto &siteArgs = *site;
-      size_t argIndex = std::get<2>(isolatedArg);
+      size_t argIndex = std::get<2>(defaultArg);
 
       // Apply the current index adjustment if we haven't changed
       // sites.

--- a/test/SILGen/default_arguments_delayed.swift
+++ b/test/SILGen/default_arguments_delayed.swift
@@ -1,0 +1,268 @@
+// RUN: %target-swift-emit-silgen %s
+// TODO: filecheck
+
+protocol P {}
+protocol Q {}
+
+protocol HasDefault {
+  static var defaultValue: Self { get }
+}
+
+// MARK: - Core Bug: Default Arguments Before inout Generic Parameters
+
+// CHECK-LABEL: sil hidden @$s{{.*}}24testDefaultBeforeInout
+func testDefaultBeforeInout(_ input: any P) {
+  var local = input
+  fnDefaultBeforeInout(b: &local)
+}
+// CHECK: [[OPEN:%.*]] = open_existential_addr
+// CHECK: [[DEFAULT_FN:%.*]] = function_ref @$s{{.*}}fnDefaultBeforeInout
+// CHECK: apply [[DEFAULT_FN]]
+// Verify open_existential_addr dominates the default argument initializer
+
+func fnDefaultBeforeInout<Value: P>(a: Bool = false, b: inout Value) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}31testMultipleDefaultsBeforeInout
+func testMultipleDefaultsBeforeInout(_ input: any P) {
+  var local = input
+  fnMultipleDefaults(c: &local)
+}
+
+func fnMultipleDefaults<Value: P>(a: Int = 1, b: String = "test", c: inout Value) {}
+
+// MARK: - Control: Default Arguments After inout (Should Work)
+
+// CHECK-LABEL: sil hidden @$s{{.*}}23testDefaultAfterInout
+func testDefaultAfterInout(_ input: any P) {
+  var local = input
+  fnDefaultAfterInout(a: &local)
+}
+
+func fnDefaultAfterInout<Value: P>(a: inout Value, b: Bool = false) {}
+
+// MARK: - Parameter Type Variations
+
+// CHECK-LABEL: sil hidden @$s{{.*}}30testDefaultBeforeNonInoutGeneric
+func testDefaultBeforeNonInoutGeneric(_ input: any P) {
+  fnNonInout(b: input)
+}
+
+func fnNonInout<Value: P>(a: Bool = false, b: Value) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}32testDefaultBeforeBorrowingGeneric
+func testDefaultBeforeBorrowingGeneric(_ input: any P) {
+  fnBorrowing(b: input)
+}
+
+func fnBorrowing<Value: P>(a: Bool = false, b: borrowing Value) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}32testDefaultBeforeConsumingGeneric
+func testDefaultBeforeConsumingGeneric(_ input: any P) {
+  fnConsuming(b: input)
+}
+
+func fnConsuming<Value: P>(a: Bool = false, b: consuming Value) {}
+
+// MARK: - Multiple Generic Parameters
+
+// CHECK-LABEL: sil hidden @$s{{.*}}28testTwoGenericsDefaultBefore
+func testTwoGenericsDefaultBefore(_ p: any P, _ q: any Q) {
+  var localP = p
+  var localQ = q
+  fnTwoGenerics(b: &localP, c: &localQ)
+}
+
+func fnTwoGenerics<T: P, U: Q>(a: Bool = false, b: inout T, c: inout U) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}29testDefaultBetweenTwoGenerics
+func testDefaultBetweenTwoGenerics(_ p: any P, _ q: any P) {
+  var localP = p
+  var localQ = q
+  fnDefaultBetween(a: &localP, c: &localQ)
+}
+
+func fnDefaultBetween<T: P, U: P>(a: inout T, b: Bool = false, c: inout U) {}
+
+// MARK: - TextOutputStream
+
+protocol CustomOutputStream: TextOutputStream {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}28testCustomOutputStreamPrint
+func testCustomOutputStreamPrint(_ stream: any CustomOutputStream) {
+  var local = stream
+  customPrint("test", to: &local)
+}
+
+func customPrint<Target: CustomOutputStream>(
+  _ items: String...,
+  separator: String = " ",
+  terminator: String = "\n",
+  to output: inout Target
+) {}
+
+// MARK: - Complex Default Argument Expressions
+
+// Default argument using generic type parameter - should fail or be diagnosed
+func fnWithGenericDefault<Value: HasDefault>(
+  a: Value = Value.defaultValue,
+  b: inout Value
+) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}31testDefaultWithClosureCapture
+func testDefaultWithClosureCapture(_ input: any P) {
+  var local = input
+  fnClosureDefault(b: &local)
+}
+
+func fnClosureDefault<Value: P>(
+  a: () -> Int = { 42 },
+  b: inout Value
+) {}
+
+// MARK: - Access Patterns
+
+struct Container {
+  var value: any P
+  
+  mutating func process<T: P>(flag: Bool = true, item: inout T) {}
+  
+  // CHECK-LABEL: sil hidden @$s{{.*}}9Container16testNestedAccess
+  mutating func testNestedAccess() {
+    var local = value
+    process(item: &local)
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}26testMultipleSuccessiveCalls
+func testMultipleSuccessiveCalls(_ input: any P) {
+  var local = input
+  fnDefaultBeforeInout(b: &local)
+  fnDefaultBeforeInout(b: &local)
+}
+
+// MARK: - Optional Parameters (SE-0375)
+
+// CHECK-LABEL: sil hidden @$s{{.*}}32testDefaultBeforeOptionalGeneric
+func testDefaultBeforeOptionalGeneric(_ input: any P) {
+  fnOptional(b: input)
+}
+
+func fnOptional<Value: P>(a: Bool = false, b: Value?) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}37testDefaultBeforeOptionalInoutGeneric
+
+// TODO: figure out what's up with this one....
+// func testDefaultBeforeOptionalInoutGeneric(_ input: any P) {
+//   var local: (any P)? = input
+//   fnOptionalInout(b: &local)
+// }
+
+func fnOptionalInout<Value: P>(a: Bool = false, b: inout Value?) {}
+
+// MARK: - Workarounds
+
+// Explicit opening via helper function
+// CHECK-LABEL: sil hidden @$s{{.*}}23testExplicitOpenHelper
+func testExplicitOpenHelper(_ input: any P) {
+  func helper<T: P>(_ value: inout T) {
+    fnDefaultBeforeInout(b: &value)
+  }
+  var local = input
+  helper(&local)
+}
+
+// Providing explicit value for default parameter
+// CHECK-LABEL: sil hidden @$s{{.*}}25testExplicitDefaultValue
+func testExplicitDefaultValue(_ input: any P) {
+  var local = input
+  fnDefaultBeforeInout(a: false, b: &local)
+}
+
+// Reordered parameters (default after generic)
+// CHECK-LABEL: sil hidden @$s{{.*}}22testReorderedParameters
+func testReorderedParameters(_ input: any P) {
+  var local = input
+  fnReordered(a: &local)
+}
+
+func fnReordered<Value: P>(a: inout Value, b: Bool = false) {}
+
+// MARK: - Edge Cases
+
+// CHECK-LABEL: sil hidden @$s{{.*}}33testVariadicWithDefaultAndGeneric
+func testVariadicWithDefaultAndGeneric(_ input: any P) {
+  var local = input
+  fnVariadic(1, 2, 3, value: &local)
+}
+
+func fnVariadic<Value: P>(
+  _ items: Int...,
+  flag: Bool = false,
+  value: inout Value
+) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}28testAutoclosureDefaultArg
+func testAutoclosureDefaultArg(_ input: any P) {
+  var local = input
+  fnAutoclosure(value: &local)
+}
+
+func fnAutoclosure<Value: P>(
+  condition: @autoclosure () -> Bool = true,
+  value: inout Value
+) {}
+
+// MARK: - Mixed Scenarios
+
+// CHECK-LABEL: sil hidden @$s{{.*}}40testDefaultBeforeInoutAndRegularGeneric
+func testDefaultBeforeInoutAndRegularGeneric(_ p1: any P, _ p2: any P) {
+  var local = p1
+  fnMixedParams(b: &local, c: p2)
+}
+
+func fnMixedParams<T: P, U: P>(
+  a: Bool = false,
+  b: inout T,
+  c: U,
+  d: String = "default"
+) {}
+
+// CHECK-LABEL: sil hidden @$s{{.*}}41testMultipleExistentialsMultipleDefaults
+func testMultipleExistentialsMultipleDefaults(_ p: any P, _ q: any Q) {
+  var localP = p
+  var localQ = q
+  fnMultipleExistentials(b: &localP, d: &localQ)
+}
+
+func fnMultipleExistentials<T: P, U: Q>(
+  a: Int = 0,
+  b: inout T,
+  c: String = "test",
+  d: inout U,
+  e: Bool = true
+) {}
+
+// MARK: - Contextual Generic Functions
+
+class GenericContext<T: P> {
+  // CHECK-LABEL: sil hidden @$s{{.*}}14GenericContext26testDefaultInGenericContext
+  func testDefaultInGenericContext(_ input: any P) {
+    var local = input
+    process(item: &local)
+  }
+  
+  func process<U: P>(flag: Bool = true, item: inout U) {}
+}
+
+// MARK: - Protocol Extensions
+
+extension P {
+  // CHECK-LABEL: sil hidden @$s{{.*}}1P31testDefaultInProtocolExtension
+  mutating func testDefaultInProtocolExtension<U: P>(a: Bool = true, _ other: inout U, flag: Bool = false) {}
+  
+  // CHECK-LABEL: sil hidden @$s{{.*}}1P20callFromExtension
+  mutating func callFromExtension(_ input: any P) {
+    var local = input
+    testDefaultInProtocolExtension(&local)
+  }
+}


### PR DESCRIPTION
Currently, it is impossible to make a call to a function which:

1. Takes an `inout` generic parameter
2. Contains a default argument preceding said `inout` parameter
3. Implicitly opens an existential to bind to the `inout` parameter

Should you think this is an esoteric combination, consider this attempt to print to an existential output stream:

```swift
var stream: any TextOutputStream = ""
print("hello", to: &stream) // Crashes the compiler
```

This change extends the logic implemented to support [SE-0411](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0411) (isolated default arguments) to have SILGen emit default arguments only after all other forms of 'delayed arguments' have been emitted – in particular, default arguments will now be emitted after all formal argument accesses have began. This ensures the use of opened existentials within the default argument generators no longer violate SIL verifier expectations or other invariants which currently cause such code to crash.

See [additional forum discussion](https://forums.swift.org/t/thoughts-on-fixing-a-sil-verification-error-and-or-bad-codegen-involving-default-arguments-implicitly-opened-existentials/82409/4).

Resolves: https://github.com/swiftlang/swift/issues/65091