### PR TITLE
[stdlib] ~Escapable raw pointer access: API adoption in URP, UMRP, URBP, UMRBP

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -346,3 +346,17 @@ public func _overrideLifetime<
 ) -> T {
   dependent
 }
+
+/// Unsafely discard any lifetime dependency on the `dependent` inout
+/// argument. Return a value identical to `dependent` with a lifetime dependency
+/// on the caller's borrow scope of the `source` argument.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(dependent: borrow source)
+public func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: inout T, borrowing source: borrowing U
+) {}

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -464,14 +464,16 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T : BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
     _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
-    return unsafe baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
+    let value = unsafe baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
+    return unsafe _overrideLifetime(value, borrowing: self)
   }
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1285,10 +1285,11 @@ extension ${Self} {
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 @safe
-public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
+public func withUnsafeMutableBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
   let pointer = UnsafeMutableRawPointer(Builtin.addressof(&value))
   return try unsafe body(unsafe .init(start: pointer, count: MemoryLayout<T>.size))
 }
@@ -1317,11 +1318,12 @@ func __abi_se0413_withUnsafeMutableBytes<T, Result>(
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeMutableBytes<
-  T: ~Copyable, E: Error, Result: ~Copyable
+  T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
 #if $BuiltinUnprotectedAddressOf
   let pointer = UnsafeMutableRawPointer(Builtin.unprotectedAddressOf(&value))
 #else
@@ -1355,10 +1357,11 @@ public func _withUnprotectedUnsafeMutableBytes<
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 @safe
-public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
+public func withUnsafeBytes<T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
   let address = UnsafeRawPointer(Builtin.addressof(&value))
   return try unsafe body(unsafe .init(start: address, count: MemoryLayout<T>.size))
 }
@@ -1386,11 +1389,12 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeBytes<
-  T: ~Copyable, E: Error, Result: ~Copyable
+  T: ~Copyable & ~Escapable, E: Error, Result: ~Copyable
 >(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws(E) -> Result
 ) throws(E) -> Result {
+  unsafe _overrideLifetime(&value, borrowing: ())
 #if $BuiltinUnprotectedAddressOf
   let p = UnsafeRawPointer(Builtin.unprotectedAddressOf(&value))
 #else
@@ -1418,6 +1422,10 @@ public func _withUnprotectedUnsafeBytes<
 ///     If you want to mutate a value by writing through a pointer, use
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
+//
+// FIXME: Support `T: ~Copyable & ~Escapable` when we have an _overrideLifetime
+// that returns a borrowed value. This requires compiler support for emitting
+// tracking Builtin.Borrow<T> as ~Escapable.
 @_alwaysEmitIntoClient
 @safe
 public func withUnsafeBytes<
@@ -1451,6 +1459,10 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
 ///
 /// This function is similar to `withUnsafeBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
+//
+// FIXME: Support `T: ~Copyable & ~Escapable` when we have an _overrideLifetime
+// that returns a borrowed value. This requires compiler support for emitting
+// tracking Builtin.Borrow<T> as ~Escapable.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -559,7 +559,7 @@ extension UnsafeRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedUp<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -577,7 +577,7 @@ extension UnsafeRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedDown<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -1563,7 +1563,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedUp<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedUp<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
@@ -1581,7 +1581,7 @@ extension UnsafeMutableRawPointer {
   /// - Returns: a pointer properly aligned to store a value of type `T`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func alignedDown<T: ~Copyable>(for type: T.Type) -> Self {
+  public func alignedDown<T: ~Copyable & ~Escapable>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
     _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1422,10 +1422,11 @@ extension UnsafeMutableRawPointer {
   ///   - type: The type of `value`.
   @inlinable
   @_alwaysEmitIntoClient
-  public func storeBytes<T: BitwiseCopyable>(
+  public func storeBytes<T: BitwiseCopyable & ~Escapable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
-    unsafe Builtin.storeRaw(value, (self + offset)._rawValue)
+    let immortalValue = unsafe _overrideLifetime(value, borrowing: ())
+    unsafe Builtin.storeRaw(immortalValue, (self + offset)._rawValue)
   }
 
   /// Stores the given value's bytes into raw memory at the specified offset.

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -442,7 +442,9 @@ extension UnsafeRawPointer {
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
   @inlinable
-  public func load<T>(
+  @_preInverseGenerics
+  @lifetime(borrow self)
+  public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
@@ -488,7 +490,8 @@ extension UnsafeRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T: BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
@@ -1281,7 +1284,9 @@ extension UnsafeMutableRawPointer {
   ///   `offset`. The returned instance is memory-managed and unassociated
   ///   with the value in the memory referenced by this pointer.
   @inlinable
-  public func load<T>(
+  @_preInverseGenerics
+  @lifetime(borrow self)
+  public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
@@ -1328,7 +1333,8 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  public func loadUnaligned<T: BitwiseCopyable>(
+  @lifetime(borrow self)
+  public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {

--- a/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
+// RUN:   -strict-memory-safety \
+// RUN:   -enable-experimental-feature Lifetimes
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+
+@safe
+@_silgen_name("getRawPointer")
+func getRawPointer() -> UnsafeRawPointer
+
+@safe
+@_silgen_name("getMutRawPointer")
+func getMutRawPointer() -> UnsafeMutableRawPointer
+
+func useSpan(_: RawSpan) {}
+
+//===----------------------------------------------------------------------===//
+// raw pointer .load()
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badLoad() -> RawSpan {
+  let p = getRawPointer()
+  return unsafe p.load(as: RawSpan.self) // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'p'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodLoad(p: UnsafeRawPointer) -> RawSpan {
+  unsafe useSpan(p.load(as: RawSpan.self))
+  return unsafe p.load(as: RawSpan.self)
+}
+
+//===----------------------------------------------------------------------===//
+// raw pointer .loadUnaligned()
+//
+// TODO: test non-BitwiseCopyable loadUnaligned
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+@_lifetime(immortal)
+func badBitwiseLoadUnaligned() -> RawSpan {
+  let p = getRawPointer()
+  return unsafe p.loadUnaligned(as: RawSpan.self) // expected-error{{lifetime-dependent value escapes its scope}}
+    // expected-note@-2{{it depends on the lifetime of variable 'p'}}
+    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+}
+
+@available(Span 0.1, *)
+@_lifetime(borrow p)
+func goodBitwiseLoadUnaligned(p: UnsafeRawPointer) -> RawSpan {
+  unsafe useSpan(p.loadUnaligned(as: RawSpan.self))
+  return unsafe p.loadUnaligned(as: RawSpan.self)
+}
+
+/* TODO: support loadUnaligned<T: ~BitwiseCopyable>
+@_lifetime(immortal)
+func badGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> T {
+  let p = getRawPointer()
+  return unsafe p.loadUnaligned(as: T.self) // ERROR
+}
+
+@_lifetime(borrow p)
+func goodGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> T {
+  return unsafe p.loadUnaligned(as: T.self) // OK
+}
+*/

--- a/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/rawpointer_span.swift
@@ -74,3 +74,20 @@ func goodGenericLoadUnaligned<T: ~Escapable>(p: UnsafeRawPointer, _: T.Type) -> 
   return unsafe p.loadUnaligned(as: T.self) // OK
 }
 */
+
+//===----------------------------------------------------------------------===//
+// raw pointer .storeBytes()
+//===----------------------------------------------------------------------===//
+
+@available(Span 0.1, *)
+func storeSpan(span: RawSpan) {
+  let p = getMutRawPointer()
+  unsafe p.storeBytes(of: span, as: RawSpan.self)
+}
+
+/* TODO: support storeBytes<T: ~BitwiseCopyable>
+func storeGeneric<T: ~Escapable>(value: T) {
+  let p = getMutRawPointer()
+  unsafe p.storeBytes(of: value, as: T.self)
+}
+*/

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -307,16 +307,19 @@ Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature chan
 Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
+Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func withUnsafeBytes(of:_:) has parameter 0 changing from Default to Shared
-Func withUnsafeMutableBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func withUnsafeMutableBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, T : ~Escapable, Result : ~Copyable>
 Func withUnsafeMutablePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func withUnsafePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func withUnsafePointer(to:_:) has parameter 0 changing from Default to Shared

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -680,6 +680,9 @@ Func UnsafeMutableRawPointer.assumingMemoryBound(to:) is now with @_preInverseGe
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) is now with @_preInverseGenerics
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.load<A>(fromByteOffset: Swift.Int, as: A.Type) -> A' to 'Swift.UnsafeMutableRawPointer.load<A where A: ~Swift.Escapable>(fromByteOffset: Swift.Int, as: A.Type) -> A'
+Func UnsafeMutableRawPointer.load(fromByteOffset:as:) is now with @_preInverseGenerics
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has mangled name changing from 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>' to 'Swift.UnsafeMutableRawPointer.moveInitializeMemory<A where A: ~Swift.Copyable>(as: A.Type, from: Swift.UnsafeMutablePointer<A>, count: Swift.Int) -> Swift.UnsafeMutablePointer<A>'
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) is now with @_preInverseGenerics
@@ -695,6 +698,9 @@ Func UnsafeRawPointer.assumingMemoryBound(to:) is now with @_preInverseGenerics
 Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.bindMemory(to:capacity:) has mangled name changing from 'Swift.UnsafeRawPointer.bindMemory<A>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>' to 'Swift.UnsafeRawPointer.bindMemory<A where A: ~Swift.Copyable>(to: A.Type, capacity: Swift.Int) -> Swift.UnsafePointer<A>'
 Func UnsafeRawPointer.bindMemory(to:capacity:) is now with @_preInverseGenerics
+Func UnsafeRawPointer.load(fromByteOffset:as:) has generic signature change from <T> to <T where T : ~Escapable>
+Func UnsafeRawPointer.load(fromByteOffset:as:) has mangled name changing from 'Swift.UnsafeRawPointer.load<A>(fromByteOffset: Swift.Int, as: A.Type) -> A' to 'Swift.UnsafeRawPointer.load<A where A: ~Swift.Escapable>(fromByteOffset: Swift.Int, as: A.Type) -> A'
+Func UnsafeRawPointer.load(fromByteOffset:as:) is now with @_preInverseGenerics
 Func _fixLifetime(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
 Func _fixLifetime(_:) has mangled name changing from 'Swift._fixLifetime<A>(A) -> ()' to 'Swift._fixLifetime<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(A) -> ()'
 Func _fixLifetime(_:) has parameter 0 changing from Default to Shared


### PR DESCRIPTION
- **[stdlib] Unsafe[Mutable]RawPointer aligment for ~Escapable types**
  

- **[stdlib] UnsafeMutableRawPointer: load[Unaligned] ~Escapable**
  loadUnaligned only supports loading non-BitwiseCopyable values. The generic
  loadUnaligned should also be supported but it depends on UnsafePointer<T:
  ~Escapable>.
  

- **[stdlib] UnsafeMutableRawPointer: storeBytes of ~Escapable**
  Only supports non-BitwiseCopyable values. The generic storeBytes should also be
  supported but it depends on UnsafePointer<T: ~Escapable>.
  

- **Test UnsafeRawPointer load of ~Escapable**
  

- **Test UnsafeRawPointer store of ~Escapable**
  

- **Update stability-stdlib-source-base.swift.expected for URP.load**

This is necessary to allow non-Escapable values to reside in memory. Without this, it is impossible to build data types on type of Spans or other non-Escapable types.
  