### PR TITLE
[cxx-interop] Avoid spurious references to `_OBJC_CLASS` symbols for C++ foreign reference types

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4413,6 +4413,12 @@ bool Type::findIf(llvm::function_ref<bool(Type)> pred) const {
 }
 
 TypeTraitResult TypeBase::canBeClass() {
+  // Foreign reference types are represented as Swift classes in the AST,
+  // however, they use custom retain/release operations, and therefore aren't
+  // AnyObjects.
+  if (isForeignReferenceType())
+    return TypeTraitResult::IsNot;
+
   // Any bridgeable object type can be a class.
   if (isBridgeableObjectType())
     return TypeTraitResult::Is;

--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -58,6 +58,15 @@ func go() {
     y.append(x)
 // CHECK: 1
     print(y.count)
+
+    var loopCount = 0 
+    for it in y {
+// CHECK: RefType()
+        print(it)
+        loopCount += 1
+    }
+// CHECK: 1
+    print(loopCount)
 }
 
 go()


### PR DESCRIPTION
This removes erroneous references to `_OBJC_CLASS_$__xyz` symbols that Swift was emitting for certain usages of C/C++ foreign reference types. This was discovered when trying to iterate over a Swift array of foreign reference types using a Swift for-in loop.

`Builtin.canBeClass` was returning true for foreign reference types, which led to the optimizer specializing the generic `canBeClass<T>` function to unconditionally return true for foreign reference types. This meant that `_isClassOrObjCExistential` for a foreign reference type evaluated to true, which made the Swift stdlib take the code path that was intended for Objective-C classes in `ArrayBuffer.getElement`, which assumed that the `Element` type conforms to `AnyObject`. Foreign reference types do not actually conform to `AnyObject`.

rdar://161814644

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
