### PR TITLE
Serialization: Fix null dereference in witness deserialization

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9158,7 +9158,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
 
     // Determine whether we need to enter the actor isolation of the witness.
     std::optional<ActorIsolation> enterIsolation;
-    if (*rawIDIter++) {
+    if (*rawIDIter++ && witness) {
       enterIsolation = getActorIsolation(witness);
     }
 


### PR DESCRIPTION
Fix null dereference in deserialization logic for conformances. If deserializing the witness itself failed, don't try to get its actor isolation.

rdar://162158608