### PR TITLE
Use `__ehdr_start` on ELF instead of calling `dladdr()`.

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
+++ b/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
@@ -58,24 +58,15 @@ struct MetadataSections {
   /// symbol in the image that contains these sections.
   ///
   /// For Mach-O images, set this field to \c __dso_handle (i.e. the Mach header
-  /// for the image.) For ELF images, set it to \c __dso_handle (the runtime
-  /// will adjust it to the start of the ELF image when the image is loaded.)
-  /// For COFF images, set this field to \c __ImageBase.
+  /// for the image.) For ELF images, set it to \c __ehdr_start. For COFF
+  /// images, set this field to \c __ImageBase.
   ///
   /// For platforms that have a single statically-linked image or no dynamic
-  /// loader (i.e. no equivalent of \c __dso_handle or \c __ImageBase), this
-  /// field is ignored and should be set to \c nullptr.
-  ///
-  /// \bug When imported into Swift, this field is not atomic.
+  /// loader (i.e. no equivalent of \c __dso_handle, \c __ehdr_start, or
+  /// \c __ImageBase), this field is ignored and should be set to \c nullptr.
   ///
   /// \sa swift_addNewDSOImage()
-#if defined(__swift__) || defined(__STDC_NO_ATOMICS__)
   const void *baseAddress;
-#elif defined(__cplusplus)
-  std::atomic<const void *> baseAddress;
-#else
-  _Atomic(const void *) baseAddress;
-#endif
 
   /// Unused.
   ///

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -36,6 +36,16 @@ namespace swift {
 
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(swift::MetadataSections *sections) {
+#if defined(__ELF__)
+  if (!sections->baseAddress || sections->version <= 4) {
+    // The base address was either unavailable at link time or is set to the
+    // wrong value and will need to be recomputed. We can use the address of the
+    // sections structure and derive the base address from there.
+    if (auto info = swift::SymbolInfo::lookup(sections)) {
+      sections->baseAddress = info->getBaseAddress();
+    }
+  }
+#endif
   auto baseAddress = sections->baseAddress;
 
   const auto &protocols_section = sections->swift5_protocols;

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -28,67 +28,15 @@
 #include "swift/Runtime/Concurrent.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstdlib>
 
 namespace swift {
-
-static Lazy<ConcurrentReadableArray<swift::MetadataSections *>> registered;
-
-/// Adjust the \c baseAddress field of a metadata sections structure.
-///
-/// \param sections A pointer to a valid \c swift::MetadataSections structure.
-///
-/// This function should be called at least once before the structure or its
-/// address is passed to code outside this file to ensure that the structure's
-/// \c baseAddress field correctly points to the base address of the image it
-/// is describing.
-static void fixupMetadataSectionBaseAddress(swift::MetadataSections *sections) {
-  bool fixupNeeded = false;
-
-#if defined(__ELF__)
-  // If the base address was set but the image is an ELF image, it is going to
-  // be __dso_handle which is not the value we expect (Dl_info::dli_fbase), so
-  // we need to fix it up.
-  fixupNeeded = true;
-#elif !defined(__MACH__)
-  // For non-ELF, non-Apple platforms, if the base address is nullptr, it
-  // implies that this image was built against an older version of the runtime
-  // that did not capture any value for the base address.
-  auto oldBaseAddress = sections->baseAddress.load(std::memory_order_relaxed);
-  if (!oldBaseAddress) {
-    fixupNeeded = true;
-  }
-#endif
-
-  if (fixupNeeded) {
-    // We need to fix up the base address. We'll need a known-good address in
-    // the same image: `sections` itself will work nicely.
-    auto symbolInfo = SymbolInfo::lookup(sections);
-    if (symbolInfo.has_value() && symbolInfo->getBaseAddress()) {
-        sections->baseAddress.store(symbolInfo->getBaseAddress(),
-                                    std::memory_order_relaxed);
-    }
-  }
-}
+  static Lazy<ConcurrentReadableArray<swift::MetadataSections *>> registered;
 }
 
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(swift::MetadataSections *sections) {
-#if 0
-  // Ensure the base address of the sections structure is correct.
-  //
-  // Currently disabled because none of the registration functions below
-  // actually do anything with the baseAddress field. Instead,
-  // swift_enumerateAllMetadataSections() is called by other individual
-  // functions, lower in this file, that yield metadata section pointers.
-  //
-  // If one of these registration functions starts needing the baseAddress
-  // field, this call should be enabled and the calls elsewhere in the file can
-  // be removed.
-  swift::fixupMetadataSectionBaseAddress(sections);
-#endif
-  auto baseAddress = sections->baseAddress.load(std::memory_order_relaxed);
+  auto baseAddress = sections->baseAddress;
 
   const auto &protocols_section = sections->swift5_protocols;
   const void *protocols = reinterpret_cast<void *>(protocols_section.start);
@@ -144,9 +92,6 @@ void swift_enumerateAllMetadataSections(
 ) {
   auto snapshot = swift::registered->snapshot();
   for (swift::MetadataSections *sections : snapshot) {
-    // Ensure the base address is fixed up before yielding the pointer.
-    swift::fixupMetadataSectionBaseAddress(sections);
-
     // Yield the pointer and (if the callback returns false) break the loop.
     if (!(* body)(sections, context)) {
       return;
@@ -180,11 +125,6 @@ const swift::MetadataSections *swift_getMetadataSection(size_t index) {
     result = snapshot[index];
   }
 
-  if (result) {
-    // Ensure the base address is fixed up before returning it.
-    swift::fixupMetadataSectionBaseAddress(result);
-  }
-
   return result;
 }
 
@@ -197,22 +137,6 @@ swift_getMetadataSectionName(const swift::MetadataSections *section) {
     }
   }
   return "";
-}
-
-SWIFT_RUNTIME_EXPORT
-void swift_getMetadataSectionBaseAddress(const swift::MetadataSections *section,
-                                         void const **out_actual,
-                                         void const **out_expected) {
-  if (auto info = swift::SymbolInfo::lookup(section)) {
-    *out_actual = info->getBaseAddress();
-  } else {
-    *out_actual = nullptr;
-  }
-
-  // fixupMetadataSectionBaseAddress() was already called by
-  // swift_getMetadataSection(), presumably on the same thread, so we don't need
-  // to call it again here.
-  *out_expected = section->baseAddress.load(std::memory_order_relaxed);
 }
 
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -140,6 +140,18 @@ swift_getMetadataSectionName(const swift::MetadataSections *section) {
 }
 
 SWIFT_RUNTIME_EXPORT
+void swift_getMetadataSectionBaseAddress(const swift::MetadataSections *section,
+                                         void const **out_actual,
+                                         void const **out_expected) {
+  if (auto info = swift::SymbolInfo::lookup(section)) {
+    *out_actual = info->getBaseAddress();
+  } else {
+    *out_actual = nullptr;
+  }
+  *out_expected = section->baseAddress;
+}
+
+SWIFT_RUNTIME_EXPORT
 size_t swift_getMetadataSectionCount() {
   auto snapshot = swift::registered->snapshot();
   return snapshot.count();

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -51,7 +51,7 @@
 
 namespace swift {
 struct MetadataSections;
-static constexpr const uintptr_t CurrentSectionMetadataVersion = 4;
+static constexpr const uintptr_t CurrentSectionMetadataVersion = 5;
 }
 
 struct SectionInfo {

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -93,6 +93,11 @@ const char *
 swift_getMetadataSectionName(const struct swift::MetadataSections *section);
 
 SWIFT_RUNTIME_EXPORT
+void swift_getMetadataSectionBaseAddress(
+  const struct swift::MetadataSections *section,
+  void const **out_actual, void const **out_expected);
+
+SWIFT_RUNTIME_EXPORT
 size_t swift_getMetadataSectionCount();
 
 #endif // NDEBUG

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -93,11 +93,6 @@ const char *
 swift_getMetadataSectionName(const struct swift::MetadataSections *section);
 
 SWIFT_RUNTIME_EXPORT
-void swift_getMetadataSectionBaseAddress(
-  const struct swift::MetadataSections *section,
-  void const **out_actual, void const **out_expected);
-
-SWIFT_RUNTIME_EXPORT
 size_t swift_getMetadataSectionCount();
 
 #endif // NDEBUG

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -19,11 +19,11 @@
 #include <new>
 
 #if defined(__ELF__)
-extern "C" const char __dso_handle[];
+extern "C" const char __ehdr_start[];
 #elif defined(__wasm__)
 // NOTE: Multi images in a single process is not yet
 // stabilized in WebAssembly toolchain outside of Emscripten.
-static constexpr const void *__dso_handle = nullptr;
+static constexpr const void *__ehdr_start = nullptr;
 #endif
 
 #if SWIFT_ENABLE_BACKTRACING
@@ -94,7 +94,7 @@ static void swift_image_constructor() {
 
   ::new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,
-      { __dso_handle },
+      { __ehdr_start },
 
       nullptr,
       nullptr,

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -42,7 +42,7 @@ static const void *getBaseAddress(void) {
   // directly into each Swift binary rather than being exported from the Swift
   // runtime.
   Dl_info info;
-  if (dladdr(__dso_handle, &info)) [
+  if (dladdr(__dso_handle, &info)) {
     return info.dli_fbase;
   }
 #endif

--- a/test/Runtime/loaded_image_uniqueness.swift
+++ b/test/Runtime/loaded_image_uniqueness.swift
@@ -17,13 +17,6 @@ internal func _getMetadataSectionName(
   _ metadata_section: UnsafeRawPointer
 ) -> UnsafePointer<CChar>
 
-@_silgen_name("swift_getMetadataSectionBaseAddress")
-internal func _getMetadataSectionBaseAddress(
-  _ metadata_section: UnsafeRawPointer,
-  _ outActual: UnsafeMutablePointer<UnsafeRawPointer?>,
-  _ outExpected: UnsafeMutablePointer<UnsafeRawPointer?>
-) -> Void
-
 do {
   let sectionCount = _getMetadataSectionCount()
   expectGT(sectionCount, 0)
@@ -35,17 +28,6 @@ do {
       fatalError("Section \(i) failed to resolve.")
     }
     let name = String(cString: _getMetadataSectionName(section))
-
-    var actual: UnsafeRawPointer? = nil
-    var expected: UnsafeRawPointer? = nil
-    _getMetadataSectionBaseAddress(section, &actual, &expected)
-    expectEqual(
-      actual, expected,
-      """
-      Section \(name) was expected at \(String(describing: expected)) but was
-      found at \(String(describing: actual)) instead.
-      """
-    )
 
     expectFalse(sections.contains(section), "Section \(name) was found twice!")
     sections.insert(section)

--- a/test/Runtime/loaded_image_uniqueness.swift
+++ b/test/Runtime/loaded_image_uniqueness.swift
@@ -17,6 +17,13 @@ internal func _getMetadataSectionName(
   _ metadata_section: UnsafeRawPointer
 ) -> UnsafePointer<CChar>
 
+@_silgen_name("swift_getMetadataSectionBaseAddress")
+internal func _getMetadataSectionBaseAddress(
+  _ metadata_section: UnsafeRawPointer,
+  _ outActual: UnsafeMutablePointer<UnsafeRawPointer?>,
+  _ outExpected: UnsafeMutablePointer<UnsafeRawPointer?>
+) -> Void
+
 do {
   let sectionCount = _getMetadataSectionCount()
   expectGT(sectionCount, 0)
@@ -28,6 +35,17 @@ do {
       fatalError("Section \(i) failed to resolve.")
     }
     let name = String(cString: _getMetadataSectionName(section))
+
+    var actual: UnsafeRawPointer? = nil
+    var expected: UnsafeRawPointer? = nil
+    _getMetadataSectionBaseAddress(section, &actual, &expected)
+    expectEqual(
+      actual, expected,
+      """
+      Section \(name) was expected at \(String(describing: expected)) but was
+      found at \(String(describing: actual)) instead.
+      """
+    )
 
     expectFalse(sections.contains(section), "Section \(name) was found twice!")
     sections.insert(section)


### PR DESCRIPTION
This PR replaces our use of `__dso_handle` and (indirectly) `dladdr()` when figuring out the base address of loaded Swift images on ELF-based platforms. Instead, we use `__ehdr_start` which refers to the start of the image's ELF header (i.e. the start of the file) and is provided by the compiler/linker for this purpose.

This pointer is consumed by `swift_addNewDSOImage()` and, later, by Swift Testing when running tests, but is otherwise unused, so the less work we do on it at runtime, the better.

A fallback path is present that, for images that do not contain `__ehdr_start`, derives the address by calling `dladdr()` on the section structure's address.

Resolves #84997.