### PR TITLE
[SE-0491] Fix malformed arg label error with module selector

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1817,8 +1817,11 @@ public:
   /// \param loc The location of the label (empty if it doesn't exist)
   /// \param isAttr True if this is an argument label for an attribute (allows, but deprecates, use of
   ///               \c '=' instead of \c ':').
+  /// \param splittingColonColon True if \c :: tokens should be treated as two
+  ///                           adjacent colons.
   void parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc,
-                                  bool isAttr = false);
+                                  bool isAttr = false,
+                                  bool splittingColonColon = false);
 
   /// If a \c module-selector is present, returns a true value (specifically,
   /// 1 or 2 depending on how many tokens should be consumed to skip it).

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -1,5 +1,8 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-experimental-feature ModuleSelector
+// REQUIRES: swift_feature_ModuleSelector
+
 func f0(_ x: Int, y: Int, z: Int) { }
 func f1(_ x: Int, while: Int) { }
 func f2(_ x: Int, `let` _: Int) { }


### PR DESCRIPTION
The legacy parser has a special case for code like `fn(:)` which corrects it to `fn(_:)`, but the new `::` token was interfering with cases where there were two adjacent colons (e.g. `fn(::)`). Correct this issue.

~~**Reviewers:** This PR temporarily includes the changes in #84362, which hasn't quite landed yet. Please review **only** the last commit—the others will be rebased away.~~