### PR TITLE
[Performance Hints] Correctly handle user code wrapped inside implicit node

### DIFF
--- a/lib/Sema/PerformanceHints.cpp
+++ b/lib/Sema/PerformanceHints.cpp
@@ -125,16 +125,9 @@ public:
     SF->walk(Walker);
   }
 
-  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-    if (P->isImplicit())
-      return Action::SkipNode(P);
-
-    return Action::Continue(P);
-  }
-
   PostWalkResult<Pattern *> walkToPatternPost(Pattern *P) override {
-    assert(!P->isImplicit() &&
-           "Traversing implicit patterns is disabled in the pre-walk visitor");
+    if (P->isImplicit())
+      return Action::Continue(P);
 
     if (const AnyPattern *AP = dyn_cast<AnyPattern>(P)) {
       checkExistentialInPatternType(AP, Ctx.Diags);
@@ -143,17 +136,9 @@ public:
     return Action::Continue(P);
   }
 
-  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-    if (E->isImplicit())
-      return Action::SkipNode(E);
-
-    return Action::Continue(E);
-  }
-
   PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
-    assert(
-        !E->isImplicit() &&
-        "Traversing implicit expressions is disabled in the pre-walk visitor");
+    if (E->isImplicit())
+      return Action::Continue(E);
 
     if (const ClosureExpr *CE = dyn_cast<ClosureExpr>(E)) {
       checkImplicitCopyReturnType(CE, Ctx.Diags);
@@ -163,17 +148,9 @@ public:
     return Action::Continue(E);
   }
 
-  PreWalkAction walkToDeclPre(Decl *D) override {
-    if (D->isImplicit())
-      return Action::SkipNode();
-
-    return Action::Continue();
-  }
-
   PostWalkAction walkToDeclPost(Decl *D) override {
-    assert(
-        !D->isImplicit() &&
-        "Traversing implicit declarations is disabled in the pre-walk visitor");
+    if (D->isImplicit())
+      return Action::Continue();
 
     if (const FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
       checkImplicitCopyReturnType(FD, Ctx.Diags);

--- a/test/PerformanceHints/existential-any.swift
+++ b/test/PerformanceHints/existential-any.swift
@@ -71,7 +71,7 @@ func animalParam1(_ animal: any Animal) {}  // expected-error {{Performance: 'an
 // Multiple parameters
 func animalParam2(
   _ animal: any Animal,  // expected-error {{Performance: 'animal' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
-  to other: any Animal   // expected-error {{Performance: 'other' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
+  to other: any Animal  // expected-error {{Performance: 'other' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
 ) {}
 
 // Variadic parameters
@@ -144,7 +144,7 @@ func tupleTest() {
 
   let (
     animalsA,  // expected-error {{Performance: 'animalsA' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
-    animalsB   // expected-error {{Performance: 'animalsB' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
+    animalsB  // expected-error {{Performance: 'animalsB' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
   ) = ([Tiger() as any Animal], [Panda() as any Animal])
   print(type(of: animalsA))
   print(type(of: animalsB))
@@ -243,4 +243,22 @@ struct Outer<T> {
 
 func f() -> Outer<any Animal>.Inner {  // expected-error {{Performance: 'f()' returns an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
   return Outer<any Animal>().i
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Implicit AST Nodes
+////////////////////////////////////////////////////////////////////////////////
+
+func stringPlusInReduce() {
+  let animalKinds = ["Tiger", "Panda", "Tiger", "Dodo"]
+  let animals: [any Animal] = // expected-error {{Performance: 'animals' uses an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
+  animalKinds.map { animalKind in // expected-error {{Performance: closure returns an existential, leading to heap allocation, reference counting, and dynamic dispatch. Consider using generic constraints or concrete types instead.}}
+      switch animalKind {
+      case "Tiger":
+        return Tiger()
+      default:
+        return Panda()
+      }
+    }
+  print(animals)
 }


### PR DESCRIPTION
In order to avoid issuing diagnostics for compiler-generated code, we ignore the syntax subtree rooted at an implicit node. This causes our algorithm to miss user code wrapped in implicit nodes generated during desugaring. For example, expressions in implicit returns from single-expression closures and trailing closures declarations are completely ignored by the performance analyzer right now.

This change fixes the problem by introducing a simple change to the AST walker. Instead of ignoring the entire implicit-node subtree, we only ignore the implicit node but continue to descend into its children. This enables our algorithm to access non-implicit (user code) nodes nested inside implicit (compiler-generated) nodes.