### PR TITLE
build-script: remove `--verbose` when building swiftpm

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -124,7 +124,6 @@ class SwiftPM(product.Product):
             host_target,
             additional_params=[
                 "--reconfigure",
-                "--verbose",
             ],
         )
 
@@ -137,7 +136,6 @@ class SwiftPM(product.Product):
             host_target,
             compile_only_for_running_host_architecture=True,
             additional_params=[
-                '--verbose'
             ]
         )
 
@@ -155,7 +153,6 @@ class SwiftPM(product.Product):
         install_prefix = install_destdir + self.args.install_prefix
 
         self.run_bootstrap_script('install', host_target, [
-            '--verbose',
             '--prefix', install_prefix
         ])
 


### PR DESCRIPTION
The SwiftPM stage added `--verbose` in #79330 to help troubleshoot build error that were occuring on Linux.  These errors have since been addresed, but the verbosity was not removed.

Remove the `--verbose` command line argument in the SwiftPM portion of the `build-script`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
