### PR TITLE
SIL: The inner type of a SILMoveOnlyWrappedType is a lowered position

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include "swift/SIL/Lifetime.h"
 #include "llvm/ADT/Hashing.h"
@@ -109,7 +110,7 @@ private:
   SILType(CanType ty, SILValueCategory category)
       : value(ty.getPointer(), unsigned(category)) {
     if (!ty) return;
-    assert(ty->isLegalSILType() &&
+    ASSERT(ty->isLegalSILType() &&
            "constructing SILType with type that should have been "
            "eliminated by SIL lowering");
   }

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -420,6 +420,14 @@ public:
                                          substObjectType));
   }
 
+  /// MoveOnlyWrappedTypes need to have their inner types substituted
+  /// by these rules.
+  CanType visitSILMoveOnlyWrappedType(CanSILMoveOnlyWrappedType origType) {
+    CanType origInnerType = origType->getInnerType();
+    CanType substInnerType = visit(origInnerType);
+    return CanType(SILMoveOnlyWrappedType::get(substInnerType));
+  }
+
   /// Any other type would be a valid type in the AST. Just apply the
   /// substitution on the AST level and then lower that.
   CanType visitType(CanType origType) {

--- a/test/SILOptimizer/specialize_move_only_wrapped_type.swift
+++ b/test/SILOptimizer/specialize_move_only_wrapped_type.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-sil -O %s
+
+public struct Mutex<T> {
+  public init(_: T) {}
+}
+
+public struct Locked<T> {
+  public let mutex: Mutex<T>
+
+  public init(_ rawValue: consuming T) {
+    mutex = Mutex(rawValue)
+  }
+}
+
+_ = Locked { }


### PR DESCRIPTION
This wasn't handled properly, as a result specializing a `$@moveOnly T` did not lower the substituted `T`, causing an assertion failure if the substituted `T` was a function type.

Fixes rdar://161968922.
