### PR TITLE
[cxx-interop] Honor default expressions for unnamed arguments

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2549,10 +2549,6 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
                                           const swift::Type &swiftParamTy,
                                           SourceLoc paramLoc) {
   assert(param->hasDefaultArg() && "must have a C++ default argument");
-  if (!param->getIdentifier())
-    // Work around an assertion failure in CXXNameMangler::mangleUnqualifiedName
-    // when mangling std::__fs::filesystem::path::format.
-    return nullptr;
 
   ASTContext &ctx = ImporterImpl.SwiftContext;
   clang::ASTContext &clangCtx = param->getASTContext();

--- a/test/Interop/Cxx/function/Inputs/default-arguments.h
+++ b/test/Interop/Cxx/function/Inputs/default-arguments.h
@@ -126,6 +126,8 @@ inline int ambiguous(int a) { return a; }
 inline int nonTrailing(int a, int b = 2) { return a + b; }
 inline int nonTrailing(int a = 1, int b);
 
+inline int takesUnnamedParam(int = 123) { return 456; }
+
 // MARK: - Un-instantiatable default expressions
 
 class NoDefinition;

--- a/test/Interop/Cxx/function/default-arguments-module-interface.swift
+++ b/test/Interop/Cxx/function/default-arguments-module-interface.swift
@@ -66,6 +66,8 @@
 
 // CHECK: func nonTrailing(_ a: Int32 = cxxDefaultArg, _ b: Int32 = cxxDefaultArg) -> Int32
 
+// CHECK: func takesUnnamedParam(_: Int32 = cxxDefaultArg) -> Int32
+
 // CHECK: struct InvalidStruct<NoDefinition> {
 // CHECK:   func invalidDefaultExprMethod(_ x: Base<NoDefinition>)
 // CHECK: }

--- a/test/Interop/Cxx/function/default-arguments-typechecker.swift
+++ b/test/Interop/Cxx/function/default-arguments-typechecker.swift
@@ -71,3 +71,6 @@ let _ = ambiguous(1, 2)
 let _ = nonTrailing()
 let _ = nonTrailing(1)
 let _ = nonTrailing(1, 2)
+
+let _ = takesUnnamedParam()
+let _ = takesUnnamedParam(789)

--- a/test/Interop/Cxx/function/default-arguments.swift
+++ b/test/Interop/Cxx/function/default-arguments.swift
@@ -66,6 +66,14 @@ DefaultArgTestSuite.test("func with non-trailing argument") {
   expectEqual(11, t1)
 }
 
+DefaultArgTestSuite.test("func with unnamed argument") {
+  let t0 = takesUnnamedParam()
+  expectEqual(456, t0)
+
+  let t1 = takesUnnamedParam(321)
+  expectEqual(456, t1)
+}
+
 DefaultArgTestSuite.test("method with integer parameter") {
   let s = HasMethodWithDefaultArg()
   let z0 = s.isZero()


### PR DESCRIPTION
We stumbled upon an old workaround that disabled the synthesis of Swift default expressions for C++ function parameters that don't have a name.

This change removes the workaround.

rdar://162310543

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
