### PR TITLE
[update-checkout] fallback to verbose mode if tempdir is too long

### DIFF
--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -13,6 +13,7 @@
 import os
 
 from . import scheme_mock
+from unittest import mock
 
 
 class CloneTestCase(scheme_mock.SchemeMockTestCase):
@@ -41,6 +42,20 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
 
         # Test that we're actually checking out the 'extra' scheme based on the output
         self.assertIn(b"git checkout refs/heads/main", output)
+
+    def test_manager_not_called_on_long_socket(self):
+        fake_tmpdir = '/tmp/very/' + '/long' * 20 + '/tmp'
+
+        with mock.patch('tempfile.gettempdir', return_value=fake_tmpdir), \
+            mock.patch('multiprocessing.Manager') as mock_manager:
+
+            self.call([self.update_checkout_path,
+                    '--config', self.config_path,
+                    '--source-root', self.source_root,
+                    '--clone'])
+            # Ensure that we do not try to create a Manager when the tempdir
+            # is too long.
+            mock_manager.assert_not_called()
 
 
 class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):

--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -52,19 +52,20 @@ class ParallelRunner:
         self._terminal_width = shutil.get_terminal_size().columns
         self._n_processes = n_processes
         self._pool_args = pool_args
-        manager = Manager()
-        self._lock = manager.Lock()
-        self._running_tasks = manager.list()
-        self._updated_repos = manager.Value("i", 0)
         self._fn = fn
         self._pool = Pool(processes=self._n_processes)
-        self._verbose = pool_args[0].verbose
         self._output_prefix = pool_args[0].output_prefix
         self._nb_repos = len(pool_args)
         self._stop_event = Event()
-        self._monitored_fn = MonitoredFunction(
-            self._fn, self._running_tasks, self._updated_repos, self._lock
-        )
+        self._verbose = pool_args[0].verbose
+        if not self._verbose:
+            manager = Manager()
+            self._lock = manager.Lock()
+            self._running_tasks = manager.list()
+            self._updated_repos = manager.Value("i", 0)
+            self._monitored_fn = MonitoredFunction(
+                self._fn, self._running_tasks, self._updated_repos, self._lock
+            )
 
     def run(self) -> List[Any]:
         print(

--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -48,7 +48,13 @@ class ParallelRunner:
     ):
         self._monitor_polling_period = 0.1
         if n_processes == 0:
-            n_processes = cpu_count() * 2
+            if sys.version_info.minor < 10:
+                # On Python < 3.10, https://bugs.python.org/issue46391 causes
+                # Pool.map and its variants to hang. Limiting the number of
+                # processes fixes the issue.
+                n_processes = int(cpu_count() * 1.25)
+            else:
+                n_processes = cpu_count() * 2
         self._terminal_width = shutil.get_terminal_size().columns
         self._n_processes = n_processes
         self._pool_args = pool_args


### PR DESCRIPTION
The maximum path size for a Unix socket on macOS is `104` bytes (`108` on Linux). This causes `update-checkout` to fail in silent mode when `TMPDIR` is set to a long path. This is likely to happen in CI.

This patch checks if the socket path will exceed the limit and fallback to `verbose` mode if it does. `verbose` mode does not use a `Manager` and therefore does not create a socket. The patch also adds a unittest to make sure we never try to create a Manager if the TMPDIR path is too long.

rdar://162088344