### PR TITLE
[6.2] [Sema] Quick fix for non-copyable type resolution crash

### DIFF
--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -40,3 +40,8 @@ func test_ambiguity_with_placeholders(pairs: [(rank: Int, count: Int)]) -> Bool 
 
 let unboundInPlaceholder1: Array<Never> = <#T##Array#> // expected-error{{editor placeholder in source file}}
 let unboundInPlaceholder2: Array<Never> = foo(<#T##t: Array##Array<Never>#>) // expected-error{{editor placeholder in source file}}
+
+// Make sure this doesn't crash:
+<#T##(Result) -> Void#> // expected-error {{editor placeholder in source file}}
+// expected-error@-1 {{generic parameter 'Success' could not be inferred}}
+// expected-error@-2 {{generic parameter 'Failure' could not be inferred}}

--- a/validation-test/compiler_crashers_2_fixed/1e0e4ce6cf612c7b.swift
+++ b/validation-test/compiler_crashers_2_fixed/1e0e4ce6cf612c7b.swift
@@ -1,0 +1,5 @@
+// {"kind":"typecheck","signature":"checkRequirementsImpl(llvm::ArrayRef<swift::Requirement>, bool)","signatureAssert":"Assertion failed: (!firstType->hasTypeVariable()), function checkRequirementsImpl"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a<b: ~Copyable
+  extension a: Copyable where b: Copyable
+    let c  (a -> d

--- a/validation-test/compiler_crashers_2_fixed/a23d151072660954.swift
+++ b/validation-test/compiler_crashers_2_fixed/a23d151072660954.swift
@@ -1,0 +1,5 @@
+// {"kind":"typecheck","signature":"checkRequirementsImpl(llvm::ArrayRef<swift::Requirement>, bool)","signatureAssert":"Assertion failed: (!firstType->hasTypeVariable()), function checkRequirementsImpl"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a<b: ~Copyable
+  extension a: Copyable where b: Copyable
+    let c =  <#T##(a -> d)#>


### PR DESCRIPTION
*6.2 cherry-pick of #84957*

- Explanation: Fixes a crash that could occur when referencing an unbound generic type with a conditional Copyable conformance in a function parameter
- Scope: Affects type resolution diagnostic logic for non-copyable types 
- Issue: rdar://152287178
- Risk: Low, the fix is narrow and matches the existing logic we have for unbound generics that haven't been opened
- Testing: Added tests to test suite
- Reviewer: Slava Pestov