### PR TITLE
[test] IRGen: Fix some ptrauth tests after rebranch merger

### DIFF
--- a/test/IRGen/ptrauth-blocks.sil
+++ b/test/IRGen/ptrauth-blocks.sil
@@ -20,13 +20,13 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %b : $@convention(block) () -> ()
 }
 // CHECK-LABEL: define swiftcc ptr @init_header_trivial(ptr
-// CHECK:         [[HEADER:%.*]] = getelementptr inbounds { %objc_block, ptr }, ptr %0, i32 0, i32 0
-// CHECK:         [[SLOT:%.*]] = getelementptr inbounds %objc_block, ptr [[HEADER]], i32 0, i32 3
+// CHECK:         [[HEADER:%.*]] = getelementptr inbounds{{.*}} { %objc_block, ptr }, ptr %0, i32 0, i32 0
+// CHECK:         [[SLOT:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 3
 // CHECK:         [[T0:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:         [[SIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (ptr @invoke_trivial to i64), i32 0, i64 [[T0]])
 // CHECK:         [[T0:%.*]] = inttoptr i64 [[SIGNED]] to ptr
 // CHECK:         store ptr [[T0]], ptr [[SLOT]],
-// CHECK:         [[SLOT:%.*]] = getelementptr inbounds %objc_block, ptr [[HEADER]], i32 0, i32 4
+// CHECK:         [[SLOT:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 4
 // CHECK:         store ptr [[TRIVIAL_BLOCK_DESCRIPTOR]], ptr [[SLOT]]
 
 sil @invoke_trivial : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> () {
@@ -42,13 +42,13 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
   return %b : $@convention(block) () -> ()
 }
 // CHECK-LABEL: define swiftcc ptr @init_header_nontrivial(ptr
-// CHECK:         [[HEADER:%.*]] = getelementptr inbounds { %objc_block, ptr }, ptr %0, i32 0, i32 0
-// CHECK:         [[SLOT:%.*]] = getelementptr inbounds %objc_block, ptr [[HEADER]], i32 0, i32 3
+// CHECK:         [[HEADER:%.*]] = getelementptr inbounds{{.*}} { %objc_block, ptr }, ptr %0, i32 0, i32 0
+// CHECK:         [[SLOT:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 3
 // CHECK:         [[T0:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:         [[SIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (ptr @invoke_nontrivial to i64), i32 0, i64 [[T0]])
 // CHECK:         [[T0:%.*]] = inttoptr i64 [[SIGNED]] to ptr
 // CHECK:         store ptr [[T0]], ptr [[SLOT]],
-// CHECK:         [[SLOT:%.*]] = getelementptr inbounds %objc_block, ptr [[HEADER]], i32 0, i32 4
+// CHECK:         [[SLOT:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 4
 // CHECK:         store ptr [[NONTRIVIAL_BLOCK_DESCRIPTOR]], ptr [[SLOT]]
 
 sil @invoke_nontrivial : $@convention(c) (@inout_aliasable @block_storage Builtin.NativeObject) -> () {
@@ -63,7 +63,7 @@ entry(%0 : $@convention(block) () -> ()):
   return undef : $()
 }
 // CHECK-LABEL: define swiftcc void @invoke_block(ptr %0)
-// CHECK:      [[SLOT:%.*]] = getelementptr inbounds %objc_block, ptr %0, i32 0, i32 3
+// CHECK:      [[SLOT:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr %0, i32 0, i32 3
 // CHECK-NEXT: [[T0:%.*]] = load ptr, ptr [[SLOT]], align
 // CHECK-NEXT: [[DISC:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK-NEXT: call void [[T0]](ptr %0) [ "ptrauth"(i32 0, i64 [[DISC]]) ]

--- a/test/IRGen/ptrauth-global.swift
+++ b/test/IRGen/ptrauth-global.swift
@@ -13,7 +13,7 @@
 
 // CHECK2: define {{.*}}swiftcc void @"$s1A4testyyF"()
 // CHECK2:  [[T:%.*]] = call swiftcc ptr @"$s1A9ContainerV3AllAA1GVySiGycAA1VVySiGcycvau"()
-// CHECK2:  [[T1:%.*]] = getelementptr inbounds %swift.function, ptr [[T]], i32 0, i32 0
+// CHECK2:  [[T1:%.*]] = getelementptr inbounds{{.*}} %swift.function, ptr [[T]], i32 0, i32 0
 // CHECK2:  [[T4:%.*]] = load ptr, ptr [[T1]]
 // CHECK2:  call swiftcc { ptr, ptr } [[T4]]({{.*}}) [ "ptrauth"(i32 0, i64 58141) ]
 

--- a/test/IRGen/ptrauth-partial-apply.sil
+++ b/test/IRGen/ptrauth-partial-apply.sil
@@ -14,7 +14,7 @@ bb0(%0 : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> (), %1 : $Builtin.
 }
 // CHECK-LABEL: define swiftcc { ptr, ptr } @test_thin_indirect(ptr %0, i32 %1)
 // CHECK:       [[ALLOC:%.*]] = call {{.*}}swift_allocObject(
-// CHECK:       [[SLOT:%.*]] = getelementptr inbounds [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr }>]], ptr [[ALLOC]], i32 0, i32 3
+// CHECK:       [[SLOT:%.*]] = getelementptr inbounds{{.*}} [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr }>]], ptr [[ALLOC]], i32 0, i32 3
 // CHECK:       [[T0:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:       [[DISC:%.*]] = call i64 @llvm.ptrauth.blend(i64 [[T0]], i64 7185)
 // CHECK:       [[T0:%.*]] = ptrtoint ptr %0 to i64
@@ -24,7 +24,7 @@ bb0(%0 : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> (), %1 : $Builtin.
 // CHECK:       insertvalue { ptr, ptr } { ptr @"$sTA.ptrauth", ptr undef }, ptr {{.*}}, 1
 
 // CHECK-LABEL: define internal swiftcc void @"$sTA"(ptr swiftself %0)
-// CHECK:       [[SLOT:%.*]] = getelementptr inbounds [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr }>]], ptr %0, i32 0, i32 3
+// CHECK:       [[SLOT:%.*]] = getelementptr inbounds{{.*}} [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr }>]], ptr %0, i32 0, i32 3
 // CHECK:       [[T0:%.*]] = load ptr, ptr [[SLOT]], align 8
 // CHECK:       [[T1:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:       [[DISC:%.*]] = call i64 @llvm.ptrauth.blend(i64 [[T1]], i64 7185)
@@ -37,7 +37,7 @@ bb0(%0 : $@callee_owned (Builtin.Int32, Builtin.Int32) -> (), %1 : $Builtin.Int3
 }
 // CHECK-LABEL: define swiftcc { ptr, ptr } @test_thick_indirect(ptr %0, ptr %1, i32 %2)
 // CHECK:       [[ALLOC:%.*]] = call {{.*}}swift_allocObject(
-// CHECK:       [[SLOT:%.*]] = getelementptr inbounds [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr, ptr }>]], ptr {{%.*}}, i32 0, i32 4
+// CHECK:       [[SLOT:%.*]] = getelementptr inbounds{{.*}} [[CTXT_TY:<{ %swift.refcounted, i32, i32, ptr, ptr }>]], ptr {{%.*}}, i32 0, i32 4
 // CHECK:       [[T0:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:       [[DISC:%.*]] = call i64 @llvm.ptrauth.blend(i64 [[T0]], i64 7185)
 // CHECK:       [[T0:%.*]] = ptrtoint ptr %0 to i64
@@ -47,7 +47,7 @@ bb0(%0 : $@callee_owned (Builtin.Int32, Builtin.Int32) -> (), %1 : $Builtin.Int3
 // CHECK:       insertvalue { ptr, ptr } { ptr @"$sTA{{.*}}.ptrauth", ptr undef }, ptr {{.*}}, 1
 
 // CHECK-LABEL: define internal swiftcc void @"$sTA{{.*}}"(ptr swiftself %0)
-// CHECK:       [[SLOT:%.*]] = getelementptr inbounds <{ %swift.refcounted, i32, i32, ptr, ptr }>, ptr %0, i32 0, i32 4
+// CHECK:       [[SLOT:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, i32, i32, ptr, ptr }>, ptr %0, i32 0, i32 4
 // CHECK:       [[T0:%.*]] = load ptr, ptr [[SLOT]], align 8
 // CHECK:       [[T1:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:       [[DISC:%.*]] = call i64 @llvm.ptrauth.blend(i64 [[T1]], i64 7185)

--- a/test/IRGen/ptrauth_field_fptr_import.swift
+++ b/test/IRGen/ptrauth_field_fptr_import.swift
@@ -11,7 +11,7 @@ import PointerAuth
 // CHECK:   br label %9
 // CHECK: 9:
 // CHECK:   [[SECURESTRUCT:%.*]] = phi ptr [ [[CAST0]], {{.*}} ]
-// CHECK:   %.secure_func_ptr = getelementptr inbounds %TSo12SecureStructV, ptr [[SECURESTRUCT]], i32 0, i32 0
+// CHECK:   %.secure_func_ptr = getelementptr inbounds{{.*}} %TSo12SecureStructV, ptr [[SECURESTRUCT]], i32 0, i32 0
 // CHECK:   [[PTR:%.*]] = load ptr, ptr %.secure_func_ptr, align 8
 // CHECK:   [[COND:%.*]] = icmp ne ptr [[PTR]], null
 // CHECK:   br i1 [[COND]], label %resign-nonnull, label %resign-null
@@ -33,7 +33,7 @@ func test_field_fn_read() -> Int32 {
 
 // CHECK-LABEL: define hidden swiftcc void @"$s25ptrauth_field_fptr_import05test_B14_fn_ptr_modifyyyF"() #0 {
 // CHECK:   [[SECURESTRUCT:%.*]] = phi ptr [
-// CHECK:   %.secure_func_ptr = getelementptr inbounds %TSo12SecureStructV, ptr [[SECURESTRUCT]], i32 0, i32 0
+// CHECK:   %.secure_func_ptr = getelementptr inbounds{{.*}} %TSo12SecureStructV, ptr [[SECURESTRUCT]], i32 0, i32 0
 // CHECK:   store i64 ptrtoint (ptr @returnInt.ptrauth to i64), ptr %ptrauth.temp, align 8
 // CHECK:   [[LD:%.*]] = load ptr, ptr %ptrauth.temp, align 8
 // CHECK:   [[COND:%.*]] = icmp ne ptr [[LD]], null
@@ -53,7 +53,7 @@ func test_field_fn_ptr_modify() {
 // CHECK:   br label %[[L1:[0-9]+]]
 // CHECK: [[L1]]:
 // CHECK:   [[AddressDiscriminatedSecureStruct:%.*]] = phi ptr [ [[CAST0]]
-// CHECK:   %.secure_func_ptr = getelementptr inbounds %TSo32AddressDiscriminatedSecureStructV, ptr [[AddressDiscriminatedSecureStruct]], i32 0, i32 0
+// CHECK:   %.secure_func_ptr = getelementptr inbounds{{.*}} %TSo32AddressDiscriminatedSecureStructV, ptr [[AddressDiscriminatedSecureStruct]], i32 0, i32 0
 // CHECK:   [[PTR:%.*]] = load ptr, ptr %.secure_func_ptr, align 8
 // CHECK:   [[COND:%.*]] = icmp ne ptr [[PTR]], null
 // CHECK:   br i1 [[COND]], label %resign-nonnull, label %resign-null
@@ -79,7 +79,7 @@ func test_addr_discriminated_field_fn_read() -> Int32 {
 // CHECK:   br label %[[L1:[0-9]+]]
 // CHECK: [[L1]]:
 // CHECK:   [[AddressDiscriminatedSecureStruct:%.*]] = phi ptr [ [[CAST0]]
-// CHECK:   %.secure_func_ptr = getelementptr inbounds %TSo32AddressDiscriminatedSecureStructV, ptr [[AddressDiscriminatedSecureStruct]], i32 0, i32 0
+// CHECK:   %.secure_func_ptr = getelementptr inbounds{{.*}} %TSo32AddressDiscriminatedSecureStructV, ptr [[AddressDiscriminatedSecureStruct]], i32 0, i32 0
 // CHECK:   store i64 ptrtoint (ptr @returnInt.ptrauth to i64), ptr %ptrauth.temp, align 8
 // CHECK:   [[LD:%.*]] = load ptr, ptr %ptrauth.temp, align 8
 // CHECK:   [[COND:%.*]] = icmp ne ptr [[LD]], null

--- a/test/IRGen/ptrauth_field_fptr_import.swift
+++ b/test/IRGen/ptrauth_field_fptr_import.swift
@@ -2,6 +2,9 @@
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
 
+// rdar://162381284
+// XFAIL: CPU=arm64e && OS=ios
+
 import PointerAuth
 
 // CHECK: define hidden swiftcc i32 @"$s25ptrauth_field_fptr_import05test_B8_fn_reads5Int32VyF"() #0 {


### PR DESCRIPTION
Adjust FileCheck patterns for new `nuw` attribute. This attribute was introduced in https://github.com/llvm/llvm-project/pull/107257. Match it using a wildcard regex, since it is not relevant to these tests.

rdar://162082531