### PR TITLE
Fix moveSubranges documentation issue

### DIFF
--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -379,8 +379,8 @@ extension MutableCollection {
   ///     var letters = Array("ABCdeFGhijkLMNOp")
   ///     let uppercaseRanges = letters.indices(where: { $0.isUppercase })
   ///     let rangeOfUppercase = letters.moveSubranges(uppercaseRanges, to: 10)
-  ///     // String(letters) == "dehiABCFGLMNOjkp"
-  ///     // rangeOfUppercase == 4..<13
+  ///     // String(letters) == "dehijABCFGLMNOkp"
+  ///     // rangeOfUppercase == 5..<14
   ///
   /// - Parameters:
   ///   - subranges: The subranges of the elements to move.


### PR DESCRIPTION
### Summary

This PR fixes a documentation issue reported in the Swift forums:  
https://forums.swift.org/t/error-in-swift-documentation/82417

### Details

- Correct documentation from #69766.
- Ensure the documentation matches the intended Swift behavior and improves clarity for readers.

### Motivation

The previous text could cause confusion for readers and does not reflect the correct usage/behavior.  

This change aligns the documentation with the actual standard library implementation.

### Verification

- Verified the fix locally by running the example code.

```shell
swift repl
Welcome to Apple Swift version 6.0 (swiftlang-6.0.0.9.10 clang-1600.0.26.2).
Type :help for assistance.
  1> var letters = Array("ABCdeFGhijkLMNOp")
  2. let uppercaseRanges = letters.indices(where: { $0.isUppercase })
  3. let rangeOfUppercase = letters.moveSubranges(uppercaseRanges, to: 10)
letters: [String.Element] = 16 values {
  [0] = "d"
  [1] = "e"
  [2] = "h"
  [3] = "i"
  [4] = "j"
  [5] = "A"
  [6] = "B"
  [7] = "C"
  [8] = "F"
  [9] = "G"
  [10] = "L"
  [11] = "M"
  [12] = "N"
  [13] = "O"
  [14] = "k"
  [15] = "p"
}
uppercaseRanges: RangeSet<[String.Element].Index> = {
  _ranges = {
    _storage = 3 values {
      [0] = 0..<3
      [1] = 5..<7
      [2] = 11..<15
    }
  }
}
rangeOfUppercase: Range<[String.Element].Index> = 5..<14
  4> letters
$R0: [String.Element] = 16 values {
  [0] = "d"
  [1] = "e"
  [2] = "h"
  [3] = "i"
  [4] = "j"
  [5] = "A"
  [6] = "B"
  [7] = "C"
  [8] = "F"
  [9] = "G"
  [10] = "L"
  [11] = "M"
  [12] = "N"
  [13] = "O"
  [14] = "k"
  [15] = "p"
}
```