### PR TITLE
[cxx-interop] Do not treat SWIFT_RETURNS_INDEPENDENT_VALUE unsafe

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8782,7 +8782,7 @@ ClangDeclExplicitSafety::evaluate(Evaluator &evaluator,
   
   // Explicitly unsafe.
   auto decl = desc.decl;
-  if (hasUnsafeAPIAttr(decl) || hasSwiftAttribute(decl, "unsafe"))
+  if (hasSwiftAttribute(decl, "unsafe"))
     return ExplicitSafety::Unsafe;
   
   // Explicitly safe.

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -93,6 +93,12 @@ using TTakePtr = TTake<int *>;
 using TTakeSafeTuple = TTake<SafeTuple>;
 using TTakeUnsafeTuple = TTake<UnsafeTuple>;
 
+struct HoldsShared {
+  SharedObject* obj;
+
+  SharedObject* getObj() const SWIFT_RETURNS_INDEPENDENT_VALUE;
+};
+
 //--- test.swift
 
 import Test
@@ -183,8 +189,9 @@ func useSharedReference(frt: SharedObject, x: OwnedData) {
 }
 
 @available(SwiftStdlib 5.8, *)
-func useSharedReference(frt: DerivedFromSharedObject) {
+func useSharedReference(frt: DerivedFromSharedObject, h: HoldsShared) {
   let _ = frt
+  let _ = h.getObj()
 }
 
 func useTTakeInt(x: TTakeInt) {


### PR DESCRIPTION
The explicit safety analysis inadvertently considered every instance method with this annotation unsafe. We trust these annotations, so let's not consider the annotated methods unsafe.

rdar://162602614