### PR TITLE
[Sema] Quick fix for non-copyable type resolution crash

### DIFF
--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -46,3 +46,8 @@ func test_ambiguity_with_placeholders(pairs: [(rank: Int, count: Int)]) -> Bool 
 
 let unboundInPlaceholder1: Array<Never> = <#T##Array#> // expected-error{{editor placeholder in source file}}
 let unboundInPlaceholder2: Array<Never> = foo(<#T##t: Array##Array<Never>#>) // expected-error{{editor placeholder in source file}}
+
+// Make sure this doesn't crash:
+<#T##(Result) -> Void#> // expected-error {{editor placeholder in source file}}
+// expected-error@-1 {{generic parameter 'Success' could not be inferred}}
+// expected-error@-2 {{generic parameter 'Failure' could not be inferred}}

--- a/validation-test/compiler_crashers_2_fixed/1e0e4ce6cf612c7b.swift
+++ b/validation-test/compiler_crashers_2_fixed/1e0e4ce6cf612c7b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"checkRequirementsImpl(llvm::ArrayRef<swift::Requirement>, bool)","signatureAssert":"Assertion failed: (!firstType->hasTypeVariable()), function checkRequirementsImpl"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b: ~Copyable
   extension a: Copyable where b: Copyable
-    let c =  <#T##(a -> d)#>
+    let c  (a -> d

--- a/validation-test/compiler_crashers_2_fixed/a23d151072660954.swift
+++ b/validation-test/compiler_crashers_2_fixed/a23d151072660954.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"checkRequirementsImpl(llvm::ArrayRef<swift::Requirement>, bool)","signatureAssert":"Assertion failed: (!firstType->hasTypeVariable()), function checkRequirementsImpl"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b: ~Copyable
   extension a: Copyable where b: Copyable
-    let c  (a -> d
+    let c =  <#T##(a -> d)#>


### PR DESCRIPTION
Add a guard to make sure we don't attempt to check for Copyable conformance if the type contains type variables. This matches the existing behavior where we won't check for unbound generic types. Neither behavior is correct since we won't do the proper check once the generic type is opened, but this at least makes the behavior consistent and fixes the crash. It's also a very low risk fix that can be cherry-picked.

rdar://152287178