### PR TITLE
[cxx-interop] Avoid crashing upon invalid function template instantiation

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -616,6 +616,9 @@ namespace swift {
 
     /// Don't emit any warnings
     bool suppressWarnings = false;
+
+    /// Don't emit any notes
+    bool suppressNotes = false;
     
     /// Don't emit any remarks
     bool suppressRemarks = false;
@@ -663,6 +666,10 @@ namespace swift {
     void setSuppressWarnings(bool val) { suppressWarnings = val; }
     bool getSuppressWarnings() const { return suppressWarnings; }
     
+    /// Whether to skip emitting notes
+    void setSuppressNotes(bool val) { suppressNotes = val; }
+    bool getSuppressNotes() const { return suppressNotes; }
+
     /// Whether to skip emitting remarks
     void setSuppressRemarks(bool val) { suppressRemarks = val; }
     bool getSuppressRemarks() const { return suppressRemarks; }
@@ -708,6 +715,7 @@ namespace swift {
     void swap(DiagnosticState &other) {
       std::swap(showDiagnosticsAfterFatalError, other.showDiagnosticsAfterFatalError);
       std::swap(suppressWarnings, other.suppressWarnings);
+      std::swap(suppressNotes, other.suppressNotes);
       std::swap(suppressRemarks, other.suppressRemarks);
       std::swap(warningsAsErrors, other.warningsAsErrors);
       std::swap(fatalErrorOccurred, other.fatalErrorOccurred);
@@ -902,6 +910,12 @@ namespace swift {
     void setSuppressWarnings(bool val) { state.setSuppressWarnings(val); }
     bool getSuppressWarnings() const {
       return state.getSuppressWarnings();
+    }
+
+    /// Whether to skip emitting notes
+    void setSuppressNotes(bool val) { state.setSuppressNotes(val); }
+    bool getSuppressNotes() const {
+      return state.getSuppressNotes();
     }
 
     /// Whether to skip emitting remarks

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -58,6 +58,9 @@ public:
   /// Suppress all warnings
   bool SuppressWarnings = false;
   
+  /// Suppress all notes
+  bool SuppressNotes = false;
+
   /// Suppress all remarks
   bool SuppressRemarks = false;
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -643,7 +643,7 @@ private:
                                      const LangOptions &LangOpts,
                                      const ClangImporterOptions &clangImporterOpts,
                                      const CASOptions &casOpts,
-                                     bool suppressRemarks);
+                                     bool suppressNotes, bool suppressRemarks);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
                                            DiagnosticEngine &subInstanceDiags,
                                            SwiftInterfaceInfo &interfaceInfo,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -929,6 +929,10 @@ def Wwarning : Separate<["-"], "Wwarning">,
   MetaVarName<"<diagnostic_group>">,
   HelpText<"Treat this warning group as warning">;
 
+def suppress_notes : Flag<["-"], "suppress-notes">,
+  Flags<[FrontendOption]>,
+  HelpText<"Suppress all notes">;
+
 def suppress_remarks : Flag<["-"], "suppress-remarks">,
   Flags<[FrontendOption]>,
   HelpText<"Suppress all remarks">;

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1345,6 +1345,11 @@ DiagnosticState::determineBehavior(const Diagnostic &diag) const {
     if (suppressWarnings)
       lvl = DiagnosticBehavior::Ignore;
   }
+
+  if (lvl == DiagnosticBehavior::Note) {
+    if (suppressNotes)
+      lvl = DiagnosticBehavior::Ignore;
+  }
   
   if (lvl == DiagnosticBehavior::Remark) {
     if (suppressRemarks)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2652,6 +2652,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   }
 
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
+  Opts.SuppressNotes |= Args.hasArg(OPT_suppress_notes);
   Opts.SuppressRemarks |= Args.hasArg(OPT_suppress_remarks);
   for (const Arg *arg : Args.filtered(OPT_warning_treating_Group)) {
     Opts.WarningsAsErrorsRules.push_back([&] {
@@ -2731,6 +2732,9 @@ static void configureDiagnosticEngine(
   }
   if (Options.SuppressWarnings) {
     Diagnostics.setSuppressWarnings(true);
+  }
+  if (Options.SuppressNotes) {
+    Diagnostics.setSuppressNotes(true);
   }
   if (Options.SuppressRemarks) {
     Diagnostics.setSuppressRemarks(true);

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1663,7 +1663,7 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     FrontendOptions::ActionType requestedAction,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
     const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
-    bool suppressRemarks) {
+    bool suppressNotes, bool suppressRemarks) {
   GenericArgs.push_back("-frontend");
   // Start with a genericSubInvocation that copies various state from our
   // invoking ASTContext.
@@ -1751,6 +1751,12 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   // user is not in a position to address them.
   genericSubInvocation.getDiagnosticOptions().SuppressWarnings = true;
   GenericArgs.push_back("-suppress-warnings");
+
+  // Inherit the parent invocation's setting on whether to suppress remarks
+  if (suppressNotes) {
+    genericSubInvocation.getDiagnosticOptions().SuppressNotes = true;
+    GenericArgs.push_back("-suppress-notes");
+  }
 
   // Inherit the parent invocation's setting on whether to suppress remarks
   if (suppressRemarks) {
@@ -1863,6 +1869,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   genericSubInvocation.setMainExecutablePath(LoaderOpts.mainExecutablePath);
   inheritOptionsForBuildingInterface(LoaderOpts.requestedAction, searchPathOpts,
                                      langOpts, clangImporterOpts, casOpts,
+                                     Diags->getSuppressNotes(),
                                      Diags->getSuppressRemarks());
   // Configure front-end input.
   auto &SubFEOpts = genericSubInvocation.getFrontendOptions();

--- a/test/Interop/Cxx/templates/static-cast-typecheck.swift
+++ b/test/Interop/Cxx/templates/static-cast-typecheck.swift
@@ -1,0 +1,44 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks -suppress-notes \
+// RUN:     -cxx-interoperability-mode=default \
+// RUN:     -I %t%{fs-sep}Inputs %t%{fs-sep}main.swift \
+// RUN:     -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}header.h
+
+//--- Inputs/module.modulemap
+module CxxHeader {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/header.h
+#pragma once
+
+// TODO: the following diagnostics should be moved to main.swift at the call site
+//       that triggers the instantiation
+// expected-error@+4 {{could not substitute parameters for C++ function template 'cxxCast': BaseT, UnrelatedT}}
+// expected-error@+3 {{could not substitute parameters for C++ function template 'cxxCast': BaseT, SubClassT}}
+// expected-error@+2 {{could not substitute parameters for C++ function template 'cxxCast': BaseT, SubProtectedT}}
+// expected-error@+1 {{could not substitute parameters for C++ function template 'cxxCast': BaseT, SubPrivateT}}
+template <class O, class I> O cxxCast(I i) { return static_cast<O>(i); }
+// expected-error@-1 {{cannot cast 'const SubPrivateT' to its private base class 'const BaseT'}}
+// expected-error@-2 {{cannot cast 'const SubProtectedT' to its protected base class 'const BaseT'}}
+// expected-error@-3 {{cannot cast 'const SubClassT' to its private base class 'const BaseT'}}
+// expected-error@-4 {{no matching conversion for static_cast from 'UnrelatedT' to 'BaseT'}}
+
+struct BaseT { };
+
+struct SubT          : BaseT            { }; // publicly inherit from BaseT
+struct SubPrivateT   : private BaseT    { }; // privately inherit from BaseT
+struct SubProtectedT : protected BaseT  { }; // privately inherit from BaseT
+class  SubClassT     : BaseT            { }; // privately inherit from BaseT
+struct UnrelatedT                       { }; // does not inherit from BaseT
+
+
+//--- main.swift
+import CxxHeader
+
+let _: BaseT = cxxCast(SubT())          // valid:   upcast to public base
+let _: BaseT = cxxCast(SubPrivateT())   // invalid: upcast to non-public base
+let _: BaseT = cxxCast(SubProtectedT()) // invalid: upcast to non-public base
+let _: BaseT = cxxCast(SubClassT())     // invalid: upcast to non-public base
+let _: BaseT = cxxCast(UnrelatedT())    // invalid: cast to unrelated type


### PR DESCRIPTION
We were previously not handling cases where the instantiation of the
**declaration** of a function template is valid, but the instantiation
of its **definition** is invalid (e.g., because it contains an invalid
static_cast() or static_assert()). This patch teaches ClangImporter to
correctly diagnose these as compiler errors, rather than simply
crashing.

rdar://137456897

Builds on #84723