### PR TITLE
[ImportResolution] Only disallow explicit `std` imports (allow implicit)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -875,6 +875,8 @@ WARNING(sema_import_current_module_with_file,none,
         (StringRef, Identifier))
 ERROR(sema_opening_import,Fatal,
       "opening import file for module %0: %1", (Identifier, StringRef))
+NOTE(sema_module_aliased,none,
+     "module name '%0' is aliased to '%1'", (StringRef, StringRef))
 
 REMARK(serialization_skipped_invalid_decl,none,
        "serialization skipped invalid %kind0",

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2415,10 +2415,6 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
   ModuleDecl *MD = nullptr;
   ASTContext &ctx = getNameImporter().getContext();
 
-  // `CxxStdlib` is the only accepted spelling of the C++ stdlib module name.
-  if (path.front().Item.is("std") ||
-      path.front().Item.str().starts_with("std_"))
-    return nullptr;
   if (path.front().Item == ctx.Id_CxxStdlib) {
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
@@ -8891,7 +8887,7 @@ bool importer::isCxxStdModule(StringRef moduleName, bool IsSystem) {
 ImportPath::Builder ClangImporter::Implementation::getSwiftModulePath(const clang::Module *M) {
   ImportPath::Builder builder;
   while (M) {
-    if (!M->isSubModule() && isCxxStdModule(M))
+    if (!M->isSubModule() && M->Name == "std")
       builder.push_back(SwiftContext.Id_CxxStdlib);
     else
       builder.push_back(SwiftContext.getIdentifier(M->Name));

--- a/test/ImportResolution/import-alias-fail.swift
+++ b/test/ImportResolution/import-alias-fail.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -module-alias Foo=Bar
+
+import Foo // expected-error{{no such module 'Bar'}}
+// expected-note@-1{{module name 'Foo' is aliased to 'Bar'}}
+

--- a/test/ImportResolution/import-std-fail.swift
+++ b/test/ImportResolution/import-std-fail.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// These errors are fatal, so test each one separately
+
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/a.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/b.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/c.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/d.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/e.swift -verify-additional-prefix aliased- -module-alias FooBar=std_foo_bar
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/e.swift -verify-additional-prefix unaliased-
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/f.swift -verify-additional-prefix aliased- -module-alias X=std_x_h
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default %t/f.swift -verify-additional-prefix unaliased-
+
+//--- a.swift
+import std // expected-error{{no such module 'std'}}
+           // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-11=CxxStdlib}} {{none}}
+
+//--- b.swift
+import std_ // expected-error{{no such module 'std_'}}
+            // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-12=CxxStdlib}} {{none}}
+
+//--- c.swift
+import std_error_h // expected-error{{no such module 'std_error_h'}}
+                   // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-19=CxxStdlib}} {{none}}
+
+//--- d.swift
+import std_core.math.abs // expected-error{{no such module 'std_core.math.abs'}}
+                         // expected-note@-1{{did you mean 'CxxStdlib'?}}{{8-16=CxxStdlib}} {{none}}
+
+//--- e.swift
+import FooBar // expected-aliased-error{{no such module 'std_foo_bar'}}
+              // expected-aliased-note@-1{{did you mean 'CxxStdlib'?}}{{8-14=CxxStdlib}} {{none}}
+              // expected-aliased-note@-2{{module name 'FooBar' is aliased to 'std_foo_bar'}} {{none}}
+              // expected-unaliased-error@-3{{no such module 'FooBar'}}
+
+//--- f.swift
+import X
+// expected-aliased-error@-1{{no such module 'std_x_h'}}
+// expected-aliased-note@-2{{did you mean 'CxxStdlib'?}}{{8-9=CxxStdlib}} {{none}}
+// expected-aliased-note@-3{{module name 'X' is aliased to 'std_x_h'}} {{none}}
+// expected-unaliased-error@-4{{no such module 'X'}}

--- a/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
+++ b/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
@@ -1,0 +1,33 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
+
+// Test that implicit imports can refer to std_core etc., even though Swift source code may not.
+
+//--- Inputs/module.modulemap
+module TestClang {
+    header "test.h"
+    requires cplusplus
+    export std_core.cstddef.size_t
+    export span
+}
+
+//--- Inputs/test.h
+
+#include <__cstddef/size_t.h>
+#include <span>
+#include <lifetimebound.h>
+
+using FloatSpan = std::span<const float>;
+
+size_t foo(FloatSpan x __noescape);
+
+//--- test.swift
+import TestClang
+  
+func test(x: Span<Float>) {
+  let _ = foo(x)
+}
+

--- a/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
+++ b/test/Interop/Cxx/swiftify-import/transitive-std-core-import.swift
@@ -1,8 +1,13 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: OS=macosx
 
+// Don't run this test with libc++ versions 17-19, when the top-level std module was split into multiple top-level modules.
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
+// RUN: %target-clangxx %S/../stdlib/Inputs/check-libcxx-version.cpp -o %t/check-libcxx-version
+// RUN: %target-codesign %t/check-libcxx-version
+
+// RUN: %target-run %t/check-libcxx-version || split-file %s %t
+// RUN: %target-run %t/check-libcxx-version || %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20
 
 // Test that implicit imports can refer to std_core etc., even though Swift source code may not.
 


### PR DESCRIPTION
When expanding a Swift macro in a clang module where the original clang module imported a submodule in a C++ standard library module other than `std`, e.g. a submodule to `std_core`, this would result in an error. This is because `std_core.math.abs` would be imported as `CxxStdlib.math.abs`, which would later be translated back as `std.math.abs` which doesn’t exist.

This changes the mapping to only map `std` to `CxxStdlib`. To prevent errors when importing modules starting with `std_`, this error is moved from the late-stage module import to the earlier processing of `ImportDecl`s. This results in these module names still being forbidden in explicit imports (i.e. naming them in source code), while still being allowed in implicit imports inherited from clang modules.

This also fixes a fix-it bug where only the first 3 characters would be selected for replacing with `CxxStdlib` when importing `std_core`.

This also fixes a diagnostic bug where aliased modules would refer to the module name in the source code rather than the real module name, and adds a note clarifying the situation.

rdar://161795429
rdar://161795673
rdar://161795793

Extracted from https://github.com/swiftlang/swift/pull/84642