### PR TITLE
[Distributed] Copy @available and spi for resolvable extensions

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -26,6 +26,12 @@ public struct DistributedResolvableMacro: ExtensionMacro, PeerMacro {
 
 extension DistributedResolvableMacro {
 
+  static let attributesToCopy: [String] = [
+    "available",
+    "_spi",
+    "_spi_available",
+  ]
+
   /// Introduce the `extension MyDistributedActor` which contains default
   /// implementations of the protocol's requirements.
   public static func expansion(
@@ -46,7 +52,9 @@ extension DistributedResolvableMacro {
     }
 
     let attributes = proto.attributes.filter { attr in
-      attr.as(AttributeSyntax.self)?.attributeName.trimmed.description == "_spi"
+      Self.attributesToCopy.contains(
+        attr.as(AttributeSyntax.self)?.attributeName.trimmed.description ?? ""
+      )
     }
     let accessModifiers = proto.accessControlModifiers
 
@@ -67,7 +75,7 @@ extension DistributedResolvableMacro {
 
     let extensionDecl: DeclSyntax =
       """
-      \(raw: attributes.map({$0.description}).joined(separator: "\n"))
+      \(attributes)
       extension \(proto.name.trimmed) where Self: Distributed._DistributedActorStub {
         \(raw: requirementStubs)
       }
@@ -160,7 +168,7 @@ extension DistributedResolvableMacro {
       guard let ident = attr.attributeName.as(IdentifierTypeSyntax.self) else {
         return false
       }
-      return ident.name.text == "_spi"
+      return Self.attributesToCopy.contains(ident.name.text)
     }
     let accessModifiers = proto.accessControlModifiers
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_availability.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_availability.swift
@@ -12,6 +12,7 @@
 import Distributed
 
 @Resolvable
+@available(iOS 666, macOS 777, tvOS 888, visionOS 999, *)
 public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   @available(iOS 6666, macOS 7777, tvOS 8888, visionOS 9999, *)
   distributed func greet(name: String) -> String
@@ -22,12 +23,14 @@ public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSys
 
 // @Resolvable ->
 
+// CHECK: @available(iOS 666, macOS 777, tvOS 888, visionOS 999, *)
 // CHECK: public distributed actor $Greeter<ActorSystem>: Greeter,
 // CHECK:   Distributed._DistributedActorStub
 // CHECK:   where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK: {
 // CHECK: }
 
+// CHECK: @available(iOS 666, macOS 777, tvOS 888, visionOS 999, *)
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK:   @available(iOS 6666, macOS 7777, tvOS 8888, visionOS 9999, *)
 // CHECK:   public

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
@@ -8,13 +8,15 @@
 // RUN: %empty-directory(%t-scratch)
 
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -parse-as-library -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-swift-frontend -Onone -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -parse-as-library -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-swift-frontend -O -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -parse-as-library -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
 
 import Distributed
 import FakeDistributedActorSystems
 
 @Resolvable
 @_spi(CoolFeatures)
+@available(SwiftStdlib 6.0, *)
 public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet(name: String) -> String
 }
@@ -22,6 +24,7 @@ public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSys
 // @Resolvable ->
 
 // CHECK: @_spi(CoolFeatures)
+// CHECK: @available(SwiftStdlib 6.0, *)
 // CHECK: distributed actor $Greeter<ActorSystem>: Greeter,
 // CHECK-NEXT: Distributed._DistributedActorStub
 // CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>
@@ -29,6 +32,7 @@ public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSys
 // CHECK: }
 
 // CHECK: @_spi(CoolFeatures)
+// CHECK: @available(SwiftStdlib 6.0, *)
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK:       distributed func greet(name: String) -> String {
 // CHECK-NEXT:     if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
@@ -41,6 +45,7 @@ public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSys
 
 @_spi(DistributedSPIForTesting)
 @Resolvable
+@available(SwiftStdlib 6.0, *)
 public protocol GreeterWithSPISystem: DistributedActor where ActorSystem == FakeActorSystemWithSPI {
   distributed func greet(name: String) -> String
 }
@@ -48,6 +53,7 @@ public protocol GreeterWithSPISystem: DistributedActor where ActorSystem == Fake
 // @Resolvable ->
 
 // CHECK: @_spi(DistributedSPIForTesting)
+// CHECK: @available(SwiftStdlib 6.0, *)
 // CHECK: public distributed actor $GreeterWithSPISystem: GreeterWithSPISystem,
 // CHECK-NEXT: Distributed._DistributedActorStub
 // CHECK-NEXT: {
@@ -55,6 +61,7 @@ public protocol GreeterWithSPISystem: DistributedActor where ActorSystem == Fake
 // CHECK-NEXT: }
 
 // CHECK: @_spi(DistributedSPIForTesting)
+// CHECK: @available(SwiftStdlib 6.0, *)
 // CHECK: extension GreeterWithSPISystem where Self: Distributed._DistributedActorStub {
 // CHECK:       public distributed func greet(name: String) -> String {
 // CHECK-NEXT:     if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {


### PR DESCRIPTION
Seems we missed doing so on the type itself, even if we did on member functions already

Relates to rdar://162800185
