### PR TITLE
Move `span` to conditional header in libstdc++ module map

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1108,6 +1108,9 @@ public:
   /// Check if this is a std.string type from C++.
   bool isCxxString();
 
+  /// Check if this is the type Unicode.Scalar from the Swift standard library.
+  bool isUnicodeScalar();
+
   /// Check if this type is known to represent key paths.
   bool isKnownKeyPathType();
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1307,6 +1307,25 @@ bool TypeBase::isCxxString() {
          ctx.Id_basic_string.is(clangDecl->getName());
 }
 
+bool TypeBase::isUnicodeScalar() {
+  if (!is<StructType>())
+    return false;
+  const auto *structType = castTo<StructType>();
+  if (!structType->getDecl()->getName().is("Scalar"))
+    return false;
+
+  Type parent = structType->getParent();
+  if (!parent->is<EnumType>())
+    return false;
+  const auto enumDecl = parent->castTo<EnumType>()->getDecl();
+  if (!enumDecl->getName().is("Unicode"))
+    return false;
+  const auto *parentDC = enumDecl->getDeclContext();
+  if (!parentDC->isModuleScopeContext() && parentDC->getParentModule()->isStdlibModule())
+    return false;
+  return true;
+}
+
 bool TypeBase::isKnownKeyPathType() {
   return isKeyPath() || isWritableKeyPath() || isReferenceWritableKeyPath() ||
          isPartialKeyPath() || isAnyKeyPath();

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -416,7 +416,21 @@ static void getLibStdCxxFileMapping(
       "bits/unique_lock.h", "bits/unique_ptr.h", "bits/unordered_map.h",
       "bits/unordered_set.h", "bits/uses_allocator.h",
       "bits/uses_allocator_args.h", "bits/valarray_after.h",
-      "bits/valarray_array.h", "bits/valarray_before.h"};
+      "bits/valarray_array.h", "bits/valarray_before.h", "bits/version.h",
+      // C++20 and newer:
+      "barrier",
+      "compare",
+      "concepts",
+      "format",
+      "latch",
+      "numbers",
+      "ranges",
+      "semaphore",
+      "source_location",
+      "span",
+      "stop_token",
+      "syncstream",
+    };
   std::string additionalHeaderDirectives;
   llvm::raw_string_ostream os(additionalHeaderDirectives);
   os << contents.substr(0, headerInjectionPoint);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4675,8 +4675,14 @@ namespace {
           // Do not attempts to import ObjCBool values, for similar reasons.
           bool isObjCBool = (type && type->isObjCBool()) ||
                             (type && synthesizer.isObjCBool(type));
+          // Do not attempts to import CWideChar (wchar_t) values. CWideChar is
+          // a typealias for Unicode.Scalar, which does not
+          // implement _ExpressibleByBuiltinIntegerLiteral.
+          // FIXME: import using _ExpressibleByUnicodeScalarLiteral.
+          bool isUnicodeScalar = (type && type->isUnicodeScalar()) ||
+                                 (type && synthesizer.isUnicodeScalar(type));
 
-          if (type && !isCGFloat && !isObjCBool) {
+          if (type && !isCGFloat && !isObjCBool && !isUnicodeScalar) {
             auto convertKind = ConstantConvertKind::None;
             // Request conversions on enums, and swift_wrapper((enum/struct))
             // types

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -219,6 +219,16 @@ bool SwiftDeclSynthesizer::isObjCBool(Type type) {
   return importTy->isObjCBool();
 }
 
+bool SwiftDeclSynthesizer::isUnicodeScalar(Type type) {
+  auto found = ImporterImpl.RawTypes.find(type->getAnyNominal());
+  if (found == ImporterImpl.RawTypes.end()) {
+    return false;
+  }
+
+  Type importTy = found->second;
+  return importTy->isUnicodeScalar();
+}
+
 ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
                                                 DeclContext *dc, Type type,
                                                 const clang::APValue &value,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -356,6 +356,8 @@ public:
 
   bool isObjCBool(Type type);
 
+  bool isUnicodeScalar(Type type);
+
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 

--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
@@ -42,7 +42,6 @@ module std {
   header "ostream"
   header "queue"
   header "set"
-  header "span"
   header "sstream"
   header "stack"
   header "stdexcept"

--- a/test/Interop/C/chars/Inputs/import-cchar-types.h
+++ b/test/Interop/C/chars/Inputs/import-cchar-types.h
@@ -6,6 +6,10 @@
 extern char a_char;
 extern wchar_t a_wchar;
 
+// This case is a regression test for a crash when importing constant initializers for wchar_t,
+// since Unicode.Scalar cannot be initialized with integer literals.
+const wchar_t an_initialized_wchar = 2;
+
 #if __cplusplus
 extern char8_t small_char;
 #endif

--- a/test/Interop/C/chars/import-cchar-types.swift
+++ b/test/Interop/C/chars/import-cchar-types.swift
@@ -3,5 +3,6 @@
 
 // CHECK: var a_char: CChar
 // CHECK: var a_wchar: wchar_t
+// CHECK: var an_initialized_wchar: wchar_t { get }
 
 // CHECK-CXX: var small_char: UInt8


### PR DESCRIPTION
`span` is not available in all versions of libstd++, so make it a conditional header. Also adds other missing c++20 headers.

Fixing this triggered an assert when importing a constant initialized `wchar_t` variable, so that is also fixed. The reason is that `wchar_t` is mapped to `Unicode.Scalar`, which cannot be directly initialized by integer literals in Swift, triggering an assert when looking up the protocol conformance for `_ExpressibleByBuiltinIntegerLiteral`.

rdar://162074714
rdar://161999183