### PR TITLE
[test] Disable `Sema/large_int_array.swift.gyb` for watchOS simulator due to timeout

### DIFF
--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -3,6 +3,9 @@
 // RUN: %target-swift-frontend -typecheck -verify %t/large_int_array.swift
 // RUN: %target-swift-frontend %t/large_int_array.swift -emit-sil -o %t
 
+// rdar://162566682
+// UNSUPPORTED: OS=watchossimulator
+
 % num_elements = 65537
 
 let v = 0


### PR DESCRIPTION
rdar://162566682