### PR TITLE
[Optimizer] Use valid inst range to broadcast inlining changes.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -113,7 +113,8 @@ extension MutatingContext {
     bridgedPassContext.inlineFunction(apply.bridged, mandatoryInline)
 
     if let instBeforeInlining = instBeforeInlining?.next,
-       let instAfterInlining = instAfterInlining {
+       let instAfterInlining = instAfterInlining,
+       !instAfterInlining.isDeleted {
       notifyNewInstructions(from: instBeforeInlining, to: instAfterInlining)
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -96,23 +96,23 @@ extension MutatingContext {
   func inlineFunction(apply: FullApplySite, mandatoryInline: Bool) {
     // This is only a best-effort attempt to notify the new cloned instructions as changed.
     // TODO: get a list of cloned instructions from the `inlineFunction`
-    let instAfterInling: Instruction?
+    let instAfterInlining: Instruction?
     switch apply {
     case is ApplyInst:
-      instAfterInling = apply.next
+      instAfterInlining = apply.next
     case let beginApply as BeginApplyInst:
       let next = beginApply.next!
-      instAfterInling = (next is EndApplyInst ? nil : next)
+      instAfterInlining = (next is EndApplyInst ? nil : next)
     case is TryApplyInst:
-      instAfterInling = apply.parentBlock.next?.instructions.first
+      instAfterInlining = apply.parentBlock.next?.instructions.first
     default:
-      instAfterInling = nil
+      instAfterInlining = nil
     }
 
     bridgedPassContext.inlineFunction(apply.bridged, mandatoryInline)
 
-    if let instAfterInling = instAfterInling {
-      notifyNewInstructions(from: apply, to: instAfterInling)
+    if let instAfterInlining = instAfterInlining {
+      notifyNewInstructions(from: apply, to: instAfterInlining)
     }
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -96,6 +96,7 @@ extension MutatingContext {
   func inlineFunction(apply: FullApplySite, mandatoryInline: Bool) {
     // This is only a best-effort attempt to notify the new cloned instructions as changed.
     // TODO: get a list of cloned instructions from the `inlineFunction`
+    let instBeforeInlining = apply.previous
     let instAfterInlining: Instruction?
     switch apply {
     case is ApplyInst:
@@ -111,8 +112,9 @@ extension MutatingContext {
 
     bridgedPassContext.inlineFunction(apply.bridged, mandatoryInline)
 
-    if let instAfterInlining = instAfterInlining {
-      notifyNewInstructions(from: apply, to: instAfterInlining)
+    if let instBeforeInlining = instBeforeInlining?.next,
+       let instAfterInlining = instAfterInlining {
+      notifyNewInstructions(from: instBeforeInlining, to: instAfterInlining)
     }
   }
 

--- a/validation-test/SILOptimizer/rdar161433604.swift
+++ b/validation-test/SILOptimizer/rdar161433604.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend \
+// RUN:     -disable-availability-checking \
+// RUN:     -target %target-swift-5.9-abi-triple \
+// RUN:     -emit-sil -verify \
+// RUN:     -enable-experimental-feature LifetimeDependence \
+// RUN:     -enable-experimental-feature Embedded \
+// RUN:     %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_LifetimeDependence
+
+// XFAIL: *
+
+struct NoEscapeNoCopy: ~Escapable, ~Copyable {}
+
+protocol Foo {
+    var bar: NoEscapeNoCopy {get}
+}
+
+public struct Baz: Foo {
+    var bar: NoEscapeNoCopy {
+      NoEscapeNoCopy() // expected-error{{lifetime-dependent value escapes its scope}}
+                       // expected-note@-1{{it depends on the lifetime of this parent value}}
+    } // expected-note{{this use causes the lifetime-dependent value to escape}}
+}

--- a/validation-test/SILOptimizer/rdar161433604.swift
+++ b/validation-test/SILOptimizer/rdar161433604.swift
@@ -10,8 +10,6 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_LifetimeDependence
 
-// XFAIL: *
-
 struct NoEscapeNoCopy: ~Escapable, ~Copyable {}
 
 protocol Foo {


### PR DESCRIPTION
When inlining from the SwiftCompilerSources, sometimes a "best effort" list of instructions (in function order) more or less representing which instructions were cloned into the caller is constructed.  A loop from the first instruction to the last instruction in that range is performed, and the instructions found are broadcasted to have changed.  If the first instruction has been deleted, walking over the instructions in function order doesn't work, so instead of using the apply which inlining deletes, walk from the instruction "which is where the apply used to be" after inlining.  And if the last instruction has been deleted, waklnig over the instructions never stops because no instruction seen when walking the instructions in function order is ever equal to the deleted instruction.  Rather than just saying that every single instruction after the apply is changed, just don't bother to broadcast if the end of the range is deleted.  This matches the preexisting best effort approach which also doesn't broadcast if for example the inlined callee is a `begin_apply` immediately followed by any `end_apply`.

Fixes a compiler crash.

rdar://161433604
