### PR TITLE
[cxx-interop] Assign correct owning module to class template specializations

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -316,6 +316,8 @@ public:
   virtual SwiftLookupTable *
   findLookupTable(const clang::Module *clangModule) = 0;
 
+  virtual const clang::Module *getClangOwningModule(ClangNode Node) const = 0;
+
   virtual DeclName
   importName(const clang::NamedDecl *D,
              clang::DeclarationName givenName = clang::DeclarationName()) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -487,7 +487,7 @@ public:
   bool dumpPrecompiledModule(StringRef modulePath, StringRef outputPath);
 
   bool runPreprocessor(StringRef inputPath, StringRef outputPath);
-  const clang::Module *getClangOwningModule(ClangNode Node) const;
+  const clang::Module *getClangOwningModule(ClangNode Node) const override;
   bool hasTypedef(const clang::Decl *typeDecl) const;
 
   void verifyAllModules() override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3199,13 +3199,13 @@ getClangOwningModule(ClangNode Node, const clang::ASTContext &ClangCtx) {
         originalDecl = pattern;
       }
     }
-    if (!originalDecl->hasOwningModule()) {
-      if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(D)) {
-        if (auto pattern = cxxRecordDecl->getTemplateInstantiationPattern()) {
-          // Class template instantiations sometimes don't have an owning Clang
-          // module, if the instantiation is not typedef-ed.
-          originalDecl = pattern;
-        }
+    if (auto classTemplateSpecDecl =
+            dyn_cast<clang::ClassTemplateSpecializationDecl>(D)) {
+      if (auto pattern =
+              classTemplateSpecDecl->getTemplateInstantiationPattern()) {
+        // Class template instantiations sometimes don't have an owning Clang
+        // module, if the instantiation is not typedef-ed.
+        originalDecl = pattern;
       }
     }
 

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -16,6 +16,12 @@ module StdVector {
   export *
 }
 
+module StdVectorNoCPlusPlusRequirement {
+  header "std-vector-no-cplusplus-requirement.h"
+  // NO requires cplusplus
+  export *
+}
+
 module StdSpan {
   header "std-span.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector-no-cplusplus-requirement.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector-no-cplusplus-requirement.h
@@ -1,0 +1,3 @@
+#include <vector>
+
+using VectorOfFloat = std::vector<float>;

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -2,6 +2,7 @@
 // XFAIL: OS=linux-androideabi
 
 import StdVector
+import StdVectorNoCPlusPlusRequirement
 import CxxStdlib
 
 func takeCopyable<T: Copyable>(_ x: T) {} 
@@ -19,4 +20,12 @@ takeCxxVector(vecNC)
 let vecPointer = VectorOfPointer()
 takeCopyable(vecPointer)
 takeCxxVector(vecPointer)
+// CHECK-NOT: error
+
+// Make sure that a specialization of std::vector that is declared in a Clang
+// module which does not declare 'requires cplusplus' is still conformed to
+// CxxVector.
+let vecFloat = VectorOfFloat()
+takeCopyable(vecFloat)
+takeCxxVector(vecFloat)
 // CHECK-NOT: error


### PR DESCRIPTION
When importing C++ class template specializations into Swift, we were assigning the owning module to the imported Swift structs inconsistently. For specializations that had a typedef (or a using-decl), we assumed the module that declares the typedef to be the owning module for the specialization. For specializations that do not have a typedef, we assumed the module that declares the class template itself to be the owning module. This changes the behavior to always assume the latter.

rdar://158589803

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
