### PR TITLE
[test] Mark test as UNSUPPORTED when maccatalyst_support is enabled

### DIFF
--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -10,6 +10,10 @@
 // On iOS _stdlib_isOSVersionAtLeast() is @_transparent, which affects codegen.
 // UNSUPPORTED: OS=ios
 
+// When macCatalyst support is enabled, isOSVersionAtLeast transforms into
+// isOSVersionAtLeastOrVariantVersionAtLeast
+// UNSUPPORTED: maccatalyst_support
+
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
 


### PR DESCRIPTION
If one tries to enable maccatalyst_support (which doesn't work correctly, see #77506), this test fails because `Swift.swiftmodule` gets generated with both `-target` and `-target-variant` `swift-module-flags`, which triggers the usage of the `isOSVersionAtLeastOrVariantAtLeast` version of version check, which does not match the test `CHECK` lines.

Mark the test as `UNSUPPORTED` when the feature is enabled. Not sure if the test can be rewritten conditionally on a feature being support and checking for different functions in the IR.

This should not affect swift.org CI because that CI never enables maccatalyst_support.
