### PR TITLE
Set LIBLTO_PATH with env in lit.cfg

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -236,7 +236,7 @@ elif platform.system() == 'Darwin':
     if not llvm_libs_dir:
         lit_config.fatal('No LLVM libs dir set.')
     lto_flags = "-Xlinker -lto_library -Xlinker %s/libLTO.dylib" % llvm_libs_dir
-    use_just_built_liblto = "LIBLTO_PATH=%s/libLTO.dylib" % llvm_libs_dir
+    use_just_built_liblto = "env LIBLTO_PATH=%s/libLTO.dylib" % llvm_libs_dir
 
 config.substitutions.append( ('%lto_flags', lto_flags) )
 config.substitutions.append( ('%use_just_built_liblto', use_just_built_liblto) )


### PR DESCRIPTION
Fixes:
-  test/Interpreter/lto_static_lib.swift
-  test/Interpreter/llvm_link_time_opt.swift
-  test/IRGen/hermetic-seal-exec.swift
-  test/IRGen/thinlto.swift

Partially address #84407 