### PR TITLE
[SILGen]: ban forward captures of let temporary allocations

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -827,14 +827,15 @@ public:
       if (isUninitialized)
         address = SGF.B.createMarkUninitializedVar(vd, address);
       DestroyCleanup = SGF.enterDormantTemporaryCleanup(address, *lowering);
-      SGF.VarLocs[vd] = SILGenFunction::VarLoc(address,
-                                               SILAccessEnforcement::Unknown);
+
+      // N.B. We do not register the address in VarLocs yet so that the capture-
+      // before-definition machinery will diagnose such cases.
     }
     // Push a cleanup to destroy the let declaration.  This has to be
-    // inactive until the variable is initialized: if control flow exits the
+    // inactive until the variable is initialized: if control flow exits
     // before the value is bound, we don't want to destroy the value.
     //
-    // Cleanups are required for all lexically scoped variables to delimite
+    // Cleanups are required for all lexically scoped variables to delimit
     // the variable scope, even if the cleanup does nothing.
     SGF.Cleanups.pushCleanupInState<DestroyLocalVariable>(
       CleanupState::Dormant, vd);
@@ -1006,7 +1007,17 @@ public:
   void finishInitialization(SILGenFunction &SGF) override {
     assert(!DidFinish &&
            "called LetValueInit::finishInitialization twice!");
-    assert(SGF.VarLocs.count(vd) && "Didn't bind a value to this let!");
+
+    if (address) {
+      // We should have delayed registration to detect forward-declared
+      // captures.
+      assert(!SGF.VarLocs.count(vd) && "Should not have bound the let yet!");
+      SGF.VarLocs[vd] =
+          SILGenFunction::VarLoc(address, SILAccessEnforcement::Unknown);
+    } else {
+      // We should have already registered the variable in the non-address case.
+      assert(SGF.VarLocs.count(vd) && "Didn't bind a value to this let!");
+    }
 
     // Deactivate any cleanups we made when splitting the tuple.
     for (auto cleanup : SplitCleanups)


### PR DESCRIPTION
This addresses the same problem as https://github.com/swiftlang/swift/pull/37935
but handles address-only lets rather than vars.

fixes: https://github.com/swiftlang/swift/issues/85028
