### PR TITLE
[cxx-interop] Do not import template type arguments

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -625,9 +625,11 @@ void simple_display(llvm::raw_ostream &out, CxxValueSemanticsDescriptor desc);
 SourceLoc extractNearestSourceLoc(CxxValueSemanticsDescriptor desc);
 
 struct ClangTypeExplicitSafetyDescriptor final {
-  clang::QualType type;
+  clang::CanQualType type;
 
-  ClangTypeExplicitSafetyDescriptor(clang::QualType type) : type(type) {}
+  ClangTypeExplicitSafetyDescriptor(clang::CanQualType type) : type(type) {}
+  ClangTypeExplicitSafetyDescriptor(clang::QualType type)
+      : type(type->getCanonicalTypeUnqualified()) {}
 
   friend llvm::hash_code
   hash_value(const ClangTypeExplicitSafetyDescriptor &desc) {

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -624,6 +624,51 @@ private:
 void simple_display(llvm::raw_ostream &out, CxxValueSemanticsDescriptor desc);
 SourceLoc extractNearestSourceLoc(CxxValueSemanticsDescriptor desc);
 
+struct ClangTypeExplicitSafetyDescriptor final {
+  clang::QualType type;
+
+  ClangTypeExplicitSafetyDescriptor(clang::QualType type) : type(type) {}
+
+  friend llvm::hash_code
+  hash_value(const ClangTypeExplicitSafetyDescriptor &desc) {
+    return llvm::hash_combine(desc.type.getTypePtrOrNull());
+  }
+
+  friend bool operator==(const ClangTypeExplicitSafetyDescriptor &lhs,
+                         const ClangTypeExplicitSafetyDescriptor &rhs) {
+    return lhs.type == rhs.type;
+  }
+
+  friend bool operator!=(const ClangTypeExplicitSafetyDescriptor &lhs,
+                         const ClangTypeExplicitSafetyDescriptor &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    ClangTypeExplicitSafetyDescriptor desc);
+SourceLoc extractNearestSourceLoc(ClangTypeExplicitSafetyDescriptor desc);
+
+/// Determine the safety of the given Clang declaration.
+class ClangTypeExplicitSafety
+    : public SimpleRequest<ClangTypeExplicitSafety,
+                           ExplicitSafety(ClangTypeExplicitSafetyDescriptor),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // Source location
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+  bool isCached() const { return true; }
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ExplicitSafety evaluate(Evaluator &evaluator,
+                          ClangTypeExplicitSafetyDescriptor desc) const;
+};
+
 struct CxxDeclExplicitSafetyDescriptor final {
   const clang::Decl *decl;
   bool isClass;

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -48,6 +48,9 @@ SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
 SWIFT_REQUEST(ClangImporter, CxxValueSemantics,
               CxxValueSemanticsKind(CxxValueSemanticsDescriptor), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, ClangTypeExplicitSafety,
+              ExplicitSafety(ClangTypeExplicitSafetyDescriptor), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
               ExplicitSafety(CxxDeclExplicitSafetyDescriptor), Cached,
               NoLocationInfo)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8766,7 +8766,6 @@ static bool hasUnsafeType(Evaluator &evaluator, clang::QualType clangType) {
 ExplicitSafety
 ClangDeclExplicitSafety::evaluate(Evaluator &evaluator,
                                   CxxDeclExplicitSafetyDescriptor desc) const {
-  // FIXME: Somewhat duplicative with importAsUnsafe.
   // FIXME: Also similar to hasPointerInSubobjects
   // FIXME: should probably also subsume IsSafeUseOfCxxDecl
   

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8642,8 +8642,8 @@ SourceLoc swift::extractNearestSourceLoc(SafeUseOfCxxDeclDescriptor desc) {
 
 void swift::simple_display(llvm::raw_ostream &out,
                            ClangTypeExplicitSafetyDescriptor desc) {
-  out << "Checking if type '" << desc.type.getAsString()
-      << "' is explicitly safe.\n";
+  auto qt = static_cast<clang::QualType>(desc.type);
+  out << "Checking if type '" << qt.getAsString() << "' is explicitly safe.\n";
 }
 
 SourceLoc swift::extractNearestSourceLoc(ClangTypeExplicitSafetyDescriptor desc) {
@@ -8652,7 +8652,7 @@ SourceLoc swift::extractNearestSourceLoc(ClangTypeExplicitSafetyDescriptor desc)
 
 ExplicitSafety ClangTypeExplicitSafety::evaluate(
     Evaluator &evaluator, ClangTypeExplicitSafetyDescriptor desc) const {
-  auto clangType = desc.type;
+  auto clangType = static_cast<clang::QualType>(desc.type);
 
   // Handle pointers.
   auto pointeeType = clangType->getPointeeType();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -68,6 +68,7 @@
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
@@ -2295,6 +2296,40 @@ namespace {
               Impl.importDecl(baseRecordDecl, getVersion());
             }
           }
+        }
+      }
+
+      if (const auto *ctsd =
+              dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
+        for (auto arg : ctsd->getTemplateArgs().asArray()) {
+          auto done = false;
+          auto checkUnsafe = [&](clang::TemplateArgument tyArg) {
+            if (tyArg.getKind() != clang::TemplateArgument::Type)
+              return;
+
+            auto safety =
+                evaluateOrDefault(Impl.SwiftContext.evaluator,
+                                  ClangTypeExplicitSafety({tyArg.getAsType()}),
+                                  ExplicitSafety::Unspecified);
+
+            if (safety == ExplicitSafety::Unsafe) {
+              result->getAttrs().add(new (Impl.SwiftContext)
+                                         UnsafeAttr(/*implicit=*/true));
+              done = true;
+            }
+          };
+
+          if (arg.getKind() == clang::TemplateArgument::Pack) {
+            for (auto pkArg : arg.getPackAsArray()) {
+              checkUnsafe(pkArg);
+              if (done)
+                break;
+            }
+          } else {
+            checkUnsafe(arg);
+          }
+          if (done)
+            break;
         }
       }
 

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -78,6 +78,17 @@ struct OwnedData {
   void takeSharedObject(SharedObject *) const;
 };
 
+// A class template that throws away its type argument.
+//
+// If this template is instantiated with an unsafe type, it should be considered
+// unsafe even if that type is never used.
+template <typename> struct TTake {};
+
+using TTakeInt = TTake<int>;
+using TTakePtr = TTake<int *>;
+using TTakeSafeTuple = TTake<SafeTuple>;
+using TTakeUnsafeTuple = TTake<UnsafeTuple>;
+
 //--- test.swift
 
 import Test
@@ -166,4 +177,22 @@ func useSharedReference(frt: SharedObject, x: OwnedData) {
 @available(SwiftStdlib 5.8, *)
 func useSharedReference(frt: DerivedFromSharedObject) {
   let _ = frt
+}
+
+func useTTakeInt(x: TTakeInt) {
+  _ = x
+}
+
+func useTTakePtr(x: TTakePtr) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func useTTakeSafeTuple(x: TTakeSafeTuple) {
+  _ = x
+}
+
+func useTTakeUnsafeTuple(x: TTakeUnsafeTuple) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
 }

--- a/test/Interop/Cxx/templates/sfinae-template-type-arguments.swift
+++ b/test/Interop/Cxx/templates/sfinae-template-type-arguments.swift
@@ -1,0 +1,53 @@
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}main.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %t/Inputs/CxxHeader.h
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+struct Empty {};
+template <typename T> struct MissingMember { typename T::Missing member; };
+using SUB = MissingMember<Empty>;
+
+struct Incomplete;
+template <typename T> struct IncompleteField { T member; };
+using INC = IncompleteField<Incomplete>;
+
+template <typename S = SUB, typename I = INC> struct DefaultedTemplateArgs {};
+using DefaultedTemplateArgsInst = DefaultedTemplateArgs<>;
+
+// CHECK: struct DefaultedTemplateArgs<MissingMember<Empty>, IncompleteField<Incomplete>> {
+// CHECK: }
+// CHECK: typealias DefaultedTemplateArgsInst = DefaultedTemplateArgs<MissingMember<Empty>, IncompleteField<Incomplete>>
+
+template <typename S, typename I> struct ThrowsAwayTemplateArgs {};
+using ThrowsAwayTemplateArgsInst = ThrowsAwayTemplateArgs<SUB, INC>;
+
+// CHECK: struct ThrowsAwayTemplateArgs<MissingMember<Empty>, IncompleteField<Incomplete>> {
+// CHECK: }
+// CHECK: typealias ThrowsAwayTemplateArgsInst = ThrowsAwayTemplateArgs<MissingMember<Empty>, IncompleteField<Incomplete>>
+
+//--- cxx.cpp
+// expected-no-diagnostics
+#include <CxxHeader.h>
+void make(void) {
+  DefaultedTemplateArgs<>   dta{};
+  DefaultedTemplateArgsInst dtai{};
+
+  ThrowsAwayTemplateArgs<SUB, INC>  tata{};
+  ThrowsAwayTemplateArgsInst        tatai{};
+}
+
+//--- main.swift
+import CxxModule
+func make() {
+  let _: DefaultedTemplateArgsInst = .init()
+  let _: ThrowsAwayTemplateArgsInst = .init()
+}


### PR DESCRIPTION
Prior to this patch, we eagerly imported template type arguments. A consequence of doing so is that we over-instantiate (potentially unused) type arguments, which causes unnecessary errors.

The only apparent use we have for these type arguments are to check whether they are unsafe, so that we can mark the instantiated type as unsafe as well... even if the instantiated type does not use its unsafe template type argument at all.

Note that using un-instantiatable types in template type arguments is supported in C++. The test case included in this patch validates this behavior, for both missing member and incomplete type errors.

Note, also, that as of this patch, dumping the module interface of CxxModule actually causes swift-ide-test to emit compiler errors, since it tries to instantiate the invalid types MissingMember<Empty> and IncompleteField<Incomplete>. However, these errors are simply swallowed by swift-ide-test, so they should be harmless, though we should probably get rid of them entirely in future work.

rdar://145238539