### PR TITLE
fix: make sure rhs is negated in all cases when subtracting two Array.TangentVectors

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -157,7 +157,7 @@ where Element: AdditiveArithmetic & Differentiable {
     rhs: Array.DifferentiableView
   ) -> Array.DifferentiableView {
     if lhs.base.count == 0 {
-      return rhs
+      return Array.DifferentiableView(rhs.base.map { .zero - $0 })
     }
     if rhs.base.count == 0 {
       return lhs

--- a/test/AutoDiff/stdlib/array_differentiation.swift
+++ b/test/AutoDiff/stdlib/array_differentiation.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import _Differentiation
+import StdlibUnittest
+
+var ArrayDifferentiationTests = TestSuite("ArrayDifferentiation")
+
+ArrayDifferentiationTests.test("Array.DifferentiableView+") {
+  let zero1: Array<Float>.DifferentiableView = [0, 0, 0]
+  let zero2: Array<Float>.DifferentiableView = .zero
+  let a: Array<Float>.DifferentiableView = [1, 2, 3]
+  
+  expectEqual(a + a, [2, 4, 6])
+  
+  expectEqual(a + zero1, [1, 2, 3])
+  expectEqual(zero1 + a, [1, 2, 3])
+  
+  expectEqual(a + zero2, [1, 2, 3])
+  expectEqual(zero2 + a, [1, 2, 3])
+}
+
+ArrayDifferentiationTests.test("Array.DifferentiableView-") {
+  let zero1: Array<Float>.DifferentiableView = [0, 0, 0]
+  let zero2: Array<Float>.DifferentiableView = .zero
+  let a: Array<Float>.DifferentiableView = [1, 2, 3]
+  
+  expectEqual(a - a, [0, 0, 0])
+  
+  expectEqual(a - zero1, [1, 2, 3])
+  expectEqual(zero1 - a, [-1, -2, -3])
+  
+  expectEqual(a - zero2, [1, 2, 3])
+  expectEqual(zero2 - a, [-1, -2, -3])
+}
+
+runAllTests()


### PR DESCRIPTION
`Array.TangentVector` conformance to `AdditiveArithmetic` was incorrect as the returned values weren't negated if the lhs was an empty vector (considered to be a zero tangentvector)

The problem can be identified by running the following test:
```swift
@Test
func checkIncorrectTangentImplementation() {

    let a: [Double].DifferentiableView = [1, 2, 3]
    
    let zeroVector1: [Double].DifferentiableView = [0, 0, 0]
    let zeroVector2: [Double].DifferentiableView = .zero
    
    #expect(zeroVector1 - a == [-1, -2, -3]) // passes
    #expect(zeroVector2 - a == [-1.0, -2.0, -3.0]) // Expectation failed: (zeroVector2 - a → [1.0, 2.0, 3.0]) == [-1.0, -2.0, -3.0]
}
```

I'm a little surprised we haven't caught this yet, probably because in actual use of `DifferentiableView` you rarely end up in a path where the left hand side is still a zero vector as per the convention that an empty `DifferentiableView` is a zero tangentvector of arbitrary length. 