### PR TITLE
[Test][Distributed] Convert VAR=value to env VAR=value for Lit shell

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-future-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
+// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: libdispatch
 // REQUIRES: executable_test

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-future-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
+// RUN: env %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: libdispatch
 // REQUIRES: executable_test

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir
 // RUN: %target-build-swift -module-name ActorsFramework -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %env-SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out 2>&1 | %FileCheck %s --color --dump-input=always
+// RUN: env SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out 2>&1 | %FileCheck %s --color --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir
 // RUN: %target-build-swift -module-name ActorsFramework -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: env SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out 2>&1 | %FileCheck %s --color --dump-input=always
+// RUN: env %env-SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out 2>&1 | %FileCheck %s --color --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
@@ -67,7 +67,7 @@
 // RUN: %target-codesign %t/%target-library-name(ResilientImplLib)
 
 // Run and verify output
-// RUN: env SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out                                                   \
+// RUN: env %env-SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out                                                   \
 // RUN:     %t/%target-library-name(FakeDistributedActorSystems)               \
 // RUN:     %t/%target-library-name(ResilientAPILib)                           \
 // RUN:     %t/%target-library-name(ResilientImplLib)                          \

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_accessibleFunctions_crossModule.swift
@@ -67,7 +67,7 @@
 // RUN: %target-codesign %t/%target-library-name(ResilientImplLib)
 
 // Run and verify output
-// RUN: %env-SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out                                                   \
+// RUN: env SWIFT_DUMP_ACCESSIBLE_FUNCTIONS=true %target-run %t/a.out                                                   \
 // RUN:     %t/%target-library-name(FakeDistributedActorSystems)               \
 // RUN:     %t/%target-library-name(ResilientAPILib)                           \
 // RUN:     %t/%target-library-name(ResilientImplLib)                          \


### PR DESCRIPTION
Convert `VAR=value cmd` to `env VAR=value cmd` in Distributed tests to ensure compatibility with LLVM Lit’s internal shell.

Partially address #84407
