### PR TITLE
[Runtime] Don't check suppressed protocols when the extended existential is metatype constrained

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -2229,6 +2229,14 @@ checkInvertibleRequirementsStructural(const Metadata *type,
   case MetadataKind::ExtendedExistential: {
     auto existential = cast<ExtendedExistentialTypeMetadata>(type);
     auto &shape = *existential->Shape;
+
+    // If this is an extended existential metatype, then just allow it. Metatypes
+    // are always copyable and escapable so there can't possibly be a
+    // suppression issue.
+    if (shape.Flags.isMetatypeConstrained()) {
+      return std::nullopt;
+    }
+
     llvm::ArrayRef<GenericRequirementDescriptor> reqs(
         shape.getReqSigRequirements(), shape.getNumReqSigRequirements());
     // Look for any suppressed protocol requirements. If the existential

--- a/test/Interpreter/extended_existential.swift
+++ b/test/Interpreter/extended_existential.swift
@@ -49,3 +49,21 @@ print(h)
 let i: Any = (any A & B & ~Copyable).self
 // CHECK: any A & B<Self: ~Swift.Copyable>
 print(i)
+
+@inline(never)
+func test() -> Bool {
+  return [].first == nil
+}
+
+// CHECK: true
+print(test())
+
+let j: [any (~Copyable & ~Escapable).Type] = []
+
+// CHECK: Array<any Any<Self: ~Swift.Copyable, Self: ~Swift.Escapable>.Type>
+print(type(of: j))
+
+let k: [(any ~Copyable & ~Escapable).Type] = []
+
+// CHECK: Array<(any Any<Self: ~Swift.Copyable, Self: ~Swift.Escapable>).Type>
+print(type(of: k))


### PR DESCRIPTION
When checking the generic requirements of a type and its generic arguments, we have to check that an extended existential doesn't invert some protocols that the bound generic type isn't expecting. However, for extended existentials that are metatypes, e.g. `any (~Copyable & ~Escapable).Type` or `any Collection<Int>.Type`, they are always copyable and escapable. Don't do inverse protocol requirement checking on these.

Resolves: rdar://153105845