### PR TITLE
[CS] Use `simplifyType` in `isDependentMemberTypeWithBaseThatContainsUnresolvedPackExpansions`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7104,8 +7104,11 @@ static bool isDependentMemberTypeWithBaseThatContainsUnresolvedPackExpansions(
   if (!type->is<DependentMemberType>())
     return false;
 
-  auto baseTy = cs.getFixedTypeRecursive(type->getDependentMemberRoot(),
-                                         /*wantRValue=*/true);
+  // FIXME: It's really unfortunate we need to use `simplifyType` here since
+  // this is called from `matchTypes`. We need to completely simplify the type
+  // though since pack expansions can be present in fixed types for nested
+  // type vars.
+  auto baseTy = cs.simplifyType(type->getDependentMemberRoot());
   llvm::SmallPtrSet<TypeVariableType *, 2> typeVars;
   baseTy->getTypeVariables(typeVars);
   return llvm::any_of(typeVars, [](const TypeVariableType *typeVar) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -833,3 +833,23 @@ func test_dependent_members() {
     return Variadic.f(c1, c2) // Ok
   }
 }
+
+protocol P2 {
+  associatedtype X
+}
+
+extension P2 {
+  func foo() where X == Bool {}
+  func foo() where X == String {}
+}
+
+do {
+  struct S<each E>: P2 {
+    typealias X = String
+    init(_ fn: () -> (repeat each E)) {}
+  }
+
+  func foo(_ x: Int) {
+    S { x }.foo() // Make sure we can pick the right 'foo' here.
+  }
+}


### PR DESCRIPTION
The pack expansion type variable may be a nested in the fixed type of another type variable, and as such we unfortunately need to fully `simplifyType` here. This fixes a regression from #84729.

rdar://162545380