### PR TITLE
[ClangImporter] Deduplicate clang buffers representing the same file

### DIFF
--- a/lib/ClangImporter/ClangSourceBufferImporter.cpp
+++ b/lib/ClangImporter/ClangSourceBufferImporter.cpp
@@ -58,7 +58,6 @@ SourceLoc ClangSourceBufferImporter::resolveSourceLocation(
     // different contents in different modules, despite the same name.
     auto IDOpt = swiftSourceManager.getIDForBufferIdentifier(bufIdent);
     if (IDOpt.has_value() && clangSrcMgr.getFileEntryForID(clangFileID)) {
-      CONDITIONAL_ASSERT(llvm::sys::fs::exists(bufIdent));
       mirrorID = IDOpt.value();
     } else
       mirrorID = swiftSourceManager.addNewSourceBuffer(std::move(mirrorBuffer));


### PR DESCRIPTION
Clang can end up with multiple file IDs representing the same file, but in different contexts. For example, files in the current module always have file IDs >0, while files in imported modules always have file IDs <-1. As we end up compiling multiple modules, the same file can be seen both as the "current" module, and a transitive import. We don't want multiple Swift buffer IDs for the same file, as it breaks things like -verify that compare buffer IDs.

rdar://162661286