### PR TITLE
[Caching] Adjust the bridging header chaining rule

### DIFF
--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -57,6 +57,17 @@
 // RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
 // RUN:   -scanner-output-dir %t/header-1 -I %t
 
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies\
+// RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
+// RUN:   -scanner-output-dir %t/header-1 -I %t > %t/bridging-header1.h
+// RUN: %FileCheck %s --input-file=%t/bridging-header1.h --check-prefix=HEADER
+
+// HEADER: # 1 "<module-Test-embedded-bridging-header>" 1
+
 // RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -o %t/deps-4.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \

--- a/test/ScanDependencies/bridging-header-autochaining.swift
+++ b/test/ScanDependencies/bridging-header-autochaining.swift
@@ -60,9 +60,8 @@
 // RUN:   %t/user.swift -auto-bridging-header-chaining -o %t/User.swiftmodule \
 // RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -I %t > %t/header1.h
 // RUN:   %FileCheck %s --check-prefix=HEADER1 --input-file=%t/header1.h
-// HEADER1: # 1 "<module-Test>/Bridging.h" 1
-// HEADER1: #include "Foo.h"
-// HEADER1: #include "Foo2.h"
+// HEADER1: #include
+// HEADER1-SAME: Bridging.h
 
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps2.json bridgingHeader > %t/header1.cmd
 // RUN: %target-swift-frontend @%t/header1.cmd -disable-implicit-swift-modules -O -o %t/bridging1.pch
@@ -94,8 +93,10 @@
 // RUN:   %t/user.swift -auto-bridging-header-chaining -o %t/User.swiftmodule -import-objc-header %t/Bridging2.h \
 // RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -I %t > %t/header2.h
 // RUN:   %FileCheck %s --check-prefix=HEADER2 --input-file=%t/header2.h
-// HEADER2: # 1 "<module-Test>/Bridging.h" 1
-// HEADER2: # 1 "<module-User>/Bridging2.h" 1
+// HEADER2: #include
+// HEADER2-SAME: Bridging.h
+// HEADER2: #include
+// HEADER2-SAME: Bridging2.h
 
 // RUN: %FileCheck %s --check-prefix DEPS_JSON --input-file=%t/deps3.json
 // DEPS_JSON: "chainedBridgingHeaderPath":


### PR DESCRIPTION
Adjust the rule for how bridging header chaining is performed to increase compatibilities with existing project configuration.

Previously in #84442, bridging header chaining was done via content concatenation, rather than `#include` via absolute path, to enable prefix mapping to drop references to absolute path. This triggers an incompatibility since the directory of the header file is also considered as part of the search path when resolve the include directives in the file. Simple concatenation will result in some `#include` can no longer be resolved.

Now relax the rule to do header content concatenation only when prefix map is used. This will keep the breakage minimal, and the breakage can always be fixed by additional include paths when turning on prefix mapping.

In the future, we should move towards internal bridging header implementation to avoid the need of chaining completely.

rdar://161854282

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
