### PR TITLE
[CAS] Update swift CAS file system usage after llvm-project change

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -527,7 +527,7 @@ GROUPED_ERROR(error_invalid_cas_id, CompilationCaching, none, "CAS cannot parse 
 GROUPED_ERROR(error_cas, CompilationCaching, none, "CAS error encountered during %0: %1", (StringRef, StringRef))
 GROUPED_ERROR(error_cas_fs_creation, CompilationCaching, none, "cannot create CAS filesystem: %0", (StringRef))
 GROUPED_ERROR(error_cache_key_creation, CompilationCaching, none, "cannot create cache key for compilation %0: %1", (StringRef, StringRef))
-GROUPED_ERROR(error_cas_file_ref, CompilationCaching, none, "cannot load file %0 from CAS filesystem", (StringRef))
+GROUPED_ERROR(error_cas_file_ref, CompilationCaching, none, "cannot load file %0 from CAS filesystem: %1", (StringRef, StringRef))
 GROUPED_ERROR(error_cas_conflict_options, CompilationCaching, none, "cannot setup CAS due to conflicting '-cas-*' options", ())
 GROUPED_ERROR(error_cas_initialization, CompilationCaching, none, "CAS cannot be initialized from the specified '-cas-*' options: %0", (StringRef))
 GROUPED_ERROR(error_cas_malformed_input, CompilationCaching, none, "CAS input '%0' is malformed: %1", (StringRef, StringRef))

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -17,6 +17,7 @@
 #include "swift/Serialization/ScanningLoaders.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "llvm/CAS/CASReference.h"
+#include "llvm/CAS/CASFileSystem.h"
 #include "llvm/Support/ThreadPool.h"
 
 namespace swift {
@@ -249,7 +250,7 @@ public:
     return *CAS;
   }
 
-  llvm::vfs::FileSystem &getSharedCachingFS() const {
+  llvm::cas::CASBackedFileSystem &getSharedCachingFS() const {
     assert(CacheFS && "Expect CacheFS available");
     return *CacheFS;
   }
@@ -358,7 +359,7 @@ private:
   /// File prefix mapper.
   std::unique_ptr<llvm::PrefixMapper> PrefixMapper;
   /// CAS file system for loading file content.
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> CacheFS;
+  llvm::IntrusiveRefCntPtr<llvm::cas::CASBackedFileSystem> CacheFS;
   /// Protect worker access.
   std::mutex WorkersLock;
   /// Count of filesystem queries performed

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -549,14 +549,14 @@ private:
     // action cache. We just use the CASID of the binary module itself as key.
     auto Ref = CASFS.getObjectRefForFileContent(path);
     if (!Ref) {
-      instance.getDiags().diagnose(SourceLoc(), diag::error_cas_file_ref, path);
+      instance.getDiags().diagnose(SourceLoc(), diag::error_cas_file_ref, path,
+                                   toString(Ref.takeError()));
       return true;
     }
-    assert(*Ref && "Binary module should be loaded into CASFS already");
-    depInfo.updateModuleCacheKey(CAS.getID(**Ref).toString());
+    depInfo.updateModuleCacheKey(CAS.getID(*Ref).toString());
 
     swift::cas::CompileJobCacheResult::Builder Builder;
-    Builder.addOutput(file_types::ID::TY_SwiftModuleFile, **Ref);
+    Builder.addOutput(file_types::ID::TY_SwiftModuleFile, *Ref);
     auto Result = Builder.build(CAS);
     if (!Result) {
       instance.getDiags().diagnose(SourceLoc(), diag::error_cas,
@@ -564,7 +564,7 @@ private:
                                    toString(Result.takeError()));
       return true;
     }
-    if (auto E = instance.getActionCache().put(CAS.getID(**Ref),
+    if (auto E = instance.getActionCache().put(CAS.getID(*Ref),
                                                CAS.getID(*Result))) {
       instance.getDiags().diagnose(
           SourceLoc(), diag::error_cas,


### PR DESCRIPTION
Update swift compiler to go with llvm CAS update to decouple CAS file system from VFS that breaks layering violation.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
