### PR TITLE
Drop CMakeConfig.h from Config.h

### DIFF
--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -134,9 +134,6 @@ endif()
 target_include_directories(swiftDistributed PRIVATE
   # FIXME: Use of `swift/Runtime/...`, `swift/ABI/...`, and `swift/Demangling/...`
   "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include"
-  # For `swift/runtime/CMakeConfig.h`, which should be generated
-  # by the Core build system.
-  "${${PROJECT_NAME}_PATH_TO_SWIFT_RUNTIME_HEADERS}"
   # For llvm/support headers
   "${PROJECT_SOURCE_DIR}/include")
 

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -110,10 +110,7 @@ set_target_properties(swiftObservation PROPERTIES
 # FIXME: We should split out the parts that are needed by the runtime to avoid
 # pulling in headers from the compiler.
 target_include_directories(swiftObservation PRIVATE
-  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include"
-  # For `swift/runtime/CMakeConfig.h`, which should be generated
-  # by the Core build system.
-  "${${PROJECT_NAME}_PATH_TO_SWIFT_RUNTIME_HEADERS}")
+  "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include")
 target_link_libraries(swiftObservation PRIVATE
   swiftShims
   swiftCore

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -18,7 +18,6 @@
 #define SWIFT_RUNTIME_CONFIG_H
 
 #include "swift/Basic/Compiler.h"
-#include "swift/Runtime/CMakeConfig.h"
 
 /// SWIFT_RUNTIME_WEAK_IMPORT - Marks a symbol for weak import.
 #if (__has_attribute(weak_import))


### PR DESCRIPTION
Config.h does not use the Swift version written into CMakeConfig.h. CMakeConfig.h isn't installed, while Config.h is, resulting in a situation where you can't actually build against products that are installed because headers are missing. This affects the Distributed and Observation builds build, which indirectly includes Config.h.

```
In file included from .../Swift-Project/swift/Runtimes/Supplemental/Distributed/DistributedActor.cpp:17:
In file included from .../Swift-Project/swift/Runtimes/Supplemental/Distributed/../../../include/swift/ABI/Actor.h:20:
In file included from .../Swift-Project/swift/Runtimes/Supplemental/Distributed/../../../include/swift/ABI/HeapObject.h:20:
In file included from .../Swift-Project/swift/Runtimes/Core/SwiftShims/swift/shims/../../swift/shims/HeapObject.h:15:
In file included from .../Swift-Project/swift/Runtimes/Core/SwiftShims/swift/shims/../../swift/shims/RefCount.h:38:
In file included from .../Swift-Project/swift/Runtimes/Supplemental/Distributed/../../../include/swift/Runtime/Atomic.h:20:
.../Swift-Project/swift/Runtimes/Supplemental/Distributed/../../../include/swift/Runtime/Config.h:21:10: fatal error: 'swift/Runtime/CMakeConfig.h' file not found
   21 | #include "swift/Runtime/CMakeConfig.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

By dropping the unneeded include of CMakeConfig.h, we don't need to access files from swiftCore sources and the runtime libraries are closer to being self-contained projects. The files that do need `CMakeConfig.h`, which just contains version information, include it directly.