### PR TITLE
[VariadicGenerics] Fix memeffect of metadata accessor call.

### DIFF
--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -395,9 +395,8 @@ public:
 
   // Emit a call to the given generic type metadata access function.
   MetadataResponse emitGenericTypeMetadataAccessFunctionCall(
-                                          llvm::Function *accessFunction,
-                                          ArrayRef<llvm::Value *> args,
-                                          DynamicMetadataRequest request);
+      llvm::Function *accessFunction, ArrayRef<llvm::Value *> args,
+      DynamicMetadataRequest request, bool hasPacks = false);
 
   // Emit a reference to the canonical type metadata record for the given AST
   // type. This can be used to identify the type at runtime. For types with

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -750,7 +750,7 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
             theDecl, genericArgs.Types, NotForDefinition);
 
     response = IGF.emitGenericTypeMetadataAccessFunctionCall(
-        accessor, genericArgs.Values, request);
+        accessor, genericArgs.Values, request, genericArgs.hasPacks);
   }
 
   IGF.setScopedLocalTypeMetadata(theType, response);
@@ -2462,11 +2462,9 @@ void irgen::emitCacheAccessFunction(IRGenModule &IGM, llvm::Function *accessor,
   IGF.Builder.CreateRet(ret);
 }
 
-MetadataResponse
-IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
-                                              llvm::Function *accessFunction,
-                                              ArrayRef<llvm::Value *> args,
-                                              DynamicMetadataRequest request) {
+MetadataResponse IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
+    llvm::Function *accessFunction, ArrayRef<llvm::Value *> args,
+    DynamicMetadataRequest request, bool hasPacks) {
 
   SmallVector<llvm::Value *, 8> callArgs;
 
@@ -2490,7 +2488,7 @@ IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
                                  accessFunction, callArgs);
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
-  call->setMemoryEffects(allocatedArgsBuffer
+  call->setMemoryEffects(hasPacks || allocatedArgsBuffer
                              ? llvm::MemoryEffects::inaccessibleOrArgMemOnly()
                              : llvm::MemoryEffects::none());
 

--- a/validation-test/IRGen/rdar161606892_2.swift
+++ b/validation-test/IRGen/rdar161606892_2.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift \
+// RUN:     -emit-module \
+// RUN:     -target %target-swift-5.9-abi-triple \
+// RUN:     %t/Library.swift \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Library \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                              \
+// RUN:     %t/Downstream.swift                             \
+// RUN:     -emit-irgen                                     \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -module-name main                               \
+// RUN:     -lLibrary                                       \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Downstream.swift --check-prefixes=CHECK,CHECK-OLD
+
+//--- Library.swift
+
+public struct Pack<each T> {
+  public init() {}
+}
+
+public func sink<T>(_ t: T) {}
+
+//--- Downstream.swift
+
+import Library
+
+// CHECK: doit
+// CHECK: @"$s7Library4PackVMa"{{.*}} [[CALL:#[^,]+]]
+
+// CHECK: attributes [[CALL]] = { nounwind memory(argmem: readwrite, inaccessiblemem: readwrite) }
+@_silgen_name("doit")
+func doit<each T, each U>(ts: repeat each T, us: repeat each U) {
+  sink(Pack<repeat each T, repeat each U>())
+}


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift/pull/84635/ .

The metadata accessor for a variadic generic type takes as arguments packs of metadata records and witness tables, and each such pack is passed in a buffer. So the call to any such accessor is not correctly annotated `memory(none)`.

rdar://161606892
