### PR TITLE
[AutoDiff][Gardening] Use `SILFunction::getSourceFile` instead of dup logic

### DIFF
--- a/lib/SILOptimizer/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Differentiation/ADContext.cpp
@@ -62,10 +62,8 @@ ADContext::ADContext(SILModuleTransform &transform)
 
 /// Get the source file for the given `SILFunction`.
 static SourceFile &getSourceFile(SILFunction *f) {
-  if (f->hasLocation())
-    if (auto *declContext = f->getLocation().getAsDeclContext())
-      if (auto *parentSourceFile = declContext->getParentSourceFile())
-        return *parentSourceFile;
+  if (SourceFile *file = f->getSourceFile())
+    return *file;
   for (auto *file : f->getModule().getSwiftModule()->getFiles())
     if (auto *sourceFile = dyn_cast<SourceFile>(file))
       return *sourceFile;


### PR DESCRIPTION
In 025902fa994d83a213f6765277605c8d2f83c247, `SILFunction::getSourceFile()`
is introduced. This patch makes use of that to avoid duplicating the
logic in `static SourceFile &getSourceFile(SILFunction *f)` in
lib/SILOptimizer/Differentiation/ADContext.cpp.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
