### PR TITLE
6.2: [VariadicGenerics] Fix memeffect of metadata accessor.

### DIFF
--- a/include/swift/IRGen/GenericRequirement.h
+++ b/include/swift/IRGen/GenericRequirement.h
@@ -109,6 +109,11 @@ public:
   bool isAnyWitnessTable() const {
     return kind == Kind::WitnessTable || kind == Kind::WitnessTablePack;
   }
+
+  bool isAnyPack() const {
+    return kind == Kind::MetadataPack || kind == Kind::WitnessTablePack;
+  }
+
   bool isValue() const {
     return kind == Kind::Value;
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2996,8 +2996,9 @@ void irgen::emitLazyMetadataAccessor(IRGenModule &IGM,
   if (IGM.getOptions().optimizeForSize())
     accessor->addFnAttr(llvm::Attribute::NoInline);
 
-  bool isReadNone = (genericArgs.Types.size() <=
-                     NumDirectGenericTypeMetadataAccessFunctionArgs);
+  bool isReadNone =
+      !genericArgs.hasPacks && (genericArgs.Types.size() <=
+                                NumDirectGenericTypeMetadataAccessFunctionArgs);
 
   emitCacheAccessFunction(
       IGM, accessor, /*cache*/ nullptr, /*cache type*/ nullptr,

--- a/lib/IRGen/GenericArguments.h
+++ b/lib/IRGen/GenericArguments.h
@@ -50,8 +50,9 @@ struct GenericArguments {
   /// The values to use to initialize the arguments structure.
   SmallVector<llvm::Value *, 8> Values;
   SmallVector<llvm::Type *, 8> Types;
+  bool hasPacks = false;
 
- void collectTypes(IRGenModule &IGM, NominalTypeDecl *nominal) {
+  void collectTypes(IRGenModule &IGM, NominalTypeDecl *nominal) {
     GenericTypeRequirements requirements(IGM, nominal);
     collectTypes(IGM, requirements);
   }
@@ -59,6 +60,7 @@ struct GenericArguments {
   void collectTypes(IRGenModule &IGM,
                     const GenericTypeRequirements &requirements) {
     for (auto &requirement : requirements.getRequirements()) {
+      hasPacks = hasPacks || requirement.isAnyPack();
       Types.push_back(requirement.getType(IGM));
     }
   }

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -395,9 +395,8 @@ public:
 
   // Emit a call to the given generic type metadata access function.
   MetadataResponse emitGenericTypeMetadataAccessFunctionCall(
-                                          llvm::Function *accessFunction,
-                                          ArrayRef<llvm::Value *> args,
-                                          DynamicMetadataRequest request);
+      llvm::Function *accessFunction, ArrayRef<llvm::Value *> args,
+      DynamicMetadataRequest request, bool hasPacks = false);
 
   // Emit a reference to the canonical type metadata record for the given AST
   // type. This can be used to identify the type at runtime. For types with

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -750,7 +750,7 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
             theDecl, genericArgs.Types, NotForDefinition);
 
     response = IGF.emitGenericTypeMetadataAccessFunctionCall(
-        accessor, genericArgs.Values, request);
+        accessor, genericArgs.Values, request, genericArgs.hasPacks);
   }
 
   IGF.setScopedLocalTypeMetadata(theType, response);
@@ -2467,11 +2467,9 @@ void irgen::emitCacheAccessFunction(IRGenModule &IGM, llvm::Function *accessor,
   IGF.Builder.CreateRet(ret);
 }
 
-MetadataResponse
-IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
-                                              llvm::Function *accessFunction,
-                                              ArrayRef<llvm::Value *> args,
-                                              DynamicMetadataRequest request) {
+MetadataResponse IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
+    llvm::Function *accessFunction, ArrayRef<llvm::Value *> args,
+    DynamicMetadataRequest request, bool hasPacks) {
 
   SmallVector<llvm::Value *, 8> callArgs;
 
@@ -2495,7 +2493,7 @@ IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
                                  accessFunction, callArgs);
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
-  call->setMemoryEffects(allocatedArgsBuffer
+  call->setMemoryEffects(hasPacks || allocatedArgsBuffer
                              ? llvm::MemoryEffects::inaccessibleOrArgMemOnly()
                              : llvm::MemoryEffects::none());
 

--- a/validation-test/IRGen/rdar161606892.swift
+++ b/validation-test/IRGen/rdar161606892.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-irgen | %IRGenFileCheck %s
+
+// CHECK: Attrs: noinline nounwind{{$}}
+// CHECK-NEXT: define {{.*}}@"$s13rdar1616068921PVMa"
+
+public struct P<each T> {
+  public var teas: (repeat each T)
+}

--- a/validation-test/IRGen/rdar161606892_2.swift
+++ b/validation-test/IRGen/rdar161606892_2.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift \
+// RUN:     -emit-module \
+// RUN:     -target %target-swift-5.9-abi-triple \
+// RUN:     %t/Library.swift \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Library \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                              \
+// RUN:     %t/Downstream.swift                             \
+// RUN:     -emit-irgen                                     \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -module-name main                               \
+// RUN:     -lLibrary                                       \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Downstream.swift --check-prefixes=CHECK,CHECK-OLD
+
+//--- Library.swift
+
+public struct Pack<each T> {
+  public init() {}
+}
+
+public func sink<T>(_ t: T) {}
+
+//--- Downstream.swift
+
+import Library
+
+// CHECK: doit
+// CHECK: @"$s7Library4PackVMa"{{.*}} [[CALL:#[^,]+]]
+
+// CHECK: attributes [[CALL]] = { nounwind memory(argmem: readwrite, inaccessiblemem: readwrite) }
+@_silgen_name("doit")
+func doit<each T, each U>(ts: repeat each T, us: repeat each U) {
+  sink(Pack<repeat each T, repeat each U>())
+}


### PR DESCRIPTION
**Explanation**: Fix a miscompile caused by incorrect function and call attributes applied by IRGen to metadata accessors for types with variadic generic arguments.

Metadata accessors are used to obtain the runtime representation of a type (i.e. its metadata).  If the type is generic, the generic arguments (types and conformances) are provided as arguments.  Each of a type's generic arguments which is variadic is specified by a list of types or conformances.  Each such list is passed to the accessor in a buffer.  In its implementation (in fact, in the runtime which the accessor calls into), the metadata is instantiated by examining those arguments, including any variadic generic arguments.  To be explicit, it _reads_ the data in such buffers.

Previously, both the metadata accessor and calls to it were annotated `memory(none)` even when it had variadic generic arguments.  This annotation told the LLVM optimizer that it was free to move memory operations (such as stores) around the function call because the function would not read that memory.  When it was profitable to do so, the optimizer did just this.  The result was to leave these buffers partially uninitialized, resulting in runtime crashes during metadata instantiation when attempting to read from the buffers.

Here, this is fixed by removing the incorrect annotation.  Now, whenever a metadata accessor includes in its argument list a variadic generic, neither the accessor itself is annotated `memory(none)` nor are calls to it annotated thus.
**Scope**: Affects code with variadic generics.
**Issue**: rdar://161606892
**Original PR**: https://github.com/swiftlang/swift/pull/84635 , https://github.com/swiftlang/swift/pull/84667
**Risk**: Low.  The patch worsens the effects applied to functions and function calls, obstructing optimizations.
**Testing**: Added tests.
**Reviewer**: John McCall ( @rjmccall ), Arnold Schwaighofer ( @aschwaighofer )