### PR TITLE
[update-checkout] force the use of verbose mode if -j is set to a high value

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -801,6 +801,15 @@ repositories.
             "sockets will exceed the size limit. Falling back to verbose mode."
         )
         args.verbose = True
+    elif (
+        sys.version_info.minor < 10
+        and args.n_processes > ParallelRunner._max_processes()
+    ):
+        print(
+            "Falling back to verbose mode due to a Python 3.9 limitation. "
+            f"Lower `-j` below {ParallelRunner._max_processes()} to use non verbose mode."
+        )
+        args._verbose = True
 
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh


### PR DESCRIPTION
ebd6b99a51f23ede20c809ff987674aa7a93c03f limits the number of processes when running with Python 3.9. However, some CI scripts still set `-j` to a higher value which causes the deadlock issue.

This patch falls back to verbose mode if `-j` is set to a value which is too high.