### PR TITLE
[AST] Remove UnresolvedType

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1044,7 +1044,6 @@ public:
 
   // Builtin type and simple types that are used frequently.
   const CanType TheErrorType;             /// This is the ErrorType singleton.
-  const CanType TheUnresolvedType;        /// This is the UnresolvedType singleton.
   const CanType TheEmptyTupleType;        /// This is '()', aka Void
   const CanType TheEmptyPackType;
   const CanType TheAnyType;               /// This is 'Any', the empty protocol composition

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -117,12 +117,6 @@ private:
 #define SINGLETON_TYPE(SHORT_ID, ID) TRIVIAL_CASE(ID##Type)
 #include "swift/AST/TypeNodes.def"
 
-    bool visitUnresolvedType(CanUnresolvedType firstType, Type secondType,
-                             Type sugaredFirstType) {
-      // Unresolved types never match.
-      return mismatch(firstType.getPointer(), secondType, sugaredFirstType);
-    }
-
     bool visitTupleType(CanTupleType firstTuple, Type secondType,
                         Type sugaredFirstType) {
       if (auto secondTuple = secondType->getAs<TupleType>()) {

--- a/include/swift/AST/TypeNodes.def
+++ b/include/swift/AST/TypeNodes.def
@@ -123,7 +123,6 @@
 #if !defined(SINGLETON_TYPE)
 
 TYPE(Error, Type)
-UNCHECKED_TYPE(Unresolved, Type)
 UNCHECKED_TYPE(Placeholder, Type)
 ABSTRACT_TYPE(Builtin, Type)
   ABSTRACT_TYPE(AnyBuiltinInteger, BuiltinType)

--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -109,7 +109,6 @@ case TypeKind::Id:
 #define TYPE(Id, Parent)
 #include "swift/AST/TypeNodes.def"
     case TypeKind::Error:
-    case TypeKind::Unresolved:
     case TypeKind::TypeVariable:
     case TypeKind::Placeholder:
     case TypeKind::SILToken:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -141,61 +141,58 @@ public:
     /// This type expression contains a GenericTypeParamType.
     HasTypeParameter     = 0x04,
 
-    /// This type expression contains an UnresolvedType.
-    HasUnresolvedType    = 0x08,
-
     /// Whether this type expression contains an unbound generic type.
-    HasUnboundGeneric    = 0x10,
+    HasUnboundGeneric    = 0x08,
 
     /// This type expression contains an LValueType other than as a
     /// function input, and can be loaded to convert to an rvalue.
-    IsLValue             = 0x20,
+    IsLValue             = 0x10,
 
     /// This type expression contains an opened existential ArchetypeType.
-    HasOpenedExistential = 0x40,
+    HasOpenedExistential = 0x20,
 
     /// This type expression contains a DynamicSelf type.
-    HasDynamicSelf       = 0x80,
+    HasDynamicSelf       = 0x40,
 
     /// This type contains an Error type.
-    HasError             = 0x100,
+    HasError             = 0x80,
 
     /// This type contains an Error type without an underlying original type.
-    HasBareError         = 0x200,
+    HasBareError         = 0x100,
 
     /// This type contains a DependentMemberType.
-    HasDependentMember   = 0x400,
+    HasDependentMember   = 0x200,
 
     /// This type contains an OpaqueTypeArchetype.
-    HasOpaqueArchetype   = 0x800,
+    HasOpaqueArchetype   = 0x400,
 
     /// This type contains a type placeholder.
-    HasPlaceholder       = 0x1000,
+    HasPlaceholder       = 0x800,
 
     /// This type contains a generic type parameter that is declared as a
     /// parameter pack.
-    HasParameterPack = 0x2000,
+    HasParameterPack = 0x1000,
 
     /// This type contains a parameterized existential type \c any P<T>.
-    HasParameterizedExistential = 0x4000,
+    HasParameterizedExistential = 0x2000,
 
     /// This type contains an ElementArchetypeType.
-    HasElementArchetype = 0x8000,
+    HasElementArchetype = 0x4000,
 
     /// Whether the type is allocated in the constraint solver arena. This can
     /// differ from \c HasTypeVariable for types such as placeholders, which do
     /// not have type variables, but we still want to allocate in the solver if
     /// they have a type variable originator.
-    SolverAllocated = 0x10000,
+    SolverAllocated = 0x8000,
 
     /// Contains a PackType.
-    HasPack = 0x20000,
+    HasPack = 0x10000,
 
     /// Contains a PackArchetypeType. Also implies HasPrimaryArchetype.
-    HasPackArchetype = 0x40000,
+    HasPackArchetype = 0x20000,
 
     /// Whether this type contains an unsafe type.
-    IsUnsafe = 0x080000,
+    IsUnsafe = 0x040000,
 
     Last_Property = IsUnsafe
   };
@@ -227,9 +224,6 @@ public:
   
   /// Does a type with these properties have a type parameter somewhere in it?
   bool hasTypeParameter() const { return Bits & HasTypeParameter; }
-
-  /// Does a type with these properties have an unresolved type somewhere in it?
-  bool hasUnresolvedType() const { return Bits & HasUnresolvedType; }
 
   /// Is a type with these properties an lvalue?
   bool isLValue() const { return Bits & IsLValue; }
@@ -755,11 +749,6 @@ public:
   /// Determine where this type is a type variable or a dependent
   /// member root in a type variable.
   bool isTypeVariableOrMember();
-
-  /// Determine whether this type involves a UnresolvedType.
-  bool hasUnresolvedType() const {
-    return getRecursiveProperties().hasUnresolvedType();
-  }
 
   /// Determine whether this type involves a \c PlaceholderType.
   bool hasPlaceholder() const {
@@ -1712,25 +1701,6 @@ public:
   }
 };
 DEFINE_EMPTY_CAN_TYPE_WRAPPER(ErrorType, Type)
-
-/// UnresolvedType - This represents a type variable that cannot be resolved to
-/// a concrete type because the expression is ambiguous.  This is produced when
-/// parsing expressions and producing diagnostics.  Any instance of this should
-/// cause the entire expression to be ambiguously typed.
-class UnresolvedType : public TypeBase {
-  friend class ASTContext;
-  // The Unresolved type is always canonical.
-  UnresolvedType(ASTContext &C)
-    : TypeBase(TypeKind::Unresolved, &C,
-       RecursiveTypeProperties(RecursiveTypeProperties::HasUnresolvedType)) { }
-public:
-  // Implement isa/cast/dyncast/etc.
-  static bool classof(const TypeBase *T) {
-    return T->getKind() == TypeKind::Unresolved;
-  }
-};
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(UnresolvedType, Type)
-
   
 /// BuiltinType - An abstract class for all the builtin types.
 class BuiltinType : public TypeBase {

--- a/include/swift/IDE/TypeCheckCompletionCallback.h
+++ b/include/swift/IDE/TypeCheckCompletionCallback.h
@@ -92,7 +92,7 @@ struct WithSolutionSpecificVarTypesRAII {
       } else {
         RestoreVarTypes[var] = Type();
       }
-      if (!ty->hasArchetype() && !ty->hasUnresolvedType()) {
+      if (!ty->hasArchetype()) {
         setInterfaceType(const_cast<VarDecl *>(var), ty);
       } else {
         setInterfaceType(const_cast<VarDecl *>(var), ErrorType::get(ty));

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5856,7 +5856,7 @@ ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
   case TypeKind::GenericTypeParam:
   case TypeKind::TypeVariable:
   case TypeKind::DependentMember:
-  case TypeKind::Unresolved:
+  case TypeKind::Error:
   case TypeKind::Placeholder:
   case TypeKind::PrimaryArchetype:
   case TypeKind::PackArchetype:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -808,10 +808,8 @@ ASTContext::ASTContext(
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
       blockListConfig(SourceMgr),
-      TheErrorType(new(*this, AllocationArena::Permanent) ErrorType(
-          *this, Type(), RecursiveTypeProperties::HasError)),
-      TheUnresolvedType(new(*this, AllocationArena::Permanent)
-                            UnresolvedType(*this)),
+      TheErrorType(new (*this, AllocationArena::Permanent)
+                       ErrorType(*this, Type())),
       TheEmptyTupleType(TupleType::get(ArrayRef<TupleTypeElt>(), *this)),
       TheEmptyPackType(PackType::get(*this, {})),
       TheAnyType(ProtocolCompositionType::theAnyType(*this)),
@@ -3637,8 +3635,7 @@ Type ErrorType::get(Type originalType) {
 
   void *mem = ctx.Allocate(sizeof(ErrorType) + sizeof(Type),
                            alignof(ErrorType), arena);
-  return entry = new (mem) ErrorType(ctx, originalType,
-                                     RecursiveTypeProperties::HasError);
+  return entry = new (mem) ErrorType(ctx, originalType);
 }
 
 void ErrorUnionType::Profile(llvm::FoldingSetNodeID &id, ArrayRef<Type> terms) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -6062,8 +6062,6 @@ namespace {
       printFoot();
     }
 
-    TRIVIAL_TYPE_PRINTER(Unresolved, unresolved)
-
     void visitPlaceholderType(PlaceholderType *T, Label label) {
       printCommon("placeholder_type", label);
       auto originator = T->getOriginator();

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1417,7 +1417,6 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
       llvm_unreachable("Cannot mangle module type yet");
 
     case TypeKind::Error:
-    case TypeKind::Unresolved:
     case TypeKind::Placeholder:
       appendOperator("Xe");
       return;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6204,14 +6204,6 @@ public:
     }
   }
 
-  void visitUnresolvedType(UnresolvedType *T,
-                           NonRecursivePrintOptions nrOptions) {
-    if (Options.PrintTypesForDebugging)
-      Printer << "<<unresolvedtype>>";
-    else
-      Printer << "_";
-  }
-
   void visitErrorUnionType(ErrorUnionType *T,
                            NonRecursivePrintOptions nrOptions) {
     Printer << "error_union(";

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -609,10 +609,9 @@ LookupConformanceInModuleRequest::evaluate(
   if (type->isTypeVariableOrMember())
     return ProtocolConformanceRef::forAbstract(type, protocol);
 
-  // UnresolvedType is a placeholder for an unknown type used when generating
-  // diagnostics.  We consider it to conform to all protocols, since the
-  // intended type might have. Same goes for PlaceholderType.
-  if (type->is<UnresolvedType>() || type->is<PlaceholderType>())
+  // PlaceholderType is a placeholder for an unknown type. We consider it to
+  // conform to all protocols, since the intended type might have.
+  if (type->is<PlaceholderType>())
     return ProtocolConformanceRef::forAbstract(type, protocol);
 
   // Pack types can conform to protocols.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -983,11 +983,10 @@ static void formatDiagnosticArgument(StringRef Modifier,
       needsQualification = typeSpellingIsAmbiguous(type, Args, printOptions);
     }
 
-    // If a type has an unresolved type, print it with syntax sugar removed for
+    // If a type has a bare error type, print it with syntax sugar removed for
     // clarity. For example, print `Array<_>` instead of `[_]`.
-    if (type->hasUnresolvedType()) {
+    if (type->hasBareError())
       type = type->getWithoutSyntaxSugar();
-    }
 
     if (needsQualification &&
         isa<OpaqueTypeArchetypeType>(type.getPointer()) &&

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -519,7 +519,6 @@ void SubstitutionMap::verify(bool allowInvalid) const {
           !substType->is<PackElementType>() &&
           !substType->is<ArchetypeType>() &&
           !substType->isTypeVariableOrMember() &&
-          !substType->is<UnresolvedType>() &&
           !substType->is<PlaceholderType>() &&
           !substType->is<ErrorType>()) {
         ABORT([&](auto &out) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -237,7 +237,6 @@ bool CanType::isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
   // Nothing else is statically just a class reference.
   case TypeKind::SILBlockStorage:
   case TypeKind::Error:
-  case TypeKind::Unresolved:
   case TypeKind::BuiltinInteger:
   case TypeKind::BuiltinIntegerLiteral:
   case TypeKind::BuiltinFloat:
@@ -761,7 +760,6 @@ bool TypeBase::hasTypeRepr() const {
   return !Type(const_cast<TypeBase *>(this)).findIf([](Type subTy) -> bool {
     switch (subTy->getKind()) {
     case TypeKind::Error:
-    case TypeKind::Unresolved:
     case TypeKind::TypeVariable:
       return true;
 
@@ -1768,7 +1766,6 @@ CanType TypeBase::computeCanonicalType() {
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
   case TypeKind::Error:
-  case TypeKind::Unresolved:
   case TypeKind::TypeVariable:
   case TypeKind::Placeholder:
   case TypeKind::BuiltinTuple:
@@ -2318,10 +2315,9 @@ bool TypeBase::mayBeCallable(DeclContext *dc) {
     return true;
 
   // Unresolved types that could potentially be callable.
-  if (isPlaceholder() || is<UnresolvedType>() ||
-      isTypeParameter() || isTypeVariableOrMember()) {
+  if (isPlaceholder() || isTypeParameter() || isTypeVariableOrMember())
     return true;
-  }
+
   // Callable nominal types.
   if (isCallAsFunctionType(dc) || hasDynamicCallableAttribute())
     return true;
@@ -4568,7 +4564,6 @@ ReferenceCounting TypeBase::getReferenceCounting() {
   case TypeKind::SILFunction:
   case TypeKind::SILBlockStorage:
   case TypeKind::Error:
-  case TypeKind::Unresolved:
   case TypeKind::BuiltinInteger:
   case TypeKind::BuiltinIntegerLiteral:
   case TypeKind::BuiltinFloat:

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -35,7 +35,6 @@ class Traversal : public TypeVisitor<Traversal, bool>
   TypeWalker &Walker;
 
   bool visitErrorType(ErrorType *ty) { return false; }
-  bool visitUnresolvedType(UnresolvedType *ty) { return false; }
   bool visitPlaceholderType(PlaceholderType *ty) { return false; }
   bool visitBuiltinType(BuiltinType *ty) { return false; }
   bool visitIntegerType(IntegerType *ty) { return false; }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2064,7 +2064,6 @@ private:
     return pass(ty, /*found=*/true);
   }
 
-  NEVER_VISIT(UnresolvedType)
   NEVER_VISIT(PlaceholderType)
   NEVER_VISIT(BuiltinType)
   NEVER_VISIT(BuiltinTupleType)

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -201,7 +201,7 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
     }
   }
   if (ExpectedCallType &&
-      (ExpectedCallType->hasUnresolvedType() ||
+      (ExpectedCallType->hasError() ||
        ExpectedCallType->hasUnboundGenericType())) {
     ExpectedCallType = Type();
   }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -693,7 +693,7 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
 
       // For a GenericFunctionType, we only want to substitute the
       // param/result types, as otherwise we might end up with a bad generic
-      // signature if there are UnresolvedTypes present in the base type. Note
+      // signature if there are ErrorTypes present in the base type. Note
       // we pass in DesugarMemberTypes so that we see the actual concrete type
       // witnesses instead of type alias types.
       if (auto *GFT = T->getAs<GenericFunctionType>()) {

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -123,7 +123,7 @@ void ConformingMethodListCallbacks::readyForTypeChecking(SourceFile *SrcFile) {
   Type T = Res.Ty;
   WithSolutionSpecificVarTypesRAII VarType(Res.SolutionSpecificVarTypes);
 
-  if (!T || T->is<ErrorType>() || T->is<UnresolvedType>())
+  if (!T || T->is<ErrorType>())
     return;
 
   T = T->getRValueType();

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -420,7 +420,7 @@ void PostfixCompletionCallback::collectResults(
     // tuple. But that doesn’t really make sense so we shouldn't be suggesting
     // any operators based on `Void`.
     if (IncludeOperators && !Result.BaseIsStaticMetaType &&
-        !Result.BaseTy->isVoid() &&
+        !Result.BaseTy->isVoid() && !Result.BaseTy->hasError() &&
         !ProcessedBaseTypes.contains(Result.BaseTy)) {
       addOperatorResults(Result.BaseTy, Operators, DC, Lookup);
     }

--- a/lib/IDE/SelectedOverloadInfo.cpp
+++ b/lib/IDE/SelectedOverloadInfo.cpp
@@ -56,7 +56,7 @@ swift::ide::getSelectedOverloadInfo(const Solution &S,
         OverloadChoiceKind::KeyPathApplication) {
       auto Params = Result.ValueTy->getAs<AnyFunctionType>()->getParams();
       if (Params.size() == 1 &&
-          Params[0].getPlainType()->is<UnresolvedType>()) {
+          Params[0].getPlainType()->is<ErrorType>()) {
         auto *KPDecl = CS.getASTContext().getKeyPathDecl();
         Type KPTy =
             KPDecl->mapTypeIntoContext(KPDecl->getDeclaredInterfaceType());

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -27,7 +27,7 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
   // Use the contextual type, unless it is still unresolved, in which case fall
   // back to getting the type from the expression.
   if (auto ContextualType = S.getContextualType(Node)) {
-    if (!ContextualType->hasUnresolvedType() &&
+    if (!ContextualType->hasError() &&
         !ContextualType->hasUnboundGenericType()) {
       return ContextualType;
     }
@@ -46,7 +46,7 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
     Result = S.getResolvedType(Node);
   }
 
-  if (Result && Result->is<UnresolvedType>()) {
+  if (Result && Result->is<ErrorType>()) {
     Result = Type();
   }
   return Result;

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -129,7 +129,7 @@ void ContextInfoCallbacks::readyForTypeChecking(SourceFile *SrcFile) {
   SmallVector<TypeContextInfoItem, 2> results;
 
   for (auto T : TypeCheckCallback.getTypes()) {
-    if (T->is<ErrorType>() || T->is<UnresolvedType>())
+    if (T->is<ErrorType>())
       continue;
 
     T = T->getRValueType();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2320,7 +2320,6 @@ private:
     // The following types exist primarily for internal use by the type
     // checker.
     case TypeKind::Error:
-    case TypeKind::Unresolved:
     case TypeKind::LValue:
     case TypeKind::TypeVariable:
     case TypeKind::ErrorUnion:

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -115,7 +115,6 @@ static bool isGenericParameter(TypeVariableType *TypeVar) {
 bool PotentialBinding::isViableForJoin() const {
   return Kind == AllowedBindingKind::Supertypes &&
          !BindingType->hasLValueType() &&
-         !BindingType->hasUnresolvedType() &&
          !BindingType->hasTypeVariable() &&
          !BindingType->hasPlaceholder() &&
          !BindingType->hasUnboundGenericType() &&

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7424,7 +7424,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 #include "swift/AST/TypeNodes.def"
 
     case TypeKind::Error:
-    case TypeKind::Unresolved:
       return getTypeMatchFailure(locator);
 
     case TypeKind::BuiltinFixedArray: {
@@ -8453,7 +8452,6 @@ ConstraintSystem::simplifyConstructionConstraint(
   case TypeKind::BuiltinTuple:
     llvm_unreachable("BuiltinTupleType in constraint");
     
-  case TypeKind::Unresolved:
   case TypeKind::Error:
   case TypeKind::Placeholder:
     return SolutionKind::Error;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -300,7 +300,6 @@ static bool backwardScanAcceptsTrailingClosure(
       paramTy->is<ArchetypeType>() ||
       paramTy->is<AnyFunctionType>() ||
       paramTy->isTypeVariableOrMember() ||
-      paramTy->is<UnresolvedType>() ||
       paramTy->isAny();
 }
 
@@ -10109,8 +10108,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
   MemberLookupResult result;
 
-  if (instanceTy->isTypeVariableOrMember() ||
-      instanceTy->is<UnresolvedType>()) {
+  if (instanceTy->isTypeVariableOrMember()) {
     result.OverallResult = MemberLookupResult::Unsolved;
     return result;
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1166,8 +1166,7 @@ void ConstraintSystem::shrink(Expr *expr) {
 
       auto base = collection.getPointer();
       auto isInvalidType = [](Type type) -> bool {
-        return type.isNull() || type->hasUnresolvedType() ||
-               type->hasError();
+        return type.isNull() || type->hasError();
       };
 
       // Array type.
@@ -1179,9 +1178,6 @@ void ConstraintSystem::shrink(Expr *expr) {
 
       // Map or Set or any other associated collection type.
       if (auto boundGeneric = dyn_cast<BoundGenericType>(base)) {
-        if (boundGeneric->hasUnresolvedType())
-          return boundGeneric;
-
         // Avoid handling InlineArray, building a tuple would be wrong, and
         // we want to eliminate shrink.
         if (boundGeneric->getDecl() == ctx.getInlineArrayDecl())
@@ -1290,9 +1286,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         auto elementType = extractElementType(contextualType);
         // If we couldn't deduce element type for the collection, let's
         // not attempt to solve it.
-        if (!elementType ||
-            elementType->hasError() ||
-            elementType->hasUnresolvedType())
+        if (!elementType || elementType->hasError())
           return;
 
         contextualType = elementType;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1157,7 +1157,7 @@ void ConstraintSystem::shrink(Expr *expr) {
     ///
     /// \param collection The type of the collection container.
     ///
-    /// \returns Null type, ErrorType or UnresolvedType on failure,
+    /// \returns Null type or ErrorType on failure,
     /// properly constructed type otherwise.
     Type extractElementType(Type collection) {
       auto &ctx = CS.getASTContext();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1886,7 +1886,7 @@ Type Solution::simplifyType(Type type, bool wantInterfaceType) const {
   ASSERT(!(wantInterfaceType && resolvedType->hasPrimaryArchetype()));
 
   // We may have type variables and placeholders left over. These are solver
-  // allocated so cannot escape this function. Turn them into UnresolvedType.
+  // allocated so cannot escape this function. Turn them into ErrorType.
   // - Type variables may still be present from unresolved pack expansions where
   //   e.g the count type is a hole, so the pattern may never become a
   //   concrete type.
@@ -1900,7 +1900,7 @@ Type Solution::simplifyType(Type type, bool wantInterfaceType) const {
 
           auto *typePtr = type.getPointer();
           if (isa<TypeVariableType>(typePtr) || isa<PlaceholderType>(typePtr))
-            return Type(ctx.TheUnresolvedType);
+            return ErrorType::get(ctx);
 
           return std::nullopt;
         });
@@ -4298,7 +4298,7 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
     // If callee couldn't be resolved due to expression
     // issues e.g. it's a reference to an invalid member
     // let's just return here.
-    if (simplifyType(rawFnType)->is<UnresolvedType>())
+    if (simplifyType(rawFnType)->is<ErrorType>())
       return std::nullopt;
 
     // A tuple construction is spelled in the AST as a function call, but

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -143,7 +143,7 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   // For check on specializable archetype see comment on
   // ContainsSpecializableArchetype.
   if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType() ||
-      BaseTy->hasUnresolvedType() || BaseTy->hasError() ||
+      BaseTy->hasError() ||
       ContainsSpecializableArchetype::check(DC, BaseTy))
     return true;
 
@@ -181,7 +181,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
   // We can't leak type variables into another constraint system.
   // We can't do anything if the base type has unbound generic parameters.
   if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType()||
-      BaseTy->hasUnresolvedType() || BaseTy->hasError())
+      BaseTy->hasError())
     return true;
 
   if (isa<TypeAliasDecl>(VD) && BaseTy->is<ProtocolType>()) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5616,17 +5616,6 @@ public:
     llvm_unreachable("should not serialize an ErrorType");
   }
 
-  void visitUnresolvedType(const UnresolvedType *) {
-    // If for some reason we have an unresolved type while compiling with
-    // errors, just serialize an ErrorType and continue.
-    if (S.getASTContext().LangOpts.AllowModuleWithCompilerErrors) {
-      visitErrorType(
-          cast<ErrorType>(ErrorType::get(S.getASTContext()).getPointer()));
-      return;
-    }
-    llvm_unreachable("should not serialize an UnresolvedType");
-  }
-
   void visitPlaceholderType(const PlaceholderType *) {
     // If for some reason we have a placeholder type while compiling with
     // errors, just serialize an ErrorType and continue.


### PR DESCRIPTION
Remove the remaining uses in `simplifyType`/`resolveType`, producing an ErrorType instead.