### PR TITLE
build.ps1: change default for `-Windows` to `$False`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -195,7 +195,7 @@ param
   [string] $AndroidSDKVersionDefault = "Android",
 
   # Windows SDK Options
-  [switch] $Windows = $true,
+  [switch] $Windows = $false,
   [ValidatePattern("^\d+\.\d+\.\d+(?:-\w+)?")]
   [string] $WinSDKVersion = "",
   [string[]] $WindowsSDKArchitectures = @("X64","X86","Arm64"),


### PR DESCRIPTION
This disables the Windows SDK by default. Windows SDKs can still be built by passing `-Windows` to `build.ps1`. This is already present in the invocation used by CI.