### PR TITLE
Allow Builtin.Load/Take -> ~Escapable

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -240,6 +240,7 @@ BUILTIN_SIL_OPERATION(LoadRaw, "loadRaw", Special)
 BUILTIN_SIL_OPERATION(LoadInvariant, "loadInvariant", Special)
 
 /// Take has type (Builtin.RawPointer) -> T
+/// where T: ~Copyable & ~Escapable
 BUILTIN_SIL_OPERATION(Take, "take", Special)
 
 /// Destroy has type (T.Type, Builtin.RawPointer) -> ()

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -923,8 +923,7 @@ static ValueDecl *getRefCountingOperation(ASTContext &ctx, Identifier id) {
 static ValueDecl *getLoadOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
                             _generics(_unrestricted,
-                                      _conformsTo(_typeparam(0), _copyable),
-                                      _conformsTo(_typeparam(0), _escapable)),
+                                      _conformsTo(_typeparam(0), _copyable)),
                             _parameters(_rawPointer),
                             _typeparam(0));
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -931,8 +931,7 @@ static ValueDecl *getLoadOperation(ASTContext &ctx, Identifier id) {
 
 static ValueDecl *getTakeOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted,
-                                      _conformsTo(_typeparam(0), _escapable)),
+                            _generics(_unrestricted),
                             _parameters(_rawPointer),
                             _typeparam(0));
 }


### PR DESCRIPTION
- **Allow Builtin.Take -> ~Escapable**
  
- **Allow Builtin.Load -> ~Escapable**

Unit tests are in https://github.com/swiftlang/swift/pull/84701

This is necessary to allow non-Escapable values to reside in memory. Without this, it is impossible to build data types on type of Spans or other non-Escapable types.
  