### PR TITLE
Fix malformed AST with property or subscript returning dynamic Self on an opened existential

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1809,7 +1809,6 @@ namespace {
       result = adjustTypeForDeclReference(result, resultTySelf,
                                           resultType(adjustedRefTySelf),
                                           locator);
-      closeExistentials(result, locator);
 
       // If the property is of dynamic 'Self' type, wrap an implicit
       // conversion around the resulting expression, with the destination
@@ -1820,6 +1819,8 @@ namespace {
         result = cs.cacheType(new (ctx) CovariantReturnConversionExpr(
             result, resultTy));
       }
+
+      closeExistentials(result, locator);
 
       // If we need to load, do so now.
       if (loadImmediately) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2510,8 +2510,27 @@ namespace {
       // Coerce the index argument.
       auto openedFullFnType = simplifyType(selected.adjustedOpenedFullType)
                                   ->castTo<FunctionType>();
+
+      auto openedFullFnTypeSelf = openedFullFnType;
+
+      // Now, deal with DynamicSelfType.
+      if (selected.adjustedOpenedFullType->hasDynamicSelfType()) {
+        openedFullFnTypeSelf = simplifyType(
+            selected.adjustedOpenedFullType->eraseDynamicSelfType())
+                  ->castTo<FunctionType>();
+        auto replacementTy = getDynamicSelfReplacementType(
+            baseTy, subscript, memberLoc);
+        openedFullFnType = simplifyType(
+              selected.adjustedOpenedFullType
+                  ->replaceDynamicSelfType(replacementTy))
+                  ->castTo<FunctionType>();
+      }
+
       auto fullSubscriptTy = openedFullFnType->getResult()
                                   ->castTo<FunctionType>();
+      auto fullSubscriptTySelf = openedFullFnTypeSelf->getResult()
+                                  ->castTo<FunctionType>();
+
       auto appliedWrappers =
           solution.getAppliedPropertyWrappers(memberLoc->getAnchor());
       args = coerceCallArguments(
@@ -2565,37 +2584,27 @@ namespace {
       if (!base)
         return nullptr;
 
-      bool hasDynamicSelf = fullSubscriptTy->hasDynamicSelfType();
-
       // Form the subscript expression.
       auto subscriptExpr = SubscriptExpr::create(
           ctx, base, args, subscriptRef, isImplicit, semantics);
       subscriptExpr->setIsSuper(isSuper);
 
-      if (!hasDynamicSelf) {
-        cs.setType(subscriptExpr, fullSubscriptTy->getResult());
-      } else {
-        cs.setType(subscriptExpr,
-                   fullSubscriptTy->getResult()
-                      ->replaceDynamicSelfType(containerTy));
-      }
+      cs.setType(subscriptExpr, fullSubscriptTySelf->getResult());
 
       Expr *result = subscriptExpr;
-      closeExistentials(result, locator);
 
       // If the element is of dynamic 'Self' type, wrap an implicit conversion
       // around the resulting expression, with the destination type having
       // 'Self' swapped for the appropriate replacement type -- usually the
       // base object type.
-      if (hasDynamicSelf) {
-        const auto conversionTy = simplifyType(
-            selected.adjustedOpenedType->castTo<FunctionType>()->getResult());
-
-        if (!containerTy->isEqual(conversionTy)) {
-          result = cs.cacheType(
-              new (ctx) CovariantReturnConversionExpr(result, conversionTy));
-        }
+      if (!fullSubscriptTy->getResult()->isEqual(
+            fullSubscriptTySelf->getResult())) {
+        result = cs.cacheType(
+            new (ctx) CovariantReturnConversionExpr(
+                result, fullSubscriptTy->getResult()));
       }
+
+      closeExistentials(result, locator);
 
       return result;
     }

--- a/test/SILGen/dynamic_self_opened_existential.swift
+++ b/test/SILGen/dynamic_self_opened_existential.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen %s
+
+public class C {
+  public func f() -> Self { return self }
+  public var v: Self { return self }
+  public subscript() -> Self { return self }
+
+  public func g1() {}
+}
+
+public protocol P {
+  func g2()
+}
+
+func f(_ p: any P & C) {
+  p.f().g1()
+  p.f().g2()
+
+  p.v.g1()
+  p.v.g2()
+
+  // FIXME
+  // p[].g1()
+  // p[].g2()
+}
+

--- a/test/SILGen/dynamic_self_opened_existential.swift
+++ b/test/SILGen/dynamic_self_opened_existential.swift
@@ -19,8 +19,7 @@ func f(_ p: any P & C) {
   p.v.g1()
   p.v.g2()
 
-  // FIXME
-  // p[].g1()
-  // p[].g2()
+  p[].g1()
+  p[].g2()
 }
 

--- a/test/SILGen/dynamic_self_opened_existential_2.swift
+++ b/test/SILGen/dynamic_self_opened_existential_2.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-silgen %s
+
+class AA {
+  subscript<T>(_: T.Type) -> T? {
+    get { fatalError() }
+    set {}
+  }
+}
+
+class C {
+  typealias A = AA
+
+  func f() {
+    let a = AA()
+    guard let result = a[Self.A.self] else { return }
+    _ = result
+  }
+}


### PR DESCRIPTION
This worked for functions, but for properties and subscripts, there was a long-standing bug where we did things in the wrong order.

There is some duplicated logic between buildVarMember() and buildSubscriptHelper() in CSApply that is now even more apparent. At some point we should try to consolidate this to prevent such issues from appearing again in the future.

Fixes rdar://160816868 and rdar://161588385.