### PR TITLE
[cxx-interop] Do not warn for implicit default constructors

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2544,15 +2544,6 @@ namespace {
         //    constructor available in Swift.
         ConstructorDecl *defaultCtor =
             synthesizer.createDefaultConstructor(result);
-        if (cxxRecordDecl) {
-          auto attr = AvailableAttr::createUniversallyDeprecated(
-              defaultCtor->getASTContext(),
-              "This zero-initializes the backing memory of the struct, which "
-              "is unsafe for some C++ structs. Consider adding an explicit "
-              "default initializer for this C++ struct.",
-              "");
-          defaultCtor->getAttrs().add(attr);
-        }
         ctors.push_back(defaultCtor);
       }
 

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -136,7 +136,6 @@
 // CHECK-NEXT: public func getCopyCounter() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT: public struct CopyTrackedBaseClass {
 // CHECK-NEXT:   public init(_ x: Int32)
-// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getX() -> Int32
@@ -147,7 +146,6 @@
 
 // CHECK-NEXT: public struct CopyTrackedDerivedClass {
 // CHECK-NEXT:   public init(_ x: Int32)
-// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getDerivedX() -> Int32
@@ -167,7 +165,6 @@
 
 // CHECK-NEXT: public struct CopyTrackedDerivedDerivedClass {
 // CHECK-NEXT:   public init(_ x: Int32)
-// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getY() -> Int32

--- a/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
+++ b/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
@@ -3,4 +3,4 @@
 
 import Darwin
 
-_ = pthread_mutexattr_t() // expected-warning {{'init()' is deprecated: This zero-initializes the backing memory of the struct}}
+_ = pthread_mutexattr_t()

--- a/test/Interop/Cxx/templates/enable-if-module-interface.swift
+++ b/test/Interop/Cxx/templates/enable-if-module-interface.swift
@@ -3,7 +3,6 @@
 // The `init<T>` constructor template is not yet supported in Swift.
 
 // CHECK: struct HasConstructorWithEnableIf {
-// CHECK-NEXT:  @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:  init()
 // CHECK-NEXT:}
 


### PR DESCRIPTION
The diagnostic that Swift was emitting (`This zero-initializes the backing memory of the struct ...`) was flaky, because it was only emitted when the default constructor of a C++ struct was instantiated by Swift. If it was instantiated by Clang, the diagnostic wasn't emitted. There is not a lot of value in it. Let's make the behavior consistent by removing the diagnostic.

rdar://161999293

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
