### PR TITLE
[SE-0494] `isTriviallyIdentical(to:)` [memory regions]

### DIFF
--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -701,6 +701,15 @@ extension RawSpan {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
 
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
   /// Returns the offsets where the memory of `other` is located within
   /// the memory represented by `self`
   ///

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -751,6 +751,15 @@ extension Span where Element: ~Copyable {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
 
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
   /// Returns the indices within `self` where the memory represented by `other`
   /// is located, or `nil` if `other` is not located within `self`.
   ///

--- a/stdlib/public/core/UTF8SpanComparisons.swift
+++ b/stdlib/public/core/UTF8SpanComparisons.swift
@@ -104,6 +104,19 @@ extension UTF8Span {
   }
 }
 
+@available(SwiftStdlib 6.2, *)
+extension UTF8Span {
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region, and have the same flags (such as ``isKnownASCII``).
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._unsafeBaseAddress == other._unsafeBaseAddress) &&
+    (self._countAndFlags == other._countAndFlags)
+  }
+}
+
 // // FIXME: remove
 // @available(SwiftStdlib 6.2, *)
 // extension UTF8Span {

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -600,6 +600,18 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 %end
 }
 
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @safe
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._position == other._position) && (self.count == other.count)
+  }
+}
+
 extension Unsafe${Mutable}BufferPointer {
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1217,6 +1217,18 @@ extension Unsafe${Mutable}RawBufferPointer {
 % end
 }
 
+extension Unsafe${Mutable}RawBufferPointer {
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @safe
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._position == other._position) && (self._end == other._end)
+  }
+}
+
 @_unavailableInEmbedded
 extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.

--- a/test/stdlib/UTF8SpanQueriesComparisons.swift
+++ b/test/stdlib/UTF8SpanQueriesComparisons.swift
@@ -98,8 +98,8 @@ if #available(SwiftStdlib 6.2, *) {
       case notNFC
     }
 
-    let nfcQCNo = "\u{0374}"
-    let nfcQCYes = "\u{0374}"
+    // FIXME: let nfcQCNo = "\u{0374}"
+    // FIXME: let nfcQCYes = "\u{0374}"
 
     let tests: [(String, Normalness)] = [
       ("abc", .known),
@@ -177,15 +177,55 @@ if #available(SwiftStdlib 6.2, *) {
         // Equivalence means no-one is less than the other
         expectFalse(utf8Decomposed.isCanonicallyLessThan(utf8Precomposed))
         expectFalse(utf8Precomposed.isCanonicallyLessThan(utf8Decomposed))
-
       }
-
     }
-
-
   }
 
+  suite.test("isTriviallyIdentical(to:)") {
+    func checkTriviallyIdentical(
+      _ x: Span<UInt8>,
+      _ y: Span<UInt8>,
+      _ expected: Bool,
+      stackTrace: SourceLocStack = SourceLocStack(),
+      showFrame: Bool = true,
+      file: String = #file,
+      line: UInt = #line
+    ) throws(UTF8.ValidationError) {
+      let stackTrace = stackTrace.pushIf(showFrame, file: file, line: line)
+      do {
+        expectEqual(expected, x.isTriviallyIdentical(to: y), stackTrace: stackTrace)
+      }
+      do {
+        let x = try UTF8Span(validating: x)
+        let y = try UTF8Span(validating: y)
+        expectEqual(expected, x.isTriviallyIdentical(to: y), stackTrace: stackTrace)
+      }
+    }
 
+    let a = Span<UInt8>()
+    let b: Span<UInt8> = "isTriviallyIdentical(to:)".utf8.span
+    let c = b.extracting(first: 20)
+    let d = b.extracting(last: 23)
+    let e = c.extracting(last: 18)
+    let f = d.extracting(first: 18)
+
+    do throws(UTF8.ValidationError) {
+      try checkTriviallyIdentical(a, a, true)
+      try checkTriviallyIdentical(b, b, true)
+      try checkTriviallyIdentical(c, c, true)
+      try checkTriviallyIdentical(d, d, true)
+      try checkTriviallyIdentical(e, e, true)
+      try checkTriviallyIdentical(f, f, true)
+
+      try checkTriviallyIdentical(a, b, false)
+      try checkTriviallyIdentical(b, c, false)
+      try checkTriviallyIdentical(c, d, false)
+      try checkTriviallyIdentical(d, e, false)
+      try checkTriviallyIdentical(e, f, true)
+    } catch {
+      expectUnreachableCatch(error)
+    }
+  }
 }
 
 // TODO: Rest of this file is in-progress TODOs


### PR DESCRIPTION
Add `isTriviallyIdentical(to:)` methods to:

* `Span`
* `RawSpan`
* `UTF8Span`
* `UnsafeBufferPointer`
* `UnsafeMutableBufferPointer`
* `UnsafeRawBufferPointer`
* `UnsafeMutableRawBufferPointer`

Part of issue swiftlang/swift#84991.
