### PR TITLE
Add `REQUIRES: executable_test` to `for-expr.swift`

### DIFF
--- a/test/stmt/for-expr.swift
+++ b/test/stmt/for-expr.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature ForExpressions) | %FileCheck %s
 
 // REQUIRES: swift_feature_ForExpressions
+// REQUIRES: executable_test
 
 func f() -> String {
   for (i, x) in "hello".enumerated() {


### PR DESCRIPTION
The lack of this condition made some jobs fail, e.g. https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/9749

rdar://162140584