### PR TITLE
NFC: CMake: Runtime build housekeeping

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -21,13 +21,9 @@
 
 # TODO:
 # Platform support:
-#   - Work on/Verify cross-compiling
-#   - Work on/Verify Windows and Linux native builds
+#   - Work on/Verify Linux native builds
 # Embedded
 #   -- -Xfrontend -emit-empty-object-file
-# Catalyst Support
-#   -- Will need shadow invocations to generate swiftmodules for Swift parts
-# Install *.abi.json, swiftdoc, and swiftsourceinfo
 
 cmake_minimum_required(VERSION 3.29)
 # TODO before requiring CMake 4.1 or later

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -18,34 +18,34 @@ function(emit_swift_interface target)
   if(NOT module_name)
     set(module_name ${target})
   endif()
+  set(module_directory "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
   # Account for an existing swiftmodule file
   # generated with the previous logic
-  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
-     AND NOT IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
-    message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
-    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  if(EXISTS "${module_directory}" AND NOT IS_DIRECTORY "${module_directory}")
+    message(STATUS "Removing regular file ${module_directory} to support nested swiftmodule generation")
+    file(REMOVE "${module_directory}")
   endif()
   target_compile_options(${target} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
   endif()
-  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+  add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})
   target_sources(${target}
     INTERFACE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>)
+      $<BUILD_INTERFACE:${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface>)
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${module_directory}/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface>)
     if(SwiftCore_VARIANT_MODULE_TRIPLE)
       target_compile_options(${target} PRIVATE
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
     endif()
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -27,9 +27,17 @@ function(emit_swift_interface target)
   endif()
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
+  set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
   endif()
   add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})
@@ -42,10 +50,16 @@ function(emit_swift_interface target)
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftinterface>
       $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${module_directory}/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface>)
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftinterface"
+      "${module_directory}/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface")
     if(SwiftCore_VARIANT_MODULE_TRIPLE)
       target_compile_options(${target} PRIVATE
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface>"
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+      set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+        "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface"
+        "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface")
     endif()
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>

--- a/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
@@ -18,34 +18,34 @@ function(emit_swift_interface target)
   if(NOT module_name)
     set(module_name ${target})
   endif()
+  set(module_directory "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
   # Account for an existing swiftmodule file
   # generated with the previous logic
-  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
-     AND NOT IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
-    message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
-    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  if(EXISTS "${module_directory}" AND NOT IS_DIRECTORY "${module_directory}")
+    message(STATUS "Removing regular file '${module_directory}' to support nested swiftmodule generation")
+    file(REMOVE ${module_directory})
   endif()
   target_compile_options(${target} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>")
   if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule>")
   endif()
-  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
+  add_custom_command(OUTPUT "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})
   target_sources(${target}
     INTERFACE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>)
+      $<BUILD_INTERFACE:${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftOverlay_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface>)
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface>)
     if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
       target_compile_options(${target} PRIVATE
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
     endif()
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>

--- a/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
@@ -27,9 +27,17 @@ function(emit_swift_interface target)
   endif()
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>")
+  set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
+    "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftdoc"
+    "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftsourceinfo")
   if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule"
+      "${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftdoc"
+      "${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
   endif()
   add_custom_command(OUTPUT "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
     DEPENDS ${target})
@@ -42,10 +50,16 @@ function(emit_swift_interface target)
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftinterface>
       $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface>)
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.swiftinterface"
+      "${module_directory}/${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface")
     if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
       target_compile_options(${target} PRIVATE
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface>"
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+    set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+      "${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface"
+      "${module_directory}/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface")
     endif()
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>


### PR DESCRIPTION
Doing some housekeeping and cleanups.

Updating the Todo comments on SwiftCore to be more accurate about where things stand. Really the main thing remaining are the embedded builds.

Then doing some cleanups regarding the swift module emission. The swiftmodule directory was being used in several places so I factored that out into a separate variable to make things a bit more readable. Also added the supplemental module outputs to the list of cleanup files so that running `ninja clean` will work without warning about the swiftmodule directory containing files.