### PR TITLE
[NameLookup] Prefer property wrapper over attached macro on local var

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -852,10 +852,11 @@ BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedStringRef cName,
                                                bool underscored);
 
-SWIFT_NAME(
-    "BridgedCustomAttr.createParsed(_:atLoc:type:initContext:argumentList:)")
+SWIFT_NAME("BridgedCustomAttr.createParsed(atLoc:type:declContext:initContext:"
+           "argumentList:)")
 BridgedCustomAttr BridgedCustomAttr_createParsed(
-    BridgedASTContext cContext, swift::SourceLoc atLoc, BridgedTypeRepr cType,
+    swift::SourceLoc atLoc, BridgedTypeRepr cType,
+    BridgedDeclContext cDeclContext,
     BridgedNullableCustomAttributeInitializer cInitContext,
     BridgedNullableArgumentList cArgumentList);
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -350,10 +350,10 @@ private:
 
 /// Request the nominal type declaration to which the given custom
 /// attribute refers.
-class CustomAttrNominalRequest :
-    public SimpleRequest<CustomAttrNominalRequest,
-                         NominalTypeDecl *(CustomAttr *, DeclContext *),
-                         RequestFlags::Cached> {
+class CustomAttrNominalRequest
+    : public SimpleRequest<CustomAttrNominalRequest,
+                           NominalTypeDecl *(CustomAttr *),
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -361,8 +361,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  NominalTypeDecl *
-  evaluate(Evaluator &evaluator, CustomAttr *attr, DeclContext *dc) const;
+  NominalTypeDecl *evaluate(Evaluator &evaluator, CustomAttr *attr) const;
 
 public:
   // Caching

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -19,8 +19,7 @@ SWIFT_REQUEST(NameLookup, AnyObjectLookupRequest,
               QualifiedLookupResult(const DeclContext *, DeclName, NLOptions),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
-              NominalTypeDecl *(CustomAttr *, DeclContext *), Cached,
-              NoLocationInfo)
+              NominalTypeDecl *(CustomAttr *), Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, DirectLookupRequest,
               TinyPtrVector<ValueDecl *>(DirectLookupDescriptor), Uncached,
               NoLocationInfo)

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -197,12 +197,15 @@ BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
 }
 
 BridgedCustomAttr BridgedCustomAttr_createParsed(
-    BridgedASTContext cContext, SourceLoc atLoc, BridgedTypeRepr cType,
+    SourceLoc atLoc, BridgedTypeRepr cType, BridgedDeclContext cDeclContext,
     BridgedNullableCustomAttributeInitializer cInitContext,
     BridgedNullableArgumentList cArgumentList) {
-  ASTContext &context = cContext.unbridged();
+  DeclContext *DC = cDeclContext.unbridged();
+  ASTContext &context = DC->getASTContext();
+  // Note we set a DeclContext as the owner, which we'll change to the attached
+  // Decl if necessary when attaching the attributes.
   return CustomAttr::create(
-      context, atLoc, new (context) TypeExpr(cType.unbridged()),
+      context, atLoc, new (context) TypeExpr(cType.unbridged()), /*owner*/ DC,
       cInitContext.unbridged(), cArgumentList.unbridged());
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3971,9 +3971,11 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
       parsedGenericParams->getRAngleLoc());
 }
 
-NominalTypeDecl *
-CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
-                                   CustomAttr *attr, DeclContext *dc) const {
+NominalTypeDecl *CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
+                                                    CustomAttr *attr) const {
+  auto owner = attr->getOwner();
+  auto *dc = owner.getDeclContext();
+
   // Look for names at module scope, so we don't trigger name lookup for
   // nested scopes. At this point, we're looking to see whether there are
   // any suitable macros.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3971,6 +3971,18 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
       parsedGenericParams->getRAngleLoc());
 }
 
+static bool shouldPreferPropertyWrapperOverMacro(CustomAttrOwner owner) {
+  // If we have a VarDecl in a local context, prefer to use a property wrapper
+  // if one exists. This is necessary since we don't properly support peer
+  // declarations in local contexts, so want to use a property wrapper if one
+  // exists.
+  if (auto *D = dyn_cast_or_null<VarDecl>(owner.getAsDecl())) {
+    if (D->getDeclContext()->isLocalContext())
+      return true;
+  }
+  return false;
+}
+
 NominalTypeDecl *CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                                     CustomAttr *attr) const {
   auto owner = attr->getOwner();
@@ -3978,13 +3990,15 @@ NominalTypeDecl *CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
 
   // Look for names at module scope, so we don't trigger name lookup for
   // nested scopes. At this point, we're looking to see whether there are
-  // any suitable macros.
+  // any suitable macros. If we're preferring property wrappers we wait to see
+  // if any property wrappers are in scope before returning.
   auto [module, macro] = attr->destructureMacroRef();
   auto moduleName = (module) ? module->getNameRef() : DeclNameRef();
   auto macroName = (macro) ? macro->getNameRef() : DeclNameRef();
   auto macros = namelookup::lookupMacros(dc, moduleName, macroName,
                                          getAttachedMacroRoles());
-  if (!macros.empty())
+  auto shouldPreferPropWrapper = shouldPreferPropertyWrapperOverMacro(owner);
+  if (!macros.empty() && !shouldPreferPropWrapper)
     return nullptr;
 
   // Find the types referenced by the custom attribute.
@@ -4004,6 +4018,15 @@ NominalTypeDecl *CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
   auto nominals = resolveTypeDeclsToNominal(evaluator, ctx, decls.first,
                                             ResolveToNominalOptions(),
                                             modulesFound, anyObject);
+  // If we're preferring property wrappers and found a suitable match, continue.
+  // Otherwise we can bail and resolve as a macro.
+  if (shouldPreferPropWrapper) {
+    auto hasPropWrapper = llvm::any_of(nominals, [](NominalTypeDecl *NTD) {
+      return NTD->getAttrs().hasAttribute<PropertyWrapperAttr>();
+    });
+    if (!macros.empty() && !hasPropWrapper)
+      return nullptr;
+  }
   if (nominals.size() == 1 && !isa<ProtocolDecl>(nominals.front()))
     return nominals.front();
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -2285,9 +2285,9 @@ extension ASTGenVisitor {
     }
 
     return .createParsed(
-      self.ctx,
       atLoc: self.generateSourceLoc(node.atSign),
       type: type,
+      declContext: declContext,
       initContext: initContext.asNullable,
       argumentList: argList.asNullable
     )

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6262,8 +6262,8 @@ void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl* toDecl) {
     case DeclAttrKind::Custom: {
       CustomAttr *cAttr = cast<CustomAttr>(attr);
       attrs.add(CustomAttr::create(context, SourceLoc(), cAttr->getTypeExpr(),
-                                   cAttr->getInitContext(), cAttr->getArgs(),
-                                   true));
+                                   /*owner*/ toDecl, cAttr->getInitContext(),
+                                   cAttr->getArgs(), /*implicit*/ true));
       break;
     }
     case DeclAttrKind::DiscardableResult: {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4215,10 +4215,12 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(SourceLoc atLoc) {
            "Cannot parse a trailing closure here");
   }
 
-  // Form the attribute.
+  // Form the attribute. We set a DeclContext as the owner, which we'll change
+  // to the attached Decl if necessary when attaching the attributes.
   auto *TE = new (Context) TypeExpr(type.get());
-  auto *customAttr = CustomAttr::create(Context, atLoc, TE, initContext,
-                                        argList);
+  auto *customAttr =
+      CustomAttr::create(Context, atLoc, TE,
+                         /*owner*/ CurDeclContext, initContext, argList);
   if (status.hasCodeCompletion() && CodeCompletionCallbacks) {
     CodeCompletionCallbacks->setCompletingInAttribute(customAttr);
   }

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2595,7 +2595,8 @@ static void applySolutionToClosurePropertyWrappers(ClosureExpr *closure,
       auto &context = wrappedValueVar->getASTContext();
       auto *typeExpr = TypeExpr::createImplicit(backingType, context);
       auto *attr =
-          CustomAttr::create(context, SourceLoc(), typeExpr, /*implicit=*/true);
+          CustomAttr::create(context, SourceLoc(), typeExpr,
+                             /*owner*/ wrappedValueVar, /*implicit=*/true);
       wrappedValueVar->getAttrs().add(attr);
     }
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -268,8 +268,8 @@ static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
   // Attach a result builder attribute if needed.
   if (resultBuilderType) {
     auto typeExpr = TypeExpr::createImplicit(resultBuilderType, ctx);
-    auto attr =
-        CustomAttr::create(ctx, SourceLoc(), typeExpr, /*implicit=*/true);
+    auto attr = CustomAttr::create(ctx, SourceLoc(), typeExpr, /*owner*/ arg,
+                                   /*implicit=*/true);
     arg->getAttrs().add(attr);
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4619,9 +4619,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   auto dc = D->getDeclContext();
 
   // Figure out which nominal declaration this custom attribute refers to.
-  auto *nominal = evaluateOrDefault(
-    Ctx.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
-
+  auto *nominal = attr->getNominalDecl();
   if (!nominal) {
     if (attr->isInvalid())
       return;
@@ -8780,19 +8778,10 @@ template <typename ATTR>
 static void forEachCustomAttribute(
     Decl *decl,
     llvm::function_ref<void(CustomAttr *attr, NominalTypeDecl *)> fn) {
-  auto &ctx = decl->getASTContext();
-
   for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
-    auto *mutableAttr = const_cast<CustomAttr *>(attr);
-
-    auto *nominal = evaluateOrDefault(
-        ctx.evaluator,
-        CustomAttrNominalRequest{mutableAttr, decl->getDeclContext()}, nullptr);
-    if (!nominal)
-      continue;
-
-    if (nominal->getAttrs().hasAttribute<ATTR>())
-      fn(mutableAttr, nominal);
+    auto *nominal = attr->getNominalDecl();
+    if (nominal && nominal->getAttrs().hasAttribute<ATTR>())
+      fn(attr, nominal);
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -609,8 +609,7 @@ bool diagnoseSendabilityErrorBasedOn(
 /// and perform any necessary resolution and diagnostics, returning the
 /// global actor attribute and type it refers to (or \c std::nullopt).
 std::optional<std::pair<CustomAttr *, NominalTypeDecl *>>
-checkGlobalActorAttributes(SourceLoc loc, DeclContext *dc,
-                           ArrayRef<CustomAttr *> attrs);
+checkGlobalActorAttributes(SourceLoc loc, ArrayRef<CustomAttr *> attrs);
 
 /// Get the explicit global actor specified for a closure.
 Type getExplicitGlobalActor(ClosureExpr *closure);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -2241,7 +2241,12 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
 
   // When a macro is not found for a custom attribute, it may be a non-macro.
   // So bail out to prevent diagnostics from the contraint system.
-  if (macroRef.getAttr()) {
+  if (auto *attr = macroRef.getAttr()) {
+    // If we already resolved this CustomAttr to a nominal, this isn't for a
+    // macro.
+    if (attr->getNominalDecl())
+      return ConcreteDeclRef();
+
     auto foundMacros = namelookup::lookupMacros(dc, macroRef.getModuleName(),
                                                 macroRef.getMacroName(), roles);
     if (foundMacros.empty())

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -440,13 +440,9 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
   llvm::TinyPtrVector<CustomAttr *> result;
 
   for (auto attr : var->getExpandedAttrs().getAttributes<CustomAttr>()) {
-    auto mutableAttr = const_cast<CustomAttr *>(attr);
-    // Figure out which nominal declaration this custom attribute refers to.
-    auto *nominal = evaluateOrDefault(
-      ctx.evaluator, CustomAttrNominalRequest{mutableAttr, dc}, nullptr);
-
     // If we didn't find a nominal type with a @propertyWrapper attribute,
     // skip this custom attribute.
+    auto *nominal = attr->getNominalDecl();
     if (!nominal || !nominal->getAttrs().hasAttribute<PropertyWrapperAttr>())
       continue;
 
@@ -454,7 +450,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
     // the semantic checking required.
     auto sourceFile = dc->getParentSourceFile();
     if (!sourceFile) {
-      result.push_back(mutableAttr);
+      result.push_back(attr);
       continue;
     }
       
@@ -545,7 +541,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       }
     }
 
-    result.push_back(mutableAttr);
+    result.push_back(attr);
   }
 
   // Attributes are stored in reverse order in the AST, but we want them in

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -175,24 +175,13 @@ bool SuppressesConformanceRequest::evaluate(Evaluator &evaluator,
   return false;
 }
 
-CustomAttr *
-AttachedResultBuilderRequest::evaluate(Evaluator &evaluator,
-                                         ValueDecl *decl) const {
-  ASTContext &ctx = decl->getASTContext();
-  auto dc = decl->getDeclContext();
+CustomAttr *AttachedResultBuilderRequest::evaluate(Evaluator &evaluator,
+                                                   ValueDecl *decl) const {
   for (auto attr : decl->getAttrs().getAttributes<CustomAttr>()) {
-    auto mutableAttr = const_cast<CustomAttr *>(attr);
-    // Figure out which nominal declaration this custom attribute refers to.
-    auto *nominal = evaluateOrDefault(ctx.evaluator,
-                                      CustomAttrNominalRequest{mutableAttr, dc},
-                                      nullptr);
-
-    if (!nominal)
-      continue;
-
     // Return the first custom attribute that is a result builder type.
-    if (nominal->getAttrs().hasAttribute<ResultBuilderAttr>())
-      return mutableAttr;
+    auto *nominal = attr->getNominalDecl();
+    if (nominal && nominal->getAttrs().hasAttribute<ResultBuilderAttr>())
+      return attr;
   }
 
   return nullptr;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3419,8 +3419,8 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
 
 Type TypeResolver::resolveGlobalActor(SourceLoc loc, TypeResolutionOptions options,
                                       CustomAttr *&attr, TypeAttrSet &attrs) {
-  auto foundGlobalActor = checkGlobalActorAttributes(
-      loc, getDeclContext(), attrs.getCustomAttrs());
+  auto foundGlobalActor =
+      checkGlobalActorAttributes(loc, attrs.getCustomAttrs());
   if (!foundGlobalActor)
     return Type();
 

--- a/test/NameLookup/property_wrapper_and_macro.swift
+++ b/test/NameLookup/property_wrapper_and_macro.swift
@@ -1,0 +1,89 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-ir -primary-file %t/valid.swift %t/definitions.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix main- -primary-file %t/main.swift %t/definitions.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix other- -parse-as-library -primary-file %t/other.swift %t/definitions.swift
+
+//--- definitions.swift
+@attached(peer)
+macro SomeAttr() = #externalMacro(module: "", type: "") // expected-note {{declared here}}
+// expected-main-note@-1 2{{declared here}}
+
+@propertyWrapper
+struct SomeAttr<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+  init(projectedValue: Self) { self = projectedValue}
+  var projectedValue: Self { self }
+}
+
+struct Err: Error {}
+
+//--- valid.swift
+func foo() throws {
+  // Make sure we prefer the property wrapper over the macro here.
+  @SomeAttr var x = 0
+  let _: Int = x
+  let _: SomeAttr<Int> = _x
+  let _: SomeAttr<Int> = $x
+
+  _ = {
+    @SomeAttr var y = 0
+    let _: Int = y
+    let _: SomeAttr<Int> = _y
+    let _: SomeAttr<Int> = $y
+  }
+
+  func bar(@SomeAttr x: Int) {
+    let _: Int = x
+    let _: SomeAttr<Int> = _x
+    let _: SomeAttr<Int> = $x
+  }
+
+  bar($x: SomeAttr(wrappedValue: 0))
+
+  func baz(_ fn: (SomeAttr<Int>) -> Void) {}
+  baz { x in }
+  baz { $x in }
+
+  _ = if .random() {
+    @SomeAttr var z = 0
+    let _: SomeAttr<Int> = _z
+    let _: SomeAttr<Int> = $z
+    throw Err()
+  } else {
+    0
+  }
+}
+
+//--- main.swift
+struct S1 {
+  var x = if .random() {
+    @SomeAttr var y = 0
+    let _: SomeAttr<Int> = _y
+    let _: SomeAttr<Int> = $y
+    throw Err() // expected-error {{errors cannot be thrown out of a property initializer}}
+  } else {
+    0
+  }
+}
+
+// Here we prefer the macro.
+struct S2 {
+  @SomeAttr var x = 0 // expected-error {{could not be found for macro}}
+}
+
+func bar() {
+  @SomeAttr func baz() {} // expected-error {{could not be found for macro}}
+}
+
+@SomeAttr var x = 0 // expected-error {{could not be found for macro}}
+
+_ = { @SomeAttr<Int> in }
+// expected-error@-1 {{attribute @SomeAttr<Int> is not supported on a closure}}
+// expected-warning@-2 {{cannot specialize a non-generic external macro 'SomeAttr()'}}
+
+//--- other.swift
+
+// Also check for a library file
+@SomeAttr var x = 0 // expected-error {{could not be found for macro}}


### PR DESCRIPTION
We don't properly support peer declarations in local contexts, as such if we have both a property wrapper and macro with a given name on a local var, let's prefer the property wrapper.

rdar://148782639