### PR TITLE
Fix bug in internal func _tryLock in OpenBSDImpl.swift

### DIFF
--- a/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
@@ -39,7 +39,7 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    pthread_mutex_trylock(value._address) != 0
+    pthread_mutex_trylock(value._address) == 0
   }
 
   @available(SwiftStdlib 6.0, *)


### PR DESCRIPTION
`pthread_mutex_trylock` return `0` on success.

```
NAME
     pthread_mutex_trylock – attempt to lock a mutex without blocking

SYNOPSIS
     #include <pthread.h>

     int
     pthread_mutex_trylock(pthread_mutex_t *mutex);

DESCRIPTION
     The pthread_mutex_trylock() function locks mutex.  If the mutex is already locked,
     pthread_mutex_trylock() will not block waiting for the mutex, but will return an error
     condition.

RETURN VALUES
     If successful, pthread_mutex_trylock() will return zero, otherwise an error number will
     be returned to indicate the error.

ERRORS
     The pthread_mutex_trylock() function will fail if:

     [EINVAL]           The value specified by mutex is invalid.

     [EBUSY]            Mutex is already locked.
```