### PR TITLE
[Utils] Sanitize %t with PathSanitizingFileCheck

### DIFF
--- a/test/CAS/cached_diagnostics_remap.swift
+++ b/test/CAS/cached_diagnostics_remap.swift
@@ -36,9 +36,9 @@
 // RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift -cache-replay-prefix-map /^test %t 2>&1 | %FileCheck %s --check-prefix REMAP
 
 // BRIDGE: /^test/objc.h:3:2: warning: warning in bridging header
-// BRIDGE-REMAP: BUILD_DIR{{.*}}{{/|\\}}objc.h:3:2: warning: warning in bridging header
+// BRIDGE-REMAP: TMP_DIR{{/|\\}}objc.h:3:2: warning: warning in bridging header
 // CHECK: /^test/test.swift:1:10: warning: this is a warning
-// REMAP: BUILD_DIR{{.*}}{{/|\\}}test.swift:1:10: warning: this is a warning
+// REMAP: TMP_DIR{{/|\\}}test.swift:1:10: warning: this is a warning
 
 //--- test.swift
 #warning("this is a warning")

--- a/test/CAS/debug_info_pcm.swift
+++ b/test/CAS/debug_info_pcm.swift
@@ -17,7 +17,7 @@
 // RUN: dwarfdump --debug-info @%t/A.path | %FileCheck %s
 
 // CHECK: DW_AT_GNU_dwo_name
-// CHECK-SAME: BUILD_DIR
+// CHECK-SAME: TMP_DIR
 
 //--- test.swift
 import A

--- a/test/CAS/module_deps_clang_extras.swift
+++ b/test/CAS/module_deps_clang_extras.swift
@@ -17,11 +17,11 @@
 // RUN: %validate-json %t/deps.json &>/dev/null
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/fs.casid
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s -DDIR=%basename_t -check-prefix FS_ROOT
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s -check-prefix FS_ROOT
 
-// FS_ROOT: [[DIR]].tmp/hidden/Dummy.h
-// FS_ROOT: [[DIR]].tmp/hidden/a.h
-// FS_ROOT: [[DIR]].tmp/hidden/b.h
+// FS_ROOT: TMP_DIR/hidden/Dummy.h
+// FS_ROOT: TMP_DIR/hidden/a.h
+// FS_ROOT: TMP_DIR/hidden/b.h
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
 // RUN: %swift_frontend_plain @%t/shim.cmd

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -67,7 +67,7 @@
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -Xcc -working-directory -Xcc %/t -c %/s | %FileCheck %s -check-prefix=CLANG
 // CLANG: -Xcc -working-directory -Xcc SOURCE_DIR
-// CLANG-SAME: -Xcc -working-directory -Xcc BUILD_DIR
+// CLANG-SAME: -Xcc -working-directory -Xcc TMP_DIR
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_OBJ
 // OUTPUT_IMPLICIT_OBJ: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.o

--- a/test/Macros/macro_plugin_broken_shlib.swift
+++ b/test/Macros/macro_plugin_broken_shlib.swift
@@ -18,8 +18,8 @@
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix SERVER %s
 
 // SERVER-NOT: {{error|warning}}
-// SERVER: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'BUILD_DIR/{{.*}}/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/swift-plugin-server'; loader error: dlopen(BUILD_DIR/{{.*}}/libTestPlugin.dylib, {{.*}}): tried: 'BUILD_DIR/{{.*}}/plugins/libTestPlugin.dylib'
-// SERVER: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'BUILD_DIR/{{.*}}/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/swift-plugin-server'; loader error: dlopen(BUILD_DIR/{{.*}}/libTestPlugin.dylib, {{.*}}): tried: 'BUILD_DIR/{{.*}}/plugins/libTestPlugin.dylib'
+// SERVER: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'TMP_DIR/plugins/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/swift-plugin-server'; loader error: dlopen(TMP_DIR/plugins/libTestPlugin.dylib, {{.*}}): tried: 'TMP_DIR/plugins/libTestPlugin.dylib'
+// SERVER: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'TMP_DIR/plugins/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/swift-plugin-server'; loader error: dlopen(TMP_DIR/plugins/libTestPlugin.dylib, {{.*}}): tried: 'TMP_DIR/plugins/libTestPlugin.dylib'
 // SERVER: test.swift:1:33: note: 'fooMacro' declared here
 // SERVER-NOT: {{error|warning}}
 
@@ -34,8 +34,8 @@
 // RUN: c-index-test -read-diagnostics %t/macro_expand_inproc.dia 2>&1 | %FileCheck -check-prefix INPROC %s
 
 // INPROC-NOT: {{error|warning}}
-// INPROC: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'BUILD_DIR/{{.*}}/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/libSwiftInProcPluginServer.dylib'; loader error: dlopen(BUILD_DIR/{{.*}}/libTestPlugin.dylib, 0x0005): tried: 'BUILD_DIR/{{.*}}/libTestPlugin.dylib'
-// INPROC: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'BUILD_DIR/{{.*}}/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/libSwiftInProcPluginServer.dylib'; loader error: dlopen(BUILD_DIR/{{.*}}/libTestPlugin.dylib, 0x0005): tried: 'BUILD_DIR/{{.*}}/libTestPlugin.dylib'
+// INPROC: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'TMP_DIR/plugins/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/libSwiftInProcPluginServer.dylib'; loader error: dlopen(TMP_DIR/plugins/libTestPlugin.dylib, 0x0005): tried: 'TMP_DIR/plugins/libTestPlugin.dylib'
+// INPROC: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'; failed to load library plugin 'TMP_DIR/plugins/libTestPlugin.dylib' in plugin server 'BUILD_DIR/{{.*}}/libSwiftInProcPluginServer.dylib'; loader error: dlopen(TMP_DIR/plugins/libTestPlugin.dylib, 0x0005): tried: 'TMP_DIR/plugins/libTestPlugin.dylib'
 // INPROC: test.swift:1:33: note: 'fooMacro' declared here
 // INPROC-NOT: {{error|warning}}
 

--- a/test/ModuleInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ModuleInterface/ModuleCache/SDKDependencies.swift
@@ -221,7 +221,6 @@
 //
 // DEPCHANGE-DAG: SdkLib.swiftinterface
 // DEPCHANGE-DAG: ExportedLib.swiftinterface
-// DEPCHANGE-DAG: SDKDependencies.swift
 
 import SdkLib
 

--- a/test/ModuleInterface/availability-scopes.swift
+++ b/test/ModuleInterface/availability-scopes.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -dump-availability-scopes 2>&1 | %FileCheck --strict-whitespace %s
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Test.swiftinterface -o /dev/null -module-name Test -dump-availability-scopes 2>&1 | %FileCheck --strict-whitespace %s
 
-// CHECK: {{^}}(root {{.*}} file={{.*}}{{/|\\}}availability-scopes.swift.tmp{{/|\\}}Test.swiftinterface
+// CHECK: {{^}}(root {{.*}} file=TMP_DIR{{/|\\}}Test.swiftinterface
 // CHECK: {{^}}  (decl {{.*}}unavailable=* decl=unavailable()
 @available(*, unavailable)
 public func unavailable() { }

--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -92,8 +92,8 @@ def fixit_loc(start_col, orig_suffix):
 //
 
 // CHECK-LABEL: // Mappings from '#fileID' to '#filePath':
-// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{.*}}{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}magic_identifier_file_conflicting.swift'
-// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{.*}}{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}other_path_b{{[/\\]}}magic_identifier_file_conflicting.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'TMP_DIR{{[/\\]}}magic_identifier_file_conflicting.swift'
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'TMP_DIR{{[/\\]}}other_path_b{{[/\\]}}magic_identifier_file_conflicting.swift' (alternate)
 // CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'magic_identifier_file_conflicting.swift' (alternate)
 // CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting_other.swift' => 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}SILGen{{[/\\]}}Inputs{{[/\\]}}magic_identifier_file_conflicting_other.swift'
 // CHECK-NEXT:  //   'Foo/other_file_a.swift' => 'other_file_a.swift'

--- a/test/ScanDependencies/binary_module_only.swift
+++ b/test/ScanDependencies/binary_module_only.swift
@@ -10,7 +10,7 @@ import Foo
 
 // BINARY_MODULE_ONLY: "swiftPrebuiltExternal": "Foo"
 // BINARY_MODULE_ONLY:  "swiftPrebuiltExternal": {
-// BINARY_MODULE_ONLY-NEXT:  "compiledModulePath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/binary_module_only.swift.tmp/binaryModuleOnly/Foo.swiftmodule",
+// BINARY_MODULE_ONLY-NEXT:  "compiledModulePath": "TMP_DIR/binaryModuleOnly/Foo.swiftmodule",
 
 // HAS_NO_COMPILED-NOT: "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
 

--- a/test/ScanDependencies/cxx-overlay-source-lookup.swift
+++ b/test/ScanDependencies/cxx-overlay-source-lookup.swift
@@ -8,7 +8,7 @@
 /// --------Main module
 // CHECK-LABEL: "modulePath": "deps.swiftmodule",
 // CHECK-NEXT: "sourceFiles": [
-// CHECK-NEXT: cxx-overlay-source-lookup.swift
+// CHECK-NEXT: client.swift
 // CHECK-NEXT: ],
 // CHECK: "directDependencies": [
 // CHECK-DAG: "swift": "Swift"

--- a/test/ScanDependencies/diagnose_dependency_cycle_shadow.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle_shadow.swift
@@ -22,7 +22,7 @@
 // RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -module-name CycleKit  &> %t/out.txt
 // RUN: %FileCheck --check-prefix=CHECK-NONSDK %s < %t/out.txt
 
-// CHECK-NONSDK: note: source target 'CycleKit' shadowing a Swift module with the same name at: '{{.*}}{{/|\\}}diagnose_dependency_cycle_shadow.swift.tmp{{/|\\}}inputs'
+// CHECK-NONSDK: note: source target 'CycleKit' shadowing a Swift module with the same name at: 'TMP_DIR{{/|\\}}inputs'
 
 // SDK dependency shadowing
 // RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -module-name CycleKit -sdk %t/mock.sdk &> %t/out-sdk.txt

--- a/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
@@ -55,7 +55,7 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json -Rmodule-loading -Xcc -Rmodule-import %s 2>&1 | %FileCheck %s
 
-// CHECK: <unknown>:0: remark: importing module 'A' from {{.*}}{{/|\\}}explicit-module-map-clang-and-swift.swift.tmp{{/|\\}}inputs{{/|\\}}A.pcm'
+// CHECK: <unknown>:0: remark: importing module 'A' from 'TMP_DIR{{/|\\}}inputs{{/|\\}}A.pcm'
 
 import A
 

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -131,34 +131,34 @@ func testIndirect() { funcRedirectedIndirect() }
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay.yaml",
 // CHECK-NEXT: "-Xcc",
 // CHECK-NEXT: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay-2.yaml",
 // CHECK: ],
 
 /// --------Clang module F
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
 // CHECK: "commandLine": [
 // CHECK: "-vfsoverlay",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay.yaml",
 // CHECK-NEXT: "-vfsoverlay",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay-2.yaml",
 // CHECK: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay.yaml",
 // CHECK-NEXT: "-Xcc",
 // CHECK-NEXT: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay-2.yaml",
 // CHECK: ]
 
 /// --------Clang module Indirect
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Indirect-{{.*}}.pcm",
 // CHECK-NOT: overlay.yaml
 // CHECK: "-vfsoverlay",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay-2.yaml",
 // CHECK: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
-// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK-NEXT: "TMP_DIR{{/|\\}}overlay-2.yaml",

--- a/test/ScanDependencies/separate_clang_scan_cache.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache.swift
@@ -10,6 +10,6 @@
 // Ensure we the modules' output path is set to the module cache
 // CHECK-DEPS: "swift": "A"
 // CHECK-DEPS:            "swift": "A"
-// CHECK-DEPS:      "modulePath": "{{.*}}separate_clang_scan_cache.swift.tmp.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
+// CHECK-DEPS:      "modulePath": "TMP_DIR.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
 
 import A

--- a/test/ScanDependencies/separate_clang_scan_cache.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %empty-directory(%t.scanner-cache)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND
-// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND --enable-yaml-compatibility
+// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS --enable-yaml-compatibility
 
 // Ensure we prefer clang scanner module cache path
 // CHECK-CLANG-COMMAND: '-fmodules-cache-path={{.*}}.scanner-cache'

--- a/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %empty-directory(%t.scanner-cache)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -import-objc-header %S/Inputs/CHeaders/Bridging.h -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND
-// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -import-objc-header %S/Inputs/CHeaders/Bridging.h -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND --enable-yaml-compatibility
+// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS --enable-yaml-compatibility
 
 // Ensure we prefer clang scanner module cache path
 // CHECK-CLANG-COMMAND: '-fmodules-cache-path={{.*}}.scanner-cache'

--- a/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
@@ -14,12 +14,12 @@
 // CHECK-DEPS:            "clang": "F"
 // CHECK-DEPS-NEXT:     },
 // CHECK-DEPS-NEXT:     {
-// CHECK-DEPS-NEXT:       "modulePath": "{{.*}}separate_clang_scan_cache_bridging.swift.tmp.module-cache{{/|\\\\}}F-{{.*}}.pcm"
+// CHECK-DEPS-NEXT:       "modulePath": "TMP_DIR.module-cache{{/|\\\\}}F-{{.*}}.pcm"
 
 // CHECK-DEPS:            "swift": "A"
 // CHECK-DEPS-NEXT:     },
 // CHECK-DEPS-NEXT:     {
-// CHECK-DEPS-NEXT:       "modulePath": "{{.*}}separate_clang_scan_cache_bridging.swift.tmp.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
+// CHECK-DEPS-NEXT:       "modulePath": "TMP_DIR.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
 
 
 

--- a/test/SourceKit/Indexing/indexstore_multifile.swift
+++ b/test/SourceKit/Indexing/indexstore_multifile.swift
@@ -17,7 +17,7 @@ struct Foo {
 // CHECK: indexstore_multifile.o-{{.*}}
 // CHECK: module-name: indexstoremodule
 // CHECK: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}SourceKit{{/|\\}}Indexing{{/|\\}}indexstore_multifile.swift
-// CHECK: out-file: BUILD_DIR{{.*}}indexstore_multifile.o
+// CHECK: out-file: TMP_DIR{{/|\\}}indexstore_multifile.o
 // CHECK: is-debug: 1
 // CHECK: Unit | system | Swift | {{.*}}{{/|\\}}Swift.swiftmodule
 // CHECK: Record | user | SOURCE_DIR{{/|\\}}test{{/|\\}}SourceKit{{/|\\}}Indexing{{/|\\}}indexstore_multifile.swift | indexstore_multifile.swift-{{.*}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3114,17 +3114,12 @@ if hasattr(config, 'target_link_sdk_future_version'):
     config.substitutions.append(('%target-link-sdk-future-version',
                                  config.target_link_sdk_future_version))
 
-run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --ignore-runtime-warnings --use-filecheck %s %s %s' % (
+run_filecheck = '%s %s --allow-unused-prefixes --sanitize TMP_DIR=%s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --ignore-runtime-warnings --use-filecheck %s %s %s' % (
         shell_quote(sys.executable),
         shell_quote(config.PathSanitizingFileCheck),
-        # LLVM Lit performs realpath with the config path, so all paths are relative
-        # to the real path. cmake_binary_dir and swift_src_root come from CMake, which
-        # might not do real path. Because we have to match what Lit uses against what
-        # we provide we use realpath here. Because PathSanitizingFileCheck only
-        # understands sanitize patterns with forward slashes, and realpath normalizes
-        # the slashes, we have to replace them back to forward slashes.
-        shell_quote(lit.util.abs_path_preserve_drive(config.cmake_binary_dir).replace("\\", "/")),
-        shell_quote(lit.util.abs_path_preserve_drive(config.swift_src_root).replace("\\", "/")),
+        shell_quote('%t'),
+        shell_quote(config.cmake_binary_dir),
+        shell_quote(config.swift_src_root),
         shell_quote(config.filecheck),
         '--color' if config.color_output else '',
         '--enable-windows-compatibility' if kIsWindows else '')

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -11,10 +11,24 @@
 
 import argparse
 import io
+import os
+import platform
 import re
 import subprocess
 import sys
 
+# LLVM Lit performs realpath with the config path, so all paths are relative
+# to the real path. Paths that come from CMake (like cmake_binary_dir and
+# swift_src_root), might not do real path. Use realpath to normalize. Because
+# this normalizes Windows paths to use backslashes, we have to replace them
+# back to forward slashes.
+def normalize_if_path(s):
+    if not os.path.exists(s):
+        return s
+    if platform.system() == "Windows":
+        return os.path.abspath(s).replace('\\', '/')
+    else:
+        return os.path.realpath(s)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -78,13 +92,13 @@ constants.""")
 
     stdin = io.open(sys.stdin.fileno(), 'r', encoding='utf-8', errors='ignore').read()
 
-    for s in args.sanitize_strings:
+    for s in sorted(args.sanitize_strings, key=len, reverse=True):
         replacement, pattern = s.split('=', 1)
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
         stdin = re.sub(re.sub(r'\\/' if sys.version_info[0] < 3 else r'/',
-                              slashes_re, re.escape(pattern)),
+                              slashes_re, re.escape(normalize_if_path(pattern))),
                        replacement, stdin)
 
     # Because we force the backtracer on in the tests, we can get runtime

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -23,7 +23,9 @@ import sys
 # this normalizes Windows paths to use backslashes, we have to replace them
 # back to forward slashes.
 def normalize_if_path(s):
-    if not os.path.exists(s):
+    # Check dirname for cases like a file named `%t.out.txt`
+    # There won't be a `%t` path, but we still want to match this path substring.
+    if not os.path.exists(s) and not os.path.exists(os.path.dirname(s)):
         return s
     if platform.system() == "Windows":
         return os.path.abspath(s).replace('\\', '/')


### PR DESCRIPTION
This adds sanitizing of the expansion of the `%t` temp dir to
PathSanitizingFileCheck. Because the expansion of this path is different
for each test case, lit.cfg cannot use the expanded version. Instead it
relies on lit expanding the `%t` substring. This requires path
normalization to occur in PathSanitizingFileCheck instead of lit.cfg.
All strings matching the expansion of `%t` are now replaced with
`TMP_DIR`. This is especially useful when source files are created in
`%t` using `split-file`.

Also sorts the patterns to sanitize based on length, to guarantee that
patterns that are substrings of some other pattern are always tested
after the longer patterns has already been tested. Otherwise the longer
pattern may never match.