### PR TITLE
[WinSDK] Modularize `<winapifamily.h>`

### DIFF
--- a/stdlib/public/Platform/winsdk_shared.modulemap
+++ b/stdlib/public/Platform/winsdk_shared.modulemap
@@ -14,3 +14,8 @@ module _GUIDDef {
   header "guiddef.h"
   export *
 }
+
+module WinAPIFamily {
+  header "winapifamily.h"
+  export *
+}


### PR DESCRIPTION
This prevents other Clang modules from hijacking this header, causing modularization errors. For example, several WinRT headers `#include <winapifamily.h>`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
