### PR TITLE
build.ps1: allow building without the legacy SDK

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3902,6 +3902,7 @@ function Build-Installer([Hashtable] $Platform) {
   $Properties = @{
     BundleFlavor = "offline";
     ImageRoot = "$(Get-InstallDir $Platform)\";
+    IncludeLegacySDK = if ($HostPlatform.DefaultSDK -match "Experimental") { "False" } else { "True" };
     INCLUDE_SWIFT_DOCC = $INCLUDE_SWIFT_DOCC;
     SWIFT_DOCC_BUILD = "$(Get-ProjectBinaryCache $HostPlatform DocC)\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";


### PR DESCRIPTION
Update the installer build to exclude the legacy SDK content from packaging. This prepares us to remove the legacy SDK entirely from the build.