### PR TITLE
CMake: add Observation dependency to libraries that import Foundation...

### DIFF
--- a/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(swift_stdlib_unittest_compile_flags)
 
+if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
+  # This library imports Foundation from the SDK, which re-exports
+  # Observation which is part of this build.
+  list(APPEND swift_stdlib_unicode_unittest_darwin_dependencies Observation)
+endif()
+
 add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -10,6 +16,12 @@ add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD
   WordBreaking.swift
 
   SWIFT_MODULE_DEPENDS StdlibUnittest
+  SWIFT_MODULE_DEPENDS_IOS ${swift_stdlib_unicode_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_stdlib_unicode_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_stdlib_unicode_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_stdlib_unicode_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_XROS ${swift_stdlib_unicode_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_stdlib_unicode_unittest_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_LINUX_STATIC Musl

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -9,6 +9,12 @@ if((SWIFT_BUILD_CLANG_OVERLAYS
   list(APPEND swift_stdlib_unittest_darwin_dependencies _Builtin_float)
 endif()
 
+if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
+  # This library imports Foundation from the SDK, which re-exports
+  # Observation which is part of this build.
+  list(APPEND swift_stdlib_unittest_darwin_dependencies Observation)
+endif()
+
 set(swift_stdlib_unittest_compile_flags
   "-Xfrontend" "-disable-objc-attr-requires-foundation-module")
 

--- a/stdlib/private/StdlibUnittestFoundationExtras/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittestFoundationExtras/CMakeLists.txt
@@ -1,9 +1,21 @@
+if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
+  # This library imports Foundation from the SDK, which re-exports
+  # Observation which is part of this build.
+  list(APPEND swift_stdlib_unittest_foundationextras_darwin_dependencies Observation)
+endif()
+
 add_swift_target_library(swiftStdlibUnittestFoundationExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   StdlibUnittestFoundationExtras.swift
   UnavailableFoundationMethodThunks.mm
 
+  SWIFT_MODULE_DEPENDS_IOS ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_XROS ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_stdlib_unittest_foundationextras_darwin_dependencies}
   SWIFT_MODULE_DEPENDS StdlibUnittest
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental


### PR DESCRIPTION
when building for Apple platforms.

In this scenario we are not building our own Foundation, but we are importing the one from the underlying SDK -- this in turns requires Observation, which is something we typically build.

Addresses rdar://162286123