### PR TITLE
[Test][InterfaceHash] Rewrite cp commands for Lit shell

### DIFF
--- a/test/InterfaceHash/added_method-type.swift
+++ b/test/InterfaceHash/added_method-type.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_class_private_property.swift
+++ b/test/InterfaceHash/added_private_class_private_property.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_class_property.swift
+++ b/test/InterfaceHash/added_private_class_property.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_enum_private_property.swift
+++ b/test/InterfaceHash/added_private_enum_private_property.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_enum_property.swift
+++ b/test/InterfaceHash/added_private_enum_property.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_method.swift
+++ b/test/InterfaceHash/added_private_method.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_method_value_types.swift
+++ b/test/InterfaceHash/added_private_method_value_types.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swiftt
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_method_value_types.swift
+++ b/test/InterfaceHash/added_private_method_value_types.swift
@@ -6,7 +6,7 @@
 // RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/b.swift %t/x.swiftt
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_protocol_method.swift
+++ b/test/InterfaceHash/added_private_protocol_method.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_protocol_property.swift
+++ b/test/InterfaceHash/added_private_protocol_property.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_struct_private_property.swift
+++ b/test/InterfaceHash/added_private_struct_private_property.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/added_private_struct_property.swift
+++ b/test/InterfaceHash/added_private_struct_property.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -4,10 +4,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-interface %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main -module-cache-path %t/ModuleCache -Rmodule-loading
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-interface %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main -module-cache-path %t/ModuleCache -Rmodule-loading
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -4,10 +4,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: cp %t/{a,x}.swift
+// RUN: cp %t/a.swift %t/x.swift
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-interface %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main -module-cache-path %t/ModuleCache -Rmodule-loading
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
-// RUN: cp %t/{b,x}.swift
+// RUN: cp %t/b.swift %t/x.swift
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-interface %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main -module-cache-path %t/ModuleCache -Rmodule-loading
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 


### PR DESCRIPTION
Convert `// RUN: cp %t/{a,x}.swift` to `// RUN: cp %t/a.swift %t/x.swift` in InterfaceHash test for compatibility with LLVM Lit's internal shell.

Partially address #84407 