### PR TITLE
[Serialization] Serialize isAddressable on param decls

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4167,6 +4167,7 @@ public:
     bool isCompileTimeLiteral, isConstValue;
     bool isSending;
     bool isCallerIsolated;
+    bool isAddressable;
     uint8_t rawDefaultArg;
     TypeID defaultExprType;
     uint8_t rawDefaultArgIsolation;
@@ -4180,6 +4181,7 @@ public:
                                          isConstValue,
                                          isSending,
                                          isCallerIsolated,
+                                         isAddressable,
                                          rawDefaultArg,
                                          defaultExprType,
                                          rawDefaultArgIsolation,
@@ -4226,6 +4228,7 @@ public:
     param->setConstValue(isConstValue);
     param->setSending(isSending);
     param->setCallerIsolated(isCallerIsolated);
+    param->setAddressable(isAddressable);
 
     // Decode the default argument kind.
     // FIXME: Default argument expression, if available.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 963; // Add @inline(always)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 964; // serialize param decl isAddressable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1746,6 +1746,7 @@ namespace decls_block {
     BCFixed<1>,              // isConst?
     BCFixed<1>,              // isSending?
     BCFixed<1>,              // isCallerIsolated?
+    BCFixed<1>,              // isAddressable?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type
     ActorIsolationField,     // default argument isolation

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4785,6 +4785,7 @@ public:
         param->isConstVal(),
         param->isSending(),
         param->isCallerIsolated(),
+        param->isAddressable(),
         getRawStableDefaultArgumentKind(argKind),
         S.addTypeRef(defaultExprType),
         getRawStableActorIsolationKind(isolation.getKind()),

--- a/test/Serialization/Inputs/lifetime_dependence.swift
+++ b/test/Serialization/Inputs/lifetime_dependence.swift
@@ -1,0 +1,23 @@
+import Builtin
+
+@frozen
+@safe
+public struct Ref<T: ~Copyable>: Copyable, ~Escapable {
+  @usableFromInline
+  let _pointer: UnsafePointer<T>
+
+  @_lifetime(borrow value)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(_ value: borrowing @_addressable T) {
+    unsafe _pointer = UnsafePointer(Builtin.unprotectedAddressOfBorrow(value))
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript() -> T {
+    @_transparent
+    unsafeAddress {
+      unsafe _pointer
+    }
+  }
+}

--- a/test/Serialization/lifetime_dependence.swift
+++ b/test/Serialization/lifetime_dependence.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-builtin-module -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -module-name lifetime_dependence_ref -o %t %S/Inputs/lifetime_dependence.swift
+// RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+import lifetime_dependence_ref
+
+public func foo() {
+  let x = 123
+  let y = Ref(x)
+
+  // CHECK: print
+  print(y[])
+}

--- a/test/Serialization/lifetime_dependence.swift
+++ b/test/Serialization/lifetime_dependence.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
 
 // REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_AddressableParameters
 
 import lifetime_dependence_ref
 


### PR DESCRIPTION
We weren't serializing this bit, so when deserializing these declarations, we would generate an `address_for_dep` instead of just an `address` lifetime dependency.

Resolves: rdar://149400463