### PR TITLE
CMake: allow to specify a SDK when building a triple for Embedded Swift

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -155,6 +155,10 @@ option(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING
 set(SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES "" CACHE STRING
     "List of extra target triples to build the embedded Swift standard library for")
 
+set(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES "" CACHE STRING
+    "List of SDKs to use for target triples, in the form triple@sdkpath.
+    Using this variable precludes setting directly the value for  SWIFT_SDK_embedded_ARCH_\$\{ARCH\}_PATH")
+
 if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "linux") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "wasi") AND
@@ -273,7 +277,7 @@ foreach(triple ${SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES})
   list(GET list 0 arch)
   list(GET list 1 vendor)
   list(GET list 2 os)
-  string(REGEX REPLACE "[0-9]+(\\.[0-9]+)+" " " mod "${triple}")
+  string(REGEX REPLACE "[0-9]+(\\.[0-9]+)+" "" mod "${triple}")
 
   list(FILTER EMBEDDED_STDLIB_TARGET_TRIPLES EXCLUDE REGEX " ${mod} ")
 
@@ -281,6 +285,25 @@ foreach(triple ${SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES})
     "${arch} ${mod} ${triple}"
   )
 endforeach()
+
+if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+  message(WARNING "Configuring SDKs using content of SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES \
+    Setting directly SWIFT_SDK_embedded_ARCH_\$\{ARCH\}_PATH will not work")
+  foreach(triple_configuration ${SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES})
+    if(triple_configuration STREQUAL "")
+      continue()
+    endif()
+
+    # Line format: <triple>[@<path to SDK>]
+    string(REPLACE "@" ";" triple_configuration_list "${triple_configuration}")
+    list(LENGTH triple_configuration_list triple_configuration_list_length)
+    if(triple_configuration_list_length GREATER_EQUAL 2)
+      list(GET triple_configuration_list 0 triple)
+      list(GET triple_configuration_list 1 sdk_path)
+      set(EMBEDDED_STDLIB_SDK_FOR_${triple} "${sdk_path}")
+    endif()
+  endforeach()
+endif()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(triples)

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -55,6 +55,9 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
       set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
       set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
       set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+      if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+        set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+      endif()
       add_swift_target_library_single(
         embedded-builtin_float-${mod}
         swift_Builtin_float

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -335,6 +335,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
 
     # lib/swift/embedded/_Concurrency.swiftmodule
     # lib/swift/embedded/<triple>/libswift_Concurrency.a

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -189,6 +189,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
     add_swift_target_library_single(
       embedded-synchronization-${mod}
       swiftSynchronization

--- a/stdlib/public/Volatile/CMakeLists.txt
+++ b/stdlib/public/Volatile/CMakeLists.txt
@@ -33,6 +33,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
     add_swift_target_library_single(
       embedded-volatile-${mod}
       swift_Volatile

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -527,6 +527,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
     add_swift_target_library_single(
       embedded-stdlib-${mod}
       swiftCore

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -28,6 +28,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
 
     add_swift_target_library_single(
       embedded-unicode-${mod}


### PR DESCRIPTION
To achieve this, add a new cache variable
`SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES` to be set like in the
following examples.
    
```
-DSWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES=aarch64-vendor-os@/usr/local/aarch64-vendor-os-sdk;aaarch-vendor-anotheros@/opt/aarch64-vendor-anotheros-sdk
```
    
We chose to use another setting instead of e.g. folding this into
`SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES` so it is clear this is opt
in and it does not regress existing configurations that set the SDK
directly (like it's the case for the WASM stdlib).

Addresses rdar://162368529