### PR TITLE
limit span-execution to macos for now

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
@@ -11,6 +11,8 @@
 
 // REQUIRES: executable_test
 
+// REQUIRES: OS=macosx || rdar-161999258
+
 //--- header.h
 #include <string>
 #include <span>


### PR DESCRIPTION
This test is failing in Linux CI.