### PR TITLE
ExistentialTransform: fix a wrong result type of `open_existential_addr`

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -443,7 +443,7 @@ void ExistentialTransform::populateThunkBody() {
       switch (ExistentialRepr) {
       case ExistentialRepresentation::Opaque: {
         archetypeValue = Builder.createOpenExistentialAddr(
-            Loc, OrigOperand, OpenedSILType, it->second.AccessType);
+            Loc, OrigOperand, OpenedSILType.getAddressType(), it->second.AccessType);
         SILValue calleeArg = archetypeValue;
         if (OriginallyConsumed) {
           // open_existential_addr projects a borrowed address into the


### PR DESCRIPTION
It needs to be the address type of the opened type and not the object type.
Unfortunately I don't have a test case for this fix.

Fixes a compiler crash
rdar://162149588
