### PR TITLE
[6.2] [Serialization] Serialize isAddressable on param decls

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4118,6 +4118,7 @@ public:
     bool isCompileTimeLiteral, isConstValue;
     bool isSending;
     bool isCallerIsolated;
+    bool isAddressable;
     uint8_t rawDefaultArg;
     TypeID defaultExprType;
     uint8_t rawDefaultArgIsolation;
@@ -4131,6 +4132,7 @@ public:
                                          isConstValue,
                                          isSending,
                                          isCallerIsolated,
+                                         isAddressable,
                                          rawDefaultArg,
                                          defaultExprType,
                                          rawDefaultArgIsolation,
@@ -4177,6 +4179,7 @@ public:
     param->setConstValue(isConstValue);
     param->setSending(isSending);
     param->setCallerIsolated(isCallerIsolated);
+    param->setAddressable(isAddressable);
 
     // Decode the default argument kind.
     // FIXME: Default argument expression, if available.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 948; // @_expose kind
+const uint16_t SWIFTMODULE_VERSION_MINOR = 949; // serialize param decl isAddressable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1730,6 +1730,7 @@ namespace decls_block {
     BCFixed<1>,              // isConst?
     BCFixed<1>,              // isSending?
     BCFixed<1>,              // isCallerIsolated?
+    BCFixed<1>,              // isAddressable?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type
     ActorIsolationField,     // default argument isolation

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4764,6 +4764,7 @@ public:
         param->isConstVal(),
         param->isSending(),
         param->isCallerIsolated(),
+        param->isAddressable(),
         getRawStableDefaultArgumentKind(argKind),
         S.addTypeRef(defaultExprType),
         getRawStableActorIsolationKind(isolation.getKind()),

--- a/test/Serialization/Inputs/lifetime_dependence.swift
+++ b/test/Serialization/Inputs/lifetime_dependence.swift
@@ -1,0 +1,23 @@
+import Builtin
+
+@frozen
+@safe
+public struct Ref<T: ~Copyable>: Copyable, ~Escapable {
+  @usableFromInline
+  let _pointer: UnsafePointer<T>
+
+  @_lifetime(borrow value)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(_ value: borrowing @_addressable T) {
+    unsafe _pointer = UnsafePointer(Builtin.unprotectedAddressOfBorrow(value))
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript() -> T {
+    @_transparent
+    unsafeAddress {
+      unsafe _pointer
+    }
+  }
+}

--- a/test/Serialization/lifetime_dependence.swift
+++ b/test/Serialization/lifetime_dependence.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-builtin-module -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -module-name lifetime_dependence_ref -o %t %S/Inputs/lifetime_dependence.swift
+// RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_AddressableParameters
+
+import lifetime_dependence_ref
+
+public func foo() {
+  let x = 123
+  let y = Ref(x)
+
+  // CHECK: print
+  print(y[])
+}


### PR DESCRIPTION
* **Explanation**: Resolves a problem with other modules declaring `@_addressable` parameters in some contexts causing clients to fail to deserialize them.
* **Risk**: Low. Only affects the new `@_addressable` attribute which isn't very common at all
* **Original** **PR**: https://github.com/swiftlang/swift/pull/84625
* **Reviewed** **by**: @jckarter 
* **Resolves**: rdar://161844406
* **Tests**: Added a test exercising the exact failure I and others were seeing with this attribute.