### PR TITLE
[AutoDiff][test] Enable some previously XFAIL'ed tests

### DIFF
--- a/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
@@ -17,6 +17,7 @@
 //       run we currently do not perform any transformation because ownership
 //       eliminator is run before. Disabled tests below rely on the second
 //       pass run performing transformation, so they currently fail.
+//       https://github.com/swiftlang/swift/issues/84920
 // TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK1
 // TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK2
 // TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK3

--- a/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
@@ -11,13 +11,17 @@
 // RUN: %target-run %t/opt.out
 
 // RUN: %target-swift-frontend -emit-sil %s -O -o %t/out.sil
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK1
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK2
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK3
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
 
-// TODO: re-enable this test once we have OSSA throughout the pipeline
-// XFAIL: *
+// TODO: Re-enable these tests once we have OSSA throughout the pipeline.
+//       AutoDiff Closure Specialization pass runs twice, but at the second
+//       run we currently do not perform any transformation because ownership
+//       eliminator is run before. Disabled tests below rely on the second
+//       pass run performing transformation, so they currently fail.
+// TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK1
+// TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK2
+// TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK3
+
+// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
 
 import DifferentiationUnittest
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
@@ -11,11 +11,15 @@
 // RUN: %target-run %t/opt.out
 
 // RUN: %target-swift-frontend -emit-sil %s -O -o %t/out.sil
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
-// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK5
 
-// TODO: re-enable this test once we have OSSA throughout the pipeline
-// XFAIL: *
+// TODO: Re-enable these tests once we have OSSA throughout the pipeline.
+//       AutoDiff Closure Specialization pass runs twice, but at the second
+//       run we currently do not perform any transformation because ownership
+//       eliminator is run before. Disabled tests below rely on the second
+//       pass run performing transformation, so they currently fail.
+// TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
+
+// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK5
 
 import DifferentiationUnittest
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
@@ -17,6 +17,7 @@
 //       run we currently do not perform any transformation because ownership
 //       eliminator is run before. Disabled tests below rely on the second
 //       pass run performing transformation, so they currently fail.
+//       https://github.com/swiftlang/swift/issues/84920
 // TODO: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
 
 // RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK5


### PR DESCRIPTION
In #84704, some tests were XFAIL'ed since they've become failing. The root cause of failures is lack of ownership info on the 2nd run of AutoDiff closure specialization pass. Ownership info is required for the pass run after #84704, so at the moment only the 1st run of the pass is effective.

Several test cases still remain passing because for some cases we are lucky and all the inlining required for specialization is done before the 1st pass run. This patch enables such test cases back so we have at least some test coverage.
