### PR TITLE
Implicit import fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -875,6 +875,8 @@ WARNING(sema_import_current_module_with_file,none,
         (StringRef, Identifier))
 ERROR(sema_opening_import,Fatal,
       "opening import file for module %0: %1", (Identifier, StringRef))
+NOTE(sema_module_aliased,none,
+     "module name '%0' is aliased to '%1'", (StringRef, StringRef))
 
 REMARK(serialization_skipped_invalid_decl,none,
        "serialization skipped invalid %kind0",

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -46,6 +46,12 @@ public:
   /// allow diagnostics at <unknown>, that is controlled by VerifyIgnoreUnknown.
   bool VerifyIgnoreUnrelated = false;
 
+  /// Indicates whether to ignore \c diag::in_macro_expansion. This is useful
+  /// for when they occur in unnamed buffers (such as clang attribute buffers),
+  /// but VerifyIgnoreUnrelated is too blunt of a tool. Note that notes of this
+  /// kind are not printed by \c PrintingDiagnosticConsumer.
+  bool VerifyIgnoreMacroLocationNote = false;
+
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -100,6 +100,7 @@ class DiagnosticVerifier : public DiagnosticConsumer {
   bool AutoApplyFixes;
   bool IgnoreUnknown;
   bool IgnoreUnrelated;
+  bool IgnoreMacroLocationNote;
   bool UseColor;
   ArrayRef<std::string> AdditionalExpectedPrefixes;
 
@@ -107,11 +108,13 @@ public:
   explicit DiagnosticVerifier(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
                               ArrayRef<std::string> AdditionalFilePaths,
                               bool AutoApplyFixes, bool IgnoreUnknown,
-                              bool IgnoreUnrelated, bool UseColor,
+                              bool IgnoreUnrelated,
+                              bool IgnoreMacroLocationNote, bool UseColor,
                               ArrayRef<std::string> AdditionalExpectedPrefixes)
       : SM(SM), BufferIDs(BufferIDs), AdditionalFilePaths(AdditionalFilePaths),
         AutoApplyFixes(AutoApplyFixes), IgnoreUnknown(IgnoreUnknown),
-        IgnoreUnrelated(IgnoreUnrelated), UseColor(UseColor),
+        IgnoreUnrelated(IgnoreUnrelated),
+        IgnoreMacroLocationNote(IgnoreMacroLocationNote), UseColor(UseColor),
         AdditionalExpectedPrefixes(AdditionalExpectedPrefixes) {}
 
   virtual void handleDiagnostic(SourceManager &SM,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -167,6 +167,8 @@ def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,
   HelpText<"Allow diagnostics for '<unknown>' location in verify mode">;
 def verify_ignore_unrelated: Flag<["-"], "verify-ignore-unrelated">,
   HelpText<"Allow diagnostics in files outside those with expected diagnostics in verify mode">;
+def verify_ignore_macro_note: Flag<["-"], "verify-ignore-macro-note">,
+  HelpText<"Skip verifying notes about macro location">;
 def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
   MetaVarName<"<module-name>">,
   HelpText<"Verify the generic signatures in the given module">;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2415,10 +2415,6 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
   ModuleDecl *MD = nullptr;
   ASTContext &ctx = getNameImporter().getContext();
 
-  // `CxxStdlib` is the only accepted spelling of the C++ stdlib module name.
-  if (path.front().Item.is("std") ||
-      path.front().Item.str().starts_with("std_"))
-    return nullptr;
   if (path.front().Item == ctx.Id_CxxStdlib) {
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
@@ -8897,7 +8893,7 @@ bool importer::isCxxStdModule(StringRef moduleName, bool IsSystem) {
 ImportPath::Builder ClangImporter::Implementation::getSwiftModulePath(const clang::Module *M) {
   ImportPath::Builder builder;
   while (M) {
-    if (!M->isSubModule() && isCxxStdModule(M))
+    if (!M->isSubModule() && M->Name == "std")
       builder.push_back(SwiftContext.Id_CxxStdlib);
     else
       builder.push_back(SwiftContext.getIdentifier(M->Name));

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2852,6 +2852,12 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     auto addImplicitImport = [&implicitImportInfo, &Imported,
                               this](const clang::Module *M,
                                     bool guaranteedUnique) {
+      const bool cannotBeImported = llvm::any_of(M->Requirements, [](auto &Req) {
+        return !Req.RequiredState && Req.FeatureName == "swift";
+      });
+      if (cannotBeImported) {
+        return;
+      }
       ImportPath::Builder builder = getSwiftModulePath(M);
       if (!guaranteedUnique && Imported.count(builder.get()))
         return;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2598,6 +2598,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     Opts.VerifyMode = DiagnosticOptions::VerifyAndApplyFixes;
   Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
   Opts.VerifyIgnoreUnrelated |= Args.hasArg(OPT_verify_ignore_unrelated);
+  Opts.VerifyIgnoreMacroLocationNote |= Args.hasArg(OPT_verify_ignore_macro_note);
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1502,6 +1502,8 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
   // because there's no reason to verify them.
   if (Info.ID == diag::verify_encountered_fatal.ID)
     return;
+  if (IgnoreMacroLocationNote && Info.ID == diag::in_macro_expansion.ID)
+    return;
   SmallVector<CapturedFixItInfo, 2> fixIts;
   for (const auto &fixIt : Info.FixIts) {
     fixIts.emplace_back(SM, fixIt);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -435,7 +435,8 @@ bool CompilerInstance::setupDiagnosticVerifierIfNeeded() {
         SourceMgr, InputSourceCodeBufferIDs, diagOpts.AdditionalVerifierFiles,
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
         diagOpts.VerifyIgnoreUnknown, diagOpts.VerifyIgnoreUnrelated,
-        diagOpts.UseColor, diagOpts.AdditionalDiagnosticVerifierPrefixes);
+        diagOpts.VerifyIgnoreMacroLocationNote, diagOpts.UseColor,
+        diagOpts.AdditionalDiagnosticVerifierPrefixes);
 
     addDiagnosticConsumer(DiagVerifier.get());
   }

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -366,7 +366,7 @@ void ImportResolver::visitImportDecl(ImportDecl *ID) {
   if (front == "std" || front.starts_with("std_")) {
     SmallString<64> modulePathStr;
     path.getString(modulePathStr);
-    auto diagKind = (ctx.LangOpts.DebuggerSupport || true) ? diag::sema_no_import_repl
+    auto diagKind = ctx.LangOpts.DebuggerSupport ? diag::sema_no_import_repl
                                                  : diag::sema_no_import;
     const SourceLoc importLoc = ID->getLoc();
     const ImportPath sourcePath = ID->getImportPath();

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -359,6 +359,26 @@ static bool isSubmodule(const ModuleDecl* M) {
 void ImportResolver::visitImportDecl(ImportDecl *ID) {
   assert(unboundImports.empty());
 
+  // `CxxStdlib` is the only accepted spelling of the C++ stdlib module name.
+  ImportPath::Builder builder;
+  const ImportPath path = ID->getRealImportPath(builder);
+  const llvm::StringRef front = path.front().Item.str();
+  if (front == "std" || front.starts_with("std_")) {
+    SmallString<64> modulePathStr;
+    path.getString(modulePathStr);
+    auto diagKind = (ctx.LangOpts.DebuggerSupport || true) ? diag::sema_no_import_repl
+                                                 : diag::sema_no_import;
+    const SourceLoc importLoc = ID->getLoc();
+    const ImportPath sourcePath = ID->getImportPath();
+    const llvm::StringRef sourceFront = sourcePath.front().Item.str();
+    ctx.Diags.diagnose(importLoc, diagKind, modulePathStr);
+    ctx.Diags.diagnose(importLoc, diag::did_you_mean_cxxstdlib)
+        .fixItReplaceChars(importLoc, importLoc.getAdvancedLoc(sourceFront.size()), "CxxStdlib");
+    if (front != sourceFront)
+      ctx.Diags.diagnose(importLoc, diag::sema_module_aliased, sourceFront, front);
+    return;
+  }
+
   unboundImports.emplace_back(ID);
   bindPendingImports();
 }
@@ -513,13 +533,15 @@ UnboundImport::getTopLevelModule(ModuleDecl *M, SourceFile &SF) {
 // MARK: Implicit imports
 //===----------------------------------------------------------------------===//
 
-static void tryStdlibFixit(ASTContext &ctx,
-                           StringRef moduleName,
-                           SourceLoc loc) {
-  if (moduleName.starts_with("std")) {
-    ctx.Diags.diagnose(loc, diag::did_you_mean_cxxstdlib)
-      .fixItReplaceChars(loc, loc.getAdvancedLoc(3), "CxxStdlib");
+ImportPath::Module getRealModulePath(ImportPath::Builder &builder, ImportPath::Module path, ASTContext &ctx) {
+  for (size_t i = 0; i < path.size(); i++) {
+    if (i == 0) {
+      builder.push_back(ctx.getRealModuleName(path[i].Item));
+    } else {
+      builder.push_back(path[i]);
+    }
   }
+  return builder.get().getModulePath(false);
 }
 
 static void diagnoseNoSuchModule(ModuleDecl *importingModule,
@@ -534,13 +556,20 @@ static void diagnoseNoSuchModule(ModuleDecl *importingModule,
                        importingModule->getName());
   } else {
     SmallString<64> modulePathStr;
-    modulePath.getString(modulePathStr);
+    ImportPath::Builder builder;
+    ImportPath::Module realModulePath = getRealModulePath(builder, modulePath, ctx);
+    realModulePath.getString(modulePathStr);
 
     auto diagKind = diag::sema_no_import;
     if (nonfatalInREPL && ctx.LangOpts.DebuggerSupport)
       diagKind = diag::sema_no_import_repl;
     ctx.Diags.diagnose(importLoc, diagKind, modulePathStr);
-    tryStdlibFixit(ctx, modulePathStr, importLoc);
+
+    const llvm::StringRef sourceFront = modulePath.front().Item.str();
+    const llvm::StringRef realFront = realModulePath.front().Item.str();
+    if (realFront != sourceFront)
+      ctx.Diags.diagnose(importLoc, diag::sema_module_aliased, sourceFront,
+                         realFront);
   }
 
   if (ctx.SearchPathOpts.getSDKPath().empty() &&

--- a/test/ImportResolution/import-alias-fail.swift
+++ b/test/ImportResolution/import-alias-fail.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -module-alias Foo=Bar -verify-ignore-unknown
+
+import Foo // expected-error{{no such module 'Bar'}}
+// expected-note@-1{{module name 'Foo' is aliased to 'Bar'}}
+

--- a/test/ImportResolution/import-alias-fail.swift
+++ b/test/ImportResolution/import-alias-fail.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -module-alias Foo=Bar -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -module-alias Foo=Bar -verify-ignore-unknown
 
 import Foo // expected-error{{no such module 'Bar'}}
 // expected-note@-1{{module name 'Foo' is aliased to 'Bar'}}

--- a/test/ImportResolution/import-alias-fail.swift
+++ b/test/ImportResolution/import-alias-fail.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -module-alias Foo=Bar -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -module-alias Foo=Bar
 
 import Foo // expected-error{{no such module 'Bar'}}
 // expected-note@-1{{module name 'Foo' is aliased to 'Bar'}}

--- a/test/ImportResolution/import-std-fail.swift
+++ b/test/ImportResolution/import-std-fail.swift
@@ -1,22 +1,42 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -module-alias FooBar=std_foo_bar -module-alias X=std_x_h
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// These errors are fatal, so test each one separately
+
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/a.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/b.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/c.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/d.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/e.swift -verify-additional-prefix aliased- -module-alias FooBar=std_foo_bar
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/e.swift -verify-additional-prefix unaliased-
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/f.swift -verify-additional-prefix aliased- -module-alias X=std_x_h
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/f.swift -verify-additional-prefix unaliased-
+
+//--- a.swift
 import std // expected-error{{no such module 'std'}}
            // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-11=CxxStdlib}} {{none}}
 
+//--- b.swift
 import std_ // expected-error{{no such module 'std_'}}
             // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-12=CxxStdlib}} {{none}}
 
+//--- c.swift
 import std_error_h // expected-error{{no such module 'std_error_h'}}
                    // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-19=CxxStdlib}} {{none}}
 
+//--- d.swift
 import std_core.math.abs // expected-error{{no such module 'std_core.math.abs'}}
                          // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-16=CxxStdlib}} {{none}}
 
-import FooBar // expected-error{{no such module 'std_foo_bar'}}
-              // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-14=CxxStdlib}} {{none}}
-              // expected-note@-2{{module name 'FooBar' is aliased to 'std_foo_bar'}} {{none}}
+//--- e.swift
+import FooBar // expected-aliased-error{{no such module 'std_foo_bar'}}
+              // expected-aliased-note@-1{{did you mean 'CxxStdlib'?}}{{8-14=CxxStdlib}} {{none}}
+              // expected-aliased-note@-2{{module name 'FooBar' is aliased to 'std_foo_bar'}} {{none}}
+              // expected-unaliased-error@-3{{no such module 'FooBar'}}
 
+//--- f.swift
 import X
-// expected-error@-1{{no such module 'std_x_h'}}
-// expected-note@-2{{did you mean 'CxxStdlib'?}}{{8-9=CxxStdlib}} {{none}}
-// expected-note@-3{{module name 'X' is aliased to 'std_x_h'}} {{none}}
+// expected-aliased-error@-1{{no such module 'std_x_h'}}
+// expected-aliased-note@-2{{did you mean 'CxxStdlib'?}}{{8-9=CxxStdlib}} {{none}}
+// expected-aliased-note@-3{{module name 'X' is aliased to 'std_x_h'}} {{none}}
+// expected-unaliased-error@-4{{no such module 'X'}}

--- a/test/ImportResolution/import-std-fail.swift
+++ b/test/ImportResolution/import-std-fail.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -module-alias FooBar=std_foo_bar -module-alias X=std_x_h
+
+import std // expected-error{{no such module 'std'}}
+           // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-11=CxxStdlib}} {{none}}
+
+import std_ // expected-error{{no such module 'std_'}}
+            // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-12=CxxStdlib}} {{none}}
+
+import std_error_h // expected-error{{no such module 'std_error_h'}}
+                   // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-19=CxxStdlib}} {{none}}
+
+import std_core.math.abs // expected-error{{no such module 'std_core.math.abs'}}
+                         // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-16=CxxStdlib}} {{none}}
+
+import FooBar // expected-error{{no such module 'std_foo_bar'}}
+              // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-14=CxxStdlib}} {{none}}
+              // expected-note@-2{{module name 'FooBar' is aliased to 'std_foo_bar'}} {{none}}
+
+import X
+// expected-error@-1{{no such module 'std_x_h'}}
+// expected-note@-2{{did you mean 'CxxStdlib'?}}{{8-9=CxxStdlib}} {{none}}
+// expected-note@-3{{module name 'X' is aliased to 'std_x_h'}} {{none}}

--- a/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/succeed.swift
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -dump-source-file-imports 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
 
 // Tests that we don't try to import modules that don't work well with Swift
 

--- a/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/succeed.swift
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -dump-source-file-imports 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
 
 // Tests that we don't try to import modules that don't work well with Swift
 

--- a/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
@@ -1,0 +1,81 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/succeed.swift
+// RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -dump-source-file-imports 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h
+
+// Tests that we don't try to import modules that don't work well with Swift
+
+// CHECK: imports for {{.*}}fail.swift:
+// CHECK-NEXT: Swift
+// CHECK-NEXT: _StringProcessing
+// CHECK-NEXT: _SwiftConcurrencyShims
+// CHECK-NEXT: _Concurrency
+// CHECK-NEXT: B1
+// CHECK-NEXT: A1
+
+// CHECK-NEXT: imports for A1.foo:
+
+// CHECK-NEXT: imports for @__swiftmacro{{.*}}foo{{.*}}_SwiftifyImport{{.*}}.swift:
+// CHECK-NEXT: Swift
+// CHECK-NEXT: B1
+// CHECK-NEXT: _StringProcessing
+// CHECK-NEXT: _SwiftConcurrencyShims
+// CHECK-NEXT: _Concurrency
+
+//--- Inputs/module.modulemap
+module A1 {
+  explicit module B1 {
+    header "B1.h"
+    explicit module C1 {
+      header "C1.h"
+      requires !swift
+    }
+  }
+}
+
+//--- Inputs/B1.h
+#pragma once
+
+#include "C1.h"
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+// We can use bar without C1 causing errors
+void bar(void * _Nonnull __sized_by(size), int size);
+// foo causes an error when we try to refer to c1_t from the '!swift' module C1
+c1_t foo(void * _Nonnull __sized_by(size), int size);
+/*
+expected-note@-2{{'foo' declared here}}
+expected-expansion@-3:52{{
+  expected-error@2:110{{cannot find type 'c1_t' in scope}}
+}}
+*/
+
+//--- Inputs/C1.h
+#pragma once
+
+typedef int c1_t;
+
+//--- fail.swift
+import A1.B1
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  let _ = foo(p, 13)
+}
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  let _ = foo(p) // expected-error{{cannot convert value of type 'UnsafeMutableRawBufferPointer' to expected argument type 'UnsafeMutableRawPointer'}}
+                 // expected-error@-1{{missing argument}}
+}
+
+//--- succeed.swift
+import A1.B1
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  bar(p, 13)
+}
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  bar(p)
+}

--- a/test/Interop/Cxx/swiftify-import/clang-includes-no-cxx.swift
+++ b/test/Interop/Cxx/swiftify-import/clang-includes-no-cxx.swift
@@ -1,0 +1,148 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// Tests that we don't try to import modules that don't work well with C++ interop (when enabled)
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// Case 1: a.swift calls A1.B1.foo with C++ interop
+// RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/a.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-A,CHECK-A-CXX %s
+// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/a.swift -verify -verify-additional-prefix cxx- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
+
+// Case 2: a.swift calls A1.B1.foo without C++ interop
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/a.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-A,CHECK-A-C %s
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/a.swift -verify
+
+// Case 3: b.swift calls A2.B2.foo with C++ interop
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/b.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-B,CHECK-B-CXX %s
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/b.swift -verify
+
+// Case 4: b.swift calls A2.B2.foo without C++ interop
+// RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/b.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefix CHECK-B %s
+// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers %t/b.swift -verify -verify-additional-prefix c- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B2.h -verify-ignore-macro-note
+
+// CHECK-A:      imports for {{.*}}a.swift:
+// CHECK-A-NEXT: 	Swift
+// CHECK-A-CXX-NEXT: 	CxxShim
+// CHECK-A-CXX-NEXT: 	Cxx
+// CHECK-A-NEXT: 	_StringProcessing
+// CHECK-A-NEXT: 	_SwiftConcurrencyShims
+// CHECK-A-NEXT: 	_Concurrency
+// CHECK-A-NEXT: 	B1
+// CHECK-A-NEXT: 	A1
+// CHECK-A-NEXT: imports for A1.foo:
+
+// CHECK-A-NEXT: imports for @__swiftmacro{{.*}}foo{{.*}}_SwiftifyImport{{.*}}.swift:
+// CHECK-A-NEXT: Swift
+// CHECK-A-C-NEXT: C1
+// CHECK-A-NEXT: B1
+// CHECK-A-CXX-NEXT: CxxShim
+// CHECK-A-CXX-NEXT: Cxx
+// CHECK-A-NEXT: _StringProcessing
+// CHECK-A-NEXT: _SwiftConcurrencyShims
+// CHECK-A-NEXT: _Concurrency
+
+// CHECK-B:      imports for {{.*}}b.swift:
+// CHECK-B-NEXT: 	Swift
+// CHECK-B-CXX-NEXT: 	CxxShim
+// CHECK-B-CXX-NEXT: 	Cxx
+// CHECK-B-NEXT: 	_StringProcessing
+// CHECK-B-NEXT: 	_SwiftConcurrencyShims
+// CHECK-B-NEXT: 	_Concurrency
+// CHECK-B-NEXT: 	B2
+// CHECK-B-NEXT: 	A2
+// CHECK-B-NEXT: imports for A2.bar:
+
+// CHECK-B-NEXT: imports for @__swiftmacro{{.*}}bar{{.*}}_SwiftifyImport{{.*}}.swift:
+// CHECK-B-NEXT: Swift
+// CHECK-B-CXX-NEXT: C2
+// CHECK-B-NEXT: B2
+// CHECK-B-CXX-NEXT: CxxShim
+// CHECK-B-CXX-NEXT: Cxx
+// CHECK-B-NEXT: _StringProcessing
+// CHECK-B-NEXT: _SwiftConcurrencyShims
+// CHECK-B-NEXT: _Concurrency
+
+
+//--- Inputs/module.modulemap
+  module A1 {
+    explicit module B1 {
+      header "B1.h"
+      explicit module C1 {
+        header "C1.h"
+        requires !cplusplus
+      }
+    }
+  }
+  module A2 {
+    explicit module B2 {
+      header "B2.h"
+      explicit module C2 {
+        header "C2.h"
+        requires cplusplus
+      }
+    }
+  }
+
+//--- Inputs/B1.h
+  #pragma once
+  
+  #include "C1.h"
+  #define __sized_by(s) __attribute__((__sized_by__(s)))
+  
+  // foo causes an error with cxx-interop
+  c1_t foo(void * _Nonnull __sized_by(size), int size);
+  /*
+  expected-cxx-note@-2{{'foo' declared here}}
+  expected-cxx-expansion@-3:54{{
+    expected-cxx-error@2:110{{cannot find type 'c1_t' in scope}}
+  }}
+  */
+
+//--- Inputs/B2.h
+  #pragma once
+  
+  #include "C2.h"
+  #define __sized_by(s) __attribute__((__sized_by__(s)))
+  
+  // bar causes an error without cxx-interop
+  c2_t bar(void * _Nonnull __sized_by(size), int size);
+  /*
+  expected-c-note@-2{{'bar' declared here}}
+  expected-c-expansion@-3:54{{
+    expected-c-error@2:110{{cannot find type 'c2_t' in scope}}
+  }}
+  */
+
+//--- Inputs/C1.h
+  #pragma once
+  
+  typedef int c1_t;
+
+//--- Inputs/C2.h
+  #pragma once
+  
+  typedef int c2_t;
+
+//--- a.swift
+  import A1.B1
+  
+  public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+    let _ = foo(p, 13)
+  }
+  public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+    let _ = foo(p) // expected-cxx-error{{cannot convert value of type 'UnsafeMutableRawBufferPointer' to expected argument type 'UnsafeMutableRawPointer'}}
+                   // expected-cxx-error@-1{{missing argument}}
+  }
+  
+//--- b.swift
+  import A2.B2
+
+  public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+    let _ = bar(p, 13)
+  }
+  public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+    let _ = bar(p) // expected-c-error{{cannot convert value of type 'UnsafeMutableRawBufferPointer' to expected argument type 'UnsafeMutableRawPointer'}}
+                   // expected-c-error@-1{{missing argument}}
+
+  }

--- a/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
+++ b/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
@@ -6,7 +6,6 @@
 // RUN: %target-clangxx %S/../stdlib/Inputs/check-libcxx-version.cpp -o %t/check-libcxx-version
 // RUN: %target-codesign %t/check-libcxx-version
 
-// RUN: %target-run %t/check-libcxx-version || %empty-directory(%t)
 // RUN: %target-run %t/check-libcxx-version || split-file %s %t
 // RUN: %target-run %t/check-libcxx-version || %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
 

--- a/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
+++ b/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
@@ -1,0 +1,33 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
+
+// Test that implicit imports can refer to std_core etc., even though Swift source code may not.
+
+//--- Inputs/module.modulemap
+module TestClang {
+    header "test.h"
+    requires cplusplus
+    export std_core.cstddef.size_t
+    export span
+}
+
+//--- Inputs/test.h
+
+#include <__cstddef/size_t.h>
+#include <span>
+#include <lifetimebound.h>
+
+using FloatSpan = std::span<const float>;
+
+size_t foo(FloatSpan x __noescape);
+
+//--- test.swift
+import TestClang
+  
+func test(x: Span<Float>) {
+  let _ = foo(x)
+}
+

--- a/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
+++ b/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
@@ -1,8 +1,14 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: OS=macosx
 
+// Don't run this test with libc++ versions 17-19, when the top-level std module was split into multiple top-level modules.
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
+// RUN: %target-clangxx %S/../stdlib/Inputs/check-libcxx-version.cpp -o %t/check-libcxx-version
+// RUN: %target-codesign %t/check-libcxx-version
+
+// RUN: %target-run %t/check-libcxx-version || %empty-directory(%t)
+// RUN: %target-run %t/check-libcxx-version || split-file %s %t
+// RUN: %target-run %t/check-libcxx-version || %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
 
 // Test that implicit imports can refer to std_core etc., even though Swift source code may not.
 


### PR DESCRIPTION
This fixes some bugs related to implicitly inherited imports that block enabling safe interop wrappers by default.

rdar://161795145
rdar://161795429
rdar://161795673
rdar://161795793