### PR TITLE
[CMake] pass the specified c++ stdlib to swiftc internal clang

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -109,6 +109,13 @@ function(add_swift_compiler_modules_library name)
       "-Xcc" "-DCOMPILED_WITH_SWIFT" "-Xcc" "-DSWIFT_TARGET"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
 
+  # append c++ flags to swift internal clang compile options
+  set(swift_compile_cxx_flags ${CMAKE_CXX_FLAGS})
+  separate_arguments(swift_compile_cxx_flags)
+  foreach(cxx_flag ${swift_compile_cxx_flags})
+    list(APPEND swift_compile_options "-Xcc" ${cxx_flag})
+  endforeach()
+
   if (NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
     if(SWIFT_MIN_RUNTIME_VERSION)
       list(APPEND swift_compile_options

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -109,11 +109,14 @@ function(add_swift_compiler_modules_library name)
       "-Xcc" "-DCOMPILED_WITH_SWIFT" "-Xcc" "-DSWIFT_TARGET"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
 
-  # append c++ flags to swift internal clang compile options
+  # Pass the declared C++ stdlib for swift's internal clang.
   set(swift_compile_cxx_flags ${CMAKE_CXX_FLAGS})
   separate_arguments(swift_compile_cxx_flags)
   foreach(cxx_flag ${swift_compile_cxx_flags})
-    list(APPEND swift_compile_options "-Xcc" ${cxx_flag})
+    if (cxx_flag MATCHES "^-stdlib=")
+      list(APPEND swift_compile_options "-Xcc" ${cxx_flag})
+      break()
+    endif()
   endforeach()
 
   if (NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")


### PR DESCRIPTION
On linux if llvm is built with `LLVM_ENABLE_LIBCXX` or `-stdlib=libc++` it is not used by the internal swift clang and causes linkage errors.
It may also apply to `-FPIC` or `-FPIE` flags

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
