### PR TITLE
[DiagnosticVerifier] Fix Twine use after free

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -431,14 +431,15 @@ bool DiagnosticVerifier::verifyUnrelated(
     printDiagnostic(diag);
 
     auto FileName = SM.getIdentifierForBuffer(SM.findBufferContainingLoc(Loc));
-    auto NoteMessage = ("file '" + FileName +
-                        "' is not parsed for 'expected' statements. Use "
-                        "'-verify-additional-file " +
-                        FileName +
-                        "' to enable, or '-verify-ignore-unrelated' to "
-                        "ignore diagnostics in this file");
     auto noteDiag =
-        SM.GetMessage(Loc, llvm::SourceMgr::DK_Note, NoteMessage, {}, {});
+        SM.GetMessage(Loc, llvm::SourceMgr::DK_Note,
+                      ("file '" + FileName +
+                       "' is not parsed for 'expected' statements. Use "
+                       "'-verify-additional-file " +
+                       FileName +
+                       "' to enable, or '-verify-ignore-unrelated' to "
+                       "ignore diagnostics in this file"),
+                      {}, {});
     printDiagnostic(noteDiag);
   }
 

--- a/test/Frontend/DiagnosticVerifier/broken-c-module.swift
+++ b/test/Frontend/DiagnosticVerifier/broken-c-module.swift
@@ -3,9 +3,14 @@
 // This needs to be a separate test from verify.swift because compilation will
 // terminate after the failing import statement.
 
-// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 
-// CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build
+// CHECK: <unknown>:0: error: fatal error encountered while in -verify mode
+// CHECK: [[@LINE+7]]:8: error: unexpected error produced: could not build
+// CHECK: error: unexpected note produced: in file included from <module-includes>:1:
+// CHECK: note: file '<module-includes>' is not parsed for 'expected' statements. Use '-verify-additional-file <module-includes>' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
+// CHECK: error: unexpected error produced: expected function body after function declarator
+// CHECK: note: file '{{.*}}broken_c.h' is not parsed for 'expected' statements. Use '-verify-additional-file {{.*}}broken_c.h' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: note: diagnostic produced elsewhere: in file included from <module-includes>
 // CHECK: broken_c.h:2:11: error: diagnostic produced elsewhere: expected function body after function declarator
 import BrokenCModule

--- a/test/Frontend/DiagnosticVerifier/fixits.swift
+++ b/test/Frontend/DiagnosticVerifier/fixits.swift
@@ -1,10 +1,11 @@
 // Tests for fix-its on `-verify` mode.
 
-// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 
 func labeledFunc(aa: Int, bb: Int) {}
 
 func testNoneMarkerCheck() {
+  // CHECK: [[@LINE+2]]:78: error: expected no fix-its; actual fix-it seen: {{.*}}3-16=unlabeledFunc{{.*}}
   // CHECK: [[@LINE+1]]:87: error: A second {{\{\{}}none}} was found. It may only appear once in an expectation.
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}} {{none}}
 
@@ -197,34 +198,44 @@ func test1Fixits() {
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
 
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{200:15-200:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{201:15-201:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{202:15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{203:15-18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-204:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-205:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-0:15-+0:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15--0:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {+0:15-210:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {+0:15-211:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{+1:15-+1:18=bb}}
               bbx: 1)
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{216:15-+1:18=bb}}
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{217:15-+1:18=bb}}
               bbx: 1)
 
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{62:15-18=aa}}
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-1:15-18=aa}}
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{+0:15--1:18=aa}}
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-+1:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{62:15-+1:18=aa}}
 }
 
+// CHECK: [[@LINE+10]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+9]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+8]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+7]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+6]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+5]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+4]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+3]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+2]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
+// CHECK: [[@LINE+1]]:6: error: unexpected note produced: 'unlabeledFunc' declared here
 func unlabeledFunc(_ aa: Int) {}
 
 func testDefaultedLineNumbers() {

--- a/test/Frontend/DiagnosticVerifier/multiple_prefix_invalid.swift
+++ b/test/Frontend/DiagnosticVerifier/multiple_prefix_invalid.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -verify -verify-additional-prefix first- -verify-additional-prefix first-second- -emit-sil -o /dev/null 2>&1 | %FileCheck %s
+// RUN: not --crash %target-swift-frontend %s -verify -verify-additional-prefix first- -verify-additional-prefix first-second- -emit-sil -o /dev/null 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 
 // This test makes sure that if we add prefixes such that an earlier prefix is a
 // prefix of a later prefix, we crash. We do this since the earlier prefix will
@@ -9,6 +9,10 @@
 // CHECK: Error! Found a verifier diagnostic additional prefix that is a prefix of a later prefix. The later prefix will never be pattern matched!
 // CHECK: First Prefix: first-
 // CHECK: Second Prefix: first-second-
+// CHECK: <unknown>:0: error: fatal error encountered during compilation; please submit a bug report
+// CHECK: <unknown>:0: note: Standard compiler error!
+
+// CHECK: error:
 
 func test() {
 

--- a/test/Frontend/DiagnosticVerifier/verify.swift
+++ b/test/Frontend/DiagnosticVerifier/verify.swift
@@ -1,6 +1,6 @@
 // Tests for the Swift frontends `-verify` mode.
 
-// RUN: not %target-typecheck-verify-swift -verify-ignore-unrelated 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 
 // CHECK: [[@LINE+1]]:1: error: unexpected error produced: cannot find 'undefinedFunc' in scope
 undefinedFunc()
@@ -30,6 +30,8 @@ fn(())    // expected-error {{argument passed to call that takes no arguments}} 
 // CHECK: [[@LINE+1]]:81: error: expected no fix-its; actual fix-it seen: {{[{][{]4-6=[}][}]}}
 fn(())    // expected-error {{argument passed to call that takes no arguments}} {{none}}
 
-// CHECK: [[@LINE+2]]:8: error: unexpected error produced: generic type 'Array' specialized with too many type parameters
-// CHECK: note: diagnostic produced elsewhere: generic struct 'Array' declared here
+// CHECK: [[@LINE+1]]:8: error: unexpected error produced: generic type 'Array' specialized with too many type parameters
 let x: Array<Int, Int>
+// CHECK: error: unexpected note produced: generic struct 'Array' declared here
+// CHECK: note: file 'Swift.Array' is not parsed for 'expected' statements. Use '-verify-additional-file Swift.Array' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
+// CHECK: note: diagnostic produced elsewhere: generic struct 'Array' declared here

--- a/test/Frontend/DiagnosticVerifier/verify2.swift
+++ b/test/Frontend/DiagnosticVerifier/verify2.swift
@@ -1,36 +1,36 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -serialize-diagnostics-path %t/serialized.dia %s 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefix CHECK-WARNINGS-AS-ERRORS
+// RUN: not %target-swift-frontend -typecheck -verify -serialize-diagnostics-path %t/serialized.dia %s 2>&1 | %FileCheck %s --check-prefixes CHECK,CHECK-WARNINGS-AS-WARNINGS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+// RUN: not %target-swift-frontend -typecheck -verify -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefixes CHECK,CHECK-WARNINGS-AS-ERRORS --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
 // RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/serialized.dia
 
 // Wrong message
 let x: Int = "hello, world!" // expected-error {{foo bar baz}}
 // CHECK-NOT: error: cannot convert value of type 'String' to specified type 'Int'
-// CHECK: error: incorrect message found
+// CHECK: [[@LINE-2]]:50: error: incorrect message found
 
 // Wrong column
 let y: Int = "hello, world!" // expected-error@:49 {{cannot convert value of type}}
-// CHECK: message found at column 14 but was expected to appear at column 49
+// CHECK: error: message found at column 14 but was expected to appear at column 49
 
 // Wrong fix-it
 let z: Int = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{3-3=foobarbaz}}
-// CHECK: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36-36= as! Int{{[}][}]}}
+// CHECK: error: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36-36= as! Int{{[}][}]}}
 
 // Expected no fix-it
 let a: Bool = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{none}}
-// CHECK: expected no fix-its; actual fix-it seen: {{[{][{]}}37-37= as! Bool{{[}][}]}}
+// CHECK: error: expected no fix-its; actual fix-it seen: {{[{][{]}}37-37= as! Bool{{[}][}]}}
 
 // Unexpected error
 _ = foo()
-// CHECK: unexpected error produced: cannot find 'foo' in scope
+// CHECK: error: unexpected error produced: cannot find 'foo' in scope
 
 func b() {
   let c = 2
 }
-// CHECK: unexpected warning produced: initialization of immutable value 'c' was never used
-// CHECK-WARNINGS-AS-ERRORS: unexpected error produced: initialization of immutable value 'c' was never used
+// CHECK-WARNINGS-AS-WARNINGS: error: unexpected warning produced: initialization of immutable value 'c' was never used
+// CHECK-WARNINGS-AS-ERRORS: error: unexpected error produced: initialization of immutable value 'c' was never used
 
 typealias Crap = () -> ()
 extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{documentation-file=foo-bar-baz}}
@@ -41,6 +41,10 @@ extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') c
 
 extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{documentation-file=nominal-types,foo-bar-baz}}
 // CHECK: error: expected documentation file not seen; actual documentation file: {{[{][{]}}documentation-file=nominal-types{{[}][}]}}
+
+// CHECK: error: unexpected note produced: 'Bool' declared here
+// CHECK: note: file 'Swift.Bool' is not parsed for 'expected' statements. Use '-verify-additional-file Swift.Bool' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
+// CHECK: note: diagnostic produced elsewhere: 'Bool' declared here
 
 // Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA


### PR DESCRIPTION
`llvm::Twine` is not valid after the end of the statement. Pass it directly as a parameter without storing it in a local variable to prevent UAF. Also updates DiagnosticVerifier tests to capture all relevant output.

rdar://162095046