### PR TITLE
Run closure specialization only if ownership info is present in callee

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -166,7 +166,16 @@ let autodiffClosureSpecialization = FunctionPass(name: "autodiff-closure-special
     var changed = false
     for inst in function.instructions {
       if let partialApply = inst as? PartialApplyInst,
-         partialApply.isPullbackInResultOfAutodiffVJP
+         partialApply.isPullbackInResultOfAutodiffVJP,
+         // Calling `cloneRecursively` from `SpecializationInfo.cloneClosures`
+         // requires the pullback having ownership info. Otherwise, the cloner
+         // uses `recordFoldedValue` instead of `recordClonedInstruction`, and
+         // `postProcess` hook is not called, which leads to an assertion
+         // failure in `BridgedClonerImpl::cloneInst`.
+         // TODO: investigate why the assertion fails only on Linux. See
+         // * https://github.com/swiftlang/swift/pull/84800#issuecomment-3398200989
+         // * https://github.com/swiftlang/swift/issues/84955
+         partialApply.referencedFunction?.hasOwnership == true
       {
         if trySpecialize(apply: partialApply, context) {
           changed = true


### PR DESCRIPTION
Calling `cloneRecursively` from `SpecializationInfo.cloneClosures` requires the callee having ownership info. Otherwise, the cloner uses `recordFoldedValue` instead of `recordClonedInstruction`, and `postProcess` hook is not called, which leads to an assertion failure in `BridgedClonerImpl::cloneInst`.
