### PR TITLE
CXX Interop: Disable Test

### DIFF
--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar162095015
+
 // Tests that a C++ class can conform to a Swift protocol.
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop


### PR DESCRIPTION
The protocol-conformance-typechecker test is failing in PR testing with the following output:

```
[2025-10-07T21:11:49.057Z] <module-includes>:1:10: error: unexpected note produced: in file included from <module-includes>:1:
[2025-10-07T21:11:49.057Z] #include "protocol-conformance.h"
[2025-10-07T21:11:49.057Z]          ^
[2025-10-07T21:11:49.057Z] <module-includes>:1:10: note: file '<module-includes>' is not parsed for 'expected' statements. Use '-verify-additional-file <module-includes>' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
[2025-10-07T21:11:49.057Z] #include "protocol-conformance.h"
[2025-10-07T21:11:49.057Z]          ^
[2025-10-07T21:11:49.057Z] /home/build-user/swift/test/Interop/Cxx/class/Inputs/protocol-conformance.h:76:14: error: unexpected warning produced: declaring overloaded 'operator()' as 'static' is a C++23 extension
[2025-10-07T21:11:49.057Z]   static int operator()(int x) { return x * 2; }
[2025-10-07T21:11:49.057Z]              ^
[2025-10-07T21:11:49.058Z] /home/build-user/swift/test/Interop/Cxx/class/Inputs/protocol-conformance.h:76:14: note: file '/home/build-user/swift/test/Interop/Cxx/class/Inputs/protocol-conformance.h' is not parsed for 'expected' statements. Use '-verify-additional-file /home/build-user/swift/test/Interop/Cxx/class/Inputs/protocol-conformance.h' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
[2025-10-07T21:11:49.058Z]   static int operator()(int x) { return x * 2; }
[2025-10-07T21:11:49.058Z]              ^
[2025-10-07T21:11:49.058Z] <module-includes>:1:10: note: diagnostic produced elsewhere: in file included from <module-includes>:1:
[2025-10-07T21:11:49.058Z] #include "protocol-conformance.h"
[2025-10-07T21:11:49.058Z]          ^
[2025-10-07T21:11:49.058Z] /home/build-user/swift/test/Interop/Cxx/class/Inputs/protocol-conformance.h:76:14: warning: diagnostic produced elsewhere: declaring overloaded 'operator()' as 'static' is a C++23 extension
[2025-10-07T21:11:49.058Z]   static int operator()(int x) { return x * 2; }
[2025-10-07T21:11:49.058Z]              ^
```

Blocking on rdar://162095015