### PR TITLE
[Index] Convert the `-index-store-compress` command line option to a `FrontendOption`

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -97,6 +97,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.IndexSystemModules |= Args.hasArg(OPT_index_system_modules);
   Opts.IndexIgnoreStdlib |= Args.hasArg(OPT_index_ignore_stdlib);
   Opts.IndexIncludeLocals |= Args.hasArg(OPT_index_include_locals);
+  Opts.IndexStoreCompress |= Args.hasArg(OPT_index_store_compress);
   Opts.SerializeDebugInfoSIL |=
       Args.hasArg(OPT_experimental_serialize_debug_info);
 

--- a/test/Index/Store/index_compress.swift
+++ b/test/Index/Store/index_compress.swift
@@ -1,6 +1,11 @@
+// REQUIRES: shell
+
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -index-store-path %t/idx -index-store-compress -o %t.o -typecheck %s
 // RUN: c-index-test core -print-record %t/idx | %FileCheck %s
+
+// Check that the unit file starts with CIDXR, indicating that the record is indeed compressed.
+// RUN: head -1 %t/idx/**/records/**/*index_compress.swift* | grep '^CIDXR'
 
 func foo() {}
 // CHECK: [[@LINE-1]]:6 | function/Swift | s:4main3fooyyF | Def | rel: 0


### PR DESCRIPTION
When I added the `-index-store-compress` option, I forgot to translate it into the `FrontendOptions` struct, which rendered the command line option useless. Correctly set the value in `FrontendOptions` to fix this.
