### PR TITLE
[6.2] [IRGen] Correctly sext instead of zext for negative integer types

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3598,8 +3598,8 @@ IRGenFunction::emitTypeMetadataRefForLayout(SILType ty,
 
 llvm::Value *IRGenFunction::emitValueGenericRef(CanType type) {
   if (auto integer = type->getAs<IntegerType>()) {
-    return llvm::ConstantInt::get(IGM.SizeTy,
-                    integer->getValue().zextOrTrunc(IGM.SizeTy->getBitWidth()));
+    auto value = integer->getValue().sextOrTrunc(IGM.SizeTy->getBitWidth());
+    return llvm::ConstantInt::get(IGM.SizeTy, value);
   }
 
   return tryGetLocalTypeData(type, LocalTypeDataKind::forValue());

--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -5,7 +5,11 @@
 
 // REQUIRES: executable_test
 
-struct A<let N: Int, let M: Int> {}
+struct A<let N: Int, let M: Int> {
+  func foo() {
+    print("Lower: \(N), Upper: \(M)")
+  }
+}
 
 extension A where N == 2 {
   struct B {}
@@ -36,3 +40,24 @@ let x: A<-5, -5> = getA()
 
 // CHECK: main.A<-5, -5>
 print(_typeName(type(of: x), qualified: true))
+
+// CHECK: Lower: 1, Upper: 8
+A<1, 8>().foo()
+
+// CHECK: Lower: 0, Upper: 8
+A<0, 8>().foo()
+
+// CHECK: Lower: -1, Upper: 8
+A< -1, 8>().foo()
+
+// CHECK: Lower: -2, Upper: 8
+A< -2, 8>().foo()
+
+// CHECK: Lower: -3, Upper: 8
+A< -3, 8>().foo()
+
+// CHECK: Lower: -4, Upper: 8
+A< -4, 8>().foo()
+
+// CHECK: Lower: -5, Upper: 8
+A< -5, 8>().foo()


### PR DESCRIPTION
* **Explanation**: Resolves a problem where IRGen was using zext to get the static value of a compile time integer generic. This caused issues with negative integer generics incorrectly being reported as somewhat random values instead of their desired value. Use sext instead.
* **Risk**: Low. Only affects debugs builds (as far as I'm aware) and negative integer generics should be rare still.
* **Original** **PR**: https://github.com/swiftlang/swift/pull/84655
* **Reviewed** **by**: @slavapestov and @rjmccall 
* **Resolves**: rdar://162147174
* **Tests**: Added a test exercising the exact failure described from the forum post that was failing.