### PR TITLE
Add methods to print various SIL things with a SILPrintContext

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -914,6 +914,7 @@ public:
   /// Pretty-print the value.
   void dump() const;
   void print(raw_ostream &OS) const;
+  void print(SILPrintContext &ctx) const;
 
   /// Pretty-print the value with DebugInfo.
   void dump(bool DebugInfo) const;
@@ -921,8 +922,9 @@ public:
   /// Pretty-print the value in context, preceded by its operands (if the
   /// value represents the result of an instruction) and followed by its
   /// users.
-  void dumpInContext() const;
   void printInContext(raw_ostream &OS) const;
+  void printInContext(SILPrintContext &ctx) const;
+  void dumpInContext() const;
 
   static bool classof(SILNodePointer node) {
     return node->getKind() >= SILNodeKind::First_SILInstruction &&

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -1145,7 +1145,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
 void verificationFailure(const Twine &complaint,
               const SILInstruction *atInstruction,
               const SILArgument *atArgument,
-              llvm::function_ref<void(llvm::raw_ostream &OS)> extraContext);
+              llvm::function_ref<void(SILPrintContext &ctx)> extraContext);
 
 inline bool SILOptions::supportsLexicalLifetimes(const SILModule &mod) const {
   switch (mod.getStage()) {

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -33,6 +33,7 @@ class NonSingleValueInstruction;
 class SILModule;
 class ValueBase;
 class SILNode;
+class SILPrintContext;
 class SILValue;
 
 /// An enumeration which contains values for all the nodes in SILNodes.def.
@@ -430,12 +431,14 @@ public:
   /// will be valid SIL assembly; otherwise, it will be an arbitrary
   /// format suitable for debugging.
   void print(raw_ostream &OS) const;
+  void print(SILPrintContext &ctx) const;
   void dump() const;
 
   /// Pretty-print the node in context, preceded by its operands (if the
   /// value represents the result of an instruction) and followed by its
   /// users.
   void printInContext(raw_ostream &OS) const;
+  void printInContext(SILPrintContext &ctx) const;
   void dumpInContext() const;
 
   // Cast to SingleValueInstruction.  This is an implementation detail

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3372,6 +3372,9 @@ void SILNode::dump() const {
 
 void SILNode::print(raw_ostream &OS) const {
   SILPrintContext Ctx(OS);
+  print(Ctx);
+}
+void SILNode::print(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).print(this);
 }
 
@@ -3391,6 +3394,9 @@ void SingleValueInstruction::dump() const {
 
 void SILInstruction::print(raw_ostream &OS) const {
   SILPrintContext Ctx(OS);
+  print(Ctx);
+}
+void SILInstruction::print(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).print(this);
 }
 
@@ -3413,7 +3419,9 @@ void SILBasicBlock::dump(bool DebugInfo) const {
 /// Pretty-print the SILBasicBlock to the designated stream.
 void SILBasicBlock::print(raw_ostream &OS) const {
   SILPrintContext Ctx(OS);
-
+  print(Ctx);
+}
+void SILBasicBlock::print(SILPrintContext &Ctx) const {
   // Print the debug scope (and compute if we didn't do it already).
   auto &SM = this->getParent()->getModule().getASTContext().SourceMgr;
   for (auto &I : *this) {
@@ -3421,10 +3429,6 @@ void SILBasicBlock::print(raw_ostream &OS) const {
     P.printDebugScope(I.getDebugScope(), SM);
   }
 
-  SILPrinter(Ctx).print(this);
-}
-
-void SILBasicBlock::print(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).print(this);
 }
 
@@ -4234,6 +4238,9 @@ void SILNode::dumpInContext() const {
 }
 void SILNode::printInContext(llvm::raw_ostream &OS) const {
   SILPrintContext Ctx(OS);
+  printInContext(Ctx);
+}
+void SILNode::printInContext(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).printInContext(this);
 }
 
@@ -4242,6 +4249,9 @@ void SILInstruction::dumpInContext() const {
 }
 void SILInstruction::printInContext(llvm::raw_ostream &OS) const {
   SILPrintContext Ctx(OS);
+  printInContext(Ctx);
+}
+void SILInstruction::printInContext(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).printInContext(asSILNode());
 }
 

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -615,13 +615,12 @@ static FunctionTest DeadEndEdgesTest("dead_end_edges", [](auto &function,
   auto visitingSet = edges.createVisitingSet(/*includeUnreachable*/ true);
 
   auto &out = llvm::outs();
+  SILPrintContext ctx(out);
   for (auto &srcBB : function) {
     for (auto *dstBB : srcBB.getSuccessorBlocks()) {
       if (auto regionIndex = edges.entersDeadEndRegion(&srcBB, dstBB)) {
-        srcBB.printID(out, false);
-        out << " -> ";
-        dstBB->printID(out, false);
-        out << " (region " << *regionIndex << "; ";
+        out << ctx.getID(&srcBB) << " -> " << ctx.getID(dstBB)
+            << " (region " << *regionIndex << "; ";
         if (visitingSet.visitEdgeTo(dstBB)) {
           out << "last edge)";
         } else {


### PR DESCRIPTION
Use those methods to make the tests I added in #84811 work even in non-asserts builds, since apparently printID does not.

Fixes some bot failures.