### PR TITLE
[cxx-interop] Adjust expectations in a test

### DIFF
--- a/test/Interop/Cxx/foreign-reference/array-of-classes.swift
+++ b/test/Interop/Cxx/foreign-reference/array-of-classes.swift
@@ -61,7 +61,7 @@ func go() {
 
     var loopCount = 0 
     for it in y {
-// CHECK: RefType()
+// CHECK: {{RefType()|(Foreign Reference Type)}}
         print(it)
         loopCount += 1
     }


### PR DESCRIPTION
Printing an object of a foreign reference type is only supported properly with a new runtime and compiler. When running the tests, we might be testing with an older runtime.

Printing is tested separately in `print-reference.swift`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
