### PR TITLE
[update-checkout] fix final line cleanup

### DIFF
--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -113,7 +113,7 @@ class ParallelRunner:
 
             time.sleep(self._monitor_polling_period)
 
-        sys.stdout.write("\r" + " " * len(last_output) + "\r\n")
+        sys.stdout.write("\r" + " " * self._terminal_width + "\r")
         sys.stdout.flush()
 
     @staticmethod


### PR DESCRIPTION
This patch properly cleans up the last printed line by filling the full terminal width with spaces instead of the length of the last output only, the latter being unreliable.