### PR TITLE
sema: avoid diagnosing typed_throw_in_objc_forbidden in textual interface files

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -846,7 +846,7 @@ bool swift::isRepresentableInLanguage(
   }
 
   // Check that @objc functions can't have typed throw.
-  if (AFD->hasThrows()) {
+  if (!AFD->getDeclContext()->isInSwiftinterface() && AFD->hasThrows()) {
     Type thrownType = AFD->getThrownInterfaceType();
     // TODO: only `throws(Error)` is allowed.
     // Throwing `any MyError` that confronts `Error` is not implemented yet.


### PR DESCRIPTION

PR #81054 introduced diagnostics for that @objc function shouldn't be using typed throws. Emitting this fatal diagnostics in Swift textual interface files seems to be redundant because (1) it should be already diagnosed in the source code, and (2) downstream clients have no control over the contents of upstream textual interfaces.

rdar://162138214
