### PR TITLE
[test] Fix compatibility span calculation for unified builds

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2338,7 +2338,7 @@ if run_vendor == 'apple':
                 "Compatibility span back deploy libraries not found at "
                 f"{compatibility_span_back_deploy_path}. Falling back to local build...")
             compatibility_span_back_deploy_path = os.path.join(
-                swift_obj_root, 'lib', 'swift-6.2', xcrun_sdk_name)
+                config.swift_lib_dir, 'swift-6.2', xcrun_sdk_name)
             if not os.path.isdir(compatibility_span_back_deploy_path):
                 lit_config.fatal(
                   "Compatibility span back deploy libraries "


### PR DESCRIPTION
In unified builds `swift_obj_root` is in a different place in the CMake build tree, so using it as the base for finding `lib` is not correct.

Change the usage of `swift_obj_root/lib` for `config.swift_lib_dir` which should be correct in both unified and non-unified builds.
