### PR TITLE
Fix -Wdangling-assignment-gsl warnings

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -897,10 +897,7 @@ public:
                      const std::pair<SILInstruction *, InterestingUser> &)>>;
   UserBlockRange getAllUserBlocks() const {
     assert(isInitialized());
-    function_ref<SILBasicBlock *(
-        const std::pair<SILInstruction *, InterestingUser> &)>
-        op;
-    op = [](const std::pair<SILInstruction *, InterestingUser> &pair)
+    auto op = [](const std::pair<SILInstruction *, InterestingUser> &pair)
         -> SILBasicBlock * { return pair.first->getParent(); };
     return UserBlockRange(getAllUsers(), op);
   }

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -990,8 +990,7 @@ public:
                      function_ref<SILBasicBlock *(const SILInstruction *&)>>;
   NonLifetimeEndingUsesInLiveOutBlocksRange
   getNonLifetimeEndingUsesInLiveOutBlocks() const {
-    function_ref<SILBasicBlock *(const SILInstruction *&)> op;
-    op = [](const SILInstruction *&ptr) -> SILBasicBlock * {
+    auto op = [](const SILInstruction *&ptr) -> SILBasicBlock * {
       return ptr->getParent();
     };
     return NonLifetimeEndingUsesInLiveOutBlocksRange(

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1850,8 +1850,7 @@ bool TermInst::isProgramTerminating() const {
 
 TermInst::SuccessorBlockArgumentListTy
 TermInst::getSuccessorBlockArgumentLists() const {
-  function_ref<ArrayRef<SILArgument *>(const SILSuccessor &)> op;
-  op = [](const SILSuccessor &succ) -> ArrayRef<SILArgument *> {
+  auto op = [](const SILSuccessor &succ) -> ArrayRef<SILArgument *> {
     return succ.getBB()->getArguments();
   };
   return SuccessorBlockArgumentListTy(getSuccessors(), op);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7400,10 +7400,11 @@ computeLinearityParameters(ArrayRef<ParsedAutoDiffParameter> parsedLinearParams,
   if (isCurried)
     transposeResultType =
         transposeResultType->castTo<AnyFunctionType>()->getResult();
+  TupleTypeElt elementType(transposeResultType);
   if (auto resultTupleType = transposeResultType->getAs<TupleType>()) {
     transposeResultTypes = resultTupleType->getElements();
   } else {
-    transposeResultTypes = ArrayRef<TupleTypeElt>(transposeResultType);
+    transposeResultTypes = ArrayRef<TupleTypeElt>(elementType);
   }
 
   // If `self` is a linearity parameter, the transpose function must be static.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2255,11 +2255,7 @@ static Type validateParameterType(ParamDecl *decl) {
   if (isa<AbstractClosureExpr>(dc)) {
     options = TypeResolutionOptions(TypeResolverContext::ClosureExpr);
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;
-    unboundTyOpener = [](auto unboundTy) {
-      // FIXME: Don't let unbound generic types escape type resolution.
-      // For now, just return the unbound generic type.
-      return unboundTy;
-    };
+    unboundTyOpener = TypeResolution::defaultUnboundTypeOpener;
     // FIXME: Don't let placeholder types escape type resolution. For now, just
     // return the placeholder type, which we open in `inferClosureType`.
     placeholderOpener = PlaceholderType::get;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -845,11 +845,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
     HandlePlaceholderTypeReprFn placeholderHandler = nullptr;
     OpenPackElementFn packElementOpener = nullptr;
     if (pattern.allowsInference()) {
-      unboundTyOpener = [](auto unboundTy) {
-        // FIXME: Don't let unbound generic types escape type resolution.
-        // For now, just return the unbound generic type.
-        return unboundTy;
-      };
+      unboundTyOpener = TypeResolution::defaultUnboundTypeOpener;
       // FIXME: Don't let placeholder types escape type resolution.
       // For now, just return the placeholder type.
       placeholderHandler = PlaceholderType::get;
@@ -913,11 +909,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
       HandlePlaceholderTypeReprFn placeholderHandler = nullptr;
       OpenPackElementFn packElementOpener = nullptr;
       if (pattern.allowsInference()) {
-        unboundTyOpener = [](auto unboundTy) {
-          // FIXME: Don't let unbound generic types escape type resolution.
-          // For now, just return the unbound generic type.
-          return unboundTy;
-        };
+        unboundTyOpener = TypeResolution::defaultUnboundTypeOpener;
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
         placeholderHandler = PlaceholderType::get;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6940,12 +6940,7 @@ Type CustomAttrTypeRequest::evaluate(Evaluator &eval, CustomAttr *attr,
   OpenUnboundGenericTypeFn unboundTyOpener = nullptr;
   // Property delegates allow their type to be an unbound generic.
   if (typeKind == CustomAttrTypeKind::PropertyWrapper) {
-    unboundTyOpener = [](auto unboundTy) {
-      // FIXME: Don't let unbound generic types
-      // escape type resolution. For now, just
-      // return the unbound generic type.
-      return unboundTy;
-    };
+    unboundTyOpener = TypeResolution::defaultUnboundTypeOpener;
   }
 
   const auto type = TypeResolution::resolveContextualType(

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -675,6 +675,12 @@ public:
     return unboundTyOpener;
   }
 
+  static Type defaultUnboundTypeOpener(UnboundGenericType *ty) {
+    // FIXME: Don't let unbound generic types escape type resolution.
+    // For now, just return the unbound generic type.
+    return ty;
+  }
+
   HandlePlaceholderTypeReprFn getPlaceholderHandler() const {
     return placeholderHandler;
   }


### PR DESCRIPTION
Fix new clang warnings that can indicate potential use-after-free from
dangling pointers.

The issues are mostly coming from `llvm::function_ref` are not owning
the function, and `std::function` should be used in those cases.
