### PR TITLE
[DiagnosticVerifier] Do not capture 'fatal error encountered' errors

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/DiagnosticVerifier.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/ColorUtils.h"
 #include "swift/Basic/SourceManager.h"
@@ -1264,6 +1265,10 @@ void DiagnosticVerifier::printRemainingDiagnostics() const {
 /// file.
 void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
                                           const DiagnosticInfo &Info) {
+  // Ignore "fatal error encountered while in -verify mode" errors,
+  // because there's no reason to verify them.
+  if (Info.ID == diag::verify_encountered_fatal.ID)
+    return;
   SmallVector<CapturedFixItInfo, 2> fixIts;
   for (const auto &fixIt : Info.FixIts) {
     fixIts.emplace_back(SM, fixIt);

--- a/test/Frontend/DiagnosticVerifier/expect-the-expected.swift
+++ b/test/Frontend/DiagnosticVerifier/expect-the-expected.swift
@@ -1,0 +1,3 @@
+// RUN: %target-typecheck-verify-swift
+
+import Expected // expected-error {{no such module 'Expected'}}


### PR DESCRIPTION
When the diagnostic verifier encounters a fatal error, it reports:

    <unknown>:0: error: fatal error encountered while in -verify mode

If we capture this, and fail to match this against an expected-error, the diagnostic verifier complains:

    <unknown>:0: error: unexpected error produced: fatal error encountered while in -verify mode
    <unknown>:0: error: diagnostic produced elsewhere: fatal error encountered while in -verify mode

The current workaround is to use -verify-ignore-unknown, but that in turn may mask actual errors coming from unknown source locations. Ignoring these errors about errors removes the need for that workaround.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
