### PR TITLE
Windows: complete migration support

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1943,7 +1943,7 @@ function Build-SPMProject {
     $RuntimeInstallRoot = [IO.Path]::Combine((Get-InstallDir $BuildPlatform), "Runtimes", $ProductVersion)
 
     $env:Path = "$(Get-PinnedToolchainRuntime);$(Get-PinnedToolchainToolsDir);${env:Path}"
-    $env:SDKROOT = (Get-PinnedToolchainSDK -OS $Platform.OS)
+    $env:SDKROOT = Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
     $env:SWIFTCI_USE_LOCAL_DEPS = "1"
 
     $Arguments = @(
@@ -2213,7 +2213,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
     SWIFT_ENABLE_VOLATILE = "YES";
     SWIFT_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
     SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
-    SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK -OS $Platform.OS);
+    SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental");
     SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
     SWIFT_STDLIB_ASSERTIONS = "NO";
     SWIFTSYNTAX_ENABLE_ASSERTIONS = "NO";
@@ -2230,7 +2230,7 @@ function Build-Compilers([Hashtable] $Platform, [string] $Variant) {
     -Platform $Platform `
     -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
     -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("C", "CXX", "Swift") }) `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets @("install-distribution") `
     -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake `
     -Defines (Get-CompilersDefines $Platform $Variant)
@@ -2298,7 +2298,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
       -Platform $Platform `
       -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
       -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("C", "CXX", "Swift") }) `
-      -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+      -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
       -BuildTargets $Targets `
       -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake `
       -Defines $TestingDefines
@@ -3066,7 +3066,7 @@ function Build-FoundationMacros([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       SwiftSyntax_DIR = $SwiftSyntaxDir;
     }
@@ -3351,7 +3351,7 @@ function Build-System([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform System) `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3365,7 +3365,7 @@ function Build-Subprocess([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Subprocess) `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3383,7 +3383,7 @@ function Build-Build([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,CXX,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines (@{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3404,7 +3404,7 @@ function Build-ToolsSupportCore([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3419,7 +3419,7 @@ function Build-LLBuild([Hashtable] $Platform) {
     -Platform $Platform `
     -UseMSVCCompilers $(if ($UseHostToolchain) { @("CXX") } else { @("") }) `
     -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("CXX", "Swift") }) `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       LLBUILD_SUPPORT_BINDINGS = "Swift";
@@ -3467,7 +3467,7 @@ function Build-ArgumentParser([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       BUILD_TESTING = "NO";
@@ -3482,7 +3482,7 @@ function Build-Driver([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,CXX,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3504,7 +3504,7 @@ function Build-Crypto([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Crypto) `
     -Platform $Platform `
     -UsePinnedCompilers ASM,C,CXX,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3520,7 +3520,7 @@ function Build-Collections([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3533,7 +3533,7 @@ function Build-ASN1([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ASN1) `
     -Platform $Platform `
     -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3547,7 +3547,7 @@ function Build-Certificates([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Certificates) `
     -Platform $Platform `
     -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3570,7 +3570,7 @@ function Build-PackageManager([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_Swift_FLAGS = @("-DCRYPTO_v2");
@@ -3619,7 +3619,7 @@ function Build-Markdown([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3636,7 +3636,7 @@ function Build-Format([Hashtable] $Platform) {
     -Platform $Platform `
     -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
     -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("C", "Swift") }) `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);
@@ -3695,7 +3695,7 @@ function Build-LMDB([Hashtable] $Platform) {
 }
 
 function Build-IndexStoreDB([Hashtable] $Platform) {
-  $SDKROOT = Get-PinnedToolchainSDK -OS $Platform.OS
+  $SDKROOT = Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
   Build-CMakeProject `
     -Src $SourceCache\indexstore-db `
     -Bin (Get-ProjectBinaryCache $Platform IndexStoreDB) `
@@ -3719,7 +3719,7 @@ function Build-SourceKitLSP([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
     -UsePinnedCompilers C,Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
       SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
@@ -3831,7 +3831,7 @@ function Build-TestingMacros([Hashtable] $Platform) {
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr"  `
     -Platform $Platform `
     -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -Defines @{
       SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
     }
@@ -4097,7 +4097,7 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-CDispatch $HostPlatform
   Invoke-BuildStep Build-Compilers $HostPlatform -Variant "Asserts"
 
-  Extract-MSM "$(Get-PinnedToolchainRedistributables)\rtl.$($HostPlatform.Architecture.VSName).msm" "$($HostPlatform.ToolchainInstallRoot)\usr\bin\"
+  Extract-MSM "$(Get-PinnedToolchainRedistributables)\rtl.shared.$($HostPlatform.Architecture.VSName).msm" "$($HostPlatform.ToolchainInstallRoot)\usr\bin\"
 
   $KnownPlatforms.Values | Where-Object {
     switch ($_.OS) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -269,14 +269,14 @@ if ($UseHostToolchain -is [string]) {
 
 $DefaultPinned = @{
   AMD64 = @{
-    PinnedBuild = "https://download.swift.org/swift-6.1.2-release/windows10/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-windows10.exe";
-    PinnedSHA256 = "92A0323ED7DD333C3B05E6E0E428F3A91C77D159F6CCFC8626A996F2ACE09A0B";
-    PinnedVersion = "6.1.2";
+    PinnedBuild = "https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a-windows10.exe"
+    PinnedSHA256 = "A69B3966BD9521F094ED6633D5301E52D31429DA4AD0C683F5244C14D00A22C8";
+    PinnedVersion = "0.0.0";
   };
   ARM64 = @{
-    PinnedBuild = "https://download.swift.org/swift-6.1.2-release/windows10-arm64/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-windows10-arm64.exe";
-    PinnedSHA256 = "121FB407E578178F82DCCF39A4D03527873D8F7611A801A8FC26DA52503A0C5C";
-    PinnedVersion = "6.1.2";
+    PinnedBuild = "https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a-windows10-arm64.exe"
+    PinnedSHA256 = "";
+    PinnedVersion = "0.0.0";
   };
 }
 
@@ -2160,6 +2160,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
   return $TestDefines + $DebugDefines + @{
     CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
     CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
+    CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
     CMAKE_Swift_FLAGS = $SwiftFlags;
     LibXml2_DIR = "$BinaryCache\$($Platform.Triple)\usr\lib\cmake\libxml2-2.11.5";
     LLDB_LIBXML2_VERSION = "2.11.5";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2224,6 +2224,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
     SWIFT_TOOLCHAIN_VERSION = "${ToolchainIdentifier}";
     SWIFT_BUILD_SWIFT_SYNTAX = "YES";
     SWIFT_CLANG_LOCATION = (Get-PinnedToolchainToolsDir);
+    SWIFT_EARLY_SWIFT_DRIVER_BUILD = "$(Get-ProjectBinaryCache $BuildPlatform EarlySwiftDriver)\bin";
     SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY = "YES";
     SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP = "YES";
     SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING = "YES";


### PR DESCRIPTION
This pull request makes significant changes to the Windows build script (`utils/build.ps1`) to standardize usage of a new "experimental" Swift toolchain and SDK for building and testing projects. The update replaces previous hardcoded release toolchain references with development snapshots, introduces support for an "EarlySwiftDriver" build, and consistently applies the new toolchain and SDK across all major build and test functions. These changes improve reproducibility, make the build more future-proof, and simplify maintenance.

**Toolchain and SDK Standardization**
* Updated the default pinned toolchain URLs and SHA256 hashes to use a development snapshot, and set the default version to `"0.0.0"` for both `AMD64` and `ARM64` architectures.
* Added a new helper function, `Get-PinnedToolchainRedistributables`, to locate redistributable files for the pinned toolchain.
* Changed all build and test functions to use the new experimental SDK via `Get-PinnedToolchainSDK -Identifier "$($Platform.OS)Experimental"` and to use pinned compilers for Swift and other languages, replacing previous usage of built compilers and default SDKs. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3058-R3091) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3343-R3376) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3357-R3390) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3375-R3408) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3396-L3403) [[6]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3414-R3444) [[7]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3463-R3492) [[8]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3478-R3507) [[9]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3500-R3529) [[10]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3516-R3545) [[11]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2222-R2255) [[12]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2290-R2323)

**Build Process Improvements**
* Updated environment variable setup and compiler path resolution to consistently use the new pinned toolchain locations for all build and test steps, including `swiftc.exe` and runtime/toolchain directories. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1633-R1643) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1753-R1763) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1864-R1876) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1936-R1955)
* Modified defines and build flags to support static library builds for Swift, and added new CMake flags for Swift projects. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R2193) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R2227) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2205-R2238)

**Project and Build Target Expansion**
* Added new project enums for `EarlySwiftDriver` and `PackageManagerRuntime` to support building these components. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R838) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R857)
* Introduced a new build function, `Build-EarlySwiftDriver`, to build the Swift driver early in the toolchain setup process using the experimental SDK and pinned compilers.

**Testing Adjustments**
* Updated test functions to use the experimental SDK and pinned toolchain for linking and running tests, ensuring that all testing is consistent with the new build environment. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L2275-R2308) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L3444-R3472)

**Cleanup and Consistency**
* Removed redundant environment variable settings and legacy paths, ensuring all builds use the new standardized approach.

These changes collectively modernize the Windows build process for Swift, ensuring all projects are built and tested against the latest development toolchain and SDK.