### PR TITLE
SILGen: revise emission of UnreachableExpr

### DIFF
--- a/test/SILGen/unreachable_expr.swift
+++ b/test/SILGen/unreachable_expr.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-silgen %s -verify -sil-verify-all | %FileCheck %s --check-prefixes CHECK,REG
+// RUN: %target-swift-emit-silgen %s -verify -sil-verify-all -enable-sil-opaque-values | %FileCheck %s --check-prefixes CHECK,OV
+
+// CHECK-LABEL:   sil{{.*}} [ossa] @{{.*}}uninhabited_generic{{.*}}
+// CHECK:           [[NEVER:%[^,]+]] = apply {{.*}} -> Never
+// CHECK-NEXT:      ignored_use [[NEVER]]
+// CHECK-NEXT:      unreachable
+//
+// CHECK:         bb1:
+// CHECK-NOT:         Preds
+
+            // Without opaque values, take from an undef address,
+            // through a temporary alloc, to eventually the out-parameter %0
+// REG-NEXT:      [[BOGUS_ALLOC:%.*]] = alloc_stack $T
+// REG-NEXT:      copy_addr [take] undef to [init] [[BOGUS_ALLOC]]
+// REG-NEXT:      copy_addr [take] [[BOGUS_ALLOC]] to [init] %0
+
+            // With opaque values, simply return the undef value
+// OV-NEXT:       return undef : $T
+func uninhabited_generic<T>() -> T { fatalError("todo") }

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -430,6 +430,16 @@ func convertVoidPayloads() {
   convertPayloads(as: Void.self)
 }
 
+// CHECK-LABEL:   sil{{.*}} [ossa] @{{.*}}convertPayloads{{.*}} :
+// CHECK:           ignored_use {{.*}}
+// CHECK-NEXT:      unreachable
+//
+// CHECK:           bb1:
+// CHECK-NOT:         Preds
+// CHECK:             [[BOGUS_ALLOC:%.*]] = alloc_stack $(repeat each Value)
+// CHECK-NEXT:        copy_addr [take] undef to [init] [[BOGUS_ALLOC]]
+//
+// CHECK:             = tuple_pack_element_addr {{.*}} of [[BOGUS_ALLOC]]
 func convertPayloads<each Value>(as valueTypes: repeat (each Value).Type) -> (repeat each Value) {
   fatalError()
 }


### PR DESCRIPTION
The prior emission strategy produced some scary SIL where we have a copy of uninitialized memory:

```
  ignored_use %14
  %16 = alloc_stack $T
  unreachable

bb1:
  copy_addr [take] %16 to [init] %0
  dealloc_stack %16
```

I assume this was done to dodge the SILVerifier, which will catch a take of an uninitialized address, had the alloc_stack been in any reachable predecessor.

We already have a representation for an undefined value in SIL, so I'd rather use that than try to sneak one past the verifier.

This adjusted emission also is opaque values friendly, as it doesn't assume the result value is an address.

resolves rdar://162239557