### PR TITLE
[windows] fix DebugInfo tests

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/basic.swiftmodule %S/basic.swift
+// RUN: %target-swift-frontend -emit-module-path %t/advanced.swiftmodule %S/advanced.swift
 
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -c -module-name Foo %s -I %t -g -o %t.o
@@ -10,13 +10,13 @@
 // CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\\\}}DebugInfo{{/|\\\\}}Imports.swift",
 // CHECK-DAG: ![[SWIFTMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Swift"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[SWIFTMODULE]]
-// CHECK-DAG: ![[BASICMODULE:[0-9]+]] = !DIModule({{.*}}, name: "basic"
+// CHECK-DAG: ![[BASICMODULE:[0-9]+]] = !DIModule({{.*}}, name: "advanced"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[BASICMODULE]]
-import basic
+import advanced
 import typealias Swift.Optional
 
 func markUsed<T>(_ t: T) {}
-markUsed(basic.foo(1, 2))
+markUsed(advanced.foo(1, 2))
 
 // DWARF: .debug_info
 // DWARF: DW_TAG_module
@@ -26,7 +26,7 @@ markUsed(basic.foo(1, 2))
 // DWARF:   DW_AT_name ("Swift")
 // DWARF:   DW_AT_LLVM_include_path
 // DWARF: DW_TAG_module
-// DWARF:   DW_AT_name ("basic")
+// DWARF:   DW_AT_name ("advanced")
 
 // DWARF-NOT: "Swift.Optional"
 

--- a/test/DebugInfo/ParseableInterfaceImports.swift
+++ b/test/DebugInfo/ParseableInterfaceImports.swift
@@ -1,23 +1,23 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-typecheck %S/basic.swift \
-// RUN:    -emit-module-interface-path %t/basic.swiftinterface
+// RUN: %target-swift-frontend-typecheck %S/advanced.swift \
+// RUN:    -emit-module-interface-path %t/advanced.swiftinterface
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
 // RUN:    | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
 // RUN:    -sdk %t | %FileCheck %s --check-prefix=SDK
 
-import basic
+import advanced
 
-// CHECK: !DIModule(scope: null, name: "basic",
+// CHECK: !DIModule(scope: null, name: "advanced",
 // CHECK-SAME:      includePath: "
-// CHECK-SAME:      basic.swiftinterface"
+// CHECK-SAME:      advanced.swiftinterface"
 
 // Even if the module interface is in the SDK, we still return the path
 // to the swiftinterface.
-// SDK:   !DIModule(scope: null, name: "basic",
+// SDK:   !DIModule(scope: null, name: "advanced",
 // SDK-SAME:        includePath: "
-// SDK-SAME:        basic{{.*}}.swiftinterface"
+// SDK-SAME:        advanced{{.*}}.swiftinterface"
 
 func markUsed<T>(_ t: T) {}
-markUsed(basic.foo(1, 2))
+markUsed(advanced.foo(1, 2))
 


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/84234 we refactored the `DebugInfo/basic.swift` test. However both `test/DebugInfo/Imports.swift` and `test/DebugInfo/ParseableInterfaceImports.swift` depend on `basic.swift`, which has now been renamed to `advanced.swift`. This causes both tests to fail.

This patch modifies the 2 failing tests to point them to `advanced.swift` instead of `basic.swift`.