### PR TITLE
[DiagnosticVerifier] Add -verify-ignore-macro-note

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -46,6 +46,12 @@ public:
   /// allow diagnostics at <unknown>, that is controlled by VerifyIgnoreUnknown.
   bool VerifyIgnoreUnrelated = false;
 
+  /// Indicates whether to ignore \c diag::in_macro_expansion. This is useful
+  /// for when they occur in unnamed buffers (such as clang attribute buffers),
+  /// but VerifyIgnoreUnrelated is too blunt of a tool. Note that notes of this
+  /// kind are not printed by \c PrintingDiagnosticConsumer.
+  bool VerifyIgnoreMacroLocationNote = false;
+
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -100,6 +100,7 @@ class DiagnosticVerifier : public DiagnosticConsumer {
   bool AutoApplyFixes;
   bool IgnoreUnknown;
   bool IgnoreUnrelated;
+  bool IgnoreMacroLocationNote;
   bool UseColor;
   ArrayRef<std::string> AdditionalExpectedPrefixes;
 
@@ -107,11 +108,13 @@ public:
   explicit DiagnosticVerifier(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
                               ArrayRef<std::string> AdditionalFilePaths,
                               bool AutoApplyFixes, bool IgnoreUnknown,
-                              bool IgnoreUnrelated, bool UseColor,
+                              bool IgnoreUnrelated,
+                              bool IgnoreMacroLocationNote, bool UseColor,
                               ArrayRef<std::string> AdditionalExpectedPrefixes)
       : SM(SM), BufferIDs(BufferIDs), AdditionalFilePaths(AdditionalFilePaths),
         AutoApplyFixes(AutoApplyFixes), IgnoreUnknown(IgnoreUnknown),
-        IgnoreUnrelated(IgnoreUnrelated), UseColor(UseColor),
+        IgnoreUnrelated(IgnoreUnrelated),
+        IgnoreMacroLocationNote(IgnoreMacroLocationNote), UseColor(UseColor),
         AdditionalExpectedPrefixes(AdditionalExpectedPrefixes) {}
 
   virtual void handleDiagnostic(SourceManager &SM,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -167,6 +167,8 @@ def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,
   HelpText<"Allow diagnostics for '<unknown>' location in verify mode">;
 def verify_ignore_unrelated: Flag<["-"], "verify-ignore-unrelated">,
   HelpText<"Allow diagnostics in files outside those with expected diagnostics in verify mode">;
+def verify_ignore_macro_note: Flag<["-"], "verify-ignore-macro-note">,
+  HelpText<"Skip verifying notes about macro location">;
 def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
   MetaVarName<"<module-name>">,
   HelpText<"Verify the generic signatures in the given module">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2598,6 +2598,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     Opts.VerifyMode = DiagnosticOptions::VerifyAndApplyFixes;
   Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
   Opts.VerifyIgnoreUnrelated |= Args.hasArg(OPT_verify_ignore_unrelated);
+  Opts.VerifyIgnoreMacroLocationNote |= Args.hasArg(OPT_verify_ignore_macro_note);
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1502,6 +1502,8 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
   // because there's no reason to verify them.
   if (Info.ID == diag::verify_encountered_fatal.ID)
     return;
+  if (IgnoreMacroLocationNote && Info.ID == diag::in_macro_expansion.ID)
+    return;
   SmallVector<CapturedFixItInfo, 2> fixIts;
   for (const auto &fixIt : Info.FixIts) {
     fixIts.emplace_back(SM, fixIt);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -435,7 +435,8 @@ bool CompilerInstance::setupDiagnosticVerifierIfNeeded() {
         SourceMgr, InputSourceCodeBufferIDs, diagOpts.AdditionalVerifierFiles,
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
         diagOpts.VerifyIgnoreUnknown, diagOpts.VerifyIgnoreUnrelated,
-        diagOpts.UseColor, diagOpts.AdditionalDiagnosticVerifierPrefixes);
+        diagOpts.VerifyIgnoreMacroLocationNote, diagOpts.UseColor,
+        diagOpts.AdditionalDiagnosticVerifierPrefixes);
 
     addDiagnosticConsumer(DiagVerifier.get());
   }


### PR DESCRIPTION
The _SwiftifyImport macro is emitted into an unnamed buffer and then parsed, pretending it was in the header all along. This makes it hard to add `expected-note` comments for `diag::in_macro_expansion` when they point here. That's okay, because the macro expansion has already been pointed out by `expected-expansion` directives. But -verify-ignore-unrelated is too blunt of a tool, so this adds -verify-ignore-macro-note to ignore these specific diagnostics.

Extracted from https://github.com/swiftlang/swift/pull/84642/commits/3e25af2d64dc1e6b2700a5343de6c450cd86500b