### PR TITLE
Add new `swift-corelibs-blocksruntime` to the `update-checkout` script.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -54,6 +54,8 @@
             "remote": { "id": "swiftlang/swift-foundation" } },
         "swift-corelibs-libdispatch": {
             "remote": { "id": "swiftlang/swift-corelibs-libdispatch" } },
+        "swift-corelibs-blocksruntime": {
+            "remote": { "id": "swiftlang/swift-corelibs-blocksruntime" } },
         "swift-integration-tests": {
             "remote": { "id": "swiftlang/swift-integration-tests" } },
         "swift-xcode-playground-support": {
@@ -159,6 +161,7 @@
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
+                "swift-corelibs-blocksruntime": "main",
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "v1.13.1",
@@ -587,6 +590,7 @@
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
+                "swift-corelibs-blocksruntime": "main",
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "v1.13.1",
@@ -645,6 +649,7 @@
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
+                "swift-corelibs-blocksruntime": "main",
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "v1.13.1",


### PR DESCRIPTION
Add the new repo to the standard set of "main" checkouts.
(Nothing is yet using this repo.  This just gets it into the checkouts.)