### PR TITLE
[windows] Add option to smoke test installer

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -117,6 +117,10 @@ steps.
 .PARAMETER SkipPackaging
 Skip building the MSI installers and packaging. Useful for development builds.
 
+.PARAMETER SmokeTest
+Smoke test the installer. Mutually exclusive with `-SkipPackaging`.
+Requires Docker installation with Windows container support.
+
 .PARAMETER Test
 An array of names of projects to run tests for. Use '*' to run all tests.
 Available tests: lld, lldb, lldb-swift, swift, dispatch, foundation, xctest, swift-format, sourcekit-lsp
@@ -211,6 +215,9 @@ param
   [switch] $SkipPackaging = $false,
   [string[]] $Test = @(),
 
+  # XXX: True temporarily for testing. Do not merge.
+  [switch] $SmokeTest = $true,
+
   [switch] $IncludeDS2 = $false,
   [ValidateSet("none", "full", "thin")]
   [string] $LTO = "none",
@@ -246,6 +253,21 @@ $UnixToolsBinDir = "$env:SystemDrive\Program Files\Git\usr\bin"
 # Validate that if one is set all are set.
 if (($PinnedBuild -or $PinnedSHA256 -or $PinnedVersion) -and -not ($PinnedBuild -and $PinnedSHA256 -and $PinnedVersion)) {
   throw "If any of PinnedBuild, PinnedSHA256, or PinnedVersion is set, all three must be set."
+}
+
+if ($SmokeTest -and $SkipPackaging) {
+  throw "Cannot use -SmokeTest with -SkipPackaging."
+}
+
+if ($SmokeTest) {
+  $osBuild = [int](Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber
+  if ($osBuild -ge 20348) {
+    $SmokeTestDockerSubdir = "ltsc2022-full"
+  } elseif ($osBuild -ge 17763) {
+    $SmokeTestDockerSubdir = "1809-full"
+  } else {
+    throw "-SmokeTest is not supported on this Windows version (build $osBuild)."
+  }
 }
 
 # Work around limitations of cmd passing in array arguments via powershell.exe -File
@@ -4256,6 +4278,75 @@ function Copy-BuildArtifactsToStage([Hashtable] $Platform) {
   Invoke-Program "$($WiX.Path)\wix.exe" -- burn detach "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\installer.exe" -engine "$Stage\installer-engine.exe" -intermediateFolder "$BinaryCache\$($Platform.Triple)\installer\$($Platform.Architecture.VSName)\"
 }
 
+# Ensure:
+# - Docker is installed
+# - Docker is configured for Windows containers
+# If all conditions are not met, exit with an error.
+function Check-DockerRequirements() {
+  try {
+    $dockerVersion = docker version 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      throw "Docker is not installed or not running"
+    }
+
+    $dockerInfo = docker info 2>$null
+    if (-not ($dockerInfo -match "OSType:\s*windows")) {
+      Write-Host $dockerInfo
+      throw "Docker is not configured for Windows containers."
+    }
+  } catch {
+    Write-Host -ForegroundColor Red "Docker requirements check failed: $_"
+    exit 1
+  }
+}
+
+function Run-SmokeTests([Hashtable] $Platform) {
+  # XXX: temp for testing! PR runs don't seem to pull down swift-docker
+  if (-not (Test-Path "$SourceCache\swift-docker")) {
+    git clone https://github.com/swiftlang/swift-docker "$SourceCache\swift-docker"
+  }
+
+  Check-DockerRequirements
+
+  $InstallerPath = "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\installer.exe"
+  if (-not (Test-Path $InstallerPath)) {
+    throw "Installer not found at: $InstallerPath"
+  }
+
+  $SmokeTestDir = Join-Path $PSScriptRoot "windows-smoke-tests"
+  $InstallerFileName = Split-Path $InstallerPath -Leaf
+
+  Copy-Item $InstallerPath (Join-Path $SmokeTestDir $InstallerFileName) -Force
+
+  Push-Location $SmokeTestDir
+  try {
+    Record-OperationTime $Platform "SmokeTests-DockerBuild" {
+      Write-Host "Building Docker image with installer"
+      docker build `
+          --file "$SourceCache\swift-docker\swift-ci\main\windows\smoketest\$SmokeTestDockerSubdir\Dockerfile" `
+          --build-arg SWIFT_INSTALLER_PATH=$InstallerFileName `
+          --build-arg ENTRY_POINT=smoke_test.ps1 `
+          -t swift-smoke-test .
+      if ($LASTEXITCODE -ne 0) {
+        throw "Docker build failed"
+      }
+    }
+
+    Record-OperationTime $Platform "SmokeTest-DockerRun" {
+      Write-Host "Running smoke test container"
+      docker run --rm swift-smoke-test
+      if ($LASTEXITCODE -ne 0) {
+        throw "Smoke test failed"
+      }
+    }
+
+    Write-Host -ForegroundColor Green "Smoke test completed successfully!"
+  } finally {
+    Pop-Location
+    Remove-Item (Join-Path $SmokeTestDir $InstallerFileName) -ErrorAction SilentlyContinue
+  }
+}
+
 function Build-NoAssertsToolchain() {
   Write-Host -ForegroundColor Cyan "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Building NoAsserts Toolchain ..."
 
@@ -4605,6 +4696,12 @@ if (-not $IsCrossCompiling) {
       } catch {
       }
     }
+  }
+}
+
+if ($SmokeTest) {
+  Record-OperationTime $HostPlatform "Run-SmokeTests" {
+    Run-SmokeTests $HostPlatform
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -215,8 +215,7 @@ param
   [switch] $SkipPackaging = $false,
   [string[]] $Test = @(),
 
-  # XXX: True temporarily for testing. Do not merge.
-  [switch] $SmokeTest = $true,
+  [switch] $SmokeTest = $false,
 
   [switch] $IncludeDS2 = $false,
   [ValidateSet("none", "full", "thin")]
@@ -267,6 +266,11 @@ if ($SmokeTest) {
     $SmokeTestDockerSubdir = "1809-full"
   } else {
     throw "-SmokeTest is not supported on this Windows version (build $osBuild)."
+  }
+
+  $SmokeTestDockerfile = "$SourceCache\swift-docker\swift-ci\main\windows\smoketest\$SmokeTestDockerSubdir\Dockerfile"
+  if (-not (Test-Path $SmokeTestDockerfile)) {
+    throw "-SmokeTest requires a swift-docker checkout at '$SourceCache\swift-docker' (expected Dockerfile at '$SmokeTestDockerfile')."
   }
 }
 
@@ -4301,11 +4305,6 @@ function Check-DockerRequirements() {
 }
 
 function Run-SmokeTests([Hashtable] $Platform) {
-  # XXX: temp for testing! PR runs don't seem to pull down swift-docker
-  if (-not (Test-Path "$SourceCache\swift-docker")) {
-    git clone https://github.com/swiftlang/swift-docker "$SourceCache\swift-docker"
-  }
-
   Check-DockerRequirements
 
   $InstallerPath = "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\installer.exe"

--- a/utils/windows-smoke-tests/smoke_test.ps1
+++ b/utils/windows-smoke-tests/smoke_test.ps1
@@ -1,0 +1,11 @@
+# Smoke-tests the installed Swift toolchain.
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Starting smoke test"
+Write-Host ""
+
+swift --version
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Write-Host ""
+
+Write-Host "Smoke test completed successfully!" -ForegroundColor Green

--- a/utils/windows-smoke-tests/smoke_test.ps1
+++ b/utils/windows-smoke-tests/smoke_test.ps1
@@ -6,6 +6,3 @@ Write-Host ""
 
 swift --version
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-Write-Host ""
-
-Write-Host "Smoke test completed successfully!" -ForegroundColor Green


### PR DESCRIPTION
This adds a new option, `-SmokeTest`, to `build.ps1` which:
- Brings up a Windows Docker container
- Installs the just-built installer to it
- Runs an arbitrary smoke test on it

Right now the smoke test just consists of `swift --version`, but this is enough to catch many of the practical "broken installer" issues we've seen. Adding https://github.com/swiftlang/swift-integration-tests is planned in a future change.

Requirements:
- `swift-docker` checkout
- Docker installed and set up for Windows containers (NB: this is not the default)

Scheduled CI currently checks out `swift-docker`, but PR CI does *not*, so it is not currently possible to test this in PR CI without modification (checking out `swift-docker` explicitly). Successful run which defaults `-SmokeTest` to true and checks out `swift-docker`: https://ci-external.swift.org/job/swift-PR-build-toolchain-windows/6502/