### PR TITLE
[cxx-interop] Check for simple destructors when checking value semantics

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8292,6 +8292,9 @@ static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {
 }
 
 static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl) {
+  if (decl->hasSimpleDestructor())
+    return true;
+
   if (auto dtor = decl->getDestructor()) {
     if (dtor->isDeleted() || dtor->isIneligibleOrNotSelected() ||
         dtor->getAccess() != clang::AS_public) {

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -79,6 +79,9 @@ struct SWIFT_NONCOPYABLE NonCopyableNonMovable { // expected-note {{record 'NonC
     NonCopyableNonMovable(NonCopyableNonMovable&& other) = delete;
 };
 
+template<typename T> struct SWIFT_COPYABLE_IF(T) DisposableContainer {};
+struct POD { int x; float y; }; // special members are implicit, but should be copyable
+using DisposablePOD = DisposableContainer<POD>; // should also be copyable
 
 //--- test.swift
 import Test
@@ -128,4 +131,8 @@ func doubleAnnotation() {
 func missingLifetimeOperation() {
     let s = NonCopyableNonMovable() // expected-error {{cannot find 'NonCopyableNonMovable' in scope}}
     takeCopyable(s)
+}
+
+func copyableDisposablePOD(p: DisposablePOD) {
+  takeCopyable(p)
 }


### PR DESCRIPTION
hasDestroyTypeOperations() does not account for the scenario where decl has an implicit destructor that has not yet been materialized (i.e., using clang::Sema::{Declare,Define}ImplicitDestructor()). This can sometimes happen to a type Foo if we check the value semantics of, say, std::vector<Foo> (which recursively checks the value semantics of Foo without first importing Foo).

rdar://162539654