### PR TITLE
[ast] Requestify performImportResolution.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5538,6 +5538,22 @@ public:
   }
 };
 
+class SourceFileImportResolutionRequest
+    : public SimpleRequest<SourceFileImportResolutionRequest,
+                           bool(SourceFile *), RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Defined in libSwiftSema
+  bool evaluate(Evaluator &evaluator, SourceFile *SF) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -664,3 +664,7 @@ SWIFT_REQUEST(TypeChecker, AvailabilityDomainForDeclRequest,
 SWIFT_REQUEST(TypeChecker, IsCustomAvailabilityDomainPermanentlyEnabled,
               bool(const CustomAvailabilityDomain *),
               SeparatelyCached, NoLocationInfo)
+
+SWIFT_REQUEST(TypeChecker, SourceFileImportResolutionRequest,
+              bool (SourceFile *),
+              Cached, NoLocationInfo)


### PR DESCRIPTION
When making improvements to sil_llvm_opt_main, I noticed that when we performed
IRRequest, we hadn't performed Sema... so I then added code that ran Sema. I
then discovered that OptimizedIRRequest actually also performed Sema causing a
crash to occur. It then appeared to me... no one had requestified
performImportResolution even though it is a perfect case. I am not going to need
to do this soon (I am going to move a performImportResolution into IRRequest)...
but it seemed like a good thing to do and a clear improvement.

----

I also as an additional change, moved the actual call in OptimizedIRRequest -> IRRequest since OptimizedIRRequest already calls IRRequest.