### PR TITLE
FreeBSD: Static libxml2 build

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1357,6 +1357,7 @@ llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 #===------------------------------------------------------------------------===#
 [preset: mixin_freebsd_package_products]
 
+static-libxml2
 foundation
 indexstore-db
 libdispatch


### PR DESCRIPTION
FreeBSD does not maintain a stable libxml2 version within a given OS release. The library is not ABI stable so when users update their packages, they are susceptible to seeing the compilers fail to launch. By bundling it, we are able to mitigate the issue.