### PR TITLE
[Macros] Pass a static build configuration to macro implementations

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -58,6 +58,7 @@ class IfConfigClauseRangeInfo;
 class GenericSignature;
 class GenericSignatureImpl;
 struct LabeledStmtInfo;
+class LangOptions;
 class LayoutConstraint;
 class LayoutConstraintInfo;
 struct LifetimeDescriptor;
@@ -82,6 +83,7 @@ enum class RequirementReprKind : unsigned;
 struct BridgedASTType;
 class BridgedCanType;
 class BridgedASTContext;
+class BridgedLangOptions;
 struct BridgedSubstitutionMap;
 struct BridgedGenericSignature;
 struct BridgedConformance;
@@ -193,13 +195,118 @@ BridgedDeclNameLoc_createParsed(BridgedASTContext cContext,
                                 swift::SourceLoc baseNameLoc);
 
 //===----------------------------------------------------------------------===//
-// MARK: ASTContext
+// MARK: LangOptions
 //===----------------------------------------------------------------------===//
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
   EndianLittle,
   EndianBig,
 };
+
+class BridgedLangOptions {
+  const swift::LangOptions * _Nonnull LangOpts;
+
+public:
+  SWIFT_UNAVAILABLE("Use init(raw:) instead")
+  BRIDGED_INLINE BridgedLangOptions(const swift::LangOptions &langOpts);
+
+  SWIFT_UNAVAILABLE("Use '.raw' instead")
+  BRIDGED_INLINE const swift::LangOptions &unbridged() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  const void *_Nonnull getRaw() const { return LangOpts; }
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getMajorLanguageVersion() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getTargetPointerBitWidth() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedEndianness getTargetEndianness() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getAttachCommentsToDecls() const;
+};
+
+/// Key used when enumerating build configuration entries to the
+/// StaticBuildConfiguration initializer for an ASTContext.
+enum ENUM_EXTENSIBILITY_ATTR(closed) BuildConfigurationKey : size_t {
+  BCKCustomCondition,
+  BCKFeature,
+  BCKAttribute,
+  BCKTargetOSName,
+  BCKTargetArchitecture,
+  BCKTargetEnvironment,
+  BCKTargetRuntime,
+  BCKTargetPointerAuthenticationScheme,
+  BCKTargetObjectFileFormat
+};
+
+SWIFT_NAME("BridgedLangOptions.hasFeature(self:_:)")
+bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
+                                   BridgedFeature feature);
+
+SWIFT_NAME("BridgedLangOptions.customConditionSet(self:_:)")
+bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
+                                           BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.hasFeatureNamed(self:_:)")
+bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
+                                        BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.hasAttributeNamed(self:_:)")
+bool BridgedLangOptions_hasAttributeNamed(BridgedLangOptions cLangOpts,
+                                          BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetOS(self:_:)")
+bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
+                                         BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetArchitecture(self:_:)")
+bool BridgedLangOptions_isActiveTargetArchitecture(BridgedLangOptions cLangOpts,
+                                                   BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetEnvironment(self:_:)")
+bool BridgedLangOptions_isActiveTargetEnvironment(BridgedLangOptions cLangOpts,
+                                                  BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetRuntime(self:_:)")
+bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetPtrAuth(self:_:)")
+bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.getTargetAtomicBitWidths(self:_:)")
+SwiftInt BridgedLangOptions_getTargetAtomicBitWidths(BridgedLangOptions cLangOpts,
+                                                     SwiftInt* _Nullable * _Nonnull cComponents);
+
+SWIFT_NAME("BridgedLangOptions.getLanguageVersion(self:_:)")
+SwiftInt BridgedLangOptions_getLanguageVersion(BridgedLangOptions cLangOpts,
+                                               SwiftInt* _Nullable * _Nonnull cComponents);
+
+SWIFT_NAME("BridgedLangOptions.getCompilerVersion(self:_:)")
+SwiftInt BridgedLangOptions_getCompilerVersion(BridgedLangOptions cLangOpts,
+                                               SwiftInt* _Nullable * _Nonnull cComponents);
+
+/* Deallocate an array of Swift int values that was allocated in C++. */
+void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
+
+/// Enumerate all of the key/value pairs for the build configuration by calling
+/// the given callback for each one.
+SWIFT_NAME("BridgedLangOptions.enumerateBuildConfigurationEntries(self:callbackContext:callback:)")
+void BridgedLangOptions_enumerateBuildConfigurationEntries(
+    BridgedLangOptions cLangOpts,
+    void * _Nonnull callbackContext,
+    void (* _Nonnull callback)(
+        BridgedLangOptions cLangOpts, void * _Nonnull callbackContext,
+        BuildConfigurationKey key, BridgedStringRef value));
+
+//===----------------------------------------------------------------------===//
+// MARK: ASTContext
+//===----------------------------------------------------------------------===//
 
 class BridgedASTContext {
   swift::ASTContext * _Nonnull Ctx;
@@ -216,15 +323,6 @@ public:
 
   SWIFT_COMPUTED_PROPERTY
   unsigned getMajorLanguageVersion() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  unsigned getLangOptsTargetPointerBitWidth() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  bool getLangOptsAttachCommentsToDecls() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  BridgedEndianness getLangOptsTargetEndianness() const;
 
   SWIFT_COMPUTED_PROPERTY
   BridgedAvailabilityMacroMap getAvailabilityMacroMap() const;
@@ -259,56 +357,8 @@ SWIFT_NAME("BridgedASTContext.getDollarIdentifier(self:_:)")
 swift::Identifier
 BridgedASTContext_getDollarIdentifier(BridgedASTContext cContext, size_t idx);
 
-SWIFT_NAME("BridgedASTContext.langOptsHasFeature(self:_:)")
-bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
-                                          BridgedFeature feature);
-
-SWIFT_NAME("BridgedASTContext.langOptsCustomConditionSet(self:_:)")
-bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
-                                                  BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsHasFeatureNamed(self:_:)")
-bool BridgedASTContext_langOptsHasFeatureNamed(BridgedASTContext cContext,
-                                               BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsHasAttributeNamed(self:_:)")
-bool BridgedASTContext_langOptsHasAttributeNamed(BridgedASTContext cContext,
-                                                 BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetOS(self:_:)")
-bool BridgedASTContext_langOptsIsActiveTargetOS(BridgedASTContext cContext,
-                                                BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetArchitecture(self:_:)")
-bool BridgedASTContext_langOptsIsActiveTargetArchitecture(BridgedASTContext cContext,
-                                                          BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetEnvironment(self:_:)")
-bool BridgedASTContext_langOptsIsActiveTargetEnvironment(BridgedASTContext cContext,
-                                                         BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetRuntime(self:_:)")
-bool BridgedASTContext_langOptsIsActiveTargetRuntime(BridgedASTContext cContext,
-                                                     BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetPtrAuth(self:_:)")
-bool BridgedASTContext_langOptsIsActiveTargetPtrAuth(BridgedASTContext cContext,
-                                                     BridgedStringRef cName);
-
-SWIFT_NAME("BridgedASTContext.langOptsGetTargetAtomicBitWidths(self:_:)")
-SwiftInt BridgedASTContext_langOptsGetTargetAtomicBitWidths(BridgedASTContext cContext,
-                                                      SwiftInt* _Nullable * _Nonnull cComponents);
-
-SWIFT_NAME("BridgedASTContext.langOptsGetLanguageVersion(self:_:)")
-SwiftInt BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext,
-                                                      SwiftInt* _Nullable * _Nonnull cComponents);
-
-SWIFT_NAME("BridgedASTContext.langOptsGetCompilerVersion(self:_:)")
-SwiftInt BridgedASTContext_langOptsGetCompilerVersion(BridgedASTContext cContext,
-                                                      SwiftInt* _Nullable * _Nonnull cComponents);
-
-/* Deallocate an array of Swift int values that was allocated in C++. */
-void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
+SWIFT_NAME("getter:BridgedASTContext.langOpts(self:)")
+BridgedLangOptions BridgedASTContext_langOpts(BridgedASTContext cContext);
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCanImportVersion : size_t {
   CanImportUnversioned,

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -194,115 +194,6 @@ BridgedDeclNameLoc_createParsed(BridgedASTContext cContext,
                                 swift::SourceLoc moduleSelectorLoc,
                                 swift::SourceLoc baseNameLoc);
 
-//===----------------------------------------------------------------------===//
-// MARK: LangOptions
-//===----------------------------------------------------------------------===//
-
-enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
-  EndianLittle,
-  EndianBig,
-};
-
-class BridgedLangOptions {
-  const swift::LangOptions * _Nonnull LangOpts;
-
-public:
-  SWIFT_UNAVAILABLE("Use init(raw:) instead")
-  BRIDGED_INLINE BridgedLangOptions(const swift::LangOptions &langOpts);
-
-  SWIFT_UNAVAILABLE("Use '.raw' instead")
-  BRIDGED_INLINE const swift::LangOptions &unbridged() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  const void *_Nonnull getRaw() const { return LangOpts; }
-
-  SWIFT_COMPUTED_PROPERTY
-  unsigned getMajorLanguageVersion() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  unsigned getTargetPointerBitWidth() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  BridgedEndianness getTargetEndianness() const;
-
-  SWIFT_COMPUTED_PROPERTY
-  bool getAttachCommentsToDecls() const;
-};
-
-/// Key used when enumerating build configuration entries to the
-/// StaticBuildConfiguration initializer for an ASTContext.
-enum ENUM_EXTENSIBILITY_ATTR(closed) BuildConfigurationKey : size_t {
-  BCKCustomCondition,
-  BCKFeature,
-  BCKAttribute,
-  BCKTargetOSName,
-  BCKTargetArchitecture,
-  BCKTargetEnvironment,
-  BCKTargetRuntime,
-  BCKTargetPointerAuthenticationScheme,
-  BCKTargetObjectFileFormat
-};
-
-SWIFT_NAME("BridgedLangOptions.hasFeature(self:_:)")
-bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
-                                   BridgedFeature feature);
-
-SWIFT_NAME("BridgedLangOptions.customConditionSet(self:_:)")
-bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
-                                           BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.hasFeatureNamed(self:_:)")
-bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
-                                        BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.hasAttributeNamed(self:_:)")
-bool BridgedLangOptions_hasAttributeNamed(BridgedLangOptions cLangOpts,
-                                          BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetOS(self:_:)")
-bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
-                                         BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetArchitecture(self:_:)")
-bool BridgedLangOptions_isActiveTargetArchitecture(BridgedLangOptions cLangOpts,
-                                                   BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetEnvironment(self:_:)")
-bool BridgedLangOptions_isActiveTargetEnvironment(BridgedLangOptions cLangOpts,
-                                                  BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetRuntime(self:_:)")
-bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetPtrAuth(self:_:)")
-bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.getTargetAtomicBitWidths(self:_:)")
-SwiftInt BridgedLangOptions_getTargetAtomicBitWidths(BridgedLangOptions cLangOpts,
-                                                     SwiftInt* _Nullable * _Nonnull cComponents);
-
-SWIFT_NAME("BridgedLangOptions.getLanguageVersion(self:_:)")
-SwiftInt BridgedLangOptions_getLanguageVersion(BridgedLangOptions cLangOpts,
-                                               SwiftInt* _Nullable * _Nonnull cComponents);
-
-SWIFT_NAME("BridgedLangOptions.getCompilerVersion(self:_:)")
-SwiftInt BridgedLangOptions_getCompilerVersion(BridgedLangOptions cLangOpts,
-                                               SwiftInt* _Nullable * _Nonnull cComponents);
-
-/* Deallocate an array of Swift int values that was allocated in C++. */
-void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
-
-/// Enumerate all of the key/value pairs for the build configuration by calling
-/// the given callback for each one.
-SWIFT_NAME("BridgedLangOptions.enumerateBuildConfigurationEntries(self:callbackContext:callback:)")
-void BridgedLangOptions_enumerateBuildConfigurationEntries(
-    BridgedLangOptions cLangOpts,
-    void * _Nonnull callbackContext,
-    void (* _Nonnull callback)(
-        BridgedLangOptions cLangOpts, void * _Nonnull callbackContext,
-        BuildConfigurationKey key, BridgedStringRef value));
 
 //===----------------------------------------------------------------------===//
 // MARK: ASTContext
@@ -326,6 +217,9 @@ public:
 
   SWIFT_COMPUTED_PROPERTY
   BridgedAvailabilityMacroMap getAvailabilityMacroMap() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedDiagnosticEngine getDiags() const;
 };
 
 #define IDENTIFIER_WITH_NAME(Name, _)                                          \
@@ -360,6 +254,10 @@ BridgedASTContext_getDollarIdentifier(BridgedASTContext cContext, size_t idx);
 SWIFT_NAME("getter:BridgedASTContext.langOpts(self:)")
 BridgedLangOptions BridgedASTContext_langOpts(BridgedASTContext cContext);
 
+SWIFT_NAME("BridgedLangOptions.hasAttributeNamed(self:_:)")
+bool BridgedLangOptions_hasAttributeNamed(BridgedLangOptions cLangOpts,
+                                          BridgedStringRef cName);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCanImportVersion : size_t {
   CanImportUnversioned,
   CanImportVersion,
@@ -373,6 +271,9 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
                                  BridgedCanImportVersion versionKind,
                                  const SwiftInt *_Nullable versionComponents,
                                  SwiftInt numVersionComponents);
+
+SWIFT_NAME("getter:BridgedASTContext.staticBuildConfigurationPtr(self:)")
+void * _Nonnull BridgedASTContext_staticBuildConfiguration(BridgedASTContext cContext);
 
 //===----------------------------------------------------------------------===//
 // MARK: AST nodes

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -67,6 +67,17 @@ swift::DeclNameLoc BridgedDeclNameLoc::unbridged() const {
 }
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedLangOptions
+//===----------------------------------------------------------------------===//
+
+BridgedLangOptions::BridgedLangOptions(const swift::LangOptions &langOpts)
+  : LangOpts(&langOpts) { }
+
+const swift::LangOptions &BridgedLangOptions::unbridged() const {
+  return *LangOpts;
+}
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedASTContext
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/ASTContextGlobalCache.h
+++ b/include/swift/AST/ASTContextGlobalCache.h
@@ -84,6 +84,10 @@ struct ASTContext::GlobalCache {
     const NormalProtocolConformance *,
     std::vector<ConformanceIsolationError>
   > conformanceIsolationErrors;
+
+  /// The static build configuration. This points to an instance of the Swift
+  /// StaticBuildConfiguration.
+  void *StaticBuildConfiguration = nullptr;
 };
 
 } // end namespace 

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -505,34 +505,6 @@ SWIFT_NAME("BridgedLangOptions.hasFeature(self:_:)")
 bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
                                    BridgedFeature feature);
 
-SWIFT_NAME("BridgedLangOptions.customConditionSet(self:_:)")
-bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
-                                           BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.hasFeatureNamed(self:_:)")
-bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
-                                        BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetOS(self:_:)")
-bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
-                                         BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetArchitecture(self:_:)")
-bool BridgedLangOptions_isActiveTargetArchitecture(BridgedLangOptions cLangOpts,
-                                                   BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetEnvironment(self:_:)")
-bool BridgedLangOptions_isActiveTargetEnvironment(BridgedLangOptions cLangOpts,
-                                                  BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetRuntime(self:_:)")
-bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName);
-
-SWIFT_NAME("BridgedLangOptions.isActiveTargetPtrAuth(self:_:)")
-bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName);
-
 SWIFT_NAME("BridgedLangOptions.getTargetAtomicBitWidths(self:_:)")
 SwiftInt BridgedLangOptions_getTargetAtomicBitWidths(BridgedLangOptions cLangOpts,
                                                      SwiftInt* _Nullable * _Nonnull cComponents);

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -61,6 +61,7 @@ class VersionTuple;
 } // end namespace llvm
 
 namespace swift {
+class LangOptions;
 class SourceLoc;
 class SourceRange;
 class CharSourceRange;
@@ -450,6 +451,112 @@ struct BridgedSwiftClosure {
 
   BRIDGED_INLINE void operator()(const void *_Nullable);
 };
+
+//===----------------------------------------------------------------------===//
+// MARK: LangOptions
+//===----------------------------------------------------------------------===//
+
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
+  EndianLittle,
+  EndianBig,
+};
+
+class BridgedLangOptions {
+  const swift::LangOptions * _Nonnull LangOpts;
+
+public:
+  SWIFT_UNAVAILABLE("Use init(raw:) instead")
+  BRIDGED_INLINE BridgedLangOptions(const swift::LangOptions &langOpts);
+
+  SWIFT_UNAVAILABLE("Use '.raw' instead")
+  BRIDGED_INLINE const swift::LangOptions &unbridged() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  const void *_Nonnull getRaw() const { return LangOpts; }
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getMajorLanguageVersion() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getTargetPointerBitWidth() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedEndianness getTargetEndianness() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getAttachCommentsToDecls() const;
+};
+
+/// Key used when enumerating build configuration entries to the
+/// StaticBuildConfiguration initializer for an ASTContext.
+enum ENUM_EXTENSIBILITY_ATTR(closed) BuildConfigurationKey : size_t {
+  BCKCustomCondition,
+  BCKFeature,
+  BCKAttribute,
+  BCKTargetOSName,
+  BCKTargetArchitecture,
+  BCKTargetEnvironment,
+  BCKTargetRuntime,
+  BCKTargetPointerAuthenticationScheme,
+  BCKTargetObjectFileFormat
+};
+
+SWIFT_NAME("BridgedLangOptions.hasFeature(self:_:)")
+bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
+                                   BridgedFeature feature);
+
+SWIFT_NAME("BridgedLangOptions.customConditionSet(self:_:)")
+bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
+                                           BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.hasFeatureNamed(self:_:)")
+bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
+                                        BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetOS(self:_:)")
+bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
+                                         BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetArchitecture(self:_:)")
+bool BridgedLangOptions_isActiveTargetArchitecture(BridgedLangOptions cLangOpts,
+                                                   BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetEnvironment(self:_:)")
+bool BridgedLangOptions_isActiveTargetEnvironment(BridgedLangOptions cLangOpts,
+                                                  BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetRuntime(self:_:)")
+bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.isActiveTargetPtrAuth(self:_:)")
+bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName);
+
+SWIFT_NAME("BridgedLangOptions.getTargetAtomicBitWidths(self:_:)")
+SwiftInt BridgedLangOptions_getTargetAtomicBitWidths(BridgedLangOptions cLangOpts,
+                                                     SwiftInt* _Nullable * _Nonnull cComponents);
+
+SWIFT_NAME("BridgedLangOptions.getLanguageVersion(self:_:)")
+SwiftInt BridgedLangOptions_getLanguageVersion(BridgedLangOptions cLangOpts,
+                                               SwiftInt* _Nullable * _Nonnull cComponents);
+
+SWIFT_NAME("BridgedLangOptions.getCompilerVersion(self:_:)")
+SwiftInt BridgedLangOptions_getCompilerVersion(BridgedLangOptions cLangOpts,
+                                               SwiftInt* _Nullable * _Nonnull cComponents);
+
+/* Deallocate an array of Swift int values that was allocated in C++. */
+void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
+
+/// Enumerate all of the key/value pairs for the build configuration by calling
+/// the given callback for each one.
+SWIFT_NAME("BridgedLangOptions.enumerateBuildConfigurationEntries(self:callbackContext:callback:)")
+void BridgedLangOptions_enumerateBuildConfigurationEntries(
+    BridgedLangOptions cLangOpts,
+    void * _Nonnull callbackContext,
+    void (* _Nonnull callback)(
+        BridgedLangOptions cLangOpts, void * _Nonnull callbackContext,
+        BuildConfigurationKey key, BridgedStringRef value));
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/Bridging/BasicSwift.h
+++ b/include/swift/Bridging/BasicSwift.h
@@ -1,0 +1,32 @@
+//===--- BasicSwift.h -------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BRIDGING_BASICSWIFT_H
+#define SWIFT_BRIDGING_BASICSWIFT_H
+
+#include "swift/Basic/BasicBridging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Create a new static build configuration for the given language options.
+void * _Nonnull swift_Basic_createStaticBuildConfiguration(BridgedLangOptions cLangOpts);
+
+/// Free the given static build configuration.
+void swift_Basic_freeStaticBuildConfiguration(void * _Nonnull staticBuildConfiguration);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SWIFT_BRIDGING_BASICSWIFT_H

--- a/include/swift/Bridging/MacroEvaluation.h
+++ b/include/swift/Bridging/MacroEvaluation.h
@@ -14,6 +14,7 @@
 #define SWIFT_BRIDGING_MACROS_H
 
 #include "swift/Basic/BasicBridging.h"
+#include "swift/AST/ASTBridging.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,13 +41,13 @@ void swift_Macros_freeExpansionReplacements(
     ptrdiff_t *_Nullable replacementsPtr, ptrdiff_t numReplacements);
 
 ptrdiff_t swift_Macros_expandFreestandingMacro(
-    void *_Nonnull diagEngine, const void *_Nonnull macro,
+    BridgedASTContext cContext, const void *_Nonnull macro,
     const char *_Nonnull discriminator, uint8_t rawMacroRole,
     void *_Nonnull sourceFile, const void *_Nullable sourceLocation,
     BridgedStringRef *_Nonnull evaluatedSourceOut);
 
 ptrdiff_t swift_Macros_expandAttachedMacro(
-    void *_Nonnull diagEngine, const void *_Nonnull macro,
+    BridgedASTContext cContext, const void *_Nonnull macro,
     const char *_Nonnull discriminator, const char *_Nonnull qualifiedType,
     const char *_Nonnull conformances, uint8_t rawMacroRole,
     void *_Nonnull customAttrSourceFile,

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -326,6 +326,10 @@ public:
   /// exit.
   bool PrintTargetInfo = false;
 
+  /// Indicates that the frontend should print the static build configuration
+  /// information as JSON.
+  bool PrintBuildConfig = false;
+
   /// Indicates that the frontend should print the supported features and then
   /// exit.
   bool PrintSupportedFeatures = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1542,6 +1542,9 @@ def target_legacy_spelling : Joined<["--"], "target=">,
 def print_target_info : Flag<["-"], "print-target-info">,
     Flags<[FrontendOption]>,
     HelpText<"Print target information for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
+def print_static_build_config : Flag<["-"], "print-static-build-config">,
+    Flags<[FrontendOption]>,
+    HelpText<"Print static build configuration that can be used to evaluate #ifs in Swift source code">;
 
 def print_supported_features : Flag<["-"], "print-supported-features">,
     Flags<[FrontendOption]>,

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -36,114 +36,12 @@ Identifier BridgedASTContext_getDollarIdentifier(BridgedASTContext cContext,
   return cContext.unbridged().getDollarIdentifier(idx);
 }
 
-bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
-                                          BridgedFeature feature) {
-  return cContext.unbridged().LangOpts.hasFeature((Feature)feature);
+BridgedLangOptions BridgedASTContext_langOpts(BridgedASTContext cContext) {
+  return cContext.unbridged().LangOpts;
 }
 
 unsigned BridgedASTContext::getMajorLanguageVersion() const {
   return unbridged().LangOpts.EffectiveLanguageVersion[0];
-}
-
-bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
-                                                  BridgedStringRef cName) {
-  ASTContext &ctx = cContext.unbridged();
-  auto name = cName.unbridged();
-  if (name.starts_with("$") && ctx.LangOpts.hasFeature(name.drop_front()))
-    return true;
-
-  return ctx.LangOpts.isCustomConditionalCompilationFlagSet(name);
-}
-
-bool BridgedASTContext_langOptsHasFeatureNamed(BridgedASTContext cContext,
-                                               BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.hasFeature(cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsHasAttributeNamed(BridgedASTContext cContext,
-                                                 BridgedStringRef cName) {
-  return hasAttribute(cContext.unbridged().LangOpts, cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsIsActiveTargetOS(BridgedASTContext cContext,
-                                                BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.checkPlatformCondition(
-      PlatformConditionKind::OS, cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsIsActiveTargetArchitecture(
-    BridgedASTContext cContext, BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.checkPlatformCondition(
-      PlatformConditionKind::Arch, cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsIsActiveTargetEnvironment(
-    BridgedASTContext cContext, BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.checkPlatformCondition(
-      PlatformConditionKind::TargetEnvironment, cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsIsActiveTargetRuntime(BridgedASTContext cContext,
-                                                     BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.checkPlatformCondition(
-      PlatformConditionKind::Runtime, cName.unbridged());
-}
-
-bool BridgedASTContext_langOptsIsActiveTargetPtrAuth(BridgedASTContext cContext,
-                                                     BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts.checkPlatformCondition(
-      PlatformConditionKind::PtrAuth, cName.unbridged());
-}
-
-unsigned BridgedASTContext::getLangOptsTargetPointerBitWidth() const {
-  return unbridged().LangOpts.Target.isArch64Bit()   ? 64
-         : unbridged().LangOpts.Target.isArch32Bit() ? 32
-         : unbridged().LangOpts.Target.isArch16Bit() ? 16
-                                                     : 0;
-}
-
-bool BridgedASTContext::getLangOptsAttachCommentsToDecls() const {
-  return unbridged().LangOpts.AttachCommentsToDecls;
-}
-
-BridgedEndianness BridgedASTContext::getLangOptsTargetEndianness() const {
-  return unbridged().LangOpts.Target.isLittleEndian() ? EndianLittle
-                                                      : EndianBig;
-}
-
-/// Convert an array of numbers into a form we can use in Swift.
-namespace {
-template <typename Arr>
-SwiftInt convertArray(const Arr &array, SwiftInt **cElements) {
-  SwiftInt numElements = array.size();
-  *cElements = (SwiftInt *)malloc(sizeof(SwiftInt) * numElements);
-  for (SwiftInt i = 0; i != numElements; ++i)
-    (*cElements)[i] = array[i];
-  return numElements;
-}
-} // namespace
-
-void deallocateIntBuffer(SwiftInt *_Nullable cComponents) { free(cComponents); }
-
-SwiftInt
-BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext,
-                                             SwiftInt **cComponents) {
-  auto theVersion = cContext.unbridged().LangOpts.EffectiveLanguageVersion;
-  return convertArray(theVersion, cComponents);
-}
-
-SWIFT_NAME("BridgedASTContext.langOptsGetCompilerVersion(self:_:)")
-SwiftInt
-BridgedASTContext_langOptsGetCompilerVersion(BridgedASTContext cContext,
-                                             SwiftInt **cComponents) {
-  auto theVersion = version::Version::getCurrentLanguageVersion();
-  return convertArray(theVersion, cComponents);
-}
-
-SwiftInt BridgedASTContext_langOptsGetTargetAtomicBitWidths(
-    BridgedASTContext cContext, SwiftInt *_Nullable *_Nonnull cElements) {
-  return convertArray(cContext.unbridged().LangOpts.getAtomicBitWidthValues(),
-                      cElements);
 }
 
 bool BridgedASTContext_canImport(BridgedASTContext cContext,

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -89,11 +89,6 @@ BridgedAvailabilityMacroMap BridgedASTContext::getAvailabilityMacroMap() const {
   return &unbridged().getAvailabilityMacroMap();
 }
 
-bool BridgedLangOptions_hasAttributeNamed(BridgedLangOptions cLangOpts,
-                                          BridgedStringRef cName) {
-  return hasAttribute(cLangOpts.unbridged(), cName.unbridged());
-}
-
 void *BridgedASTContext_staticBuildConfiguration(BridgedASTContext cContext) {
   ASTContext &ctx = cContext.unbridged();
   void *staticBuildConfiguration = ctx.getGlobalCache().StaticBuildConfiguration;

--- a/lib/AST/Bridging/CMakeLists.txt
+++ b/lib/AST/Bridging/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(swiftAST PRIVATE
   DiagnosticsBridging.cpp
   ExprBridging.cpp
   GenericsBridging.cpp
+  LangOptionsBridging.cpp
   MiscBridging.cpp
   PatternBridging.cpp
   PluginBridging.cpp

--- a/lib/AST/Bridging/CMakeLists.txt
+++ b/lib/AST/Bridging/CMakeLists.txt
@@ -7,7 +7,6 @@ target_sources(swiftAST PRIVATE
   DiagnosticsBridging.cpp
   ExprBridging.cpp
   GenericsBridging.cpp
-  LangOptionsBridging.cpp
   MiscBridging.cpp
   PatternBridging.cpp
   PluginBridging.cpp

--- a/lib/AST/Bridging/LangOptionsBridging.cpp
+++ b/lib/AST/Bridging/LangOptionsBridging.cpp
@@ -1,0 +1,231 @@
+//===--- Bridging/LangOptsBridging.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTBridging.h"
+
+#include "swift/Basic/LangOptions.h"
+
+using namespace swift;
+
+bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
+                                   BridgedFeature feature) {
+  return cLangOpts.unbridged().hasFeature((Feature)feature);
+}
+
+
+bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
+                                           BridgedStringRef cName) {
+  const LangOptions &langOpts = cLangOpts.unbridged();
+  auto name = cName.unbridged();
+  if (name.starts_with("$") && langOpts.hasFeature(name.drop_front()))
+    return true;
+
+  return langOpts.isCustomConditionalCompilationFlagSet(name);
+}
+
+bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
+                                        BridgedStringRef cName) {
+  return cLangOpts.unbridged().hasFeature(cName.unbridged());
+}
+
+bool BridgedLangOptions_hasAttributeNamed(BridgedLangOptions cLangOpts,
+                                          BridgedStringRef cName) {
+  return hasAttribute(cLangOpts.unbridged(), cName.unbridged());
+}
+
+bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
+                                         BridgedStringRef cName) {
+  return cLangOpts.unbridged().checkPlatformCondition(
+      PlatformConditionKind::OS, cName.unbridged());
+}
+
+bool BridgedLangOptions_isActiveTargetArchitecture(
+    BridgedLangOptions cLangOpts, BridgedStringRef cName) {
+  return cLangOpts.unbridged().checkPlatformCondition(
+      PlatformConditionKind::Arch, cName.unbridged());
+}
+
+bool BridgedLangOptions_isActiveTargetEnvironment(
+    BridgedLangOptions cLangOpts, BridgedStringRef cName) {
+  return cLangOpts.unbridged().checkPlatformCondition(
+      PlatformConditionKind::TargetEnvironment, cName.unbridged());
+}
+
+bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName) {
+  return cLangOpts.unbridged().checkPlatformCondition(
+      PlatformConditionKind::Runtime, cName.unbridged());
+}
+
+bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
+                                              BridgedStringRef cName) {
+  return cLangOpts.unbridged().checkPlatformCondition(
+      PlatformConditionKind::PtrAuth, cName.unbridged());
+}
+
+unsigned BridgedLangOptions::getTargetPointerBitWidth() const {
+  return unbridged().Target.isArch64Bit()   ? 64
+         : unbridged().Target.isArch32Bit() ? 32
+         : unbridged().Target.isArch16Bit() ? 16
+                                            : 0;
+}
+
+BridgedEndianness BridgedLangOptions::getTargetEndianness() const {
+  return unbridged().Target.isLittleEndian() ? EndianLittle : EndianBig;
+}
+
+bool BridgedLangOptions::getAttachCommentsToDecls() const {
+  return unbridged().AttachCommentsToDecls;
+}
+
+/// Convert an array of numbers into a form we can use in Swift.
+namespace {
+template <typename Arr>
+SwiftInt convertArray(const Arr &array, SwiftInt **cElements) {
+  SwiftInt numElements = array.size();
+  *cElements = (SwiftInt *)malloc(sizeof(SwiftInt) * numElements);
+  for (SwiftInt i = 0; i != numElements; ++i)
+    (*cElements)[i] = array[i];
+  return numElements;
+}
+} // namespace
+
+void deallocateIntBuffer(SwiftInt *_Nullable cComponents) { free(cComponents); }
+
+SwiftInt
+BridgedLangOptions_getLanguageVersion(BridgedLangOptions cLangOpts,
+                                      SwiftInt **cComponents) {
+  auto theVersion = cLangOpts.unbridged().EffectiveLanguageVersion;
+  return convertArray(theVersion, cComponents);
+}
+
+SwiftInt
+BridgedLangOptions_getCompilerVersion(BridgedLangOptions cLangOpts,
+                                      SwiftInt **cComponents) {
+  auto theVersion = version::Version::getCurrentLanguageVersion();
+  return convertArray(theVersion, cComponents);
+}
+
+SwiftInt BridgedLangOptions_getTargetAtomicBitWidths(
+    BridgedLangOptions cLangOpts, SwiftInt *_Nullable *_Nonnull cElements) {
+  return convertArray(cLangOpts.unbridged().getAtomicBitWidthValues(),
+                      cElements);
+}
+
+void BridgedLangOptions_enumerateBuildConfigurationEntries(
+    BridgedLangOptions cLangOpts,
+    void * _Nonnull callbackContext,
+    void (* _Nonnull callback)(
+        BridgedLangOptions cLangOpts, void * _Nonnull callbackContext,
+        BuildConfigurationKey key, BridgedStringRef value)) {
+  const LangOptions &langOpts = cLangOpts.unbridged();
+
+  // Enumerate custom conditions.
+  for (const auto &customCondition: langOpts.getCustomConditionalCompilationFlags()) {
+    callback(cLangOpts, callbackContext, BCKCustomCondition,
+             StringRef(customCondition));
+  }
+
+  // Enumerate features that are enabled.
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
+  if (langOpts.hasFeature(Feature::FeatureName))                               \
+    callback(cLangOpts, callbackContext, BCKFeature, StringRef(#FeatureName));
+#include "swift/Basic/Features.def"
+
+  // Enumerate attributes that are available.
+#define DECL_ATTR(SPELLING, CLASS, REQUIREMENTS, BEHAVIORS, CODE)              \
+  if (hasAttribute(langOpts, #SPELLING))                                       \
+    callback(cLangOpts, callbackContext, BCKAttribute, StringRef(#SPELLING));
+#include "swift/AST/DeclAttr.def"
+
+#define TYPE_ATTR(SPELLING, CLASS)                                             \
+  if (hasAttribute(langOpts, #SPELLING))                                       \
+    callback(cLangOpts, callbackContext, BCKAttribute, StringRef(#SPELLING));
+#include "swift/AST/TypeAttr.def"
+
+  // Deal with all of the target platform/architecture information.
+  for (const auto &[kind, value] : langOpts.getPlatformConditionValues()) {
+    switch (kind) {
+      case PlatformConditionKind::OS:
+        callback(cLangOpts, callbackContext, BCKTargetOSName, StringRef(value));
+
+        // Special case that macOS is an alias of OSX.
+        if (value == "OSX") {
+          callback(cLangOpts, callbackContext, BCKTargetOSName,
+                   StringRef("macOS"));
+        }
+        break;
+
+      case PlatformConditionKind::Arch:
+        callback(cLangOpts, callbackContext, BCKTargetArchitecture, StringRef(value));
+        break;
+
+      case PlatformConditionKind::Runtime:
+        callback(cLangOpts, callbackContext, BCKTargetRuntime, StringRef(value));
+        break;
+
+      case PlatformConditionKind::TargetEnvironment:
+        callback(cLangOpts, callbackContext, BCKTargetEnvironment,
+                 StringRef(value));
+
+        // When compiling for iOS we consider "macCatalyst" to be a
+        // synonym of "macabi". This enables the use of
+        // #if targetEnvironment(macCatalyst) as a compilation
+        // condition for macCatalyst.
+        if (value == "macabi" && langOpts.Target.isiOS()) {
+          callback(cLangOpts, callbackContext, BCKTargetEnvironment,
+                   StringRef("macCatalyst"));
+        }
+        break;
+
+      case PlatformConditionKind::PtrAuth:
+        callback(cLangOpts, callbackContext, BCKTargetPointerAuthenticationScheme,
+                 StringRef(value));
+        break;
+
+      case PlatformConditionKind::Endianness:
+      case PlatformConditionKind::PointerBitWidth:
+      case PlatformConditionKind::CanImport:
+      case PlatformConditionKind::HasAtomicBitWidth:
+        // Handled separately.
+        break;
+    }
+  }
+
+  // Object file format.
+  llvm::Triple triple(langOpts.Target.getTriple());
+  switch (triple.getObjectFormat()) {
+    case llvm::Triple::ObjectFormatType::COFF:
+      callback(cLangOpts, callbackContext, BCKTargetObjectFileFormat,
+               StringRef("COFF"));
+      break;
+    case llvm::Triple::ObjectFormatType::ELF:
+      callback(cLangOpts, callbackContext, BCKTargetObjectFileFormat,
+               StringRef("ELF"));
+      break;
+    case llvm::Triple::ObjectFormatType::MachO:
+      callback(cLangOpts, callbackContext, BCKTargetObjectFileFormat,
+               StringRef("MachO"));
+      break;
+    case llvm::Triple::ObjectFormatType::SPIRV:
+      callback(cLangOpts, callbackContext, BCKTargetObjectFileFormat,
+               StringRef("SPIRV"));
+      break;
+    case llvm::Triple::ObjectFormatType::Wasm:
+      callback(cLangOpts, callbackContext, BCKTargetObjectFileFormat,
+               StringRef("Wasm"));
+      break;
+    default:
+      // Ignore others.
+      break;
+  }
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -180,7 +180,7 @@ target_link_libraries(swiftAST
 
 if (SWIFT_BUILD_SWIFT_SYNTAX)
   target_link_libraries(swiftAST
-    PRIVATE swiftASTGen)
+    PRIVATE swiftASTGen swiftBasicSwift)
 endif()
 
 set_swift_llvm_is_available(swiftAST)

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -126,21 +126,6 @@ extension BridgedLabeledStmtInfo: /*@retroactive*/ Swift.ExpressibleByNilLiteral
   }
 }
 
-extension String {
-  init(bridged: BridgedStringRef) {
-    self.init(
-      decoding: UnsafeBufferPointer(start: bridged.data, count: bridged.count),
-      as: UTF8.self
-    )
-  }
-
-  public mutating func withBridgedString<R>(_ body: (BridgedStringRef) throws -> R) rethrows -> R {
-    try withUTF8 { buffer in
-      try body(BridgedStringRef(data: buffer.baseAddress, count: buffer.count))
-    }
-  }
-}
-
 extension SyntaxText {
   var bridged: BridgedStringRef {
     BridgedStringRef(data: self.baseAddress, count: self.count)

--- a/lib/ASTGen/Sources/ASTGen/BuiltinPound.swift
+++ b/lib/ASTGen/Sources/ASTGen/BuiltinPound.swift
@@ -76,7 +76,7 @@ extension ASTGenVisitor {
       let keypathExpr = self.generateObjCKeyPathExpr(freestandingMacroExpansion: node)
       return .generated(.expr(keypathExpr))
 
-    case .assert where ctx.langOptsHasFeature(.StaticAssert):
+    case .assert where ctx.langOpts.hasFeature(.StaticAssert):
       let assertStmtOpt = self.generatePoundAssertStmt(freestandingMacroExpansion: node)
       return .generated(assertStmtOpt.map({ .stmt($0.asStmt) }))
 
@@ -143,7 +143,7 @@ extension ASTGenVisitor {
   }
 
   func generatePoundAssertStmt(freestandingMacroExpansion node: some FreestandingMacroExpansionSyntax) -> BridgedPoundAssertStmt? {
-    assert(self.ctx.langOptsHasFeature(.StaticAssert))
+    assert(self.ctx.langOpts.hasFeature(.StaticAssert))
     var args = node.arguments[...]
     let conditionExpr = self.generateConsumingAttrOption(args: &args, label: nil) { conditionNode in
       self.generate(expr: conditionNode)

--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -20,7 +20,6 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   Regex.swift
   SourceFile.swift
   StableHasher.swift
-  StaticBuildConfiguration+ASTContext.swift
   Stmts.swift
   TypeAttrs.swift
   Types.swift
@@ -38,4 +37,5 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
     _CompilerSwiftParser
     _CompilerSwiftParserDiagnostics
     _CompilerSwiftDiagnostics
+    swiftBasicSwift
 )

--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -20,6 +20,7 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   Regex.swift
   SourceFile.swift
   StableHasher.swift
+  StaticBuildConfiguration+ASTContext.swift
   Stmts.swift
   TypeAttrs.swift
   Types.swift
@@ -27,6 +28,7 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   DEPENDENCIES
     swiftAST
   SWIFT_DEPENDENCIES
+    _CompilerSwiftCompilerPluginMessageHandling
     _CompilerRegexParser
     _CompilerSwiftSyntax
     _CompilerSwiftIfConfig

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -30,21 +30,21 @@ struct CompilerBuildConfiguration: BuildConfiguration {
   func isCustomConditionSet(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsCustomConditionSet(nameRef)
+      ctx.langOpts.customConditionSet(nameRef)
     }
   }
   
   func hasFeature(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsHasFeatureNamed(nameRef)
+      ctx.langOpts.hasFeatureNamed(nameRef)
     }
   }
   
   func hasAttribute(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsHasAttributeNamed(nameRef)
+      ctx.langOpts.hasAttributeNamed(nameRef)
     }
   }
   
@@ -89,21 +89,21 @@ struct CompilerBuildConfiguration: BuildConfiguration {
   func isActiveTargetOS(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsIsActiveTargetOS(nameRef)
+      ctx.langOpts.isActiveTargetOS(nameRef)
     }
   }
   
   func isActiveTargetArchitecture(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsIsActiveTargetArchitecture(nameRef)
+      ctx.langOpts.isActiveTargetArchitecture(nameRef)
     }
   }
   
   func isActiveTargetEnvironment(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsIsActiveTargetEnvironment(nameRef)
+      ctx.langOpts.isActiveTargetEnvironment(nameRef)
     }
   }
   
@@ -117,31 +117,31 @@ struct CompilerBuildConfiguration: BuildConfiguration {
     }
 
     return name.withBridgedString { nameRef in
-      ctx.langOptsIsActiveTargetRuntime(nameRef)
+      ctx.langOpts.isActiveTargetRuntime(nameRef)
     }
   }
   
   func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
     var name = name
     return name.withBridgedString { nameRef in
-      ctx.langOptsIsActiveTargetPtrAuth(nameRef)
+      ctx.langOpts.isActiveTargetPtrAuth(nameRef)
     }
   }
   
   var targetPointerBitWidth: Int {
-    Int(ctx.langOptsTargetPointerBitWidth)
+    Int(ctx.langOpts.targetPointerBitWidth)
   }
 
   var targetAtomicBitWidths: [Int] {
     var bitWidthsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOptsGetTargetAtomicBitWidths(&bitWidthsBuf)
+    let count = ctx.langOpts.getTargetAtomicBitWidths(&bitWidthsBuf)
     let bitWidths = Array(UnsafeMutableBufferPointer(start: bitWidthsBuf, count: count))
     deallocateIntBuffer(bitWidthsBuf);
     return bitWidths
   }
 
   var endianness: Endianness {
-    switch ctx.langOptsTargetEndianness {
+    switch ctx.langOpts.targetEndianness {
     case .EndianBig: return .big
     case .EndianLittle: return .little
     }
@@ -149,7 +149,7 @@ struct CompilerBuildConfiguration: BuildConfiguration {
 
   var languageVersion: VersionTuple { 
     var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOptsGetLanguageVersion(&componentsBuf)
+    let count = ctx.langOpts.getLanguageVersion(&componentsBuf)
     let version = VersionTuple(
       components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
     )
@@ -159,7 +159,7 @@ struct CompilerBuildConfiguration: BuildConfiguration {
 
   var compilerVersion: VersionTuple { 
     var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOptsGetCompilerVersion(&componentsBuf)
+    let count = ctx.langOpts.getCompilerVersion(&componentsBuf)
     let version = VersionTuple(
       components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
     )

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -10,11 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BasicBridging
 import ASTBridging
+import swiftBasicSwift
 import SwiftDiagnostics
 @_spi(Compiler) import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+
+extension BridgedASTContext {
+  /// Retrieve the (cached) static build configuration for this ASTContext.
+  public var staticBuildConfiguration: StaticBuildConfiguration {
+    staticBuildConfigurationPtr.assumingMemoryBound(
+      to: StaticBuildConfiguration.self
+    ).pointee
+  }
+}
 
 /// A build configuration that uses the compiler's ASTContext to answer
 /// queries.

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -31,32 +31,25 @@ extension BridgedASTContext {
 /// queries.
 struct CompilerBuildConfiguration: BuildConfiguration {
   let ctx: BridgedASTContext
+  let staticBuildConfiguration: StaticBuildConfiguration
   let sourceBuffer: UnsafeBufferPointer<UInt8>
 
   init(ctx: BridgedASTContext, sourceBuffer: UnsafeBufferPointer<UInt8>) {
     self.ctx = ctx
+    self.staticBuildConfiguration = ctx.staticBuildConfiguration
     self.sourceBuffer = sourceBuffer
   }
 
-  func isCustomConditionSet(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.customConditionSet(nameRef)
-    }
+  func isCustomConditionSet(name: String) -> Bool {
+    staticBuildConfiguration.isCustomConditionSet(name: name)
   }
   
-  func hasFeature(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.hasFeatureNamed(nameRef)
-    }
+  func hasFeature(name: String) -> Bool {
+    staticBuildConfiguration.hasFeature(name: name)
   }
   
-  func hasAttribute(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.hasAttributeNamed(nameRef)
-    }
+  func hasAttribute(name: String) -> Bool {
+    staticBuildConfiguration.hasAttribute(name: name)
   }
   
   func canImport(
@@ -97,85 +90,50 @@ struct CompilerBuildConfiguration: BuildConfiguration {
     }
   }
   
-  func isActiveTargetOS(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.isActiveTargetOS(nameRef)
-    }
+  func isActiveTargetOS(name: String) -> Bool {
+    staticBuildConfiguration.isActiveTargetOS(name: name)
   }
   
-  func isActiveTargetArchitecture(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.isActiveTargetArchitecture(nameRef)
-    }
+  func isActiveTargetArchitecture(name: String) -> Bool {
+    staticBuildConfiguration.isActiveTargetArchitecture(name: name)
   }
   
-  func isActiveTargetEnvironment(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.isActiveTargetEnvironment(nameRef)
-    }
+  func isActiveTargetEnvironment(name: String) -> Bool {
+    staticBuildConfiguration.isActiveTargetEnvironment(name: name)
   }
   
   func isActiveTargetRuntime(name: String) throws -> Bool {
-    var name = name
-
     // Complain if the provided runtime isn't one of the known values.
     switch name {
     case "_Native", "_ObjC", "_multithreaded": break
     default: throw IfConfigError.unexpectedRuntimeCondition
     }
 
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.isActiveTargetRuntime(nameRef)
-    }
+    return staticBuildConfiguration.isActiveTargetRuntime(name: name)
   }
-  
-  func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
-    var name = name
-    return name.withBridgedString { nameRef in
-      ctx.langOpts.isActiveTargetPtrAuth(nameRef)
-    }
+
+  func isActiveTargetPointerAuthentication(name: String) -> Bool {
+    staticBuildConfiguration.isActiveTargetPointerAuthentication(name: name)
   }
   
   var targetPointerBitWidth: Int {
-    Int(ctx.langOpts.targetPointerBitWidth)
+    staticBuildConfiguration.targetPointerBitWidth
   }
 
   var targetAtomicBitWidths: [Int] {
-    var bitWidthsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOpts.getTargetAtomicBitWidths(&bitWidthsBuf)
-    let bitWidths = Array(UnsafeMutableBufferPointer(start: bitWidthsBuf, count: count))
-    deallocateIntBuffer(bitWidthsBuf);
-    return bitWidths
+    staticBuildConfiguration.targetAtomicBitWidths
   }
 
   var endianness: Endianness {
-    switch ctx.langOpts.targetEndianness {
-    case .EndianBig: return .big
-    case .EndianLittle: return .little
-    }
+    staticBuildConfiguration.endianness
   }
 
-  var languageVersion: VersionTuple { 
-    var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOpts.getLanguageVersion(&componentsBuf)
-    let version = VersionTuple(
-      components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
-    )
-    deallocateIntBuffer(componentsBuf);
-    return version
+  var languageVersion: VersionTuple {
+    staticBuildConfiguration.languageVersion
   }
 
-  var compilerVersion: VersionTuple { 
-    var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
-    let count = ctx.langOpts.getCompilerVersion(&componentsBuf)
-    let version = VersionTuple(
-      components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
-    )
-    deallocateIntBuffer(componentsBuf);
-    return version
+  var compilerVersion: VersionTuple {
+    staticBuildConfiguration.compilerVersion
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -31,7 +31,7 @@ extension ASTGenVisitor {
 
     // Comments.
     COMMENT: if
-      self.ctx.langOptsAttachCommentsToDecls,
+      self.ctx.langOpts.attachCommentsToDecls,
       let firstTok = node.firstToken(viewMode: .sourceAccurate)
     {
       var pos = firstTok.position
@@ -2228,7 +2228,7 @@ extension ASTGenVisitor {
   }
 
   func generateUnavailableInEmbeddedAttr(attribute node: AttributeSyntax) -> BridgedAvailableAttr? {
-    if ctx.langOptsHasFeature(.Embedded) {
+    if ctx.langOpts.hasFeature(.Embedded) {
       return BridgedAvailableAttr.createUnavailableInEmbedded(
         self.ctx,
         atLoc: self.generateSourceLoc(node.atSign),

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -396,10 +396,10 @@ extension ASTGenVisitor {
     case .`init`:
       return .Init
     case .read:
-      precondition(ctx.langOptsHasFeature(.CoroutineAccessors), "(compiler bug) 'read' accessor should only be parsed with 'CoroutineAccessors' feature")
+      precondition(ctx.langOpts.hasFeature(.CoroutineAccessors), "(compiler bug) 'read' accessor should only be parsed with 'CoroutineAccessors' feature")
       return .read
     case .modify:
-      precondition(ctx.langOptsHasFeature(.CoroutineAccessors), "(compiler bug) 'modify' accessor should only be parsed with 'CoroutineAccessors' feature")
+      precondition(ctx.langOpts.hasFeature(.CoroutineAccessors), "(compiler bug) 'modify' accessor should only be parsed with 'CoroutineAccessors' feature")
       return .modify
     default:
       self.diagnose(.unknownAccessorSpecifier(specifier))

--- a/lib/ASTGen/Sources/ASTGen/EmbeddedSupport.swift
+++ b/lib/ASTGen/Sources/ASTGen/EmbeddedSupport.swift
@@ -68,26 +68,26 @@ struct EmbeddedBuildConfiguration: BuildConfiguration {
     self.configuration = .init(ctx: ctx, sourceBuffer: sourceBuffer)
   }
 
-  func isCustomConditionSet(name: String) throws -> Bool {
+  func isCustomConditionSet(name: String) -> Bool {
     // $Embedded is set when building Embedded Swift
     if name == "$Embedded" {
       return true
     }
 
-    return try configuration.isCustomConditionSet(name: name)
+    return configuration.isCustomConditionSet(name: name)
   }
 
-  func hasFeature(name: String) throws -> Bool {
+  func hasFeature(name: String) -> Bool {
     // The "Embedded" feature is set when building Embedded Swift.
     if name == "Embedded" {
       return true
     }
 
-    return try configuration.hasFeature(name: name)
+    return configuration.hasFeature(name: name)
   }
 
-  func hasAttribute(name: String) throws -> Bool {
-    return try configuration.hasAttribute(name: name)
+  func hasAttribute(name: String) -> Bool {
+    return configuration.hasAttribute(name: name)
   }
 
   func canImport(
@@ -100,24 +100,24 @@ struct EmbeddedBuildConfiguration: BuildConfiguration {
     return false
   }
 
-  func isActiveTargetOS(name: String) throws -> Bool {
-    return try configuration.isActiveTargetOS(name: name)
+  func isActiveTargetOS(name: String) -> Bool {
+    return configuration.isActiveTargetOS(name: name)
   }
 
-  func isActiveTargetArchitecture(name: String) throws -> Bool {
-    return try configuration.isActiveTargetArchitecture(name: name)
+  func isActiveTargetArchitecture(name: String) -> Bool {
+    return configuration.isActiveTargetArchitecture(name: name)
   }
 
-  func isActiveTargetEnvironment(name: String) throws -> Bool {
-    return try configuration.isActiveTargetEnvironment(name: name)
+  func isActiveTargetEnvironment(name: String) -> Bool {
+    return configuration.isActiveTargetEnvironment(name: name)
   }
 
   func isActiveTargetRuntime(name: String) throws -> Bool {
     return try configuration.isActiveTargetRuntime(name: name)
   }
 
-  func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
-    return try configuration.isActiveTargetPointerAuthentication(name: name)
+  func isActiveTargetPointerAuthentication(name: String) -> Bool {
+    return configuration.isActiveTargetPointerAuthentication(name: name)
   }
 
   var targetPointerBitWidth: Int {

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ASTBridging
+import swiftBasicSwift
 import SwiftDiagnostics
 @_spi(Compiler) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -72,7 +72,7 @@ extension Parser.ExperimentalFeatures {
     guard let context = context else { return }
 
     func mapFeature(_ bridged: BridgedFeature, to feature: Self) {
-      if context.langOptsHasFeature(bridged) {
+      if context.langOpts.hasFeature(bridged) {
         insert(feature)
       }
     }

--- a/lib/ASTGen/Sources/ASTGen/StaticBuildConfiguration+ASTContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/StaticBuildConfiguration+ASTContext.swift
@@ -1,0 +1,133 @@
+//===--- StaticBuildConfiguration+ASTContext.swift ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ASTBridging
+@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
+import SwiftDiagnostics
+@_spi(Compiler) import SwiftIfConfig
+@_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+
+extension StaticBuildConfiguration {
+  /// Configuration entries captured in the initializer from a bridged context.
+  private struct ConfigurationEntries {
+    var customConditions: Set<String> = []
+    var features: Set<String> = []
+    var attributes: Set<String> = []
+    var targetOSNames: Set<String> = []
+    var targetArchitectures: Set<String> = []
+    var targetEnvironments: Set<String> = []
+    var targetRuntimes: Set<String> = []
+    var targetPointerAuthenticationSchemes: Set<String> = []
+    var targetObjectFileFormats: Set<String> = []
+  }
+
+  /// Initialize a static build configuration for the given language options.
+  init(langOptions: BridgedLangOptions) {
+    var entries = ConfigurationEntries()
+
+    langOptions.enumerateBuildConfigurationEntries(callbackContext: &entries) { cContext, entries, key, value in
+      let entries = entries.assumingMemoryBound(to: ConfigurationEntries.self)
+      switch key {
+      case .BCKAttribute:
+        entries.pointee.attributes.insert(String(bridged: value))
+      case .BCKCustomCondition:
+        entries.pointee.customConditions.insert(String(bridged: value))
+      case .BCKFeature:
+        entries.pointee.features.insert(String(bridged: value))
+      case .BCKTargetOSName:
+        entries.pointee.targetOSNames.insert(String(bridged: value))
+      case .BCKTargetArchitecture:
+        entries.pointee.targetArchitectures.insert(String(bridged: value))
+      case .BCKTargetEnvironment:
+        entries.pointee.targetEnvironments.insert(String(bridged: value))
+      case .BCKTargetRuntime:
+        entries.pointee.targetRuntimes.insert(String(bridged: value))
+      case .BCKTargetPointerAuthenticationScheme:
+        entries.pointee.targetPointerAuthenticationSchemes.insert(String(bridged: value))
+      case .BCKTargetObjectFileFormat:
+        entries.pointee.targetObjectFileFormats.insert(String(bridged: value))
+      }
+    }
+
+    let targetPointerBitWidth = Int(langOptions.targetPointerBitWidth)
+
+    // Atomic bit widths.
+    let targetAtomicBitWidths: [Int]
+    do {
+      var bitWidthsBuf: UnsafeMutablePointer<SwiftInt>? = nil
+      let bitWidthsCount = langOptions.getTargetAtomicBitWidths(&bitWidthsBuf)
+      targetAtomicBitWidths = Array(UnsafeMutableBufferPointer(start: bitWidthsBuf, count: bitWidthsCount))
+      deallocateIntBuffer(bitWidthsBuf);
+    }
+
+    let endianness: Endianness
+    switch langOptions.targetEndianness {
+    case .EndianBig: endianness = .big
+    case .EndianLittle: endianness = .little
+    }
+
+    let languageVersion = getVersionTuple { langOptions.getLanguageVersion(&$0) }
+    let compilerVersion = getVersionTuple { langOptions.getCompilerVersion(&$0) }
+    self.init(
+      customConditions: entries.customConditions,
+      features: entries.features,
+      attributes: entries.attributes,
+      targetOSs: entries.targetOSNames,
+      targetArchitectures: entries.targetArchitectures,
+      targetEnvironments: entries.targetEnvironments,
+      targetRuntimes: entries.targetRuntimes,
+      targetPointerAuthenticationSchemes: entries.targetPointerAuthenticationSchemes,
+      targetObjectFileFormats: entries.targetObjectFileFormats,
+      targetPointerBitWidth: targetPointerBitWidth,
+      targetAtomicBitWidths: targetAtomicBitWidths,
+      endianness: endianness,
+      languageVersion: languageVersion,
+      compilerVersion: compilerVersion
+    )
+  }
+}
+
+/// Get a version tuple from C++.
+private func getVersionTuple(
+  body: (inout UnsafeMutablePointer<SwiftInt>?) -> Int
+) -> VersionTuple {
+  var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
+  let count = body(&componentsBuf)
+  let version = VersionTuple(
+    components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
+  )
+  deallocateIntBuffer(componentsBuf);
+  return version
+}
+
+@_cdecl("swift_ASTGen_printStaticBuildConfiguration")
+public func printStaticBuildConfiguration(
+  langOptions: BridgedLangOptions
+) -> BridgedStringRef {
+  let config = StaticBuildConfiguration(langOptions: langOptions)
+  let result = try? JSON.encode(config).withUnsafeBufferPointer { buffer in
+    let ptr = UnsafeMutablePointer<UInt8>.allocate(
+      capacity: buffer.count + 1
+    )
+    if let baseAddress = buffer.baseAddress {
+      ptr.initialize(from: baseAddress, count: buffer.count)
+    }
+
+    // null terminate, for client's convenience.
+    ptr[buffer.count] = 0
+
+    return BridgedStringRef(data: ptr, count: buffer.count)
+  }
+
+  return result ?? BridgedStringRef()
+}

--- a/lib/ASTGen/Sources/BasicSwift/CMakeLists.txt
+++ b/lib/ASTGen/Sources/BasicSwift/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_pure_swift_host_library(swiftBasicSwift STATIC CXX_INTEROP
+  StaticBuildConfiguration+LangOptions.swift
+  String+BridgedString.swift
+
+  DEPENDENCIES
+    swiftBasic
+  SWIFT_DEPENDENCIES
+    _CompilerSwiftCompilerPluginMessageHandling
+    _CompilerSwiftSyntax
+    _CompilerSwiftIfConfig
+)

--- a/lib/ASTGen/Sources/BasicSwift/StaticBuildConfiguration+LangOptions.swift
+++ b/lib/ASTGen/Sources/BasicSwift/StaticBuildConfiguration+LangOptions.swift
@@ -131,3 +131,19 @@ public func printStaticBuildConfiguration(
 
   return result ?? BridgedStringRef()
 }
+
+@_cdecl("swift_Basic_createStaticBuildConfiguration")
+public func createStaticBuildConfiguration(
+  cLangOpts: BridgedLangOptions
+) -> UnsafeMutableRawPointer {
+  let storage = UnsafeMutablePointer<StaticBuildConfiguration>.allocate(capacity: 1)
+  storage.initialize(to: StaticBuildConfiguration(langOptions: cLangOpts))
+  return UnsafeMutableRawPointer(storage)
+}
+
+/// Free the given static build configuration.
+@_cdecl("swift_Basic_freeStaticBuildConfiguration")
+public func freeStaticBuildConfiguration(pointer: UnsafeMutableRawPointer) {
+  pointer.assumingMemoryBound(to: StaticBuildConfiguration.self)
+    .deinitialize(count: 1).deallocate()
+}

--- a/lib/ASTGen/Sources/BasicSwift/String+BridgedString.swift
+++ b/lib/ASTGen/Sources/BasicSwift/String+BridgedString.swift
@@ -1,0 +1,28 @@
+//===--- String+BridgedString.swift ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import BasicBridging
+
+extension String {
+  public init(bridged: BridgedStringRef) {
+    self.init(
+      decoding: UnsafeBufferPointer(start: bridged.data, count: bridged.count),
+      as: UTF8.self
+    )
+  }
+
+  public mutating func withBridgedString<R>(_ body: (BridgedStringRef) throws -> R) rethrows -> R {
+    try withUTF8 { buffer in
+      try body(BridgedStringRef(data: buffer.baseAddress, count: buffer.count))
+    }
+  }
+}

--- a/lib/ASTGen/Sources/CMakeLists.txt
+++ b/lib/ASTGen/Sources/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(BasicSwift)
 add_subdirectory(ASTGen)
 add_subdirectory(MacroEvaluation)
 add_subdirectory(SwiftIDEUtilsBridging)

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -201,8 +201,8 @@ class PluginDiagnosticsEngine {
   private let bridgedDiagEngine: BridgedDiagnosticEngine
   private var exportedSourceFileByName: [String: UnsafePointer<ExportedSourceFile>] = [:]
 
-  init(cxxDiagnosticEngine: UnsafeMutableRawPointer) {
-    self.bridgedDiagEngine = BridgedDiagnosticEngine(raw: cxxDiagnosticEngine)
+  init(cContext: BridgedASTContext) {
+    self.bridgedDiagEngine = cContext.diags
   }
 
   /// Failable convenience initializer for optional cxx engine pointer.

--- a/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
@@ -23,6 +23,10 @@ class SourceManager {
     self.bridgedDiagEngine = BridgedDiagnosticEngine(raw: cxxDiagnosticEngine)
   }
 
+  init(cContext: BridgedASTContext) {
+    self.bridgedDiagEngine = cContext.diags
+  }
+
   /// The bridged diagnostic engine (just the wrapped C++ `DiagnosticEngine`).
   let bridgedDiagEngine: BridgedDiagnosticEngine
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -59,6 +59,7 @@ add_swift_host_library(swiftBasic STATIC
   ParseableOutput.cpp
   JSONSerialization.cpp
   LangOptions.cpp
+  LangOptionsBridging.cpp
   LoadDynamicLibrary.cpp
   Located.cpp
   Mangler.cpp

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -252,6 +252,9 @@ LangOptions::getPlatformConditionValue(PlatformConditionKind Kind) const {
 
 bool LangOptions::
 checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
+  // Note: BridgedASTContext_enumerateBuildConfigurationEntries has a redundant
+  // copy of these special cases.
+
   // Check a special case that "macOS" is an alias of "OSX".
   if (Kind == PlatformConditionKind::OS && Value == "macOS")
     return checkPlatformCondition(Kind, "OSX");

--- a/lib/Basic/LangOptionsBridging.cpp
+++ b/lib/Basic/LangOptionsBridging.cpp
@@ -22,51 +22,6 @@ bool BridgedLangOptions_hasFeature(BridgedLangOptions cLangOpts,
 }
 
 
-bool BridgedLangOptions_customConditionSet(BridgedLangOptions cLangOpts,
-                                           BridgedStringRef cName) {
-  const LangOptions &langOpts = cLangOpts.unbridged();
-  auto name = cName.unbridged();
-  if (name.starts_with("$") && langOpts.hasFeature(name.drop_front()))
-    return true;
-
-  return langOpts.isCustomConditionalCompilationFlagSet(name);
-}
-
-bool BridgedLangOptions_hasFeatureNamed(BridgedLangOptions cLangOpts,
-                                        BridgedStringRef cName) {
-  return cLangOpts.unbridged().hasFeature(cName.unbridged());
-}
-
-bool BridgedLangOptions_isActiveTargetOS(BridgedLangOptions cLangOpts,
-                                         BridgedStringRef cName) {
-  return cLangOpts.unbridged().checkPlatformCondition(
-      PlatformConditionKind::OS, cName.unbridged());
-}
-
-bool BridgedLangOptions_isActiveTargetArchitecture(
-    BridgedLangOptions cLangOpts, BridgedStringRef cName) {
-  return cLangOpts.unbridged().checkPlatformCondition(
-      PlatformConditionKind::Arch, cName.unbridged());
-}
-
-bool BridgedLangOptions_isActiveTargetEnvironment(
-    BridgedLangOptions cLangOpts, BridgedStringRef cName) {
-  return cLangOpts.unbridged().checkPlatformCondition(
-      PlatformConditionKind::TargetEnvironment, cName.unbridged());
-}
-
-bool BridgedLangOptions_isActiveTargetRuntime(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName) {
-  return cLangOpts.unbridged().checkPlatformCondition(
-      PlatformConditionKind::Runtime, cName.unbridged());
-}
-
-bool BridgedLangOptions_isActiveTargetPtrAuth(BridgedLangOptions cLangOpts,
-                                              BridgedStringRef cName) {
-  return cLangOpts.unbridged().checkPlatformCondition(
-      PlatformConditionKind::PtrAuth, cName.unbridged());
-}
-
 unsigned BridgedLangOptions::getTargetPointerBitWidth() const {
   return unbridged().Target.isArch64Bit()   ? 64
          : unbridged().Target.isArch32Bit() ? 32

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1985,6 +1985,27 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
     return false;
   }
 
+  if (Args.hasArg(options::OPT_print_static_build_config)) {
+    SmallVector<const char *, 5> commandLine;
+    commandLine.push_back("-frontend");
+    commandLine.push_back("-print-static-build-config");
+
+    std::string executable = getSwiftProgramPath();
+
+    // FIXME(https://github.com/apple/swift/issues/54554): This bypasses
+    // mechanisms like -v and -###.
+    sys::TaskQueue queue;
+    queue.addTask(executable.c_str(), commandLine);
+    queue.execute(nullptr,
+                  [](sys::ProcessId PID, int returnCode, StringRef output,
+                     StringRef errors, sys::TaskProcessInformation ProcInfo,
+                     void *unused) -> sys::TaskFinishedResponse {
+                    llvm::outs() << output;
+                    llvm::errs() << errors;
+                    return sys::TaskFinishedResponse::ContinueExecution;
+                  });
+    return false;
+  }
   return true;
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -210,6 +210,10 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.PrintTargetInfo = true;
   }
 
+  if (Args.hasArg(OPT_print_static_build_config)) {
+    Opts.PrintBuildConfig = true;
+  }
+
   if (Args.hasArg(OPT_print_supported_features)) {
     Opts.PrintSupportedFeatures = true;
   }

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -27,4 +27,9 @@ target_link_libraries(swiftFrontendTool PRIVATE
     swiftSILOptimizer
     swiftThreading)
 
+if (SWIFT_BUILD_SWIFT_SYNTAX)
+  target_link_libraries(swiftFrontendTool PRIVATE
+    swiftASTGen)
+endif()
+
 set_swift_llvm_is_available(swiftFrontendTool)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -23,6 +23,7 @@
 #include "swift/FrontendTool/FrontendTool.h"
 #include "Dependencies.h"
 #include "TBD.h"
+#include "swift/AST/ASTBridging.h"
 #include "swift/AST/ASTDumper.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/AvailabilityScope.h"
@@ -38,6 +39,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/TBDGenRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Edit.h"
 #include "swift/Basic/FileSystem.h"
@@ -50,6 +52,7 @@
 #include "swift/Basic/TargetInfo.h"
 #include "swift/Basic/UUID.h"
 #include "swift/Basic/Version.h"
+#include "swift/Bridging/ASTGen.h"
 #include "swift/ConstExtract/ConstExtract.h"
 #include "swift/DependencyScan/ScanDependencies.h"
 #include "swift/Frontend/CachedDiagnostics.h"
@@ -2255,6 +2258,14 @@ public:
   };
 };
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+extern "C" BridgedStringRef
+swift_ASTGen_printStaticBuildConfiguration(BridgedLangOptions cLangOpts);
+#pragma clang diagnostic pop
+#endif
+
 int swift::performFrontend(ArrayRef<const char *> Args,
                            const char *Argv0, void *MainAddr,
                            FrontendObserver *observer) {
@@ -2382,6 +2393,16 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   if (Invocation.getFrontendOptions().PrintTargetInfo) {
     swift::targetinfo::printTargetInfo(Invocation, llvm::outs());
+    return finishDiagProcessing(0, /*verifierEnabled*/ false);
+  }
+
+  if (Invocation.getFrontendOptions().PrintBuildConfig) {
+#if SWIFT_BUILD_SWIFT_SYNTAX
+    auto resultText =
+        swift_ASTGen_printStaticBuildConfiguration(Invocation.getLangOptions());
+    llvm::outs() << resultText.unbridged();
+    swift_ASTGen_freeBridgedString(resultText);
+#endif
     return finishDiagProcessing(0, /*verifierEnabled*/ false);
   }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1217,7 +1217,7 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
     BridgedStringRef evaluatedSourceOut{nullptr, 0};
     assert(!externalDef.isError());
     swift_Macros_expandFreestandingMacro(
-        &ctx.Diags, externalDef.get(), discriminator->c_str(),
+        ctx, externalDef.get(), discriminator->c_str(),
         getRawMacroRole(macroRole), astGenSourceFile,
         expansion->getSourceRange().Start.getOpaquePointerValue(),
         &evaluatedSourceOut);
@@ -1574,7 +1574,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
     BridgedStringRef evaluatedSourceOut{nullptr, 0};
     assert(!externalDef.isError());
     swift_Macros_expandAttachedMacro(
-        &ctx.Diags, externalDef.get(), discriminator->c_str(),
+        ctx, externalDef.get(), discriminator->c_str(),
         extendedType.c_str(), conformanceList.c_str(), getRawMacroRole(role),
         astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
         astGenDeclSourceFile, startLoc.getOpaquePointerValue(),
@@ -1717,7 +1717,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro,
     BridgedStringRef evaluatedSourceOut{nullptr, 0};
     assert(!externalDef.isError());
     swift_Macros_expandAttachedMacro(
-        &ctx.Diags, externalDef.get(), discriminator->c_str(),
+        ctx, externalDef.get(), discriminator->c_str(),
         "", "", getRawMacroRole(role),
         astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
         astGenClosureSourceFile, startLoc.getOpaquePointerValue(),

--- a/test/Frontend/print-static-build-config.swift
+++ b/test/Frontend/print-static-build-config.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -print-static-build-config -DSOMETHING | %FileCheck %s
+// REQUIRES: swift_swift_parser
+
+// CHECK: "attributes":
+// CHECK-SAME: "escaping"
+
+// CHECK-SAME: "customConditions":["SOMETHING"]
+
+// CHECK-SAME: "features":
+// CHECK-SAME: "AttachedMacros"

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2980,3 +2980,21 @@ public struct BigEndianAccessorMacro: AccessorMacro {
         ]
     }
 }
+
+public struct CustomConditionCheckMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let firstElement = node.arguments.first,
+          let stringLiteral = firstElement.expression
+      .as(StringLiteralExprSyntax.self),
+          stringLiteral.segments.count == 1,
+          case let .stringSegment(conditionName)? = stringLiteral.segments.first else {
+      throw CustomError.message("macro requires a string literal containing the name of a custom condition")
+    }
+
+    let isSet = try context.buildConfiguration?.isCustomConditionSet(name: conditionName.content.text) ?? false
+    return "\(literal: isSet)"
+  }
+}

--- a/test/Macros/macro_build_config.swift
+++ b/test/Macros/macro_build_config.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
+
+// Execution testing
+// RUN: %target-build-swift -swift-version 5 -g -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -Xfrontend -emit-dependencies-path -Xfrontend %t/main.d -Xfrontend -emit-reference-dependencies-path -Xfrontend %t/main.swiftdeps -DDEBUG
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+@freestanding(expression) macro isCustomConditionSet(_ name: String) -> Bool = #externalMacro(module: "MacroDefinition", type: "CustomConditionCheckMacro")
+
+// CHECK: Release = false
+print("Release = \(#isCustomConditionSet("RELEASE"))")
+
+// CHECK: Debug = true
+print("Debug = \(#isCustomConditionSet("DEBUG"))")

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -30,9 +30,9 @@
 
 // CHECK: ->(plugin:[[#PID:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
 // CHECK: <-(plugin:[[#PID]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}func test{{.*}}],"macro":{"moduleName":"TestPlugin","name":"testString","typeName":"TestStringMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":5,"offset":301},"source":"#testString(123)"}}}
+// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}func test{{.*}}],"macro":{"moduleName":"TestPlugin","name":"testString","typeName":"TestStringMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":5,"offset":301},"source":"#testString(123)"}}}
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"\"123\"\n  +   \"foo  \""}}
-// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"testStringWithError","typeName":"TestStringWithErrorMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":6,"offset":336},"source":"#testStringWithError(321)"}}}
+// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"testStringWithError","typeName":"TestStringWithErrorMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":6,"offset":336},"source":"#testStringWithError(321)"}}}
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[],"message":"message from plugin","notes":[],"position":{"fileName":"{{.*}}test.swift","offset":336},"severity":"error"}],"expandedSource":"\"bar\""}}
 
 //--- test.swift

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -18,14 +18,14 @@
 
 // CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":7,"offset":[[#]]},"source":"#fooMacro(1)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":7,"offset":[[#]]},"source":"#fooMacro(1)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"invalidResponse":{}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":9,"offset":[[#]]},"source":"#fooMacro(2)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":9,"offset":[[#]]},"source":"#fooMacro(2)"}}}
 // ^ This messages causes the mock plugin exit because there's no matching expected message.
 
 // CHECK: ->(plugin:[[#PID2:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION]]}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":11,"offset":[[#]]},"source":"#fooMacro(3)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":11,"offset":[[#]]},"source":"#fooMacro(3)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
 
 //--- test.swift

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -71,9 +71,9 @@
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
 // CHECK-NEXT: ->(plugin:[[#PID1]]) {"loadPluginLibrary":{"libraryPath":"{{.*}}EvilMacros.{{dylib|so|dll}}","moduleName":"EvilMacros"}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(a + b)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(a + b)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"expandMacroResult":{"diagnostics":[],"expandedSource":"(a + b, \"a + b\")"}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"EvilMacros","name":"evil","typeName":"CrashingMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#evil(42)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"EvilMacros","name":"evil","typeName":"CrashingMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#evil(42)"}}}
 // ^ This crashes the plugin server.
 
 // CHECK: ->(plugin:[[#PID2:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION]]}}}
@@ -82,12 +82,12 @@
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
 // CHECK-NEXT: ->(plugin:[[#PID2]]) {"loadPluginLibrary":{"libraryPath":"{{.*}}EvilMacros.{{dylib|so|dll}}","moduleName":"EvilMacros"}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(b + a)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(b + a)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandMacroResult":{"diagnostics":[],"expandedSource":"(b + a, \"b + a\")"}}
 
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"missing","typeName":"TypeDoesNotExist"},"macroRole":"expression","syntax":{"kind":"expression","location":{{({.+})}},"source":"#missing()"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"missing","typeName":"TypeDoesNotExist"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{({.+})}},"source":"#missing()"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[{{{.*}}}],"message":"type 'MacroDefinition.TypeDoesNotExist' could not be found in library plugin '{{.*}}MacroDefinition.{{dylib|so|dll}}'","notes":[],"position":{{{.*}}},"severity":"error"}]}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"notMacro","typeName":"NotMacroStruct"},"macroRole":"expression","syntax":{"kind":"expression","location":{{({.+})}},"source":"#notMacro()"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","lexicalContext":[{{.*}}],"macro":{"moduleName":"MacroDefinition","name":"notMacro","typeName":"NotMacroStruct"},"macroRole":"expression","staticBuildConfiguration"{{.*}},"syntax":{"kind":"expression","location":{{({.+})}},"source":"#notMacro()"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[{{{.*}}}],"message":"type 'MacroDefinition.NotMacroStruct' is not a valid macro implementation type in library plugin '{{.*}}MacroDefinition.{{dylib|so|dll}}'","notes":[],"position":{{{.*}}},"severity":"error"}]}}
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")


### PR DESCRIPTION
Implement support for creating a `StaticBuildConfiguration` from `LangOptions`. That static build configuration can be printed as JSON to standard output with the new `-print-static-build-config` frontend option, and will be passed down to macro implementations so that can perform `#if`-related evaluations based on the context in which the macro is expanded. To ensure completeness, reseat the existing `CompilerBuildConfiguration` on top of the created `StaticBuildConfiguration` so all `#if`-handling code in the compiler goes through it.

There is a bit of code reshuffling here to establish another layer of Swift library between the C++ Basic and AST libraries. The code to form a `StaticBuildConfiguration` exists in this layer, so it can be used without an established `ASTContext`. The `ASTContext` does, however, have the ability to build a cache the `StaticBuildConfiguration` instance.

Tracked by rdar://146868706