### PR TITLE
Optimizer: some small (mandatory) optimization improvements for static initialization of globals

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -220,7 +220,8 @@ struct AliasAnalysis {
          is StrongCopyUnmanagedValueInst,
          is StrongCopyWeakValueInst,
          is BeginBorrowInst,
-         is BeginCOWMutationInst:
+         is BeginCOWMutationInst,
+         is DebugStepInst:
       return .noEffects
 
     case let load as LoadInst:

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
@@ -53,6 +53,10 @@ import SIL
 let deadStoreElimination = FunctionPass(name: "dead-store-elimination") {
   (function: Function, context: FunctionPassContext) in
 
+  eliminateDeadStores(in: function, context)
+}
+
+func eliminateDeadStores(in function: Function, _ context: FunctionPassContext) {
   // Avoid quadratic complexity by limiting the number of visited instructions.
   // This limit is sufficient for most "real-world" functions, by far.
   var complexityBudget = 10_000

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -210,7 +210,7 @@ private extension LoadingInstruction {
         return false
       }
       switch address.accessBase {
-      case .box, .stack:
+      case .box, .stack, .global:
         break
       default:
         return false

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -219,6 +219,12 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
     changed = context.eliminateDeadAllocations(in: function) || changed
   }
+
+  if function.isGlobalInitOnceFunction {
+    // Cleanup leftovers from simplification. The InitializeStaticGlobals pass cannot deal with dead
+    // stores in global init functions.
+    eliminateDeadStores(in: function, context)
+  }
 }
 
 private func inlineAndDevirtualize(apply: FullApplySite, alreadyInlinedFunctions: inout Set<PathFunctionTuple>,

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
@@ -77,7 +77,8 @@ private extension Instruction {
          is StoreBorrowInst,
          is MarkDependenceInst,
          is MarkDependenceAddrInst,
-         is DebugValueInst:
+         is DebugValueInst,
+         is DebugStepInst:
       return true
     default:
       return false

--- a/test/SILOptimizer/mandatory-redundant-load-elim.sil
+++ b/test/SILOptimizer/mandatory-redundant-load-elim.sil
@@ -1922,3 +1922,17 @@ bb0(%0 : $MyInt, %1 : @guaranteed $Foo, %2 : @guaranteed $Baz):
   dealloc_stack %3 : $*MyInt
   return %38 : $MyInt
 } // end sil function '$s27capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n'
+
+sil_global @gi : $Int
+
+// CHECK:     sil [ossa] @test_global :
+// CHECK-NOT:   load
+// CHECK:       return %0
+// CHECK:     } // end sil function 'test_global'
+sil [ossa] @test_global : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = global_addr @gi : $*Int
+  store %0 to [trivial] %1
+  %3 = load [trivial] %1
+  return %3
+}

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -15,6 +15,7 @@ struct NonTrivialStruct {
 
 sil_global [let] @g1 : $Int32
 sil_global [let] @g2 : $Int32
+sil_global [let] @g3 : $Int32
 
 sil @paable : $@convention(thin) (Builtin.Int64) -> ()
 sil @moved_pai_callee : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
@@ -159,6 +160,25 @@ bb0:
   store %3 to [trivial] %1 : $*Int32
   %6 = tuple ()
   return %6 : $()
+}
+
+// CHECK-LABEL: sil [global_init_once_fn] [no_locks] [perf_constraint] [ossa] @remove_loads_and_stores_in_globalinit :
+// CHECK-NOT:     store
+// CHECK:         debug_step
+// CHECK-NOT:     load
+// CHECK:       } // end sil function 'remove_loads_and_stores_in_globalinit'
+sil [global_init_once_fn] [no_locks] [ossa] @remove_loads_and_stores_in_globalinit : $@convention(c) () -> () {
+bb0:
+  alloc_global @g3
+  %1 = global_addr @g3 : $*Int32
+  %2 = integer_literal $Builtin.Int32, 10
+  %3 = struct $Int32 (%2)
+  store %3 to [trivial] %1
+  debug_step
+  %6 = load [trivial] %1
+  store %6 to [trivial] %1
+  %r = tuple ()
+  return %r
 }
 
 // Check that we don't crash on global init-once declarations.

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1266,6 +1266,18 @@ bb0:
   return %r : $()
 }
 
+// CHECK-LABEL: @test_debug_step
+// CHECK:       PAIR #0.
+// CHECK-NEXT:     debug_step
+// CHECK-NEXT:     %0 = argument of bb0
+// CHECK-NEXT:     r=0,w=0
+sil [ossa] @test_debug_step : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  debug_step
+  %99 = tuple ()
+  return %99 : $()
+}
+
 // CHECK-LABEL: @test_store_assign
 // CHECK:       PAIR #0.
 // CHECK-NEXT:      store %2 to [assign] %0 : $*C

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -22,7 +22,7 @@ struct Str : P {
     return a + x
   }
 
-  static let s = 27
+  static let s = 27 << 0
   static var s2 = 10 + s
   static var s3 = initFunc() // expected-error {{global/static variable initialization can cause locking}}
 }


### PR DESCRIPTION
* AliasAnalysis: handle `debug_step` in `computeMemoryEffect`
* MandatoryRedundantLoadElimination: remove redundant loads from global variables
* MandatoryPerformanceOptimizations: run DeadStoreElimination for global init functions.