### PR TITLE
tests: temporarily disable the SIL verifier in Sema/large_int_array.swift.gyb

### DIFF
--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/large_int_array.swift
 // RUN: %target-swift-frontend -typecheck -verify %t/large_int_array.swift
-// RUN: %target-swift-frontend %t/large_int_array.swift -emit-sil -o %t
+
+// verification is disabled because the ownership verifier takes too long: rdar://162566682
+// RUN: %target-swift-frontend -sil-verify-none %t/large_int_array.swift -emit-sil -o %t
 
 % num_elements = 65537
 


### PR DESCRIPTION
The ownership verifier takes too long.

rdar://162566682
