### PR TITLE
[ASTPrinter/Parse] Disambiguate accessor block in .swiftinterface

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -367,6 +367,11 @@ extension ASTGenVisitor {
         break
 
       case .none:
+        // '@_accessorBlock' is a parser only disambiguation marker, ignore.
+        if attrName == "_accessorBlock" {
+          return
+        }
+
         // Fall back to CustomAttr.
         break
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8167,6 +8167,14 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
   bool IsFirstAccessor = true;
   bool hasEffectfulGet = false;
   accessors.LBLoc = consumeToken(tok::l_brace);
+
+  // Skip accessor-block disambiguation attribute if exist.
+  if (Tok.is(tok::at_sign) &&
+      peekToken().isContextualKeyword("_accessorBlock")) {
+    consumeToken(tok::at_sign);
+    consumeToken();
+  }
+
   while (!Tok.isAny(tok::r_brace, tok::eof)) {
     // Parse introducer if possible.
     DeclAttributes Attributes;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1127,6 +1127,10 @@ bool Parser::isStartOfGetSetAccessor() {
   // Eat the "{".
   consumeToken(tok::l_brace);
 
+  // '@_accessorBlock' is a builtin disambiguation marker.
+  if (peekToken().isContextualKeyword("_accessorBlock"))
+    return true;
+
   // Eat attributes, if present.
   while (consumeIf(tok::at_sign)) {
     if (!consumeIf(tok::identifier))

--- a/test/ModuleInterface/var-with-init-and-accessors.swiftinterface
+++ b/test/ModuleInterface/var-with-init-and-accessors.swiftinterface
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
+
+// RUN: %FileCheck %s --check-prefix INTERFACE --input-file %t/Test.swiftinterface
+
+@frozen public struct Struct {
+    public var values: [Int] = .init() {
+        willSet {}
+    }
+}
+// INTERFACE: @frozen public struct Struct {
+// INTERFACE-LABEL: @_hasStorage public var values: [Swift.Int] = .init() { @_accessorBlock
+// INTERFACE-NEXT:     @_transparent get
+// INTERFACE-NEXT:     set
+// INTERFACE-NEXT:   }
+// INTERFACE: }


### PR DESCRIPTION
.swiftinterface sometimes prints a pattern binding initializer and the accessor block. However the parser doesn't expect such constructs and the disambiguation from trailing closures would be fragile. To make it reliable, introduce a disambiguation marker `@_accessorBlock` . `ASTPrinter` print it right after `{` only if 1) The accrssor block is for a pattern binding declration, 2) the decl has an initializer printed, and 3) the non-observer accessor block is being printed. In the parser, If the block after an initializer starts with `{ @_accessorBlock` it's always parsed as an accessor block instead of a trailing closure.

rdar://140943107
