### PR TITLE
Cherry-pick [6.2] [Swiftify] Add support for free functions imported as instance methods

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -100,6 +100,12 @@ GROUPED_WARNING(clang_ignored_sendable_attr, ClangDeclarationImport, none,
         "cannot be added to it",
         (Type))
 
+GROUPED_WARNING(warn_clang_ignored_bounds_on_self, ClangDeclarationImport, none,
+                "bounds attribute '%0' ignored on parameter mapped to 'self'",
+                (StringRef))
+NOTE(note_swift_name_instance_method, none,
+     "swift_name maps free function to instance method here", ())
+
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -468,7 +468,14 @@ struct FunctionCallBuilder: BoundsCheckedThunkBuilder {
     let functionRef = DeclReferenceExprSyntax(baseName: base.name)
     let args: [ExprSyntax] = base.signature.parameterClause.parameters.enumerated()
       .map { (i: Int, param: FunctionParameterSyntax) in
-        return pointerArgs[i] ?? ExprSyntax("\(param.name)")
+        if let overrideArg = pointerArgs[i] {
+          return overrideArg
+        }
+        if isInout(getParam(base.signature, i).type) {
+          return ExprSyntax("&\(param.name)")
+        } else {
+          return ExprSyntax("\(param.name)")
+        }
       }
     let labels: [TokenSyntax?] = base.signature.parameterClause.parameters.map { param in
       let firstName = param.firstName.trimmed

--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
@@ -42,6 +42,7 @@ module std {
   header "ostream"
   header "queue"
   header "set"
+  header "span"
   header "sstream"
   header "stack"
   header "stdexcept"

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -10,7 +10,7 @@
 //--- test.swift
 import Instance
 
-@available(macOS 13.3.0, *)
+@available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
 func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C/*, b: B, bb: inout B*/) {
   aa.basic(&p)
   aa.bar(&p)

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -11,15 +11,15 @@
 import Instance
 
 @available(macOS 13.3.0, *)
-func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout B) {
+func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C/*, b: B, bb: inout B*/) {
   aa.basic(&p)
   aa.bar(&p)
   a.constSelf(&p)
   a.valSelf(&p)
   let _: MutableSpan<CInt> = a.lifetimeBoundSelf(3)
   c.refSelf(&p)
-  b.nonescaping(&p)
-  let _: MutableSpan<CInt> = bb.nonescapingLifetimebound(73)
+  //b.nonescaping(&p)
+  //let _: MutableSpan<CInt> = bb.nonescapingLifetimebound(73)
 
 #if VERIFY
   aa.countedSelf(&p)
@@ -55,9 +55,11 @@ void refSelf(struct C *c, int * __counted_by(len) p __noescape, int len) __attri
 
 int * __counted_by(len) lifetimeBoundSelf(struct A a __lifetimebound, int len) __attribute__((swift_name("A.lifetimeBoundSelf(self:_:)")));
 
-void nonescaping(const struct B *d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("B.nonescaping(self:_:_:)")));
+//void nonescaping(const struct B *d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("B.nonescaping(self:_:_:)")));
 
-int * __counted_by(len) nonescapingLifetimebound(struct B *d __lifetimebound, int len) __attribute__((swift_name("B.nonescapingLifetimebound(self:_:)")));
+// Swift 6.2 error: a mutating method cannot have a ~Escapable 'self'
+// requires https://github.com/swiftlang/swift/pull/84010
+//int * __counted_by(len) nonescapingLifetimebound(struct B *d __lifetimebound, int len) __attribute__((swift_name("B.nonescapingLifetimebound(self:_:)")));
 
 //--- Inputs/module.modulemap
 module Instance {
@@ -189,24 +191,5 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
     return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
       return unsafe refSelf(c, _pPtr.baseAddress!, len)
     }
-}
-------------------------------
-@__swiftmacro_So1BV11nonescaping15_SwiftifyImportfMp_.swift
-------------------------------
-/// This is an auto-generated wrapper for safer interop
-@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-public func nonescaping(_ p: inout MutableSpan<Int32>) {
-    let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe nonescaping(_pPtr.baseAddress!, len)
-    }
-}
-------------------------------
-@__swiftmacro_So1BV24nonescapingLifetimebound15_SwiftifyImportfMp_.swift
-------------------------------
-/// This is an auto-generated wrapper for safer interop
-@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy self) @_disfavoredOverload
-public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nonescapingLifetimebound(len), count: Int(len)), copying: ())
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -1,0 +1,212 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -dump-macro-expansions -I %bridging-path 2> %t/out.txt
+// RUN: diff --strip-trailing-cr %t/out.txt %t/out.expected
+
+//--- test.swift
+import Instance
+
+@available(macOS 13.3.0, *)
+func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout B) {
+  aa.basic(&p)
+  aa.bar(&p)
+  a.constSelf(&p)
+  a.valSelf(&p)
+  let _: MutableSpan<CInt> = a.lifetimeBoundSelf(3)
+  c.refSelf(&p)
+  b.nonescaping(&p)
+  let _: MutableSpan<CInt> = bb.nonescapingLifetimebound(73)
+
+#if VERIFY
+  aa.countedSelf(&p)
+  a.basic(&p) // expected-error{{cannot use mutating member on immutable value: 'a' is a 'let' constant}}
+#endif
+}
+
+//--- Inputs/instance.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+#include <swift/bridging>
+
+struct A {};
+struct SWIFT_NONESCAPABLE B {};
+struct SWIFT_IMMORTAL_REFERENCE C {};
+
+void basic(struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.basic(self:_:_:)")));
+
+void renamed(struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.bar(self:_:_:)")));
+
+void countedSelf(struct A * __counted_by(len)
+  a, // expected-warning{{bounds attribute '__counted_by' ignored on parameter mapped to 'self'}}
+  int * __counted_by(len) p __noescape, int len)
+  __attribute__((
+  swift_name // expected-note{{swift_name maps free function to instance method here}}
+  ("A.countedSelf(self:_:_:)")));
+
+void constSelf(const struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.constSelf(self:_:_:)")));
+
+void valSelf(struct A a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.valSelf(self:_:_:)")));
+
+void refSelf(struct C *c, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("C.refSelf(self:_:_:)")));
+
+int * __counted_by(len) lifetimeBoundSelf(struct A a __lifetimebound, int len) __attribute__((swift_name("A.lifetimeBoundSelf(self:_:)")));
+
+void nonescaping(const struct B *d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("B.nonescaping(self:_:_:)")));
+
+int * __counted_by(len) nonescapingLifetimebound(struct B *d __lifetimebound, int len) __attribute__((swift_name("B.nonescapingLifetimebound(self:_:)")));
+
+//--- Inputs/module.modulemap
+module Instance {
+  header "instance.h"
+}
+
+//--- out.expected
+@__swiftmacro_So1AV5basic15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public mutating func basic(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe basic(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So5basic15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.basic(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe basic(a, _pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1AV3bar15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public mutating func bar(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe bar(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So7renamed15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.bar(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe renamed(a, _pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1AV9constSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func constSelf(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe constSelf(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So9constSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.constSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe constSelf(a, _pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1AV7valSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func valSelf(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe valSelf(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So7valSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.valSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe valSelf(a, _pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1AV17lifetimeBoundSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload
+public func lifetimeBoundSelf(_ len: Int32) -> MutableSpan<Int32> {
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe lifetimeBoundSelf(len), count: Int(len)), copying: ())
+}
+------------------------------
+@__swiftmacro_So17lifetimeBoundSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.lifetimeBoundSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow a) @_disfavoredOverload
+public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe lifetimeBoundSelf(a, len), count: Int(len)), copying: ())
+}
+------------------------------
+@__swiftmacro_So1CV7refSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func refSelf(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe refSelf(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So7refSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "C.refSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe refSelf(c, _pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1BV11nonescaping15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func nonescaping(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe nonescaping(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+@__swiftmacro_So1BV24nonescapingLifetimebound15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy self) @_disfavoredOverload
+public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32> {
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nonescapingLifetimebound(len), count: Int(len)), copying: ())
+}
+------------------------------

--- a/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
+++ b/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
@@ -5,9 +5,6 @@
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
-
 //--- Inputs/swiftify-non-public.h
 #pragma once
 

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -8,9 +8,6 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
-
 #if !BRIDGING_HEADER
 import StdSpan
 #endif

--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -1,8 +1,5 @@
 // RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers)
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu
-
 // TODO: test failed in Windows PR testing: rdar://144384453
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,8 +1,5 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu
-
 import StdSpan
 
 let arr: [Int32] = [1, 2, 3]

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu
-
 // TODO: test failed in Windows PR testing: rdar://144384453
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
@@ -1,0 +1,310 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20 -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -cxx-interoperability-mode=default -Xcc -std=c++20 -dump-macro-expansions 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --implicit-check-not __swiftmacro
+
+//--- test.swift
+import Instance
+
+func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, s: IntSpan, cs: ConstIntSpan, asp: AliasingSpan, b: inout baz.B) {
+  aa.basic(&p)
+  aa.bar(&p)
+  a.constSelf(&p)
+  a.valSelf(&p)
+  aa.refSelf(&p)
+  aa.namespaced(&p)
+  b.decapseman(&p)
+  baz.bar(&aa, &p)
+  baz.this(&aa, &p)
+
+  let _: IntSpan = unsafe s.spanSelf()
+  let _: MutableSpan<CInt> = unsafe s.spanSelf()
+  let _: IntSpan = unsafe s.spanConstSelf()
+  let _: MutableSpan<CInt> = unsafe s.spanConstSelf()
+  let _: ConstIntSpan = unsafe cs.constSpanSelf()
+  let _: Span<CInt> = unsafe cs.constSpanSelf()
+  let _: IntSpan = unsafe asp.spanSelf()
+  let _: MutableSpan<CInt> = unsafe asp.spanSelf()
+#if VERIFY
+  p.spanSelf() // expected-error{{value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') has no member 'spanSelf'}}
+#endif
+}
+
+//--- Inputs/instance.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+#include <span>
+
+struct A {};
+
+using IntSpan = std::span<int>;
+using ConstIntSpan = std::span<const int>;
+using AliasingSpan = std::span<int>;
+
+void basic(A *a, IntSpan p __noescape) __attribute__((swift_name("A.basic(self:_:)")));
+
+void renamed(A *a, IntSpan p __noescape) __attribute__((swift_name("A.bar(self:_:)")));
+
+void constSelf(const A *a, IntSpan p __noescape) __attribute__((swift_name("A.constSelf(self:_:)")));
+
+void valSelf(A a, IntSpan p __noescape) __attribute__((swift_name("A.valSelf(self:_:)")));
+
+void refSelf(A &a, IntSpan p __noescape) __attribute__((swift_name("A.refSelf(self:_:)")));
+
+IntSpan spanSelf(IntSpan p __lifetimebound) __attribute__((swift_name("IntSpan.spanSelf(self:)")));
+
+const IntSpan spanConstSelf(const IntSpan p __lifetimebound) __attribute__((swift_name("IntSpan.spanConstSelf(self:)")));
+
+ConstIntSpan constSpanSelf(ConstIntSpan p __lifetimebound) __attribute__((swift_name("ConstIntSpan.constSpanSelf(self:)")));
+
+namespace baz {
+  void namespaced(A *a, IntSpan p __noescape) __attribute__((swift_name("A.namespaced(self:_:)")));
+  struct B {};
+  void renamed(A &a, IntSpan p __noescape) __attribute__((swift_name("baz.bar(_:_:)")));
+  void that(A &a, IntSpan p __noescape) __attribute__((swift_name("this(_:_:)")));
+}
+
+void decapseman(baz::B *b, IntSpan p __noescape) __attribute__((swift_name("baz.B.decapseman(self:_:)")));
+
+//--- Inputs/module.modulemap
+module Instance {
+  header "instance.h"
+  export *
+}
+
+//--- out.expected
+// CHECK:@__swiftmacro_{{.*}}basic{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public mutating func basic(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe basic(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}basic{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.basic(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe basic(a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}bar{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public mutating func bar(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe bar(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}renamed{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.bar(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe renamed(a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}constSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func constSelf(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe constSelf(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}constSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.constSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe constSelf(a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}valSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func valSelf(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe valSelf(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}valSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.valSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func valSelf(_ a: A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe valSelf(a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}refSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public mutating func refSelf(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe refSelf(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}refSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.refSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func refSelf(_ a: inout A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe refSelf(&a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}namespaced{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public mutating func namespaced(_ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe namespaced(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}namespaced{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.namespaced(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:  public static func namespaced(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe namespaced(a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}Instance{{.*}}decapseman{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public mutating func decapseman(_ p: inout MutableSpan<CInt>)  {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe decapseman(IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}decapseman{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.B.decapseman(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func decapseman(_ b: UnsafeMutablePointer<baz.B>!, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe decapseman(b, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}Instance{{.*}}bar{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public static func bar(_ a: inout A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe bar(&a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}renamed{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.bar(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:  public static func renamed(_ a: inout A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe renamed(&a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}this{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public static func this(_ a: inout A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe this(&a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}that{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "this(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:  public static func that(_ a: inout A, _ p: inout MutableSpan<CInt>) {
+// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe that(&a, IntSpan(_pPtr))
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}Instance{{.*}}spanSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload
+// CHECK-NEXT:public func spanSelf() -> MutableSpan<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe spanSelf()), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_So8spanSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "IntSpan.spanSelf(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func spanSelf(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe spanSelf(IntSpan(_pPtr))
+// CHECK-NEXT:            }), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}Instance{{.*}}spanConstSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload
+// CHECK-NEXT:public func spanConstSelf() -> MutableSpan<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe spanConstSelf()), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}spanConstSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "IntSpan.spanConstSelf(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
+// CHECK-NEXT:public func spanConstSelf(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:      return unsafe spanConstSelf(IntSpan(_pPtr))
+// CHECK-NEXT:            }), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}Instance{{.*}}constSpanSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload
+// CHECK-NEXT:public func constSpanSelf() -> Span<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe constSpanSelf()), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:@__swiftmacro_{{.*}}constSpanSelf{{.*}}_SwiftifyImportfMp_.swift
+// CHECK-NEXT:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "ConstIntSpan.constSpanSelf(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload
+// CHECK-NEXT:public func constSpanSelf(_ p: Span<CInt>) -> Span<CInt> {
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe constSpanSelf(ConstIntSpan(p))), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------

--- a/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
@@ -9,16 +9,16 @@
 //--- test.swift
 import Instance
 
-func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, s: IntSpan, cs: ConstIntSpan, asp: AliasingSpan, b: inout baz.B) {
+func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, s: IntSpan, cs: ConstIntSpan, asp: AliasingSpan/*, b: inout baz.B*/) {
   aa.basic(&p)
   aa.bar(&p)
   a.constSelf(&p)
   a.valSelf(&p)
   aa.refSelf(&p)
-  aa.namespaced(&p)
-  b.decapseman(&p)
-  baz.bar(&aa, &p)
-  baz.this(&aa, &p)
+  //aa.namespaced(&p)
+  //b.decapseman(&p)
+  //baz.bar(&aa, &p)
+  //baz.this(&aa, &p)
 
   let _: IntSpan = unsafe s.spanSelf()
   let _: MutableSpan<CInt> = unsafe s.spanSelf()
@@ -60,6 +60,9 @@ const IntSpan spanConstSelf(const IntSpan p __lifetimebound) __attribute__((swif
 
 ConstIntSpan constSpanSelf(ConstIntSpan p __lifetimebound) __attribute__((swift_name("ConstIntSpan.constSpanSelf(self:)")));
 
+/*
+ * Swift 6.2 error: 'swift_name' attribute has invalid identifier for the base name.
+ * Requires https://github.com/llvm/llvm-project/pull/145947
 namespace baz {
   void namespaced(A *a, IntSpan p __noescape) __attribute__((swift_name("A.namespaced(self:_:)")));
   struct B {};
@@ -68,6 +71,7 @@ namespace baz {
 }
 
 void decapseman(baz::B *b, IntSpan p __noescape) __attribute__((swift_name("baz.B.decapseman(self:_:)")));
+*/
 
 //--- Inputs/module.modulemap
 module Instance {
@@ -173,86 +177,6 @@ module Instance {
 // CHECK-NEXT:public func refSelf(_ a: inout A, _ p: inout MutableSpan<CInt>) {
 // CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe refSelf(&a, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}namespaced{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:public mutating func namespaced(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe namespaced(IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}namespaced{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.namespaced(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:  public static func namespaced(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe namespaced(a, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}Instance{{.*}}decapseman{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:public mutating func decapseman(_ p: inout MutableSpan<CInt>)  {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe decapseman(IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}decapseman{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.B.decapseman(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:public func decapseman(_ b: UnsafeMutablePointer<baz.B>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe decapseman(b, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}Instance{{.*}}bar{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:public static func bar(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe bar(&a, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}renamed{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.bar(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:  public static func renamed(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe renamed(&a, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}this{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:public static func this(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe this(&a, IntSpan(_pPtr))
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:@__swiftmacro_{{.*}}baz{{.*}}that{{.*}}_SwiftifyImportfMp_.swift
-// CHECK-NEXT:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "this(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT:  public static func that(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-// CHECK-NEXT:      return unsafe that(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 // CHECK-NEXT:------------------------------

--- a/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
+++ b/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
@@ -1,8 +1,5 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
-
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t/Inputs -Xcc -std=c++20 -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/method.swift -dump-macro-expansions -verify 2>&1 | %FileCheck %s

--- a/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
@@ -9,9 +9,6 @@
 // RUN: %target-codesign %t/swift-cxx-execution
 // RUN: %target-run %t/swift-cxx-execution | %FileCheck %s
 
-// FIXME swift-ci linux tests do not support std::span
-// UNSUPPORTED: OS=linux-gnu
-
 // REQUIRES: executable_test
 
 //--- header.h

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -68,3 +68,5 @@ config.substitutions.insert(0, (r'%check-interop-cxx-header-in-clang\(([^)]+)\)'
 config.substitutions.insert(0, (r'%check-interop-c-header-in-clang\(([^)]+)\)',
                              SubstituteCaptures(r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c11-extensions -Wno-pre-c11-compat \1 && '
                                                 r'%check-c-header-in-clang -std=c11 -Wno-padded -Wno-pre-c11-compat \1')))
+
+config.substitutions.insert(0, ('%bridging-path', '%swift_src_root%{fs-sep}lib%{fs-sep}ClangImporter%{fs-sep}SwiftBridging'))


### PR DESCRIPTION
- **Explanation**:
This adds support for safe wrappers for functions imported as methods using the `swift_name` attribute.
- **Scope**:
This currently only affects code with the experimental SafeInteropWrappers feature enabled, that imports headers with bounds annotations and `swift_name` importing the function as a method (annotated in the header or through API notes) 
- **Issues**:
rdar://156288883
- **Original PRs**:
https://github.com/swiftlang/swift/pull/84507
- **Risk**:
A project fulfilling the criteria listed in the Scope section could go from compiling to having compilation errors, if the resulting expansion is invalid.
- **Testing**:
Local testing has been done. More extensive testing will be done before enabling SafeInteropWrappers by default (which would increase the scope of affected projects).
- **Reviewers**:
@Xazax-hun 
@DougGregor 