### PR TITLE
LifetimeDependenceDefUseWalker: store to unsafeMutableAddress

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -147,14 +147,7 @@ extension TypeProperties {
   public var isDynamicSelf: Bool { rawType.bridged.isDynamicSelf()}
   public var isBox: Bool { rawType.bridged.isBox() }
 
-  /// True if this is the type which represents an integer literal used in a type position.
-  /// For example `N` in `struct T<let N: Int> {}`
-  public var isInteger: Bool { rawType.bridged.isInteger() }
-
   public var canBeClass: Type.TraitResult { rawType.bridged.canBeClass().result }
-
-  /// True if this the nominal type `Swift.Optional`.
-  public var isOptional: Bool { rawType.bridged.isOptional() }
 
   /// True if this type is a value type (struct/enum) that defines a `deinit`.
   public var isValueTypeWithDeinit: Bool {
@@ -162,6 +155,34 @@ extension TypeProperties {
       return true
     }
     return false
+  }
+
+  //===--------------------------------------------------------------------===//
+  //                      Checks for stdlib types
+  //===--------------------------------------------------------------------===//
+
+  /// True if this is the type which represents an integer literal used in a type position.
+  /// For example `N` in `struct T<let N: Int> {}`
+  public var isInteger: Bool { rawType.bridged.isInteger() }
+
+  /// True if this the nominal type `Swift.Optional`.
+  public var isOptional: Bool { rawType.bridged.isOptional() }
+
+  /// A non-nil result type implies isUnsafe[Raw][Mutable]Pointer. A raw
+  /// pointer has a `void` element type.
+  public var unsafePointerElementType: Type? {
+    Type(bridgedOrNil: rawType.bridged.getAnyPointerElementType())
+  }
+
+  public var isAnyUnsafePointer: Bool {
+    unsafePointerElementType != nil
+  }
+
+  public var isAnyUnsafeBufferPointer: Bool {
+    rawType.bridged.isUnsafeBufferPointerType()
+      || rawType.bridged.isUnsafeMutableBufferPointerType()
+      || rawType.bridged.isUnsafeRawBufferPointerType()
+      || rawType.bridged.isUnsafeMutableRawBufferPointerType()
   }
 
   //===--------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -52,6 +52,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var isConvertPointerToPointerArgument: Bool { bridged.isConvertPointerToPointerArgument() }
 
+  public var isAddressor: Bool { bridged.isAddressor() }
+
   public var specializationLevel: Int { bridged.specializationLevel() }
 
   public var isSpecialization: Bool { bridged.isSpecialization() }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -512,6 +512,22 @@ public extension PointerToAddressInst {
     }
     return nil
   }
+
+  // If this address is the result of a call to unsafe[Mutable]Address, return the 'self' operand of the apply. This
+  // represents the base value into which this address projects.
+  func isResultOfUnsafeAddressor() -> Operand? {
+    if isStrict,
+       let extract = pointer as? StructExtractInst,
+       extract.`struct`.type.isAnyUnsafePointer,
+       let addressorApply = extract.`struct` as? ApplyInst,
+       let addressorFunc = addressorApply.referencedFunction,
+       addressorFunc.isAddressor
+    {
+      let selfArgIdx = addressorFunc.selfArgumentIndex!
+      return addressorApply.argumentOperands[selfArgIdx]
+    }
+    return nil
+  }
 }
 
 /// TODO: migrate AccessBase to use this instead of GlobalVariable because many utilities need to get back to a

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2955,6 +2955,11 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isBuiltinFixedWidthInteger(SwiftInt width) const;
   BRIDGED_INLINE bool isOptional() const;
   BRIDGED_INLINE bool isBuiltinType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getAnyPointerElementType() const;
+  BRIDGED_INLINE bool isUnsafeBufferPointerType() const;
+  BRIDGED_INLINE bool isUnsafeMutableBufferPointerType() const;
+  BRIDGED_INLINE bool isUnsafeRawBufferPointerType() const;
+  BRIDGED_INLINE bool isUnsafeMutableRawBufferPointerType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getNominalOrBoundGenericNominal() const;
   BRIDGED_INLINE TraitResult canBeClass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getAnyNominal() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -566,6 +566,26 @@ bool BridgedASTType::isBuiltinType() const {
   return unbridged()->isBuiltinType();
 }
 
+BridgedASTType BridgedASTType::getAnyPointerElementType() const {
+  return {unbridged()->getCanonicalType()->getAnyPointerElementType().getPointer()};
+}
+
+bool BridgedASTType::isUnsafeBufferPointerType() const {
+  return unbridged()->isUnsafeBufferPointer();
+}
+
+bool BridgedASTType::isUnsafeMutableBufferPointerType() const {
+  return unbridged()->isUnsafeMutableBufferPointer();
+}
+
+bool BridgedASTType::isUnsafeRawBufferPointerType() const {
+  return unbridged()->isUnsafeRawBufferPointer();
+}
+
+bool BridgedASTType::isUnsafeMutableRawBufferPointerType() const {
+  return unbridged()->isUnsafeMutableRawBufferPointer();
+}
+
 OptionalBridgedDeclObj BridgedASTType::getNominalOrBoundGenericNominal() const {
   return {unbridged()->getNominalOrBoundGenericNominal()};
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -562,6 +562,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool isSpecialization() const;
   bool isTrapNoReturn() const;
   bool isConvertPointerToPointerArgument() const;
+  bool isAddressor() const;
   bool isAutodiffVJP() const;
   SwiftInt specializationLevel() const;
   SWIFT_IMPORT_UNSAFE BridgedSubstitutionMap getMethodSubstitutions(BridgedSubstitutionMap contextSubs,

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -511,6 +511,13 @@ bool BridgedFunction::isConvertPointerToPointerArgument() const {
   return false;
 }
 
+bool BridgedFunction::isAddressor() const {
+  if (auto declRef = dyn_cast_or_null<AccessorDecl>(getFunction()->getDeclRef().getDecl())) {
+    return declRef->isAnyAddressor();
+  }
+  return false;
+}
+
 bool BridgedFunction::isAutodiffVJP() const {
   return swift::isDifferentiableFuncComponent(
       getFunction(), swift::AutoDiffFunctionComponent::VJP);


### PR DESCRIPTION
- **SwiftCompilerSources: bridge Type.unsafePointerElementType**
  

- **SwiftCompilerSources: bridge Function.isAddressor()**
  

- **LifetimeDependenceDefUseWalker: store to unsafeMutableAddress**
  Handle storing to a mutable property implemented as unsafeMutableAddress. In
  SIL, the stored address comes from pointer_to_address. Recognize the addressor
  pattern and handle the store as if it writes to a regular property of 'self'.
  
  Required for UnsafePointer<~Escapable>.pointee.

Unit tests are PR: https://github.com/swiftlang/swift/pull/84233