### PR TITLE
LoopInvariantCodeMotion: fix check for hoisting `load_borrow` instructions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -1221,10 +1221,10 @@ private extension ScopedInstruction {
       }
       return true
 
-    case is BeginAccessInst:
+    case let beginAccess as BeginAccessInst:
       for fullApplyInst in analyzedInstructions.fullApplies {
-        guard mayWriteToMemory && fullApplyInst.mayReadOrWrite(address: operands.first!.value, context.aliasAnalysis) ||
-              !mayWriteToMemory && fullApplyInst.mayWrite(toAddress: operands.first!.value, context.aliasAnalysis) else {
+        guard mayWriteToMemory && fullApplyInst.mayReadOrWrite(address: beginAccess.address, context.aliasAnalysis) ||
+              !mayWriteToMemory && fullApplyInst.mayWrite(toAddress: beginAccess.address, context.aliasAnalysis) else {
           continue
         }
 
@@ -1234,7 +1234,7 @@ private extension ScopedInstruction {
         }
       }
       
-      switch operands.first!.value.accessPath.base {
+      switch beginAccess.address.accessPath.base {
       case .class, .global:
         for sideEffect in analyzedInstructions.loopSideEffects where sideEffect.mayRelease {
           // Since a class might have a deinitializer, hoisting begin/end_access pair could violate

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1771,6 +1771,34 @@ bb3:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_hoist_load_borrow :
+// CHECK:       bb1:
+// CHECK-NEXT:    copy_addr
+// CHECK-NEXT:    load_borrow
+// CHECK:       } // end sil function 'dont_hoist_load_borrow'
+sil [ossa] @dont_hoist_load_borrow : $@convention(thin) (@in_guaranteed String) -> () {
+bb0(%0 : $*String):
+  %1 = alloc_stack $String
+  br bb1
+
+bb1:
+  copy_addr %0 to [init] %1
+  %3 = load_borrow %1
+  fix_lifetime %3
+  end_borrow %3
+  %6 = load [take] %1
+  destroy_value %6
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  dealloc_stack %1
+  %r = tuple()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil [ossa] @dont_hoist_struct :
 // CHECK:       bb1:
 // CHECK-NEXT:    struct $NonCopyable


### PR DESCRIPTION
We need to check aliasing for all kind of side-effect instructions, not just stores and destroys