### PR TITLE
RequirementMachine: Diagnose unsupported value generic parameter definitions properly

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8592,8 +8592,8 @@ ERROR(value_type_used_in_type_parameter,none,
       "cannot use value type %0 for generic argument %1", (Type, Type))
 ERROR(invalid_value_type_value_generic,none,
       "%0 is not a supported value type for %1", (Type, Type))
-ERROR(invalid_value_generic_conformance,none,
-      "value generic type %0 cannot conform to protocol %1", (Type, Type))
+ERROR(invalid_value_generic_constraint,none,
+      "cannot use type constraint with generic value parameter %0", (Type))
 ERROR(invalid_value_generic_same_type,none,
       "cannot constrain value parameter %0 to be type %1", (Type, Type))
 ERROR(integer_type_not_accepted,none,

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -247,14 +247,14 @@ bool swift::rewriting::diagnoseRequirementErrors(
       break;
     }
 
-    case RequirementError::Kind::InvalidValueGenericConformance: {
+    case RequirementError::Kind::InvalidValueGenericConstraint: {
       auto req = error.getRequirement();
 
       if (req.hasError())
         break;
 
-      ctx.Diags.diagnose(loc, diag::invalid_value_generic_conformance,
-                         req.getFirstType(), req.getSecondType());
+      ctx.Diags.diagnose(loc, diag::invalid_value_generic_constraint,
+                         req.getFirstType());
       diagnosedError = true;
       break;
     }

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -59,9 +59,9 @@ struct RequirementError {
     /// An unexpected value type used in a value generic,
     /// e.g. 'let N: String'.
     InvalidValueGenericType,
-    /// A value generic type was used to conform to a protocol,
-    /// e.g. 'where N: P' where N == 'let N: Int' and P is some protocol.
-    InvalidValueGenericConformance,
+    /// A generic value parameter was used as the subject of a subtype
+    /// constraint, e.g. `N: X` in `struct S<let N: Int> where N: X`.
+    InvalidValueGenericConstraint,
     /// A value generic type was used to same-type to an unrelated type,
     /// e.g. 'where N == Int' where N == 'let N: Int'.
     InvalidValueGenericSameType,
@@ -176,9 +176,12 @@ public:
     return {Kind::InvalidValueGenericType, requirement, loc};
   }
 
-  static RequirementError forInvalidValueGenericConformance(Requirement req,
-                                                            SourceLoc loc) {
-    return {Kind::InvalidValueGenericConformance, req, loc};
+  static RequirementError forInvalidValueGenericConstraint(Type subjectType,
+                                                           Type constraint,
+                                                           SourceLoc loc) {
+    Requirement requirement(RequirementKind::Conformance, subjectType,
+                            constraint);
+    return {Kind::InvalidValueGenericConstraint, requirement, loc};
   }
 
   static RequirementError forInvalidValueGenericSameType(Type subjectType,

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -55,7 +55,8 @@ void realizeTypeRequirement(DeclContext *dc,
                             Type constraintType,
                             SourceLoc loc,
                             SmallVectorImpl<StructuralRequirement> &result,
-                            SmallVectorImpl<RequirementError> &errors);
+                            SmallVectorImpl<RequirementError> &errors,
+                            bool isFromInheritanceClause);
 
 void realizeRequirement(DeclContext *dc,
                         Requirement req, RequirementRepr *reqRepr,

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 protocol P {}
+protocol Q {}
+class Class {}
 
 func invalid<let N>() { // expected-error {{value generic 'N' must have an explicit value type declared}}
                         // expected-error@-1 {{generic parameter 'N' is not used in function signature}}
@@ -37,8 +39,6 @@ struct A<let N: Int> {
     fatalError()
   }
 }
-
-extension A where N: P {} // expected-error {{value generic type 'N' cannot conform to protocol 'P'}}
 
 extension A where N == Int {} // expected-error {{cannot constrain value parameter 'N' to be type 'Int'}}
 
@@ -77,7 +77,38 @@ func m(_: GenericWithIntParam<Int, 123>) {} // OK
 
 typealias One = 1 // expected-error {{expected type in type alias declaration}}
 
-struct B<let N: UInt8> {} // expected-error {{'UInt8' is not a supported value type for 'N'}}
+// Unsupported type in value type parameter definition.
+do {
+  struct S1<let N: UInt8> {}
+  // expected-error@-1:20 {{'UInt8' is not a supported value type for 'N'}}
+  struct S2<let N: Any> {}
+  // expected-error@-1:20 {{'Any' is not a supported value type for 'N'}}
+  struct S3<let N: AnyObject> {}
+  // expected-error@-1:20 {{'AnyObject' is not a supported value type for 'N'}}
+  struct S4<let N: Class> {}
+  // expected-error@-1:20 {{'Class' is not a supported value type for 'N'}}
+  struct S5<let N: P> {}
+  // expected-error@-1:20 {{'P' is not a supported value type for 'N'}}
+  struct S6<let N: P & Q> {}
+  // expected-error@-1:20 {{'P & Q' is not a supported value type for 'N'}}
+  struct S7<let N: ~Copyable> {}
+  // expected-error@-1:20 {{'~Copyable' is not a supported value type for 'N'}}
+}
+
+// Subtype constraint on value type parameter.
+
+struct S1<let x: Int> where x: Class, x: P, x: P & Q, x: Int, x: ~Copyable {}
+// expected-error@-1:30 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-2:40 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-3:46 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-4:56 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-5:64 {{cannot use type constraint with generic value parameter 'x'}}
+extension S1 where x: Class, x: P, x: P & Q, x: Int, x: ~Copyable {}
+// expected-error@-1:21 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-2:31 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-3:37 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-4:47 {{cannot use type constraint with generic value parameter 'x'}}
+// expected-error@-5:55 {{cannot use type constraint with generic value parameter 'x'}}
 
 struct C<let N: Int, let M: Int> {}
 

--- a/validation-test/compiler_crashers_2_fixed/43f7a6012f6a255a.swift
+++ b/validation-test/compiler_crashers_2_fixed/43f7a6012f6a255a.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-ir","original":"493cc9db","signature":"(anonymous namespace)::TypeContextDescriptorBuilderBase<(anonymous namespace)::StructContextDescriptorBuilder, swift::StructDecl>::emit()"}
-// RUN: not --crash %target-swift-frontend -emit-ir %s
+// RUN: not %target-swift-frontend -emit-ir %s
 class a<b> {
 }
 @available(SwiftStdlib 6.2, *)


### PR DESCRIPTION
The flow was such that we recorded subtype constraints regardless of the subject type's nature. Extract value generics handling out of the devious `else if` chain, and never record any subtype constraints if the subject type is a non-type parameter.

While we're here, generalize the diagnostic message for user-written subtype constraints on value generic parameters and emit it consistently, not just if the right-hand side contains a protocol type.
