### PR TITLE
[ASTGen/CMake] Link swiftOnoneSupport in "Debug" build

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -292,6 +292,9 @@ function(add_pure_swift_host_library name)
   force_target_link_libraries(${name} PUBLIC
     ${APSHL_SWIFT_DEPENDENCIES}
   )
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(${name} PUBLIC swiftSwiftOnoneSupport)
+  endif()
 
   if(APSHL_EMIT_MODULE)
     set(module_triple "${SWIFT_HOST_MODULE_TRIPLE}")
@@ -457,6 +460,9 @@ function(add_pure_swift_host_tool name)
   force_target_link_libraries(${name} PUBLIC
     ${APSHT_SWIFT_DEPENDENCIES}
   )
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(${name} PUBLIC swiftSwiftOnoneSupport)
+  endif()
 
   # Make sure we can use the host libraries.
   target_include_directories(${name} PUBLIC


### PR DESCRIPTION
When building the swift compler with "Debug" configuration, modules written in Swift must be linked to swiftOnoneSupport. Explicitly link it as some linker doesn't auto-link it.

rdar://162631685

NOTE: This still won't work in non-Darwin platform if the stdlib is also being compiled "Debug" (`--debug-swift-stdlib`) because when building the compiler, it's linked against the stdlib (incl. `swiftOnoneSupport`) in the builder which is probably optimized. But in runtime, it uses the just-built stdlib. Since there're ABI mismatch between optimized/unoptimized `swiftOnoneSupport`, some symbols would be missing.