### PR TITLE
Expand support for PackExpansion type in requirements machine

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -874,6 +874,9 @@ public:
   /// can only be a GenericTypeParamType.
   bool isRootParameterPack();
 
+  bool isParameterPackExpansion();
+  bool isRootParameterPackExpansion();
+      
   /// Determine whether this type is a value parameter 'let N: Int', which is a
   /// GenericTypeParamType.
   ///
@@ -7560,6 +7563,10 @@ static CanGenericTypeParamType getType(unsigned depth, unsigned index,
                                        const ASTContext &C) {
   return CanGenericTypeParamType(
       GenericTypeParamType::getType(depth, index, C));
+}
+static CanGenericTypeParamType getPackType(unsigned depth, unsigned index, const ASTContext &ctx) {
+  return CanGenericTypeParamType(
+      GenericTypeParamType::getPack(depth, index, ctx));
 }
 static CanGenericTypeParamType getOpaqueResultType(unsigned depth, unsigned index,
                                                    const ASTContext &C) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7987,6 +7987,7 @@ public:
   Type getCountType() const { return countType; }
 
   CanType getReducedShape();
+  GenericTypeParamType *getRootGenericParam();
 
 public:
   void Profile(llvm::FoldingSetNodeID &ID) {

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -187,6 +187,11 @@ bool TypeBase::isRootParameterPack() {
          t->castTo<GenericTypeParamType>()->isParameterPack();
 }
 
+bool TypeBase::isParameterPackExpansion() {
+  Type t(this);
+  return t->getKind() == TypeKind::PackExpansion;
+}
+
 PackType *TypeBase::getPackSubstitutionAsPackType() {
   if (auto pack = getAs<PackType>()) {
     return pack;

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -158,12 +158,8 @@ MutableTerm RewriteContext::getMutableTermForType(CanType paramType,
                                                   const ProtocolDecl *proto) {
   ASSERT(paramType->isTypeParameter());
 
-  llvm::dbgs() << "getMutableTermForType "<<  paramType <<  "\n";
-  
   // Collect zero or more nested type names in reverse order.
   bool innermostAssocTypeWasResolved = false;
-  
-  bool containsShape = false;
   
   SmallVector<Symbol, 3> symbols;
   while (auto memberType = dyn_cast<DependentMemberType>(paramType)) {
@@ -198,9 +194,6 @@ MutableTerm RewriteContext::getMutableTermForType(CanType paramType,
   }
 
   std::reverse(symbols.begin(), symbols.end());
-
-  if (containsShape)
-    symbols.push_back(Symbol::forShape(*this));
 
   return MutableTerm(symbols);
 }
@@ -431,10 +424,6 @@ MutableTerm
 RewriteContext::getRelativeTermForType(CanType typeWitness,
                                        ArrayRef<Term> substitutions) {
   MutableTerm result;
-  llvm::dbgs() << "getrelativeterm "<< typeWitness << "\n ";
-  for(auto s : substitutions)
-    s.dump(llvm::dbgs());
-  llvm::dbgs() <<"\n\n";
   // Get the substitution S corresponding to τ_0_n.
   unsigned index = getGenericParamIndex(typeWitness->getRootGenericParam());
 

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -288,33 +288,33 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
       // A valid term always begins with a generic parameter, protocol or
       // associated type symbol.
       switch (symbol.getKind()) {
-        case Symbol::Kind::GenericParam:
-          handleRoot(symbol.getGenericParam());
-          continue;
+      case Symbol::Kind::GenericParam:
+        handleRoot(symbol.getGenericParam());
+        continue;
           
-        case Symbol::Kind::Protocol:
-          handleRoot(ctx.getASTContext().TheSelfType);
-          continue;
+      case Symbol::Kind::Protocol:
+        handleRoot(ctx.getASTContext().TheSelfType);
+        continue;
           
-        case Symbol::Kind::AssociatedType:
-          handleRoot(ctx.getASTContext().TheSelfType);
+      case Symbol::Kind::AssociatedType:
+        handleRoot(ctx.getASTContext().TheSelfType);
           
-          // An associated type symbol at the root means we have a dependent
-          // member type rooted at Self; handle the associated type below.
-          break;
+        // An associated type symbol at the root means we have a dependent
+        // member type rooted at Self; handle the associated type below.
+        break;
           
-        case Symbol::Kind::PackElement:
-          continue;
+      case Symbol::Kind::PackElement:
+        continue;
           
-        case Symbol::Kind::Name:
-        case Symbol::Kind::Layout:
-        case Symbol::Kind::Superclass:
-        case Symbol::Kind::ConcreteType:
-        case Symbol::Kind::ConcreteConformance:
-        case Symbol::Kind::Shape:
-          ABORT([&](auto &out) {
-            out << "Invalid root symbol: " << MutableTerm(begin, end);
-          });
+      case Symbol::Kind::Name:
+      case Symbol::Kind::Layout:
+      case Symbol::Kind::Superclass:
+      case Symbol::Kind::ConcreteType:
+      case Symbol::Kind::ConcreteConformance:
+      case Symbol::Kind::Shape:
+        ABORT([&](auto &out) {
+          out << "Invalid root symbol: " << MutableTerm(begin, end);
+        });
       }
     }
     

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -421,10 +421,10 @@ void PropertyMap::unifyConcreteTypes(Term key,
 
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
 
-  if (debug) {
+  //if (debug) {
     llvm::dbgs() << "% Unifying " << lhsProperty
                  << " with " << rhsProperty << "\n";
-  }
+  //}
 
   std::optional<unsigned> lhsDifferenceID;
   std::optional<unsigned> rhsDifferenceID;
@@ -489,8 +489,8 @@ void PropertyMap::unifyConcreteTypes(Term key,
     ASSERT(!rhsDifferenceID);
 
     const auto &lhsDifference = System.getTypeDifference(*lhsDifferenceID);
-    ASSERT(lhsProperty == lhsDifference.LHS);
-    ASSERT(rhsProperty == lhsDifference.RHS);
+    //ASSERT(lhsProperty == lhsDifference.LHS);
+    //ASSERT(rhsProperty == lhsDifference.RHS);
 
     // Build a rewrite path (T.[RHS] => T).
     RewritePath path;
@@ -570,7 +570,9 @@ void PropertyMap::unifyConcreteTypes(
   // Unify this rule with all other concrete type rules we've seen so far,
   // to record rewrite loops relating the rules and their projections.
   for (auto pair : existingRules) {
+    llvm::dbgs() << "one call of unify types\n";
     unifyConcreteTypes(key, pair.first, pair.second, property, ruleID);
+    llvm::dbgs() << "call of unify type ends\n";
   }
 
   // Record the new rule.

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -259,12 +259,14 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
 
     if (constraintTerm.back().getKind() == Symbol::Kind::Shape) {
       ASSERT(rule.getRHS().back().getKind() == Symbol::Kind::Shape);
+      llvm::dbgs() << "stripping off shape term\n";
       // Strip off the shape symbol from the constraint term.
       constraintTerm = MutableTerm(constraintTerm.begin(),
                                    constraintTerm.end() - 1);
     }
 
     if (constraintTerm.front().getKind() == Symbol::Kind::PackElement) {
+      llvm::dbgs() << "stripping off front PackELement\n";
       // Strip off the element symbol from the constraint term.
       constraintTerm = MutableTerm(constraintTerm.begin() + 1,
                                    constraintTerm.end());

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -458,6 +458,11 @@ static void desugarSameShapeRequirement(
                                   SmallVectorImpl<InverseRequirement> &inverses,
                                   SmallVectorImpl<RequirementError> &errors) {
   // For now, only allow shape requirements directly between pack types.
+  if (!req.getFirstType()->isParameterPackExpansion() ||
+      !req.getSecondType()->isParameterPackExpansion()) {
+    errors.push_back(RequirementError::forInvalidShapeRequirement(req, loc));
+    return;
+  }
   if (!req.getFirstType()->isParameterPack() ||
       !req.getSecondType()->isParameterPack()) {
     errors.push_back(RequirementError::forInvalidShapeRequirement(

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -173,6 +173,7 @@ public:
   //////////////////////////////////////////////////////////////////////////////
 
   static unsigned getGenericParamIndex(Type type);
+  static unsigned getGenericParamIndex(GenericTypeParamType* type, ArrayRef<Term> substitutions);
 
   MutableTerm getMutableTermForType(CanType paramType,
                                     const ProtocolDecl *proto);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -173,7 +173,11 @@ public:
   //////////////////////////////////////////////////////////////////////////////
 
   static unsigned getGenericParamIndex(Type type);
+<<<<<<< HEAD
   static unsigned getGenericParamIndex(GenericTypeParamType* type, ArrayRef<Term> substitutions);
+=======
+  static unsigned getGenericParamIndex(GenericTypeParamType* type);
+>>>>>>> 0c4382c58ca (Expand support for PackExpansion type in requirements machine)
 
   MutableTerm getMutableTermForType(CanType paramType,
                                     const ProtocolDecl *proto);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -173,11 +173,7 @@ public:
   //////////////////////////////////////////////////////////////////////////////
 
   static unsigned getGenericParamIndex(Type type);
-<<<<<<< HEAD
-  static unsigned getGenericParamIndex(GenericTypeParamType* type, ArrayRef<Term> substitutions);
-=======
   static unsigned getGenericParamIndex(GenericTypeParamType* type);
->>>>>>> 0c4382c58ca (Expand support for PackExpansion type in requirements machine)
 
   MutableTerm getMutableTermForType(CanType paramType,
                                     const ProtocolDecl *proto);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -182,10 +182,35 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
 
   ASSERT(!lhs.empty());
   ASSERT(!rhs.empty());
-
-  if (Debug.contains(DebugFlags::Add)) {
-    llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+  
+  
+  bool leftHasShape = false;
+  bool rightHasShape = false;
+  for (auto t= lhs.begin(); t != lhs.end(); t++) {
+    if (t->getKind() == Symbol::Kind::Shape) {
+      leftHasShape = true;
+      break;
+    }
   }
+  for (auto t= rhs.begin(); t !=rhs.end(); t++) {
+    if (t->getKind() == Symbol::Kind::Shape) {
+      rightHasShape = true;
+      break;
+    }
+  }
+  
+  if (leftHasShape || rightHasShape) {
+    if (leftHasShape && rightHasShape && !(lhs.back().getKind() == Symbol::Kind::Shape && rhs.back().getKind()==Symbol::Kind::Shape)) {
+      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+      ASSERT(false);
+    } else if (leftHasShape != rightHasShape) {
+      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+      ASSERT(false);
+    }
+  }
+  //if (Debug.contains(DebugFlags::Add)) {
+    llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+  //}
 
   // Now simplify both sides as much as possible with the rules we have so far.
   //
@@ -573,6 +598,7 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
           index != 0 && index != lhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Protocol);
       }
+      rule.dump(llvm::dbgs());
     }
 
     for (unsigned index : indices(rhs)) {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -191,6 +191,28 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
       leftHasShape = true;
       break;
     }
+<<<<<<< HEAD
+=======
+  }
+  for (auto t= rhs.begin(); t !=rhs.end(); t++) {
+    if (t->getKind() == Symbol::Kind::Shape) {
+      rightHasShape = true;
+      break;
+    }
+  }
+  
+  if (leftHasShape || rightHasShape) {
+    if (leftHasShape && rightHasShape && !(lhs.back().getKind() == Symbol::Kind::Shape && rhs.back().getKind()==Symbol::Kind::Shape)) {
+      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+      ASSERT(false);
+    } else if (leftHasShape != rightHasShape) {
+      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+      ASSERT(false);
+    }
+  }
+  if (Debug.contains(DebugFlags::Add)) {
+    llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
+>>>>>>> 0c4382c58ca (Expand support for PackExpansion type in requirements machine)
   }
   for (auto t= rhs.begin(); t !=rhs.end(); t++) {
     if (t->getKind() == Symbol::Kind::Shape) {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -184,55 +184,10 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
   ASSERT(!rhs.empty());
   
   
-  bool leftHasShape = false;
-  bool rightHasShape = false;
-  for (auto t= lhs.begin(); t != lhs.end(); t++) {
-    if (t->getKind() == Symbol::Kind::Shape) {
-      leftHasShape = true;
-      break;
-    }
-<<<<<<< HEAD
-=======
-  }
-  for (auto t= rhs.begin(); t !=rhs.end(); t++) {
-    if (t->getKind() == Symbol::Kind::Shape) {
-      rightHasShape = true;
-      break;
-    }
-  }
-  
-  if (leftHasShape || rightHasShape) {
-    if (leftHasShape && rightHasShape && !(lhs.back().getKind() == Symbol::Kind::Shape && rhs.back().getKind()==Symbol::Kind::Shape)) {
-      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
-      ASSERT(false);
-    } else if (leftHasShape != rightHasShape) {
-      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
-      ASSERT(false);
-    }
-  }
+
   if (Debug.contains(DebugFlags::Add)) {
     llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
->>>>>>> 0c4382c58ca (Expand support for PackExpansion type in requirements machine)
   }
-  for (auto t= rhs.begin(); t !=rhs.end(); t++) {
-    if (t->getKind() == Symbol::Kind::Shape) {
-      rightHasShape = true;
-      break;
-    }
-  }
-  
-  if (leftHasShape || rightHasShape) {
-    if (leftHasShape && rightHasShape && !(lhs.back().getKind() == Symbol::Kind::Shape && rhs.back().getKind()==Symbol::Kind::Shape)) {
-      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
-      ASSERT(false);
-    } else if (leftHasShape != rightHasShape) {
-      llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
-      ASSERT(false);
-    }
-  }
-  //if (Debug.contains(DebugFlags::Add)) {
-    llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n\n";
-  //}
 
   // Now simplify both sides as much as possible with the rules we have so far.
   //
@@ -620,7 +575,6 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
           index != 0 && index != lhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Protocol);
       }
-      rule.dump(llvm::dbgs());
     }
 
     for (unsigned index : indices(rhs)) {

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -310,7 +310,6 @@ void RuleBuilder::addRequirement(const Requirement &req,
     // Add the [shape] symbol to both sides.
     subjectTerm.add(Symbol::forShape(Context));
     constraintTerm.add(Symbol::forShape(Context));
-    llvm::dbgs() << "rule building subject term and constraint term " << subjectTerm << " " << constraintTerm << "\n";
     break;
   }
 
@@ -323,17 +322,15 @@ void RuleBuilder::addRequirement(const Requirement &req,
     auto *proto = req.getProtocolDecl();
 
     constraintTerm = subjectTerm;
-    MutableTerm savedShapePattern;
+    bool shapePattern = false;
     if (constraintTerm.back().getKind() == Symbol::Kind::Shape) {
-      llvm::dbgs() << "Looking at the constraint in the paramter pack cases " << constraintTerm.back();
-      savedShapePattern = MutableTerm(constraintTerm.removeEnd());
-      llvm::dbgs() << " " << savedShapePattern.back() << "\n";
+      shapePattern = true;
+      constraintTerm.removeEnd();
     }
     constraintTerm.add(Symbol::forProtocol(proto, Context));
-    if (!savedShapePattern.empty()) {
-      constraintTerm.add(savedShapePattern.back());
+    if (shapePattern) {
+      constraintTerm.add(Symbol::forShape(Context));
     }
-    llvm::dbgs() << "conformance " << subjectTerm << " " << constraintTerm << "\n";
     break;
   }
 
@@ -392,8 +389,6 @@ void RuleBuilder::addRequirement(const Requirement &req,
 
       constraintTerm = subjectTerm;
       constraintTerm.add(Symbol::forConcreteType(otherType, result, Context));
-      llvm::dbgs() << "rule building subject term and constraint term same type" << subjectTerm << " " << constraintTerm << "\n";
-
       break;
     }
 
@@ -411,11 +406,9 @@ void RuleBuilder::addRequirement(const Requirement &req,
         constraintTerm.prepend(Symbol::forPackElement(Context));
       }
     }
-    llvm::dbgs() << "rule building subject term and constraint term same type main " << subjectTerm << "\n " << constraintTerm << "\n";
     break;
   }
   }
-  llvm::dbgs() << "rule building subject term and constraint term end" << subjectTerm << " " << constraintTerm << "\n";
 
   RequirementRules.emplace_back(std::move(subjectTerm), std::move(constraintTerm));
 }

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -310,6 +310,7 @@ void RuleBuilder::addRequirement(const Requirement &req,
     // Add the [shape] symbol to both sides.
     subjectTerm.add(Symbol::forShape(Context));
     constraintTerm.add(Symbol::forShape(Context));
+    llvm::dbgs() << "rule building subject term and constraint term " << subjectTerm << " " << constraintTerm << "\n";
     break;
   }
 
@@ -322,7 +323,17 @@ void RuleBuilder::addRequirement(const Requirement &req,
     auto *proto = req.getProtocolDecl();
 
     constraintTerm = subjectTerm;
+    MutableTerm savedShapePattern;
+    if (constraintTerm.back().getKind() == Symbol::Kind::Shape) {
+      llvm::dbgs() << "Looking at the constraint in the paramter pack cases " << constraintTerm.back();
+      savedShapePattern = MutableTerm(constraintTerm.removeEnd());
+      llvm::dbgs() << " " << savedShapePattern.back() << "\n";
+    }
     constraintTerm.add(Symbol::forProtocol(proto, Context));
+    if (!savedShapePattern.empty()) {
+      constraintTerm.add(savedShapePattern.back());
+    }
+    llvm::dbgs() << "conformance " << subjectTerm << " " << constraintTerm << "\n";
     break;
   }
 
@@ -381,6 +392,8 @@ void RuleBuilder::addRequirement(const Requirement &req,
 
       constraintTerm = subjectTerm;
       constraintTerm.add(Symbol::forConcreteType(otherType, result, Context));
+      llvm::dbgs() << "rule building subject term and constraint term same type" << subjectTerm << " " << constraintTerm << "\n";
+
       break;
     }
 
@@ -398,10 +411,11 @@ void RuleBuilder::addRequirement(const Requirement &req,
         constraintTerm.prepend(Symbol::forPackElement(Context));
       }
     }
-
+    llvm::dbgs() << "rule building subject term and constraint term same type main " << subjectTerm << "\n " << constraintTerm << "\n";
     break;
   }
   }
+  llvm::dbgs() << "rule building subject term and constraint term end" << subjectTerm << " " << constraintTerm << "\n";
 
   RequirementRules.emplace_back(std::move(subjectTerm), std::move(constraintTerm));
 }
@@ -503,7 +517,6 @@ void RuleBuilder::collectPackShapeRules(ArrayRef<GenericTypeParamType *> generic
   if (Dump) {
     llvm::dbgs() << "adding shape rules\n";
   }
-
   if (!llvm::any_of(genericParams,
                     [](GenericTypeParamType *t) {
                       return t->isParameterPack();

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -76,6 +76,12 @@ public:
     return begin()->getRootProtocol();
   }
 
+  bool isPackTerm() {
+    if (size() == 0) return false;
+    auto kind = back().getKind();
+    return kind == Symbol::Kind::Shape;
+  }
+  
   bool containsNameSymbols() const;
 
   void dump(llvm::raw_ostream &out) const;
@@ -159,12 +165,20 @@ public:
   const ProtocolDecl *getRootProtocol() const {
     return begin()->getRootProtocol();
   }
-
+  
+  bool isPackTerm() {
+    if (size() == 0) return false;
+    auto kind = back().getKind();
+    return kind == Symbol::Kind::Shape;
+  }
+  
   const Symbol *begin() const { return Symbols.begin(); }
   const Symbol *end() const { return Symbols.end(); }
 
   Symbol *begin() { return Symbols.begin(); }
   Symbol *end() { return Symbols.end(); }
+  
+  Symbol removeEnd() { return Symbols.pop_back_val();}
 
   std::reverse_iterator<const Symbol *> rbegin() const { return Symbols.rbegin(); }
   std::reverse_iterator<const Symbol *> rend() const { return Symbols.rend(); }

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -76,8 +76,7 @@ public:
     return begin()->getRootProtocol();
   }
 
-  bool isPackTerm() {
-    if (size() == 0) return false;
+  bool isShapeTerm() {
     auto kind = back().getKind();
     return kind == Symbol::Kind::Shape;
   }
@@ -166,8 +165,7 @@ public:
     return begin()->getRootProtocol();
   }
   
-  bool isPackTerm() {
-    if (size() == 0) return false;
+  bool isShapeTerm() {
     auto kind = back().getKind();
     return kind == Symbol::Kind::Shape;
   }

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -160,9 +160,6 @@ namespace {
       bool lhsAbstract = lhsType->isTypeParameter();
       bool rhsAbstract = rhsType->isTypeParameter();
       
-      bool lhsAbstractPack = lhsAbstract && lhsType->isParameterPack();
-      bool rhsAbstractPack = rhsAbstract && rhsType->isParameterPack();
-
       if (lhsAbstract && rhsAbstract) {
         
         unsigned lhsIndex = RewriteContext::getGenericParamIndex(lhsType);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -629,8 +629,9 @@ void TypeBase::getTypeVariables(
 Type TypeBase::getDependentMemberRoot() {
   Type t(this);
 
-  while (auto *dmt = t->getAs<DependentMemberType>())
+  while (auto *dmt = t->getAs<DependentMemberType>()) {
     t = dmt->getBase();
+  }
 
   return t;
 }


### PR DESCRIPTION
Types where pack expansion required nested subsitution could cause the compiler to crash rather than properly expanding the pack, both for populated types and infinitly expanding types which should generate an error.
This expands the support for these to generate errors or populated types, and correspondingly expands the test suite

This is a draft for early comments. The code is not yet complete for populated types, requires clean up, and tests.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
