### PR TITLE
[Test] Fix StdlibDeploymentTarget for non-macOS cases.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -567,11 +567,9 @@ def availability_macro_to_current(macro):
     }.get(run_os)
 
     orig_vers = vers_by_platform.get(platform_name)
-    if orig_vers is not None and orig_vers != "9999":
-      ver = platform.mac_ver()[0]
-
-      if version_gt(orig_vers, ver):
-        return f"StdlibDeploymentTarget {stdlib_vers}:{platform_name} {ver}"
+    if orig_vers is not None and orig_vers != "9999" \
+       and version_gt(orig_vers, run_vers):
+      return f"StdlibDeploymentTarget {stdlib_vers}:{platform_name} {run_vers}"
 
     return f"StdlibDeploymentTarget {stdlib_vers}:{orig_spec}"
 


### PR DESCRIPTION
We should be using `run_vers`, not `platform.mac_ver()[0]`.

rdar://159238613
