### PR TITLE
Sema: Enable prepared overloads by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1021,7 +1021,7 @@ namespace swift {
     bool SolverDisableSplitter = false;
 
     /// Enable the experimental "prepared overloads" optimization.
-    bool SolverEnablePreparedOverloads = false;
+    bool SolverEnablePreparedOverloads = true;
   };
 
   /// Options for controlling the behavior of the Clang importer.


### PR DESCRIPTION
This can be turned off with -solver-disable-prepared-overloads.