### PR TITLE
[test] Add requires for embedded_stdlib for test that uses the stdlib

### DIFF
--- a/validation-test/SILOptimizer/rdar161433604.swift
+++ b/validation-test/SILOptimizer/rdar161433604.swift
@@ -9,6 +9,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: embedded_stdlib
 
 struct NoEscapeNoCopy: ~Escapable, ~Copyable {}
 


### PR DESCRIPTION
The test enables the Embedded experimental feature, but beside the compiler support, it also requires loading the stdlib for embedded, but the test is not marked as such. For configurations that do not build the embedded stdlibs, this makes the test fail, because the stdlib is not available. Mark it with the appropriate requires to avoid this problem.

This should not change the results in the swift.org CI because those CI configurations build the embedded stdlibs by default.

