### PR TITLE
LifetimeDependenceDiagnostics: extend temp alloc to unreachable.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -744,10 +744,9 @@ extension ScopeExtension {
 
     // Append each scope that needs extension to scopesToExtend from the inner to the outer scope.
     for extScope in scopes.reversed() {
-      // An outer scope might not originally cover one of its inner scopes. Therefore, extend 'extendedUseRange' to to
-      // cover this scope's end instructions. The extended scope must at least cover the original scopes because the
-      // original scopes may protect other operations.
       var mustExtend = false
+      // Iterating over scopeEndInst ignores unreachable paths which may not include the dealloc_stack. This is fine
+      // because the stack allocation effectively covers the entire unreachable path.
       for scopeEndInst in extScope.endInstructions {
         switch extendedUseRange.overlaps(pathBegin: extScope.firstInstruction, pathEnd: scopeEndInst, context) {
         case .containsPath, .containsEnd, .disjoint:
@@ -757,6 +756,10 @@ extension ScopeExtension {
           break
         case .containsBegin, .overlappedByPath:
           // containsBegin can occur when the extendable scope has the same begin as the use range.
+          //
+          // An outer scope might not originally cover one of its inner scopes. Therefore, extend 'extendedUseRange' to
+          // to cover this scope's end instructions. The extended scope must at least cover the original scopes because
+          // the original scopes may protect other operations.
           extendedUseRange.insert(scopeEndInst)
           break
         }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -70,6 +70,9 @@ sil @addressInt : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(bor
 sil @addressOfInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow address 0) @owned Span<Int>
 sil @noAddressInt : $@convention(thin) (@in_guaranteed Int) -> @lifetime(borrow 0) @owned Span<Int>
 sil @useSpan : $@convention(thin) (@guaranteed Span<Int>) -> ()
+sil @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> @error any Error
+
+sil @getInlineSpan : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address 0) @owned RawSpan
 
 // Test returning a owned dependence on a trivial value
 sil [ossa] @return_trivial_dependence : $@convention(thin) (@guaranteed C) -> @lifetime(borrow 0) @owned NE {
@@ -351,4 +354,30 @@ bb0(%0: $Int):
   destroy_value %11 // expected-note{{this use of the lifetime-dependent value is out of scope}}
   %18 = tuple ()
   return %18
+}
+
+// Test dependence on the temporary stack address of a trivial value. computeAddressableRange must extend the lifetime
+// of %tempAddr into the unreachable.
+sil hidden [ossa] @testTempAddressUnreachable : $@convention(thin) (@in_guaranteed InlineInt) -> () {
+bb0(%0 : $*InlineInt):
+  %loadArg = load [trivial] %0
+  %tempAddr = alloc_stack $InlineInt
+  store %loadArg to [trivial] %tempAddr
+
+  %f1 = function_ref @getInlineSpan : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address 0) @owned RawSpan
+  %call = apply %f1(%tempAddr) : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address 0) @owned RawSpan
+  %md = mark_dependence [unresolved] %call on %tempAddr
+
+  %f2 = function_ref @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> @error any Error
+  try_apply %f2(%md) : $@convention(thin) (@guaranteed RawSpan) -> @error any Error, normal bb1, error bb2
+
+bb1(%void : $()):
+  destroy_value %md
+  dealloc_stack %tempAddr
+  %99 = tuple ()
+  return %99
+
+bb2(%error : @owned $any Error):
+  destroy_value [dead_end] %md
+  unreachable
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -381,3 +381,42 @@ bb2(%error : @owned $any Error):
   destroy_value [dead_end] %md
   unreachable
 }
+
+// Test dependence on the temporary stack address of a trivial value. computeAddressableRange must extend the lifetime
+// of %tempAddr into the unreachable.
+//
+// Note that the computed instruction range is marked Invalid because it does not have a single dominating
+// block. Nonetheless, the range still include all blocks in which the stack allocation is live, which is all we care
+// about.
+sil hidden [ossa] @testTempAddressNondominatedUnreachable : $@convention(thin) (@in_guaranteed InlineInt) -> () {
+bb0(%0 : $*InlineInt):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb5
+
+bb2:
+  %loadArg = load [trivial] %0
+  %tempAddr = alloc_stack $InlineInt
+  store %loadArg to [trivial] %tempAddr
+
+  %f1 = function_ref @getInlineSpan : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address 0) @owned RawSpan
+  %call = apply %f1(%tempAddr) : $@convention(thin) (@in_guaranteed InlineInt) -> @lifetime(borrow address 0) @owned RawSpan
+  %md = mark_dependence [unresolved] %call on %tempAddr
+
+  %f2 = function_ref @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> @error any Error
+  try_apply %f2(%md) : $@convention(thin) (@guaranteed RawSpan) -> @error any Error, normal bb3, error bb4
+
+bb3(%void : $()):
+  destroy_value %md
+  dealloc_stack %tempAddr
+  %99 = tuple ()
+  return %99
+
+bb4(%error : @owned $any Error):
+  destroy_value [dead_end] %md
+  br bb5
+
+bb5:
+  unreachable
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -405,7 +405,7 @@ func returnTempBorrow() -> Borrow<Int> {
 //     store %arg to [trivial] temp
 //     apply %get_span(%temp)
 //
-// If we use InlineArray instead, we get a store_borrow, which is a completely different situatio.
+// If we use InlineArray instead, we get a store_borrow, which is a completely different situation.
 func test(inline: InlineInt) {
   inline.span.withUnsafeBytes { _ = $0 }
 }


### PR DESCRIPTION
  When a non-Escapable value depends on the address of a trivial value, we use a
  special computeAddressableRange analysis to compute the trivial value's
  scope. Extend that analysis to include unreachable paths.
  
  Fixes this pattern:
  
      inlineStorage.span.withUnsafeBytes
  
  where inlineStorage is a trivial type defined in the user module. This
  does not reproduce directly with InlineArray, but it is a problem for
  user modules that have their own trivial wrapper around an InlineArray.
  
  Fixes rdar://161630684 (Incorrect diagnostic: error: lifetime-dependent value escapes its scope)
  