### PR TITLE
build.ps1: build brotli for Android

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4215,6 +4215,7 @@ if (-not $SkipBuild) {
       }
 
       Invoke-BuildStep Build-ZLib $Build
+      Invoke-BuildStep Build-Brotli $Build
       Invoke-BuildStep Build-XML2 $Build
       Invoke-BuildStep Build-CURL $Build
     }


### PR DESCRIPTION
This is currently preventing the Windows nightlies from passing. Ensure that we build the brotli library for Android as well.