### PR TITLE
Don't ask about stored properties of resilient types in various places

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1190,22 +1190,24 @@ private:
         Name);
     // Collect the members.
     SmallVector<MemberDIType, 16> MemberTypes;
-    for (VarDecl *VD : Decl->getStoredProperties()) {
-      auto memberTy = Type->getTypeOfMember(VD);
-      if (auto DbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
-              memberTy,
-              IGM.getTypeInfoForUnlowered(
-                  IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-              IGM))
-        MemberTypes.emplace_back(VD->getName().str(),
-                                 getByteSize() *
-                                     DbgTy->getAlignment().getValue(),
-                                 getOrCreateType(*DbgTy));
-      else
-        // Without complete type info we can only create a forward decl.
-        return DBuilder.createForwardDecl(
-            llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, Line,
-            llvm::dwarf::DW_LANG_Swift, SizeInBits, 0);
+    if (!IGM.isResilient(Decl, ResilienceExpansion::Maximal)) {
+      for (VarDecl *VD : Decl->getStoredProperties()) {
+        auto memberTy = Type->getTypeOfMember(VD);
+        if (auto DbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
+                memberTy,
+                IGM.getTypeInfoForUnlowered(
+                    IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
+                IGM))
+          MemberTypes.emplace_back(VD->getName().str(),
+                                   getByteSize() *
+                                       DbgTy->getAlignment().getValue(),
+                                   getOrCreateType(*DbgTy));
+        else
+          // Without complete type info we can only create a forward decl.
+          return DBuilder.createForwardDecl(
+              llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, Line,
+              llvm::dwarf::DW_LANG_Swift, SizeInBits, 0);
+      }
     }
 
     SmallVector<llvm::Metadata *, 16> Members;
@@ -1245,17 +1247,21 @@ private:
         UniqueID, Name);
     // Collect the members.
     SmallVector<MemberDIType, 16> MemberTypes;
-    for (VarDecl *VD : Decl->getStoredProperties()) {
-      Type memberTy = UnsubstitutedType->getTypeOfMember(VD);
-      auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-          memberTy,
-          IGM.getTypeInfoForUnlowered(
-              IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-          IGM);
-      MemberTypes.emplace_back(VD->getName().str(),
-                               getByteSize() * DbgTy.getAlignment().getValue(),
-                               getOrCreateType(DbgTy));
+
+    if (!IGM.isResilient(Decl, ResilienceExpansion::Maximal)) {
+      for (VarDecl *VD : Decl->getStoredProperties()) {
+        Type memberTy = UnsubstitutedType->getTypeOfMember(VD);
+        auto DbgTy = DebugTypeInfo::getFromTypeInfo(
+            memberTy,
+            IGM.getTypeInfoForUnlowered(
+                IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
+            IGM);
+        MemberTypes.emplace_back(VD->getName().str(),
+                                 getByteSize() * DbgTy.getAlignment().getValue(),
+                                 getOrCreateType(DbgTy));
+      }
     }
+
     SmallVector<llvm::Metadata *, 16> Members;
     for (auto &Member : MemberTypes) {
       unsigned OffsetInBits = 0;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -804,7 +804,10 @@ unsigned SILModule::getFieldIndex(NominalTypeDecl *decl, VarDecl *field) {
   if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
     for (auto *superDecl = classDecl->getSuperclassDecl(); superDecl != nullptr;
          superDecl = superDecl->getSuperclassDecl()) {
-      index += superDecl->getStoredProperties().size();
+      if (!superDecl->isResilient(getSwiftModule(),
+                                  ResilienceExpansion::Maximal)) {
+        index += superDecl->getStoredProperties().size();
+      }
     }
   }
   for (VarDecl *property : decl->getStoredProperties()) {

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -162,6 +162,11 @@ bool SILType::isEmpty(const SILFunction &F) const {
     // Also, a struct is empty if it either has no fields or if all fields are
     // empty.
     SILModule &module = F.getModule();
+    if (structDecl->isResilient(module.getSwiftModule(),
+                                F.getResilienceExpansion())) {
+      return false;
+    }
+
     TypeExpansionContext typeEx = F.getTypeExpansionContext();
     for (VarDecl *field : structDecl->getStoredProperties()) {
       if (!getFieldType(field, module, typeEx).isEmpty(F))

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -66,6 +66,13 @@ TypeSubElementCount::TypeSubElementCount(SILType type, SILModule &mod,
   }
 
   if (auto *structDecl = getFullyReferenceableStruct(type)) {
+    // A resilient struct has 1 element.
+    if (structDecl->isResilient(mod.getSwiftModule(),
+                                ResilienceExpansion::Maximal)) {
+      number = 1;
+      return;
+    }
+
     unsigned numElements = 0;
     for (auto *fieldDecl : structDecl->getStoredProperties())
       numElements += TypeSubElementCount(

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -80,6 +80,12 @@ bool DestructorAnalysis::isSafeType(CanType Ty) {
         areTypeParametersSafe(Ty))
       return cacheResult(Ty, true);
 
+    // Not allowed to look at stored properties of resilient types.
+    if (Struct->isResilient(Mod->getSwiftModule(),
+                            ResilienceExpansion::Maximal)) {
+      return cacheResult(Ty, false);
+    }
+
     // Check the stored properties.
     for (auto SP : Struct->getStoredProperties()) {
       if (!isSafeType(SP->getInterfaceType()->getCanonicalType()))
@@ -97,6 +103,8 @@ bool DestructorAnalysis::isSafeType(CanType Ty) {
   }
 
   // TODO: enum types.
+  // TODO: Don't forget to check resilience of enum decl, like
+  // we do for structs above.
 
   return cacheResult(Ty, false);
 }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -102,6 +102,11 @@ static unsigned getNumSubElements(SILType T, SILFunction &F,
   }
   
   if (auto *SD = getFullyReferenceableStruct(T)) {
+    if (SD->isResilient(F.getModule().getSwiftModule(),
+                        F.getResilienceExpansion())) {
+      return false;
+    }
+
     unsigned NumElements = 0;
     for (auto *D : SD->getStoredProperties())
       NumElements +=

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -232,6 +232,14 @@ bool CircularityChecker::expandTuple(CanTupleType tupleType, unsigned depth) {
 /// Visit a nominal type and try to expand it one level.
 bool CircularityChecker::expandNominal(CanType type, NominalTypeDecl *D,
                                        unsigned depth) {
+  if (D->isResilient(OriginalDecl->getParentModule(),
+                     ResilienceExpansion::Maximal)) {
+    LLVM_DEBUG(llvm::dbgs() << std::string(depth, ' ')
+                            << "skipping resilient nominal "
+                            << type << "\n";);
+    return false;
+  }
+
   LLVM_DEBUG(llvm::dbgs() << std::string(depth, ' ') << "expanding nominal "
                           << type << "\n";);
   if (auto S = dyn_cast<StructDecl>(D)) {

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -154,6 +154,10 @@ static void checkInvertibleConformanceCommon(DeclContext *dc,
           ctx.Diags.diagnose(conformanceLoc,
                              diag::invertible_conformance_other_source_file,
                              getInvertibleProtocolKindName(ip), nominalDecl);
+
+          // Skip further work to avoid asking for stored properties of
+          // resilient types.
+          return;
         }
       }
 


### PR DESCRIPTION
A resilient type built from a module interface does not have stored properties, and a resilient type built from a binary module may have stored properties that do not reflect the actual layout at runtime. Since the layout of a resilient type is meant to be completely opaque to clients, avoid asking for it in various places.

Some were harmless, and some more concerning.

I did not land the actual assertion I used to catch these bugs, because to do it properly would require changing `getStoredProperties()` to take the client module and resilience expansion. Maybe we can do it at a later date, but for now, just fix some of the problems my experiment exposed.