### PR TITLE
SIL: Fix crash in remapParentFunction() due to missing generic signature

### DIFF
--- a/include/swift/SIL/GenericSpecializationMangler.h
+++ b/include/swift/SIL/GenericSpecializationMangler.h
@@ -83,7 +83,9 @@ class GenericSpecializationMangler : public SpecializationMangler {
     return Function->getLoweredFunctionType()->getInvocationGenericSignature();
   }
 
-  void appendSubstitutions(GenericSignature sig, SubstitutionMap subs);
+  void appendSubstitutions(GenericSignature calleeSig,
+                           SubstitutionMap calleeSubs,
+                           GenericSignature callerSig);
 
   std::string manglePrespecialized(GenericSignature sig,
                                       SubstitutionMap subs);
@@ -112,7 +114,9 @@ public:
   std::string mangleReabstracted(SubstitutionMap subs, bool alternativeMangling,
                                  const SmallBitVector &paramsRemoved = SmallBitVector());
 
-  std::string mangleForDebugInfo(GenericSignature sig, SubstitutionMap subs,
+  std::string mangleForDebugInfo(GenericSignature calleeSig,
+                                 SubstitutionMap calleeSubs,
+                                 GenericSignature callerSubs,
                                  bool forInlining);
 
   std::string manglePrespecialized(SubstitutionMap subs) {

--- a/test/SILOptimizer/specialize_output_generic_signature.swift
+++ b/test/SILOptimizer/specialize_output_generic_signature.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil -O %s
+
+extension Array: Comparable where Element: Comparable {
+  public static func < (lhs: Array<Element>, rhs: Array<Element>) -> Bool {
+    // Contents do not matter
+    for (l, r) in zip(lhs, rhs) { if l != r { return l < r } }
+    return lhs.count < rhs.count
+  }
+}
+
+public struct Wrapper<Symbol: Hashable & Comparable>: Hashable {
+  public var partitions: PartitionSet<Array<Symbol>>
+}
+
+public struct PartitionSet<Symbol: Hashable & Comparable>: Equatable, Hashable {
+  public var partitions: Set<Set<Symbol>>
+}


### PR DESCRIPTION
We need to pass down the generic signature of the caller to correctly mangle the substitution map, because the replacement types in this substitution maps are interface types for the caller's generic signature.

- Fixes rdar://problem/161968922.
- Fixes https://github.com/swiftlang/swift/issues/84692.