### PR TITLE
[Debug] Print only description of value types that conform to CustomStringConvertible

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -214,18 +214,22 @@ public enum _DebuggerSupport {
   
     print(String(repeating: " ", count: indent), terminator: "", to: &target)
 
-    // Do not expand types that conform to Custom(Debug)StringConvertible,
-    // unless the type also conform to CustomReflectable.
-    let isCustomStringConvertible = false
+    // 1. Do not expand classes, unless they conform to CustomReflectable.
+    // 2. Do not expand value types that conform to CustomStringConvertible
+    //    or CustomDebugStringConvertible, unless the type also conform to
+    //    CustomReflectable.
+    let isNonClass = mirror.displayStyle != .`class`
+    let isStringConvertible: Bool
     let isCustomReflectable: Bool
     if let value = value {
       isCustomReflectable = value is CustomReflectable
-      isCustomStringConvertible =
+      isStringConvertible =
         value is CustomStringConvertible || value is CustomDebugStringConvertible
     } else {
       isCustomReflectable = true
+      isStringConvertible = false
     }
-    let willExpand = isCustomReflectable || !isCustomStringConvertible
+    let willExpand = (isNonClass && !isStringConvertible) || isCustomReflectable
 
     let count = mirror.children.count
     let bullet = isRoot && (count == 0 || !willExpand) ? ""

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -214,18 +214,18 @@ public enum _DebuggerSupport {
   
     print(String(repeating: " ", count: indent), terminator: "", to: &target)
 
-    // do not expand classes with no custom Mirror
-    // yes, a type can lie and say it's a class when it's not since we only
-    // check the displayStyle - but then the type would have a custom Mirror
-    // anyway, so there's that...
-    let isNonClass = mirror.displayStyle != .`class`
+    // Do not expand types that conform to Custom(Debug)StringConvertible,
+    // unless the type also conform to CustomReflectable.
+    let isCustomStringConvertible = false
     let isCustomReflectable: Bool
     if let value = value {
       isCustomReflectable = value is CustomReflectable
+      isCustomStringConvertible =
+        value is CustomStringConvertible || value is CustomDebugStringConvertible
     } else {
       isCustomReflectable = true
     }
-    let willExpand = isNonClass || isCustomReflectable
+    let willExpand = isCustomReflectable || !isCustomStringConvertible
 
     let count = mirror.children.count
     let bullet = isRoot && (count == 0 || !willExpand) ? ""

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -313,6 +313,18 @@ public enum _DebuggerSupport {
     }
   }
 
+  /// Returns a string representation of `value` for display by the `po` LLDB
+  /// command.
+  ///
+  /// When the value conforms to `CustomDebugStringConvertible`, its
+  /// `debugDescription` is returned. Otherwise, if it conforms to
+  /// `CustomStringConvertible`, its `description` is returned. When it conforms
+  /// to neither, a mirror-based tree of the value's contents is produced,
+  /// similar to `dump(_:)`.
+  ///
+  /// Types that conform to `CustomReflectable` in addition to one of the string
+  /// convertible protocols will display both the custom description and their
+  /// mirrored contents.
   public static func stringForPrintObject(_ value: Any) -> String {
     var maxItemCounter = Int.max
     var refs = Set<ObjectIdentifier>()

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -15,6 +15,11 @@ struct StructIsNonCopyable: ~Copyable {
   var b = "Hello World"
 }
 
+struct StructWithMembersAndDescription: CustomStringConvertible {
+  var a = 1
+  var description: String { "Hello World" }
+}
+
 class ClassWithMembers {
   var a = 1
   var b = "Hello World"
@@ -64,6 +69,11 @@ let StringForPrintObjectTests = TestSuite("StringForPrintObject")
 StringForPrintObjectTests.test("StructWithMembers") {
   let printed = _stringForPrintObject(StructWithMembers())
   expectEqual(printed, "▿ StructWithMembers\n  - a : 1\n  - b : \"Hello World\"\n")
+}
+
+StringForPrintObjectTests.test("StructWithMembersAndDescription") {
+  let printed = _stringForPrintObject(StructWithMembersAndDescription())
+  expectEqual(printed, "Hello World\n")
 }
 
 #if _runtime(_ObjC)


### PR DESCRIPTION
This is for lldb, where the `po` command for Swift is implemented in `_DebuggerSupport.stringForPrintObject`.

Up to now, a Swift struct which conforms to `CustomStringConvertible` will print both its `description`, and also recursively print its internals.

This differs from a class, where only the `description` is printed.

This changes `stringForPrintObject` to print only the `description` of value types that conform to `CustomStringConvertible` (or `debugDescription` for `CustomDebugStringConvertible`) – unless the also type conforms to `CustomReflectable`, in which case its children are printed.

This issue was raised for `FilePath`, which prints excessively verbosely, like so:

```
(lldb) po FilePath("/tmp")
▿ "/tmp"
  ▿ _storage : "/tmp"
    ▿ nullTerminatedStorage : 5 elements
      ▿ 0 : SystemChar
        - rawValue : 47
      ▿ 1 : SystemChar
        - rawValue : 116
      ▿ 2 : SystemChar
        - rawValue : 109
      ▿ 3 : SystemChar
        - rawValue : 112
      ▿ 4 : SystemChar
        - rawValue : 0
```

rdar://161919005