### PR TITLE
SimplifyCFG: insert compensating destroy when replacing a `switch_enum`

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1793,7 +1793,11 @@ bool SimplifyCFG::simplifySwitchEnumUnreachableBlocks(SwitchEnumInst *SEI) {
   }
 
   if (Dest->args_empty()) {
-    SILBuilderWithScope(SEI).createBranch(SEI->getLoc(), Dest);
+    SILBuilderWithScope builder(SEI);
+    if (SEI->getOperand()->getOwnershipKind() == OwnershipKind::Owned) {
+      builder.createDestroyValue(SEI->getLoc(), SEI->getOperand());
+    }
+    builder.createBranch(SEI->getLoc(), Dest);
 
     addToWorklist(SEI->getParent());
     addToWorklist(Dest);

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1944,6 +1944,24 @@ bb3:
   return %t : $()
 }
 
+// CHECK-LABEL: sil [ossa] @insert_compensating_destroy_in_switch_enum_destination_block :
+// CHECK:       bb0(%0 : @owned $Optional<AnyObject>):
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'insert_compensating_destroy_in_switch_enum_destination_block'
+sil [ossa] @insert_compensating_destroy_in_switch_enum_destination_block : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+bb0(%0 : @owned $Optional<AnyObject>):
+  switch_enum %0, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt: bb2
+
+bb1:
+  %15 = tuple ()
+  return %15
+
+bb2(%4 : @owned $AnyObject):
+  destroy_value %4
+  unreachable
+}
+
 // CHECK-LABEL: sil [ossa] @replace_phi_arg_with_borrowed_from_use :
 // CHECK:       bb3([[R:%.*]] : @reborrow $B):
 // CHECK:       bb6([[G:%.*]] : @guaranteed $E):


### PR DESCRIPTION
When replacing a `switch_enum` of an owned enum value with a branch to a non-payload case destination, we need to insert a destroy of the enum value.

Fixes a SIL ownership verification failure.
https://github.com/swiftlang/swift/issues/84552
rdar://161482601
