### PR TITLE
Android: correct module name for `_math`

### DIFF
--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(swift_math
   Math.swift)
 set_target_properties(swift_math PROPERTIES
-  Swift_MODULE_NAME math)
+  Swift_MODULE_NAME _math)
 target_link_libraries(swift_math PRIVATE
   SwiftAndroid
   swiftCore)


### PR DESCRIPTION
This module was named improperly during the migration. Correct the name to `_math`.