### PR TITLE
[Embedded] Prefer linkonce_odr to weak_odr for nonunique definitions

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -930,6 +930,10 @@ public:
   /// function, such as swift_retain.
   bool isSwiftRuntimeFunction() const;
 
+  /// Helper method that determines whether a function with the given name and
+  /// parent module is a Swift runtime function such as swift_retain.
+  static bool isSwiftRuntimeFunction(StringRef name, const ModuleDecl *module);
+
   /// Helper method which returns true if the linkage of the SILFunction
   /// indicates that the object's definition might be required outside the
   /// current SILModule.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1757,5 +1757,12 @@ bool LinkEntity::hasNonUniqueDefinition() const {
     return true;
   }
 
+  // Always treat witness tables as having non-unique definitions.
+  if (getKind() == Kind::ProtocolWitnessTable) {
+    if (auto context = getDeclContextForEmission())
+      if (context->getParentModule()->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+        return true;
+  }
+
   return false;
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -1038,15 +1038,18 @@ bool SILFunction::hasValidLinkageForFragileRef(SerializedKind_t callerSerialized
   return hasPublicOrPackageVisibility(getLinkage(), /*includePackage*/ true);
 }
 
-bool SILFunction::isSwiftRuntimeFunction() const {
-  if (!getName().starts_with("swift_") &&
-      !getName().starts_with("_swift_"))
+bool SILFunction::isSwiftRuntimeFunction(
+    StringRef name, const ModuleDecl *module) {
+  if (!name.starts_with("swift_") && !name.starts_with("_swift_"))
     return false;
 
-  auto module = getParentModule();
   return !module ||
       module->getName().str() == "Swift" ||
       module->getName().str() == "_Concurrency";
+}
+
+bool SILFunction::isSwiftRuntimeFunction() const {
+  return isSwiftRuntimeFunction(getName(), getParentModule());
 }
 
 bool

--- a/test/embedded/linkage/diamond.swift
+++ b/test/embedded/linkage/diamond.swift
@@ -86,6 +86,25 @@ public func getPointOffsets() -> [Int] {
   enumerateByteOffsets(Point.self)
 }
 
+public class PointClass {
+  public var x, y: Int
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+public protocol Reflectable: AnyObject {
+  func reflect()
+}
+
+extension PointClass: Reflectable {
+  public func reflect() {
+    swap(&x, &y)
+  }
+}
+
 //--- ClientA.swift
 import Root
 
@@ -97,6 +116,10 @@ public struct Color {
 
 public func getPointAndColorOffsets() -> [Int] {
   getPointOffsets() + enumerateByteOffsets(Color.self)
+}
+
+public func getReflectableA() -> any AnyObject & Reflectable {
+  return PointClass(x: 5, y: 5)
 }
 
 //--- ClientB.swift
@@ -112,6 +135,10 @@ public func getExtraPoint3DOffsets() -> [Int] {
   return Array(point3DOffsets[pointOffsets.count...])
 }
 
+public func getReflectableB() -> any AnyObject & Reflectable {
+  return PointClass(x: 5, y: 5)
+}
+
 //--- Application.swift
 import ClientA
 import ClientB
@@ -124,6 +151,7 @@ struct Main {
     print(pointAndColorOffsets.count)
     print(extraColor3DOffsets.count)
 
+    let reflected = [getReflectableA(), getReflectableB()]
     // CHECK: DONE
     print("DONE")
   }

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -21,13 +21,13 @@
 
 //--- Library.swift
 
-// LIBRARY-IR: @"$e7Library10PointClassCN" = weak_odr {{.*}}global
+// LIBRARY-IR: @"$e7Library10PointClassCN" = linkonce_odr {{.*}}global
 
 // Never referenced.
-// LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr {{(protected |dllexport )?}}global
+// LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = linkonce_odr {{(protected |dllexport )?}}global
 
 // Note: referenced by swift_allocEmptyBox.
-// LIBRARY-IR: @"$es16_emptyBoxStorageSi_Sitvp" = weak_odr {{(protected |dllexport )?}}global
+// LIBRARY-IR: @"$es16_emptyBoxStorageSi_Sitvp" = linkonce_odr {{(protected |dllexport )?}}global
 
 // LIBRARY-IR-NOT: define {{.*}}@"$e7Library5helloSaySiGyF"()
 public func hello() -> [Int] {

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -21,7 +21,7 @@
 
 //--- Library.swift
 
-// LIBRARY-IR: @"$e7Library10PointClassCN" = weak_odr global
+// LIBRARY-IR: @"$e7Library10PointClassCN" = weak_odr {{.*}}global
 
 // Never referenced.
 // LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr {{(protected |dllexport )?}}global

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -21,6 +21,8 @@
 
 //--- Library.swift
 
+// LIBRARY-IR: @"$e7Library10PointClassCN" = weak_odr global
+
 // Never referenced.
 // LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr {{(protected |dllexport )?}}global
 
@@ -53,6 +55,34 @@ public func unnecessary() -> Int64 { 5 }
 // LIBRARY-IR: define {{.*}} @"$e7Library14unusedYetThere
 @_neverEmitIntoClient
 public func unusedYetThere() -> Int64 { 5 }
+
+public class PointClass {
+  public var x, y: Int
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+public protocol Reflectable: AnyObject {
+  func reflect()
+}
+
+// LIBRARY-IR: define linkonce_odr hidden swiftcc void @"$es4swapyyxz_xztlFSi_Tg5"
+// LIBRARY-IR: define linkonce_odr hidden swiftcc void @"$e7Library10PointClassCAA11ReflectableA2aDP7reflectyyFTW"
+
+extension PointClass: Reflectable {
+  public func reflect() {
+    swap(&x, &y)
+  }
+}
+
+// LIBRARY-IR: define {{.*}} @"$e7Library18createsExistentialAA11Reflectable_pyF"()
+@_neverEmitIntoClient
+public func createsExistential() -> any Reflectable {
+  return PointClass(x: 5, y: 5)
+}
 
 // LIBRARY-IR-NOT: define swiftcc
 // LIBRARY-IR-NOT: define hidden swiftcc


### PR DESCRIPTION
This allows the implementation to drop definitions that it does not need, earlier in the pipeline. We need to exempt Swift runtime functions from this behavior.