### PR TITLE
Sema: In embedded, consider functions as fragile unless `@_neverEmitIntoClient`

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -202,7 +202,7 @@ struct ConformanceDiagnostic {
   ProtocolDecl *ExistingExplicitProtocol;
 };
 
-/// Used in diagnostic %selects.
+/// Used in diagnostic %selects via FRAGILE_FUNC_KIND.
 struct FragileFunctionKind {
   enum Kind : unsigned {
     Transparent,
@@ -211,6 +211,7 @@ struct FragileFunctionKind {
     DefaultArgument,
     PropertyInitializer,
     BackDeploy,
+    EmbeddedAlwaysEmitIntoClient,
     None
   };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7312,7 +7312,8 @@ ERROR(usable_from_inline_attr_in_protocol,none,
   "an '@_alwaysEmitIntoClient' function|" \
   "a default argument value|" \
   "a property initializer in a '@frozen' type|" \
-  "a '@backDeployed' function'}"
+  "a '@backDeployed' function|" \
+  "an embedded function not marked '@_neverEmitIntoClient'}"
 
 ERROR(local_type_in_inlinable_function,
       none, "type %0 cannot be nested inside " FRAGILE_FUNC_KIND "1",

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -687,6 +687,9 @@ void swift::simple_display(llvm::raw_ostream &out,
   case FragileFunctionKind::BackDeploy:
     out << "backDeploy";
     return;
+  case FragileFunctionKind::EmbeddedAlwaysEmitIntoClient:
+    out << "embeddedAlwaysEmitIntoClient";
+    return;
   case FragileFunctionKind::None:
     out << "none";
     return;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5223,7 +5223,8 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
   // restriction, macros would need to either be expanded when printed in
   // swiftinterfaces or be parsable as macros by module clients.
   auto fragileKind = DC->getFragileFunctionKind();
-  if (fragileKind.kind != FragileFunctionKind::None) {
+  if (fragileKind.kind != FragileFunctionKind::None &&
+      fragileKind.kind != FragileFunctionKind::EmbeddedAlwaysEmitIntoClient) {
     for (auto availSpec : info->getQueries()) {
       if (availSpec->getMacroLoc().isValid()) {
         diags.diagnose(availSpec->getMacroLoc(),

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -97,6 +97,14 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
     return false;
   }
 
+  // Embedded functions can reference non-public decls as they are visible
+  // to clients. Still report references to decls imported non-publicly
+  // to enforce access-level on imports.
+  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
+  if (fragileKind.kind == FragileFunctionKind::EmbeddedAlwaysEmitIntoClient &&
+      !problematicImport)
+    return false;
+
   DowngradeToWarning downgradeToWarning = DowngradeToWarning::No;
 
   // Swift 4.2 did not perform any checks for type aliases.
@@ -127,7 +135,6 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
 
-  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
       problematicImport->accessLevel < D->getFormalAccess()) {
     Context.Diags.diagnose(problematicImport->importLoc,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2946,7 +2946,8 @@ public:
 
     // We don't allow nested types inside inlinable contexts.
     auto kind = DC->getFragileFunctionKind();
-    if (kind.kind != FragileFunctionKind::None) {
+    if (kind.kind != FragileFunctionKind::None &&
+        kind.kind != FragileFunctionKind::EmbeddedAlwaysEmitIntoClient) {
       NTD->diagnose(diag::local_type_in_inlinable_function, NTD->getName(),
                     kind.getSelector());
     }

--- a/test/Sema/access-level-import-embedded.swift
+++ b/test/Sema/access-level-import-embedded.swift
@@ -1,0 +1,181 @@
+/// Test @_implementationOnly internal import exportability diagnostics in embedded mode.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
+// RUN:   %S/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t \
+// RUN:   %S/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// REQUIRES: swift_feature_Embedded
+
+@_implementationOnly internal import directs
+// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+// expected-note @-2 19 {{struct 'StructFromDirect' imported as 'internal' from 'directs' here}}
+// expected-note @-3 12 {{initializer 'init()' imported as 'internal' from 'directs' here}}
+import indirects
+
+internal func localInternalFunc() {} // expected-note {{global function 'localInternalFunc()' is not '@usableFromInline' or public}}
+
+@inlinable
+public func explicitlyInlinable(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' is internal and cannot be referenced from a default argument value}}
+// expected-error @-2 {{struct 'StructFromDirect' is internal and cannot be referenced from a default argument value}}
+// expected-error @-3 {{struct 'StructFromDirect' is internal and cannot be referenced from an '@inlinable' function}}
+// expected-error @-4 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-5 {{struct 'StructFromDirect' is imported by this file as 'internal' from 'directs'}}
+  _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an '@inlinable' function}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+  nested()
+
+  localInternalFunc() // expected-error {{global function 'localInternalFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate() // expected-error {{global function 'implicitlyInlinablePrivate(arg:)' is private and cannot be referenced from an '@inlinable' function}}
+  explicitNonInliable()
+}
+
+public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' is internal and cannot be referenced from a default argument value}}
+// expected-error @-2 {{struct 'StructFromDirect' is internal and cannot be referenced from a default argument value}}
+// expected-error @-3 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+// expected-error @-4 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-5 {{struct 'StructFromDirect' is imported by this file as 'internal' from 'directs'}}
+  _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+// expected-note @-2 {{global function 'implicitlyInlinablePrivate(arg:)' is not '@usableFromInline' or public}}
+  _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+    // expected-error@-1 {{struct 'StructFromDirect' is internal and cannot be referenced from an embedded function not marked '@_neverEmitIntoClient'}}
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+@_neverEmitIntoClient
+public func explicitNonInliable(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' is internal and cannot be referenced from a default argument value}}
+// expected-error @-2 {{struct 'StructFromDirect' is internal and cannot be referenced from a default argument value}}
+// expected-error @-3 {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+// expected-error @-4 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-5 {{struct 'StructFromDirect' is imported by this file as 'internal' from 'directs'}}
+  _ = StructFromDirect()
+
+  if (true) {
+    _ = StructFromDirect()
+  }
+
+  @_neverEmitIntoClient
+  func nested() {
+    _ = StructFromDirect()
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+@_neverEmitIntoClient
+internal func explicitNonInliableInternal(arg: StructFromDirect = StructFromDirect()) {
+  _ = StructFromDirect()
+
+  if (true) {
+    _ = StructFromDirect()
+  }
+
+  @_neverEmitIntoClient
+  func nested() {
+    _ = StructFromDirect()
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+public func legalAccessToIndirect(arg: StructFromIndirect = StructFromIndirect()) {
+  _ = StructFromIndirect()
+
+  if (true) {
+    _ = StructFromIndirect()
+  }
+
+  func nested() {
+    _ = StructFromIndirect()
+  }
+  nested()
+}
+
+public struct ExposedLayoutPublic {
+  public var publicField: StructFromDirect // expected-error {{property cannot be declared public because its type uses an internal type}}
+  // expected-error @-1 {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+  // expected-note @-2 {{struct 'StructFromDirect' is imported by this file as 'internal' from 'directs'}}
+
+  private var privateField: StructFromDirect
+}
+
+private struct ExposedLayoutPrivate {
+  private var privateField: StructFromDirect
+}

--- a/test/Sema/access-level-import-embedded.swift
+++ b/test/Sema/access-level-import-embedded.swift
@@ -3,18 +3,19 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
 // RUN:   %S/Inputs/implementation-only-imports/indirects.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t \
 // RUN:   %S/Inputs/implementation-only-imports/directs.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // RUN: %target-swift-frontend -typecheck -verify %s -I %t \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly internal import directs
 // expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}

--- a/test/Sema/access-level-import-embedded.swift
+++ b/test/Sema/access-level-import-embedded.swift
@@ -10,7 +10,7 @@
 // RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
-// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated %s -I %t \
 // RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -1,0 +1,171 @@
+/// Test @_implementationOnly import exportability diagnostics in embedded mode.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
+// RUN:   %S/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t\
+// RUN:    %S/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// REQUIRES: swift_feature_Embedded
+
+@_implementationOnly import directs
+// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+import indirects
+
+internal func localInternalFunc() {} // expected-note {{global function 'localInternalFunc()' is not '@usableFromInline' or public}}
+
+@inlinable
+public func explicitlyInlinable(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-2 {{struct 'StructFromDirect' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-3 {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  }
+  nested()
+
+  localInternalFunc() // expected-error {{global function 'localInternalFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate() // expected-error {{global function 'implicitlyInlinablePrivate(arg:)' is private and cannot be referenced from an '@inlinable' function}}
+  explicitNonInliable()
+}
+
+public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-2 {{struct 'StructFromDirect' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-3 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+
+  _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+// expected-note @-2 {{global function 'implicitlyInlinablePrivate(arg:)' is not '@usableFromInline' or public}}
+
+  _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+
+  if (true) {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  }
+
+  func nested() {
+    _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+    // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+@_neverEmitIntoClient
+public func explicitNonInliable(arg: StructFromDirect = StructFromDirect()) {
+// expected-error @-1 {{initializer 'init()' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-2 {{struct 'StructFromDirect' cannot be used in a default argument value because 'directs' was imported implementation-only}}
+// expected-error @-3 {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+
+  _ = StructFromDirect()
+
+  if (true) {
+    _ = StructFromDirect()
+  }
+
+  func nested() {
+    _ = StructFromDirect()
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+@_neverEmitIntoClient
+internal func explicitNonInliableInternal(arg: StructFromDirect = StructFromDirect()) {
+  _ = StructFromDirect()
+
+  if (true) {
+    _ = StructFromDirect()
+  }
+
+  func nested() {
+    _ = StructFromDirect()
+  }
+  nested()
+
+  localInternalFunc()
+
+  explicitlyInlinable()
+  implicitlyInlinablePublic()
+  implicitlyInlinablePrivate()
+  explicitNonInliable()
+}
+
+public func legalAccessToIndirect(arg: StructFromIndirect = StructFromIndirect()) {
+  _ = StructFromIndirect()
+
+  if (true) {
+    _ = StructFromIndirect()
+  }
+
+  func nested() {
+    _ = StructFromIndirect()
+  }
+  nested()
+}
+
+public struct ExposedLayoutPublic {
+  public var publicField: StructFromDirect // expected-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+
+  private var privateField: StructFromDirect // FIXME should error
+}
+
+private struct ExposedLayoutPrivate {
+  private var privateField: StructFromDirect // FIXME should error
+}

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -150,6 +150,39 @@ internal func explicitNonInliableInternal(arg: StructFromDirect = StructFromDire
   explicitNonInliable()
 }
 
+struct Accessors {
+  public var var1: Int {
+    get {
+      globalFunctionFromDirect() // expected-error {{global function 'globalFunctionFromDirect()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+      return 0
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public var var2: Int {
+    get {
+      globalFunctionFromDirect() // expected-error {{global function 'globalFunctionFromDirect()' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'directs' was imported implementation-only}}
+      return 0
+    }
+  }
+
+  @_neverEmitIntoClient
+  public var var3: Int {
+    get {
+      globalFunctionFromDirect()
+      return 0
+    }
+  }
+
+  public var var4: Int {
+    @_neverEmitIntoClient
+    get {
+      globalFunctionFromDirect()
+      return 0
+    }
+  }
+}
+
 public func legalAccessToIndirect(arg: StructFromIndirect = StructFromIndirect()) {
   _ = StructFromIndirect()
 

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -3,19 +3,20 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
 // RUN:   %S/Inputs/implementation-only-imports/indirects.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t\
 // RUN:    %S/Inputs/implementation-only-imports/directs.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // RUN: %target-swift-frontend -typecheck -verify %s -I %t \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -define-availability "availMacro:macOS 26.0, iOS 26.0" \
 // RUN:   -enable-experimental-feature Embedded
 
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly import directs
 // expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -10,7 +10,7 @@
 // RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
-// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated %s -I %t \
 // RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -define-availability "availMacro:macOS 26.0, iOS 26.0" \
 // RUN:   -enable-experimental-feature Embedded

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -148,6 +148,8 @@ internal func explicitNonInliableInternal(arg: StructFromDirect = StructFromDire
   implicitlyInlinablePublic()
   implicitlyInlinablePrivate()
   explicitNonInliable()
+
+  struct NestedStruct {}
 }
 
 struct Accessors {

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -12,6 +12,7 @@
 
 // RUN: %target-swift-frontend -typecheck -verify %s -I %t \
 // RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -define-availability "availMacro:macOS 26.0, iOS 26.0" \
 // RUN:   -enable-experimental-feature Embedded
 
 // REQUIRES: swift_feature_Embedded
@@ -73,6 +74,8 @@ public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()
   implicitlyInlinablePublic()
   implicitlyInlinablePrivate()
   explicitNonInliable()
+
+  if #available(availMacro, *) { }
 }
 
 private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {

--- a/test/embedded/implementation-only-import-build.swift
+++ b/test/embedded/implementation-only-import-build.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
+// RUN:   %S/../Sema/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t\
+// RUN:    %S/../Sema/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -emit-sil %s -I %t \
+// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -enable-experimental-feature Embedded
+
+// REQUIRES: swift_feature_Embedded
+
+@_implementationOnly import directs
+import indirects
+
+internal func localInternalFunc() {}
+
+public func implicitlyInlinablePublic() {
+  localInternalFunc()
+}
+
+private func implicitlyInlinablePrivate() {
+  localInternalFunc()
+}
+
+@_neverEmitIntoClient
+public func explicitNonInliable() {
+  _ = StructFromDirect()
+
+  if (true) {
+    _ = StructFromDirect()
+  }
+
+  @_neverEmitIntoClient
+  func nested() {
+    _ = StructFromDirect()
+  }
+  nested()
+
+  localInternalFunc()
+}
+
+@_alwaysEmitIntoClient
+public func legalAccessToIndirect() {
+  _ = StructFromIndirect()
+
+  if (true) {
+    _ = StructFromIndirect()
+  }
+
+  func nested() {
+    _ = StructFromIndirect()
+  }
+  nested()
+}

--- a/test/embedded/implementation-only-import-build.swift
+++ b/test/embedded/implementation-only-import-build.swift
@@ -1,15 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
 // RUN:   %S/../Sema/Inputs/implementation-only-imports/indirects.swift \
-// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t\
 // RUN:    %S/../Sema/Inputs/implementation-only-imports/directs.swift \
-// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // RUN: %target-swift-frontend -emit-sil %s -I %t \
-// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/implementation-only-import-build.swift
+++ b/test/embedded/implementation-only-import-build.swift
@@ -1,18 +1,19 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule \
 // RUN:   %S/../Sema/Inputs/implementation-only-imports/indirects.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t\
 // RUN:    %S/../Sema/Inputs/implementation-only-imports/directs.swift \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // RUN: %target-swift-frontend -emit-sil %s -I %t \
-// RUN:   -swift-version 5 -target arm64-apple-macosx15.0 \
+// RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded
 
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly import directs
 import indirects

--- a/test/embedded/implementation-only-import-build.swift
+++ b/test/embedded/implementation-only-import-build.swift
@@ -57,3 +57,12 @@ public func legalAccessToIndirect() {
   }
   nested()
 }
+
+extension Array {
+  @_alwaysEmitIntoClient
+  public var myMutableSpan: Int {
+    get {
+      return 0
+    }
+  }
+}


### PR DESCRIPTION
Consider functions in embedded mode to be fragile unless marked with `@_neverEmitIntoClient`. Basically treating them as if they were `@_alwaysEmitIntoClient` by default. A fragile function cannot reference restricted imports such as `@_implementationOnly`, `internal import`, etc.

We consider them as fragile only for type-checking, at the SIL level they remain treated as normal functions like before. This allows the later optimization to work as expected. We may want to likely align both ends of the compiler once this is properly supported in sema.

This is enabled only in embedded. Fragile functions in library-evolution are marked with attributes and are already checked. We do not need this is non-embedded non-library-evolution as CMO handles inlining and already takes into consideration `@_implementationOnly` imports.

Note: We'll need a similar check for memory layouts exposed to clients. We can still see compiler crashes and miscompiles in this scenario. This will apply to both embedded and non-library-evolution modes. That will likely need to extend the `@_neverEmitIntoClient` attribute and may require a staged deployment.

rdar://161365361