### PR TITLE
[test] Fix availability in `import-as-instance-method.swift`

### DIFF
--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -10,7 +10,7 @@
 //--- test.swift
 import Instance
 
-@available(macOS 13.3.0, *)
+@available(SwiftStdlib 5.8, *)
 func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout B) {
   aa.basic(&p)
   aa.bar(&p)


### PR DESCRIPTION
This test can run with non-macOS targets, update the availability condition to be platform agnostic.