### PR TITLE
Sema: Fix a MemberImportVisibility regression in `resolveDeclRefExpr()`

### DIFF
--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -16,6 +16,24 @@ infix operator <<<
 infix operator >>>
 infix operator <>
 
+@available(*, deprecated)
+public func shadowedByMemberOnXinA() { }
+
+@available(*, deprecated)
+public func shadowedByMemberOnXinB() { }
+
+@available(*, deprecated)
+public func shadowedByMemberOnXinC() { }
+
+@available(*, deprecated)
+public func shadowedByStaticMemberOnXinA() { }
+
+@available(*, deprecated)
+public func shadowedByStaticMemberOnXinB() { }
+
+@available(*, deprecated)
+public func shadowedByStaticMemberOnXinC() { }
+
 extension X {
   public func XinA() { }
 
@@ -28,6 +46,9 @@ extension X {
 
   public struct NestedInA {}
   public protocol ProtoNestedInA {}
+
+  public func shadowedByMemberOnXinA() { }
+  public static func shadowedByStaticMemberOnXinA() { }
 }
 
 extension Y {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -11,6 +11,11 @@ extension X {
   public var propXinB: Bool { return true }
   package var propXinB_package: Bool { return true }
 
+  public func shadowedByMemberOnXinB() { }
+  public static func shadowedByStaticMemberOnXinB() { }
+
+  public static var max: Int { return Int.min }
+
   public static func >>>(a: Self, b: Self) -> Self { b }
 
   public struct NestedInB {}

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -10,6 +10,9 @@ extension X {
 
   public var propXinC: Bool { return true }
 
+  public func shadowedByMemberOnXinC() { }
+  public static func shadowedByStaticMemberOnXinC() { }
+
   public static func <>(a: Self, b: Self) -> Self { a }
 
   public struct NestedInC {}

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -99,6 +99,24 @@ extension X {
   func hasNestedInAInGenericReqs<T>(_ t: T) where T: ProtoNestedInA { }
   func hasNestedInBInGenericReqs<T>(_ t: T) where T: ProtoNestedInB { } // expected-member-visibility-error{{protocol 'ProtoNestedInB' is not available due to missing import of defining module 'members_B'}}
   func hasNestedInCInGenericReqs<T>(_ t: T) where T: ProtoNestedInC { }
+
+  func testMembersShadowingGlobals() {
+    shadowedByMemberOnXinA()
+    shadowedByMemberOnXinB() // expected-member-visibility-warning{{'shadowedByMemberOnXinB()' is deprecated}}
+    shadowedByMemberOnXinC()
+
+    _ = max(0, 1) // expected-ambiguity-error{{static member 'max' cannot be used on instance of type 'X'}}
+    // expected-ambiguity-error@-1{{cannot call value of non-function type 'Int'}}
+  }
+
+  static func testStaticMembersShadowingGlobals() {
+    shadowedByStaticMemberOnXinA()
+    shadowedByStaticMemberOnXinB() // expected-member-visibility-warning{{'shadowedByStaticMemberOnXinB()' is deprecated}}
+    shadowedByStaticMemberOnXinC()
+
+    _ = max(0, 1) // expected-ambiguity-error{{use of 'max' refers to instance method rather than global function 'max' in module 'Swift'}}
+    // expected-ambiguity-note@-1{{use 'Swift.' to reference the global function in module 'Swift'}}
+  }
 }
 
 extension X.NestedInA {}


### PR DESCRIPTION
The changes from https://github.com/swiftlang/swift/pull/84259/ caused a regression in which declarations from an outer scope could be shadowed inappropriately by member declarations from a module that has not been imported. This fix addresses the issue by refactoring `resolveDeclRefExpr()` so that it performs lookups in two passes. First, it attempts to resolve the decl ref using the complete lookup algorithm and standard name lookup options, which will ignore members from modules that haven't been imported if `MemberImportVisibility` is enabled. Then, if no results were found it re-runs the full lookup algorithm again with `NameLookupFlags::IgnoreMissingImports` included to find additional results that ought to be diagnosed as unavailable. This insures that the unavailable results are not considered until after the main lookup has already failed.

Resolves rdar://161078015.
