### PR TITLE
[6.2][TypeChecker] Avoid checking lazy property accessors if they haven't …

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2608,6 +2608,25 @@ private:
       return;
     }
 
+    // Avoid checking lazy property accessors if they haven't been
+    // synthesized yet, their availability is going to match the
+    // property itself. This is a workaround for lazy type-checking
+    // because synthesis of accessors for such properties requires
+    // a reference to `self` which won't be available because pattern
+    // binding for the variable was skipped.
+    //
+    // TODO: To fix this properly `getParentPatternBinding()`
+    // has to be refactored into a request to help establish association
+    // between a variable declaration and its pattern binding on demand
+    // instead of by using `typeCheckPatternBinding` called from the
+    // declaration checker.
+    if (D->getAttrs().hasAttribute<LazyAttr>()) {
+      auto *DC = D->getDeclContext();
+      if (DC->isTypeContext() && !(D->getAccessor(AccessorKind::Get) &&
+                                   D->getAccessor(AccessorKind::Set)))
+        return;
+    }
+
     // Check availability of accessor functions.
     // TODO: if we're talking about an inlineable storage declaration,
     // this probably needs to be refined to not assume that the accesses are

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -378,3 +378,7 @@ extension PublicStruct {
     lhs = rhs
   }
 }
+
+public class LazyPropertyWithClosureType {
+  public lazy var lazyVar: Int = { 2 }()
+}

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -142,3 +142,8 @@ func testOperators() {
   var a: PublicStruct
   a <<< PublicStruct(x: 2)
 }
+
+func testLazyPropertyWithInitClosureReference(t: LazyPropertyWithClosureType) {
+  _ = t.lazyVar
+  t.lazyVar = 42
+}


### PR DESCRIPTION
…been synthesized yet

- Explanation:

  Their availability is going to match the property itself. This is a workaround for lazy type-checking because synthesis of accessors for such properties requires a reference to `self` which won't be available because pattern binding for the variable was skipped.

- Resolves: rdar://129359362 rdar://159463230 https://github.com/swiftlang/swift/issues/84041

- Main Branch PR: https://github.com/swiftlang/swift/pull/84066

- Risk: Low. This is a narrow workaround for lazy type-checking (not enabled by default).

- Reviewed By: @tshortli   

- Testing: Added new test-cases to the suite.

(cherry picked from commit 6e7de5c1e035e64d0da9e7f39e6454c41260ad3e)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
