### PR TITLE
[cxx-interop] Quote identifiers more consistently in Clang diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -351,11 +351,11 @@ NOTE(forward_declared_protocol_label, none,
 
 NOTE(forward_declared_interface_clashes_with_imported_objc_Swift_interface, none,
      "interface %0 is incomplete and cannot be imported as a stub; "
-     "its name conflicts with a %1 in module %2",
+     "its name conflicts with a %1 in module '%2'",
      (const clang::NamedDecl*, StringRef, StringRef))
 NOTE(forward_declared_protocol_clashes_with_imported_objc_Swift_protocol, none,
      "protocol %0 is incomplete and cannot be imported as a stub; "
-     "its name conflicts with a %1 in module %2",
+     "its name conflicts with a %1 in module '%2'",
      (const clang::NamedDecl*, StringRef, StringRef))
 
 GROUPED_WARNING(return_escapable_with_lifetimebound,  ClangDeclarationImport, none,

--- a/test/ClangImporter/incomplete_objc_types_compatibility_complete_incomplete_inter_file_swift_definition.swift
+++ b/test/ClangImporter/incomplete_objc_types_compatibility_complete_incomplete_inter_file_swift_definition.swift
@@ -31,7 +31,7 @@ class Main {
         // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete
         // CHECK-NEXT: Foo *returnAFoo();
         // CHECK-NEXT: ^
-        // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+        // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
         // CHECK-NEXT: @class Foo;
         // CHECK-NEXT: ^
         // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' forward declared here

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
@@ -26,7 +26,7 @@ takeAFoo(foo)
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete
 // CHECK-NEXT: void takeAFoo(Foo *foo);
 // CHECK-NEXT:               ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class Foo;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' forward declared here
@@ -46,7 +46,7 @@ _ = returnAFoo()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete
 // CHECK-NEXT: Foo *returnAFoo();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class Foo;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' forward declared here
@@ -66,7 +66,7 @@ takeABaz(bar)
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete
 // CHECK-NEXT: void takeABaz(Baz *baz);
 // CHECK-NEXT:               ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class Baz;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' forward declared here
@@ -86,7 +86,7 @@ _ = returnABaz()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete
 // CHECK-NEXT: Baz *returnABaz();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class Baz;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Baz' forward declared here
@@ -106,7 +106,7 @@ takeASubscript(corge)
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete
 // CHECK-NEXT: void takeASubscript(subscript *param);
 // CHECK-NEXT:                     ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class subscript;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' forward declared here
@@ -126,7 +126,7 @@ _ = returnASubscript()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete
 // CHECK-NEXT: subscript* returnASubscript();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class subscript;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'subscript' forward declared here
@@ -146,7 +146,7 @@ _ = returnAProtocolFoo()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolFoo' is incomplete
 // CHECK-NEXT: id<ProtocolFoo> returnAProtocolFoo();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolFoo' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolFoo' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @protocol ProtocolFoo;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolFoo' forward declared here
@@ -166,7 +166,7 @@ _ = returnAProtocolBaz()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolBaz' is incomplete
 // CHECK-NEXT: id<ProtocolBaz> returnAProtocolBaz();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolBaz' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolBaz' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @protocol ProtocolBaz;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolBaz' forward declared here

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported_implementationOnly.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported_implementationOnly.swift
@@ -22,7 +22,7 @@ _ = returnAFoo()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete
 // CHECK-NEXT: Foo *returnAFoo();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class Foo;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' forward declared here

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported_name_conflict.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported_name_conflict.swift
@@ -24,7 +24,7 @@ takeAConflictingTypeName(qux)
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete
 // CHECK-NEXT: void takeAConflictingTypeName(ConflictingTypeName *param);
 // CHECK-NEXT:                               ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class ConflictingTypeName;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' forward declared here
@@ -44,7 +44,7 @@ _ = returnAConflictingTypeName()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete
 // CHECK-NEXT: ConflictingTypeName *returnAConflictingTypeName();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a class in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @class ConflictingTypeName;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ConflictingTypeName' forward declared here
@@ -64,7 +64,7 @@ _ = returnAProtocolConflictingTypeName()
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolConflictingTypeName' is incomplete
 // CHECK-NEXT: id<ProtocolConflictingTypeName> returnAProtocolConflictingTypeName();
 // CHECK-NEXT: ^
-// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module CompleteSwiftTypes
+// CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolConflictingTypeName' is incomplete and cannot be imported as a stub; its name conflicts with a protocol in module 'CompleteSwiftTypes'
 // CHECK-NEXT: @protocol ProtocolConflictingTypeName;
 // CHECK-NEXT: ^
 // CHECK-NEXT: objc-library-forward-declaring-complete-swift-types.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'ProtocolConflictingTypeName' forward declared here


### PR DESCRIPTION
This is a tiny improvement to the diagnostic messages emitted by Swift. Conventionally we wrap identifiers, such as module names, in single quotes in the diagnostic messages.

rdar://138812125

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
