### PR TITLE
[test] Add -verify-ignore-unrelated to a few tests

### DIFF
--- a/test/AssociatedTypeInference/rdar127575477.swift
+++ b/test/AssociatedTypeInference/rdar127575477.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-typecheck-verify-swift
+// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated
 
 // This is highly invalid, so just don't crash.
 

--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension-library %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension-library %s
 
 // REQUIRES: OS=ios
 

--- a/test/ClangImporter/availability_watchos.swift
+++ b/test/ClangImporter/availability_watchos.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules %s
 
 // REQUIRES: OS=watchos
 

--- a/test/Frontend/DiagnosticVerifier/broken-c-module.swift
+++ b/test/Frontend/DiagnosticVerifier/broken-c-module.swift
@@ -3,7 +3,7 @@
 // This needs to be a separate test from verify.swift because compilation will
 // terminate after the failing import statement.
 
-// RUN: not %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
 
 // CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build
 // CHECK: note: diagnostic produced elsewhere: in file included from <module-includes>

--- a/test/Frontend/DiagnosticVerifier/verify.swift
+++ b/test/Frontend/DiagnosticVerifier/verify.swift
@@ -1,6 +1,6 @@
 // Tests for the Swift frontends `-verify` mode.
 
-// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated 2>&1 | %FileCheck %s
 
 // CHECK: [[@LINE+1]]:1: error: unexpected error produced: cannot find 'undefinedFunc' in scope
 undefinedFunc()

--- a/test/Frontend/DiagnosticVerifier/verify2.swift
+++ b/test/Frontend/DiagnosticVerifier/verify2.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck -verify -serialize-diagnostics-path %t/serialized.dia %s 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -verify -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefix CHECK-WARNINGS-AS-ERRORS
+// RUN: not %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -serialize-diagnostics-path %t/serialized.dia %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefix CHECK-WARNINGS-AS-ERRORS
 // RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/serialized.dia
 
 // Wrong message

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 // README: If you just added support for protocol composition to the
 // ClangTypeConverter, please update this test to use a different type that we


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/84685 introduced a new flag `-verify-ignore-unrelated` that was missed from a few tests causing some failures in different CI configurations.

Resolves: rdar://162095011