### PR TITLE
build.ps1: adjust search path for dispatch for Android

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3064,7 +3064,7 @@ function Build-XCTest([Hashtable] $Platform) {
   $SwiftFlags = if ($Platform.OS -eq [OS]::Windows) {
     @();
   } else {
-    @("-I$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr\lib\swift");
+    @("-I$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr\include");
   }
 
   Build-CMakeProject `
@@ -3127,7 +3127,7 @@ function Build-Testing([Hashtable] $Platform) {
   $SwiftFlags = if ($Platform.OS -eq [OS]::Windows) {
     @();
   } else {
-    @("-I$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr\lib\swift");
+    @("-I$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr\include");
   }
 
   Build-CMakeProject `


### PR DESCRIPTION
The current build relocates the headers to the proper location which was not previously done. Adjust the search paths accordingly.