### PR TITLE
IRGen: Use LLVM's OptimizationLevel::O3 under Swift's -O/-Ospeed

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -286,7 +286,9 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     PTO.MergeFunctions = !Opts.DisableLLVMMergeFunctions;
     // Splitting trades code size to enhance memory locality, avoid in -Osize.
     DoHotColdSplit = Opts.EnableHotColdSplit && !Opts.optimizeForSize();
-    level = llvm::OptimizationLevel::Os;
+    level = (Opts.OptMode == OptimizationMode::ForSpeed)
+                ? llvm::OptimizationLevel::O3
+                : llvm::OptimizationLevel::Os;
   } else {
     level = llvm::OptimizationLevel::O0;
   }

--- a/test/IRGen/cold_split.swift
+++ b/test/IRGen/cold_split.swift
@@ -1,22 +1,28 @@
 // RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
 // RUN:   -enable-throws-prediction -O -enable-split-cold-code \
+// RUN:   -Xllvm -inline-threshold=50 \
 // RUN:       | %FileCheck --check-prefix CHECK-ENABLED %s
 
 //// Test disabling just the pass doesn't yield a split.
 // RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -Xllvm -inline-threshold=50 \
 // RUN:   -enable-throws-prediction -O -disable-split-cold-code \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
 //// Test using -Osize doesn't yield a split.
 // RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -Xllvm -inline-threshold=50 \
 // RUN:   -enable-throws-prediction -Osize -enable-split-cold-code \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
 //// Test disabling optimization entirely doesn't yield a split.
 // RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -Xllvm -inline-threshold=50 \
 // RUN:   -enable-throws-prediction -enable-split-cold-code \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
+// Note: Using a higher inline threshold will cause the function that would be
+// cold-hot split to be inlined.
 
 // CHECK-ENABLED: cold
 


### PR DESCRIPTION
This will enable a small number of optimizations in LLVM's pipeling such as more aggressive loop unswitching, call site splitting, and argument promotion.
Furthermore, this will change LLVM's inliner thresholds to be more aggressive.

rdar://161740033