### PR TITLE
[cxx-interop] Adjust the test for default construction of C types

### DIFF
--- a/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
+++ b/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
@@ -3,4 +3,4 @@
 
 import Darwin
 
-_ = pthread_mutexattr_t() // expected-warning {{'init()' is deprecated: This zero-initializes the backing memory of the struct}}
+_ = pthread_mutexattr_t() // expected-no-diagnostics


### PR DESCRIPTION
`pthread_mutexattr_t` should be getting its implicit default constructor instantiated by Clang. Due to a Clang bug, the constructor was being instantiated, `needsImplicitDefaultConstructor` was being set to `false`, but the constructor wasn't being added to `decl->members()`. This prevented Swift from correctly importing the constructor.

This relies on John's change: https://github.com/llvm/llvm-project/pull/161933.

rdar://161999293

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
