### PR TITLE
[Build] Disable library evolution in the Static SDK for Linux.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -357,7 +357,7 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER=1")
   endif()
 
-  if(SWIFT_STDLIB_STABLE_ABI)
+  if(SWIFT_STDLIB_STABLE_ABI AND NOT "${CFLAGS_SDK}" STREQUAL "LINUX_STATIC")
     list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=1")
   else()
     list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=0")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -549,7 +549,9 @@ function(_compile_swift_files
   endif()
 
   # The standard library and overlays are built resiliently when SWIFT_STDLIB_STABLE_ABI=On.
-  if(SWIFTFILE_IS_STDLIB AND NOT SWIFTFILE_IS_FRAGILE AND SWIFT_STDLIB_STABLE_ABI)
+  if(SWIFTFILE_IS_STDLIB AND NOT SWIFTFILE_IS_FRAGILE
+      AND SWIFT_STDLIB_STABLE_ABI
+      AND NOT "${SWIFTFILE_SDK}" STREQUAL "LINUX_STATIC")
     list(APPEND swift_flags "-enable-library-evolution")
     list(APPEND swift_flags "-library-level" "api")
     list(APPEND swift_flags "-Xfrontend" "-require-explicit-availability=ignore")
@@ -721,7 +723,9 @@ function(_compile_swift_files
     set(sibopt_file "${module_base}.O.sib")
     set(sibgen_file "${module_base}.sibgen")
 
-    if(SWIFT_ENABLE_MODULE_INTERFACES AND NOT SWIFTFILE_IS_FRAGILE)
+    if(SWIFT_ENABLE_MODULE_INTERFACES
+        AND NOT SWIFTFILE_IS_FRAGILE
+        AND NOT "${SWIFTFILE_SDK}" STREQUAL "LINUX_STATIC")
       set(interface_file "${module_base}.swiftinterface")
       set(interface_file_static "${module_base_static}.swiftinterface")
       set(private_interface_file "${module_base}.private.swiftinterface")


### PR DESCRIPTION
We don't want library evolution turned on for the Static SDK.

We can't do this in the `StdlibOptions.cmake` file because that's testing the *host*, not the *target* (the code in there is wrong).

rdar://160455139
