### PR TITLE
[WinRT] Start exposing Windows Runtime headers to Swift

### DIFF
--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -25,6 +25,12 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk_shared.modulemap"
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/winrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/WinRT.modulemap"
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/ucrt"
     type: directory
     contents:
@@ -55,4 +61,5 @@ install(FILES
   vcruntime.modulemap
   winsdk_um.modulemap
   winsdk_shared.modulemap
+  WinRT.modulemap
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -160,6 +160,7 @@ copy_files(public/Platform Overlay/Windows/clang
     ucrt.modulemap
     winsdk_um.modulemap
     winsdk_shared.modulemap
+    WinRT.modulemap
     vcruntime.modulemap
     vcruntime.apinotes)
 

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -506,6 +506,15 @@ void GetWindowsFileMappings(
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
                                                AuxiliaryFile);
+
+    llvm::sys::path::remove_filename(WinSDKInjection);
+    llvm::sys::path::remove_filename(WinSDKInjection);
+    llvm::sys::path::append(WinSDKInjection, "winrt", "module.modulemap");
+    AuxiliaryFile =
+        GetPlatformAuxiliaryFile("windows", "WinRT.modulemap", SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
+                                               AuxiliaryFile);
   }
 
   struct {

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -15,6 +15,12 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk_shared.modulemap"
+  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\winrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\WinRT.modulemap"
   - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\ucrt"
     type: directory
     contents:

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -469,6 +469,7 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
       vcruntime.modulemap
       winsdk_um.modulemap
       winsdk_shared.modulemap
+      WinRT.modulemap
     DESTINATION "share"
     COMPONENT sdk-overlay)
 endif()

--- a/stdlib/public/Platform/WinRT.modulemap
+++ b/stdlib/public/Platform/WinRT.modulemap
@@ -1,0 +1,31 @@
+//===--- WinRT.modulemap --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module WinRT [system] {
+  link "WindowsApp.lib"
+  export *
+
+  module Base {
+    header "WinRTBase.h"
+    export *
+  }
+
+  module hstring {
+    header "hstring.h"
+    export *
+  }
+
+  module RoAPI {
+    header "roapi.h"
+    export *
+  }
+}

--- a/test/stdlib/WinRT_HSTRING.swift
+++ b/test/stdlib/WinRT_HSTRING.swift
@@ -1,0 +1,8 @@
+// RUN: %target-build-swift %s
+// REQUIRES: OS=windows-msvc
+
+// Make sure that importing WinRT brings in the HSTRING type.
+
+import WinRT
+
+public func usesHSTRING(_ x: HSTRING) {}


### PR DESCRIPTION
This adds an initial Clang modulemap for the WinRT module. The modulemap is injected into the `winrt/` include search path using VFS.

For now, the modulemap only exposes a small number of utility headers from WinRT. It will be extended in the future to cover more of the WinRT API surface.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
