### PR TITLE
TempRValueElimination: fix a problem with non-copyable types

### DIFF
--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -42,6 +42,13 @@ public enum FakeOptional<T> {
 
 struct MOS: ~Copyable {}
 
+struct NCWithDeinit : ~Copyable {
+  var x: Int
+
+  deinit
+}
+
+
 protocol P {
   func foo()
 }
@@ -1330,6 +1337,22 @@ sil [ossa] @take_from_original_copy_addr__final_use_apply__move_only : $() -> ()
   dealloc_stack %src : $*MOS
   %tuple = tuple ()
   return %tuple : $()
+}
+
+// CHECK-LABEL: sil [ossa] @missing_destroy :
+// CHECK-NOT:     destroy_addr
+// CHECK-NOT:     copy_addr
+// CHECK:           = drop_deinit %0
+// CHECK-NEXT:      = tuple ()
+// CHECK-LABEL: } // end sil function 'missing_destroy'
+sil [ossa] @missing_destroy : $@convention(thin) (@in NCWithDeinit) -> () {
+bb0(%0 : $*NCWithDeinit):
+  %1 = alloc_stack $NCWithDeinit
+  copy_addr [take] %0 to [init] %1
+  %3 = drop_deinit %1
+  dealloc_stack %1
+  %5 = tuple ()
+  return %5
 }
 
 // CHECK-LABEL: sil [ossa] @test_temprvoborrowboundary1 :


### PR DESCRIPTION
In case of a non-copyable type the final destroy (or take) of a stack location can be missing if the value has only trivial fields. The optimization inserted a `destroy_addr` in this case although it wasn't there before.

Beside fixing this problem I also refactored the code a bit to make it more readable.
