### PR TITLE
Tests: Fix `ClangImporter/availability_ios.swift` expected diagnostics

### DIFF
--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension-library %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension %s -verify-additional-prefix extension-
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension-library %s -verify-additional-prefix extension-
 
 // REQUIRES: OS=ios
 // UNSUPPORTED: OS=maccatalyst
@@ -31,9 +31,9 @@ func deprecatedOnMacCatalystButNotIOS() { }
 func maccatalyst_tests() {
   deprecatedOnMacCatalystButNotIOS() // no-warning
 
-  availableOnIOSButUnavailableOniOSAppExtension() // no-error
+  availableOnIOSButUnavailableOniOSAppExtension() // expected-extension-error {{'availableOnIOSButUnavailableOniOSAppExtension()' is unavailable in application extensions for iOS}}
   availableOnIOSAppExtensionButUnavailableOnmacCatalystAppExtension() // no-error
 
-  availableOnIOSButDeprecatedOniOSAppExtension() // no-warning
+  availableOnIOSButDeprecatedOniOSAppExtension() // expected-extension-warning {{'availableOnIOSButDeprecatedOniOSAppExtension()' was deprecated in application extensions for iOS 9.0}}
   availableOnIOSAppExtensionButDeprecatedOnmacCatalystAppExtension() // no-warning
 }

--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -application-extension-library %s
 
 // REQUIRES: OS=ios
+// UNSUPPORTED: OS=maccatalyst
 
 import Foundation
 import AvailabilityExtras
@@ -13,4 +14,26 @@ func test_unavailable_because_deprecated() {
 
 func test_swift_unavailable_wins() {
   unavailableWithOS() // expected-error {{'unavailableWithOS()' is unavailable in Swift}}
+}
+
+
+@available(iOS, introduced: 1.0)
+@available(macCatalyst, introduced: 1.0, obsoleted: 2.0)
+func obsoletedOnMacCatalystButNotIOS() { }
+
+obsoletedOnMacCatalystButNotIOS() // no-error
+
+@available(iOS, introduced: 1.0)
+@available(macCatalyst, introduced: 1.0, deprecated: 2.0)
+func deprecatedOnMacCatalystButNotIOS() { }
+
+@available(iOS, introduced: 8.0)
+func maccatalyst_tests() {
+  deprecatedOnMacCatalystButNotIOS() // no-warning
+
+  availableOnIOSButUnavailableOniOSAppExtension() // no-error
+  availableOnIOSAppExtensionButUnavailableOnmacCatalystAppExtension() // no-error
+
+  availableOnIOSButDeprecatedOniOSAppExtension() // no-warning
+  availableOnIOSAppExtensionButDeprecatedOnmacCatalystAppExtension() // no-warning
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -90,6 +90,24 @@ __attribute__((availability(ios,introduced=8.0)))
 
 @end
 
+
+/// macCatalyst availability
+
+void availableOnIOSButUnavailableOnmacCatalyst() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(maccatalyst, unavailable)));
+void availableOnIOSButDeprecatedOnmacCatalyst() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(maccatalyst,  introduced=8.0, deprecated=9.0)));
+
+void unavailableOnIOS() __attribute__((availability(ios, unavailable)));
+void deprecatedOniOSButNotOnmacCatalyst() __attribute__((availability(ios, introduced=8.0, deprecated=9.0))) __attribute__((availability(maccatalyst, introduced=8.0)));
+
+void availableOnIOSButUnavailableOniOSAppExtension() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(ios_app_extension, unavailable)));
+void availableOnIOSButUnavailableOnmacCatalystAppExtension() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(maccatalyst_app_extension, unavailable)));
+void availableOnIOSAppExtensionButUnavailableOnmacCatalystAppExtension() __attribute__((availability(ios_application_extension, introduced=8.0))) __attribute__((availability(maccatalyst_app_extension, unavailable)));
+
+void availableOnIOSButDeprecatedOniOSAppExtension() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(ios_app_extension, introduced=8.0, deprecated=9.0)));
+void availableOnIOSButDeprecatedOnmacCatalystAppExtension() __attribute__((availability(ios, introduced=8.0))) __attribute__((availability(maccatalyst_app_extension, introduced=8.0, deprecated=9.0)));
+void availableOnIOSAppExtensionButDeprecatedOnmacCatalystAppExtension() __attribute__((availability(ios_application_extension, introduced=8.0))) __attribute__((availability(maccatalyst_app_extension, introduced=8.0, deprecated=9.0)));
+
+
 @class NSString, NSArray, NSDictionary, NSSet, NSEnumerator;
 
 @class NSMutableArray<ObjectType>;


### PR DESCRIPTION
Upstream missing test content and fix expected diagnostics in that content.

Resolves rdar://162439072.