### PR TITLE
[stdlib] Remove an unneeded `unsafe` operator

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -624,7 +624,7 @@ extension String {
     _connectOrphanedFoundationSubclassesIfNeeded()
 
     if _guts.isSmall {
-      return unsafe _guts.asSmall.withUTF8 { bufPtr in
+      return _guts.asSmall.withUTF8 { bufPtr in
         // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
         if _guts.isSmallASCII, let result = unsafe _createCFString(
           bufPtr.baseAddress._unsafelyUnwrappedUnchecked,


### PR DESCRIPTION
Building the stdlib generates a warning below, this pr fixes it:
```
/Volumes/Workspace/Swift/swift/stdlib/public/core/StringBridge.swift:627:14: warning: no unsafe operations occur within 'unsafe' expression
625 | 
626 |     if _guts.isSmall {
627 |       return unsafe _guts.asSmall.withUTF8 { bufPtr in
    |              `- warning: no unsafe operations occur within 'unsafe' expression
628 |         // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
629 |         if _guts.isSmallASCII, let result = unsafe _createCFString(
```