### PR TITLE
[IRGen] Use linkonce_odr hidden linkage for _swift_dead_method_stub

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2191,11 +2191,17 @@ void IRGenModule::emitVTableStubs() {
     
     if (!stub) {
       // Create a single stub function which calls swift_deletedMethodError().
+      // Use linkonce_odr hidden to merge these symbols, except on
+      // COFF where the linker cannot merge them.
+      bool canLinkOnce = !Module.getTargetTriple().isOSBinFormatCOFF();
+      auto linkage = canLinkOnce ? llvm::GlobalValue::LinkOnceODRLinkage
+                                 : llvm::GlobalValue::InternalLinkage;
       stub = llvm::Function::Create(llvm::FunctionType::get(VoidTy, false),
-                                    llvm::GlobalValue::LinkOnceODRLinkage,
-                                    "_swift_dead_method_stub",
+                                    linkage, "_swift_dead_method_stub",
                                     &Module);
-      ApplyIRLinkage(IRLinkage::InternalLinkOnceODR).to(stub);
+      ApplyIRLinkage(canLinkOnce ? IRLinkage::InternalLinkOnceODR
+                                 : IRLinkage::Internal)
+          .to(stub);
       stub->setAttributes(constructInitialAttributes());
       stub->setCallingConv(DefaultCC);
       auto *entry = llvm::BasicBlock::Create(getLLVMContext(), "entry", stub);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2192,10 +2192,11 @@ void IRGenModule::emitVTableStubs() {
     if (!stub) {
       // Create a single stub function which calls swift_deletedMethodError().
       stub = llvm::Function::Create(llvm::FunctionType::get(VoidTy, false),
-                                    llvm::GlobalValue::InternalLinkage,
-                                    "_swift_dead_method_stub");
+                                    llvm::GlobalValue::LinkOnceODRLinkage,
+                                    "_swift_dead_method_stub",
+                                    &Module);
+      ApplyIRLinkage(IRLinkage::InternalLinkOnceODR).to(stub);
       stub->setAttributes(constructInitialAttributes());
-      Module.getFunctionList().push_back(stub);
       stub->setCallingConv(DefaultCC);
       auto *entry = llvm::BasicBlock::Create(getLLVMContext(), "entry", stub);
       auto *errorFunc = getDeletedMethodErrorFn();

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -15,12 +15,12 @@ open class C {
   private func foo() async {}
 }
 
-// CHECK: @"$s1M1CC3foo33_{{.*}}Tu" = hidden global %swift.async_func_pointer <{ {{.*}} @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
+// CHECK: @"$s1M1CC3foo33_{{.*}}Tu" = hidden global %swift.async_func_pointer <{ {{.*}} @_swift_dead_method_stub
 
-// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), ptr @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
-// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM" = hidden alias void (), ptr @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
+// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), ptr @_swift_dead_method_stub
+// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM" = hidden alias void (), ptr @_swift_dead_method_stub
 
-// CHECK: define hidden void @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"()
+// CHECK: define linkonce_odr hidden void @_swift_dead_method_stub()
 // CHECK: entry:
 // CHECK:   tail call void @swift_deletedMethodError()
 

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -20,7 +20,7 @@ open class C {
 // CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), ptr @_swift_dead_method_stub
 // CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM" = hidden alias void (), ptr @_swift_dead_method_stub
 
-// CHECK: define linkonce_odr hidden void @_swift_dead_method_stub()
+// CHECK: define {{(linkonce_odr )?}}hidden void @_swift_dead_method_stub()
 // CHECK: entry:
 // CHECK:   tail call void @swift_deletedMethodError()
 

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -8,6 +8,10 @@
 
 // REQUIRES: concurrency
 
+// Note: Windows uses internal linkage, which puts an extra step symbol before
+// _swift_dead_method_stub.
+// UNSUPPORTED: OS=windows-msvc
+
 //--- A.swift
 open class C {
   private var i: [ObjectIdentifier:Any] = [:]

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -10,6 +10,6 @@ class C {
 
 // CHECK: @"$s7zombies1CC1i33_{{.*}}vs" = hidden {{(dllexport )?}}alias void (), ptr @_swift_dead_method_stub
 
-// CHECK: define linkonce_odr hidden void @_swift_dead_method_stub
+// CHECK: define {{(linkonce_odr )?}}hidden void @_swift_dead_method_stub
 // CHECK: entry:
 // CHECK:  tail call void @swift_deletedMethodError()

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -1,5 +1,9 @@
 // RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
 
+// Note: Windows uses internal linkage, which puts an extra step symbol before
+// _swift_dead_method_stub.
+// UNSUPPORTED: OS=windows-msvc
+
 // rdar://24121475
 //   Ideally, these wouldn't be in the v-table at all; but as long as they
 //   are, we need to emit symbols for them.

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -8,8 +8,8 @@ class C {
   init(i: Int) { self.i = i }
 }
 
-// CHECK: @"$s7zombies1CC1i33_{{.*}}vs" = hidden {{(dllexport )?}}alias void (), ptr @"$s7zombies1CC1i33_45489CBEFBF369AB7AEE3A799A95D78DLLSivg"
+// CHECK: @"$s7zombies1CC1i33_{{.*}}vs" = hidden {{(dllexport )?}}alias void (), ptr @_swift_dead_method_stub
 
-// CHECK: define hidden void @"$s7zombies1CC1i33_45489CBEFBF369AB7AEE3A799A95D78DLLSivg"()
+// CHECK: define linkonce_odr hidden void @_swift_dead_method_stub
 // CHECK: entry:
 // CHECK:  tail call void @swift_deletedMethodError()

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -56,13 +56,15 @@ public func unnecessary() -> Int64 { 5 }
 @_neverEmitIntoClient
 public func unusedYetThere() -> Int64 { 5 }
 
-public class PointClass {
+open class PointClass {
   public var x, y: Int
 
   public init(x: Int, y: Int) {
     self.x = x
     self.y = y
   }
+
+  private func notUsed() { }
 }
 
 public protocol Reflectable: AnyObject {
@@ -88,6 +90,9 @@ public func createsExistential() -> any Reflectable {
 // LIBRARY-IR-NOT: define hidden swiftcc
 
 // LIBRARY-IR-NOT: define {{.*}} @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
+
+
+// LIBRARY-IR: define linkonce_odr hidden void @_swift_dead_method_stub
 
 // LIBRARY-SIL: sil @$e7Library5helloSaySiGyF
 // LIBRARY-SIL: sil @$e7Library8getArraySaySiGyF : $@convention(thin) () -> @owned Array<Int> {


### PR DESCRIPTION
IRGen introduces the symbol _swift_dead_method_stub for dead vtable entries to point to. This symbol was given internal linkage, which would result in multiply-defined symbols when combined with Embedded Swift's use of aggressive CMO. Switch to linkonce_odr hidden linkage so multiple versions of this symbol can be coalesced by the linker (and dropped if not needed).

Fixes rdar://162392119.
