### PR TITLE
CrossModuleOptimization: fix a crash with dynamic functions

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -921,7 +921,7 @@ void CrossModuleOptimization::serializeInstruction(SILInstruction *inst,
                                        const FunctionFlags &canSerializeFlags) {
   // Put callees onto the worklist if they should be serialized as well.
   if (auto *FRI = dyn_cast<FunctionRefBaseInst>(inst)) {
-    SILFunction *callee = FRI->getReferencedFunctionOrNull();
+    SILFunction *callee = FRI->getInitiallyReferencedFunction();
     assert(callee);
     if (!callee->isDefinition() || callee->isAvailableExternally())
       return;

--- a/test/embedded/dynamic-functions.swift
+++ b/test/embedded/dynamic-functions.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -g -enable-experimental-feature Embedded -emit-ir | %FileCheck %s
+// REQUIRES: swift_feature_Embedded
+
+
+// CHECK-LABEL: define {{.*}} @"$e4main3fooyS2iF"
+// CHECK:         call ptr @swift_getFunctionReplacement
+// CHECK:         ret
+dynamic func foo(_ i: Int) -> Int {
+  return i
+}
+
+public func test(_ i: Int) -> Int {
+  return foo(i)
+}


### PR DESCRIPTION
Use the correct `FunctionRefBaseInst` API to get the callee.

Fixes a compiler crash when using `dynamic` functions in embedded swift. rdar://162309631
