### PR TITLE
[update-checkout] force verbose mode if python 3.9

### DIFF
--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -48,7 +48,7 @@ class ParallelRunner:
     ):
         self._monitor_polling_period = 0.1
         if n_processes == 0:
-            n_processes = ParallelRunner._max_processes()
+            n_processes = cpu_count() * 2
         self._terminal_width = shutil.get_terminal_size().columns
         self._n_processes = n_processes
         self._pool_args = pool_args
@@ -140,13 +140,3 @@ class ParallelRunner:
                 if r.stderr:
                     print(r.stderr.decode())
         return fail_count
-
-    @staticmethod
-    def _max_processes() -> int:
-        if sys.version_info.minor < 10:
-            # On Python < 3.10, https://bugs.python.org/issue46391 causes
-            # Pool.map and its variants to hang. Limiting the number of
-            # processes fixes the issue.
-            return int(cpu_count() * 1.25)
-        else:
-            return cpu_count() * 2

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -809,20 +809,18 @@ repositories.
             sys.exit(1)
 
     if is_unix_sock_path_too_long():
-        print(
-            f"TEMPDIR={tempfile.gettempdir()} is too long and multiprocessing "
-            "sockets will exceed the size limit. Falling back to verbose mode."
-        )
+        if not args.dump_hashes and not args.dump_hashes_config:
+            # Do not print anything other than the json dump.
+            print(
+                f"TEMPDIR={tempfile.gettempdir()} is too long and multiprocessing "
+                "sockets will exceed the size limit. Falling back to verbose mode."
+            )
         args.verbose = True
-    elif (
-        sys.version_info.minor < 10
-        and args.n_processes > ParallelRunner._max_processes()
-    ):
-        print(
-            "Falling back to verbose mode due to a Python 3.9 limitation. "
-            f"Lower `-j` below {ParallelRunner._max_processes()} to use non verbose mode."
-        )
-        args._verbose = True
+    if sys.version_info.minor < 10:
+        if not args.dump_hashes and not args.dump_hashes_config:
+            # Do not print anything other than the json dump.
+            print("Falling back to verbose mode due to a Python 3.9 limitation.")
+        args.verbose = True
 
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh


### PR DESCRIPTION
This patch forces verbose mode if the version of Python is inferior to 3.10. This fixes a deadlock issue.