### PR TITLE
[AST] Avoid computing `getValueType` in `GenericTypeParamType`'s decl constructor

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2237,7 +2237,10 @@ GenericTypeParamType::GenericTypeParamType(GenericTypeParamDecl *param,
   Weight = 0;
   Index = param->getIndex();
   ParamKind = param->getParamKind();
-  ValueType = param->getValueType();
+  // Note we intentionally don't compute `ValueType` here since that could
+  // trigger a request cycle with the interface type computation of the
+  // GenericTypeParamDecl. Instead, `getValueType` forwards the query to the
+  // decl.
 }
 
 GenericTypeParamType::GenericTypeParamType(Identifier name,

--- a/validation-test/compiler_crashers_2_fixed/421ddf67435bd4aa.swift
+++ b/validation-test/compiler_crashers_2_fixed/421ddf67435bd4aa.swift
@@ -1,0 +1,8 @@
+// {"kind":"typecheck","original":"06207482","signature":"swift::InferredGenericSignatureRequest::evaluate(swift::Evaluator&, swift::GenericSignatureImpl const*, swift::GenericParamList*, swift::WhereClauseOwner, llvm::SmallVector<swift::Requirement, 2u>, llvm::SmallVector<swift::TypeBase*, 2u>, swift::SourceLoc, swift::ExtensionDecl*, bool) const","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
+// RUN: %target-typecheck-verify-swift
+@available(SwiftStdlib 6.2, *)
+class a<let b: b> {
+  // expected-error@-1 {{circular reference}}
+  // expected-note@-2 {{through reference here}}
+  // expected-note@-3 {{while resolving type 'b'}}
+}

--- a/validation-test/compiler_crashers_2_fixed/70bfb18ab58de217.swift
+++ b/validation-test/compiler_crashers_2_fixed/70bfb18ab58de217.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::GenericContext::getGenericSignature() const","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a < let b : c
   class c < b : a

--- a/validation-test/compiler_crashers_2_fixed/7d21b6234014b45d.swift
+++ b/validation-test/compiler_crashers_2_fixed/7d21b6234014b45d.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::TypeResolution::applyUnboundGenericArguments(swift::GenericTypeDecl*, swift::Type, swift::SourceLoc, llvm::ArrayRef<swift::Type>) const","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a < let b : a<Int>> {
 }


### PR DESCRIPTION
Doing so can result in a request cycle for the interface type, which results in an ErrorType, which violates the assumption that a `GenericTypeParamDecl` always has a `GenericTypeParamType` interface type. We already have the code in place to defer the query to the decl, so we don't actually need to set it at all.