### PR TITLE
[autolink-extract] Update deduplication list for new Foundation, Testing, and WASI platform

### DIFF
--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -236,6 +236,7 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       "-lswiftSynchronization",
       "-lswiftGlibc",
       "-lswiftAndroid",
+      "-lswiftWASILibc",
       "-lBlocksRuntime",
       // Dispatch-specific Swift runtime libs
       "-ldispatch",
@@ -249,6 +250,9 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       "-lFoundationInternationalization",
       "-lFoundationNetworking",
       "-lFoundationXML",
+      "-l_CFXMLInterface",
+      "-l_FoundationCShims",
+      "-l_FoundationCollections",
       // Foundation support libs
       "-lcurl",
       "-lxml2",
@@ -256,12 +260,20 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       "-lTesting",
       // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
       "-lXCTest",
+      // swift-testing libraries
+      "-l_TestingInternals",
+      "-l_TestDiscovery",
+      "-l_Testing_Foundation",
       // Common-use ordering-agnostic Linux system libs
       "-lm",
       "-lpthread",
       "-lutil",
       "-ldl",
       "-lz",
+      // Common-use ordering-agnostic WASI system libs
+      "-lwasi-emulated-getpid",
+      "-lwasi-emulated-mman",
+      "-lwasi-emulated-signal",
   };
   std::unordered_map<std::string, bool> SwiftRuntimeLibraries;
   for (const auto &RuntimeLib : SwiftRuntimeLibsOrdered) {


### PR DESCRIPTION
We now have several new runtime libraries in the toolchain but they are not listed in the autolink deduplication list. This can lead to an excessive memory footprint when linking on platforms that use autolink-extract.

See https://github.com/swiftlang/swift/issues/58380
As a data point, this change reduced the memory footprint of our wasm-ld process from 33.34 GiB → 2.22 GiB and link time from 46.4 s → 1.4 s.
