### PR TITLE
Optimizer: don't run AccessPathVerification

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -643,11 +643,6 @@ static void addPerfDebugSerializationPipeline(SILPassPipelinePlan &P) {
 static void addPrepareOptimizationsPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("PrepareOptimizationPasses");
 
-  // Verify AccessStorage once in OSSA before optimizing.
-#ifndef NDEBUG
-  P.addAccessPathVerification();
-#endif
-
   P.addForEachLoopUnroll();
   P.addSimplification();
   P.addAccessMarkerElimination();
@@ -895,14 +890,6 @@ static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
   // addAccessEnforcementDom might provide potential for LICM:
   // A loop might have only one dynamic access now, i.e. hoistable
   P.addLoopInvariantCodeMotion();
-
-  // Verify AccessStorage once again after optimizing and lowering OSSA.
-#ifndef NDEBUG
-  // Temporarily disabled because it triggers a false alarm when building
-  // SwiftDocC on linux: rdar://141270464
-  // TODO: re-enable when the problem is fixed.
-  // P.addAccessPathVerification();
-#endif
 
   // Only has an effect if the -assume-single-thread option is specified.
   if (P.getOptions().AssumeSingleThreaded) {

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -4,8 +4,6 @@
 // https://github.com/apple/swift/issues/56816
 // UNSUPPORTED: OS=linux-gnu
 
-// REQUIRES: rdar162433770
-
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 5 minutes.
 // If the compiler needs more than 5 minutes, there is probably a real problem.


### PR DESCRIPTION
This pass has a complexity problem and can let compilation time get very long.
AccessPathVerification is not that important anymore because new passes written in Swift are using SmallProjectionPath instead.

rdar://162433770