### PR TITLE
🍒[cxx-interop] Fix lifetime-operation-methods.swift

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
@@ -62,18 +62,18 @@ struct CRTPDerived : CRTPBase<CRTPDerived> {
 struct VirtualRetainRelease {
   int value;
   mutable int refCount = 1;
+  mutable bool calledBase = false;
   VirtualRetainRelease(int value) : value(value) {}
 
-  virtual void doRetainVirtual() const { refCount++; }
-  virtual void doReleaseVirtual() const { refCount--; }
+  virtual void doRetainVirtual() const { refCount++; calledBase = true; }
+  virtual void doReleaseVirtual() const { refCount--; calledBase = true; }
   virtual ~VirtualRetainRelease() = default;
 } SWIFT_SHARED_REFERENCE(.doRetainVirtual, .doReleaseVirtual);
 
 struct DerivedVirtualRetainRelease : VirtualRetainRelease {
   DerivedVirtualRetainRelease(int value) : VirtualRetainRelease(value) {}
 
-  mutable bool calledDerived = false;
-  void doRetainVirtual() const override { refCount++; calledDerived = true; }
+  void doRetainVirtual() const override { refCount++; }
   void doReleaseVirtual() const override { refCount--; }
 };
 

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
@@ -63,7 +63,7 @@ LifetimeMethodsTestSuite.test("virtual retain/release") {
 LifetimeMethodsTestSuite.test("overridden virtual retain/release") {
   let a = DerivedVirtualRetainRelease(456)
   expectEqual(a.value, 456)
-  expectTrue(a.calledDerived)
+  expectFalse(a.calledBase) // in optimized builds, we might not call retain/release at all
   expectTrue(a.refCount > 0)
   expectTrue(a.refCount < 10) // optimizations would affect the exact number
 }

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xfrontend -disable-availability-checking)
 
+// REQUIRES: executable_test
+
 // Temporarily disable when running with an older runtime (rdar://128681137)
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime


### PR DESCRIPTION
This is a test-only change that addresses CI failures after https://github.com/swiftlang/swift/pull/84343 got merged.

rdar://161132127