### PR TITLE
Lifetimes: add a diagnostic note for implicit accessors

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -284,6 +284,7 @@ private struct DiagnoseDependence {
         diagnose(sourceLoc, .lifetime_value_outside_thunk, thunkSelect, function.name)
       }
     }
+    diagnoseImplicitFunction()
     reportScope()
     // Identify the use point.
     if let userSourceLoc = operand.instruction.location.sourceLoc {
@@ -321,6 +322,23 @@ private struct DiagnoseDependence {
       } else {
         diagnose(parentLoc, .lifetime_outside_scope_value)
       }
+    }
+  }
+
+  func diagnoseImplicitFunction() {
+    guard let funcLoc = function.location.sourceLoc else {
+      return
+    }
+    if let kindName = {
+         if function.isInitializer {
+           return "init"
+         }
+         if function.isDeinitializer {
+           return "deinit"
+         }
+         return function.accessorKindName
+       }() {
+      diagnose(funcLoc, .implicit_function_note, kindName)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -267,6 +267,18 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     return StringRef(bridged: bridged.getAccessorName()).string
   }
 
+  public var isInitializer: Bool {
+    return bridged.isInitializer()
+  }
+
+  public var isDeinitializer: Bool {
+    return bridged.isDeinitializer()
+  }
+
+  public var isImplicit: Bool {
+    return bridged.isImplicit()
+  }
+
   /// True, if the function runs with a swift 5.1 runtime.
   /// Note that this is function specific, because inlinable functions are de-serialized
   /// in a client module, which might be compiled with a different deployment target.

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1240,6 +1240,8 @@ NOTE(lifetime_outside_scope_use, none,
 NOTE(lifetime_outside_scope_escape, none,
      "this use causes the lifetime-dependent value to escape", ())
 
+NOTE(implicit_function_note, none, "error in compiler-generated '%0'", (StringRef))
+
 ERROR(noncopyable_shared_case_block_unimplemented, none,
       "matching a non-'Copyable' value using a case label that has multiple patterns is not implemented", ())
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -509,6 +509,9 @@ struct BridgedFunction {
   BridgedOwnedString getDebugDescription() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLocation getLocation() const;
   BRIDGED_INLINE bool isAccessor() const;
+  BRIDGED_INLINE bool isInitializer() const;
+  BRIDGED_INLINE bool isDeinitializer() const;
+  BRIDGED_INLINE bool isImplicit() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getAccessorName() const;
   BRIDGED_INLINE bool hasOwnership() const;
   BRIDGED_INLINE bool hasLoweredAddresses() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -701,6 +701,21 @@ BridgedStringRef BridgedFunction::getAccessorName() const {
   return accessorKindName(accessorDecl->getAccessorKind());
 }
 
+bool BridgedFunction::isInitializer() const {
+  return getFunction()->getDeclRef().isConstructor();
+}
+
+bool BridgedFunction::isDeinitializer() const {
+  return getFunction()->getDeclRef().isDestructor();
+}
+
+bool BridgedFunction::isImplicit() const {
+  if (auto *funcDecl = getFunction()->getDeclRef().getAbstractFunctionDecl()) {
+    return funcDecl->isImplicit();
+  }
+  return false;
+}
+
 bool BridgedFunction::hasOwnership() const { return getFunction()->hasOwnership(); }
 
 bool BridgedFunction::hasLoweredAddresses() const { return getFunction()->getModule().useLoweredAddresses(); }


### PR DESCRIPTION
Lifetime diagnostics may report an error within an implicit initializer or
accessor. The source location is misleading in these cases and causes much
consternation.

This is not directly tested because, normally, compiler generated methods should not generate any diagnostic errors. This does, however, occur periodically because of compiler bugs or unforeseen cases. We need the bug reports to contain useful information.
