### PR TITLE
utils: Support multiple CMake versions in build.ps1

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -126,6 +126,9 @@ else()
   set(clang_headers_location "${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION_MAJOR}")
 endif()
 
+# Normalize the path.
+cmake_path(CONVERT "${clang_headers_location}" TO_CMAKE_PATH_LIST clang_headers_location NORMALIZE)
+
 add_custom_command_target(unused_var
     COMMAND
       "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}"

--- a/utils/android-overrides.cmake
+++ b/utils/android-overrides.cmake
@@ -1,0 +1,24 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+# Included via CMAKE_PROJECT_INCLUDE for Android builds that use Swift.
+#
+# Handles Clang-only driver flags that Swift doesn't understand:
+# - --ld-path: specifies the linker binary (Clang driver flag)
+# - -Qunused-arguments: suppresses Clang warnings about unused flags
+#
+# The NDK's -Wl,<arg> linker flags are handled in build.ps1 by pre-setting
+# CMAKE_*_LINKER_FLAGS with -Xlinker <arg> form before CMake runs.
+
+# --ld-path for using the built lld instead of the NDK linker.
+if(SWIFT_ANDROID_LD_PATH)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX,ASM>:--ld-path=${SWIFT_ANDROID_LD_PATH}>)
+endif()
+
+# Clang-only driver flag, not understood by Swift.
+add_link_options($<$<LINK_LANGUAGE:C,CXX,ASM>:-Qunused-arguments>)

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -524,6 +524,15 @@ function Get-CMake {
   throw "CMake not found on Path nor in the Visual Studio Installation. Please Install CMake to continue."
 }
 
+$cmake = Get-CMake
+$CMakeVersionString = & $cmake --version | Select-String -Pattern 'cmake version ([\d\.]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+$CMakeVersion = [Version]$CMakeVersionString
+# Starting with CMake 3.30, CMake propagates linker flags to Swift.
+$CMakePassesSwiftLinkerFlags = $CMakeVersion -ge [version]'3.30'
+# CMP0181 enables support for the `LINKER:flag1,flag2,...` syntax in
+# `CMAKE_[EXE|SHARED|MODULE]_LINKER_FLAGS[_<CONFIG>]` variables.
+$CMakeSupportsCMP0181 = $CMakeVersion -ge [version]'4.0'
+
 function Get-Ninja {
   try {
     return (Get-Command "Ninja.exe" -ErrorAction Stop).Source
@@ -535,7 +544,6 @@ function Get-Ninja {
   throw "Ninja not found on Path nor in the Visual Studio Installation. Please Install Ninja to continue."
 }
 
-$cmake = Get-CMake
 $ninja = Get-Ninja
 
 $NugetRoot = "$BinaryCache\nuget"
@@ -1431,8 +1439,56 @@ function Build-CMakeProject {
     $UseCXX = $UseBuiltCompilers.Contains("CXX") -or $UseMSVCCompilers.Contains("CXX") -or $UsePinnedCompilers.Contains("CXX")
     $UseSwift = $UseBuiltCompilers.Contains("Swift") -or $UsePinnedCompilers.Contains("Swift")
 
+    # We need to manually prefix linker flags with `-Xlinker` if we are using
+    # the GNU driver or if Swift is used as the linker driver.
+    # This is not necessary with CMake 4.0+ as CMP0181 simplifies the handling
+    # of linker arguments.
+    enum LinkerFlagHandling {
+      CMP0181
+      XLinkerPrefix
+      None
+    }
+    $FlagHandling = if ($CMakeSupportsCMP0181) {
+      # With CMP0181, the `LINKER:` generator expression can always be used.
+      [LinkerFlagHandling]::CMP0181
+    } elseif ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX")) {
+      # MSVC's link.exe does not require any special handling for linker flags.
+      [LinkerFlagHandling]::None
+    } else {
+      # Otherwise, we are probably using clang, clang-cl and/or swift, prefix
+      # the linker flags with `-Xlinker`.
+      [LinkerFlagHandling]::XLinkerPrefix
+    }
+
+    # Helper cmdlet to add linker flags with the appropriate handling based on
+    # the linker driver and CMake version.
+    function Add-LinkerFlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
+      $Value = switch ($FlagHandling) {
+        CMP0181 {
+          $Value | ForEach-Object { "LINKER:$_" }
+        }
+        XLinkerPrefix {
+          $NewValue = @()
+          foreach ($Flag in $Value) {
+            $NewValue += "-Xlinker"
+            $NewValue += $Flag
+          }
+          $NewValue
+        }
+        None {
+          $Value
+        }
+      }
+      Add-FlagsDefine $Defines $Name $Value
+    }
+
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
+
+    # Always enable CMP0181 if available.
+    if ($CMakeSupportsCMP0181) {
+      Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0181 NEW
+    }
 
     Add-KeyValueIfNew $Defines CMAKE_BUILD_TYPE Release
 
@@ -1603,22 +1659,30 @@ function Build-CMakeProject {
             @("-gnone")
           }
 
-          # Disable EnC as that introduces padding in the conformance tables
-          $SwiftFlags += @("-Xlinker", "/INCREMENTAL:NO")
-          # Swift requires COMDAT folding and de-duplication
-          $SwiftFlags += @("-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
+          if (-not $CMakePassesSwiftLinkerFlags) {
+            # Disable EnC as that introduces padding in the conformance tables
+            $SwiftFlags += @("-Xlinker", "/INCREMENTAL:NO")
+            # Swift requires COMDAT folding and de-duplication
+            $SwiftFlags += @("-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
+          }
 
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags
           # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
+
+          if ($CMakePassesSwiftLinkerFlags) {
+            # CMake 3.30+ passes all linker flags to Swift as the linker driver,
+            # including those from the internal CMake modules files, without
+            # a `-Xlinker` prefix. This causes build failures as Swift cannot
+            # parse linker flags.
+            # Overwrite the release linker flags to be empty to avoid this.
+            Add-KeyValueIfNew $Defines CMAKE_EXE_LINKER_FLAGS_RELEASE ""
+            Add-KeyValueIfNew $Defines CMAKE_SHARED_LINKER_FLAGS_RELEASE ""
+          }
         }
 
-        $LinkerFlags = if ($UseGNUDriver) {
-          @("-Xlinker", "/INCREMENTAL:NO", "-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
-        } else {
-          @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
-        }
+        $LinkerFlags = @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
 
         if ($DebugInfo) {
           if ($UseASM -or $UseC -or $UseCXX) {
@@ -1629,28 +1693,20 @@ function Build-CMakeProject {
             Add-KeyValueIfNew $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
             Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0141 NEW
 
-            $LinkerFlags += if ($UseGNUDriver) {
-              @("-Xlinker", "/DEBUG")
-            } else {
-              @("/DEBUG")
-            }
+            $LinkerFlags += @("/DEBUG")
 
             # The linker flags are shared across every language, and `/IGNORE:longsections` is an
             # `lld-link.exe` argument, not `link.exe`, so this can only be enabled when we use
             # `lld-link.exe` for linking.
             # TODO: Investigate supporting fission with PE/COFF, this should avoid this warning.
-            if ($SwiftDebugFormat -eq "dwarf") {
-              if ($UseGNUDriver) {
-                $LinkerFlags += @("-Xlinker", "/IGNORE:longsections")
-              } elseif (-not $UseMSVCCompilers.Contains("C") -and -not $UseMSVCCompilers.Contains("CXX")) {
-                $LinkerFlags += @("/IGNORE:longsections")
-              }
+            if ($SwiftDebugFormat -eq "dwarf" -and -not ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX"))) {
+              $LinkerFlags += @("/IGNORE:longsections")
             }
           }
         }
 
-        Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $LinkerFlags
-        Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $LinkerFlags
+        Add-LinkerFlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $LinkerFlags
+        Add-LinkerFlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $LinkerFlags
       }
 
       Android {
@@ -1734,8 +1790,40 @@ function Build-CMakeProject {
           # and not support all required relocations needed by the Swift
           # runtime.
           $ld = ([IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "ld.lld"))
-          Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ld"
-          Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ld"
+          if ($UseSwift) {
+            # The Android NDK injects `-Wl,<arg>` flags into
+            # `CMAKE_*_LINKER_FLAGS` via `CMAKE_*_LINKER_FLAGS_INIT` variables.
+            # CMake 3.30+ passes these to the Swift driver, which doesn't
+            # understand the `-Wl,` syntax. Pre-set the flags in a portable form
+            # (`-Xlinker <arg>`) from the command line as this takes precedence
+            # over the NDK's `*_INIT` mechanism.
+            #
+            # `--ld-path` and `-Qunused-arguments` are Clang driver flags,
+            # handled via `CMAKE_PROJECT_INCLUDE` with a `LINK_LANGUAGE` guard,
+            # so they do not affect Swift linking.
+            $AndroidLinkerFlags = @(
+              "-Xlinker", "--build-id=sha1",
+              "-Xlinker", "--no-rosegment",
+              "-Xlinker", "--no-undefined-version",
+              "-Xlinker", "--fatal-warnings",
+              "-Xlinker", "--gc-sections",
+              "-Xlinker", "--no-undefined"
+            )
+            Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $AndroidLinkerFlags
+            Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS ($AndroidLinkerFlags + @("-Xlinker", "--gc-sections"))
+            Add-FlagsDefine $Defines CMAKE_MODULE_LINKER_FLAGS $AndroidLinkerFlags
+            Add-KeyValueIfNew $Defines SWIFT_ANDROID_LD_PATH $ld
+            Add-KeyValueIfNew $Defines CMAKE_PROJECT_INCLUDE "$SourceCache\swift\utils\android-overrides.cmake"
+          } else {
+            # Clang Runtime explicitly sets linker flags for every target,
+            # making the `add_link_options()` approach via
+            # `CMAKE_PROJECT_INCLUDE` not viable. Since the problem that the
+            # above block aims to solve only concerns projects that use Swift,
+            # we can get away with just overriding `CMAKE_*_LINKER_FLAGS` for
+            # non-Swift projects.
+            Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ld"
+            Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ld"
+          }
         }
 
         # TODO(compnerd) we should understand why CMake does not understand

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -524,15 +524,6 @@ function Get-CMake {
   throw "CMake not found on Path nor in the Visual Studio Installation. Please Install CMake to continue."
 }
 
-$cmake = Get-CMake
-$CMakeVersionString = & $cmake --version | Select-String -Pattern 'cmake version ([\d\.]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
-$CMakeVersion = [Version]$CMakeVersionString
-# Starting with CMake 3.30, CMake propagates linker flags to Swift.
-$CMakePassesSwiftLinkerFlags = $CMakeVersion -ge [version]'3.30'
-# CMP0181 enables support for the `LINKER:flag1,flag2,...` syntax in
-# `CMAKE_[EXE|SHARED|MODULE]_LINKER_FLAGS[_<CONFIG>]` variables.
-$CMakeSupportsCMP0181 = $CMakeVersion -ge [version]'4.0'
-
 function Get-Ninja {
   try {
     return (Get-Command "Ninja.exe" -ErrorAction Stop).Source
@@ -544,6 +535,10 @@ function Get-Ninja {
   throw "Ninja not found on Path nor in the Visual Studio Installation. Please Install Ninja to continue."
 }
 
+$cmake = Get-CMake
+$CMakeVersion = if ((& $cmake --version | Select-Object -First 1) -Match '(\d+\.\d+\.\d+)') {
+  [version]$Matches[1]
+}
 $ninja = Get-Ninja
 
 $NugetRoot = "$BinaryCache\nuget"
@@ -1439,6 +1434,12 @@ function Build-CMakeProject {
     $UseCXX = $UseBuiltCompilers.Contains("CXX") -or $UseMSVCCompilers.Contains("CXX") -or $UsePinnedCompilers.Contains("CXX")
     $UseSwift = $UseBuiltCompilers.Contains("Swift") -or $UsePinnedCompilers.Contains("Swift")
 
+    # Starting with CMake 3.30, CMake propagates linker flags to Swift.
+    $CMakePassesSwiftLinkerFlags = $CMakeVersion -ge [version]'3.30'
+    # CMP0181 enables support for the `LINKER:flag1,flag2,...` syntax in
+    # `CMAKE_[EXE|SHARED|MODULE]_LINKER_FLAGS[_<CONFIG>]` variables.
+    $CMakeSupportsCMP0181 = $CMakeVersion -ge [version]'4.0'
+
     # We need to manually prefix linker flags with `-Xlinker` if we are using
     # the GNU driver or if Swift is used as the linker driver.
     # This is not necessary with CMake 4.0+ as CMP0181 simplifies the handling
@@ -1462,7 +1463,7 @@ function Build-CMakeProject {
 
     # Helper cmdlet to add linker flags with the appropriate handling based on
     # the linker driver and CMake version.
-    function Add-LinkerFlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
+    function Add-LinkerFlagsDefine([hashtable]$Defines, [string[]]$Value) {
       $Value = switch ($FlagHandling) {
         CMP0181 {
           $Value | ForEach-Object { "LINKER:$_" }
@@ -1479,7 +1480,9 @@ function Build-CMakeProject {
           $Value
         }
       }
-      Add-FlagsDefine $Defines $Name $Value
+
+      Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $Value
+      Add-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $Value
     }
 
     # Add additional defines (unless already present)
@@ -1659,7 +1662,15 @@ function Build-CMakeProject {
             @("-gnone")
           }
 
-          if (-not $CMakePassesSwiftLinkerFlags) {
+          if ($CMakePassesSwiftLinkerFlags) {
+            # CMake 3.30+ passes all linker flags to Swift as the linker driver,
+            # including those from the internal CMake modules files, without
+            # a `-Xlinker` prefix. This causes build failures as Swift cannot
+            # parse linker flags.
+            # Overwrite the release linker flags to be empty to avoid this.
+            Add-KeyValueIfNew $Defines CMAKE_EXE_LINKER_FLAGS_RELEASE ""
+            Add-KeyValueIfNew $Defines CMAKE_SHARED_LINKER_FLAGS_RELEASE ""
+          } else {
             # Disable EnC as that introduces padding in the conformance tables
             $SwiftFlags += @("-Xlinker", "/INCREMENTAL:NO")
             # Swift requires COMDAT folding and de-duplication
@@ -1670,19 +1681,9 @@ function Build-CMakeProject {
           # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
-
-          if ($CMakePassesSwiftLinkerFlags) {
-            # CMake 3.30+ passes all linker flags to Swift as the linker driver,
-            # including those from the internal CMake modules files, without
-            # a `-Xlinker` prefix. This causes build failures as Swift cannot
-            # parse linker flags.
-            # Overwrite the release linker flags to be empty to avoid this.
-            Add-KeyValueIfNew $Defines CMAKE_EXE_LINKER_FLAGS_RELEASE ""
-            Add-KeyValueIfNew $Defines CMAKE_SHARED_LINKER_FLAGS_RELEASE ""
-          }
         }
 
-        $LinkerFlags = @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
+        Add-LinkerFlagsDefine $Defines @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF")
 
         if ($DebugInfo) {
           if ($UseASM -or $UseC -or $UseCXX) {
@@ -1693,20 +1694,17 @@ function Build-CMakeProject {
             Add-KeyValueIfNew $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
             Add-KeyValueIfNew $Defines CMAKE_POLICY_DEFAULT_CMP0141 NEW
 
-            $LinkerFlags += @("/DEBUG")
+            Add-LinkerFlagsDefine $Defines @("/DEBUG")
 
             # The linker flags are shared across every language, and `/IGNORE:longsections` is an
             # `lld-link.exe` argument, not `link.exe`, so this can only be enabled when we use
             # `lld-link.exe` for linking.
             # TODO: Investigate supporting fission with PE/COFF, this should avoid this warning.
             if ($SwiftDebugFormat -eq "dwarf" -and -not ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX"))) {
-              $LinkerFlags += @("/IGNORE:longsections")
+              Add-LinkerFlagsDefine $Defines @("/IGNORE:longsections")
             }
           }
         }
-
-        Add-LinkerFlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS $LinkerFlags
-        Add-LinkerFlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS $LinkerFlags
       }
 
       Android {


### PR DESCRIPTION
Starting with CMake 3.30, CMake is passing linker flags to the Swift invocation used as the linker driver. This causes issues because Swift does not understand the linker flags and fails to link.

This is essentially a reland of https://github.com/swiftlang/swift/pull/84306 with a few changes:
* A new helper cmdlet takes care of adding the "right" version of the linker flags depending on the CMake version and the project configuration.
* Android linker flags are handled differently to work around issues in the NDK CMake files. In addition, we need to pass a linker driver flag for C/C++/ASM libraries to use the just built ld.lld linker. This argument is not understood by the Swift driver so it can only be used with clang used as the linker driver.

This also fixes a minor path normalization issue in swift shims, which causes a build failure with CMake 3.30+.