### PR TITLE
build.ps1: clean up the `Get-Dependencies` output

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -813,7 +813,7 @@ function Invoke-BuildStep {
           $NextArg = $RemainingArgs[$RemainingArgs.IndexOf($Arg) + 1]
           if ($NextArg -is [string] -and !$NextArg.StartsWith('-')) {
             $SplatArgs[$ParamName] = $NextArg
-            $Enumerator.MoveNext() # Skip NextArg
+            $Enumerator.MoveNext() | Out-Null # Skip NextArg
             continue
           }
         }


### PR DESCRIPTION
This pull request refactors the output messages in the `Get-Dependencies` function in `utils/build.ps1` to improve clarity and consistency. It introduces a new `Write-Success` helper function for standardized success messages and replaces many previous verbose `Write-Output` statements with this new format. Additionally, several unnecessary or redundant output lines have been commented out to reduce noise during dependency extraction and installation.

**Output improvements:**

* Added a `Write-Success` function that prints a standardized success message after each dependency is installed or extracted, improving clarity and consistency.
* Replaced many `Write-Output` statements with calls to `Write-Success` for dependencies such as `syft`, `WiX`, `sccache`, `GNUWin32 make`, `Swift Toolchain`, `Python`, `pip`, Python modules, `Android NDK`, and `flex/bison`. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1251-R1258) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1271) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1282-R1288) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1302-R1314) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1329-R1342) [[6]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1366) [[7]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1376)

**Noise reduction and code cleanup:**

* Commented out several verbose `Write-Output` statements related to extraction and installation status, reducing console clutter during builds. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1174-R1184) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1194-R1209) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1220-R1235) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1302-R1314) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1317-R1329) [[6]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1329-R1342)
* Minor update to suppress output from `$Enumerator.MoveNext()` by piping to `Out-Null` in `Invoke-BuildStep`.