### PR TITLE
[SIL] Add asmname attribute to SIL functions and global variables

### DIFF
--- a/docs/SIL/FunctionAttributes.md
+++ b/docs/SIL/FunctionAttributes.md
@@ -228,3 +228,11 @@ Specifies that the optimizer and IRGen must not add runtime calls which
 are not in the function originally. This attribute is set for functions
 with performance constraints or functions which are called from
 functions with performance constraints.
+
+### Naming
+
+```
+sil-function-attribute :: '[' asmname "' identifier '" ']'
+```
+
+Specifies that the SIL function should be lowered to LLVM IR with the given function name.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -320,6 +320,11 @@ private:
   /// The function's remaining set of specialize attributes.
   std::vector<SILSpecializeAttr*> SpecializeAttrSet;
 
+  /// The name that this function should have when it is lowered to LLVM IR.
+  ///
+  /// If empty, use the SIL function's name directly.
+  StringRef AsmName;
+
   /// Name of a section if @_section attribute was used, otherwise empty.
   StringRef Section;
 
@@ -1422,6 +1427,10 @@ public:
   /// Return whether this function has attribute @_used on it
   bool markedAsUsed() const { return MarkedAsUsed; }
   void setMarkedAsUsed(bool value) { MarkedAsUsed = value; }
+
+  /// Return custom assembler name, otherwise empty.
+  StringRef asmName() const { return AsmName; }
+  void setAsmName(StringRef value) { AsmName = value; }
 
   /// Return custom section name if @_section was used, otherwise empty
   StringRef section() const { return Section; }

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -60,6 +60,10 @@ private:
   /// binary.  A pointer into the module's lookup table.
   StringRef Name;
 
+  /// The name that this variable should have when lowered to LLVM IR. If empty,
+  /// the mangled name of the variable will be used instead.
+  StringRef AsmName;
+
   /// The lowered type of the variable.
   SILType LoweredType;
   
@@ -150,7 +154,11 @@ public:
   }
 
   StringRef getName() const { return Name; }
-  
+
+  /// Return custom assembler name, otherwise empty.
+  StringRef asmName() const { return AsmName; }
+  void setAsmName(StringRef value) { AsmName = value; }
+
   void setDeclaration(bool isD) { IsDeclaration = isD; }
 
   /// True if this is a definition of the variable.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -64,6 +64,9 @@ private:
   /// the mangled name of the variable will be used instead.
   StringRef AsmName;
 
+  /// Name of a section if @_section attribute was used, otherwise empty.
+  StringRef Section;
+
   /// The lowered type of the variable.
   SILType LoweredType;
   
@@ -159,6 +162,10 @@ public:
   StringRef asmName() const { return AsmName; }
   void setAsmName(StringRef value) { AsmName = value; }
 
+  /// Return custom section name if @_section was used, otherwise empty
+  StringRef section() const { return Section; }
+  void setSection(StringRef value) { Section = value; }
+
   void setDeclaration(bool isD) { IsDeclaration = isD; }
 
   /// True if this is a definition of the variable.
@@ -239,15 +246,6 @@ public:
   bool markedAsUsed() const { return IsUsed; }
 
   void setMarkedAsUsed(bool used) { IsUsed = used; }
-
-  /// Returns a SectionAttr if this global variable has `@_section` attribute.
-  SectionAttr *getSectionAttr() const {
-    auto *V = getDecl();
-    if (!V)
-      return nullptr;
-
-    return V->getAttrs().getAttribute<SectionAttr>();
-  }
 
   /// Return whether this variable corresponds to a Clang node.
   bool hasClangNode() const;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2865,8 +2865,8 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
       addUsedGlobal(gvar);
     else if (var->shouldBePreservedForDebugger() && forDefinition) 
       addUsedGlobal(gvar);
-    if (auto *sectionAttr = var->getSectionAttr())
-      gvar->setSection(sectionAttr->Name);
+    if (!var->section().empty())
+      gvar->setSection(var->section());
   }
   if (forDefinition && !gvar->hasInitializer()) {
     if (initVal) {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -408,6 +408,10 @@ std::string LinkEntity::mangleAsString(ASTContext &Ctx) const {
   }
 
   case Kind::SILFunction: {
+    auto asmName = getSILFunction()->asmName();
+    if (!asmName.empty())
+      return asmName.str();
+
     std::string Result(getSILFunction()->getName());
     if (isDynamicallyReplaceable()) {
       Result.append("TI");
@@ -465,8 +469,13 @@ std::string LinkEntity::mangleAsString(ASTContext &Ctx) const {
     return Result;
   }
 
-  case Kind::SILGlobalVariable:
+  case Kind::SILGlobalVariable: {
+    auto asmName = getSILGlobalVariable()->asmName();
+    if (!asmName.empty())
+      return asmName.str();
+
     return getSILGlobalVariable()->getName().str();
+  }
 
   case Kind::ReadOnlyGlobalObject:
     return getSILGlobalVariable()->getName().str() + "r";

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -91,7 +91,7 @@ bool SILGlobalVariable::isPossiblyUsedExternally() const {
   if (markedAsUsed())
     return true;
 
-  if (getSectionAttr())
+  if (!section().empty())
     return true;
 
   SILLinkage linkage = getLinkage();
@@ -151,7 +151,7 @@ SILInstruction *SILGlobalVariable::getStaticInitializerValue() {
 }
 
 bool SILGlobalVariable::mustBeInitializedStatically() const {
-  if (getSectionAttr())
+  if (!section().empty())
     return true;
 
   auto *decl = getDecl();  

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3709,6 +3709,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   if (!section().empty())
     OS << "[section \"" << section() << "\"] ";
 
+  if (!asmName().empty())
+    OS << "[asmname \"" << asmName() << "\"] ";
+
   // TODO: Handle clang node owners which don't have a name.
   if (hasClangNode() && getClangNodeOwner()->hasName()) {
     OS << "[clang ";
@@ -3776,6 +3779,9 @@ void SILGlobalVariable::print(llvm::raw_ostream &OS, bool Verbose) const {
 
   if (markedAsUsed())
     OS << "[used] ";
+
+  if (!asmName().empty())
+    OS << "[asmname \"" << asmName() << "\"] ";
 
   printName(OS);
   OS << " : " << LoweredType;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3783,6 +3783,9 @@ void SILGlobalVariable::print(llvm::raw_ostream &OS, bool Verbose) const {
   if (!asmName().empty())
     OS << "[asmname \"" << asmName() << "\"] ";
 
+  if (!section().empty())
+    OS << "[section \"" << section() << "\"] ";
+
   printName(OS);
   OS << " : " << LoweredType;
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7577,6 +7577,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
   SerializedKind_t isSerialized = IsNotSerialized;
   bool isMarkedAsUsed = false;
   StringRef asmName;
+  StringRef section;
   bool isLet = false;
 
   SILParser State(P);
@@ -7585,7 +7586,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, &isMarkedAsUsed, &asmName,
-                           nullptr, &isLet, nullptr, nullptr, nullptr, nullptr,
+                           &section, &isLet, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
@@ -7615,6 +7616,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
   GV->setLet(isLet);
   GV->setMarkedAsUsed(isMarkedAsUsed);
   GV->setAsmName(asmName);
+  GV->setSection(section);
 
   // Parse static initializer if exists.
   if (State.P.consumeIf(tok::equal) && State.P.consumeIf(tok::l_brace)) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -679,7 +679,8 @@ static bool parseDeclSILOptional(
     SILFunction **usedAdHocRequirementWitness, Identifier *objCReplacementFor,
     SILFunction::Purpose *specialPurpose, Inline_t *inlineStrategy,
     OptimizationMode *optimizationMode, PerformanceConstraints *perfConstraints,
-    bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *section,
+    bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *asmName,
+    StringRef *section,
     bool *isLet, bool *isWeakImported, bool *needStackProtection,
     bool *isSpecialized, AvailabilityRange *availability,
     bool *isWithoutActuallyEscapingThunk,
@@ -807,6 +808,20 @@ static bool parseDeclSILOptional(
       }
       *actorIsolation = *optIsolation;
       SP.P.consumeToken(tok::string_literal);
+      SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
+      continue;
+    } else if (asmName && SP.P.Tok.getText() == "asmname") {
+      SP.P.consumeToken(tok::identifier);
+      if (SP.P.Tok.getKind() != tok::string_literal) {
+        SP.P.diagnose(SP.P.Tok, diag::expected_in_attribute_list);
+        return true;
+      }
+
+      // Drop the double quotes.
+      StringRef rawString = SP.P.Tok.getText().drop_front().drop_back();
+      *asmName = SP.P.Context.getIdentifier(rawString).str();
+      SP.P.consumeToken(tok::string_literal);
+
       SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
       continue;
     } else if (section && SP.P.Tok.getText() == "section") {
@@ -7288,6 +7303,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   PerformanceConstraints perfConstr = PerformanceConstraints::None;
   bool isPerformanceConstraint = false;
   bool markedAsUsed = false;
+  StringRef asmName;
   StringRef section;
   SmallVector<std::string, 1> Semantics;
   SmallVector<ParsedSpecAttr, 4> SpecAttrs;
@@ -7306,7 +7322,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
           &DynamicallyReplacedFunction, &AdHocWitnessFunction,
           &objCReplacementFor, &specialPurpose, &inlineStrategy,
           &optimizationMode, &perfConstr, &isPerformanceConstraint,
-          &markedAsUsed, &section, nullptr, &isWeakImported,
+          &markedAsUsed, &asmName, &section, nullptr, &isWeakImported,
           &needStackProtection, nullptr, &availability,
           &isWithoutActuallyEscapingThunk, &Semantics, &SpecAttrs, &ClangDecl,
           &MRK, &actorIsolation, FunctionState, M) ||
@@ -7363,6 +7379,9 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     FunctionState.F->setPerfConstraints(perfConstr);
     FunctionState.F->setIsPerformanceConstraint(isPerformanceConstraint);
     FunctionState.F->setEffectsKind(MRK);
+    FunctionState.F->setMarkedAsUsed(markedAsUsed);
+    FunctionState.F->setAsmName(asmName);
+    FunctionState.F->setSection(section);
 
     if (ClangDecl)
       FunctionState.F->setClangNodeOwner(ClangDecl);
@@ -7557,6 +7576,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
   SourceLoc NameLoc;
   SerializedKind_t isSerialized = IsNotSerialized;
   bool isMarkedAsUsed = false;
+  StringRef asmName;
   bool isLet = false;
 
   SILParser State(P);
@@ -7564,10 +7584,10 @@ bool SILParserState::parseSILGlobal(Parser &P) {
       parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, &isMarkedAsUsed, nullptr,
-                           &isLet, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, State,
-                           M) ||
+                           nullptr, nullptr, nullptr, &isMarkedAsUsed, &asmName,
+                           nullptr, &isLet, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
       P.parseIdentifier(GlobalName, NameLoc, /*diagnoseDollarPrefix=*/false,
                         diag::expected_sil_value_name) ||
@@ -7594,6 +7614,8 @@ bool SILParserState::parseSILGlobal(Parser &P) {
 
   GV->setLet(isLet);
   GV->setMarkedAsUsed(isMarkedAsUsed);
+  GV->setAsmName(asmName);
+
   // Parse static initializer if exists.
   if (State.P.consumeIf(tok::equal) && State.P.consumeIf(tok::l_brace)) {
     SILBuilder B(GV);
@@ -7621,7 +7643,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, SP, M))
+                           nullptr, nullptr, nullptr, nullptr, nullptr, SP, M))
     return true;
   
   ValueDecl *VD;
@@ -7691,7 +7713,8 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, VTableState, M))
+                           nullptr, nullptr, nullptr, nullptr, nullptr,
+                           VTableState, M))
     return true;
 
 
@@ -7814,7 +7837,7 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr,
                            moveOnlyDeinitTableState, M))
     return true;
 
@@ -8359,8 +8382,9 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
           nullptr, &isSerialized, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-          nullptr, nullptr, nullptr, nullptr, &isSpecialized, nullptr, nullptr,
-          nullptr, nullptr, nullptr, nullptr, nullptr, WitnessState, M))
+          nullptr, nullptr, nullptr, nullptr, nullptr, &isSpecialized,
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+          WitnessState, M))
     return true;
 
   // Parse the protocol conformance.

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -74,6 +74,9 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
       M, silLinkage, IsNotSerialized, mangledName, silTy, std::nullopt, gDecl);
   silGlobal->setDeclaration(!forDef);
 
+  if (auto sectionAttr = gDecl->getAttrs().getAttribute<SectionAttr>())
+    silGlobal->setSection(sectionAttr->Name);
+
   return silGlobal;
 }
 

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -730,7 +730,7 @@ private:
             "global inst", &g);
 
         auto *decl = g.getDecl();
-        if (g.getSectionAttr()) {
+        if (!g.section().empty()) {
           module->getASTContext().Diags.diagnose(
             g.getDecl()->getLoc(), diag::bad_attr_on_non_const_global,
             "@_section");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1020,6 +1020,9 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       case ExtraStringFlavor::AsmName:
         fn->setAsmName(blobData);
         break;
+      case ExtraStringFlavor::Section:
+        fn->setSection(blobData);
+        break;
       }
       continue;
     }
@@ -4166,6 +4169,9 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
       case ExtraStringFlavor::AsmName:
         v->setAsmName(blobData);
         break;
+      case ExtraStringFlavor::Section:
+        v->setSection(blobData);
+        break;
       }
       continue;
     }
@@ -4180,6 +4186,7 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
   if (entry.Kind == llvm::BitstreamEntry::EndBlock)
     return v;
 
+  scratch.clear();
   maybeKind = SILCursor.readRecord(entry.ID, scratch, &blobData);
   if (!maybeKind)
     MF->fatal(maybeKind.takeError());

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 966; // SIL asmname
+const uint16_t SWIFTMODULE_VERSION_MINOR = 966; // SIL asmname/section
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 965; // WriteImplKindField and ReadWriteImplKindField size
+const uint16_t SWIFTMODULE_VERSION_MINOR = 966; // SIL asmname
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -81,6 +81,11 @@ enum class KeyPathComputedComponentIdKindEncoding : uint8_t {
   DeclRef,
 };
 
+enum class ExtraStringFlavor : uint8_t {
+  /// asmname attributes
+  AsmName,
+};
+
 /// The record types within the "sil-index" block.
 ///
 /// \sa SIL_INDEX_BLOCK_ID
@@ -186,6 +191,7 @@ namespace sil_block {
     SIL_SOURCE_LOC_REF,
     SIL_DEBUG_VALUE_DELIMITER,
     SIL_DEBUG_VALUE,
+    SIL_EXTRA_STRING,
   };
 
   using SILInstNoOperandLayout = BCRecordLayout<
@@ -295,6 +301,7 @@ namespace sil_block {
     BCFixed<1>,          // Is this a declaration.
     BCFixed<1>,          // Is this a let variable.
     BCFixed<1>,          // Is this marked as "used".
+    BCVBR<8>,            // # of trailing records
     TypeIDField,
     DeclIDField,
     ModuleIDField        // Parent ModuleDecl *
@@ -378,7 +385,7 @@ namespace sil_block {
                      BCFixed<1>,  // hasCReferences
                      BCFixed<1>,  // markedAsUsed
                      BCFixed<3>,  // side effect info.
-                     BCVBR<8>,    // number of specialize attributes
+                     BCVBR<8>,    // number of trailing records
                      BCFixed<1>,  // has qualified ownership
                      BCFixed<1>,  // force weak linking
                      BC_AVAIL_TUPLE, // availability for weak linking
@@ -417,6 +424,14 @@ namespace sil_block {
                      BCVBR<8>,          // argumentIndex
                      BCFixed<1>,        // argumentIndexValid
                      BCFixed<1>         // isDerived
+                     >;
+
+  /// Used for additional strings that can be associated with a record,
+  /// written out as records that trail
+  using SILExtraStringLayout =
+      BCRecordLayout<SIL_EXTRA_STRING,
+                     BCFixed<8>,    // string flavor
+                     BCBlob       // string data
                      >;
 
   // Has an optional argument list where each argument is a typed valueref.

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -84,6 +84,8 @@ enum class KeyPathComputedComponentIdKindEncoding : uint8_t {
 enum class ExtraStringFlavor : uint8_t {
   /// asmname attributes
   AsmName,
+  /// section attribute
+  Section,
 };
 
 /// The record types within the "sil-index" block.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -561,6 +561,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // count here.
   if (!F.asmName().empty())
     ++numTrailingRecords;
+  if (!F.section().empty())
+    ++numTrailingRecords;
 
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
@@ -600,6 +602,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // Each extra string emitted here needs to be reflected in the trailing
   // record count above.
   writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, F.asmName());
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::Section, F.section());
 
   if (NoBody)
     return;
@@ -3137,6 +3140,8 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
   // count here.
   if (!g.asmName().empty())
     ++numTrailingRecords;
+  if (!g.section().empty())
+    ++numTrailingRecords;
 
   SILGlobalVarLayout::emitRecord(Out, ScratchRecord,
                                  SILAbbrCodes[SILGlobalVarLayout::Code],
@@ -3149,6 +3154,7 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
                                  TyID, dID, parentModuleID);
 
   writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, g.asmName());
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::Section, g.section());
 
   // Don't emit the initializer instructions if not marked as "serialized".
   if (!g.isAnySerialized())

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -311,6 +311,9 @@ namespace {
     void writeSILBlock(const SILModule *SILMod);
     void writeIndexTables();
 
+    /// Write an extra-string record if the string itself is non-empty.
+    void writeExtraStringIfNonEmpty(ExtraStringFlavor flavor, StringRef string);
+
     /// Serialize and write SILDebugScope graph in post order.
     void writeDebugScopes(const SILDebugScope *Scope, const SourceManager &SM);
     void writeSourceLoc(SILLocation SLoc, const SourceManager &SM);
@@ -527,7 +530,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     usedAdHocWitnessFunctionID = S.addUniquedStringRef(fun->getName());
   }
 
-  unsigned numAttrs = NoBody ? 0 : F.getSpecializeAttrs().size();
+  unsigned numTrailingRecords = NoBody ? 0 : F.getSpecializeAttrs().size();
   auto resilience = F.getModule().getSwiftModule()->getResilienceStrategy();
   bool serializeDerivedEffects =
     // We must not serialize computed effects if library evolution is turned on,
@@ -544,7 +547,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     [&](int effectIdx, int argumentIndex, bool isDerived) {
       if (isDerived && !serializeDerivedEffects)
         return;
-      numAttrs++;
+      numTrailingRecords++;
     });
 
   std::optional<llvm::VersionTuple> available;
@@ -554,6 +557,11 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   }
   ENCODE_VER_TUPLE(available, available)
 
+  // Each extra string emitted below needs to update the trailing record
+  // count here.
+  if (!F.asmName().empty())
+    ++numTrailingRecords;
+
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
       (unsigned)F.isTransparent(), (unsigned)F.getSerializedKind(),
@@ -562,7 +570,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.getOptimizationMode(), (unsigned)F.getPerfConstraints(),
       (unsigned)F.getClassSubclassScope(), (unsigned)F.hasCReferences(),
       (unsigned)F.markedAsUsed(), (unsigned)F.getEffectsKind(),
-      (unsigned)numAttrs, (unsigned)F.hasOwnership(), F.isAlwaysWeakImported(),
+      (unsigned)numTrailingRecords, (unsigned)F.hasOwnership(), F.isAlwaysWeakImported(),
       LIST_VER_TUPLE_PIECES(available), (unsigned)F.isDynamicallyReplaceable(),
       (unsigned)F.isExactSelfClass(), (unsigned)F.isDistributed(),
       (unsigned)F.isRuntimeAccessible(),
@@ -588,6 +596,10 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
           Out, ScratchRecord, abbrCode, effectsStrID,
           argIdx, (unsigned)isGlobalSideEffects, (unsigned)isDerived);
     });
+
+  // Each extra string emitted here needs to be reflected in the trailing
+  // record count above.
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, F.asmName());
 
   if (NoBody)
     return;
@@ -3119,6 +3131,13 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
   if (auto *parentModule = g.getParentModule())
     parentModuleID = S.addModuleRef(parentModule);
 
+  unsigned numTrailingRecords = 0;
+
+  // Each extra string emitted below needs to update the trailing record
+  // count here.
+  if (!g.asmName().empty())
+    ++numTrailingRecords;
+
   SILGlobalVarLayout::emitRecord(Out, ScratchRecord,
                                  SILAbbrCodes[SILGlobalVarLayout::Code],
                                  toStableSILLinkage(g.getLinkage()),
@@ -3126,7 +3145,10 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
                                  (unsigned)!g.isDefinition(),
                                  (unsigned)g.isLet(),
                                  (unsigned)g.markedAsUsed(),
+                                 numTrailingRecords,
                                  TyID, dID, parentModuleID);
+
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, g.asmName());
 
   // Don't emit the initializer instructions if not marked as "serialized".
   if (!g.isAnySerialized())
@@ -3290,6 +3312,16 @@ void SILSerializer::writeSourceLoc(SILLocation Loc, const SourceManager &SM) {
   SourceLocLayout::emitRecord(Out, ScratchRecord,
                               SILAbbrCodes[SourceLocLayout::Code], Row, Column,
                               FNameID, LocationKind, (unsigned)Loc.isImplicit());
+}
+
+void SILSerializer::writeExtraStringIfNonEmpty(
+    ExtraStringFlavor flavor, StringRef string) {
+  if (string.empty())
+    return;
+
+  SILExtraStringLayout::emitRecord(
+      Out, ScratchRecord, SILAbbrCodes[SILExtraStringLayout::Code],
+      static_cast<uint8_t>(flavor), string);
 }
 
 void SILSerializer::writeDebugScopes(const SILDebugScope *Scope,
@@ -3658,6 +3690,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SourceLocLayout>();
   registerSILAbbr<SourceLocRefLayout>();
   registerSILAbbr<DebugValueDelimiterLayout>();
+  registerSILAbbr<SILExtraStringLayout>();
 
   // Write out VTables first because it may require serializations of
   // non-transparent SILFunctions (body is not needed).

--- a/test/Concurrency/global_function_pointer.swift
+++ b/test/Concurrency/global_function_pointer.swift
@@ -24,7 +24,7 @@ public func callAsync() async {
   await asyncFunc()
 }
 
-// CHECK-SIL-LABEL: sil_global @$s23global_function_pointer5gfptryyYacvp : $@async @callee_guaranteed () -> () = {
+// CHECK-SIL-LABEL: sil_global [section "__DATA,__mysection"] @$s23global_function_pointer5gfptryyYacvp : $@async @callee_guaranteed () -> () = {
 // CHECK-SIL:         %0 = function_ref @$s23global_function_pointer9callAsyncyyYaF : $@convention(thin) @async () -> ()
 // CHECK-SIL-NEXT:    %initval = thin_to_thick_function %0 : $@convention(thin) @async () -> () to $@async @callee_guaranteed () -> ()
 // CHECK-SIL-NEXT:  }

--- a/test/IRGen/asmname.sil
+++ b/test/IRGen/asmname.sil
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+
+import Swift
+
+// CHECK: @v1 = global
+sil_global [asmname "v1"] @$s4main13renamedGlobalSivp : $Int
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @f1()
+sil [asmname "f1"] @$s4main15renamedFunctionyyF : $@convention(thin) () -> () {
+  %0 = tuple ()
+  return %0
+}
+

--- a/test/IRGen/asmname.sil
+++ b/test/IRGen/asmname.sil
@@ -2,7 +2,7 @@
 
 import Swift
 
-// CHECK: @v1 = global
+// CHECK: @v1 = {{(dllexport )?}}{{(protected )?}}global
 sil_global [asmname "v1"] @$s4main13renamedGlobalSivp : $Int
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @f1()

--- a/test/SIL/Serialization/asmname.sil
+++ b/test/SIL/Serialization/asmname.sil
@@ -1,0 +1,16 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt -sil-print-types %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt -sil-print-types %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt -sil-print-types %t/tmp.2.sib -module-name asmname -emit-sorted-sil | %FileCheck %s
+
+import Swift
+
+// CHECK: sil_global [asmname "v1"] @$s4main13renamedGlobalSivp : $Int
+sil_global [asmname "v1"] @$s4main13renamedGlobalSivp : $Int
+
+// CHECK: sil [asmname "f1"] @$s4main15renamedFunctionyyF : $@convention(thin) () -> ()
+sil [asmname "f1"] @$s4main15renamedFunctionyyF : $@convention(thin) () -> () {
+  %0 = tuple ()
+  return %0
+}

--- a/test/SIL/Serialization/section.sil
+++ b/test/SIL/Serialization/section.sil
@@ -1,0 +1,18 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature SymbolLinkageMarkers %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature SymbolLinkageMarkers %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature SymbolLinkageMarkers %t/tmp.2.sib -module-name asmname -emit-sorted-sil | %FileCheck %s
+
+// REQUIRES: swift_feature_SymbolLinkageMarkers
+
+import Swift
+
+// CHECK: sil_global [section "__DATA,__mysection"] @v1 : $Int
+sil_global [section "__DATA,__mysection"] @v1 : $Int
+
+// CHECK: sil [section "__TEXT,__mysection"] @f : $@convention(thin) () -> ()
+sil [section "__TEXT,__mysection"] @f : $@convention(thin) () -> () {
+  %0 = tuple ()
+  return %0
+}

--- a/test/embedded/modules-used.swift
+++ b/test/embedded/modules-used.swift
@@ -45,7 +45,7 @@ struct Main {
 }
 
 // CHECK-SIL:      // i_am_not_referenced
-// CHECK-SIL-NEXT: sil_global [serialized] [let] [used] @$e8MyModule19i_am_not_referencedSivp : $Int = {
+// CHECK-SIL-NEXT: sil_global [serialized] [let] [used] [section "__DATA,__mysection"] @$e8MyModule19i_am_not_referencedSivp : $Int = {
 
 // CHECK: count: 1
 // CHECK: mysection[0]: 42


### PR DESCRIPTION
Adds the `asmname` attribute to SIL functions and global variables, which provides a different name that will be used when lowering the symbol to LLVM IR. Make sure asmname lowers correctly and round-trips through serialized SIL. This is part of a larger scheme to prevent Swift-level type differences in the declarations of C functions from manifesting as deserialization failures for SIL (rdar://137014448). The substantive part of that is still to come.

While here, use the SIL serialization logic needed for `asmname` to make the existing `section` attribute on SIL functions properly round-trip through SIL serialization. Do the same for SIL global variables, which also means adding support for parsing the `section` attribute on SIL global variables. Fixes rdar://162549960.