### PR TITLE
Strengthen the SIL verifier's rules for edges into dead-end regions

### DIFF
--- a/docs/SIL/SIL.md
+++ b/docs/SIL/SIL.md
@@ -780,6 +780,217 @@ _lexical_ in order to specify this property for all contributing lifetimes.
 For details see [Variable Lifetimes](Ownership.md#variable-lifetimes) in the
 Ownership document.
 
+# Dominance
+
+## Value and instruction dominance
+
+Whenever an instruction uses a [value](#values-and-operands) as an
+operand, the definition of the value must dominate the instruction.
+This is a common concept across all SSA-like representations. SIL
+uses a standard definition of dominance, modified slightly to account
+for SIL's use of basic block arguments rather than phi instructions:
+
+- The value `undef` always dominates an instruction.
+
+- An instruction result `R` dominates an instruction `I` if the
+  instruction that defines `R` dominates `I`.
+
+- An argument of a basic block `B` dominates an instruction `I` if all
+  initial paths passing through `I` must also pass through the start
+  of `B`.
+
+An instruction `D` dominates another instruction `I` if they are
+different instructions and all initial paths passing through `I`
+must also pass through `D`.
+
+See [below](#definition-of-a-path) for the formal definition of an
+initial path.
+
+## Basic block dominance
+
+A basic block `B1` dominates a basic block `B2` if they are different
+blocks and if all initial paths passing through the start of `B2` must
+also pass through through the start of `B1`.
+
+This relationship between blocks can be thought of as creating a
+directed acyclic graph of basic blocks, called the *dominance tree*.
+The dominance tree is not directly represented in SIL; it is just
+an emergent property of the dominance requirement on SIL functions.
+
+## Joint post-dominance
+
+Certain instructions are required to have a *joint post-dominance*
+relationship with certain other instructions. Informally, this means
+that all terminating paths through the first instruction must
+eventually pass through one of the others. This is common for
+instructions that define a scope in the SIL function, such as
+`alloc_stack` and `begin_access`.
+
+The dominating instruction is called the *scope instruction*,
+and the post-dominating instructions are called the *scope-ending
+instructions*. The specific joint post-dominance requirement
+defines the set of instructions that count as scope-ending
+instructions for the begin instruction.
+
+For example, an `alloc_stack` instruction must be jointly
+post-dominated by the set of `dealloc_stack` instructions
+whose operand is the result of the `alloc_stack`. The
+`alloc_stack` is the scope instruction, and the `dealloc_stack`s
+are the scope-ending instructions.
+
+The *scope* of a joint post-dominance relationship is the set
+of all points in the function following the scope instruction
+but prior to a scope-ending instruction. Making this precisely
+defined is part of the point of the joint post-dominance rules.
+A formal definition is given later.
+
+In SIL, if an instruction acts as a scope instruction, it always
+has exactly one set of scope-ending instructions associated
+with it, and so it forms exactly one scope. People will therefore
+often talk about, e.g., the scope of an `alloc_stack`, meaning
+the scope between it and its `dealloc_stack`s. Furthermore,
+there are no instructions in SIL which act as scope-ending
+instructions for multiple scopes.
+
+A scope instruction `I` is jointly post-dominated by its
+scope-ending instructions if:
+
+- All initial paths that pass through a scope-ending instruction
+  of `I` must also pass through `I`. (This is just the normal
+  dominance rule, and it is typically already required by the
+  definition of the joint post-dominance relationship. For example,
+  a `dealloc_stack` must be dominated by its associated
+  `alloc_stack` because it uses its result as an operand.)
+
+- All initial paths that pass through `I` twice must also pass
+  through a scope-ending instruction of `I` in between.
+
+- All initial paths that pass through a scope-ending instruction
+  of `I` twice must also pass through `I` in between.
+
+- All terminating initial paths that pass through `I` must also
+  pass through a scope-ending instruction of `I`.
+
+In other words, all paths must strictly alternate between `I`
+and its scope-ending instructions, starting with `I` and (if
+the path exits) ending with a scope-ending instruction.
+
+Note that a scope-ending instruction does not need to appear on
+a path following a scope instruction if the path doesn't exit
+the function. In fact, a function needn't include any scope-ending
+instructions for a particular scope instruction if all paths from
+that point are non-terminating, such as by ending in `unreachable`
+or containing an infinite loop.
+
+A scope instruction `I` is *coherently* jointly post-dominated
+by its scope-ending instructions if there is no point in the
+function for which it is possible to construct two paths, both
+ending in that point, which differ by whether they most recently
+passed through `I` or one of its scope-ending instructions.
+This is always true for points from which it is possible to
+construct a terminating path, but it can be false for dead-end
+points.
+
+Several important joint post-dominance requirements in SIL
+do not require coherence, including the stack-allocation rule.
+Non-coherence allows optimizations to be more aggressive
+across control flow that enters dead-end regions. Note that
+control flow internal to a dead-end region is not special
+in this way, so SIL analyses must not not simply check
+whether a destination block is dead-end.
+
+The *scope* defined by a joint post-dominance relationship for a
+scope instruction `I` is the set of points in the function for
+which:
+
+- there exists an initial path that ends at that point and
+  passes through `I`, but
+
+- there does not an exist a simple initial path that ends at
+  that point and passes through a scope-ending instruction
+  of `I`.
+
+In the absence of coherence, this second rule conservatively
+shrinks the scope to the set of points that cannot possibly
+have passed through a scope-ending instruction.
+
+For a coherent joint post-dominance relationship, this
+definition simplifies to the set of points for which there
+exists an initial path that ends at that point and passes
+through `I`, but which does not pass through a scope-ending
+instruction of `I`.
+
+Note that the point before a scope-ending instruction is always
+within the scope.
+
+## Definition of a path
+
+A *point* in a SIL function is the moment before an instruction.
+Every basic block has an entry point, which is the point before
+its first instruction. The entry point of the entry block is also
+called the entry point of the function.
+
+A path through a SIL function is a path (in the usual graph-theory
+sense) in the underlying directed graph of points, in which:
+
+- every point in the SIL function is a vertex in the graph,
+
+- each non-terminator instruction creates an edge from the point
+  before it to the point after it, and
+
+- each terminator instruction creates edges from the point before
+  the terminator to the initial point of each its successor blocks.
+
+A path is said to pass through an instruction if it includes
+any of the edges created by that instruction. A path is said to
+pass through the start of a basic block if it visits the entry
+point of that block.
+
+An *initial path* is a path which begins at the entry point of the
+function. A *terminating path* is a path which ends at the point
+before an exiting instruction, such as `return` or `throw`.
+
+Note that the dominance rules generally require only an initial path,
+not a terminating path. A path that simply stops in the middle of a
+block still counts for dominance. Among other things, this ensures that
+dominance holds in blocks that are part of an infinite loop.
+
+A *dead-end point* is a point which cannot be included on any
+terminating path. A *dead-end block* is a block for which the
+entry point is a dead-end point. A *dead-end region* is a
+strongly-connected component of the CFG containing only dead-end
+blocks.
+
+Note also that paths consider successors without regard to the
+nature of the terminator. Paths that are provably impossible because
+of value relationships still count for dominance. For example,
+consider the following function:
+
+```
+    bb0(%cond : $Builtin.Int1):
+      cond_br %cond, bb1, b22
+    bb1:
+      %value = integer_literal $Builtin.Int32, 0
+      br bb3
+    bb2:
+      br bb3
+    bb3:
+      cond_br %cond, bb4, bb5
+    bb4:
+      %twice_value = builtin "add_Int32"(%value, %value) : $Builtin.Int32
+      br bb6
+    bb5:
+      br bb6
+    bb6:
+      ret %cond
+```
+
+Dynamically, it is impossible to reach the `builtin` instruction
+without passing through the definition of `%value`: to reach
+the `builtin`, `%cond` must be `true`, and so the first `cond_br`
+must have branched to `bb1`. This is not taken into consideration
+by dominance, and so this function is ill-formed.
+
 # Debug Information
 
 Each instruction may have a debug location and a SIL scope reference at
@@ -1364,48 +1575,39 @@ stack deallocation instructions. It can even be paired with no
 instructions at all; by the rules below, this can only happen in
 non-terminating functions.
 
--   At any point in a SIL function, there is an ordered list of stack
-    allocation instructions called the *active allocations list*.
+- All stack allocation instructions must be jointly post-dominated
+  by stack deallocation instructions paired with them.
 
--   The active allocations list is defined to be empty at the initial
-    point of the entry block of the function.
+- No path through the function that passes through a stack allocation
+  instruction `B`, having already passed a stack allocation
+  instruction `A`, may subsequently pass through a stack deallocation
+  instruction paired with `A` without first passing through a stack
+  deallocation instruction paired with `B`.
 
--   The active allocations list is required to be the same at the
-    initial point of any successor block as it is at the final point of
-    any predecessor block. Note that this also requires all
-    predecessors/successors of a given block to have the same
-    final/initial active allocations lists.
+These two rules statically enforce that all stack allocations are
+properly nested. In simpler terms:
 
-    In other words, the set of active stack allocations must be the same
-    at a given place in the function no matter how it was reached.
+- At every point in a SIL function, there is an ordered list of stack
+  allocation instructions called the *active allocations list*.
 
--   The active allocations list for the point following a stack
-    allocation instruction is defined to be the result of adding that
-    instruction to the end of the active allocations list for the point
-    preceding the instruction.
+- The active allocations list is empty at the start of the entry block
+  of the function, and it must be empty again whenever an instruction
+  that exits the function is reached, like `return` or `throw`.
 
--   The active allocations list for the point following a stack
-    deallocation instruction is defined to be the result of removing the
-    instruction from the end of the active allocations list for the
-    point preceding the instruction. The active allocations list for the
-    preceding point is required to be non-empty, and the last
-    instruction in it must be paired with the deallocation instruction.
+- Whenever a stack allocation instruction is reached, it is added to
+  the end of the list.
 
-    In other words, all stack allocations must be deallocated in
-    last-in, first-out order, aka stack order.
+- Whenever a stack deallocation instruction is reached, its paired
+  stack allocation instruction must be at the end of the list, which it
+  is then removed from.
 
--   The active allocations list for the point following any other
-    instruction is defined to be the same as the active allocations list
-    for the point preceding the instruction.
+- The active allocations list always be the same on both sides of a
+  control flow edge. This implies both that all successors of a block
+  must start with the same list and that all predecessors of a block
+  must end with the same list.
 
--   The active allocations list is required to be empty prior to
-    `return` or `throw` instructions.
-
-    In other words, all stack allocations must be deallocated prior to
-    exiting the function.
-
-Note that these rules implicitly prevent an allocation instruction from
-still being active when it is reached.
+Note that these rules implicitly prevent stack allocations from leaking
+or being double-freed.
 
 The control-flow rule forbids certain patterns that would theoretically
 be useful, such as conditionally performing an allocation around an
@@ -1413,6 +1615,12 @@ operation. SIL generally makes this sort of pattern somewhat difficult
 to use, however, as it is illegal to locally abstract over addresses,
 and therefore a conditional allocation cannot be used in the
 intermediate operation anyway.
+
+The stack discipline rules do not require coherent joint post-dominance.
+This means that different control-flow paths entering a dead-end region
+may disagree about the state of the stack. In such a region, the stack
+discipline rules permit further allocation, but nothing that was not
+allocated within the region can be deallocated.
 
 # Structural type matching for pack indices
 

--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -14,6 +14,7 @@
 #define SWIFT_SIL_BASICBLOCKUTILS_H
 
 #include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockData.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SetVector.h"
@@ -124,6 +125,213 @@ public:
 protected:
   void propagateNewlyReachableBlocks(unsigned startIdx);
 };
+
+/// A utility for detecting edges that enter a dead-end region.
+///
+/// A dead-end region is a strongly-connected component of the CFG
+/// consisting solely of dead-end blocks (i.e. from which it is not
+/// possible to reach a function exit). The strongly-connected
+/// components of a CFG form a DAG: once control flow from the entry
+/// block has entered an SCC, it cannot return to an earlier SCC
+/// (because then by definition they would have to be the same SCC).
+///
+/// Note that the interior edges of a dead-end region do not *enter*
+/// the region. Only edges from an earlier SCC count as edges into
+/// the region.
+///
+/// For example, in this CFG:
+///
+///      /-> bb1 -> bb2 -> return
+///   bb0
+///      \-> bb3 -> bb4 -> bb5 -> unreachable
+///           ^      |
+///           \------/
+///
+/// The edge from bb0 to bb3 enters a new dead-end region, as does
+/// the edge from bb4 to bb5. The edge from bb4 to bb3 does not
+/// enter a new region because it is an internal edge of its region.
+///
+/// Edges that enter dead-end regions are special in SIL because certain
+/// joint post-dominance rules are relaxed for them. For example, the
+/// stack does need not be consistent on different edges into a dead-end
+/// region.
+class DeadEndEdges {
+  enum : unsigned {
+    /// A region data value which represents that a block is unreachable
+    /// from the entry block.
+    UnreachableRegionData = 0,
+
+    /// A region data value which represents that a block is reachable
+    /// from the entry block but not in a dead-end region.
+    NonDeadEndRegionData = 1,
+
+    /// A value that must be added to a region index when storing it in
+    /// a region data.
+    ///
+    /// This should be the smallest number such that
+    ///   (IndexOffset << IndexShift)
+    /// is always greater than all of the special region-data values
+    /// above.
+    IndexOffset = 1,
+
+    /// A mask which can be applied to a region to say that it contains
+    /// a cycle. This slightly optimizes the check in isDeadEndEdge for
+    /// the common case where regions do not have cycles.
+    HasCycleMask = 0x1,
+
+    /// The amount to shift the region index by when storing it in a
+    /// region data.
+    ///
+    /// This should be the smallest number such that an arbitrary value
+    /// left-shifted by it will not have any of the mask bits set.
+    IndexShift = 1,
+  };
+
+  /// An integer representing what we know about the SCC partition that
+  /// a particular block is in. All blocks in the same region store the
+  /// same value to make comparisons faster.
+  ///
+  /// Either:
+  /// - UnreachableRegionData, representing a block that cannot be
+  ///   reached from the entry block;
+  /// - NonDeadEndRegionData, representing a block that can be reached
+  ///   from the entry block but is not in a dead-end region; or
+  /// - an encoded region index, representing a block that is in a
+  ///   dead-end region.
+  ///
+  /// A region index is a unique value in 0..<numDeadEndRegions,
+  /// selected for a specific dead-end SCC. It is encoded by adding
+  /// IndexOffset, left-shifting by IndexShift, and then or'ing
+  /// in any appropriate summary bits like HasCycleMask.
+  ///
+  /// If regionDataForBlock isn't initialized, the function contains
+  /// no dead-end blocks.
+  std::optional<BasicBlockData<unsigned>> regionDataForBlock;
+
+  /// The total number of dead-end regions in the function.
+  unsigned numDeadEndRegions;
+
+  static constexpr bool isDeadEndRegion(unsigned regionData) {
+    return regionData >= (IndexOffset << IndexShift);
+  }
+
+  static unsigned getIndexFromRegionData(unsigned regionData) {
+    assert(isDeadEndRegion(regionData));
+    return (regionData >> IndexShift) - IndexOffset;
+  }
+
+public:
+  /// Perform the analysis on the given function. An existing
+  /// DeadEndBlocks analysis can be passed in to avoid needing to
+  /// compute it anew.
+  explicit DeadEndEdges(SILFunction *F,
+                        DeadEndBlocks *deadEndBlocks = nullptr);
+
+  /// Return the number of dead-end regions in the function.
+  unsigned getNumDeadEndRegions() const {
+    return numDeadEndRegions;
+  }
+
+  /// Does the given CFG edge enter a new dead-end region?
+  ///
+  /// If so, return the index of the dead-end region it enters.
+  std::optional<unsigned>
+  entersDeadEndRegion(SILBasicBlock *srcBB, SILBasicBlock *dstBB) const {
+    // If we didn't initialize regionDataForBlock, there are no dead-end
+    // edges at all.
+    if (!regionDataForBlock)
+      return std::nullopt;
+
+    auto dstRegionData = (*regionDataForBlock)[dstBB];
+
+    // If the destination block is not in a dead-end region, this is
+    // not a dead-end edge.
+    if (!isDeadEndRegion(dstRegionData)) return std::nullopt;
+
+    unsigned dstRegionIndex = getIndexFromRegionData(dstRegionData);
+
+    // If the destination block is in a region with no cycles, every edge
+    // to it is a dead-end edge; no need to look up the source block's
+    // region.
+    if (!(dstRegionData & HasCycleMask)) return dstRegionIndex;
+
+    // Otherwise, it's a dead-end edge if the source block is in a
+    // different region. (That region may or may not be itself be a
+    // dead-end region.)
+    auto srcRegionData = (*regionDataForBlock)[srcBB];
+    if (srcRegionData != dstRegionData) {
+      return dstRegionIndex;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /// A helper class for tracking visits to edges into dead-end regions.
+  ///
+  /// The client is assumed to be doing a walk of the function which will
+  /// naturally visit each edge exactly once. This set allows the client
+  /// to track when they've processed every edge to a particular dead-end
+  /// region and can therefore safely enter it.
+  ///
+  /// The set does not count edges from unreachable blocks by default. This
+  /// matches the normal expectation that the client is doing a CFG search
+  /// and won't try to visit edges from unreachable blocks. If you are
+  /// walking the function in some other, e.g. by iterating the blocks,
+  /// you must pass `true` for `includeUnreachableEdges`.
+  class VisitingSet {
+    const DeadEndEdges &edges;
+
+    /// Stores the remaining number of edges for each dead-end region
+    /// in the function.
+    SmallVector<unsigned> remainingEdgesForRegion;
+
+    friend class DeadEndEdges;
+    explicit VisitingSet(const DeadEndEdges &parent,
+                         bool includeUnreachableEdges);
+
+  public:
+    /// Record that a dead-end edge to the given block was visited.
+    ///
+    /// Returns true if this was the last dead-end edge to the region
+    /// containing the block.
+    ///
+    /// Do not call this multiple times for the same edge. Do not
+    /// call this for an unreachable edge if you did not create the
+    /// set including unreachable edges.
+    bool visitEdgeTo(SILBasicBlock *destBB) {
+      assert(edges.regionDataForBlock &&
+             "visiting dead-end edge in function that has none");
+      auto destRegionData = (*edges.regionDataForBlock)[destBB];
+      assert(isDeadEndRegion(destRegionData) &&
+             "destination block is not in a dead-end region");
+
+      auto destRegionIndex = getIndexFromRegionData(destRegionData);
+      assert(remainingEdgesForRegion[destRegionIndex] > 0 &&
+             "no remaining dead-end edges for region; visited "
+             "multiple times?");
+
+      auto numRemaining = --remainingEdgesForRegion[destRegionIndex];
+      return numRemaining == 0;
+    }
+
+    /// Return true if all of the edges have been visited.
+    bool visitedAllEdges() const {
+      for (auto count : remainingEdgesForRegion) {
+        if (count) return false;
+      }
+      return true;
+    }
+  };
+
+  /// Create a counter set which can be used to count edges in the
+  /// dead-end regions.
+  ///
+  /// By default, the set does not include edges from unreachable blocks.
+  VisitingSet createVisitingSet(bool includeUnreachableEdges = false) const {
+    return VisitingSet(*this, includeUnreachableEdges);
+  }
+};
+
 
 /// Compute joint-postdominating set for \p dominatingBlock and \p
 /// dominatedBlockSet found by walking up the CFG from the latter to the

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -46,6 +46,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/Support/Allocator.h"
@@ -1144,7 +1145,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
 void verificationFailure(const Twine &complaint,
               const SILInstruction *atInstruction,
               const SILArgument *atArgument,
-              const std::function<void()> &extraContext);
+              llvm::function_ref<void(llvm::raw_ostream &OS)> extraContext);
 
 inline bool SILOptions::supportsLexicalLifetimes(const SILModule &mod) const {
   switch (mod.getStage()) {

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -25,6 +25,7 @@
 #include "swift/SIL/TerminatorUtils.h"
 #include "swift/SIL/Test.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SCCIterator.h"
 
 using namespace swift;
 
@@ -456,6 +457,187 @@ static FunctionTest HasAnyDeadEndBlocksTest(
       auto deb = test.getDeadEndBlocks();
       llvm::outs() << (deb->isEmpty() ? "no dead ends\n" : "has dead ends\n");
     });
+} // end namespace swift::test
+
+//===----------------------------------------------------------------------===//
+//                               DeadEndEdges
+//===----------------------------------------------------------------------===//
+
+DeadEndEdges::DeadEndEdges(SILFunction *F,
+                           DeadEndBlocks *existingDeadEndBlocks) {
+  // Hilariously, C++ does not permit these to be written in
+  // the class definition.
+  static_assert(!isDeadEndRegion(UnreachableRegionData), "");
+  static_assert(!isDeadEndRegion(NonDeadEndRegionData), "");
+
+  std::optional<DeadEndBlocks> localDeadEndBlocks;
+  if (!existingDeadEndBlocks) {
+    localDeadEndBlocks.emplace(F);
+  }
+  DeadEndBlocks &deadEndBlocks =
+    (existingDeadEndBlocks ? *existingDeadEndBlocks : *localDeadEndBlocks);
+
+  // If there are no dead-end blocks, exit immediately, leaving
+  // regionDataForBlock empty.
+  if (deadEndBlocks.isEmpty()) {
+    numDeadEndRegions = 0;
+    return;
+  }
+
+  // Initialize regionDataForBlock to consider all blocks to be unreachable.
+  regionDataForBlock.emplace(F, [](SILBasicBlock *bb) {
+    return UnreachableRegionData;
+  });
+
+  unsigned nextDeadRegionIndex = 0;
+
+  // Iterate the strongly connected components of the CFG.
+  //
+  // We might be able to specialize the SCC algorithm to both (1) detect
+  // dead-end SCCs directly and (2) maybe even eagerly count the dead-end
+  // edges into each block. But that would require rewriting the algorithm,
+  // and this doesn't seem problematic.
+  //
+  // Note that only reachable blocks can be found by SCC iteration.
+  // So we're implicitly leaving regionDataForBlock filled with
+  // UnreachableRegionData for any unreachable blocks.
+  for (auto sccIt = scc_begin(F); !sccIt.isAtEnd(); ++sccIt) {
+    const auto &scc = *sccIt;
+
+    // If this SCC is not dead-end, just record that all of its blocks
+    // are reachable. We can check any block in the SCC for this: they
+    // can all reach each other by definition, so if any of them can
+    // reach an exit, they all can.
+    auto repBB = scc[0];
+    if (!deadEndBlocks.isDeadEnd(repBB)) {
+      for (auto *block : scc) {
+        (*regionDataForBlock)[block] = NonDeadEndRegionData;
+      }
+      continue;
+    }
+
+    // Allocate a new region index.
+    unsigned regionIndex = nextDeadRegionIndex++;
+
+    // Encode the region data.
+    unsigned regionData = (regionIndex + IndexOffset) << IndexShift;
+    if (sccIt.hasCycle()) {
+      regionData |= HasCycleMask;
+    }
+
+    assert(getIndexFromRegionData(regionData) == regionIndex);
+
+    // Assign the encoded region data to the every block in the region.
+    for (auto *block : scc) {
+      (*regionDataForBlock)[block] = regionData;
+    }
+  }
+
+  // The entry block can technically be a dead-end region if there are
+  // no reachable exits in the function, but we don't care about tracking
+  // it because we only care about edges *into* regions, and the entry
+  // region never has in-edges. So avoid the weird corner case of a region
+  // with no in-edges *and* save some space in VisitingSets by removing it.
+  auto &entryRegionData = (*regionDataForBlock).entry().data;
+  if (isDeadEndRegion(entryRegionData)) {
+    // SCC iteration is in reverse topological order, so the entry block
+    // is always the last region. It's also always the only block in
+    // its region, so it's really easy to retroactively erase from the
+    // records.
+    assert(getIndexFromRegionData(entryRegionData) == nextDeadRegionIndex - 1);
+    nextDeadRegionIndex--;
+    entryRegionData = NonDeadEndRegionData;
+  }
+
+  numDeadEndRegions = nextDeadRegionIndex;
+}
+
+DeadEndEdges::VisitingSet::VisitingSet(const DeadEndEdges &edges,
+                                       bool includeUnreachableEdges)
+    : edges(edges) {
+
+  // Skip all of this if there are no dead-end regions.
+  if (edges.numDeadEndRegions == 0)
+    return;
+
+  // Initialize all of the totals to 0.
+  remainingEdgesForRegion.resize(edges.numDeadEndRegions, 0);
+
+  // Simultaneously iterate the blocks of the function and the
+  // region data we have for each block.
+  for (auto blockAndData : *edges.regionDataForBlock) {
+    SILBasicBlock *bb = &blockAndData.block;
+    unsigned regionData = blockAndData.data;
+
+    // Ignore blocks in non-dead-end regions.
+    if (!isDeadEndRegion(regionData))
+      continue;
+
+    // Count the edges to the block that begin in other regions.
+    // But ignore edges from unreachable blocks unless requested.
+    unsigned numDeadEndEdgesToBlock = 0;
+    for (SILBasicBlock *pred : bb->getPredecessorBlocks()) {
+      auto predRegionData = (*edges.regionDataForBlock)[pred];
+      if (predRegionData != regionData &&
+          (predRegionData != UnreachableRegionData ||
+           includeUnreachableEdges)) {
+        numDeadEndEdgesToBlock++;
+      }
+    }
+
+    // Add that to the total for the block's region.
+    auto regionIndex = getIndexFromRegionData(regionData);
+    remainingEdgesForRegion[regionIndex] += numDeadEndEdgesToBlock;
+  }
+
+#ifndef NDEBUG
+  // We should have found at least one edge for every dead-end
+  // region, since they're all supposed to be reachable from the
+  // entry block. 
+  for (auto count : remainingEdgesForRegion) {
+    assert(count && "didn't find any edges to region?");
+  }
+#endif
+}
+
+namespace swift::test {
+// Arguments:
+// - none
+// Prints:
+// - a bunch of lines like
+//     %bb3 -> %bb6 (region 2; more edges remain)
+//     %bb5 -> %bb6 (region 2; last edge)
+// - either "Visited all edges" or "Did not visit all edges"
+static FunctionTest DeadEndEdgesTest("dead_end_edges", [](auto &function,
+                                                          auto &arguments,
+                                                          auto &test) {
+  DeadEndEdges edges(&function);
+  auto visitingSet = edges.createVisitingSet(/*includeUnreachable*/ true);
+
+  auto &out = llvm::outs();
+  for (auto &srcBB : function) {
+    for (auto *dstBB : srcBB.getSuccessorBlocks()) {
+      if (auto regionIndex = edges.entersDeadEndRegion(&srcBB, dstBB)) {
+        srcBB.printID(out, false);
+        out << " -> ";
+        dstBB->printID(out, false);
+        out << " (region " << *regionIndex << "; ";
+        if (visitingSet.visitEdgeTo(dstBB)) {
+          out << "last edge)";
+        } else {
+          out << "more edges remain)";
+        }
+        out << "\n";
+      }
+    }
+  }
+  if (visitingSet.visitedAllEdges()) {
+    out << "visited all edges\n";
+  } else {
+    out << "did not visit all edges\n";
+  }
+});
+
 } // end namespace swift::test
 
 //===----------------------------------------------------------------------===//

--- a/test/SIL/store_borrow_verify_errors.sil
+++ b/test/SIL/store_borrow_verify_errors.sil
@@ -55,11 +55,16 @@ bb3:
   return %1 : $()
 }
 
-// CHECK: Begin Error in function test_missing_end_borrow
-// CHECK: SIL verification failed: inconsistent active-operations sets entering basic block: state.ActiveOps == foundState.ActiveOps || isUnreachable()
-// CHECK: Verifying instruction:
-// CHECK: ->   br bb3                                       // id: %5
-// CHECK: End Error in function test_missing_end_borrow
+// CHECK:      Begin Error in function test_missing_end_borrow
+// CHECK-NEXT: SIL verification failed: inconsistent active-operations sets entering basic block
+// CHECK-NEXT: Entering basic block bb3
+// CHECK-NEXT: Current active operations: []
+// CHECK-NEXT: Recorded active operations: [
+// CHECK-NEXT:   %2 = store_borrow %0 to %1 : $*Klass
+// CHECK-NEXT: ]
+// CHECK-NEXT: Verifying instruction:
+// CHECK-NEXT: ->   br bb3                                       // id: %5
+// CHECK-NEXT: End Error in function test_missing_end_borrow
 sil [ossa] @test_missing_end_borrow_dead : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %stk = alloc_stack $Klass

--- a/test/SIL/verifier-fail-stack.sil
+++ b/test/SIL/verifier-fail-stack.sil
@@ -1,0 +1,333 @@
+// RUN: %target-sil-opt -verify-continue-on-failure -o /dev/null %s 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+
+//   Check that join points normally require the stack to match.
+// CHECK-LABEL: Begin Error in function require_match_1
+// CHECK-LABEL: Begin Error in function require_match_1
+// CHECK:       SIL verification failed: inconsistent stack states entering basic block
+// CHECK-NEXT:  Entering basic block bb3
+// CHECK-NEXT:  Current stack state: []
+// CHECK-NEXT:  Recorded stack state: [
+// CHECK-NEXT:    %0 = alloc_stack $Builtin.Int32
+// CHECK-NEXT:  ]
+// CHECK-LABEL: End Error in function require_match_1
+sil @require_match_1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %result = tuple ()
+  return %result : $()
+}
+
+//   Same as above, just with the branches switched around.
+// CHECK-LABEL: Begin Error in function require_match_2
+// CHECK-LABEL: Begin Error in function require_match_2
+// CHECK:       SIL verification failed: inconsistent stack states entering basic block
+// CHECK-NEXT:  Entering basic block bb3
+// CHECK-NEXT:  Current stack state: [
+// CHECK-NEXT:    %0 = alloc_stack $Builtin.Int32
+// CHECK-NEXT:  ]
+// CHECK-NEXT:  Recorded stack state: []
+// CHECK-LABEL: End Error in function require_match_2
+sil @require_match_2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb3
+
+bb3:
+  %result = tuple ()
+  return %result : $()
+}
+
+//   Check that such a join point is okay if it's a branch into a dead-end region.
+// CHECK-NOT:   Begin Error in function merge_unreachable_okay_1
+sil @merge_unreachable_okay_1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  unreachable
+}
+
+//   Same as above, just with the branches switched around.
+// CHECK-NOT:   Begin Error in function merge_unreachable_okay_1
+sil @merge_unreachable_okay_2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb3
+
+bb3:
+  unreachable
+}
+
+//   Check that it's not okay to subsequently dealloc the allocation.
+// CHECK-LABEL: Begin Error in function merge_unreachable_then_dealloc_1
+// CHECK:       SIL verification failed: deallocating allocation that is not the top of the stack
+// CHECK-NEXT:  Current stack state: []
+// CHECK-NEXT:  Stack allocation:
+// CHECK-NEXT:    %0 = alloc_stack $Builtin.Int32
+// CHECK-LABEL: End Error in function merge_unreachable_then_dealloc_1
+sil @merge_unreachable_then_dealloc_1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  dealloc_stack %0
+  unreachable
+}
+
+//   Same as above, just with the branches switched around.
+// CHECK-LABEL: Begin Error in function merge_unreachable_then_dealloc_2
+// CHECK:       SIL verification failed: deallocating allocation that is not the top of the stack
+// CHECK-NEXT:  Current stack state: []
+// CHECK-NEXT:  Stack allocation:
+// CHECK-NEXT:    %0 = alloc_stack $Builtin.Int32
+// CHECK-LABEL: End Error in function merge_unreachable_then_dealloc_2
+sil @merge_unreachable_then_dealloc_2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb3
+
+bb3:
+  dealloc_stack %0
+  unreachable
+}
+
+//   Parallel branches with inconsistent stack state into a dead-end loop
+// CHECK-NOT:   Begin Error in function parallel_branches_into_dead_1
+sil @parallel_branches_into_dead_1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  br bb3
+}
+
+//   Same as above, just with the dealloc switched around to trigger
+//   a different visitation pattern.
+// CHECK-NOT:   Begin Error in function parallel_branches_into_dead_2
+sil @parallel_branches_into_dead_2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  br bb3
+}
+
+//   Add an unreachable block that also branches to the dead-end region to
+//   make sure we don't fail to visit anything.
+// CHECK-NOT:   Begin Error in function parallel_branches_into_dead_with_unreachable_block
+sil @parallel_branches_into_dead_with_unreachable_block : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  br bb3
+
+bb5: // unreachable
+  br bb3
+}
+
+//   Parallel branches with inconsistent stack state into a dead-end loop
+//   that contains a dealloc
+// CHECK-LABEL:   Begin Error in function parallel_branches_into_dead_dealloc_1
+// CHECK-NEXT:    SIL verification failed: deallocating allocation that is not the top of the stack
+sil @parallel_branches_into_dead_dealloc_1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb4
+
+bb3:
+  dealloc_stack %0
+  br bb4
+
+bb4:
+  br bb3
+}
+
+//   Same as above, just with the dealloc switched around to trigger
+//   a different visitation pattern.
+// CHECK-LABEL:   Begin Error in function parallel_branches_into_dead_dealloc_2
+// CHECK-NEXT:    SIL verification failed: deallocating allocation that is not the top of the stack
+sil @parallel_branches_into_dead_dealloc_2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %0
+  br bb3
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %0
+  br bb3
+}
+
+//   Yet another visitation pattern.
+// CHECK-LABEL:   Begin Error in function parallel_branches_into_dead_dealloc_3
+// CHECK-NEXT:    SIL verification failed: deallocating allocation that is not the top of the stack
+sil @parallel_branches_into_dead_dealloc_3 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb4
+
+bb3:
+  dealloc_stack %0
+  br bb4
+
+bb4:
+  br bb3
+}
+
+//   Yet another visitation pattern.
+// CHECK-LABEL:   Begin Error in function parallel_branches_into_dead_dealloc_4
+// CHECK-NEXT:    SIL verification failed: deallocating allocation that is not the top of the stack
+sil @parallel_branches_into_dead_dealloc_4 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %0
+  br bb3
+}
+
+//   And again, add an unreachable block.
+// CHECK-LABEL:   Begin Error in function parallel_branches_into_dead_dealloc_with_unreachable_block
+// CHECK-NEXT:    SIL verification failed: deallocating allocation that is not the top of the stack
+sil @parallel_branches_into_dead_dealloc_with_unreachable_block : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  dealloc_stack %0
+  br bb4
+
+bb3:
+  dealloc_stack %0
+  br bb4
+
+bb4:
+  br bb3
+
+bb5: // unreachable
+  br bb3
+}

--- a/test/SIL/verifier_loweredsil_failures.sil
+++ b/test/SIL/verifier_loweredsil_failures.sil
@@ -19,7 +19,10 @@ sil @alloc_pack_metadata_before_tuple : $@convention(thin) () -> () {
 }
 
 // CHECK-LABEL: Begin Error in function dealloc_pack_metadata_with_bad_operand
-// CHECK:       SIL verification failed: stack dealloc does not match most recent stack alloc:
+// CHECK:       SIL verification failed: deallocating allocation that is not the top of the stack
+// CHECK-LABEL: End Error in function dealloc_pack_metadata_with_bad_operand
+// CHECK-LABEL: Begin Error in function dealloc_pack_metadata_with_bad_operand
+// CHECK:       SIL verification failed: return with stack allocs that haven't been deallocated
 // CHECK-LABEL: End Error in function dealloc_pack_metadata_with_bad_operand
 // CHECK-LABEL: Begin Error in function dealloc_pack_metadata_with_bad_operand
 // CHECK:       SIL verification failed: Must have alloc_pack_metadata operand

--- a/test/SILOptimizer/dead_end_edges.sil
+++ b/test/SILOptimizer/dead_end_edges.sil
@@ -1,0 +1,197 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: begin running test {{.*}} on all_exit: dead_end_edges
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on all_exit: dead_end_edges
+sil @all_exit : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on one_dead: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb2 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on one_dead: dead_end_edges
+sil @one_dead : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  unreachable
+
+bb3:
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on one_dead_loop: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb2 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on one_dead_loop: dead_end_edges
+sil @one_dead_loop : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb2
+
+bb3:
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on one_dead_loop_with_branch: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb2 (region 1; last edge)
+// CHECK-NEXT:  bb3 -> bb4 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on one_dead_loop_with_branch: dead_end_edges
+sil @one_dead_loop_with_branch : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb5
+
+bb2:
+  br bb3
+
+bb3:
+  cond_br undef, bb2, bb4
+
+bb4:
+  unreachable
+
+bb5:
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on complicated_one: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb2 (region 2; last edge)
+// CHECK-NEXT:  bb2 -> bb3 (region 1; last edge)
+// CHECK-NEXT:  bb3 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb5 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb6 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb9 -> bb8 (region 0; more edges remain)
+// CHECK-NEXT:  bb11 -> bb8 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on complicated_one: dead_end_edges
+sil @complicated_one : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb9
+
+bb2:
+  br bb3
+
+bb3:
+  cond_br undef, bb4, bb8
+
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  cond_br undef, bb8, bb3
+
+bb6:
+  cond_br undef, bb7, bb8
+
+bb7:
+  br bb3
+
+bb8:
+  unreachable
+
+bb9:
+  cond_br undef, bb8, bb10
+
+bb10:
+  cond_br undef, bb11, bb12
+
+bb11:
+  cond_br undef, bb9, bb8
+
+bb12:
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on trivial_dead_end: dead_end_edges
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on trivial_dead_end: dead_end_edges
+sil @trivial_dead_end : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on all_dead: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb1 (region 1; last edge)
+// CHECK-NEXT:  bb0 -> bb2 (region 2; last edge)
+// CHECK-NEXT:  bb1 -> bb3 (region 0; more edges remain)
+// CHECK-NEXT:  bb2 -> bb3 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on all_dead: dead_end_edges
+sil @all_dead : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on parallel_into_loop: dead_end_edges
+// CHECK-NEXT:  bb0 -> bb1 (region 1; last edge)
+// CHECK-NEXT:  bb0 -> bb2 (region 2; last edge)
+// CHECK-NEXT:  bb1 -> bb3 (region 0; more edges remain)
+// CHECK-NEXT:  bb2 -> bb4 (region 0; last edge)
+// CHECK-NEXT:  visited all edges
+// CHECK-NEXT:  end running test {{.*}} on parallel_into_loop: dead_end_edges
+sil @parallel_into_loop : $@convention(thin) () -> () {
+bb0:
+  specify_test "dead_end_edges"
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  br bb3
+}
+

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -115,14 +115,16 @@ bb12:
 } // end sil function 'multi_end_licm'
 
 // CHECK-LABEL: sil hidden @multi_end_licm_loop_exit : $@convention(thin) () -> () {
-// CHECK: br [[LOOPH:bb[0-9]+]]({{.*}} : $Builtin.Int64)
-// CHECK: [[LOOPH]]({{.*}} : $Builtin.Int64)
-// CHECK: begin_access [modify] [dynamic] [no_nested_conflict]
-// CHECK: cond_br {{.*}}, [[LOOPCOND1:bb[0-9]+]], [[LOOPCOND2:bb[0-9]+]]
-// CHECK: [[LOOPCOND1]]
-// CHECK-NEXT: store
-// CHECK-NEXT: end_access
-// CHECK: return
+// CHECK:       bb2:
+// CHECK:         begin_access [modify] [dynamic] [no_nested_conflict]
+// CHECK:         br bb3
+// CHECK:       bb5:
+// CHECK:         end_access
+// CHECK:       bb6:
+// CHECK:       bb7:
+// CHECK:         end_access
+// CHECK:       bb8:
+// CHECK:       } // end sil function 'multi_end_licm_loop_exit'
 sil hidden @multi_end_licm_loop_exit : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @$s3tmp13reversedArrays18ReversedCollectionVySaySiGGvp : $*ReversedCollection<Array<Int>>
@@ -185,10 +187,10 @@ bbend1:
 bbend2:
   %otherInt = struct $Int (%27 : $Builtin.Int64)
   store %otherInt to %global : $*Int
+  end_access %global : $*Int
   cond_br %47, bbOut, bb5
 
 bbOut:
-  end_access %global : $*Int
   br bb6
 
 bb5:


### PR DESCRIPTION
- Only treat edges *into* dead-end regions as special; edges internal to the region must use the normal rules.
    
- Conservatively merge information along those edges rather than just picking one at random. This requires us to not walk into the region until we've processed all of the edges to it. (This is not implemented correctly in the current PR.)
    
- Make sure we prevent *any* stack allocations from being deallocated if the stack is inconsistent entering a block.