### PR TITLE
[concurrency] new Clock and Executor symbol availability fix

### DIFF
--- a/stdlib/public/Concurrency/CFExecutor.swift
+++ b/stdlib/public/Concurrency/CFExecutor.swift
@@ -48,7 +48,7 @@ enum CoreFoundation {
 // .. Main Executor ............................................................
 
 /// A CFRunLoop-based main executor (Apple platforms only)
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 final class CFMainExecutor: DispatchMainExecutor, @unchecked Sendable {
 
   override public func run() throws {
@@ -64,7 +64,7 @@ final class CFMainExecutor: DispatchMainExecutor, @unchecked Sendable {
 // .. Task Executor ............................................................
 
 /// A `TaskExecutor` to match `CFMainExecutor` (Apple platforms only)
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 final class CFTaskExecutor: DispatchGlobalTaskExecutor,
                             @unchecked Sendable {
 

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -50,7 +50,7 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
-  @available(StdlibDeploymentTarget 6.2, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   func run(_ job: consuming ExecutorJob,
            at instant: Instant, tolerance: Duration?)
 
@@ -70,7 +70,7 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
-  @available(StdlibDeploymentTarget 6.2, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   func enqueue(_ job: consuming ExecutorJob,
                on executor: some Executor,
                at instant: Instant, tolerance: Duration?)
@@ -81,7 +81,7 @@ public protocol Clock<Duration>: Sendable {
 extension Clock {
   // The default implementation works by creating a trampoline and calling
   // the run() method.
-  @available(StdlibDeploymentTarget 6.2, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   public func enqueue(_ job: consuming ExecutorJob,
                       on executor: some Executor,
                       at instant: Instant, tolerance: Duration?) {
@@ -91,7 +91,7 @@ extension Clock {
 
   // Clocks that do not implement run will fatalError() if you try to use
   // them with an executor that does not understand them.
-  @available(StdlibDeploymentTarget 6.2, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   public func run(_ job: consuming ExecutorJob,
                   at instant: Instant, tolerance: Duration?) {
     fatalError("\(Self.self) does not implement run(_:at:tolerance:).")

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -213,7 +213,7 @@ extension ContinuousClock.Instant: InstantProtocol {
 }
 
 #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 extension ContinuousClock {
 
   public func run(_ job: consuming ExecutorJob,

--- a/stdlib/public/Concurrency/CooperativeExecutor.swift
+++ b/stdlib/public/Concurrency/CooperativeExecutor.swift
@@ -244,7 +244,7 @@ final class CooperativeExecutor: Executor, @unchecked Sendable {
 }
 
 #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 extension CooperativeExecutor: SchedulingExecutor {
 
   public var asScheduling: (any SchedulingExecutor)? {

--- a/stdlib/public/Concurrency/DispatchExecutor.swift
+++ b/stdlib/public/Concurrency/DispatchExecutor.swift
@@ -24,7 +24,7 @@ import Swift
 // .. Main Executor ............................................................
 
 /// A Dispatch-based main executor.
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 class DispatchMainExecutor: RunLoopExecutor, SchedulingExecutor,
                             @unchecked Sendable {
   var threaded = false
@@ -57,7 +57,7 @@ class DispatchMainExecutor: RunLoopExecutor, SchedulingExecutor,
   }
 }
 
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 extension DispatchMainExecutor: SerialExecutor {
 
   public func enqueue(_ job: consuming ExecutorJob) {
@@ -71,13 +71,13 @@ extension DispatchMainExecutor: SerialExecutor {
   }
 }
 
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 extension DispatchMainExecutor: MainExecutor {}
 
 // .. Task Executor ............................................................
 
 /// A Dispatch-based `TaskExecutor`
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 class DispatchGlobalTaskExecutor: TaskExecutor, SchedulingExecutor,
                                   @unchecked Sendable {
   public init() {}
@@ -148,7 +148,7 @@ fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C
   fatalError("unknown clock in Dispatch Executor")
 }
 
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 fileprivate func _dispatchEnqueue<C: Clock, E: Executor>(
   _ job: consuming ExecutorJob,
   at instant: C.Instant,

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -604,7 +604,7 @@ public protocol ExecutorFactory {
   static var defaultExecutor: any TaskExecutor { get }
 }
 
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 typealias DefaultExecutorFactory = PlatformExecutorFactory
 
 @available(StdlibDeploymentTarget 6.2, *)
@@ -616,7 +616,7 @@ public func _createExecutors<F: ExecutorFactory>(factory: F.Type) {
   Task._defaultExecutor = factory.defaultExecutor
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftStdlib 6.3, *)
 @_silgen_name("swift_createDefaultExecutors")
 func _createDefaultExecutors() {
   if Task._defaultExecutor == nil {

--- a/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
@@ -14,7 +14,7 @@
 
 import Swift
 
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static var mainExecutor: any MainExecutor {
     if CoreFoundation.isPresent {

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -191,7 +191,7 @@ extension SuspendingClock.Instant: InstantProtocol {
 }
 
 #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(StdlibDeploymentTarget 6.2, *)
+@available(StdlibDeploymentTarget 6.3, *)
 extension SuspendingClock {
 
   public func run(_ job: consuming ExecutorJob,


### PR DESCRIPTION
After we (finally) [merged](https://github.com/swiftlang/swift/pull/83294) the updated the availability macros for SwiftStdlib 6.2, some new `Clock`- and executor-related symbols had the wrong availability.

This is a simple attempt at a fix.

Addresses rdar://162819688