### PR TITLE
Add `Equatable` and `Hashable` conformance to `GUID`.

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -321,9 +321,9 @@ func _convertWindowsBoolToBool(_ b: WindowsBool) -> Bool {
 
 // GUID
 
-extension GUID: Equatable, Hashable {
+extension GUID: Equatable {
   @usableFromInline @_transparent
-  private var uint128Value: UInt128 {
+  var uint128Value: UInt128 {
     unsafe withUnsafeBytes(of: self) { buffer in
       // GUID is 32-bit-aligned only, so use loadUnaligned().
       unsafe buffer.baseAddress!.loadUnaligned(as: UInt128.self)
@@ -334,7 +334,9 @@ extension GUID: Equatable, Hashable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value
   }
+}
 
+extension GUID: Hashable {
   @_transparent
   public func hash(into: inout Hasher) {
     hasher.combine(uint128Value)

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -331,14 +331,17 @@ extension GUID {
   }
 }
 
-extension GUID: Equatable {
+// These conformances are marked @retroactive because the GUID type nominally
+// comes from the _GUIDDef clang module rather than the WinSDK clang module.
+
+extension GUID: @retroactive Equatable {
   @_transparent
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value
   }
 }
 
-extension GUID: Hashable {
+extension GUID: @retroactive Hashable {
   @_transparent
   public func hash(into hasher: inout Hasher) {
     hasher.combine(uint128Value)

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -340,7 +340,7 @@ extension GUID: Equatable {
 
 extension GUID: Hashable {
   @_transparent
-  public func hash(into: inout Hasher) {
+  public func hash(into hasher: inout Hasher) {
     hasher.combine(uint128Value)
   }
 }

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -321,15 +321,17 @@ func _convertWindowsBoolToBool(_ b: WindowsBool) -> Bool {
 
 // GUID
 
-extension GUID: Equatable {
+extension GUID {
   @usableFromInline @_transparent
-  var uint128Value: UInt128 {
+  internal var uint128Value: UInt128 {
     unsafe withUnsafeBytes(of: self) { buffer in
       // GUID is 32-bit-aligned only, so use loadUnaligned().
       unsafe buffer.baseAddress!.loadUnaligned(as: UInt128.self)
     }
   }
+}
 
+extension GUID: Equatable {
   @_transparent
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -319,3 +319,24 @@ func _convertWindowsBoolToBool(_ b: WindowsBool) -> Bool {
   return b.boolValue
 }
 
+// GUID
+
+extension GUID: Equatable, Hashable {
+  @usableFromInline @_transparent
+  private var uint128Value: UInt128 {
+    unsafe withUnsafeBytes(of: self) { buffer in
+      // GUID is 32-bit-aligned only, so use loadUnaligned().
+      unsafe buffer.baseAddress!.loadUnaligned(as: UInt128.self)
+    }
+  }
+
+  @_transparent
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.uint128Value == rhs.uint128Value
+  }
+
+  @_transparent
+  public func hash(into: inout Hasher) {
+    hasher.combine(uint128Value)
+  }
+}

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -1,4 +1,5 @@
-// RUN: %target-build-swift %s
+// RUN: %target-swift-frontend -typecheck -swift-version 6 %s -verify
+// REQUIRES: executable_test
 // REQUIRES: OS=windows-msvc
 
 // Make sure that importing WinSDK brings in the GUID type, which is declared in
@@ -7,3 +8,13 @@
 import WinSDK
 
 public func usesGUID(_ x: GUID) {}
+
+// Make sure equating and hashing GUIDs works.
+
+let guid: GUID = GUID_NULL
+assert(guid == guid)
+assert(guid.hashValue == guid.hashValue)
+
+let guid2: GUID = IID_IUnknown
+assert(guid != guid2)
+assert(guid.hashValue != guid2.hashValue) // well, probably

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -1,4 +1,4 @@
-// RUN:  %target-build-swift %s -o %t.exe
+// RUN: %target-build-swift %s -o %t.exe
 // RUN: %target-codesign %t.exe
 // RUN: %target-run %t.exe
 // REQUIRES: executable_test

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 6 %s -verify
+// RUN:  %target-build-swift %s -o %t.exe
+// RUN: %target-codesign %t.exe
+// RUN: %target-run %t.exe
 // REQUIRES: executable_test
 // REQUIRES: OS=windows-msvc
 


### PR DESCRIPTION
On Windows, `GUID` is a currency type and (along with its various typedefs) is used pervasively Windows offers `IsEqualGUID()` and `UuidHash()` for comparing and hashing them, respectively, but `IsEqualGUID()` is a macro in C mode and `UuidHash()` only provides a 16-bit hash. We should provide conformance to these protocols in the WinSDK overlay to provide equivalent functionality in Swift.