### PR TITLE
[IRGen] Correctly sext instead of zext for negative integer types

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3592,14 +3592,7 @@ IRGenFunction::emitTypeMetadataRefForLayout(SILType ty,
 
 llvm::Value *IRGenFunction::emitValueGenericRef(CanType type) {
   if (auto integer = type->getAs<IntegerType>()) {
-    auto value = integer->getValue();
-
-    if (integer->isNegative()) {
-      value = value.sextOrTrunc(IGM.SizeTy->getBitWidth());
-    } else {
-      value = value.zextOrTrunc(IGM.SizeTy->getBitWidth());
-    }
-
+    auto value = integer->getValue().sextOrTrunc(IGM.SizeTy->getBitWidth());
     return llvm::ConstantInt::get(IGM.SizeTy, value);
   }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3592,8 +3592,15 @@ IRGenFunction::emitTypeMetadataRefForLayout(SILType ty,
 
 llvm::Value *IRGenFunction::emitValueGenericRef(CanType type) {
   if (auto integer = type->getAs<IntegerType>()) {
-    return llvm::ConstantInt::get(IGM.SizeTy,
-                    integer->getValue().zextOrTrunc(IGM.SizeTy->getBitWidth()));
+    auto value = integer->getValue();
+
+    if (integer->isNegative()) {
+      value = value.sextOrTrunc(IGM.SizeTy->getBitWidth());
+    } else {
+      value = value.zextOrTrunc(IGM.SizeTy->getBitWidth());
+    }
+
+    return llvm::ConstantInt::get(IGM.SizeTy, value);
   }
 
   return tryGetLocalTypeData(type, LocalTypeDataKind::forValue());

--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -5,7 +5,11 @@
 
 // REQUIRES: executable_test
 
-struct A<let N: Int, let M: Int> {}
+struct A<let N: Int, let M: Int> {
+  func foo() {
+    print("Lower: \(N), Upper: \(M)")
+  }
+}
 
 extension A where N == 2 {
   struct B {}
@@ -36,3 +40,24 @@ let x: A<-5, -5> = getA()
 
 // CHECK: main.A<-5, -5>
 print(_typeName(type(of: x), qualified: true))
+
+// CHECK: Lower: 1, Upper: 8
+A<1, 8>().foo()
+
+// CHECK: Lower: 0, Upper: 8
+A<0, 8>().foo()
+
+// CHECK: Lower: -1, Upper: 8
+A< -1, 8>().foo()
+
+// CHECK: Lower: -2, Upper: 8
+A< -2, 8>().foo()
+
+// CHECK: Lower: -3, Upper: 8
+A< -3, 8>().foo()
+
+// CHECK: Lower: -4, Upper: 8
+A< -4, 8>().foo()
+
+// CHECK: Lower: -5, Upper: 8
+A< -5, 8>().foo()


### PR DESCRIPTION
Resolves the issue defined here: https://forums.swift.org/t/integer-generics-negative-literals-seem-broken/82481