### PR TITLE
[6.2] Add `Equatable` and `Hashable` conformance to `GUID`.

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -318,3 +318,31 @@ func _convertWindowsBoolToBool(_ b: WindowsBool) -> Bool {
   return b.boolValue
 }
 
+// GUID
+
+extension GUID {
+  @usableFromInline @_transparent
+  internal var uint128Value: UInt128 {
+    unsafe withUnsafeBytes(of: self) { buffer in
+      // GUID is 32-bit-aligned only, so use loadUnaligned().
+      unsafe buffer.baseAddress!.loadUnaligned(as: UInt128.self)
+    }
+  }
+}
+
+// These conformances are marked @retroactive because the GUID type nominally
+// comes from the _GUIDDef clang module rather than the WinSDK clang module.
+
+extension GUID: @retroactive Equatable {
+  @_transparent
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.uint128Value == rhs.uint128Value
+  }
+}
+
+extension GUID: @retroactive Hashable {
+  @_transparent
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(uint128Value)
+  }
+}

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -1,0 +1,22 @@
+// RUN: %target-build-swift %s -o %t.exe
+// RUN: %target-codesign %t.exe
+// RUN: %target-run %t.exe
+// REQUIRES: executable_test
+// REQUIRES: OS=windows-msvc
+
+// Make sure that importing WinSDK brings in the GUID type, which is declared in
+// /shared and not in /um.
+
+import WinSDK
+
+public func usesGUID(_ x: GUID) {}
+
+// Make sure equating and hashing GUIDs works.
+
+let guid: GUID = GUID_NULL
+assert(guid == guid)
+assert(guid.hashValue == guid.hashValue)
+
+let guid2: GUID = IID_IUnknown
+assert(guid != guid2)
+assert(guid.hashValue != guid2.hashValue) // well, probably


### PR DESCRIPTION
- **Explanation**: Fixes `Equatable` and `Hashable` conformance being missing in `WinSDK.GUID`. This type is supposed to be equatable and hashable but the native Windows APIs for doing so are unavailable. This functionality is needed for the correct functioning of `GUID` on Windows, and this type is used pervasively in Windows API.
- **Scope**: Windows SDK only, should not impact existing well-formed code (existing `@retroactive` conformances to these protocols may emit new compile-time diagnostics.)
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift/pull/84792 (main), https://github.com/swiftlang/swift/pull/84809 (6.2.1)
- **Risk**: Low. This PR adds trivial operations to an existing SDK type.
- **Testing**: New unit tests added.
- **Reviewers**: @compnerd