### PR TITLE
[Diagnostics] Fix a few issues with existential type mismatches

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9124,6 +9124,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         continue;
       }
 
+      // Matching existentials could introduce constraints with `instance type`
+      // element at the end if the confirming type wasn't fully resolved.
+      if (path.back().is<LocatorPathElt::InstanceType>()) {
+        path.pop_back();
+        continue;
+      }
+
       break;
     }
 
@@ -9217,7 +9224,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       }
     }
 
-    if (loc->isLastElement<LocatorPathElt::MemberRefBase>()) {
+    if (path.back().is<LocatorPathElt::MemberRefBase>()) {
       auto *fix = ContextualMismatch::create(*this, protocolTy, type, loc);
       if (!recordFix(fix))
         return SolutionKind::Solved;
@@ -9227,7 +9234,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // for example to `AnyHashable`.
     if ((kind == ConstraintKind::ConformsTo ||
          kind == ConstraintKind::NonisolatedConformsTo) &&
-        loc->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+        path.back().is<LocatorPathElt::ApplyArgToParam>()) {
       auto *fix = AllowArgumentMismatch::create(*this, type, protocolTy, loc);
       return recordFix(fix, /*impact=*/2) ? SolutionKind::Error
                                           : SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8755,8 +8755,17 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   if (shouldAttemptFixes() && result.isFailure()) {
     auto *loc = getConstraintLocator(locator);
 
-    if (loc->isLastElement<LocatorPathElt::InstanceType>())
-      loc = getConstraintLocator(loc->getAnchor(), loc->getPath().drop_back());
+    ArrayRef<LocatorPathElt> path = loc->getPath();
+    while (!path.empty()) {
+      if (!path.back().is<LocatorPathElt::InstanceType>())
+        break;
+
+      path = path.drop_back();
+    }
+
+    if (path.size() != loc->getPath().size()) {
+      loc = getConstraintLocator(loc->getAnchor(), path);
+    }
 
     ConstraintFix *fix = nullptr;
     if (loc->isLastElement<LocatorPathElt::ApplyArgToParam>()) {

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -125,7 +125,8 @@ func parameterizedExistentials() {
 func testNestedMetatype() {
   struct S: P {}
 
-  func bar<T>(_ x: T) -> T.Type { type(of: x) }
+  func bar<T>(_ x: T) -> T.Type { }
+  func metaBar<T>(_ x: T) -> T.Type.Type { }
   func foo1(_ x: P.Type) {}
   func foo2(_ x: P.Type.Type) { }
 
@@ -134,4 +135,5 @@ func testNestedMetatype() {
   // Make sure we don't crash.
   foo2(bar(S.self))
   foo2(bar(0)) // expected-error {{cannot convert value of type 'Int' to expected argument type 'any P.Type'}}
+  foo2(metaBar(0)) // expected-error {{argument type 'Int' does not conform to expected type 'P'}}
 }

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -124,12 +124,15 @@ func testNestedMetatype() {
   struct S: P {}
 
   func bar<T>(_ x: T) -> T.Type { type(of: x) }
-  func foo(_ x: P.Type.Type) { }
+  func foo1(_ x: P.Type) {}
+  func foo2(_ x: P.Type.Type) { }
+
+  foo1(bar(S.self)) // expected-error {{argument type 'S.Type' does not conform to expected type 'P'}}
 
   // Make sure we don't crash.
-  foo(bar(S.self))
+  foo2(bar(S.self))
 
   // FIXME: Bad diagnostic
   // https://github.com/swiftlang/swift/issues/83991
-  foo(bar(0)) // expected-error {{failed to produce diagnostic for expression}}
+  foo2(bar(0)) // expected-error {{failed to produce diagnostic for expression}}
 }

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -120,6 +120,8 @@ func parameterizedExistentials() {
   pt = ppt // expected-error {{cannot assign value of type 'any PP4<Int>.Type' to type 'any P4<Int>.Type'}}
 }
 
+// https://github.com/swiftlang/swift/issues/83991
+
 func testNestedMetatype() {
   struct S: P {}
 
@@ -131,8 +133,5 @@ func testNestedMetatype() {
 
   // Make sure we don't crash.
   foo2(bar(S.self))
-
-  // FIXME: Bad diagnostic
-  // https://github.com/swiftlang/swift/issues/83991
-  foo2(bar(0)) // expected-error {{failed to produce diagnostic for expression}}
+  foo2(bar(0)) // expected-error {{cannot convert value of type 'Int' to expected argument type 'any P.Type'}}
 }

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -538,5 +538,5 @@ func testYap(_ y: Yapping<NC>) {
 protocol Veggie: ~Copyable {}
 func generalized(_ x: Any.Type) {}
 func testMetatypes(_ t: (any Veggie & ~Copyable).Type) {
-  generalized(t) // expected-error {{cannot convert value of type '(any Veggie & ~Copyable).Type' to expected argument type 'any Any.Type'}}
+  generalized(t) // expected-error {{argument type 'any Veggie & ~Copyable' does not conform to expected type 'Copyable'}}
 }


### PR DESCRIPTION
- Look through `InstanceType` while attempting to diagnose conformance failures

    Matching existential types could introduce `InstanceType` element
    at the end of the locator path, it's okay to look through them to
    diagnose the underlying issue.

- Diagnose an attempt to match non-existential type to an existential one

Resolves: https://github.com/swiftlang/swift/issues/83991
Resolves: rdar://159401910

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
