### PR TITLE
[rbi] Ensure that we error when two 'inout sending' parameters are in the same region at end of function.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1201,6 +1201,12 @@ NOTE(rbi_add_generic_parameter_sendable_conformance,none,
      "consider making generic parameter %0 conform to the 'Sendable' protocol",
      (Type))
 
+ERROR(regionbasedisolation_inout_sending_in_same_region, none,
+      "'inout sending' parameters %0 and %1 can be potentially accessed from each other at function return risking data races in caller",
+      (Identifier, Identifier))
+NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,
+     "caller function assumes on return that %0 and %1 cannot be used to access each other implying sending them to different isolation domains does not risk a data race", (Identifier, Identifier))
+
 // Concurrency related diagnostics
 ERROR(cannot_find_executor_factory_type, none,
       "the DefaultExecutorFactory type could not be found", ())

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -426,6 +426,9 @@ public:
 
   bool isSending() const;
 
+  /// Returns true if this SILFunctionArgument is an 'inout sending' parameter.
+  bool isInOutSending() const;
+
   Lifetime getLifetime() const {
     return getType()
         .getLifetime(*getFunction())

--- a/include/swift/SILOptimizer/Utils/PartitionOpError.def
+++ b/include/swift/SILOptimizer/Utils/PartitionOpError.def
@@ -66,4 +66,7 @@ PARTITION_OP_ERROR(UnknownCodePattern)
 /// non-Sendable value.
 PARTITION_OP_ERROR(NonSendableIsolationCrossingResult)
 
+/// Used to signify that two 'inout sending' values are in the same region.
+PARTITION_OP_ERROR(InOutSendingParametersInSameRegion)
+
 #undef PARTITION_OP_ERROR

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -442,3 +442,10 @@ bool SILFunctionArgument::isSending() const {
     return getFunction()->getLoweredFunctionType()->hasSendingResult();
   return getKnownParameterInfo().hasOption(SILParameterInfo::Sending);
 }
+
+bool SILFunctionArgument::isInOutSending() const {
+  // Make sure that we are sending, not an indirect result (since indirect
+  // results can be sending) and have an inout convention.
+  return isSending() && !isIndirectResult() &&
+         getArgumentConvention().isInoutConvention();
+}

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -111,6 +111,18 @@ void PartitionOpError::InOutSendingReturnedError::print(
      << "        Rep: " << valueMap.getRepresentativeValue(returnedValue);
 }
 
+void PartitionOpError::InOutSendingParametersInSameRegionError::print(
+    llvm::raw_ostream &os, RegionAnalysisValueMap &valueMap) const {
+  os << "    Emitting Error. Kind: InOutSendingParametersInSameRegion!\n"
+     << "        First ID:  %%" << firstInoutSendingParam
+     << "        First Rep: "
+     << valueMap.getRepresentativeValue(firstInoutSendingParam);
+  for (auto other : otherInOutSendingParams) {
+    os << "        Other ID:  %%" << other
+       << "        Other Rep: " << valueMap.getRepresentativeValue(other);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp
 //===----------------------------------------------------------------------===//

--- a/test/Concurrency/transfernonsendable_inout_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_params.swift
@@ -176,6 +176,58 @@ func passInOutSendingMultipleTimes(_ x: inout NonSendableStruct) {
   // expected-note @-3 {{task-isolated 'x.second' is passed as a 'sending' parameter}}
 }
 
+func twoInoutSendingParamsInSameRegion(_ x: inout sending NonSendableKlass, _ y: inout sending NonSendableKlass) {
+  x = y
+} // expected-warning {{'inout sending' parameters 'x' and 'y' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x' and 'y' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func twoInoutSendingParamsInSameRegion2(_ x: inout sending NonSendableKlass, _ y: inout sending NonSendableKlass) {
+  let z = y
+  x = z
+} // expected-warning {{'inout sending' parameters 'x' and 'y' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x' and 'y' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func twoInoutSendingParamsInSameRegion3(_ x: inout sending NonSendableKlass, _ y: inout sending NonSendableKlass) {
+  let z = y
+  let y = (x, z) // expected-warning {{initialization of immutable value 'y' was never used; consider replacing with assignment to '_' or removing it}}
+} // expected-warning {{'inout sending' parameters 'x' and 'y' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x' and 'y' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func twoInoutSendingParamsInSameRegion4(_ x: inout sending NonSendableKlass, _ y: inout sending NonSendableKlass) {
+  let z = y
+  let h = x
+  func doSomething(_ x: NonSendableKlass, _ y: NonSendableKlass) {
+  }
+  doSomething(z, h)
+} // expected-warning {{'inout sending' parameters 'x' and 'y' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x' and 'y' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func multipleInOutSendingParamsInSameRegion1(_ x1: inout sending NonSendableKlass, _ x2: inout sending NonSendableKlass, _ x3: inout sending NonSendableKlass) {
+  x1 = x2
+  x2 = x3
+} // expected-warning {{'inout sending' parameters 'x2' and 'x3' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x2' and 'x3' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func multipleInOutSendingParamsInSameRegion2(_ x1: inout sending NonSendableKlass, _ x2: inout sending NonSendableKlass, _ x3: inout sending NonSendableKlass) {
+  let y = (x1, x2, x3)
+  _ = y
+} // expected-warning {{'inout sending' parameters 'x2' and 'x3' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x2' and 'x3' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+// expected-warning @-2 {{'inout sending' parameters 'x1' and 'x3' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-3 {{caller function assumes on return that 'x1' and 'x3' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+// expected-warning @-4 {{'inout sending' parameters 'x1' and 'x2' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-5 {{caller function assumes on return that 'x1' and 'x2' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+func multipleInOutSendingParamsInSameRegion3(_ x1: inout sending NonSendableKlass, _ x2: inout sending NonSendableKlass, _ x3: inout sending NonSendableKlass) {
+  let y = (x2, x3, x1)
+  _ = y
+} // expected-warning {{'inout sending' parameters 'x2' and 'x3' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{caller function assumes on return that 'x2' and 'x3' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+// expected-warning @-2 {{'inout sending' parameters 'x1' and 'x3' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-3 {{caller function assumes on return that 'x1' and 'x3' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+// expected-warning @-4 {{'inout sending' parameters 'x1' and 'x2' can be potentially accessed from each other at function return risking data races in caller; this is an error in the Swift 6 language mode}}
+// expected-note @-5 {{caller function assumes on return that 'x1' and 'x2' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
 //////////////////////////////////////
 // MARK: Return Inout Sending Tests //
 //////////////////////////////////////

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -99,6 +99,7 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
     case PartitionOpError::InOutSendingNotDisconnectedAtExit:
     case PartitionOpError::NonSendableIsolationCrossingResult:
     case PartitionOpError::InOutSendingReturned:
+    case PartitionOpError::InOutSendingParametersInSameRegion:
       llvm_unreachable("Unsupported");
     case PartitionOpError::LocalUseAfterSend: {
       auto state = std::move(error).getLocalUseAfterSendError();


### PR DESCRIPTION
The caller is allowed to assume that the 'inout sending' parameters are not in the same region on return so can be sent to different isolation domains safely. To enforce that we have to ensure on return that the two are /actually/ not in the same region.

rdar://138519484