### PR TITLE
[concurrency] Import getters with completion handlers as nonisolated(nonsending).

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6317,14 +6317,9 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
 
   // Asynchronous variants for functions imported from ObjC are
   // `nonisolated(nonsending)` by default.
-  if (value->hasClangNode()) {
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(value)) {
-      if (!isa<ProtocolDecl>(AFD->getDeclContext()) &&
-          AFD->getForeignAsyncConvention()) {
-        return {
-            {ActorIsolation::forCallerIsolationInheriting(), {}}, nullptr, {}};
-      }
-    }
+  if (value->hasClangNode() && value->isAsync() &&
+      !isa<ProtocolDecl>(value->getDeclContext())) {
+    return {{ActorIsolation::forCallerIsolationInheriting(), {}}, nullptr, {}};
   }
 
   // We did not find anything special, return unspecified.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -404,3 +404,9 @@ extension CoffeeDelegate  {
         return await self.icedMochaServiceGenerateMocha!(NSObject())
     }
 }
+
+@MainActor
+func testGetSendableClasses() async {
+  let x = ImportObjCAsyncGetter()
+  _ = await x.sendableClasses
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -11,6 +11,7 @@
   #define NONSENDABLE __attribute__((__swift_attr__("@_nonSendable")))
   #define ASSUME_NONSENDABLE_BEGIN _Pragma("clang attribute ASSUME_NONSENDABLE.push (__attribute__((swift_attr(\"@_nonSendable(_assumed)\"))), apply_to = any(objc_interface, record, enum))")
   #define ASSUME_NONSENDABLE_END _Pragma("clang attribute ASSUME_NONSENDABLE.pop")
+  #define ASYNC_NAME(NAME) __attribute__((swift_async_name(#NAME)))
 #else
   // If we take this #else, we should see minor failures of some subtests,
   // but not systematic failures of everything that uses this header.
@@ -18,6 +19,7 @@
   #define NONSENDABLE
   #define ASSUME_NONSENDABLE_BEGIN
   #define ASSUME_NONSENDABLE_END
+  #define ASYNC_NAME(NAME)
 #endif
 
 #define NS_ENUM(_type, _name) enum _name : _type _name; \
@@ -379,6 +381,15 @@ MAIN_ACTOR
 
 @protocol FailableFloatLoader
 - (void)loadFloatOrThrowWithCompletionHandler:(void (^)(float, NSError* __nullable)) completionHandler;
+@end
+
+NONSENDABLE
+@interface ImportObjCAsyncGetter : NSObject
+
+- (void)getSendableClassesWithCompletionHandler:
+    (void (^SENDABLE)(NSArray<SendableClass *> *myClasses))handler
+    ASYNC_NAME(getter:sendableClasses());
+
 @end
 
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Specifically, this means importing getters defined via swift_async_name. This just ensures that they are treated just like any other imported objc async function with completion handler.

rdar://156985950

