### PR TITLE
[Swiftify] Fix Package.swift

### DIFF
--- a/lib/Macros/Package.swift
+++ b/lib/Macros/Package.swift
@@ -35,12 +35,15 @@ let package = Package(
                 .product(name: "SwiftParser", package: "swift-syntax"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacro", package: "swift-syntax")
-			]
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax")
+			],
+			path: "Sources/SwiftMacros",
 		),
 		.target(
 			name: "SwiftifyImport",
-			dependencies: ["SwiftifyImportMacro"]
+			dependencies: ["SwiftifyImportMacro"],
+			path: "Sources/PublicCorePortal",
+			swiftSettings: [.enableExperimentalFeature("LifetimeDependence")],
 		)
 	]
 )

--- a/lib/Macros/Sources/PublicCorePortal/SwiftifyImport.swift
+++ b/lib/Macros/Sources/PublicCorePortal/SwiftifyImport.swift
@@ -1,0 +1,1 @@
+../../../../stdlib/public/core/SwiftifyImport.swift


### PR DESCRIPTION
Turns out this Package.swift file was borked all along.

Swift packages are normally in `Sources/<target-name>`, but SwiftifyImportMacro is in `Sources/SwiftMacros`, and SwiftifyImport is in `<root>/stdlib/public/core`, which is outside the package root. This sets the correct path for SwiftifyImportMacro, and creates a directory `Sources/PublicCorePortal` with a symlink to `SwiftifyImport.swift`. It also enables LifetimeDependence for SwiftifyImport.

These changes are purely to provide information to SourceKit - this file isn't actually used by CMake.