### PR TITLE
[AST/Sema] Implement `~Sendable` support behind an experimental feature flag

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -85,6 +85,7 @@ namespace swift {
   struct ExternalSourceLocs;
   class CaptureListExpr;
   class DeclRefExpr;
+  class InverseTypeRepr;
   class LiteralExpr;
   class BraceStmt;
   class DeclAttributes;
@@ -1969,6 +1970,12 @@ public:
   /// index, resolved at the given stage, or `Type()` if resolution fails.
   Type getResolvedType(unsigned i, TypeResolutionStage stage =
                                        TypeResolutionStage::Interface) const;
+
+  /// If the given index corresponds to a "suppressed" entry, returns the
+  /// information associated with it, and `std::nullopt` otherwise.
+  std::optional<std::pair<Type, InverseTypeRepr *>> getAsSuppressed(
+      unsigned i,
+      TypeResolutionStage stage = TypeResolutionStage::Interface) const;
 
   /// Returns the underlying array of inherited type entries.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8944,6 +8944,13 @@ ERROR(attr_inline_always_on_accessor,none,
       " is not final are not allowed", ())
 
 //===----------------------------------------------------------------------===//
+// MARK: `~Sendable`
+//===----------------------------------------------------------------------===//
+ERROR(tilde_sendable_requires_feature_flag,none,
+      "'~Sendable' requires -enable-experimental-feature TildeSendable",
+      ())
+
+//===----------------------------------------------------------------------===//
 // MARK: Swift Performance hints
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8950,6 +8950,10 @@ ERROR(tilde_sendable_requires_feature_flag,none,
       "'~Sendable' requires -enable-experimental-feature TildeSendable",
       ())
 
+ERROR(conformance_repression_only_on_struct_class_enum,none,
+      "conformance to %0 can only be suppressed on structs, classes, and enums",
+      (const ProtocolDecl *))
+
 //===----------------------------------------------------------------------===//
 // MARK: Swift Performance hints
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8950,6 +8950,13 @@ ERROR(tilde_sendable_requires_feature_flag,none,
       "'~Sendable' requires -enable-experimental-feature TildeSendable",
       ())
 
+NOTE(sendable_conformance_is_suppressed, none,
+     "%kind0 explicitly suppresses conformance to 'Sendable' protocol",
+     (const NominalTypeDecl *))
+
+ERROR(non_sendable_type_suppressed,none,
+      "cannot both conform to and suppress conformance to 'Sendable'", ())
+
 ERROR(conformance_repression_only_on_struct_class_enum,none,
       "conformance to %0 can only be suppressed on structs, classes, and enums",
       (const ProtocolDecl *))

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -107,7 +107,7 @@ PROTOCOL(CodingKey)
 PROTOCOL(Encodable)
 PROTOCOL(Decodable)
 
-PROTOCOL(Sendable)
+REPRESSIBLE_PROTOCOL(Sendable)
 PROTOCOL(SendableMetatype)
 PROTOCOL(UnsafeSendable)
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -406,6 +406,9 @@ public:
   /// Suppress @inline(always) attribute and emit @inline(__always) instead.
   bool SuppressInlineAlways = false;
 
+  /// Suppress printing of ~Sendable in inheritance and requirement lists.
+  bool SuppressTildeSendable = false;
+
   /// Whether to print the \c{/*not inherited*/} comment on factory initializers.
   bool PrintFactoryInitializerComment = true;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -559,6 +559,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(InlineAlways, false)
 /// Allow use of 'Swift' (Swift runtime version) in @available attributes
 EXPERIMENTAL_FEATURE(SwiftRuntimeAvailability, true)
 
+/// Allow use of `~Sendable`.
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(TildeSendable, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3285,6 +3285,12 @@ suppressingFeatureLifetimes(PrintOptions &options,
   action();
 }
 
+static void suppressingFeatureTildeSendable(PrintOptions &options,
+                                            llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<bool> scope(options.SuppressTildeSendable, true);
+  action();
+}
+
 namespace {
 struct ExcludeAttrRAII {
   std::vector<AnyAttrKind> &ExcludeAttrList;
@@ -3302,7 +3308,7 @@ struct ExcludeAttrRAII {
     ExcludeAttrList.resize(OriginalExcludeAttrCount);
   }
 };
-}
+} // namespace
 
 static void
 suppressingFeatureCoroutineAccessors(PrintOptions &options,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8223,9 +8223,19 @@ swift::getInheritedForPrinting(
       }
     }
 
-    if (options.SuppressConformanceSuppression &&
-        inherited.getEntry(i).isSuppressed()) {
-      continue;
+    if (inherited.getEntry(i).isSuppressed()) {
+      // All `~<<Protocol>>` inheritances are suppressed.
+      if (options.SuppressConformanceSuppression)
+        continue;
+
+      if (options.SuppressTildeSendable) {
+        if (auto type = inherited.getAsSuppressed(i)->first) {
+          auto *sendable =
+              decl->getASTContext().getProtocol(KnownProtocolKind::Sendable);
+          if (sendable && sendable == type->getAnyNominal())
+            continue;
+        }
+      }
     }
 
     Results.push_back(inherited.getEntry(i));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2034,6 +2034,20 @@ Type InheritedTypes::getResolvedType(unsigned i,
       .getInheritedTypeOrNull(getASTContext());
 }
 
+std::optional<std::pair<Type, InverseTypeRepr *>>
+InheritedTypes::getAsSuppressed(unsigned i, TypeResolutionStage stage) const {
+  ASTContext &ctx = isa<const ExtensionDecl *>(Decl)
+                        ? cast<const ExtensionDecl *>(Decl)->getASTContext()
+                        : cast<const TypeDecl *>(Decl)->getASTContext();
+  auto result =
+      evaluateOrDefault(ctx.evaluator, InheritedTypeRequest{Decl, i, stage},
+                        InheritedTypeResult::forDefault());
+  if (result != InheritedTypeResult::Kind::Suppressed)
+    return std::nullopt;
+
+  return result.getSuppressed();
+}
+
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
                              TypeRepr *extendedType,
                              ArrayRef<InheritedEntry> inherited,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -450,6 +450,26 @@ static bool usesFeatureInlineAlways(Decl *decl) {
 
 UNINTERESTING_FEATURE(SwiftRuntimeAvailability)
 
+static bool usesFeatureTildeSendable(Decl *decl) {
+  auto *TD = dyn_cast<TypeDecl>(decl);
+  if (!TD)
+    return false;
+
+  return llvm::any_of(
+      TD->getInherited().getEntries(), [&decl](const auto &entry) {
+        if (!entry.isSuppressed())
+          return false;
+
+        auto T = entry.getType();
+        if (!T)
+          return false;
+
+        auto &C = decl->getASTContext();
+        return C.getProtocol(KnownProtocolKind::Sendable) == T->getAnyNominal();
+      });
+}
+
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7499,6 +7499,10 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
   if (isa<ProtocolDecl>(nominal))
     return nullptr;
 
+  // An explicit use `~Sendable` suppresses the conformance.
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable))
+    return nullptr;
+
   // Actor types are always Sendable; they don't get it via this path.
   auto classDecl = dyn_cast<ClassDecl>(nominal);
   if (classDecl && classDecl->isActor())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1016,12 +1016,15 @@ static bool diagnoseSingleNonSendableType(
 
     if (type->is<FunctionType>()) {
       ctx.Diags.diagnose(loc, diag::nonsendable_function_type);
+    } else if (nominal &&
+               nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
+      nominal->diagnose(diag::sendable_conformance_is_suppressed, nominal);
     } else if (nominal && nominal->getParentModule() == module) {
       // If the nominal type is in the current module, suggest adding
       // `Sendable` if it might make sense. Otherwise, just complain.
       if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal)) {
-        auto note = nominal->diagnose(
-            diag::add_nominal_sendable_conformance, nominal);
+        auto note =
+            nominal->diagnose(diag::add_nominal_sendable_conformance, nominal);
         addSendableFixIt(nominal, note, /*unchecked=*/false);
       } else {
         nominal->diagnose(diag::non_sendable_nominal, nominal);
@@ -1302,6 +1305,9 @@ inferSendableFromInstanceStorage(NominalTypeDecl *nominal,
     }
   }
 
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable))
+    return std::nullopt;
+
   class Visitor : public StorageVisitor {
   public:
     NominalTypeDecl *nominal;
@@ -1393,6 +1399,10 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
   if (!nominal->getFormalAccessScope(
         /*useDC=*/nullptr,
         /*treatUsableFromInlineAsPublic=*/true).isPublic())
+    return;
+
+  // If `Sendable` conformance is explicitly suppressed, do nothing.
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable))
     return;
 
   // If the conformance is explicitly stated, do nothing.
@@ -7171,6 +7181,14 @@ static bool checkSendableInstanceStorage(
       }
       return true;
     }
+  }
+
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
+    auto *conformanceDecl = dc->getAsDecl() ? dc->getAsDecl() : nominal;
+    if (!isImplicitSendableCheck(check)) {
+      conformanceDecl->diagnose(diag::non_sendable_type_suppressed);
+    }
+    return true;
   }
 
   // Stored properties of structs and classes must have

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -123,6 +123,15 @@ public:
                       ctx.getProtocol(*kp));
       return Type();
     }
+
+    if (rpk == RepressibleProtocolKind::Sendable) {
+      if (!ctx.LangOpts.hasFeature(Feature::TildeSendable)) {
+        diagnoseInvalid(repr, repr.getLoc(),
+                        diag::tilde_sendable_requires_feature_flag);
+        return Type();
+      }
+    }
+
     if (auto *extension = dyn_cast<const ExtensionDecl *>(decl)) {
       diagnoseInvalid(repr, extension,
                       diag::suppress_inferrable_protocol_extension,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -132,6 +132,18 @@ public:
       }
     }
 
+    if (auto *TD = dyn_cast<const TypeDecl *>(decl)) {
+      if (!(isa<StructDecl>(TD) || isa<ClassDecl>(TD) || isa<EnumDecl>(TD))) {
+        diagnoseInvalid(repr, repr.getLoc(),
+                        diag::conformance_repression_only_on_struct_class_enum,
+                        ctx.getProtocol(*kp))
+            // Downgrade to a warning for `~BitwiseCopyable` because it was accepted
+            // in some incorrect positions before.
+            .warnUntilFutureSwiftVersionIf(kp == KnownProtocolKind::BitwiseCopyable);
+        return Type();
+      }
+    }
+
     if (auto *extension = dyn_cast<const ExtensionDecl *>(decl)) {
       diagnoseInvalid(repr, extension,
                       diag::suppress_inferrable_protocol_extension,

--- a/test/ModuleInterface/tilde_sendable.swift
+++ b/test/ModuleInterface/tilde_sendable.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature TildeSendable
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: swift_feature_TildeSendable
+
+// CHECK: #if compiler(>=5.3) && $TildeSendable
+// CHECK: public class A : ~Swift.Sendable {
+// CHECK: }
+// CHECK: #else
+// CHECK: public class A {
+// CHECK: }
+// CHECK: #endif
+public class A: ~Sendable {
+  public init() {}
+}
+
+protocol P {
+}
+
+// CHECK: #if compiler(>=5.3) && $TildeSendable
+// CHECK: public struct S : ~Swift.Sendable {
+// CHECK:   public let x: Swift.Int
+// CHECK: }
+// CHECK: #else
+// CHECK: public struct S {
+// CHECK:   public let x: Swift.Int
+// CHECK: }
+// CHECK: #endif
+
+// CHECK-NOT: extension Library.S : Swift.Sendable {}
+public struct S: P, ~Sendable {
+  public let x: Int
+}

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -7,6 +7,23 @@
 
 // This test file only exists in order to test without noncopyable_generics and can be deleted once that is always enabled.
 
+protocol P: ~BitwiseCopyable {
+  // expected-warning@-1 {{conformance to 'BitwiseCopyable' can only be suppressed on structs, classes, and enums; this will be an error in a future}}
+}
+
+protocol Q {
+  associatedtype V: ~BitwiseCopyable
+  // expected-warning@-1 {{conformance to 'BitwiseCopyable' can only be suppressed on structs, classes, and enums; this will be an error in a future}}
+}
+
+func test<T: ~BitwiseCopyable>(_: T) {
+  // expected-warning@-1 {{conformance to 'BitwiseCopyable' can only be suppressed on structs, classes, and enums; this will be an error in a future}}
+}
+
+func test<T>() -> T where T: ~BitwiseCopyable {
+  // expected-error@-1 {{type 'BitwiseCopyable' cannot be suppressed}}
+}
+
 @_nonescapable
 struct S_Implicit_Nonescapable {}
 

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TildeSendable
+
+// REQUIRES: swift_feature_TildeSendable
+
+protocol P: ~Sendable { // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+}
+
+protocol Q {
+  associatedtype T: ~Sendable
+  // expected-error@-1 {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+}
+
+struct A: ~Sendable {}
+class B: ~Sendable {}
+enum C: ~Sendable {}
+
+struct E1: Sendable, ~Sendable {}
+
+enum E2: ~Sendable, ~Sendable {} // expected-warning {{already suppressed conformance to 'Sendable'}}
+
+struct InExt {}
+
+extension InExt: ~Sendable { // expected-error {{conformance to inferrable protocol 'Sendable' cannot be suppressed in an extension}}
+}
+
+func test<T: ~Sendable>(_: T) {} // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+func test<Q>(other: Q) where Q: ~Sendable {} // expected-error {{type 'Sendable' cannot be suppressed}}
+
+struct Generic<T: ~Sendable> { // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+  var x: T
+}
+
+var x: some BinaryInteger & ~Sendable // expected-error {{type 'Sendable' cannot be suppressed}}
+


### PR DESCRIPTION
Experimental flag - `TildeSendable`.

This allows users to suppress `Sendable` inferences on structs, classes, and enums 
and gives users a clear way to indicate that the type shouldn't be considered 'Sendable'
and it's not just a missing 'Sendable' conformance annotation.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
