### PR TITLE
[DebugInfo] Use the human-readable name as name of FwdDecls of unused structs

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2694,8 +2694,9 @@ private:
       // declarations may not have a unique ID to avoid a forward declaration
       // winning over a full definition.
       auto *FwdDecl = DBuilder.createReplaceableCompositeType(
-          llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, 0, 0,
-          llvm::dwarf::DW_LANG_Swift);
+          llvm::dwarf::DW_TAG_structure_type, Name, Scope, 0, 0,
+          llvm::dwarf::DW_LANG_Swift, 0, 0, llvm::DINode::FlagFwdDecl,
+          MangledName);
       FwdDeclTypes.emplace_back(
           std::piecewise_construct, std::make_tuple(MangledName),
           std::make_tuple(static_cast<llvm::Metadata *>(FwdDecl)));

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -31,12 +31,11 @@ public let inner = S2<Double>.Inner(t:4.2)
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", 
 // CHECK-SAME: size: 64, {{.*}}identifier: "$s18BoundGenericStruct2S2V5InnerVySd_GD")
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
-// CHECK-SAME: flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift)
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, {{.*}}flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift, {{.*}}identifier: "$s18BoundGenericStruct2S2VyxGD"
 
 // DWARF-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2V5InnerVySd_GD", scope: ![[SCOPE1:[0-9]+]], {{.*}}flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift, templateParams: ![[PARAMS2:[0-9]+]])
 
-// DWARF-DAG: ![[SCOPE1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
+// DWARF-DAG: ![[SCOPE1]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}identifier: "$s18BoundGenericStruct2S2VyxGD"
 
 // DWARF-DAG: ![[PARAMS2]] = !{![[PARAMS3:[0-9]+]]}
 // DWARF-DAG: ![[PARAMS3]] = !DITemplateTypeParameter(type: ![[PARAMS4:[0-9]+]])

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -3,7 +3,7 @@ public enum E : Error { case Err }
 
 // Function throws.
 public func throwError() throws { throw E.Err }
-// CHECK: !DISubprogram(name: "throwError", {{.*}}thrownTypes: ![[THROWN:.*]])
+// CHECK-DAG: !DISubprogram(name: "throwError", {{.*}}thrownTypes: ![[THROWN:.*]])
 // CHECK-DAG: ![[THROWN]] = !{![[ERROR:[0-9]+]]}
 // CHECK-DAG: ![[ERROR]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Error"
 

--- a/test/DebugInfo/NestedTypes.swift
+++ b/test/DebugInfo/NestedTypes.swift
@@ -32,3 +32,11 @@ public let d = D<Int>(v: D.V(obj: 1), u: 2)
 // CHECK: ![[D:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "D"
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "V", scope: ![[D]],
 
+public struct Unused {
+  public struct W {}
+}
+
+public let w = Unused.W()
+
+// CHECK-DAG: ![[Unused:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Unused"
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "W", scope: ![[Unused]],

--- a/test/DebugInfo/NestedTypes.swift
+++ b/test/DebugInfo/NestedTypes.swift
@@ -16,3 +16,19 @@ public let e : Enum = .WithClass(C())
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "WithStruct",
 // CHECK-SAME:           size: 128)
 
+public struct D<U> {
+  var v : V
+  let u: U
+}
+
+extension D {
+  struct V {
+    internal var obj: Int
+  }
+}
+
+public let d = D<Int>(v: D.V(obj: 1), u: 2)
+
+// CHECK: ![[D:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "D"
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "V", scope: ![[D]],
+

--- a/test/DebugInfo/generic_arg4.swift
+++ b/test/DebugInfo/generic_arg4.swift
@@ -9,7 +9,7 @@ public struct Q<T> {
 // CHECK-SAME:       ![[ARG:.*]], !DIExpression()
 // CHECK: store ptr %0, ptr %[[ALLOCA]], align
 // No deref here: the array argument is passed by value.
-// CHECK: ![[DITY:.*]] = !DICompositeType({{.*}}name: "$sSay12generic_arg41QVyxGGD"
+// CHECK: ![[DITY:.*]] = !DICompositeType({{.*}}identifier: "$sSay12generic_arg41QVyxGGD"
 public func foo<T>(_ arg: [Q<T>]) {
 // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
 // CHECK-SAME:                        line: [[@LINE-2]], type: ![[DITY:.*]])

--- a/test/DebugInfo/generic_arg5.swift
+++ b/test/DebugInfo/generic_arg5.swift
@@ -12,7 +12,7 @@ public func foo<Type>(_ values : [S<Type>])
   // CHECK-SAME:       ![[ARG:[0-9]+]],
   // CHECK-SAME:       !DIExpression(DW_OP_deref)
   // CHECK: store ptr %1, ptr %[[ALLOCA]], align
-  // CHECK-DAG: ![[TYP:[0-9]+]] = !DICompositeType({{.*}}, name: "$s12generic_arg51SVyxGD"
+  // CHECK-DAG: ![[TYP:[0-9]+]] = !DICompositeType({{.*}}, identifier: "$s12generic_arg51SVyxGD"
   // The argument is a by-ref struct and thus needs to be dereferenced.
   // CHECK-DAG: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,{{.*}}line: [[@LINE+6]],{{.*}} type: ![[LET_TYP:[0-9]+]])
   // CHECK-DAG: ![[LET_TYP]] = !DIDerivedType(tag: DW_TAG_const_type,{{.*}} baseType: ![[TYP_CONTAINER:[0-9]+]])

--- a/test/DebugInfo/struct_resilience.swift
+++ b/test/DebugInfo/struct_resilience.swift
@@ -29,7 +29,7 @@ public func f() {
   // CHECK: store ptr %[[S1]], ptr %[[ADDR]]
 }
 
-// CHECK: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s16resilient_struct4SizeVD",
+// CHECK: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
 // CHECK: ![[LET_TY:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type,
 // CHECK-SAME:                                baseType: ![[TY:[0-9]+]])
 // CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[LET_TY]])

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -120,10 +120,11 @@ public protocol Down {
 }
 
 public typealias DependentAlias<T : Up> = T.A.A
+// CHECK-DAG: ![[DEPENDENTALIAS:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "DependentAlias", {{.*}} baseType: ![[INTTYPE]])
 
 extension Up where A.A == Int {
   public func foo() {
-    // CHECK-DAG: !DILocalVariable(name: "gg",{{.*}} type: ![[INTTYPE]]
+    // CHECK-DAG: !DILocalVariable(name: "gg",{{.*}} type: ![[DEPENDENTALIAS]]
     var gg: DependentAlias<Self> = 123
   }
 }


### PR DESCRIPTION
Use the human-readable name as name of FwdDecls of unused structs.

rdar://162080220
