### PR TITLE
[Test][IDE] Replace process substitution with temp file for internal shell

### DIFF
--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
-// RUN: diff -u <(tail -n +9 %s) %t.txt
+// RUN: tail -n +10 %s > %t/a
+// RUN: diff -u %t/a %t.txt
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -F %S/Inputs/mock-sdk > %t.txt
-// RUN: diff -u <(tail -n +9 %s) %t.txt
+// RUN: tail -n +10 %s > %t/a
+// RUN: diff -u %t/a %t.txt
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Replace `diff -u <(tail -n +9 %s) %t.txt` substitution with a temp file for LLVMs LIT internal shell

Note: Start tail at line 10 to skip `// EXPECTED OUTPUT STARTS BELOW THIS LINE` so the temp file matches the actual compiler output

Partially address #84407