### PR TITLE
IRGen: Fix rebranch build

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -657,7 +657,7 @@ namespace {
             });
 
         bool hasRequiresClause =
-            copyConstructor->getTrailingRequiresClause() != nullptr;
+            !copyConstructor->getTrailingRequiresClause().isNull();
 
         if (hasRequiresClause || hasCopyableIfAttr) {
           ctx.Diags.diagnose(copyConstructorLoc, diag::maybe_missing_annotation,


### PR DESCRIPTION
`getTrailingRequiresClause` has a different result type in `stable/21.x`.