### PR TITLE
[VariadicGenerics] Fix memeffect of metadata accessor.

### DIFF
--- a/include/swift/IRGen/GenericRequirement.h
+++ b/include/swift/IRGen/GenericRequirement.h
@@ -109,6 +109,11 @@ public:
   bool isAnyWitnessTable() const {
     return kind == Kind::WitnessTable || kind == Kind::WitnessTablePack;
   }
+
+  bool isAnyPack() const {
+    return kind == Kind::MetadataPack || kind == Kind::WitnessTablePack;
+  }
+
   bool isValue() const {
     return kind == Kind::Value;
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2993,8 +2993,9 @@ void irgen::emitLazyMetadataAccessor(IRGenModule &IGM,
   if (IGM.getOptions().optimizeForSize())
     accessor->addFnAttr(llvm::Attribute::NoInline);
 
-  bool isReadNone = (genericArgs.Types.size() <=
-                     NumDirectGenericTypeMetadataAccessFunctionArgs);
+  bool isReadNone =
+      !genericArgs.hasPacks && (genericArgs.Types.size() <=
+                                NumDirectGenericTypeMetadataAccessFunctionArgs);
 
   emitCacheAccessFunction(
       IGM, accessor, /*cache*/ nullptr, /*cache type*/ nullptr,

--- a/lib/IRGen/GenericArguments.h
+++ b/lib/IRGen/GenericArguments.h
@@ -50,8 +50,9 @@ struct GenericArguments {
   /// The values to use to initialize the arguments structure.
   SmallVector<llvm::Value *, 8> Values;
   SmallVector<llvm::Type *, 8> Types;
+  bool hasPacks = false;
 
- void collectTypes(IRGenModule &IGM, NominalTypeDecl *nominal) {
+  void collectTypes(IRGenModule &IGM, NominalTypeDecl *nominal) {
     GenericTypeRequirements requirements(IGM, nominal);
     collectTypes(IGM, requirements);
   }
@@ -59,6 +60,7 @@ struct GenericArguments {
   void collectTypes(IRGenModule &IGM,
                     const GenericTypeRequirements &requirements) {
     for (auto &requirement : requirements.getRequirements()) {
+      hasPacks = hasPacks || requirement.isAnyPack();
       Types.push_back(requirement.getType(IGM));
     }
   }

--- a/validation-test/IRGen/rdar161606892.swift
+++ b/validation-test/IRGen/rdar161606892.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-irgen | %IRGenFileCheck %s
+
+// CHECK: Attrs: noinline nounwind{{$}}
+// CHECK-NEXT: define {{.*}}@"$s13rdar1616068921PVMa"
+
+public struct P<each T> {
+  public var teas: (repeat each T)
+}


### PR DESCRIPTION
The metadata accessor for a variadic generic type takes as arguments packs of metadata records and witness tables, and each such pack is passed in a buffer.  So any such accessor is not correctly annotated `memory(none)`.

rdar://161606892
