### PR TITLE
Rework lit.cfg regex to avoid basename subshell in substitution

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1665,8 +1665,8 @@ if run_vendor == 'apple':
 
     config.target_build_swift_dylib = SubstituteCaptures(
         f"{escape_for_substitute_captures(config.target_build_swift)}"
-        r" -parse-as-library -emit-library -o '\1'"
-        r" -Xlinker -install_name -Xlinker @executable_path/$(basename '\1')"
+        r" -parse-as-library -emit-library -o '\1\2'"
+        r" -Xlinker -install_name -Xlinker @executable_path/\2"
     )
     config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
 
@@ -2938,7 +2938,7 @@ config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdli
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))
 config.substitutions.append(('%target-jit-run', subst_target_jit_run))
-config.substitutions.append(('%target-build-swift-dylib\(([^)]+)\)', config.target_build_swift_dylib))
+config.substitutions.append(('%target-build-swift-dylib\(([^)]+?)([^/()]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
 config.substitutions.append(('%target-clang', config.target_clang))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2938,6 +2938,9 @@ config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdli
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))
 config.substitutions.append(('%target-jit-run', subst_target_jit_run))
+# Capture groups:
+# \1 = path before the file name (non-greedy)
+# \2 = file name (last component, no slashes or parentheses)
 config.substitutions.append(('%target-build-swift-dylib\(([^)]+?)([^/\\()]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1764,7 +1764,7 @@ elif run_os in ['windows-msvc']:
     subst_target_swift_frontend_mock_sdk_after = ''
 
     config.target_build_swift_dylib =                                            \
-            SubstituteCaptures(r"%s -parse-as-library -emit-library -o \1" % (
+            SubstituteCaptures(r"%s -parse-as-library -emit-library -o \1\2" % (
                 escape_for_substitute_captures(config.target_build_swift)))
     config.target_add_rpath = r''
 
@@ -1902,7 +1902,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_codesign = "echo"
     config.target_build_swift_dylib = SubstituteCaptures(
         f"{escape_for_substitute_captures(config.target_build_swift)}"
-        r" -parse-as-library -emit-library -o '\1'"
+        r" -parse-as-library -emit-library -o '\1\2'"
     )
     config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
     config.target_swift_frontend = (
@@ -1996,7 +1996,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_codesign = "echo"
     config.target_build_swift_dylib = SubstituteCaptures(
         f"{escape_for_substitute_captures(config.target_build_swift)}"
-        r" -parse-as-library -emit-library -o '\1'"
+        r" -parse-as-library -emit-library -o '\1\2'"
     )
     config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
     config.target_swift_frontend = ' '.join([
@@ -2083,7 +2083,7 @@ elif kIsWASI:
     config.target_codesign = "echo"
     config.target_build_swift_dylib = SubstituteCaptures(
         f"{escape_for_substitute_captures(config.target_build_swift)}"
-        r" -parse-as-library -emit-library -static -o '\1'"
+        r" -parse-as-library -emit-library -static -o '\1\2'"
     )
     config.target_add_rpath = ''
     config.target_swift_frontend = ' '.join([
@@ -2167,7 +2167,7 @@ elif config.external_embedded_platform:
     config.target_codesign = "echo"
     config.target_build_swift_dylib = SubstituteCaptures(
         f"{escape_for_substitute_captures(config.target_build_swift)}"
-        r" -parse-as-library -emit-library -static -o '\1'"
+        r" -parse-as-library -emit-library -static -o '\1\2'"
     )
     config.target_add_rpath = ''
     config.target_swift_frontend = ' '.join([

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2938,7 +2938,7 @@ config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdli
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))
 config.substitutions.append(('%target-jit-run', subst_target_jit_run))
-config.substitutions.append(('%target-build-swift-dylib\(([^)]+?)([^/()]+)\)', config.target_build_swift_dylib))
+config.substitutions.append(('%target-build-swift-dylib\(([^)]+?)([^/\\()]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
 config.substitutions.append(('%target-clang', config.target_clang))


### PR DESCRIPTION
Changed %target-build-swift-dylib\(([^)]+)\) to %target-build-swift-dylib\(([^)]+?)([^/()]+)\)

Group 1 now captures the pat and group 2 captures the file name

Captured the basename directly in the regex instead of using a subshell since Lit's internal shell does not support

Partially address #84407 