### PR TITLE
Revert "[stdlib] Make PlatformExecutorFactory and ExecutorFactory deploy to 6.3 instead of 6.2."

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -591,7 +591,7 @@ public protocol MainExecutor: RunLoopExecutor, SerialExecutor {
 
 /// An ExecutorFactory is used to create the default main and task
 /// executors.
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public protocol ExecutorFactory {
   #if os(WASI) || !$Embedded
   /// Constructs and returns the main executor, which is started implicitly
@@ -604,7 +604,7 @@ public protocol ExecutorFactory {
   static var defaultExecutor: any TaskExecutor { get }
 }
 
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 typealias DefaultExecutorFactory = PlatformExecutorFactory
 
 @available(StdlibDeploymentTarget 6.2, *)

--- a/stdlib/public/Concurrency/PlatformExecutorCooperative.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorCooperative.swift
@@ -13,7 +13,7 @@
 import Swift
 
 // This platform uses a single, global, CooperativeExecutor
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   static let executor = CooperativeExecutor()
   public static var mainExecutor: any MainExecutor { executor }

--- a/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
@@ -14,7 +14,7 @@
 
 import Swift
 
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static var mainExecutor: any MainExecutor {
     if CoreFoundation.isPresent {

--- a/stdlib/public/Concurrency/PlatformExecutorFreeBSD.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorFreeBSD.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor

--- a/stdlib/public/Concurrency/PlatformExecutorLinux.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorLinux.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor

--- a/stdlib/public/Concurrency/PlatformExecutorNone.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorNone.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = UnimplementedMainExecutor()
   public static let defaultExecutor: any TaskExecutor = UnimplementedTaskExecutor()

--- a/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor

--- a/stdlib/public/Concurrency/PlatformExecutorWindows.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorWindows.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(StdlibDeploymentTarget 6.3, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor =


### PR DESCRIPTION
Reverts swiftlang/swift#84859

These are changes we want, but they appear to be incomplete and the partial state is blocking  https://github.com/swiftlang/swift/pull/83294 from making progress; having that change will make it easier to finish up the work for 84859 anyway.