### PR TITLE
[Sema] Reject tuple extensions early when feature is disabled

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3630,7 +3630,17 @@ NominalTypeDecl *ExtensionDecl::computeExtendedNominal(
   if (nominalTypes.empty())
     return nullptr;
 
-  return nominalTypes[0];
+  auto *result = nominalTypes[0];
+
+  // Tuple extensions are experimental, if the feature isn't enabled let's not
+  // bind this extension at all. This fixes a bunch of crashers that we don't
+  // yet properly handle with the feature enabled.
+  if (isa<BuiltinTupleDecl>(result) &&
+      !ctx.LangOpts.hasFeature(Feature::TupleConformances)) {
+    return nullptr;
+  }
+
+  return result;
 }
 
 NominalTypeDecl *

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3089,6 +3089,13 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     return error();
   }
 
+  // Tuple extensions are experimental.
+  if (extendedType->is<TupleType>() &&
+      !ctx.LangOpts.hasFeature(Feature::TupleConformances)) {
+    diags.diagnose(ext, diag::experimental_tuple_extension);
+    return error();
+  }
+
   // Cannot extend function types, metatypes, existentials, etc.
   if (!extendedType->is<TupleType>() &&
       !extendedType->getAnyNominal() &&

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3652,10 +3652,8 @@ public:
       return;
 
     auto &ctx = ED->getASTContext();
-
-    if (!ctx.LangOpts.hasFeature(Feature::TupleConformances)) {
-      ED->diagnose(diag::experimental_tuple_extension);
-    }
+    ASSERT(ctx.LangOpts.hasFeature(Feature::TupleConformances) &&
+           "Extension binding should not have permitted this");
 
     if (!isValidExtendedTypeForTupleExtension(ED)) {
       ED->diagnose(diag::tuple_extension_wrong_type,

--- a/validation-test/IDE/crashers_fixed/38a36bbe0fc496da.swift
+++ b/validation-test/IDE/crashers_fixed/38a36bbe0fc496da.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"61e9155a","signature":"swift::ide::CodeCompletionResultBuilder::takeResult()"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension ()
 where
   #^^# == <#type#>

--- a/validation-test/compiler_crashers_2_fixed/0217ed2d301f5d7b.swift
+++ b/validation-test/compiler_crashers_2_fixed/0217ed2d301f5d7b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"679d3d53","signature":"(anonymous namespace)::PrintAST::visit(swift::Decl*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 extension () {
   class let a
 }

--- a/validation-test/compiler_crashers_2_fixed/4e921915ae337fb5.swift
+++ b/validation-test/compiler_crashers_2_fixed/4e921915ae337fb5.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::ConditionalRequirementsRequest::evaluate(swift::Evaluator&, swift::NormalProtocolConformance*) const","signatureAssert":"Assertion failed: (typeSig.getCanonicalSignature().getGenericParams() == extensionSig.getCanonicalSignature().getGenericParams()), function evaluate"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a typealias b<c> = () extension b : a

--- a/validation-test/compiler_crashers_2_fixed/548b48b935d4153a.swift
+++ b/validation-test/compiler_crashers_2_fixed/548b48b935d4153a.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::NominalType::get(swift::NominalTypeDecl*, swift::Type, swift::ASTContext const&)","signatureAssert":"Assertion failed: ((!Parent || Parent->is<NominalType>() || Parent->is<BoundGenericType>() || Parent->is<UnboundGenericType>()) && \"parent must be a nominal type\"), function get"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 extension() {
   struct a extension a

--- a/validation-test/compiler_crashers_2_fixed/662d871271047482.swift
+++ b/validation-test/compiler_crashers_2_fixed/662d871271047482.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"2e2249a5","signature":"swift::TypeBase::computeCanonicalType()","signatureAssert":"Assertion failed: (Result->isCanonical()), function computeCanonicalType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a<b> = (
 >extension a where b ==  {
 c

--- a/validation-test/compiler_crashers_2_fixed/666bd08556187ed3.swift
+++ b/validation-test/compiler_crashers_2_fixed/666bd08556187ed3.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::DeclChecker::visit(swift::Decl*)","signatureAssert":"Assertion failed: (false && \"Huh?\"), function isValidExtendedTypeForTupleExtension"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-extension(a[ 0.0 b
+// RUN: not %target-swift-frontend -typecheck %s
+extension repeat (

--- a/validation-test/compiler_crashers_2_fixed/966aa8f86a7565d3.swift
+++ b/validation-test/compiler_crashers_2_fixed/966aa8f86a7565d3.swift
@@ -1,0 +1,12 @@
+// {"kind":"typecheck","original":"71a26232","signature":"swift::Decl::getDescriptiveKind() const"}
+// RUN: not %target-swift-frontend -typecheck %s
+typealias a = ()
+extension a {
+  func
+    < (b: Self, c: Self)
+  {
+    for (d, e) in repeat (each b    each c) {
+      d < &e
+    }
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/983a37d706b4923e.swift
+++ b/validation-test/compiler_crashers_2_fixed/983a37d706b4923e.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::TypeBase::getNominalParent()","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   typealias b<c> = () extension b

--- a/validation-test/compiler_crashers_2_fixed/9adf18151655a6ae.swift
+++ b/validation-test/compiler_crashers_2_fixed/9adf18151655a6ae.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::DeclChecker::visit(swift::Decl*)","signatureAssert":"Assertion failed: (false && \"Huh?\"), function isValidExtendedTypeForTupleExtension"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-extension repeat (
+// RUN: not %target-swift-frontend -typecheck %s
+typealias a<b> = (repeat b)protocol c extension a : c

--- a/validation-test/compiler_crashers_2_fixed/b4746f0a8b4efd96.swift
+++ b/validation-test/compiler_crashers_2_fixed/b4746f0a8b4efd96.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::DeclChecker::visit(swift::Decl*)","signatureAssert":"Assertion failed: (false && \"Huh?\"), function isValidExtendedTypeForTupleExtension"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-typealias a<b> = (repeat b)protocol c extension a : c
+// RUN: not %target-swift-frontend -typecheck %s
+extension(a[ 0.0 b

--- a/validation-test/compiler_crashers_2_fixed/d5eedcc26a9c0a1f.swift
+++ b/validation-test/compiler_crashers_2_fixed/d5eedcc26a9c0a1f.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeBase::getReducedShape()","signatureAssert":"Assertion failed: (!isTypeVariableOrMember()), function getReducedShape"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a <b> = ()
 extension a {
 c {

--- a/validation-test/compiler_crashers_2_fixed/e6a483a39992886f.swift
+++ b/validation-test/compiler_crashers_2_fixed/e6a483a39992886f.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::BuiltinTupleDecl::getTupleSelfType(swift::ExtensionDecl const*) const","signatureAssert":"Assertion failed: (genericParams->getParams().size() == 1), function getTupleSelfType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a<b, c> = () extension a

--- a/validation-test/compiler_crashers_2_fixed/e92d0acb419dec8e.swift
+++ b/validation-test/compiler_crashers_2_fixed/e92d0acb419dec8e.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::GenericTypeParamType::GenericTypeParamType(swift::GenericTypeParamDecl*, swift::RecursiveTypeProperties)","signatureAssert":"Assertion failed: (param->getDepth() != GenericTypeParamDecl::InvalidDepth), function GenericTypeParamType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a = () extension a {
   typealias b<c> = () extension b


### PR DESCRIPTION
Tuple extensions are still an experimental feature, but we have a number of crashers in the repo for them because we still use their type-checker machinery even when disabled. Change the logic here such that we reject them early in extension binding when the feature is disabled. This will ensure we address the crashers before productizing.