### PR TITLE
Fix 2 leftover rebranch warnings

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -134,8 +134,12 @@ public:
   }
 
   ArrayRef<FileUnit *> getFiles() const {
-    return isa<SourceFile *>(SFOrMod) ? *SFOrMod.getAddrOfPtr1()
-                                      : cast<ModuleDecl *>(SFOrMod)->getFiles();
+    if (isa<SourceFile *>(SFOrMod)) {
+      SourceFile *const *SF = SFOrMod.getAddrOfPtr1();
+      return ArrayRef((FileUnit *const *)SF, 1);
+    } else {
+      return cast<ModuleDecl *>(SFOrMod)->getFiles();
+    }
   }
 
   StringRef getFilename() const {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -623,8 +623,7 @@ void ImportResolver::addImplicitImports() {
   const ModuleDecl *moduleToInherit = nullptr;
   if (underlyingClangModule) {
     moduleToInherit = underlyingClangModule;
-    boundImports.push_back(
-        AttributedImport(ImportedModule(underlyingClangModule)));
+    boundImports.emplace_back(ImportedModule(underlyingClangModule));
   } else {
     moduleToInherit = SF.getParentModule();
   }


### PR DESCRIPTION
```
lib/Index/Index.cpp:137:41: warning: returning address of local temporary object [-Wreturn-stack-address]
lib/Sema/ImportResolution.cpp:627:9: warning: 'AttributedImport' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]
```