### PR TITLE
[CSSimplify] Avoid simplifying dependent members until pack expansion…

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -850,12 +850,11 @@ public:
   /// type variables referenced by this type.
   void getTypeVariables(SmallPtrSetImpl<TypeVariableType *> &typeVariables);
 
-private:
+public:
   /// If the receiver is a `DependentMemberType`, returns its root. Otherwise,
   /// returns the receiver.
   Type getDependentMemberRoot();
 
-public:
   /// Determine whether this type is a type parameter, which is either a
   /// GenericTypeParamType or a DependentMemberType.
   ///

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -360,7 +360,7 @@ func test_pack_expansion_specialization(tuple: (Int, String, Float)) {
 }
 
 // rdar://107280056 - "Ambiguous without more context" with opaque return type + variadics
-protocol Q {
+protocol Q<B> {
   associatedtype B
 }
 
@@ -813,5 +813,23 @@ func testPackToScalarShortFormConstructor() {
   // Make sure we diagnose.
   func foo<each T>(_ xs: repeat each T) {
     S(repeat each xs) // expected-error {{cannot pass value pack expansion to non-pack parameter of type 'Int'}}
+  }
+}
+
+
+func test_dependent_members() {
+  struct Variadic<each T>: Q {
+    typealias B = (repeat (each T)?)
+
+    init(_: repeat each T) {}
+    static func f(_: repeat each T) -> Self {}
+  }
+
+  func test_init<C1, C2>(_ c1: C1, _ c2: C2) -> some Q<(C1?, C2?)> {
+    return Variadic(c1, c2) // Ok
+  }
+
+  func test_static<C1, C2>(_ c1: C1, _ c2: C2) -> some Q<(C1?, C2?)> {
+    return Variadic.f(c1, c2) // Ok
   }
 }


### PR DESCRIPTION
…s in the based are bound

Dependent members cannot be simplified if base type contains unresolved pack expansion type variables because they don't give enough information to substitution logic to form a correct type. For example:

```
protocol P { associatedtype V }
struct S<each T> : P { typealias V = (repeat (each T)?) }
```

If pack expansion is represented as `$T1` and its pattern is `$T2`, a reference to `V` would get a type `S<Pack{$T}>.V` and simplified version would be `Optional<Pack{$T1}>` instead of `Pack{repeat Optional<$T2>}` because `$T1` is treated as a substitution for `each T` until bound.

Resolves: rdar://161207705

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
