### PR TITLE
Fix serialization of mutate accessors

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 964; // serialize param decl isAddressable
+const uint16_t SWIFTMODULE_VERSION_MINOR = 965; // WriteImplKindField and ReadWriteImplKindField size
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -209,7 +209,10 @@ enum class ReadImplKind : uint8_t {
   Read,
   Read2,
   Borrow,
+  LastReadImplKind = Borrow,
 };
+static_assert(countBitsUsed(static_cast<unsigned>(
+                  ReadImplKind::LastReadImplKind)) <= 3);
 using ReadImplKindField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
@@ -224,8 +227,11 @@ enum class WriteImplKind : uint8_t {
   Modify,
   Modify2,
   Mutate,
+  LastWriteImplKind = Mutate,
 };
-using WriteImplKindField = BCFixed<3>;
+static_assert(countBitsUsed(static_cast<unsigned>(
+                  WriteImplKind::LastWriteImplKind)) <= 4);
+using WriteImplKindField = BCFixed<4>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -239,8 +245,11 @@ enum class ReadWriteImplKind : uint8_t {
   StoredWithDidSet,
   InheritedWithDidSet,
   Mutate,
+  LastReadWriteImplKind = Mutate,
 };
-using ReadWriteImplKindField = BCFixed<3>;
+static_assert(countBitsUsed(static_cast<unsigned>(
+                  ReadWriteImplKind::LastReadWriteImplKind)) <= 4);
+using ReadWriteImplKindField = BCFixed<4>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.

--- a/test/Serialization/Inputs/borrow_accessor_container.swift
+++ b/test/Serialization/Inputs/borrow_accessor_container.swift
@@ -1,0 +1,40 @@
+public struct Container<Element: ~Copyable >: ~Copyable {
+  var _storage: UnsafeMutableBufferPointer<Element>
+  public let _count: Int
+
+  public init(_ storage: UnsafeMutableBufferPointer<Element>, _ count: Int) {
+    self._storage = storage
+    self._count = count
+  }
+
+  public var count: Int {
+    return _count
+  }
+
+  public var first: Element {
+    @_unsafeSelfDependentResult
+    borrow {
+      return _storage.baseAddress.unsafelyUnwrapped.pointee
+    }
+    @_unsafeSelfDependentResult
+    mutate {
+      return &_storage.baseAddress.unsafelyUnwrapped.pointee
+    }
+  }
+
+  public subscript(index: Int) -> Element {
+    @_unsafeSelfDependentResult
+    borrow {
+      precondition(index >= 0 && index < _count, "Index out of bounds")
+      return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+    }
+    @_unsafeSelfDependentResult
+    mutate {
+      precondition(index >= 0 && index < _count, "Index out of bounds")
+      return &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+    }
+  }
+}
+
+extension Container: Copyable where Element: Copyable {}
+

--- a/test/Serialization/borrow_accessor_client.swift
+++ b/test/Serialization/borrow_accessor_client.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name borrow_accessor_container -enable-experimental-feature BorrowAndMutateAccessors -o %t %S/Inputs/borrow_accessor_container.swift
+// RUN: %target-swift-frontend -I %t -emit-sil %s -verify | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
+import borrow_accessor_container
+
+func test() {
+  let n = 10_000
+  var arr = Array(0...n)
+  let count = arr.count
+  let sum = arr.withUnsafeMutableBufferPointer { ubpointer in
+    let container = Container(ubpointer, count)
+    var sum = 0
+    for i in 0..<container._count {
+      sum &+= container[i]
+    }
+    return sum
+  }
+  let expectedSum = n * (n + 1) / 2
+  assert(sum == expectedSum)
+  let mutated_sum = arr.withUnsafeMutableBufferPointer { ubpointer in
+    var container = Container(ubpointer, count)
+    var sum = 0
+    for i in 0..<container._count {
+      container[i] &+= 1
+      sum += container[i]
+    }
+    return sum
+  }
+  let mutatedExpectedSum = (n + 1) * (n + 2) / 2
+  assert(mutated_sum == mutatedExpectedSum)
+}
+
+// CHECK: sil @$s25borrow_accessor_container9ContainerVAARi_zrlEyxSicib : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @guaranteed Container<τ_0_0>) -> @guaranteed_addr τ_0_0
+// CHECK: sil @$s25borrow_accessor_container9ContainerVAARi_zrlEyxSiciz : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @inout Container<τ_0_0>) -> @guaranteed_addr τ_0_0
+


### PR DESCRIPTION
Expand bit width of `WriteImplKindField` and `ReadWriteImplKindField` to support mutate accessors.