### PR TITLE
Fix 82618 (casting of collection types)

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -267,7 +267,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -302,7 +302,10 @@ protected:
     /// Whether this closure was type-checked as an argument to a macro. This
     /// is only populated after type-checking, and only exists for diagnostic
     /// logic. Do not add more uses of this.
-    IsMacroArgument : 1
+    IsMacroArgument : 1,
+    
+    /// This closure is a part of a CollectionUpcastConversionExpr
+    IsConversionClosure : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -3415,23 +3418,17 @@ public:
 /// elements have some type T to the same kind of collection whose
 /// elements have type U, where U is a subtype of T.
 class CollectionUpcastConversionExpr : public ImplicitConversionExpr {
-public:
-  struct ConversionPair {
-    OpaqueValueExpr *OrigValue;
-    Expr *Conversion;
-
-    explicit operator bool() const { return OrigValue != nullptr; }
-  };
 private:
-  ConversionPair KeyConversion;
-  ConversionPair ValueConversion;
+  ClosureExpr *KeyConversion;
+  ClosureExpr *ValueConversion;
+
 public:
   CollectionUpcastConversionExpr(Expr *subExpr, Type type,
-                                 ConversionPair keyConversion,
-                                 ConversionPair valueConversion)
-    : ImplicitConversionExpr(
-        ExprKind::CollectionUpcastConversion, subExpr, type),
-      KeyConversion(keyConversion), ValueConversion(valueConversion) {
+                                 ClosureExpr *keyConversion,
+                                 ClosureExpr *valueConversion)
+      : ImplicitConversionExpr(ExprKind::CollectionUpcastConversion, subExpr,
+                               type),
+        KeyConversion(keyConversion), ValueConversion(valueConversion) {
     assert((!KeyConversion || ValueConversion)
            && "key conversion without value conversion");
   }
@@ -3439,28 +3436,27 @@ public:
   /// Returns the expression that should be used to perform a
   /// conversion of the collection's values; null if the conversion
   /// is formally trivial because the key type does not change.
-  const ConversionPair &getKeyConversion() const {
-    return KeyConversion;
-  }
-  void setKeyConversion(const ConversionPair &pair) {
-    KeyConversion = pair;
-  }
+  ClosureExpr *getKeyConversion() const { return KeyConversion; }
+  void setKeyConversion(ClosureExpr *pair) { KeyConversion = pair; }
 
   /// Returns the expression that should be used to perform a
   /// conversion of the collection's values; null if the conversion
   /// is formally trivial because the value type does not change.
-  const ConversionPair &getValueConversion() const {
-    return ValueConversion;
-  }
-  void setValueConversion(const ConversionPair &pair) {
-    ValueConversion = pair;
-  }
+  ClosureExpr *getValueConversion() const { return ValueConversion; }
+  void setValueConversion(ClosureExpr *pair) { ValueConversion = pair; }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::CollectionUpcastConversion;
   }
 };
-  
+
+struct ConversionPair {
+  OpaqueValueExpr *OrigValue;
+  Expr *Conversion;
+
+  explicit operator bool() const { return OrigValue != nullptr; }
+};
+
 /// ErasureExpr - Perform type erasure by converting a value to existential
 /// type. For example:
 ///
@@ -3481,11 +3477,11 @@ public:
 ///
 /// "Appropriate kind" means e.g. a concrete/existential metatype if the
 /// result is an existential metatype.
-class ErasureExpr final : public ImplicitConversionExpr,
-    private llvm::TrailingObjects<ErasureExpr, ProtocolConformanceRef,
-                                  CollectionUpcastConversionExpr::ConversionPair> {
+class ErasureExpr final
+    : public ImplicitConversionExpr,
+      private llvm::TrailingObjects<ErasureExpr, ProtocolConformanceRef,
+                                    ConversionPair> {
   friend TrailingObjects;
-  using ConversionPair = CollectionUpcastConversionExpr::ConversionPair;
 
   ErasureExpr(Expr *subExpr, Type type,
               ArrayRef<ProtocolConformanceRef> conformances,
@@ -4314,6 +4310,7 @@ public:
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
     Bits.ClosureExpr.IsMacroArgument = false;
+    Bits.ClosureExpr.IsConversionClosure = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4422,6 +4419,14 @@ public:
 
   void setIsMacroArgument(bool value = true) {
     Bits.ClosureExpr.IsMacroArgument = value;
+  }
+
+  bool isConversionClosure() const {
+    return Bits.ClosureExpr.IsConversionClosure;
+  }
+
+  void setIsConversionClosure(bool value = true) {
+    Bits.ClosureExpr.IsConversionClosure = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -24,10 +24,12 @@ FUNC_DECL(ArrayWitnessCast, "_arrayWitnessCast")
 FUNC_DECL(ArrayConditionalCast, "_arrayConditionalCast")
 
 FUNC_DECL(DictionaryUpCast, "_dictionaryUpCast")
+FUNC_DECL(DictionaryWitnessCast, "_dictionaryWitnessCast")
 FUNC_DECL(DictionaryDownCast, "_dictionaryDownCast")
 FUNC_DECL(DictionaryDownCastConditional, "_dictionaryDownCastConditional")
 
 FUNC_DECL(SetUpCast, "_setUpCast")
+FUNC_DECL(SetWitnessCast, "_setWitnessCast")
 FUNC_DECL(SetDownCast, "_setDownCast")
 FUNC_DECL(SetDownCastConditional, "_setDownCastConditional")
 

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -20,6 +20,7 @@
 #endif
 
 FUNC_DECL(ArrayForceCast, "_arrayForceCast")
+FUNC_DECL(ArrayWitnessCast, "_arrayWitnessCast")
 FUNC_DECL(ArrayConditionalCast, "_arrayConditionalCast")
 
 FUNC_DECL(DictionaryUpCast, "_dictionaryUpCast")

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1701,7 +1701,8 @@ public:
   /// \param locator Locator used to describe the location of this expression.
   ///
   /// \returns the coerced expression, which will have type \c ToType.
-  Expr *coerceToType(Expr *expr, Type toType, ConstraintLocator *locator);
+  Expr *coerceToType(Expr *expr, Type toType, ConstraintLocator *locator,
+                     DeclContext &dc);
 
   /// Compute the set of substitutions for a generic signature opened at the
   /// given locator.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3968,10 +3968,10 @@ public:
     printCommon(E, "collection_upcast_expr", label);
     printRec(E->getSubExpr(), Label::optional("sub_expr"));
     if (auto keyConversion = E->getKeyConversion()) {
-      printRec(keyConversion.Conversion, Label::always("key_conversion"));
+      printRec(keyConversion, Label::always("key_conversion"));
     }
     if (auto valueConversion = E->getValueConversion()) {
-      printRec(valueConversion.Conversion, Label::always("value_conversion"));
+      printRec(valueConversion, Label::always("value_conversion"));
     }
     printFoot();
   }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -967,24 +967,6 @@ public:
       OptionalEvaluations.pop_back();
     }
 
-    // Register the OVEs in a collection upcast.
-    bool shouldVerify(CollectionUpcastConversionExpr *expr) {
-      if (!shouldVerify(cast<Expr>(expr)))
-        return false;
-
-      if (auto keyConversion = expr->getKeyConversion())
-        OpaqueValues[keyConversion.OrigValue] = 0;
-      if (auto valueConversion = expr->getValueConversion())
-        OpaqueValues[valueConversion.OrigValue] = 0;
-      return true;
-    }
-    void cleanup(CollectionUpcastConversionExpr *expr) {
-      if (auto keyConversion = expr->getKeyConversion())
-        OpaqueValues.erase(keyConversion.OrigValue);
-      if (auto valueConversion = expr->getValueConversion())
-        OpaqueValues.erase(valueConversion.OrigValue);
-    }
-
     /// Canonicalize the given DeclContext pointer, in terms of
     /// producing something that can be looked up in
     /// ClosureDiscriminators.
@@ -1902,7 +1884,7 @@ public:
         //        currently visiting arguments of an apply when we
         //        find these conversions.
         if (auto *upcast = dyn_cast<CollectionUpcastConversionExpr>(subExpr)) {
-          subExpr = upcast->getValueConversion().Conversion;
+          subExpr = upcast->getValueConversion();
           continue;
         }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -881,23 +881,17 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       return nullptr;
     }
 
-    if (auto &keyConv = E->getKeyConversion()) {
-      auto kConv = keyConv.Conversion;
-      if (!kConv) {
-        return nullptr;
-      } else if (Expr *E2 = doIt(kConv)) {
-        E->setKeyConversion({keyConv.OrigValue, E2});
+    if (auto keyConv = E->getKeyConversion()) {
+      if (Expr *E2 = doIt(keyConv)) {
+        E->setKeyConversion(cast<ClosureExpr>(E2));
       } else {
         return nullptr;
       }
     }
 
-    if (auto &valueConv = E->getValueConversion()) {
-      auto vConv = valueConv.Conversion;
-      if (!vConv) {
-        return nullptr;
-      } else if (Expr *E2 = doIt(vConv)) {
-        E->setValueConversion({valueConv.OrigValue, E2});
+    if (auto valueConv = E->getValueConversion()) {
+      if (Expr *E2 = doIt(valueConv)) {
+        E->setValueConversion(cast<ClosureExpr>(E2));
       } else {
         return nullptr;
       }

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -656,6 +656,9 @@ swift::classifyDynamicCast(SILFunction *function,
   // Function casts.
   if (auto sourceFunction = dyn_cast<FunctionType>(source)) {
     if (auto targetFunction = dyn_cast<FunctionType>(target)) {
+      // Note that this logic must be aligned with with tryCastToFunction() in
+      // stdlib/public/runtime/DynamicCast.cpp
+
       // A function cast can succeed if the function types can be identical,
       // or if the target type is throwier than the original.
 
@@ -674,10 +677,10 @@ swift::classifyDynamicCast(SILFunction *function,
             != sourceFunction->getRepresentation())
         return DynamicCastFeasibility::WillFail;
 
-      if (AnyFunctionType::equalParams(sourceFunction.getParams(),
-                                       targetFunction.getParams()) &&
+      if (!AnyFunctionType::equalParams(sourceFunction.getParams(),
+                                        targetFunction.getParams()) &&
           sourceFunction.getResult() == targetFunction.getResult())
-        return DynamicCastFeasibility::WillSucceed;
+        return DynamicCastFeasibility::WillFail;
 
       // Be conservative about function type relationships we may add in
       // the future.

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -394,7 +394,7 @@ static RValue emitCollectionDowncastExpr(SILGenFunction &SGF,
   }
 
   return SGF.emitCollectionConversion(loc, fn, fromCollection, toCollection,
-                                      source, C);
+                                      source, ManagedValue(), ManagedValue(), C);
 }
 
 static ManagedValue

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -394,7 +394,8 @@ static RValue emitCollectionDowncastExpr(SILGenFunction &SGF,
   }
 
   return SGF.emitCollectionConversion(loc, fn, fromCollection, toCollection,
-                                      source, nullptr, nullptr, C);
+                                      source, /*keyConversion*/ nullptr,
+                                      /*valueConversion*/ nullptr, C);
 }
 
 static ManagedValue

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -394,7 +394,7 @@ static RValue emitCollectionDowncastExpr(SILGenFunction &SGF,
   }
 
   return SGF.emitCollectionConversion(loc, fn, fromCollection, toCollection,
-                                      source, ManagedValue(), ManagedValue(), C);
+                                      source, nullptr, nullptr, C);
 }
 
 static ManagedValue

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1599,6 +1599,7 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
         case ExprKind::DerivedToBase:
         case ExprKind::AnyHashableErasure:
         case ExprKind::MetatypeConversion:
+        case ExprKind::BridgeFromObjC:
         case ExprKind::BridgeToObjC:
         case ExprKind::InjectIntoOptional:
           return false;
@@ -1618,7 +1619,6 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
         case ExprKind::ABISafeConversion:
         case ExprKind::CovariantFunctionConversion:
         case ExprKind::CovariantReturnConversion:
-        case ExprKind::BridgeFromObjC:
         case ExprKind::ConditionalBridgeFromObjC:
         case ExprKind::ArchetypeToSuper:
         case ExprKind::ClassMetatypeToObject:
@@ -1786,6 +1786,12 @@ public:
       E->getOpaqueValue(),
       subExpr ? subExpr : E->getSubExpr(),
       subExpr->getType());
+  }
+  
+  Expr *visitBridgeFromObjCExpr(BridgeFromObjCExpr *E) {
+    Expr* subExpr = visit(E->getSubExpr());
+    if (!subExpr) return E;
+    return new (Context) BridgeFromObjCExpr(subExpr, E->getType());
   }
 
   Expr *visitExpr(Expr *E) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1798,7 +1798,19 @@ ManagedValue RValueEmitter::emitConversionClosure(CollectionUpcastConversionExpr
   auto *BS = BraceStmt::createImplicit(Context, ArrayRef(bodyNode));
   closure->setBody(BS);
 
-  //closure->setExplicitResultType();
+  auto closureParam = AnyFunctionType::Param(pair.OrigValue->getType());
+  auto extInfo = FunctionType::ExtInfo()
+    .withNoEscape()
+    .withSendable()
+    .withoutIsolation();
+  auto *fnTy = FunctionType::get(ArrayRef(closureParam), pair.Conversion->getType(), extInfo);
+  closure->setType(fnTy);
+
+  closure->setCaptureInfo(CaptureInfo::empty());
+
+  auto discriminator = Context.getNextDiscriminator(declContext);
+  closure->setDiscriminator(discriminator++);
+  Context.setMaxAssignedDiscriminator(declContext, discriminator);
 
   RValue result = visitAbstractClosureExpr(closure, C);
   return std::move(result).getScalarValue();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1659,9 +1659,22 @@ visitCollectionUpcastConversionExpr(CollectionUpcastConversionExpr *E,
       fn = SGF.SGM.getArrayForceCast(loc);
     }
   } else if (fromCollection->isDictionary()) {
+    if (needsCustomConversion(E->getKeyConversion()) ||
+        needsCustomConversion(E->getValueConversion())) {
+      fn = SGF.SGM.getDictionaryWitnessCast(loc);
+      keyConversion = emitConversionClosure(E->getKeyConversion(), C, fn, 1);
+      valueConversion =
+          emitConversionClosure(E->getValueConversion(), C, fn, 2);
+    }
     fn = SGF.SGM.getDictionaryUpCast(loc);
   } else if (fromCollection->isSet()) {
-    fn = SGF.SGM.getSetUpCast(loc);
+    if (needsCustomConversion(E->getValueConversion())) {
+      fn = SGF.SGM.getSetWitnessCast(loc);
+      valueConversion =
+          emitConversionClosure(E->getValueConversion(), C, fn, 1);
+    } else {
+      fn = SGF.SGM.getSetUpCast(loc);
+    }
   } else {
     llvm_unreachable("unsupported collection upcast kind");
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1611,9 +1611,11 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
           }
           return needsCustomConversion(upcast->getValueConversion());
         }
+        case ExprKind::DestructureTuple: {
+          return false;
+        }
         case ExprKind::Load:
         case ExprKind::ABISafeConversion:
-        case ExprKind::DestructureTuple:
         case ExprKind::CovariantFunctionConversion:
         case ExprKind::CovariantReturnConversion:
         case ExprKind::BridgeFromObjC:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1620,34 +1620,9 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
         case ExprKind::DestructureTuple: {
           return false;
         }
-        case ExprKind::Load:
-        case ExprKind::ABISafeConversion:
-        case ExprKind::CovariantFunctionConversion:
-        case ExprKind::CovariantReturnConversion:
-        case ExprKind::ConditionalBridgeFromObjC:
-        case ExprKind::ClassMetatypeToObject:
-        case ExprKind::ExistentialMetatypeToObject:
-        case ExprKind::ProtocolMetatypeToObject:
-        case ExprKind::InOutToPointer:
-        case ExprKind::ArrayToPointer:
-        case ExprKind::StringToPointer:
-        case ExprKind::PointerToPointer:
-        case ExprKind::ForeignObjectConversion:
-        case ExprKind::UnevaluatedInstance:
-        case ExprKind::UnderlyingToOpaque:
-        case ExprKind::Unreachable:
-        case ExprKind::DifferentiableFunction:
-        case ExprKind::LinearFunction:
-        case ExprKind::DifferentiableFunctionExtractOriginal:
-        case ExprKind::LinearFunctionExtractOriginal:
-        case ExprKind::LinearToDifferentiableFunction:
-        case ExprKind::ActorIsolationErasure:
-        case ExprKind::UnsafeCast:
-          conv->dump(llvm::errs());
-          llvm::errs() << "\n";
-          assert(false && "TODO");
-        default:
-          break;
+        default: {
+          llvm_unreachable("unsupported collection element conversion");
+        }
       }
     }
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1586,6 +1586,10 @@ RValue SILGenFunction::emitCollectionConversion(
 static bool
 needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pair) {
   assert(pair);
+  
+  if (pair.Conversion == pair.OrigValue) {
+    return false;
+  }
 
   if (auto conv = dyn_cast<ImplicitConversionExpr>(pair.Conversion)) {
     if (isa<ForeignObjectConversionExpr>(conv)) {
@@ -1597,6 +1601,7 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
       switch (conv->getKind()) {
         case ExprKind::Erasure:
         case ExprKind::DerivedToBase:
+        case ExprKind::ArchetypeToSuper:
         case ExprKind::AnyHashableErasure:
         case ExprKind::MetatypeConversion:
         case ExprKind::BridgeFromObjC:
@@ -1620,7 +1625,6 @@ needsCustomConversion(CollectionUpcastConversionExpr::ConversionPair const & pai
         case ExprKind::CovariantFunctionConversion:
         case ExprKind::CovariantReturnConversion:
         case ExprKind::ConditionalBridgeFromObjC:
-        case ExprKind::ArchetypeToSuper:
         case ExprKind::ClassMetatypeToObject:
         case ExprKind::ExistentialMetatypeToObject:
         case ExprKind::ProtocolMetatypeToObject:

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1765,14 +1765,10 @@ public:
                             CanType existentialType,
                             SGFContext C = SGFContext());
 
-  RValue emitCollectionConversion(SILLocation loc,
-                                  FuncDecl *fn,
-                                  CanType fromCollection,
-                                  CanType toCollection,
-                                  ManagedValue mv,
-                                  ManagedValue keyConversion,
-                                  ManagedValue valueConversion,
-                                  SGFContext C);
+  RValue emitCollectionConversion(SILLocation loc, FuncDecl *fn,
+                                  CanType fromCollection, CanType toCollection,
+                                  ManagedValue mv, ClosureExpr *keyConversion,
+                                  ClosureExpr *valueConversion, SGFContext C);
 
   //===--------------------------------------------------------------------===//
   // Recursive entry points

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1770,6 +1770,8 @@ public:
                                   CanType fromCollection,
                                   CanType toCollection,
                                   ManagedValue mv,
+                                  ManagedValue keyConversion,
+                                  ManagedValue valueConversion,
                                   SGFContext C);
 
   //===--------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -648,7 +648,7 @@ ManagedValue Transform::transform(ManagedValue v,
       }
 
       return SGF.emitCollectionConversion(Loc, fn, inputSubstType,
-                                          outputSubstType, v, ctxt)
+                                          outputSubstType, v, ManagedValue(), ManagedValue(), ctxt)
                 .getScalarValue();
     }
   }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -647,9 +647,10 @@ ManagedValue Transform::transform(ManagedValue v,
         llvm::report_fatal_error("unsupported collection upcast kind");
       }
 
-      return SGF.emitCollectionConversion(Loc, fn, inputSubstType,
-                                          outputSubstType, v, ManagedValue(), ManagedValue(), ctxt)
-                .getScalarValue();
+      return SGF
+          .emitCollectionConversion(Loc, fn, inputSubstType, outputSubstType, v,
+                                    nullptr, nullptr, ctxt)
+          .getScalarValue();
     }
   }
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -649,7 +649,8 @@ ManagedValue Transform::transform(ManagedValue v,
 
       return SGF
           .emitCollectionConversion(Loc, fn, inputSubstType, outputSubstType, v,
-                                    nullptr, nullptr, ctxt)
+                                    /*keyConversion*/ nullptr,
+                                    /*valueConversion*/ nullptr, ctxt)
           .getScalarValue();
     }
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -445,12 +445,15 @@ namespace {
     bool SuppressDiagnostics;
 
     ExprRewriter(ConstraintSystem &cs, Solution &solution,
-                 std::optional<SyntacticElementTarget> target,
-                 bool suppressDiagnostics)
-        : ctx(cs.getASTContext()), cs(cs),
-          dc(target ? target->getDeclContext() : cs.DC),
+                 SyntacticElementTarget target, bool suppressDiagnostics)
+        : ctx(cs.getASTContext()), cs(cs), dc(target.getDeclContext()),
           solution(solution), target(target),
           SuppressDiagnostics(suppressDiagnostics) {}
+
+    ExprRewriter(ConstraintSystem &cs, Solution &solution, DeclContext &dc,
+                 bool suppressDiagnostics)
+        : ctx(cs.getASTContext()), cs(cs), dc(&dc), solution(solution),
+          target(std::nullopt), SuppressDiagnostics(suppressDiagnostics) {}
 
     ConstraintSystem &getConstraintSystem() const { return cs; }
 
@@ -4529,7 +4532,7 @@ namespace {
         Expr *sub = expr->getSubExpr();
         auto subLoc =
             cs.getConstraintLocator(sub, ConstraintLocator::CoercionOperand);
-        sub = solution.coerceToType(sub, expr->getCastType(), subLoc);
+        sub = solution.coerceToType(sub, expr->getCastType(), subLoc, *dc);
         if (!sub)
           return nullptr;
 
@@ -6706,11 +6709,9 @@ static Expr *buildElementConversion(ExprRewriter &rewriter,
   return rewriter.coerceToType(element, destType, locator);
 }
 
-static CollectionUpcastConversionExpr::ConversionPair
-buildOpaqueElementConversion(ExprRewriter &rewriter, SourceRange srcRange,
-                             Type srcType, Type destType,
-                             bool bridged, ConstraintLocatorBuilder locator,
-                             unsigned typeArgIndex) {
+static ConversionPair buildOpaqueElementConversion(
+    ExprRewriter &rewriter, SourceRange srcRange, Type srcType, Type destType,
+    bool bridged, ConstraintLocatorBuilder locator, unsigned typeArgIndex) {
   // Build the conversion.
   auto &cs = rewriter.getConstraintSystem();
   ASTContext &ctx = cs.getASTContext();
@@ -6723,6 +6724,69 @@ buildOpaqueElementConversion(ExprRewriter &rewriter, SourceRange srcRange,
       opaque);
 
   return { opaque, conversion };
+}
+
+static ClosureExpr *buildClosureElementConversion(
+    ExprRewriter &rewriter, SourceRange srcRange, Type srcType, Type destType,
+    bool bridged, ConstraintLocatorBuilder locator, unsigned typeArgIndex) {
+  // Build the conversion.
+  auto &cs = rewriter.getConstraintSystem();
+  ASTContext &Context = cs.getASTContext();
+
+  DeclContext *declContext = rewriter.dc;
+
+  DeclAttributes attributes;
+  SourceRange bracketRange;
+  VarDecl *capturedSelfDecl = nullptr;
+  SourceLoc asyncLoc;
+  SourceLoc throwsLoc;
+  TypeExpr *thrownType = nullptr;
+  SourceLoc arrowLoc;
+  TypeExpr *explicitResultType = nullptr;
+  SourceLoc inLoc;
+
+  ClosureExpr *closure = new (Context) ClosureExpr(
+      attributes, bracketRange, capturedSelfDecl, nullptr, asyncLoc, throwsLoc,
+      thrownType, arrowLoc, inLoc, explicitResultType, declContext);
+  closure->setImplicit(true);
+  closure->setIsConversionClosure(true);
+
+  Identifier ident = Context.getDollarIdentifier(0);
+  ParamDecl *param = new (Context) ParamDecl(
+      SourceLoc(), SourceLoc(), Identifier(), SourceLoc(), ident, closure);
+
+  param->setSpecifier(ParamSpecifier::Default);
+  param->setInterfaceType(srcType->mapTypeOutOfEnvironment());
+  param->setImplicit();
+
+  ParameterList *params =
+      ParameterList::create(Context, SourceLoc(), ArrayRef(param), SourceLoc());
+  closure->setParameterList(params);
+
+  auto srcExp = rewriter.cs.cacheType(
+      new (Context) DeclRefExpr(param, DeclNameLoc(srcRange.Start), true,
+                                AccessSemantics::Ordinary, srcType));
+
+  Expr *conversion = buildElementConversion(
+      rewriter, srcRange, srcType, destType, bridged,
+      locator.withPathElement(LocatorPathElt::GenericArgument(typeArgIndex)),
+      srcExp);
+
+  auto *RS = ReturnStmt::createImplicit(Context, conversion);
+  ASTNode bodyNode(RS);
+  auto *BS = BraceStmt::createImplicit(Context, ArrayRef(bodyNode));
+  closure->setBody(BS);
+
+  auto closureParam = AnyFunctionType::Param(srcType);
+  auto extInfo =
+      FunctionType::ExtInfo().withNoEscape().withSendable().withoutIsolation();
+  auto *fnTy = FunctionType::get(ArrayRef(closureParam), destType, extInfo);
+  closure->setType(fnTy);
+
+  closure->setCaptureInfo(CaptureInfo::empty());
+
+  rewriter.cs.cacheType(closure);
+  return closure;
 }
 
 void ExprRewriter::peepholeArrayUpcast(ArrayExpr *expr, Type toType,
@@ -6859,10 +6923,8 @@ Expr *ExprRewriter::buildCollectionUpcastExpr(
   // Build the first value conversion.
   auto fromArgs = cs.getType(expr)->castTo<BoundGenericType>()->getGenericArgs();
   auto toArgs = toType->castTo<BoundGenericType>()->getGenericArgs();
-  auto conv =
-    buildOpaqueElementConversion(*this, expr->getLoc(),
-                                 fromArgs[0], toArgs[0],
-                                 bridged, locator, 0);
+  auto conv = buildClosureElementConversion(*this, expr->getLoc(), fromArgs[0],
+                                            toArgs[0], bridged, locator, 0);
 
   // For single-parameter collections, form the upcast.
   if (toType->isArray() || ConstraintSystem::isSetType(toType)) {
@@ -6874,10 +6936,8 @@ Expr *ExprRewriter::buildCollectionUpcastExpr(
          "Unhandled collection upcast");
 
   // Build the second value conversion.
-  auto conv2 =
-    buildOpaqueElementConversion(*this, expr->getLoc(),
-                                 fromArgs[1], toArgs[1],
-                                 bridged, locator, 1);
+  auto conv2 = buildClosureElementConversion(*this, expr->getLoc(), fromArgs[1],
+                                             toArgs[1], bridged, locator, 1);
 
   return cs.cacheType(
            new (ctx) CollectionUpcastConversionExpr(expr, toType, conv, conv2));
@@ -6959,7 +7019,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
 
   // Use the requirements of any parameterized protocols to build out fake
   // argument conversions that can be used to infer opaque types.
-  SmallVector<CollectionUpcastConversionExpr::ConversionPair, 4> argConversions;
+  SmallVector<ConversionPair, 4> argConversions;
 
   auto fromConstraintType = fromInstanceType;
   if (auto existential = fromConstraintType->getAs<ExistentialType>())
@@ -9231,7 +9291,8 @@ applySolutionToInitialization(SyntacticElementTarget target, Expr *initializer,
 
   auto locator = cs.getConstraintLocator(
       target.getAsExpr(), LocatorPathElt::ContextualType(CTP_Initialization));
-  initializer = solution.coerceToType(initializer, initType, locator);
+  initializer = solution.coerceToType(initializer, initType, locator,
+                                      *rewriter.getCurrentDC());
   if (!initializer)
     return std::nullopt;
 
@@ -9429,7 +9490,8 @@ applySolutionToForEachStmtPreamble(ForEachStmt *stmt,
 
     auto *loc = cs.getConstraintLocator(parsedSequence,
                                         ConstraintLocator::SequenceElementType);
-    auto *convertExpr = solution.coerceToType(elementExpr, info.initType, loc);
+    auto *convertExpr = solution.coerceToType(elementExpr, info.initType, loc,
+                                              *rewriter.getCurrentDC());
     if (!convertExpr)
       return std::nullopt;
 
@@ -9898,10 +9960,10 @@ ConstraintSystem::applySolution(Solution &solution,
   return resultTarget;
 }
 
-Expr *
-Solution::coerceToType(Expr *expr, Type toType, ConstraintLocator *locator) {
+Expr *Solution::coerceToType(Expr *expr, Type toType,
+                             ConstraintLocator *locator, DeclContext &dc) {
   auto &cs = getConstraintSystem();
-  ExprRewriter rewriter(cs, *this, std::nullopt, /*suppressDiagnostics=*/false);
+  ExprRewriter rewriter(cs, *this, dc, /*suppressDiagnostics=*/false);
   Expr *result = rewriter.coerceToType(expr, toType, locator);
   if (!result)
     return nullptr;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6496,7 +6496,8 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   if (!ctx.isLanguageModeAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
   if (!ctx.LangOpts.DisableAvailabilityChecking)
-    diagnoseExprAvailability(E, const_cast<DeclContext *>(DC), false);
+    diagnoseExprAvailability(E, const_cast<DeclContext *>(DC),
+                             /*preconcurrency=*/false);
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);
   diagnoseConstantArgumentRequirement(E, DC);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5389,13 +5389,17 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
     /// Returns true iff the collection upcast coercion is an Optional-to-Any
     /// coercion.
-    bool isOptionalToAnyCoercion(CollectionUpcastConversionExpr::ConversionPair
-                                   conversion) {
-      if (!conversion.OrigValue || !conversion.Conversion)
+    bool isOptionalToAnyCoercion(ClosureExpr *conversion) {
+      if (!conversion)
         return false;
 
-      auto srcType = conversion.OrigValue->getType();
-      auto destType = conversion.Conversion->getType();
+      auto fnType = conversion->getType()->getAs<FunctionType>();
+      if (!fnType)
+        return false;
+
+      assert(fnType->getNumParams() == 1);
+      auto srcType = fnType->getParams()[0].getPlainType();
+      auto destType = fnType->getResult();
       return isOptionalToAnyCoercion(srcType, destType);
     }
 
@@ -5541,10 +5545,13 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
       // We're handling the coercion of the entire collection, so we don't need
       // to re-visit a nested ErasureExpr for the value.
-      if (auto conversionExpr = valueConversion.Conversion)
+      if (valueConversion) {
+        Expr *body = valueConversion->getSingleExpressionBody();
         if (auto *erasureExpr =
-              findErasureExprThroughOptionalInjections(conversionExpr))
+                findErasureExprThroughOptionalInjections(body)) {
           IgnoredExprs.insert(erasureExpr);
+        }
+      }
 
       if (coercion.shouldSuppressDiagnostic() ||
           !isOptionalToAnyCoercion(valueConversion))
@@ -6489,7 +6496,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   if (!ctx.isLanguageModeAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
   if (!ctx.LangOpts.DisableAvailabilityChecking)
-    diagnoseExprAvailability(E, const_cast<DeclContext*>(DC));
+    diagnoseExprAvailability(E, const_cast<DeclContext *>(DC), false);
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);
   diagnoseConstantArgumentRequirement(E, DC);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2308,8 +2308,13 @@ class ExprAvailabilityWalker : public BaseDiagnosticWalker {
   }
 
 public:
-  explicit ExprAvailabilityWalker(const ExportContext &Where)
-    : Context(Where.getDeclContext()->getASTContext()), Where(Where) {}
+  explicit ExprAvailabilityWalker(const ExportContext &Where,
+                                  bool preconcurrency = false)
+      : Context(Where.getDeclContext()->getASTContext()), Where(Where) {
+    if (preconcurrency) {
+      PreconcurrencyCalleeStack.push_back(true);
+    }
+  }
 
   PreWalkAction walkToArgumentPre(const Argument &Arg) override {
     // Arguments should be walked in their own member access context which
@@ -2464,15 +2469,11 @@ public:
                                               EE->getLoc(),
                                               Where.getDeclContext());
 
-      bool preconcurrency = false;
-      if (!PreconcurrencyCalleeStack.empty()) {
-        preconcurrency = PreconcurrencyCalleeStack.back();
-      }
-
       for (ProtocolConformanceRef C : EE->getConformances()) {
-        diagnoseConformanceAvailability(E->getLoc(), C, Where, Type(), Type(),
-                                        /*useConformanceAvailabilityErrorsOpt=*/true,
-                                        /*preconcurrency=*/preconcurrency);
+        diagnoseConformanceAvailability(
+            E->getLoc(), C, Where, Type(), Type(),
+            /*useConformanceAvailabilityErrorsOpt=*/true,
+            /*preconcurrency=*/preconcurrency());
       }
     }
 
@@ -2511,18 +2512,25 @@ public:
     // differ, e.g for things like `guard #available(...)`.
     class StmtRecurseWalker : public BaseDiagnosticWalker {
       DeclContext *DC;
+      bool preconcurrency;
 
     public:
-      StmtRecurseWalker(DeclContext *DC) : DC(DC) {}
+      StmtRecurseWalker(DeclContext *DC, bool inPreconcurrency)
+          : DC(DC), preconcurrency(inPreconcurrency) {}
 
       PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-        diagnoseExprAvailability(E, DC);
+        diagnoseExprAvailability(E, DC, preconcurrency);
         return Action::SkipNode(E);
       }
     };
-    StmtRecurseWalker W(Where.getDeclContext());
+    StmtRecurseWalker W(Where.getDeclContext(), preconcurrency());
     S->walk(W);
     return Action::SkipNode(S);
+  }
+
+  bool preconcurrency() const {
+    return PreconcurrencyCalleeStack.empty() ? false
+                                             : PreconcurrencyCalleeStack.back();
   }
 
   bool
@@ -2729,7 +2737,15 @@ private:
     auto where = ExportContext::forFunctionBody(closure, closure->getStartLoc());
     if (where.isImplicit())
       return;
-    ExprAvailabilityWalker walker(where);
+
+    bool preconcurrency = false;
+    if (auto closureExpr = dyn_cast<ClosureExpr>(closure)) {
+      if (closureExpr->isConversionClosure()) {
+        preconcurrency = this->preconcurrency();
+      }
+    }
+
+    ExprAvailabilityWalker walker(where, preconcurrency);
 
     // Manually dive into the body
     closure->getBody()->walk(walker);
@@ -3236,11 +3252,12 @@ ExprAvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
 }
 
 /// Diagnose uses of unavailable declarations.
-void swift::diagnoseExprAvailability(const Expr *E, DeclContext *DC) {
+void swift::diagnoseExprAvailability(const Expr *E, DeclContext *DC,
+                                     bool preconcurrency) {
   auto where = ExportContext::forFunctionBody(DC, E->getStartLoc());
   if (where.isImplicit())
     return;
-  ExprAvailabilityWalker walker(where);
+  ExprAvailabilityWalker walker(where, preconcurrency);
   const_cast<Expr*>(E)->walk(walker);
 }
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -212,7 +212,8 @@ public:
 };
 
 /// Diagnose uses of unavailable declarations in expressions.
-void diagnoseExprAvailability(const Expr *E, DeclContext *DC);
+void diagnoseExprAvailability(const Expr *E, DeclContext *DC,
+                              bool preconcurrency);
 
 /// Diagnose uses of unavailable declarations in statements (via patterns, etc)
 /// but not expressions.

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -52,6 +52,14 @@ public func _arrayForceCast<SourceElement, TargetElement>(
   return source.map { $0 as! TargetElement }
 }
 
+@_alwaysEmitIntoClient
+public func _arrayWitnessCast<SourceElement, TargetElement>(
+  _ source: Array<SourceElement>,
+  _ witness: (SourceElement) -> TargetElement
+) -> Array<TargetElement> {
+  return source.map(witness)
+}
+
 /// Called by the casting machinery.
 @_silgen_name("_swift_arrayDownCastConditionalIndirect")
 internal func _arrayDownCastConditionalIndirect<SourceValue, TargetValue>(

--- a/stdlib/public/core/DictionaryCasting.swift
+++ b/stdlib/public/core/DictionaryCasting.swift
@@ -57,6 +57,23 @@ public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
   }!
 }
 
+@_alwaysEmitIntoClient
+public func _dictionaryWitnessCast<SourceKey, SourceValue, TargetKey, TargetValue>(
+  _ source: Dictionary<SourceKey, SourceValue>,
+  _ keyWitness: (SourceKey) -> TargetKey,
+  _ valueWitness: (SourceValue) -> TargetValue
+) -> Dictionary<TargetKey, TargetValue> {
+  return Dictionary(
+    _mapping: source,
+    // String and NSString have different concepts of equality, so
+    // NSString-keyed Dictionaries may generate key collisions when "upcasted"
+    // to String. See rdar://problem/35995647
+    allowingDuplicates: (TargetKey.self == String.self)
+  ) { k, v in
+    (keyWitness(k), valueWitness(v))
+  }!
+}
+
 /// Called by the casting machinery.
 @_silgen_name("_swift_dictionaryDownCastIndirect")
 @_unavailableInEmbedded

--- a/stdlib/public/core/SetCasting.swift
+++ b/stdlib/public/core/SetCasting.swift
@@ -56,6 +56,22 @@ public func _setUpCast<DerivedValue, BaseValue>(
   }!
 }
 
+@_alwaysEmitIntoClient
+public func _setWitnessCast<SourceElement, TargetElement>(
+  _ source: Set<SourceElement>,
+  _ witness: (SourceElement) -> TargetElement
+) -> Set<TargetElement> {
+  return Set(
+    _mapping: source,
+    // String and NSString have different concepts of equality, so Set<NSString>
+    // may generate key collisions when "upcasted" to Set<String>.
+    // See rdar://problem/35995647
+    allowingDuplicates: (TargetElement.self == String.self)
+  ) { member in
+    witness(member)
+  }!
+}
+
 /// Called by the casting machinery.
 @_silgen_name("_swift_setDownCastIndirect")
 @_unavailableInEmbedded

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -1386,6 +1386,8 @@ tryCastToTuple(
 /******************************************************************************/
 
 // The only thing that can be legally cast to a function is another function.
+// Note that this logic must be aligned with with swift::classifyDynamicCast()
+// in lib/SIL/Utils/DynamicCast.cpp
 
 static DynamicCastResult
 tryCastToFunction(

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -15,21 +15,21 @@
 // -----------------------------------------------------------------------------
 // RUN: %empty-directory(%t)
 //
-// RUN: %target-build-swift -Xfrontend -verify -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
+// RUN: %target-build-swift -Xfrontend -verify -Xfrontend -verify-additional-prefix -Xfrontend swift6- -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
 // RUN: %target-codesign %t/a.swift6.Onone.out
 // RUN: %target-run %t/a.swift6.Onone.out
 //
-// RAN: %target-build-swift -Xfrontend -verify -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
-// RAN: %target-codesign %t/a.swift6.O.out
-// RAN: %target-run %t/a.swift6.O.out
+// RUN: %target-build-swift -Xfrontend -verify -Xfrontend -verify-additional-prefix -Xfrontend swift6- -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
+// RUN: %target-codesign %t/a.swift6.O.out
+// RUN: %target-run %t/a.swift6.O.out
 //
-// RAN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
-// RAN: %target-codesign %t/a.swift5.Onone.out
-// RAN: %target-run %t/a.swift5.Onone.out
+// RUN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
+// RUN: %target-codesign %t/a.swift5.Onone.out
+// RUN: %target-run %t/a.swift5.Onone.out
 //
-// RAN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
-// RAN: %target-codesign %t/a.swift5.O.out
-// RAN: %target-run %t/a.swift5.O.out
+// RUN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
+// RUN: %target-codesign %t/a.swift5.O.out
+// RUN: %target-run %t/a.swift5.O.out
 //
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -62,7 +62,8 @@ class Derived: Base {
 
 }
 
-@preconcurrency func id(_ x: [@MainActor () -> String]) -> [@MainActor () -> String] { x }
+@preconcurrency func takeArray(_ x: [@MainActor @Sendable () -> String]) -> [@MainActor @Sendable () -> String] { x }
+@preconcurrency func takeDictionary(_ x: [AnyHashable: @MainActor @Sendable () -> String]) -> [AnyHashable: @MainActor @Sendable () -> String] { x }
 
 extension TestSuite {
   @inline(never)
@@ -591,6 +592,9 @@ ArrayCasts.testSync("Covariant") {
   expectNil(d)
 }
 
+// Currently failing
+// See https://forums.swift.org/t/casting-closure-collections/82100/10
+if false {
 ArrayCasts.testSync("Covariant nested") {
 
   typealias X = [([() -> any StringProtocol]) -> [String]]
@@ -617,11 +621,12 @@ ArrayCasts.testSync("Covariant nested") {
   let d = (a as Any) as? Y
   expectNil(d)
 }
+}
 
 ArrayCasts.testSync("Preconcurrency") {
 
   typealias X = [() -> String]
-  typealias Y = [@MainActor () -> String]
+  typealias Y = [@MainActor @Sendable () -> String]
 
   let a: X = [
     { "abc" },
@@ -629,8 +634,8 @@ ArrayCasts.testSync("Preconcurrency") {
     { "ijk" }
   ]
 
-  // expected-warning@+1 {{converting non-Sendable function value to '@MainActor @Sendable () -> String' may introduce data races}}
-  let b: Y = id(a)
+  // expected-swift6-warning@+1 {{converting non-Sendable function value to '@MainActor @Sendable () -> String' may introduce data races}}
+  let b: Y = takeArray(a)
   expectEqual(b.count, 3)
   expectEqual(b[0](), "abc")
   expectEqual(b[1](), "xyz")
@@ -649,22 +654,584 @@ let DictionaryCasts = TestSuite("DictionaryCasts")
 
 DictionaryCasts.testSync("Funtion Conversion: covariant result") {
   typealias X = [String: () -> Derived]
-  typealias Y = [AnyHashable: () -> Base]
+  typealias Y = [String: () -> Base]
 
   let a: X = [
-    "abc": { Derived(42) },
-    "xyz": { Derived(-1) },
-    "ijk": { Derived(37) }
+    "a": { Derived(42) },
+    "b": { Derived(-1) },
+    "c": { Derived(37) }
   ]
 
   let b: Y = a
   expectEqual(b.count, 3)
-  expectEqual(b["abc"]?().k, 42)
-  expectEqual(b["xyz"]?().k, -1)
-  expectEqual(b["ijk"]?().k, 37)
+  expectEqual(b["a"]!().k, 42)
+  expectEqual(b["b"]!().k, -1)
+  expectEqual(b["c"]!().k, 37)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
-  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, () -> Derived>') to 'Y' (aka 'Dictionary<AnyHashable, () -> Base>') always succeeds}}
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, () -> Derived>') to 'Y' (aka 'Dictionary<String, () -> Base>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+DictionaryCasts.testSync("Funtion Conversion: contravariant argument") {
+  typealias X = [String: (Base) -> Int]
+  typealias Y = [AnyHashable: (Derived) -> Int]
+
+  let a: X = [
+    "a": { $0.k + 42 },
+    "b": { $0.k - 1 },
+    "c": { $0.k + 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b["a"]!(probe), 52)
+  expectEqual(b["b"]!(probe), 9)
+  expectEqual(b["c"]!(probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, (Base) -> Int>') to 'Y' (aka 'Dictionary<AnyHashable, (Derived) -> Int>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+#if _runtime(_ObjC)
+DictionaryCasts.testSync("Funtion Conversion: change calling convention 1") {
+  typealias X = [String: (Base) -> Int]
+  // This crashes compiler
+  // See https://github.com/swiftlang/swift/issues/85082
+  // typealias YA = [String: @convention(block) (Derived) -> Int]
+
+  let a: X = [
+    "a": { $0.k + 42 },
+    "b": { $0.k - 1 },
+    "c": { $0.k + 37 }
+  ]
+
+  let b: [String: @convention(block) (Derived) -> Int] = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b["a"]!(probe), 52)
+  expectEqual(b["b"]!(probe), 9)
+  expectEqual(b["c"]!(probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, (Base) -> Int>') to '[String : @convention(block) (Derived) -> Int]' always succeeds}}
+  let c = a as? [String: @convention(block) (Derived) -> Int]
+  expectNil(c)
+
+  let d = (a as Any) as? [String: @convention(block) (Derived) -> Int]
+  expectNil(d)
+}
+
+DictionaryCasts.testSync("Funtion Conversion: change calling convention 2") {
+  // This crashes compiler
+  // See https://github.com/swiftlang/swift/issues/85082
+  // typealias X = [@convention(block) (Base) -> Int]
+  typealias Y = [String: (Derived) -> Int]
+
+  let a: [String: @convention(block) (Base) -> Int] = [
+    "a": { $0.k + 42 },
+    "b": { $0.k - 1 },
+    "c": { $0.k + 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b["a"]!(probe), 52)
+  expectEqual(b["b"]!(probe), 9)
+  expectEqual(b["c"]!(probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from '[String : @convention(block) (Base) -> Int]' to 'Y' (aka 'Dictionary<String, (Derived) -> Int>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+#endif
+
+DictionaryCasts.testSync("Funtion Conversion: add isolation") {
+  typealias X = [String: @Sendable () -> Int]
+  typealias Y = [AnyHashable: @MainActor @Sendable () -> Int]
+
+  let a: X = [
+    "a": { 42 },
+    "b": { -1 },
+    "c": { 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!(), 42)
+  expectEqual(b["b"]!(), -1)
+  expectEqual(b["c"]!(), 37)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, @Sendable () -> Int>') to 'Y' (aka 'Dictionary<AnyHashable, @MainActor @Sendable () -> Int>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+DictionaryCasts.test("Funtion Conversion: as @isolated(any)").require(.stdlib_6_0).code {
+  guard #available(SwiftStdlib 6.0, *) else { return }
+  typealias X = [String: @MainActor @Sendable () -> Int]
+  typealias Y = [String: @isolated(any) () -> Int]
+
+  let a: X = [
+    "a": { 42 },
+    "b": { -1 },
+    "c": { 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectEqual(await b["a"]!(), 42)
+  expectEqual(await b["b"]!(), -1)
+  expectEqual(await b["c"]!(), 37)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, @MainActor @Sendable () -> Int>') to 'Y' (aka 'Dictionary<String, @isolated(any) () -> Int>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+DictionaryCasts.testSync("Metatype Conversion") {
+  typealias X = [String: Derived.Type]
+  typealias Y = [AnyHashable: Base.Type]
+
+  let a: X = [
+    "a": Derived.self
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 1)
+  expectTrue(b["a"]! === Derived.self)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, Derived.Type>') to 'Y' (aka 'Dictionary<AnyHashable, Base.Type>') always succeeds}}
+  let c = a as? Y
+  expectTrue(c!["a"]! === Derived.self)
+
+  let d = (a as Any) as? Y
+  expectTrue(d!["a"]! === Derived.self)
+}
+
+DictionaryCasts.testSync("Erasure 1") {
+  typealias X = [String: Base]
+  typealias Y = [String: AnyObject]
+
+  let a: X = [
+    "a": Base(42),
+    "b": Base(-1),
+    "c": Base(37)
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b["a"]! === a["a"]!)
+  expectTrue(b["b"]! === a["b"]!)
+  expectTrue(b["c"]! === a["c"]!)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, Base>') to 'Y' (aka 'Dictionary<String, AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!["a"]! === a["a"]!)
+  expectTrue(c!["b"]! === a["b"]!)
+  expectTrue(c!["c"]! === a["c"]!)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!["a"]! === a["a"]!)
+  expectTrue(d!["b"]! === a["b"]!)
+  expectTrue(d!["c"]! === a["c"]!)
+}
+
+DictionaryCasts.testSync("Erasure 2") {
+  typealias X = [String: String]
+  typealias Y = [AnyHashable: any Hashable]
+
+  let a: X = [
+    "a": "abc",
+    "b": "xyz",
+    "c": "ijk"
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(b["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(b["c"]!.hashValue == a["c"]!.hashValue)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String>') to 'Y' (aka 'Dictionary<AnyHashable, any Hashable>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(c!["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(c!["c"]!.hashValue == a["c"]!.hashValue)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(d!["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(d!["c"]!.hashValue == a["c"]!.hashValue)
+}
+
+DictionaryCasts.testSync("AnyHashable erasure") {
+  typealias X = [String: String]
+  typealias Y = [String: AnyHashable]
+
+  let a: X = [
+    "a": "abc",
+    "b": "xyz",
+    "c": "ijk"
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(b["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(b["c"]!.hashValue == a["c"]!.hashValue)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String>') to 'Y' (aka 'Dictionary<String, AnyHashable>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(c!["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(c!["c"]!.hashValue == a["c"]!.hashValue)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!["a"]!.hashValue == a["a"]!.hashValue)
+  expectTrue(d!["b"]!.hashValue == a["b"]!.hashValue)
+  expectTrue(d!["c"]!.hashValue == a["c"]!.hashValue)
+}
+
+DictionaryCasts.testSync("Bridge To ObjC 1") {
+  typealias X = [String: String]
+  typealias Y = [AnyHashable: AnyObject]
+
+  let a: X = [
+    "a": "abc",
+    "b": "xyz",
+    "c": "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue((b["a"]! as! String) == a["a"]!)
+  expectTrue((b["b"]! as! String) == a["b"]!)
+  expectTrue((b["c"]! as! String) == a["c"]!)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String>') to 'Y' (aka 'Dictionary<AnyHashable, AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c!["a"]! as! String) == a["a"]!)
+  expectTrue((c!["b"]! as! String) == a["b"]!)
+  expectTrue((c!["c"]! as! String) == a["c"]!)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d!["a"]! as! String) == a["a"]!)
+  expectTrue((d!["b"]! as! String) == a["b"]!)
+  expectTrue((d!["c"]! as! String) == a["c"]!)
+}
+
+#if _runtime(_ObjC)
+DictionaryCasts.testSync("Bridge To ObjC 2") {
+  typealias X = [String: String]
+  typealias Y = [String: NSString]
+
+  let a: X = [
+    "a": "abc",
+    "b": "xyz",
+    "c": "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b["a"]! as String == a["a"]!)
+  expectTrue(b["b"]! as String == a["b"]!)
+  expectTrue(b["c"]! as String == a["c"]!)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String>') to 'Y' (aka 'Dictionary<String, NSString>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c!["a"]! as String) == a["a"]!)
+  expectTrue((c!["b"]! as String) == a["b"]!)
+  expectTrue((c!["c"]! as String) == a["c"]!)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d!["a"]! as String) == a["a"]!)
+  expectTrue((d!["b"]! as String) == a["b"]!)
+  expectTrue((d!["c"]! as String) == a["c"]!)
+}
+
+DictionaryCasts.testSync("Bridge To ObjC 3") {
+  typealias X = [String: String]
+  typealias Y = [AnyHashable: CFString]
+
+  let a: X = [
+    "a": "abc",
+    "b": "xyz",
+    "c": "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b["a"]! as String == a["a"]!)
+  expectTrue(b["b"]! as String == a["b"]!)
+  expectTrue(b["c"]! as String == a["c"]!)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String>') to 'Y' (aka 'Dictionary<AnyHashable, CFString>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c!["a"]! as String) == a["a"]!)
+  expectTrue((c!["b"]! as String) == a["b"]!)
+  expectTrue((c!["c"]! as String) == a["c"]!)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d!["a"]! as String) == a["a"]!)
+  expectTrue((d!["b"]! as String) == a["b"]!)
+  expectTrue((d!["c"]! as String) == a["c"]!)
+}
+#endif
+
+DictionaryCasts.testSync("Metatype to AnyObject 1") {
+  typealias X = [String: String.Type]
+  typealias Y = [String: AnyObject]
+
+  let a: X = [
+    "a": String.self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 1)
+  expectTrue((b["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, String.Type>') to 'Y' (aka 'Dictionary<String, AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 1)
+  expectTrue((c!["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 1)
+  expectTrue((d!["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+}
+
+DictionaryCasts.testSync("Metatype to AnyObject 2") {
+  typealias X = [String: (any Hashable).Type]
+  typealias Y = [AnyHashable: AnyObject]
+
+  let a: X = [
+    "a": (any Hashable).self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 1)
+  expectTrue((b["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, (any Hashable).Type>') to 'Y' (aka 'Dictionary<AnyHashable, AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 1)
+  expectTrue((c!["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 1)
+  expectTrue((d!["a"]! as! Any.Type) == (a["a"]! as Any.Type))
+}
+
+DictionaryCasts.testSync("Metatype to AnyObject 3") {
+  typealias X = [String: any Hashable.Type]
+  typealias Y = [String: AnyObject]
+
+  let a: X = [
+    "a": Int.self,
+    "b": String.self,
+    "c": AnyHashable.self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue((b["a"]! as! Any.Type) == a["a"]!)
+  expectTrue((b["b"]! as! Any.Type) == a["b"]!)
+  expectTrue((b["c"]! as! Any.Type) == a["c"]!)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, any Hashable.Type>') to 'Y' (aka 'Dictionary<String, AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c!["a"]! as! Any.Type) == a["a"]!)
+  expectTrue((c!["b"]! as! Any.Type) == a["b"]!)
+  expectTrue((c!["c"]! as! Any.Type) == a["c"]!)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d!["a"]! as! Any.Type) == a["a"]!)
+  expectTrue((d!["b"]! as! Any.Type) == a["b"]!)
+  expectTrue((d!["c"]! as! Any.Type) == a["c"]!)
+}
+
+DictionaryCasts.testSync("Nested") {
+  typealias X = [String: [String: String]]
+  typealias Y = [AnyHashable: [AnyHashable: AnyObject]]
+
+  let a: X = [
+    "a": ["a": "xyz", "b": "abc"],
+    "b": ["a": "ijk"],
+    "c": [:]
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!.count, 2)
+  expectEqual(b["b"]!.count, 1)
+  expectEqual(b["c"]!.count, 0)
+  expectTrue((b["a"]!["a"]! as! String) == "xyz")
+  expectTrue((b["a"]!["b"]! as! String) == "abc")
+  expectTrue((b["b"]!["a"]! as! String) == "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, Dictionary<String, String>>') to 'Y' (aka 'Dictionary<AnyHashable, Dictionary<AnyHashable, AnyObject>>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c!["a"]!.count, 2)
+  expectEqual(c!["b"]!.count, 1)
+  expectEqual(c!["c"]!.count, 0)
+  expectTrue((c!["a"]!["a"]! as! String) == "xyz")
+  expectTrue((c!["a"]!["b"]! as! String) == "abc")
+  expectTrue((c!["b"]!["a"]! as! String) == "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d!["a"]!.count, 2)
+  expectEqual(d!["b"]!.count, 1)
+  expectEqual(d!["c"]!.count, 0)
+  expectTrue((d!["a"]!["a"]! as! String) == "xyz")
+  expectTrue((d!["a"]!["b"]! as! String) == "abc")
+  expectTrue((d!["b"]!["a"]! as! String) == "ijk")
+}
+
+DictionaryCasts.testSync("Covariant") {
+
+  typealias X = [String: ([String: any StringProtocol]) -> [String: String]]
+  typealias Y = [String: ([String: String]) -> [String: any StringProtocol]]
+
+  let a: X = [
+    "a": { $0 as! [String: String] },
+    "b": { _ in ["a": "abc"] },
+    "c": {
+      var result = $0 as! [String: String]
+      for (key, value) in $0 {
+        let vs = value as! String
+        result[key + key] = vs + vs
+      }
+      return result
+    }
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  let probe: [String: String] = ["a": "xyz", "b": "ijk"]
+  expectEqual(b["a"]!(probe) as! [String: String], probe)
+  expectEqual(b["b"]!(probe) as! [String: String], ["a": "abc"])
+  expectEqual(b["c"]!(probe) as! [String: String], ["a": "xyz", "b": "ijk", "aa": "xyzxyz", "bb": "ijkijk"])
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, (Dictionary<String, any StringProtocol>) -> Dictionary<String, String>>') to 'Y' (aka 'Dictionary<String, (Dictionary<String, String>) -> Dictionary<String, any StringProtocol>>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+// Currently failing
+// See https://forums.swift.org/t/casting-closure-collections/82100/10
+if false {
+DictionaryCasts.testSync("Covariant nested") {
+
+  typealias X = [String: ([String: () -> any StringProtocol]) -> [String: String]]
+  typealias Y = [String: ([String: () -> String]) -> [String: any StringProtocol]]
+
+  let a: X = [
+    "a": { (x: [String: () -> any StringProtocol]) -> [String: String] in
+      x.mapValues { $0() as! String }
+    },
+    "b": { _ in  ["a": "abc"] },
+    "c": { (x: [String: () -> any StringProtocol]) -> [String: String] in
+      let tmp: [String: String] = x.mapValues { f in f() as! String }
+      var result = tmp
+      for (key, value) in tmp {
+        result[key + key] = value + value
+      }
+      return result
+    }
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  let probe: [String: () -> String] = ["a": { "xyz" }, "b": { "ijk" } ]
+  expectEqual(b["a"]!(probe) as! [String: String], ["a": "xyz", "b": "ijk"])
+  expectEqual(b["b"]!(probe) as! [String: String], ["a": "abc"])
+  expectEqual(b["c"]!(probe) as! [String: String], ["a": "xyz", "b": "ijk", "aa": "xyzxyz", "bb": "ijkijk"])
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, (Dictionary<String, () -> any StringProtocol>) -> Dictionary<String, String>>') to 'Y' (aka 'Dictionary<String, (Dictionary<String, () -> String>) -> Dictionary<String, any StringProtocol>>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+}
+
+DictionaryCasts.testSync("Preconcurrency") {
+
+  typealias X = [String: () -> String]
+  typealias Y = [AnyHashable: @MainActor @Sendable () -> String]
+
+  let a: X = [
+    "a": { "abc" },
+    "b": { "xyz" },
+    "c": { "ijk" }
+  ]
+
+  // expected-swift6-warning@+1 {{converting non-Sendable function value to '@MainActor @Sendable () -> String' may introduce data races}}
+  let b: Y = takeDictionary(a)
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!(), "abc")
+  expectEqual(b["b"]!(), "xyz")
+  expectEqual(b["c"]!(), "ijk")
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, () -> String>') to 'Y' (aka 'Dictionary<AnyHashable, @MainActor @Sendable () -> String>') always succeeds}}
   let c = a as? Y
   expectNil(c)
 

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -1,0 +1,280 @@
+// CollectionCasts.swift - Tests for conversion between collection types.
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Contains tests for non-trapping type conversions reported by users.
+///
+// -----------------------------------------------------------------------------
+// X-RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
+// RUN: %target-codesign %t/a.swift6.Onone.out
+// RUN: %target-run %t/a.swift6.Onone.out
+//
+// X-RUN: %target-build-swift -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
+// X-RUN: %target-codesign %t/a.swift6.O.out
+// X-RUN: %target-run %t/a.swift6.O.out
+//
+// X-RUN: %target-build-swift -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
+// X-RUN: %target-codesign %t/a.swift5.Onone.out
+// X-RUN: %target-run %t/a.swift5.Onone.out
+//
+// X-RUN: %target-build-swift -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
+// X-RUN: %target-codesign %t/a.swift5.O.out
+// X-RUN: %target-run %t/a.swift5.O.out
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+#if _runtime(_ObjC)
+import Foundation
+#endif
+
+#if _runtime(_ObjC)
+@objc
+class Root: NSObject {}
+#else
+class Root {}
+#endif
+
+@objc
+class Base: Root {
+  var k: Int
+
+  init(_ k: Int) {
+    self.k = k
+  }
+}
+
+@objc
+class Derived: Base {
+
+}
+
+extension TestSuite {
+  @inline(never)
+  public func testSync(
+    _ name: String,
+    file: String = #file, line: UInt = #line,
+    _ testFunction: @escaping @isolated(any) () -> Void
+  ) {
+    self.test(name, file: file, line: line) {
+      await testFunction()
+    }
+  }
+}
+
+let ArrayCasts = TestSuite("ArrayCasts")
+
+ArrayCasts.testSync("Funtion Conversion: covariant result") {
+  typealias X = [() -> Derived]
+  typealias Y = [() -> Base]
+
+  let a: X = [
+    { Derived(42) },
+    { Derived(-1) },
+    { Derived(37) }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectEqual(b[0]().k, 42)
+  expectEqual(b[1]().k, -1)
+  expectEqual(b[2]().k, 37)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+ArrayCasts.testSync("Funtion Conversion: contravariant argument") {
+  typealias X = [(Base) -> Int]
+  typealias Y = [(Derived) -> Int]
+
+  let a: X = [
+    { $0.k + 42 },
+    { $0.k - 1 },
+    { $0.k + 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b[0](probe), 52)
+  expectEqual(b[1](probe), 9)
+  expectEqual(b[2](probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+#if _runtime(_ObjC)
+ArrayCasts.testSync("Funtion Conversion: change calling convention 1") {
+  typealias X = [(Base) -> Int]
+  // This crashes compiler
+  // See https://github.com/swiftlang/swift/issues/85082
+  // typealias YA = [@convention(block) (Derived) -> Int]
+
+  let a: X = [
+    { $0.k + 42 },
+    { $0.k - 1 },
+    { $0.k + 37 }
+  ]
+
+  let b: [@convention(block) (Derived) -> Int] = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b[0](probe), 52)
+  expectEqual(b[1](probe), 9)
+  expectEqual(b[2](probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? [@convention(block) (Derived) -> Int]
+  expectNil(c)
+
+  let d = (a as Any) as? [@convention(block) (Derived) -> Int]
+  expectNil(d)
+}
+
+ArrayCasts.testSync("Funtion Conversion: change calling convention 2") {
+  // This crashes compiler
+  // See https://github.com/swiftlang/swift/issues/85082
+  // typealias X = [@convention(block) (Base) -> Int]
+  typealias Y = [(Derived) -> Int]
+
+  let a: [@convention(block) (Base) -> Int] = [
+    { $0.k + 42 },
+    { $0.k - 1 },
+    { $0.k + 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  let probe = Derived(10)
+  expectEqual(b[0](probe), 52)
+  expectEqual(b[1](probe), 9)
+  expectEqual(b[2](probe), 47)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+#endif
+
+ArrayCasts.testSync("Funtion Conversion: add isolation") {
+  typealias X = [@Sendable () -> Int]
+  typealias Y = [@MainActor () -> Int]
+
+  print("0")
+  let a: X = [
+    { 42 },
+    { -1 },
+    { 37 }
+  ]
+
+  print("1")
+  let b: Y = a
+  print("2")
+  expectEqual(b.count, 3)
+  expectEqual(b[0](), 42)
+  expectEqual(b[1](), -1)
+  expectEqual(b[2](), 37)
+  print("3")
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? Y
+  print("4")
+  expectNil(c)
+  print("5")
+
+  let d = (a as Any) as? Y
+  print("6")
+  expectNil(d)
+  print("7")
+}
+
+ArrayCasts.test("Funtion Conversion: as @isolated(any)").require(.stdlib_6_0).code {
+  guard #available(SwiftStdlib 6.0, *) else { return }
+  typealias X = [@MainActor () -> Int]
+  typealias Y = [@isolated(any) () -> Int]
+
+  let a: X = [
+    { 42 },
+    { -1 },
+    { 37 }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectEqual(await b[0](), 42)
+  expectEqual(await b[1](), -1)
+  expectEqual(await b[2](), 37)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+ArrayCasts.testSync("Metatype Conversion") {
+  typealias X = [Derived.Type]
+  typealias Y = [Base.Type]
+
+  let a: X = [
+    Derived.self
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 1)
+  expectTrue(b[0] === Derived.self)
+
+  let c = a as? Y
+  expectTrue(c![0] === Derived.self)
+
+  let d = (a as Any) as? Y
+  expectTrue(d![0] === Derived.self)
+}
+
+let DictionaryCasts = TestSuite("DictionaryCasts")
+
+DictionaryCasts.testSync("Funtion Conversion: covariant result") {
+  typealias X = [String: () -> Derived]
+  typealias Y = [AnyHashable: () -> Base]
+
+  let a: X = [
+    "abc": { Derived(42) },
+    "xyz": { Derived(-1) },
+    "ijk": { Derived(37) }
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectEqual(b["abc"]?().k, 42)
+  expectEqual(b["xyz"]?().k, -1)
+  expectEqual(b["ijk"]?().k, 37)
+}
+
+await runAllTestsAsync()

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -487,6 +487,93 @@ ArrayCasts.testSync("Bridge To ObjC 3") {
 }
 #endif
 
+ArrayCasts.testSync("Bridge From ObjC 1") {
+  typealias X = [AnyObject]
+  typealias Y = [String]
+
+  let a: X = [
+    "abc" as AnyObject,
+    "xyz" as AnyObject,
+    "ijk" as AnyObject
+  ]
+
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c![0], "abc")
+  expectEqual(c![1], "xyz")
+  expectEqual(c![2], "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d![0], "abc")
+  expectEqual(d![1], "xyz")
+  expectEqual(d![2], "ijk")
+}
+
+#if _runtime(_ObjC)
+ArrayCasts.testSync("Bridge From ObjC 2") {
+  typealias X = [NSString]
+  typealias Y = [String]
+
+  let a: X = [
+    "abc" as NSString,
+    "xyz" as NSString,
+    "ijk" as NSString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b[0], "abc")
+  expectEqual(b[1], "xyz")
+  expectEqual(b[2], "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<NSString>') to 'Y' (aka 'Array<String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c![0], "abc")
+  expectEqual(c![1], "xyz")
+  expectEqual(c![2], "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d![0], "abc")
+  expectEqual(d![1], "xyz")
+  expectEqual(d![2], "ijk")
+}
+
+ArrayCasts.testSync("Bridge From ObjC 3") {
+  typealias X = [CFString]
+  typealias Y = [String]
+
+  let a: X = [
+    "abc" as CFString,
+    "xyz" as CFString,
+    "ijk" as CFString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b[0], "abc")
+  expectEqual(b[1], "xyz")
+  expectEqual(b[2], "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<CFString>') to 'Y' (aka 'Array<String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c![0], "abc")
+  expectEqual(c![1], "xyz")
+  expectEqual(c![2], "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d![0], "abc")
+  expectEqual(d![1], "xyz")
+  expectEqual(d![2], "ijk")
+}
+#endif
+
 ArrayCasts.testSync("Metatype to AnyObject 1") {
   typealias X = [String.Type]
   typealias Y = [AnyObject]
@@ -1130,6 +1217,93 @@ DictionaryCasts.testSync("Bridge To ObjC 3") {
 }
 #endif
 
+DictionaryCasts.testSync("Bridge From ObjC 1") {
+  typealias X = [AnyHashable: AnyObject]
+  typealias Y = [String: String]
+
+  let a: X = [
+    "a": "abc" as AnyObject,
+    "b": "xyz" as AnyObject,
+    "c": "ijk" as AnyObject
+  ]
+
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c!["a"]!, "abc")
+  expectEqual(c!["b"]!, "xyz")
+  expectEqual(c!["c"]!, "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d!["a"]!, "abc")
+  expectEqual(d!["b"]!, "xyz")
+  expectEqual(d!["c"]!, "ijk")
+}
+
+#if _runtime(_ObjC)
+DictionaryCasts.testSync("Bridge From ObjC 2") {
+  typealias X = [String: NSString]
+  typealias Y = [AnyHashable: String]
+
+  let a: X = [
+    "a": "abc" as NSString,
+    "b": "xyz" as NSString,
+    "c": "ijk" as NSString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!, "abc")
+  expectEqual(b["b"]!, "xyz")
+  expectEqual(b["c"]!, "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, NSString>') to 'Y' (aka 'Dictionary<AnyHashable, String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c!["a"]!, "abc")
+  expectEqual(c!["b"]!, "xyz")
+  expectEqual(c!["c"]!, "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d!["a"]!, "abc")
+  expectEqual(d!["b"]!, "xyz")
+  expectEqual(d!["c"]!, "ijk")
+}
+
+DictionaryCasts.testSync("Bridge From ObjC 3") {
+  typealias X = [String: CFString]
+  typealias Y = [AnyHashable: String]
+
+  let a: X = [
+    "a": "abc" as CFString,
+    "b": "xyz" as CFString,
+    "c": "ijk" as CFString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!, "abc")
+  expectEqual(b["b"]!, "xyz")
+  expectEqual(b["c"]!, "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, CFString>') to 'Y' (aka 'Dictionary<AnyHashable, String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c!["a"]!, "abc")
+  expectEqual(c!["b"]!, "xyz")
+  expectEqual(c!["c"]!, "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d!["a"]!, "abc")
+  expectEqual(d!["b"]!, "xyz")
+  expectEqual(d!["c"]!, "ijk")
+}
+#endif
+
 DictionaryCasts.testSync("Metatype to AnyObject 1") {
   typealias X = [String: String.Type]
   typealias Y = [String: AnyObject]
@@ -1502,6 +1676,93 @@ SetCasts.testSync("Bridge To ObjC 3") {
   expectTrue(d!.contains("abc" as CFString))
   expectTrue(d!.contains("xyz" as CFString))
   expectTrue(d!.contains("ijk" as CFString))
+}
+#endif
+
+SetCasts.testSync("Bridge From ObjC 1") {
+  typealias X = Set<NSObject>
+  typealias Y = Set<String>
+
+  let a: X = [
+    "abc" as NSObject,
+    "xyz" as NSObject,
+    "ijk" as NSObject
+  ]
+
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!.contains("abc"))
+  expectTrue(c!.contains("xyz"))
+  expectTrue(c!.contains("ijk"))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!.contains("abc"))
+  expectTrue(d!.contains("xyz"))
+  expectTrue(d!.contains("ijk"))
+}
+
+#if _runtime(_ObjC)
+SetCasts.testSync("Bridge From ObjC 2") {
+  typealias X = Set<NSString>
+  typealias Y = Set<String>
+
+  let a: X = [
+    "abc" as NSString,
+    "xyz" as NSString,
+    "ijk" as NSString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b.contains("abc"))
+  expectTrue(b.contains("xyz"))
+  expectTrue(b.contains("ijk"))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Set<NSString>') to 'Y' (aka 'Set<String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!.contains("abc"))
+  expectTrue(c!.contains("xyz"))
+  expectTrue(c!.contains("ijk"))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!.contains("abc"))
+  expectTrue(d!.contains("xyz"))
+  expectTrue(d!.contains("ijk"))
+}
+
+SetCasts.testSync("Bridge From ObjC 3") {
+  typealias X = Set<CFString>
+  typealias Y = Set<String>
+
+  let a: X = [
+    "abc" as CFString,
+    "xyz" as CFString,
+    "ijk" as CFString
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b.contains("abc"))
+  expectTrue(b.contains("xyz"))
+  expectTrue(b.contains("ijk"))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Set<CFString>') to 'Y' (aka 'Set<String>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c!.contains("abc"))
+  expectTrue(c!.contains("xyz"))
+  expectTrue(c!.contains("ijk"))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d!.contains("abc"))
+  expectTrue(d!.contains("xyz"))
+  expectTrue(d!.contains("ijk"))
 }
 #endif
 

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -738,11 +738,7 @@ ArrayCasts.testSync("Covariant") {
   expectNil(d)
 }
 
-// Currently failing
-// See https://forums.swift.org/t/casting-closure-collections/82100/10
-if false {
 ArrayCasts.testSync("Covariant nested") {
-
   typealias X = [([() -> any StringProtocol]) -> [String]]
   typealias Y = [([() -> String]) -> [any StringProtocol]]
 
@@ -751,7 +747,11 @@ ArrayCasts.testSync("Covariant nested") {
     { _ in ["abc"] },
     { x in (x + x).map { $0() as! String } }
   ]
-
+  
+  // Currently failing
+  // See https://forums.swift.org/t/casting-closure-collections/82100/10
+  expectCrashLater()
+  
   let b = a as Y
   expectEqual(b.count, 3)
   let probe: [() -> String] = [{ "xyz" }, { "ijk" } ]
@@ -766,7 +766,6 @@ ArrayCasts.testSync("Covariant nested") {
 
   let d = (a as Any) as? Y
   expectNil(d)
-}
 }
 
 ArrayCasts.testSync("Preconcurrency") {
@@ -1517,11 +1516,7 @@ DictionaryCasts.testSync("Covariant") {
   expectNil(d)
 }
 
-// Currently failing
-// See https://forums.swift.org/t/casting-closure-collections/82100/10
-if false {
 DictionaryCasts.testSync("Covariant nested") {
-
   typealias X = [String: ([String: () -> any StringProtocol]) -> [String: String]]
   typealias Y = [String: ([String: () -> String]) -> [String: any StringProtocol]]
 
@@ -1539,7 +1534,11 @@ DictionaryCasts.testSync("Covariant nested") {
       return result
     }
   ]
-
+  
+  // Currently failing
+  // See https://forums.swift.org/t/casting-closure-collections/82100/10
+  expectCrashLater()
+  
   let b = a as Y
   expectEqual(b.count, 3)
   let probe: [String: () -> String] = ["a": { "xyz" }, "b": { "ijk" } ]
@@ -1554,7 +1553,6 @@ DictionaryCasts.testSync("Covariant nested") {
 
   let d = (a as Any) as? Y
   expectNil(d)
-}
 }
 
 DictionaryCasts.testSync("Preconcurrency") {

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -13,23 +13,23 @@
 /// Contains tests for non-trapping type conversions reported by users.
 ///
 // -----------------------------------------------------------------------------
-// X-RUN: %empty-directory(%t)
+// RAN: %empty-directory(%t)
 //
-// RUN: %target-build-swift -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
+// RUN: %target-build-swift -Xfrontend -verify -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
 // RUN: %target-codesign %t/a.swift6.Onone.out
 // RUN: %target-run %t/a.swift6.Onone.out
 //
-// X-RUN: %target-build-swift -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
-// X-RUN: %target-codesign %t/a.swift6.O.out
-// X-RUN: %target-run %t/a.swift6.O.out
+// RAN: %target-build-swift -Xfrontend -verify -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
+// RAN: %target-codesign %t/a.swift6.O.out
+// RAN: %target-run %t/a.swift6.O.out
 //
-// X-RUN: %target-build-swift -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
-// X-RUN: %target-codesign %t/a.swift5.Onone.out
-// X-RUN: %target-run %t/a.swift5.Onone.out
+// RAN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
+// RAN: %target-codesign %t/a.swift5.Onone.out
+// RAN: %target-run %t/a.swift5.Onone.out
 //
-// X-RUN: %target-build-swift -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
-// X-RUN: %target-codesign %t/a.swift5.O.out
-// X-RUN: %target-run %t/a.swift5.O.out
+// RAN: %target-build-swift -Xfrontend -verify -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
+// RAN: %target-codesign %t/a.swift5.O.out
+// RAN: %target-run %t/a.swift5.O.out
 //
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -94,6 +94,7 @@ ArrayCasts.testSync("Funtion Conversion: covariant result") {
   expectEqual(b[2]().k, 37)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<() -> Derived>') to 'Y' (aka 'Array<() -> Base>') always succeeds}}
   let c = a as? Y
   expectNil(c)
 
@@ -119,6 +120,7 @@ ArrayCasts.testSync("Funtion Conversion: contravariant argument") {
   expectEqual(b[2](probe), 47)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(Base) -> Int>') to 'Y' (aka 'Array<(Derived) -> Int>') always succeeds}}
   let c = a as? Y
   expectNil(c)
 
@@ -147,6 +149,7 @@ ArrayCasts.testSync("Funtion Conversion: change calling convention 1") {
   expectEqual(b[2](probe), 47)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(Base) -> Int>') to '[@convention(block) (Derived) -> Int]' always succeeds}}
   let c = a as? [@convention(block) (Derived) -> Int]
   expectNil(c)
 
@@ -174,6 +177,7 @@ ArrayCasts.testSync("Funtion Conversion: change calling convention 2") {
   expectEqual(b[2](probe), 47)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from '[@convention(block) (Base) -> Int]' to 'Y' (aka 'Array<(Derived) -> Int>') always succeeds}}
   let c = a as? Y
   expectNil(c)
 
@@ -184,39 +188,32 @@ ArrayCasts.testSync("Funtion Conversion: change calling convention 2") {
 
 ArrayCasts.testSync("Funtion Conversion: add isolation") {
   typealias X = [@Sendable () -> Int]
-  typealias Y = [@MainActor () -> Int]
+  typealias Y = [@MainActor @Sendable () -> Int]
 
-  print("0")
   let a: X = [
     { 42 },
     { -1 },
     { 37 }
   ]
 
-  print("1")
   let b: Y = a
-  print("2")
   expectEqual(b.count, 3)
   expectEqual(b[0](), 42)
   expectEqual(b[1](), -1)
   expectEqual(b[2](), 37)
-  print("3")
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<@Sendable () -> Int>') to 'Y' (aka 'Array<@MainActor @Sendable () -> Int>') always succeeds}}
   let c = a as? Y
-  print("4")
   expectNil(c)
-  print("5")
 
   let d = (a as Any) as? Y
-  print("6")
   expectNil(d)
-  print("7")
 }
 
 ArrayCasts.test("Funtion Conversion: as @isolated(any)").require(.stdlib_6_0).code {
   guard #available(SwiftStdlib 6.0, *) else { return }
-  typealias X = [@MainActor () -> Int]
+  typealias X = [@MainActor @Sendable () -> Int]
   typealias Y = [@isolated(any) () -> Int]
 
   let a: X = [
@@ -232,6 +229,7 @@ ArrayCasts.test("Funtion Conversion: as @isolated(any)").require(.stdlib_6_0).co
   expectEqual(await b[2](), 37)
 
   // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<@MainActor @Sendable () -> Int>') to 'Y' (aka 'Array<@isolated(any) () -> Int>') always succeeds}}
   let c = a as? Y
   expectNil(c)
 
@@ -251,11 +249,371 @@ ArrayCasts.testSync("Metatype Conversion") {
   expectEqual(b.count, 1)
   expectTrue(b[0] === Derived.self)
 
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<Derived.Type>') to 'Y' (aka 'Array<Base.Type>') always succeeds}}
   let c = a as? Y
   expectTrue(c![0] === Derived.self)
 
   let d = (a as Any) as? Y
   expectTrue(d![0] === Derived.self)
+}
+
+ArrayCasts.testSync("Erasure 1") {
+  typealias X = [Base]
+  typealias Y = [AnyObject]
+
+  let a: X = [
+    Base(42),
+    Base(-1),
+    Base(37)
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b[0] === a[0])
+  expectTrue(b[1] === a[1])
+  expectTrue(b[2] === a[2])
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<Base>') to 'Y' (aka 'Array<AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c![0] === a[0])
+  expectTrue(c![1] === a[1])
+  expectTrue(c![2] === a[2])
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d![0] === a[0])
+  expectTrue(d![1] === a[1])
+  expectTrue(d![2] === a[2])
+}
+
+ArrayCasts.testSync("Erasure 2") {
+  typealias X = [String]
+  typealias Y = [any Hashable]
+
+  let a: X = [
+    "abc",
+    "xyz",
+    "ijk"
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b[0].hashValue == a[0].hashValue)
+  expectTrue(b[1].hashValue == a[1].hashValue)
+  expectTrue(b[2].hashValue == a[2].hashValue)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String>') to 'Y' (aka 'Array<any Hashable>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c![0].hashValue == a[0].hashValue)
+  expectTrue(c![1].hashValue == a[1].hashValue)
+  expectTrue(c![2].hashValue == a[2].hashValue)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d![0].hashValue == a[0].hashValue)
+  expectTrue(d![1].hashValue == a[1].hashValue)
+  expectTrue(d![2].hashValue == a[2].hashValue)
+}
+
+ArrayCasts.testSync("AnyHashable erasure") {
+  typealias X = [String]
+  typealias Y = [AnyHashable]
+
+  let a: X = [
+    "abc",
+    "xyz",
+    "ijk"
+  ]
+
+  let b: Y = a
+  expectEqual(b.count, 3)
+  expectTrue(b[0].hashValue == a[0].hashValue)
+  expectTrue(b[1].hashValue == a[1].hashValue)
+  expectTrue(b[2].hashValue == a[2].hashValue)
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String>') to 'Y' (aka 'Array<AnyHashable>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue(c![0].hashValue == a[0].hashValue)
+  expectTrue(c![1].hashValue == a[1].hashValue)
+  expectTrue(c![2].hashValue == a[2].hashValue)
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue(d![0].hashValue == a[0].hashValue)
+  expectTrue(d![1].hashValue == a[1].hashValue)
+  expectTrue(d![2].hashValue == a[2].hashValue)
+}
+
+ArrayCasts.testSync("Bridge To ObjC 1") {
+  typealias X = [String]
+  typealias Y = [AnyObject]
+
+  let a: X = [
+    "abc",
+    "xyz",
+    "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue((b[0] as! String) == a[0])
+  expectTrue((b[1] as! String) == a[1])
+  expectTrue((b[2] as! String) == a[2])
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String>') to 'Y' (aka 'Array<AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c![0] as! String) == a[0])
+  expectTrue((c![1] as! String) == a[1])
+  expectTrue((c![2] as! String) == a[2])
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d![0] as! String) == a[0])
+  expectTrue((d![1] as! String) == a[1])
+  expectTrue((d![2] as! String) == a[2])
+}
+
+#if _runtime(_ObjC)
+ArrayCasts.testSync("Bridge To ObjC 2") {
+  typealias X = [String]
+  typealias Y = [NSString]
+
+  let a: X = [
+    "abc",
+    "xyz",
+    "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b[0] as String == a[0])
+  expectTrue(b[1] as String == a[1])
+  expectTrue(b[2] as String == a[2])
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String>') to 'Y' (aka 'Array<NSString>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c![0] as String) == a[0])
+  expectTrue((c![1] as String) == a[1])
+  expectTrue((c![2] as String) == a[2])
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d![0] as String) == a[0])
+  expectTrue((d![1] as String) == a[1])
+  expectTrue((d![2] as String) == a[2])
+}
+
+ArrayCasts.testSync("Bridge To ObjC 3") {
+  typealias X = [String]
+  typealias Y = [CFString]
+
+  let a: X = [
+    "abc",
+    "xyz",
+    "ijk"
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue(b[0] as String == a[0])
+  expectTrue(b[1] as String == a[1])
+  expectTrue(b[2] as String == a[2])
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String>') to 'Y' (aka 'Array<CFString>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c![0] as String) == a[0])
+  expectTrue((c![1] as String) == a[1])
+  expectTrue((c![2] as String) == a[2])
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d![0] as String) == a[0])
+  expectTrue((d![1] as String) == a[1])
+  expectTrue((d![2] as String) == a[2])
+}
+#endif
+
+ArrayCasts.testSync("Metatype to AnyObject 1") {
+  typealias X = [String.Type]
+  typealias Y = [AnyObject]
+
+  let a: X = [
+    String.self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 1)
+  expectTrue((b[0] as! Any.Type) == (a[0] as Any.Type))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<String.Type>') to 'Y' (aka 'Array<AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 1)
+  expectTrue((c![0] as! Any.Type) == (a[0] as Any.Type))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 1)
+  expectTrue((d![0] as! Any.Type) == (a[0] as Any.Type))
+}
+
+ArrayCasts.testSync("Metatype to AnyObject 2") {
+  typealias X = [(any Hashable).Type]
+  typealias Y = [AnyObject]
+
+  let a: X = [
+    (any Hashable).self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 1)
+  expectTrue((b[0] as! Any.Type) == (a[0] as Any.Type))
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(any Hashable).Type>') to 'Y' (aka 'Array<AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 1)
+  expectTrue((c![0] as! Any.Type) == (a[0] as Any.Type))
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 1)
+  expectTrue((d![0] as! Any.Type) == (a[0] as Any.Type))
+}
+
+ArrayCasts.testSync("Metatype to AnyObject 3") {
+  typealias X = [any Hashable.Type]
+  typealias Y = [AnyObject]
+
+  let a: X = [
+    Int.self,
+    String.self,
+    AnyHashable.self
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectTrue((b[0] as! Any.Type) == a[0])
+  expectTrue((b[1] as! Any.Type) == a[1])
+  expectTrue((b[2] as! Any.Type) == a[2])
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<any Hashable.Type>') to 'Y' (aka 'Array<AnyObject>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectTrue((c![0] as! Any.Type) == a[0])
+  expectTrue((c![1] as! Any.Type) == a[1])
+  expectTrue((c![2] as! Any.Type) == a[2])
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectTrue((d![0] as! Any.Type) == a[0])
+  expectTrue((d![1] as! Any.Type) == a[1])
+  expectTrue((d![2] as! Any.Type) == a[2])
+}
+
+ArrayCasts.testSync("Nested") {
+  typealias X = [[String]]
+  typealias Y = [[AnyObject]]
+
+  let a: X = [
+    ["xyz", "abc"],
+    ["ijk"],
+    []
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b[0].count, 2)
+  expectEqual(b[1].count, 1)
+  expectEqual(b[2].count, 0)
+  expectTrue((b[0][0] as! String) == "xyz")
+  expectTrue((b[0][1] as! String) == "abc")
+  expectTrue((b[1][0] as! String) == "ijk")
+
+  // Indeed succeeds
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<Array<String>>') to 'Y' (aka 'Array<Array<AnyObject>>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c![0].count, 2)
+  expectEqual(c![1].count, 1)
+  expectEqual(c![2].count, 0)
+  expectTrue((c![0][0] as! String) == "xyz")
+  expectTrue((c![0][1] as! String) == "abc")
+  expectTrue((c![1][0] as! String) == "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d![0].count, 2)
+  expectEqual(d![1].count, 1)
+  expectEqual(d![2].count, 0)
+  expectTrue((d![0][0] as! String) == "xyz")
+  expectTrue((d![0][1] as! String) == "abc")
+  expectTrue((d![1][0] as! String) == "ijk")
+}
+
+ArrayCasts.testSync("Covariant") {
+
+  typealias X = [([any StringProtocol]) -> [String]]
+  typealias Y = [([String]) -> [any StringProtocol]]
+
+  let a: X = [
+    { $0 as! [String] },
+    { _ in ["abc"] },
+    { ($0 + $0) as! [String] }
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b[0](["xyz", "ijk"]) as! [String], ["xyz", "ijk"])
+  expectEqual(b[1](["xyz", "ijk"]) as! [String], ["abc"])
+  expectEqual(b[2](["xyz", "ijk"]) as! [String], ["xyz", "ijk", "xyz", "ijk"])
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(Array<any StringProtocol>) -> Array<String>>') to 'Y' (aka 'Array<(Array<String>) -> Array<any StringProtocol>>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
+}
+
+ArrayCasts.testSync("Covariant nested") {
+
+  typealias X = [([() -> any StringProtocol]) -> [String]]
+  typealias Y = [([() -> String]) -> [any StringProtocol]]
+
+  let a: X = [
+    { x in x.map { $0() as! String } },
+    { _ in ["abc"] },
+    { x in (x + x).map { $0() as! String } }
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  let probe: [() -> String] = [{ "xyz" }, { "ijk" } ]
+  expectEqual(b[0](probe) as! [String], ["xyz", "ijk"])
+  expectEqual(b[1](probe) as! [String], ["abc"])
+  expectEqual(b[2](probe) as! [String], ["xyz", "ijk", "xyz", "ijk"])
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(Array<() -> any StringProtocol>) -> Array<String>>') to 'Y' (aka 'Array<(Array<() -> String>) -> Array<any StringProtocol>>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
 }
 
 let DictionaryCasts = TestSuite("DictionaryCasts")
@@ -275,6 +633,14 @@ DictionaryCasts.testSync("Funtion Conversion: covariant result") {
   expectEqual(b["abc"]?().k, 42)
   expectEqual(b["xyz"]?().k, -1)
   expectEqual(b["ijk"]?().k, 37)
+
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, () -> Derived>') to 'Y' (aka 'Dictionary<AnyHashable, () -> Base>') always succeeds}}
+  let c = a as? Y
+  expectNil(c)
+
+  let d = (a as Any) as? Y
+  expectNil(d)
 }
 
 await runAllTestsAsync()

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -118,6 +118,27 @@ ArrayCasts.testSync("Derived to Base") {
   expectEqual(d![2].k, 37)
 }
 
+private func arrayUpCast<Ct: Base>(_ arr: [Ct]) -> [Base] {
+  return arr
+}
+
+ArrayCasts.testSync("Archetype To Super") {
+  typealias X = [Derived]
+  typealias Y = [Base]
+
+  let a: X = [
+    Derived(42),
+    Derived(-1),
+    Derived(37)
+  ]
+
+  let b: Y = arrayUpCast(a)
+  expectEqual(b.count, 3)
+  expectEqual(b[0].k, 42)
+  expectEqual(b[1].k, -1)
+  expectEqual(b[2].k, 37)
+}
+
 ArrayCasts.testSync("Funtion Conversion: covariant result") {
   typealias X = [() -> Derived]
   typealias Y = [() -> Base]
@@ -848,6 +869,47 @@ DictionaryCasts.testSync("Derived to Base") {
   expectEqual(d!["c"]!.k, 37)
 }
 
+private func dictValueUpCast<Ct: Base>(_ dict: [String: Ct]) -> [String: Base] {
+  return dict
+}
+
+private func dictKeyUpCast<Ct: Base>(_ dict: [Ct: Int]) -> [Base: Int] {
+  return dict
+}
+
+DictionaryCasts.testSync("Archetype To Super [Value]") {
+  typealias X = [String: Derived]
+  typealias Y = [String: Base]
+
+  let a: X = [
+    "a": Derived(42),
+    "b": Derived(-1),
+    "c": Derived(37)
+  ]
+
+  let b: Y = dictValueUpCast(a)
+  expectEqual(b.count, 3)
+  expectEqual(b["a"]!.k, 42)
+  expectEqual(b["b"]!.k, -1)
+  expectEqual(b["c"]!.k, 37)
+}
+
+DictionaryCasts.testSync("Archetype To Super [Key]") {
+  typealias X = [Derived: Int]
+  typealias Y = [Base: Int]
+
+  let i = Derived(42)
+  let j = Derived(-1)
+  let k = Derived(37)
+  let a: X = [i: 1, j: 2, k: 3]
+
+  let b: Y = dictKeyUpCast(a)
+  expectEqual(b.count, 3)
+  expectEqual(b[i], 1)
+  expectEqual(b[j], 2)
+  expectEqual(b[k], 3)
+}
+
 DictionaryCasts.testSync("Funtion Conversion: covariant result") {
   typealias X = [String: () -> Derived]
   typealias Y = [String: () -> Base]
@@ -1551,6 +1613,27 @@ SetCasts.testSync("Derived to Base") {
   expectTrue(d!.contains(x))
   expectTrue(d!.contains(y))
   expectTrue(d!.contains(z))
+}
+
+private func setUpCast<Ct: Base>(_ set: Set<Ct>) -> Set<Base> {
+  return set
+}
+
+DictionaryCasts.testSync("Archetype To Super") {
+  typealias X = Set<Derived>
+  typealias Y = Set<Base>
+
+  let x = Derived(42)
+  let y = Derived(-1)
+  let z = Derived(37)
+
+  let a: X = [x, y, z]
+
+  let b: Y = setUpCast(a)
+  expectEqual(b.count, 3)
+  expectTrue(b.contains(x))
+  expectTrue(b.contains(y))
+  expectTrue(b.contains(z))
 }
 
 SetCasts.testSync("AnyHashable erasure") {

--- a/test/Casting/CollectionCasts.swift
+++ b/test/Casting/CollectionCasts.swift
@@ -688,6 +688,46 @@ ArrayCasts.testSync("Preconcurrency") {
   expectNil(d)
 }
 
+ArrayCasts.testSync("Tuple Re-labelling") {
+  typealias X = [(foo: Int, bar: String)]
+  typealias Y = [(Int, String)]
+
+  let a: X = [
+    (42, "abc"),
+    (37, "xyz"),
+    (-1, "ijk")
+  ]
+
+  let b = a as Y
+  expectEqual(b.count, 3)
+  expectEqual(b[0].0, 42)
+  expectEqual(b[0].1, "abc")
+  expectEqual(b[1].0, 37)
+  expectEqual(b[1].1, "xyz")
+  expectEqual(b[2].0, -1)
+  expectEqual(b[2].1, "ijk")
+  
+  // Despite the warning saying that this cast always succeeds, it actually fails
+  // expected-warning@+1 {{conditional cast from 'X' (aka 'Array<(foo: Int, bar: String)>') to 'Y' (aka 'Array<(Int, String)>') always succeeds}}
+  let c = a as? Y
+  expectEqual(c!.count, 3)
+  expectEqual(c![0].0, 42)
+  expectEqual(c![0].1, "abc")
+  expectEqual(c![1].0, 37)
+  expectEqual(c![1].1, "xyz")
+  expectEqual(c![2].0, -1)
+  expectEqual(c![2].1, "ijk")
+
+  let d = (a as Any) as? Y
+  expectEqual(d!.count, 3)
+  expectEqual(d![0].0, 42)
+  expectEqual(d![0].1, "abc")
+  expectEqual(d![1].0, 37)
+  expectEqual(d![1].1, "xyz")
+  expectEqual(d![2].0, -1)
+  expectEqual(d![2].1, "ijk")
+}
+
 let DictionaryCasts = TestSuite("DictionaryCasts")
 
 DictionaryCasts.testSync("Derived to Base") {
@@ -737,7 +777,7 @@ DictionaryCasts.testSync("Funtion Conversion: covariant result") {
   expectEqual(b["b"]!().k, -1)
   expectEqual(b["c"]!().k, 37)
 
-  // Despite the warning saying that this cast always succeeds, it actually fails
+  // Indeed succeeds
   // expected-warning@+1 {{conditional cast from 'X' (aka 'Dictionary<String, () -> Derived>') to 'Y' (aka 'Dictionary<String, () -> Base>') always succeeds}}
   let c = a as? Y
   expectNil(c)


### PR DESCRIPTION
This MR adds missing functionality to generate code for `KeyConversion` and `ValueConversion` in `CollectionUpcastConversionExpr`. New built-ins have been added to the standard library as `@_alwaysEmitIntoClient` for backwards compatibility.

Resolves #82618