### PR TITLE
Improve error message when integer overflow happens

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -779,6 +779,24 @@ static SILValue constantFoldBinary(BuiltinInst *BI, BuiltinValueKind ID,
   }
 }
 
+Type getIntegerType(ASTContext &Ctx, unsigned width, bool DstTySigned) {
+    if (DstTySigned) {
+      switch (width) {
+        case 8: return Ctx.getInt8Type();
+        case 16: return Ctx.getInt16Type();
+        case 32: return Ctx.getInt32Type();
+        case 64: return Ctx.getInt64Type();
+      }
+    } else {
+      switch (width) {
+        case 8: return  Ctx.getUInt8Type();
+        case 16: return Ctx.getUInt16Type();
+        case 32: return Ctx.getUInt32Type();
+        case 64: return Ctx.getUInt64Type();
+      }
+  }
+}
+
 static SILValue
 constantFoldAndCheckIntegerConversions(BuiltinInst *BI,
                                        const BuiltinInfo &Builtin,
@@ -910,7 +928,7 @@ constantFoldAndCheckIntegerConversions(BuiltinInst *BI,
       } else {
         diagnose(M.getASTContext(), Loc.getSourceLoc(),
                  diag::integer_literal_overflow_builtin_types,
-                 DstTySigned, DstTy, SrcAsString);
+                 DstTySigned, getIntegerType(M.getASTContext(), DstBitWidth, DstTySigned), SrcAsString);
       }
     } else {
       // Try to print user-visible types if they are available.
@@ -922,7 +940,8 @@ constantFoldAndCheckIntegerConversions(BuiltinInst *BI,
       // Otherwise, print the Builtin Types.
       } else {
         // Since builtin types are sign-agnostic, print the signedness
-        // separately.
+        // separately
+
         diagnose(M.getASTContext(), Loc.getSourceLoc(),
                  diag::integer_conversion_overflow_builtin_types,
                  SrcTySigned, SrcTy, DstTySigned, DstTy);


### PR DESCRIPTION
This change aims to improve, as stated in issue #83877, the way integer types are displayed to users when detecting overflows. Instead of showing, for example, Builtin.Int, it will show the integer type name as declared by the user for example Uint8.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
