### PR TITLE
Bridging: Fix typo-related bug in `isValid` property of `swift::Identifier`

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -123,7 +123,7 @@ public:
   bool nonempty() const { return !empty(); }
 #ifdef COMPILED_WITH_SWIFT
   SWIFT_COMPUTED_PROPERTY
-  bool getIsValid() const { return empty(); }
+  bool getIsValid() const { return nonempty(); }
 #endif
 
   /// isOperator - Return true if this identifier is an operator, false if it is


### PR DESCRIPTION
`isValid` should be computed as `nonempty()`, not `empty()`.

See commit 0e0fbc4160bd89c6bdb6ef0856e466426246dd83 introducing this bridge.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
