### PR TITLE
[update-checkout] switch to using a ThreadPool for scheduling git commands

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -216,7 +216,7 @@ lock = None
 
 
 def run(*args, **kwargs):
-    repo_path = os.getcwd()
+    repo_path = kwargs.pop('repo_path', os.getcwd())
     echo_output = kwargs.pop('echo', False)
     dry_run = kwargs.pop('dry_run', False)
     env = kwargs.get('env', None)
@@ -249,9 +249,9 @@ def run(*args, **kwargs):
         lock.release()
 
     if ret != 0:
-        eout = Exception()
+        eout = Exception(f"[{repo_path}] '{args}' failed with '{output.decode('utf-8')}'")
         eout.ret = ret
-        eout.args = args
+        eout.arguments = args
         eout.repo_path = repo_path
         eout.stderr = output
         raise eout

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -41,7 +41,10 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
                             '--verbose'])
 
         # Test that we're actually checking out the 'extra' scheme based on the output
-        self.assertIn(b"git checkout refs/heads/main", output)
+        self.assertIn(
+            f"git -C {os.path.join(self.source_root, 'repo1')} checkout refs/heads/main",
+            output.decode("utf-8"),
+        )
 
     def test_manager_not_called_on_long_socket(self):
         fake_tmpdir = '/tmp/very/' + '/long' * 20 + '/tmp'

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -1,0 +1,37 @@
+from typing import List, Any, Optional, Union
+
+from swift_build_support.swift_build_support import shell
+
+
+class Git:
+    @staticmethod
+    def run(repo_path: Optional[str], args: List[str], **kwargs):
+        cmd = ["git"]
+        if repo_path is not None:
+            cmd += ["-C", repo_path]
+        kwargs["repo_path"] = repo_path
+        # FIXME: The way we are passing args below is broken. shell.run takes 
+        # *args as list arguments and sometimes treats them as one positional 
+        # argument or as a list of arguments.
+        return shell.run(cmd+args, **kwargs)
+
+    @staticmethod
+    def capture(
+        repo_path: str,
+        args: List[str],
+        stderr=None,
+        env=None,
+        dry_run=None,
+        echo=True,
+        optional=False,
+        allow_non_zero_exit=False,
+    ) -> Union[str, Any, None]:
+        return shell.capture(
+            ["git", "-C", repo_path] + args,
+            stderr=stderr,
+            env=env,
+            dry_run=dry_run,
+            echo=echo,
+            optional=optional,
+            allow_non_zero_exit=allow_non_zero_exit,
+        )

--- a/utils/update_checkout/update_checkout/runner_arguments.py
+++ b/utils/update_checkout/update_checkout/runner_arguments.py
@@ -22,7 +22,8 @@ class UpdateArguments(RunnerArguments):
 
 @dataclass
 class AdditionalSwiftSourcesArguments(RunnerArguments):
-    args: RunnerArguments
+    args: Any
+    "Arguments passed during CLI invocation." # TODO: Properly type this.
     repo_info: str
     repo_branch: str
     remote: str

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -20,9 +20,9 @@ from multiprocessing import freeze_support
 from typing import Any, Dict, Optional, Set, List, Union
 
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
+from .git_command import Git
 from .runner_arguments import AdditionalSwiftSourcesArguments, UpdateArguments
 from .parallel_runner import ParallelRunner
-from swift_build_support.swift_build_support import shell
 
 
 SCRIPT_FILE = os.path.abspath(__file__)
@@ -51,7 +51,7 @@ def is_unix_sock_path_too_long() -> bool:
     sock_path = tempfile.mktemp(prefix="sock-", dir=tempfile.gettempdir())
     return len(sock_path.encode("utf-8")) > MAX_UNIX_SOCKET_PATH
 
-def confirm_tag_in_repo(tag: str, repo_name: str) -> Optional[str]:
+def confirm_tag_in_repo(repo_path: str, tag: str, repo_name: str) -> Optional[str]:
     """Confirm that a given tag exists in a git repository. This function
     assumes that the repository is already a current working directory before
     it's called.
@@ -65,8 +65,9 @@ def confirm_tag_in_repo(tag: str, repo_name: str) -> Optional[str]:
         exist.
     """
 
-    tag_exists = shell.capture(['git', 'ls-remote', '--tags',
-                                'origin', tag], echo=False)
+    tag_exists = Git.capture(
+        repo_path, ["ls-remote", "--tags", "origin", tag], echo=False
+    )
     if not tag_exists:
         print("Tag '" + tag + "' does not exist for '" +
               repo_name + "', just updating regularly")
@@ -74,17 +75,16 @@ def confirm_tag_in_repo(tag: str, repo_name: str) -> Optional[str]:
     return tag
 
 
-def find_rev_by_timestamp(timestamp: str, repo_name: str, refspec: str) -> str:
+def find_rev_by_timestamp(repo_path: str, timestamp: str, repo_name: str, refspec: str) -> str:
     refspec_exists = True
     try:
-        shell.run(["git", "rev-parse", "--verify", refspec])
+        Git.run(repo_path, ["rev-parse", "--verify", refspec])
     except Exception:
         refspec_exists = False
-    args = ["git", "log", "-1", "--format=%H", "--first-parent",
-            '--before=' + timestamp]
+    args = ["log", "-1", "--format=%H", "--first-parent", "--before=" + timestamp]
     if refspec_exists:
         args.append(refspec)
-    rev = shell.capture(args).strip()
+    rev = Git.capture(repo_path, args).strip()
     if rev:
         return rev
     else:
@@ -92,12 +92,13 @@ def find_rev_by_timestamp(timestamp: str, repo_name: str, refspec: str) -> str:
                            (repo_name, timestamp))
 
 
-def get_branch_for_repo(config, repo_name, scheme_name, scheme_map,
+def get_branch_for_repo(repo_path, config, repo_name, scheme_name, scheme_map,
                         cross_repos_pr):
     """Infer, fetch, and return a branch corresponding to a given PR, otherwise
     return a branch found in the config for this repository name.
 
     Args:
+        repo_path (str): path to the repository
         config (Dict[str, Any]): deserialized `update-checkout-config.json`
         repo_name (str): name of the repository for checking out the branch
         scheme_name (str): name of the scheme to look up in the config
@@ -119,13 +120,9 @@ def get_branch_for_repo(config, repo_name, scheme_name, scheme_map,
             cross_repo = True
             pr_id = cross_repos_pr[remote_repo_id]
             repo_branch = "ci_pr_{0}".format(pr_id)
-            shell.run(["git", "checkout", scheme_branch],
-                      echo=True)
-            shell.capture(["git", "branch", "-D", repo_branch],
-                          echo=True, allow_non_zero_exit=True)
-            shell.run(["git", "fetch", "origin",
-                       "pull/{0}/merge:{1}"
-                       .format(pr_id, repo_branch), "--tags"], echo=True)
+            Git.run(repo_path, ["checkout", scheme_branch], echo=True)
+            Git.capture(repo_path, ["branch", "-D", repo_branch], echo=True, allow_non_zero_exit=True)
+            Git.run(repo_path, ["fetch", "origin", "pull/{0}/merge:{1}".format(pr_id, repo_branch), "--tags"], echo=True)
     return repo_branch, cross_repo
 
 
@@ -142,128 +139,152 @@ def update_single_repository(pool_args: UpdateArguments):
         if verbose:
             print(prefix + "Updating '" + repo_path + "'")
 
-        with shell.pushd(repo_path, dry_run=False, echo=verbose):
-            cross_repo = False
-            checkout_target = None
-            if pool_args.tag:
-                checkout_target = confirm_tag_in_repo(pool_args.tag, repo_name)
-            elif pool_args.scheme_name:
-                checkout_target, cross_repo = get_branch_for_repo(
-                    pool_args.config, repo_name, pool_args.scheme_name, pool_args.scheme_map, pool_args.cross_repos_pr)
-                if pool_args.timestamp:
-                    checkout_target = find_rev_by_timestamp(pool_args.timestamp,
-                                                            repo_name,
-                                                            checkout_target)
+        cross_repo = False
+        checkout_target = None
+        if pool_args.tag:
+            checkout_target = confirm_tag_in_repo(
+                repo_path, pool_args.tag, repo_name
+            )
+        elif pool_args.scheme_name:
+            checkout_target, cross_repo = get_branch_for_repo(
+                repo_path,
+                pool_args.config,
+                repo_name,
+                pool_args.scheme_name,
+                pool_args.scheme_map,
+                pool_args.cross_repos_pr,
+            )
+            if pool_args.timestamp:
+                checkout_target = find_rev_by_timestamp(
+                    repo_path, pool_args.timestamp, repo_name, checkout_target
+                )
 
-            # The '--clean' and '--stash' options
-            # 1. clear the index and working tree ('--stash' stashes those
-            #   changes rather than discarding them)
-            # 2. delete ignored files
-            # 3. abort an ongoing rebase
-            if pool_args.clean or pool_args.stash:
+        # The '--clean' and '--stash' options
+        # 1. clear the index and working tree ('--stash' stashes those
+        #   changes rather than discarding them)
+        # 2. delete ignored files
+        # 3. abort an ongoing rebase
+        if pool_args.clean or pool_args.stash:
 
-                def run_for_repo_and_each_submodule_rec(cmd):
-                    shell.run(cmd, echo=verbose, prefix=prefix)
-                    shell.run(
-                        ["git", "submodule", "foreach", "--recursive"] + cmd,
-                        echo=verbose,
-                        prefix=prefix,
-                    )
+            def run_for_repo_and_each_submodule_rec(args: List[str]):
+                Git.run(repo_path, args, echo=verbose, prefix=prefix)
+                Git.run(
+                    repo_path,
+                    ["submodule", "foreach", "--recursive", "git"] + args,
+                    echo=verbose,
+                    prefix=prefix,
+                )
 
-                if pool_args.clean:
-                    # Stash tracked and untracked changes.
-                    run_for_repo_and_each_submodule_rec(["git", "stash", "-u"])
-                elif pool_args.stash:
-                    # Delete tracked changes.
-                    run_for_repo_and_each_submodule_rec(
-                        ["git", "reset", "--hard", "HEAD"]
-                    )
+            if pool_args.clean:
+                # Stash tracked and untracked changes.
+                run_for_repo_and_each_submodule_rec(["stash", "-u"])
+            elif pool_args.stash:
+                # Delete tracked changes.
+                run_for_repo_and_each_submodule_rec(
+                    ["reset", "--hard", "HEAD"]
+                )
 
-                # Delete untracked changes and ignored files.
-                run_for_repo_and_each_submodule_rec(["git", "clean", "-fdx"])
-                del run_for_repo_and_each_submodule_rec
+            # Delete untracked changes and ignored files.
+            run_for_repo_and_each_submodule_rec(["clean", "-fdx"])
+            del run_for_repo_and_each_submodule_rec
 
-                # It is possible to reset --hard and still be mid-rebase.
-                try:
-                    shell.run(['git', 'rebase', '--abort'],
-                              echo=verbose, prefix=prefix)
-                except Exception:
-                    pass
-
-            if checkout_target:
-                shell.run(['git', 'status', '--porcelain', '-uno'],
-                          echo=False)
-
-                # Some of the projects switch branches/tags when they
-                # are updated. Local checkout might not have that tag/branch
-                # fetched yet, so let's attempt to fetch before attempting
-                # checkout.
-                try:
-                    shell.run(['git', 'rev-parse', '--verify', checkout_target])
-                except Exception:
-                    shell.run(["git", "fetch", "--recurse-submodules=yes",
-                               "--tags"],
-                              echo=verbose, prefix=prefix)
-
-                try:
-                    shell.run(['git', 'checkout', checkout_target],
-                              echo=verbose, prefix=prefix)
-                except Exception:
-                    try:
-                        result = shell.run(['git', 'rev-parse', checkout_target])
-                        revision = result[0].strip()
-                        shell.run(['git', 'checkout', revision],
-                                  echo=verbose, prefix=prefix)
-                    except Exception:
-                        raise
-
-            # It's important that we checkout, fetch, and rebase, in order.
-            # .git/FETCH_HEAD updates the not-for-merge attributes based on
-            # which branch was checked out during the fetch.
-            shell.run(["git", "fetch", "--recurse-submodules=yes", "--tags"],
-                      echo=verbose, prefix=prefix)
-
-            # If we were asked to reset to the specified branch, do the hard
-            # reset and return.
-            if checkout_target and pool_args.reset_to_remote and not cross_repo:
-                full_target = full_target_name('origin', checkout_target)
-                shell.run(['git', 'reset', '--hard', full_target],
-                          echo=verbose, prefix=prefix)
-                return
-
-            # Query whether we have a "detached HEAD", which will mean that
-            # we previously checked out a tag rather than a branch.
-            detached_head = False
+            # It is possible to reset --hard and still be mid-rebase.
             try:
-                # This git command returns error code 1 if HEAD is detached.
-                # Otherwise there was some other error, and we need to handle
-                # it like other command errors.
-                shell.run(["git", "symbolic-ref", "-q", "HEAD"], echo=False)
-            except Exception as e:
-                if e.ret == 1:
-                    detached_head = True
-                else:
-                    raise  # Pass this error up the chain.
+                Git.run(repo_path, ['rebase', '--abort'], echo=verbose, prefix=prefix)
+            except Exception:
+                pass
 
-            # If we have a detached HEAD in this repository, we don't want
-            # to rebase. With a detached HEAD, the fetch will have marked
-            # all the branches in FETCH_HEAD as not-for-merge, and the
-            # "git rebase FETCH_HEAD" will try to rebase the tree from the
-            # default branch's current head, making a mess.
+        if checkout_target:
+            Git.run(repo_path, ['status', '--porcelain', '-uno'], echo=False)
 
-            # Prior to Git 2.6, this is the way to do a "git pull
-            # --rebase" that respects rebase.autostash.  See
-            # http://stackoverflow.com/a/30209750/125349
-            if not cross_repo and not detached_head:
-                shell.run(["git", "rebase", "FETCH_HEAD"],
-                          echo=verbose, prefix=prefix)
-            elif detached_head and verbose:
-                print(prefix +
-                      "Detached HEAD; probably checked out a tag. No need "
-                      "to rebase.")
+            # Some of the projects switch branches/tags when they
+            # are updated. Local checkout might not have that tag/branch
+            # fetched yet, so let's attempt to fetch before attempting
+            # checkout.
+            try:
+                Git.run(
+                    repo_path, ["rev-parse", "--verify", checkout_target], echo=verbose
+                )
+            except Exception:
+                Git.run(
+                    repo_path,
+                    ["fetch", "--recurse-submodules=yes", "--tags"],
+                    echo=verbose,
+                    prefix=prefix,
+                )
 
-            shell.run(["git", "submodule", "update", "--recursive"],
-                      echo=verbose, prefix=prefix)
+            try:
+                Git.run(
+                    repo_path,
+                    ["checkout", checkout_target],
+                    echo=verbose,
+                    prefix=prefix,
+                )
+            except Exception:
+                try:
+                    result = Git.run(repo_path, ["rev-parse", checkout_target])
+                    revision = result[0].strip()
+                    Git.run(
+                        repo_path, ["checkout", revision], echo=verbose, prefix=prefix
+                    )
+                except Exception:
+                    raise
+
+        # It's important that we checkout, fetch, and rebase, in order.
+        # .git/FETCH_HEAD updates the not-for-merge attributes based on
+        # which branch was checked out during the fetch.
+        Git.run(
+            repo_path,
+            ["fetch", "--recurse-submodules=yes", "--tags"],
+            echo=verbose,
+            prefix=prefix,
+        )
+
+        # If we were asked to reset to the specified branch, do the hard
+        # reset and return.
+        if checkout_target and pool_args.reset_to_remote and not cross_repo:
+            full_target = full_target_name(repo_path, "origin", checkout_target)
+            Git.run(
+                repo_path, ["reset", "--hard", full_target], echo=verbose, prefix=prefix
+            )
+            return
+
+        # Query whether we have a "detached HEAD", which will mean that
+        # we previously checked out a tag rather than a branch.
+        detached_head = False
+        try:
+            # This git command returns error code 1 if HEAD is detached.
+            # Otherwise there was some other error, and we need to handle
+            # it like other command errors.
+            Git.run(repo_path, ["symbolic-ref", "-q", "HEAD"], echo=False)
+        except Exception as e:
+            if e.ret == 1:
+                detached_head = True
+            else:
+                raise  # Pass this error up the chain.
+
+        # If we have a detached HEAD in this repository, we don't want
+        # to rebase. With a detached HEAD, the fetch will have marked
+        # all the branches in FETCH_HEAD as not-for-merge, and the
+        # "git rebase FETCH_HEAD" will try to rebase the tree from the
+        # default branch's current head, making a mess.
+
+        # Prior to Git 2.6, this is the way to do a "git pull
+        # --rebase" that respects rebase.autostash.  See
+        # http://stackoverflow.com/a/30209750/125349
+        if not cross_repo and not detached_head:
+            Git.run(repo_path, ["rebase", "FETCH_HEAD"], echo=verbose, prefix=prefix)
+        elif detached_head and verbose:
+            print(prefix +
+                    "Detached HEAD; probably checked out a tag. No need "
+                    "to rebase.")
+
+        Git.run(
+            repo_path,
+            ["submodule", "update", "--recursive"],
+            echo=verbose,
+            prefix=prefix,
+        )
     except Exception:
         (type, value, tb) = sys.exc_info()
         if verbose:
@@ -287,10 +308,10 @@ def get_timestamp_to_match(match_timestamp, source_root):
     """
     if not match_timestamp:
         return None
-    with shell.pushd(os.path.join(source_root, "swift"),
-                     dry_run=False, echo=False):
-        return shell.capture(["git", "log", "-1", "--format=%cI"],
-                             echo=False).strip()
+    swift_repo_path = os.path.join(source_root, "swift")
+    return Git.capture(
+        swift_repo_path, ["log", "-1", "--format=%cI"], echo=False
+    ).strip()
 
 
 def get_scheme_map(config, scheme_name):
@@ -408,41 +429,39 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
     env = dict(os.environ)
     env.update({'GIT_TERMINAL_PROMPT': '0'})
 
-    with shell.pushd(args.source_root, dry_run=False, echo=False):
+    if verbose:
+        print("Cloning '" + pool_args.repo_name + "'")
 
-        if verbose:
-            print("Cloning '" + pool_args.repo_name + "'")
+    if pool_args.skip_history:
+        Git.run(None, ['clone', '--recursive', '--depth', '1',
+                    '--branch', repo_branch, remote, repo_name] +
+                    (['--no-tags'] if skip_tags else []),
+                    cwd=args.source_root,
+                    env=env,
+                    echo=verbose)
+    elif pool_args.use_submodules:
+        Git.run(None, ['submodule', 'add', remote, repo_name] +
+                    (['--no-tags'] if skip_tags else []),
+                    cwd=args.source_root,
+                    env=env,
+                    echo=verbose)
+    else:
+        Git.run(None, ['clone', '--recursive', remote, repo_name] +
+                    (['--no-tags'] if skip_tags else []),
+                    cwd=args.source_root,
+                    env=env,
+                    echo=verbose)
 
-        if pool_args.skip_history:
-            shell.run(['git', 'clone', '--recursive', '--depth', '1',
-                       '--branch', repo_branch, remote, repo_name] +
-                      (['--no-tags'] if skip_tags else []),
-                      env=env,
-                      echo=verbose)
-        elif pool_args.use_submodules:
-            shell.run(['git', 'submodule', 'add', remote, repo_name] +
-                      (['--no-tags'] if skip_tags else []),
-                      env=env,
-                      echo=verbose)
-        else:
-            shell.run(['git', 'clone', '--recursive', remote, repo_name] +
-                      (['--no-tags'] if skip_tags else []),
-                      env=env,
-                      echo=verbose)
-        if pool_args.scheme_name:
-            src_path = os.path.join(args.source_root, repo_name, ".git")
-            shell.run(['git', '--git-dir',
-                       src_path, '--work-tree',
-                       os.path.join(args.source_root, repo_name),
-                       'checkout', repo_branch],
-                      env=env,
-                      echo=False)
-    with shell.pushd(os.path.join(args.source_root, repo_name),
-                     dry_run=False, echo=False):
-        shell.run(["git", "submodule",
-                   "update", "--recursive"],
-                  env=env,
-                  echo=False)
+    repo_path = os.path.join(args.source_root, repo_name)
+    if pool_args.scheme_name:
+        src_path = os.path.join(repo_path, ".git")
+        Git.run(
+            None,
+            ["--git-dir", src_path, "--work-tree", repo_path, "checkout", repo_branch],
+            env=env,
+            echo=False,
+        )
+    Git.run(repo_path, ["submodule", "update", "--recursive"], env=env, echo=False)
 
 
 def obtain_all_additional_swift_sources(args, config, with_ssh, scheme_name,
@@ -450,80 +469,80 @@ def obtain_all_additional_swift_sources(args, config, with_ssh, scheme_name,
                                         skip_repository_list, use_submodules):
 
     pool_args = []
-    with shell.pushd(args.source_root, dry_run=False, echo=False):
-        for repo_name, repo_info in config['repos'].items():
-            if repo_name in skip_repository_list:
-                print("Skipping clone of '" + repo_name + "', requested by "
-                      "user")
-                continue
+    for repo_name, repo_info in config['repos'].items():
+        repo_path = os.path.join(args.source_root, repo_name)
+        if repo_name in skip_repository_list:
+            print("Skipping clone of '" + repo_name + "', requested by "
+                    "user")
+            continue
 
-            if use_submodules:
-              repo_exists = False
-              submodules_status = shell.capture(['git', 'submodule', 'status'],
-                                                echo=False)
-              if submodules_status:
+        if use_submodules:
+            repo_exists = False
+            submodules_status = Git.capture(repo_path, ['submodule', 'status'],
+                                            echo=False)
+            if submodules_status:
                 for line in submodules_status.splitlines():
-                  if line[0].endswith(repo_name):
-                    repo_exists = True
-                    break
+                    if line[0].endswith(repo_name):
+                        repo_exists = True
+                        break
 
+        else:
+            repo_exists = os.path.isdir(os.path.join(repo_path, ".git"))
+
+        if repo_exists:
+            print("Skipping clone of '" + repo_name + "', directory "
+                    "already exists")
+            continue
+
+        # If we have a url override, use that url instead of
+        # interpolating.
+        remote_repo_info = repo_info['remote']
+        if 'url' in remote_repo_info:
+            remote = remote_repo_info['url']
+        else:
+            remote_repo_id = remote_repo_info['id']
+            if with_ssh is True or 'https-clone-pattern' not in config:
+                remote = config['ssh-clone-pattern'] % remote_repo_id
             else:
-              repo_exists = os.path.isdir(os.path.join(repo_name, ".git"))
+                remote = config['https-clone-pattern'] % remote_repo_id
 
-            if repo_exists:
-                print("Skipping clone of '" + repo_name + "', directory "
-                      "already exists")
-                continue
-
-            # If we have a url override, use that url instead of
-            # interpolating.
-            remote_repo_info = repo_info['remote']
-            if 'url' in remote_repo_info:
-                remote = remote_repo_info['url']
+        repo_branch = None
+        repo_not_in_scheme = False
+        if scheme_name:
+            for v in config['branch-schemes'].values():
+                if scheme_name not in v['aliases']:
+                    continue
+                # If repo is not specified in the scheme, skip cloning it.
+                if repo_name not in v['repos']:
+                    repo_not_in_scheme = True
+                    continue
+                repo_branch = v['repos'][repo_name]
+                break
             else:
-                remote_repo_id = remote_repo_info['id']
-                if with_ssh is True or 'https-clone-pattern' not in config:
-                    remote = config['ssh-clone-pattern'] % remote_repo_id
-                else:
-                    remote = config['https-clone-pattern'] % remote_repo_id
+                repo_branch = scheme_name
+        if repo_not_in_scheme:
+            continue
 
-            repo_branch = None
-            repo_not_in_scheme = False
-            if scheme_name:
-                for v in config['branch-schemes'].values():
-                    if scheme_name not in v['aliases']:
-                        continue
-                    # If repo is not specified in the scheme, skip cloning it.
-                    if repo_name not in v['repos']:
-                        repo_not_in_scheme = True
-                        continue
-                    repo_branch = v['repos'][repo_name]
-                    break
-                else:
-                    repo_branch = scheme_name
-            if repo_not_in_scheme:
-                continue
+        new_args = AdditionalSwiftSourcesArguments(
+            args=args,
+            repo_name=repo_name,
+            repo_info=repo_info,
+            repo_branch=repo_branch,
+            remote=remote,
+            with_ssh=with_ssh,
+            scheme_name=scheme_name,
+            skip_history=skip_history,
+            skip_tags=skip_tags,
+            skip_repository_list=skip_repository_list,
+            use_submodules=use_submodules,
+            output_prefix="Cloning",
+            verbose=args.verbose,
+        )
 
-            new_args = AdditionalSwiftSourcesArguments(
-                args=args,
-                repo_name=repo_name,
-                repo_info=repo_info,
-                repo_branch=repo_branch,
-                remote=remote,
-                with_ssh=with_ssh,
-                scheme_name=scheme_name,
-                skip_history=skip_history,
-                skip_tags=skip_tags,
-                skip_repository_list=skip_repository_list,
-                use_submodules=use_submodules,
-                output_prefix="Cloning",
-                verbose=args.verbose,
-            )
-
-            if use_submodules:
-                obtain_additional_swift_sources(new_args)
-            else:
-                pool_args.append(new_args)
+        if use_submodules:
+            obtain_additional_swift_sources(new_args)
+        else:
+            pool_args.append(new_args)
 
     # Only use `ParallelRunner` when submodules are not used, since `.git` dir
     # can't be accessed concurrently.
@@ -558,15 +577,12 @@ def dump_repo_hashes(args, config, branch_scheme_name='repro'):
 
 def repo_hashes(args, config):
     repos = {}
-    for repo_name, repo_info in sorted(config['repos'].items(),
-                                       key=lambda x: x[0]):
+    for repo_name, _ in sorted(config['repos'].items(), key=lambda x: x[0]):
         repo_path = os.path.join(args.source_root, repo_name)
         if os.path.exists(repo_path):
-            with shell.pushd(repo_path, dry_run=False, echo=False):
-                h = shell.capture(["git", "rev-parse", "HEAD"],
-                                  echo=False).strip()
+            h = Git.capture(repo_path, ["rev-parse", "HEAD"], echo=False).strip()
         else:
-            h = 'skip'
+            h = "skip"
         repos[repo_name] = str(h)
     return repos
 
@@ -639,13 +655,12 @@ def validate_config(config: Dict[str, Any]):
                 seen[alias] = scheme_name
 
 
-def full_target_name(repository, target):
-    tag = shell.capture(["git", "tag", "-l", target], echo=False).strip()
+def full_target_name(repo_path, repository, target):
+    tag = Git.capture(repo_path, ["tag", "-l", target], echo=False).strip()
     if tag == target:
         return tag
 
-    branch = shell.capture(["git", "branch", "--list", target],
-                           echo=False).strip().replace("* ", "")
+    branch = Git.capture(repo_path, ["branch", "--list", target], echo=False).strip().replace("* ", "")
     if branch == target:
         name = "%s/%s" % (repository, target)
         return name
@@ -875,24 +890,24 @@ repositories.
 
     swift_repo_path = os.path.join(args.source_root, 'swift')
     if 'swift' not in skip_repo_list and os.path.exists(swift_repo_path):
-        with shell.pushd(swift_repo_path, dry_run=False, echo=True):
-            # Check if `swift` repo itself needs to switch to a cross-repo branch.
-            branch_name, cross_repo = get_branch_for_repo(config, 'swift',
-                                                          scheme_name,
-                                                          scheme_map,
-                                                          cross_repos_pr)
+        # Check if `swift` repo itself needs to switch to a cross-repo branch.
+        branch_name, cross_repo = get_branch_for_repo(swift_repo_path, config, 'swift',
+                                                        scheme_name,
+                                                        scheme_map,
+                                                        cross_repos_pr)
 
-            if cross_repo:
-                shell.run(['git', 'checkout', branch_name], echo=True,
-                          prefix="[swift] ")
+        if cross_repo:
+            Git.run(
+                swift_repo_path, ["checkout", branch_name], echo=True, prefix="[swift] "
+            )
 
-                # Re-read the config after checkout.
-                config = {}
-                for config_path in args.configs:
-                    with open(config_path) as f:
-                        config = merge_config(config, json.load(f))
-                validate_config(config)
-                scheme_map = get_scheme_map(config, scheme_name)
+            # Re-read the config after checkout.
+            config = {}
+            for config_path in args.configs:
+                with open(config_path) as f:
+                    config = merge_config(config, json.load(f))
+            validate_config(config)
+            scheme_map = get_scheme_map(config, scheme_name)
 
     if args.dump_hashes:
         dump_repo_hashes(args, config)


### PR DESCRIPTION
This patch makes `update-checkout` use a `ThreadPoolExecutor` instead of a `multiprocessing.Pool`. The main benefits are:
- Using processes means that the Python modules that make up `update-checkout` get re-executed every time a subprocess starts. This causes problems when updating the `swift` repository as the `update-checkout` files are edited which can cause functions and modules to no longer be available. With threads, the modules are already loaded in memory, we don't rely on the filesystem.
- The `git` commands are invoked through `Popen` meaning they are executed in a subprocess. There is no need to open a subprocess in the `multiprocessing.Pool` to run other subprocesses. A Python thread is a more light weight solution for scheduling tasks.
- There were Timeout errors specifically on Python 3.9 due to CPython not freeing global locks properly (see https://github.com/swiftlang/swift/pull/84825). Using a ThreadPool bypasses that issue meaning that we will be able to reenable the quiet output mode on Python 3.9.

This patch also refactors the `shell.run` and `shell.capture` invocations: before, they were relying on `pushd` and `popd` with Python context managers. This does not work with multithreading as the `shell` module is now shared between threads. Now, `git` commands are executed with `git -C /repo_path` instead of relying on the working directory.

rdar://162775786