### PR TITLE
[Parse] Avoid setting closure `in` SourceLoc if missing

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2897,7 +2897,6 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
         diagnose(Tok, diag::expected_closure_in)
           .fixItInsert(Tok.getLoc(), "in ");
       }
-      inLoc = Tok.getLoc();
     }
   }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -977,14 +977,14 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
     if (auto *expr = target.dyn_cast<Expr *>()) {
       ASSERT(isa<ClosureExpr>(expr));
 
-      auto *closure = cast<ClosureExpr>(expr);
       // A closure body macro expansion replaces the full source
-      // range of the closure body starting from `in` and ending right
-      // before the closing brace.
-      return Lexer::getCharSourceRangeFromSourceRange(
-          sourceMgr, SourceRange(Lexer::getLocForEndOfToken(
-                                     sourceMgr, closure->getInLoc()),
-                                 closure->getEndLoc()));
+      // range of the closure body's contents.
+      auto *closure = cast<ClosureExpr>(expr);
+      if (auto range = closure->getBody()->getContentRange())
+        return Lexer::getCharSourceRangeFromSourceRange(sourceMgr, range);
+
+      // If we have an empty body, just use the end loc.
+      return CharSourceRange(closure->getEndLoc(), 0);
     }
 
     // If the function has a body, that's what's being replaced.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2725,6 +2725,24 @@ struct ThrowCancellationMacro: BodyMacro {
   }
 }
 
+struct EmptyBodyMacro: BodyMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    []
+  }
+
+  static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor closure: ClosureExprSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    []
+  }
+}
+
 @_spi(ExperimentalLanguageFeature)
 public struct TracedPreambleMacro: PreambleMacro {
   public static func expansion(

--- a/test/Macros/macro_expand_body_closure.swift
+++ b/test/Macros/macro_expand_body_closure.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_ClosureBodyMacro
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -enable-experimental-feature ClosureBodyMacro
+
+@attached(body)
+macro Empty() = #externalMacro(module: "MacroDefinition", type: "EmptyBodyMacro")
+
+// Make sure we can handle the lack of 'in' here.
+_ = { @Empty x -> // expected-error {{cannot infer type of closure parameter 'x' without a type annotation}}
+  0 // expected-error {{expected closure result type after '->'}} expected-error {{expected 'in' after the closure signature}}
+}
+
+_ = { @Empty in }

--- a/validation-test/IDE/crashers_fixed/pr-84278.swift
+++ b/validation-test/IDE/crashers_fixed/pr-84278.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+{ k -> #^^#

--- a/validation-test/compiler_crashers_2_fixed/3ba9659c560ebf6a.swift
+++ b/validation-test/compiler_crashers_2_fixed/3ba9659c560ebf6a.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::ast_scope::ASTScopeImpl::checkSourceRangeBeforeAddingChild(swift::ast_scope::ASTScopeImpl*, swift::ASTContext const&) const","signatureAssert":"Assertion failed: ((SM.isBefore(range.Start, range.End) || range.Start == range.End) && \"scope source range ends before start\"), function getCharSourceRangeOfScope"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   @in


### PR DESCRIPTION
Clients should be able to handle closures without a valid `in` SourceLoc, let's avoid setting it to a recovery location. This avoids crashing in cases where we set an `in` loc that's after the closure's end loc, fixing a stress tester regression from #84278.