### PR TITLE
[test] Allow custom conditions for non-standard compilations

### DIFF
--- a/test/Frontend/print-static-build-config.swift
+++ b/test/Frontend/print-static-build-config.swift
@@ -4,7 +4,7 @@
 // CHECK: "attributes":
 // CHECK-SAME: "escaping"
 
-// CHECK-SAME: "customConditions":["SOMETHING"]
+// CHECK-SAME: "customConditions":[{{.*"SOMETHING"[^]]*\]}}
 
 // CHECK-SAME: "features":
 // CHECK-SAME: "AttachedMacros"


### PR DESCRIPTION
If someone has configured their build to add some vendor macro, for example, the vendor macro will appear in `customConditions`, which will make the test fail.

Modify the test slightly to check for `customConditions` containing `"SOMETHING"`, instead of only being `["SOMETHING"]` and nothing else. This should still allow the test to pass in Swift CI, but allows vendor macros to work too.