### PR TITLE
Sema: Fix concurrency adjustment for member operator references

### DIFF
--- a/test/Concurrency/member_operator_adjustment.swift
+++ b/test/Concurrency/member_operator_adjustment.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -dump-ast -swift-version 6 %s | %FileCheck %s
+
+// CHECK: (func_decl decl_context={{.*}} range={{.*}} "test(v:)"
+func test<T: Equatable>(v: T) {
+  // CHECK: (function_conversion_expr implicit type="@Sendable (T.Type) -> (T, T) -> Bool"
+  _ = v == v
+}


### PR DESCRIPTION
There was a typo in the code which made us ignore the result of the adjusted operator reference.

This was a regression from commit 1efc9a6d0db3941400e8c320712bcec5099e1ea3.

It doesn't actually matter if an immediately-applied function reference is `@Sendable` or not... But, there is another hack in CSApply which devirtualizes a call to a member operator in a protocol, and the `@Sendable` mismatch made us *skip* this hack.

Skipping the devirtualization hack, in turn, allowed code that calls `==` on two Foundation.Data instances to type check with MemberImportVisibility off. Once again, this is probably a mistake, but it caused a regression where existing code stopped working.

Ideally, we should teach MemberImportVisibility about conformances, remove the devirtualization hack, and also skip the `@Sendable` adjustment except when the member reference is unapplied.

But the existing logic was clearly wrong, so let's fix it.

Fixes rdar://162130647.