### PR TITLE
[CoroutineAccessors] Fix overriding.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6254,9 +6254,7 @@ public:
   bool requiresOpaqueAccessor(AccessorKind kind) const;
 
   /// Does this storage require a 'get' accessor in its opaque-accessors set?
-  bool requiresOpaqueGetter() const {
-    return getOpaqueReadOwnership() != OpaqueReadOwnership::Borrowed;
-  }
+  bool requiresOpaqueGetter() const;
 
   /// Does this storage require a '_read' accessor in its opaque-accessors set?
   bool requiresOpaqueReadCoroutine() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6273,10 +6273,9 @@ public:
   /// set?
   bool requiresOpaqueModify2Coroutine() const;
 
-  /// Given that CoroutineAccessors is enabled, is _read/_modify required for
-  /// ABI stability?
-  bool requiresCorrespondingUnderscoredCoroutineAccessor(
-      AccessorKind kind, AccessorDecl const *decl = nullptr) const;
+  /// Given that CoroutineAccessors is enabled, are the accessors still
+  /// required that would have been emitted when its not?
+  bool requiresAccessorsForABICompatibilityWithPreCoroutineAccessors() const;
 
   /// Does this storage have any explicit observers (willSet or didSet) attached
   /// to it?

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5908,7 +5908,7 @@ class AbstractStorageDecl : public ValueDecl {
   friend class SetterAccessLevelRequest;
   friend class IsGetterMutatingRequest;
   friend class IsSetterMutatingRequest;
-  friend class OpaqueReadOwnershipRequest;
+  friend class DirectOpaqueReadOwnershipRequest;
   friend class StorageImplInfoRequest;
   friend class RequiresOpaqueAccessorsRequest;
   friend class RequiresOpaqueModifyCoroutineRequest;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1750,10 +1750,10 @@ public:
 };
 
 /// Request whether reading the storage yields a borrowed value.
-class OpaqueReadOwnershipRequest :
-    public SimpleRequest<OpaqueReadOwnershipRequest,
-                         OpaqueReadOwnership(AbstractStorageDecl *),
-                         RequestFlags::SeparatelyCached> {
+class DirectOpaqueReadOwnershipRequest
+    : public SimpleRequest<DirectOpaqueReadOwnershipRequest,
+                           OpaqueReadOwnership(AbstractStorageDecl *),
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -255,7 +255,7 @@ SWIFT_REQUEST(TypeChecker, EnumElementExprPatternRequest,
 SWIFT_REQUEST(TypeChecker, ResolvePatternRequest,
               Pattern *(Pattern *, DeclContext *, bool),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
+SWIFT_REQUEST(TypeChecker, DirectOpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueResultTypeRequest,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2672,6 +2672,10 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
           Options.SuppressCoroutineAccessors) {
         AddAccessorToPrint(AccessorKind::Read);
       }
+      if (ASD->getAccessor(AccessorKind::Get) &&
+          Options.SuppressCoroutineAccessors) {
+        AddAccessorToPrint(AccessorKind::Get);
+      }
       AddAccessorToPrint(AccessorKind::Read2);
       break;
     case ReadImplKind::Borrow:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3440,6 +3440,10 @@ bool AbstractStorageDecl::requiresOpaqueSetter() const {
   return true;
 }
 
+bool AbstractStorageDecl::requiresOpaqueGetter() const {
+  return getOpaqueReadOwnership() != OpaqueReadOwnership::Borrowed;
+}
+
 bool AbstractStorageDecl::requiresOpaqueReadCoroutine() const {
   ASTContext &ctx = getASTContext();
   if (ctx.LangOpts.hasFeature(Feature::CoroutineAccessors))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3725,7 +3725,7 @@ AbstractStorageDecl::mutabilityInSwift(
 OpaqueReadOwnership AbstractStorageDecl::getOpaqueReadOwnership() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
-    OpaqueReadOwnershipRequest{const_cast<AbstractStorageDecl *>(this)}, {});
+    DirectOpaqueReadOwnershipRequest{const_cast<AbstractStorageDecl *>(this)}, {});
 }
 
 bool ValueDecl::isInstanceMember() const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -774,18 +774,19 @@ void IsSetterMutatingRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
-// OpaqueReadOwnershipRequest computation.
+// DirectOpaqueReadOwnershipRequest computation.
 //----------------------------------------------------------------------------//
 
 std::optional<OpaqueReadOwnership>
-OpaqueReadOwnershipRequest::getCachedResult() const {
+DirectOpaqueReadOwnershipRequest::getCachedResult() const {
   auto *storage = std::get<0>(getStorage());
   if (storage->LazySemanticInfo.OpaqueReadOwnershipComputed)
     return OpaqueReadOwnership(storage->LazySemanticInfo.OpaqueReadOwnership);
   return std::nullopt;
 }
 
-void OpaqueReadOwnershipRequest::cacheResult(OpaqueReadOwnership value) const {
+void DirectOpaqueReadOwnershipRequest::cacheResult(
+    OpaqueReadOwnership value) const {
   auto *storage = std::get<0>(getStorage());
   storage->setOpaqueReadOwnership(value);
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -864,9 +864,8 @@ void diagnoseEffectfulGetterOnBorrowingRead(
 
 } // end anonymous namespace
 
-OpaqueReadOwnership
-DirectOpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
-                                           AbstractStorageDecl *storage) const {
+static OpaqueReadOwnership
+computeOpaqueReadOwnership(AbstractStorageDecl *storage) {
   if (auto *accessorDecl = storage->getAccessor(AccessorKind::Read)) {
     auto lifetimeDependencies = accessorDecl->getLifetimeDependencies();
     if (lifetimeDependencies.has_value() && !lifetimeDependencies->empty()) {
@@ -879,13 +878,10 @@ DirectOpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  if (storage->getAccessor(AccessorKind::Read2))
-    return OpaqueReadOwnership::Borrowed;
+  using DiagKind = DirectOpaqueReadOwnershipRequestDiagKind;
 
   if (storage->getAccessor(AccessorKind::Borrow))
     return OpaqueReadOwnership::Borrowed;
-
-  using DiagKind = DirectOpaqueReadOwnershipRequestDiagKind;
 
   if (storage->getAttrs().hasAttribute<BorrowedAttr>()) {
     diagnoseEffectfulGetterOnBorrowingRead(storage, DiagKind::BorrowedAttr);
@@ -900,6 +896,26 @@ DirectOpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
   }
 
   return OpaqueReadOwnership::Owned;
+}
+
+OpaqueReadOwnership
+DirectOpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
+                                           AbstractStorageDecl *storage) const {
+  auto computed = computeOpaqueReadOwnership(storage);
+
+  if (!storage->getAccessor(AccessorKind::Read2))
+    return computed;
+
+  if (!storage->requiresAccessorsForABICompatibilityWithPreCoroutineAccessors())
+    return OpaqueReadOwnership::Borrowed;
+
+  switch (computed) {
+  case OpaqueReadOwnership::Owned:
+  case OpaqueReadOwnership::OwnedOrBorrowed:
+    return OpaqueReadOwnership::OwnedOrBorrowed;
+  case OpaqueReadOwnership::Borrowed:
+    return OpaqueReadOwnership::Borrowed;
+  }
 }
 
 /// Insert the specified decl into the DeclContext's member list.  If the hint
@@ -2680,31 +2696,24 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-/// When the CoroutineAccessors feature is available, the coroutine accessor
-/// _could_ be required.  That non-underscored accessor would be preferred to
-/// its underscored counterpart accessor.
-///
-/// The underscored accessor could, however, still be required for ABI
-/// stability.
-static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
-    AbstractStorageDecl const *storage, AccessorKind kind,
-    AccessorDecl const *decl, AbstractStorageDecl const *derived) {
+/// When the CoroutineAccessors feature is available, different accessors may be
+/// required (e.g. read2 and modify2).  The accessors which were previously
+/// required, however, may still be required for ABI compatibility.
+static bool requiresAccessorsForABICompatibilityWithPreCoroutineAccessorsImpl(
+    AbstractStorageDecl const *storage, AbstractStorageDecl const *derived) {
   auto &ctx = storage->getASTContext();
-  assert(ctx.LangOpts.hasFeature(Feature::CoroutineAccessors));
-  assert(kind == AccessorKind::Modify2 || kind == AccessorKind::Read2);
-
-  // If any overridden decl requires the underscored version, then this decl
-  // does too.  Otherwise dispatch to the underscored version on a value
-  // statically the super but dynamically this subtype would not dispatch to an
-  // override of the underscored version but rather (incorrectly) the
-  // supertype's implementation.
+  // If any overridden storage requires accessors for ABI compatibility, then
+  // this storage does too.
+  //
+  // Otherwise dispatch to one of those required-by-some-overridden-storage
+  // accessor on an instance of a type that's statically the supertype but
+  // dynamically this subtype would not dispatch to an override provided by this
+  // subtype but rather (incorrectly) that supertype's implementation.
   if (storage == derived) {
     auto *current = storage;
     while ((current = current->getOverriddenDecl())) {
-      auto *currentDecl = cast_or_null<AccessorDecl>(
-          decl ? decl->getOverriddenDecl() : nullptr);
-      if (requiresCorrespondingUnderscoredCoroutineAccessorImpl(
-              current, kind, currentDecl, derived)) {
+      if (requiresAccessorsForABICompatibilityWithPreCoroutineAccessorsImpl(
+              current, derived)) {
         return true;
       }
     }
@@ -2719,12 +2728,6 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
   if (!isExported(storage))
     return false;
 
-  // The non-underscored accessor is not present, the underscored accessor
-  // won't be either.
-  auto *accessor = decl ? decl : storage->getOpaqueAccessor(kind);
-  if (!accessor)
-    return false;
-
   // Availability checks are only relevant on targets which support versioned
   // availability.  Otherwise, since we're building with library evolution,
   // conservatively assume that the binary must keep ABI compatibility with its
@@ -2734,7 +2737,7 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
 
   AvailabilityContext accessorAvailability = [&] {
     if (storage->getModuleContext()->isMainModule()) {
-      return AvailabilityContext::forDeclSignature(accessor);
+      return AvailabilityContext::forDeclSignature(storage);
     }
     // Calculate the availability of the imported declaration ourselves starting
     // from always available and constraining by walking the enclosing decl
@@ -2758,15 +2761,19 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
           featureAvailability))
     return false;
 
-  // The underscored accessor is required for ABI stability.
+  // ABI stability requires that accessors provieded before CoroutineAccessors
+  // was enabled be provided still.
+  //
+  // In the case of modify2, that will always mean that modify is required.
+  //
+  // In the case of read2, that could mean read OR get is required.
   return true;
 }
 
-bool AbstractStorageDecl::requiresCorrespondingUnderscoredCoroutineAccessor(
-    AccessorKind kind, AccessorDecl const *decl) const {
-  return requiresCorrespondingUnderscoredCoroutineAccessorImpl(
-      this, kind, decl,
-      /*derived=*/this);
+bool AbstractStorageDecl::
+    requiresAccessorsForABICompatibilityWithPreCoroutineAccessors() const {
+  return requiresAccessorsForABICompatibilityWithPreCoroutineAccessorsImpl(
+      this, /*derived=*/this);
 }
 
 bool RequiresOpaqueModifyCoroutineRequest::evaluate(
@@ -2779,9 +2786,10 @@ bool RequiresOpaqueModifyCoroutineRequest::evaluate(
   if (!hasCoroutineAccessorsFeature && !isUnderscored)
     return false;
 
-  if (hasCoroutineAccessorsFeature && isUnderscored) {
-    return storage->requiresCorrespondingUnderscoredCoroutineAccessor(
-        AccessorKind::Modify2);
+  if (hasCoroutineAccessorsFeature && isUnderscored &&
+      !storage
+           ->requiresAccessorsForABICompatibilityWithPreCoroutineAccessors()) {
+    return false;
   }
 
   // Only for mutable storage.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2773,13 +2773,13 @@ bool RequiresOpaqueModifyCoroutineRequest::evaluate(
     Evaluator &evaluator, AbstractStorageDecl *storage,
     bool isUnderscored) const {
   auto &ctx = storage->getASTContext();
-  bool hasModifyFeature = ctx.LangOpts.hasFeature(Feature::CoroutineAccessors);
+  bool hasCoroutineAccessorsFeature = ctx.LangOpts.hasFeature(Feature::CoroutineAccessors);
 
   // No `modify` accessor without the feature.
-  if (!hasModifyFeature && !isUnderscored)
+  if (!hasCoroutineAccessorsFeature && !isUnderscored)
     return false;
 
-  if (hasModifyFeature && isUnderscored) {
+  if (hasCoroutineAccessorsFeature && isUnderscored) {
     return storage->requiresCorrespondingUnderscoredCoroutineAccessor(
         AccessorKind::Modify2);
   }

--- a/test/IRGen/default_override.sil
+++ b/test/IRGen/default_override.sil
@@ -18,6 +18,7 @@ struct Int {
 }
 
 open class B {
+  @_borrowed
   open var i: Int { read set }
 }
 

--- a/test/Interpreter/borrowed_storage_override.swift
+++ b/test/Interpreter/borrowed_storage_override.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// Currently, D's opaque read ownership is ::Owned which results in not
+// producing an override for C.read.
+// XFAIL: *
+
+// REQUIRES: executable_test
+
+protocol P {
+  var i: Int { get }
+}
+
+class C : P {
+  @_borrowed
+  var i: Int
+
+  init() {
+    self.i = 5
+  }
+}
+
+class D : C {
+  override var i: Int {
+    get {42}
+    set {}
+  }
+}
+
+func getFromC(_ c: C) -> Int {
+  return c.i
+}
+
+func getFromD(_ c: D) -> Int {
+  return c.i
+}
+
+func getFromP<T : P>(_ c: T) -> Int {
+  return c.i
+}
+
+func doit() {
+  let c = D()
+  let ic = getFromC(c)
+  print("as C:", ic)
+  // CHECK: as C: 42
+  let id = getFromD(c)
+  print("as D:", id)
+  // CHECK: as D: 42
+  let ip = getFromP(c)
+  print("as P:", ip)
+  // CHECK: as P: 42
+}
+
+doit()

--- a/test/Interpreter/borrowed_storage_override.swift
+++ b/test/Interpreter/borrowed_storage_override.swift
@@ -1,9 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
-// Currently, D's opaque read ownership is ::Owned which results in not
-// producing an override for C.read.
-// XFAIL: *
-
 // REQUIRES: executable_test
 
 protocol P {

--- a/test/Interpreter/coroutine_accessors.swift
+++ b/test/Interpreter/coroutine_accessors.swift
@@ -1,0 +1,100 @@
+// RUN: %empty-directory(%t)
+
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     %t/Library.swift   \
+// RUN:     -enable-callee-allocated-coro-abi \
+// RUN:     -emit-module       \
+// RUN:     -module-name Library \
+// RUN:     -parse-as-library  \
+// RUN:     -enable-library-evolution \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Library)) \
+// RUN:     %t/Library.swift \
+// RUN:     -Xfrontend -enable-callee-allocated-coro-abi \
+// RUN:     -emit-module \
+// RUN:     -enable-library-evolution \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -emit-module-path %t/Library.swiftmodule \
+// RUN:     -module-name Library
+
+// RUN: %target-swift-frontend \
+// RUN:     %t/Executable.swift \
+// RUN:     -enable-callee-allocated-coro-abi \
+// RUN:     -c \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Executable \
+// RUN:     -I %t \
+// RUN:     -o %t/Executable.o
+
+// RUN: %target-build-swift \
+// RUN:     %t/Executable.o \
+// RUN:     -lLibrary \
+// RUN:     -L %t \
+// RUN:     %target-rpath(%t) \
+// RUN:     -o %t/main
+
+// RUN: %target-codesign %t/main %t/%target-library-name(Library)
+// RUN: %target-run %t/main %t/%target-library-name(Library) | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: executable_test
+
+//--- Library.swift
+
+@frozen
+public struct Uniquint {
+  public init(value: Int) { self.value = value }
+  public var value: Int
+}
+
+var _i: Uniquint = Uniquint(value: 17)
+open class Base {
+  public init() {}
+  open var i: Uniquint {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+}
+
+public func unpack(_ b: Base) -> Int {
+  return b.i.value
+}
+
+//--- Executable.swift
+
+import Library
+
+var j: Uniquint = Uniquint(value: 42)
+class Derived : Base {
+  override init() { super.init() }
+  override var i: Uniquint {
+    get {
+      return Uniquint(value: 42)
+    }
+    set {
+      j = newValue
+    }
+  }
+}
+
+@inline(never)
+func myPrint<T>(_ t: T) {
+  print(t)
+}
+
+@main struct M {
+  static func main() {
+    let b = Derived()
+    let i = unpack(b)
+    // CHECK: 42
+    myPrint(i)
+  }
+}

--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -203,6 +203,7 @@ struct I : P {
 
 open class B {
   public init() {}
+  @_borrowed
   open var i: Int {
     read {
       fatalError()
@@ -211,6 +212,7 @@ open class B {
       fatalError()
     }
   }
+  @_borrowed
   open subscript(i : Int) -> Int {
     read {
       fatalError()

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -9,6 +9,7 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 
 var _i: Int = 0
+var _j: Int = 0
 
 // CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
 // CHECK-NEXT: public var i: Swift.Int {
@@ -21,11 +22,32 @@ var _i: Int = 0
 // CHECK-NEXT:   _modify
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
+@_borrowed
 public var i: Int {
   read {
     yield _i
   }
   modify {
     yield &_i
+  }
+}
+
+// CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
+// CHECK-NEXT: public var j: Swift.Int {
+// CHECK-NEXT:   read
+// CHECK-NEXT:   modify
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public var j: Swift.Int {
+// CHECK-NEXT:   get
+// CHECK-NEXT:   _modify
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+public var j: Int {
+  read {
+    yield _j
+  }
+  modify {
+    yield &_j
   }
 }

--- a/test/SIL/Parser/default_override.sil
+++ b/test/SIL/Parser/default_override.sil
@@ -14,6 +14,7 @@ struct Int {
 }
 
 open class B {
+  @_borrowed
   open var i: Int { read set }
 }
 

--- a/test/SIL/Serialization/default_override.sil
+++ b/test/SIL/Serialization/default_override.sil
@@ -16,6 +16,7 @@ struct Int {
 }
 
 open class B {
+  @_borrowed
   open var i: Int { read set }
 }
 

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -22,6 +22,21 @@ public var o: any AnyObject
 public var _i: Int = 0
 
 public var irm: Int {
+// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV3irmSivg :
+// CHECK-SAME:      $@convention(method)
+// CHECK-SAME:      (@guaranteed S)
+// CHECK-SAME:      ->
+// CHECK-SAME:      Int
+// CHECK-SAME:  {
+// CHECK:       bb0(
+// CHECK:           [[SELF:%[^,]+]] :
+// CHECK:       ):
+// CHECK:         [[READER2:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READER2]]([[SELF]])
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
+// CHECK:         return [[VALUE]]
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivg'
 // CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivy :
 // CHECK-SAME:      $@yield_once_2
 // CHECK-SAME:      @convention(method)
@@ -44,26 +59,6 @@ public var irm: Int {
   modify {
     yield &_i
   }
-// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV3irmSivr :
-// CHECK-SAME:      $@yield_once
-// CHECK-SAME:      @convention(method)
-// CHECK-SAME:      (@guaranteed S)
-// CHECK-SAME:      ->
-// CHECK-SAME:      @yields Int
-// CHECK-SAME:  {
-// CHECK:       bb0(
-// CHECK:           [[SELF:%[^,]+]] :
-// CHECK:       ):
-// CHECK:         [[READER2:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
-// CHECK:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READER2]]([[SELF]])
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         yield [[VALUE_ADDRESS]] : $Int, resume bb1, unwind bb2
-// CHECK:       bb1:
-// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
-// CHECK:       bb2:
-// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivr'
 
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivs :
 // CHECK-SAME:      $@convention(method)

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -129,9 +129,9 @@ public func getOld() -> StructOld {
 public func readOldInlinableOld(_ n: StructOld) -> Int {
 // CHECK-LABEL: sil {{.*}}@readOldInlinableOld : {{.*}} {
 // Could be inlined into code that's running before CoroutineAccessors is
-// available--must use read.
-                  // function_ref StructOld.i.read
-// CHECK:         function_ref @$s7Library9StructOldV1iSivr
+// available--must use get.
+                  // function_ref StructOld.i.getter
+// CHECK:         function_ref @$s7Library9StructOldV1iSivg
 // CHECK-LABEL: } // end sil function 'readOldInlinableOld'
   return n.i
 }
@@ -282,9 +282,12 @@ public protocol ProtocolNew {
 }
 
 // CHECK-LABEL: sil_default_witness_table ProtocolOld {
+//                getter:
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    method #ProtocolOld.i!read2
+//                setter:
 // CHECK-NEXT:    no_default
+//                modify:
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    method #ProtocolOld.i!modify2
 // CHECK-NEXT:  }
@@ -341,8 +344,8 @@ func readOldOld() {
 // This module could be back-deployed to before CoroutineAccessors were
 // available, and nothing ensures the function is available only after the
 // feature is available--must use read.
-                  // function_ref StructOld.i.read
-// CHECK-OLD:     function_ref @$s7Library9StructOldV1iSivr
+                  // function_ref StructOld.i.getter
+// CHECK-OLD:     function_ref @$s7Library9StructOldV1iSivg
 // This module cannot be back-deployed (the deployment target is
 // available, and nothing ensures the function is available only after the
 // feature is available--must use read.
@@ -433,7 +436,7 @@ public class DerivedOldFromBaseClassOld : BaseClassOld {
 
 // CHECK-LABEL: sil_vtable [serialized] DerivedOldFromBaseClassOld {
 // CHECK-NEXT:    #BaseClassOld.init!allocator
-// CHECK-NEXT:    #BaseClassOld.i!read
+// CHECK-NEXT:    #BaseClassOld.i!getter
 // CHECK-NEXT:    #BaseClassOld.i!read2
 // CHECK-NEXT:    #BaseClassOld.i!setter
 // CHECK-NEXT:    #BaseClassOld.i!modify

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -238,6 +238,57 @@ open class BaseClassOld {
   }
 }
 
+public protocol ProtocolOld {
+  var i: Int { read set }
+}
+
+// CHECK-LABEL: sil {{.*}}@modifyProtocolOldInlinableOld : {{.*}} {
+// Binaries built with a deployment target earlier than the availability of the
+// feature must use the old accessor because conforming types may not have the
+// new accessor.
+// CHECK-NOT:     witness_method {{.*}}#ProtocolOld.i!modify2
+// CHECK:         witness_method {{.*}}#ProtocolOld.i!modify
+// CHECK-LABEL: } // end sil function 'modifyProtocolOldInlinableOld'
+@inlinable
+@_silgen_name("modifyProtocolOldInlinableOld")
+public func modifyProtocolOldInlinableOld(_ p: inout ProtocolOld) {
+  p.i.increment()
+}
+
+@_silgen_name("modifyProtocolOldNoninlinableOld")
+public func modifyProtocolOldNoninlinableOld(_ p: inout ProtocolOld) {
+// CHECK-LABEL: sil {{.*}}@modifyProtocolOldNoninlinableOld : {{.*}} {
+// In the case of old binaries running against this version, this is correct
+// because a default implementation of the accessor is provided by default
+// witness table.
+// CHECK:         witness_method {{.*}}#ProtocolOld.i!modify2
+// CHECK-LABEL: } // end sil function 'modifyProtocolOldNoninlinableOld'
+  p.i.increment()
+}
+
+@inlinable
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyProtocolOldInlinableNew")
+public func modifyProtocolOldInlinableNew(_ p: inout ProtocolOld) {
+// CHECK-LABEL: sil {{.*}}@modifyProtocolOldInlinableNew : {{.*}} {
+// CHECK:         witness_method {{.*}}#ProtocolOld.i!modify2
+// CHECK-LABEL: } // end sil function 'modifyProtocolOldInlinableNew'
+  p.i.increment()
+}
+
+@available(SwiftStdlib 9999, *)
+public protocol ProtocolNew {
+  var i: Int { read set }
+}
+
+// CHECK-LABEL: sil_default_witness_table ProtocolOld {
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    method #ProtocolOld.i!read2
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    method #ProtocolOld.i!modify2
+// CHECK-NEXT:  }
+
 //--- Downstream.swift
 
 import Library

--- a/test/SILGen/coroutine_accessors_compat.swift
+++ b/test/SILGen/coroutine_accessors_compat.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
+// RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+var _i: Int = 1
+public class C {
+  public var i: Int {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+}
+
+// CHECK-LABEL: sil_vtable C {
+// CHECK-NEXT:    #C.i!getter
+// CHECK-NEXT:    #C.i!read2
+// CHECK-NEXT:    #C.i!setter
+// CHECK-NEXT:    #C.i!modify
+// CHECK-NEXT:    #C.i!modify2
+// CHECK-NEXT:    #C.init!allocator
+// CHECK-NEXT:    #C.deinit!deallocator
+// CHECK-NEXT:  }

--- a/test/SILGen/default_override.swift
+++ b/test/SILGen/default_override.swift
@@ -22,14 +22,15 @@ public enum Open {}
 public enum Public {}
 public enum Internal {}
 
-open class OpenBase<T> {
+open class OpenBase<T, U> {
+  @_borrowed
   open var openField: T {
 // CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC9openFieldxvyTwd
 // CHECK-SAME:      : $@yield_once_2
 // CHECK-SAME:         @convention(method)
-// CHECK-SAME:         <τ_0_0> 
+// CHECK-SAME:         <τ_0_0, τ_0_1> 
 // CHECK-SAME:         (
-// CHECK-SAME:             @guaranteed OpenBase<τ_0_0>
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
 // CHECK-SAME:         )
 // CHECK-SAME:             ->
 // CHECK-SAME:         @yields @in_guaranteed τ_0_0
@@ -38,9 +39,9 @@ open class OpenBase<T> {
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField!read
-// CHECK-SAME:        <T> (OpenBase<T>) -> () -> ()
-// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0> (@guaranteed OpenBase<τ_0_0>) -> @yields @in_guaranteed τ_0_0
-// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0>([[SELF]])
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @in_guaranteed τ_0_0
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
 // CHECK:         yield [[ADDR]]
 // CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
 // CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
@@ -58,9 +59,9 @@ open class OpenBase<T> {
 // CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC9openFieldxvxTwd
 // CHECK-SAME:      : $@yield_once_2
 // CHECK-SAME:         @convention(method)
-// CHECK-SAME:         <τ_0_0>
+// CHECK-SAME:         <τ_0_0, τ_0_1>
 // CHECK-SAME:         (
-// CHECK-SAME:             @guaranteed OpenBase<τ_0_0>
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
 // CHECK-SAME:         )
 // CHECK-SAME:             ->
 // CHECK-SAME:         @yields @inout τ_0_0
@@ -69,9 +70,9 @@ open class OpenBase<T> {
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField!modify
-// CHECK:             <T> (OpenBase<T>) -> () -> ()
-// CHECK:             $@yield_once @convention(method) <τ_0_0> (@guaranteed OpenBase<τ_0_0>) -> @yields @inout τ_0_0
-// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0>([[SELF]])
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout τ_0_0
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
 // CHECK:         yield [[ADDR]]
 // CHECK:             resume [[NORMAL:bb[0-9]+]]
 // CHECK:             unwind [[UNWIND:bb[0-9]+]]
@@ -87,17 +88,624 @@ open class OpenBase<T> {
       Builtin.int_trap()
     }
   }
-  open subscript<U>(_ u: U, _ _: Open.Type) -> T {
-// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluiyTwd 
-// CHECK-SAME:      : $@yield_once_2 
-// CHECK-SAME:         @convention(method) 
-// CHECK-SAME:         <τ_0_0><τ_1_0> 
+  @_borrowed
+  open var openField2: (T, T) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField2x_xtvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1> 
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField2!read
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@yields @in_guaranteed τ_0_0, @yields @in_guaranteed τ_0_0)
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField2x_xtvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField2x_xtvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField2!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, τ_0_0)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField2x_xtvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  @_borrowed
+  open var openField3: (T, Int) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField3x_SitvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1> 
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField3!read
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@yields @in_guaranteed τ_0_0, @yields Int)
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField3x_SitvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField3x_SitvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, Int)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField3!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, Int)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField3x_SitvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  @_borrowed
+  open var openField4: (String, T) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField4SS_xtvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1> 
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField4!read
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@yields @guaranteed String, @yields @in_guaranteed τ_0_0)
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField4SS_xtvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField4SS_xtvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (String, τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField4!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (String, τ_0_0)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField4SS_xtvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  @_borrowed
+  open var openField5: (T, U) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField5x_q_tvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1> 
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         (@yields @in_guaranteed τ_0_0, @yields @in_guaranteed τ_0_1)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField5!read
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@yields @in_guaranteed τ_0_0, @yields @in_guaranteed τ_0_1)
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField5x_q_tvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC10openField5x_q_tvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, τ_0_1)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.openField5!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, τ_0_1)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC10openField5x_q_tvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open var ownedOpenField: T {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC5FieldxvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField!getter
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> T
+// CHECK-SAME:        $@convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @out τ_0_0
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack
+// CHECK:         [[EMPTY:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[ADDR]], [[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC5FieldxvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC5FieldxvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout τ_0_0
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC5FieldxvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open var ownedOpenField2: (T, T) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field2x_xtvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         (@yields @in_guaranteed τ_0_0, @yields @in_guaranteed τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField2!getter
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> (T, T)
+// CHECK-SAME:        $@convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@out τ_0_0, @out τ_0_0)
+// CHECK:         [[ADDR_1:%[^,]+]] = alloc_stack
+// CHECK:         [[ADDR_2:%[^,]+]] = alloc_stack
+// CHECK:         [[EMPTY:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[ADDR_1]], [[ADDR_2]], [[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         destroy_addr [[ADDR_2]]
+// CHECK:         dealloc_stack [[ADDR_2]]
+// CHECK:         destroy_addr [[ADDR_1]]
+// CHECK:         dealloc_stack [[ADDR_1]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_addr [[ADDR_2]]
+// CHECK:         dealloc_stack [[ADDR_2]]
+// CHECK:         destroy_addr [[ADDR_1]]
+// CHECK:         dealloc_stack [[ADDR_1]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field2x_xtvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field2x_xtvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField2!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, τ_0_0)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field2x_xtvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open var ownedOpenField3: (T, Int) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field3x_SitvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField3!getter
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> (T, Int)
+// CHECK-SAME:        $@convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@out τ_0_0, Int)
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack
+// CHECK:         [[INT:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[ADDR]], [[SELF]])
+// CHECK:         yield ([[ADDR]], [[INT]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field3x_SitvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field3x_SitvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, Int)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField3!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, Int)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field3x_SitvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open var ownedOpenField4: (String, T) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field4SS_xtvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         (@yields @guaranteed String, @yields @in_guaranteed τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField4!getter
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> (String, T)
+// CHECK-SAME:        $@convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@owned String, @out τ_0_0)
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack
+// CHECK:         [[STRING:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[ADDR]], [[SELF]])
+// CHECK:         yield ([[STRING]], [[ADDR]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         destroy_value [[STRING]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         destroy_value [[STRING]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field4SS_xtvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field4SS_xtvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (String, τ_0_0)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField4!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (String, τ_0_0)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field4SS_xtvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open var ownedOpenField5: (T, U) {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field5x_q_tvyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @in_guaranteed τ_0_0
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField5!getter
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> (T, U)
+// CHECK-SAME:        $@convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> (@out τ_0_0, @out τ_0_1)
+// CHECK:         [[ADDR_1:%[^,]+]] = alloc_stack
+// CHECK:         [[ADDR_2:%[^,]+]] = alloc_stack
+// CHECK:         [[EMPTY:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[ADDR_1]], [[ADDR_2]], [[SELF]])
+// CHECK:         yield ([[ADDR_1]], [[ADDR_2]])
+// CHECK-SAME:        resume [[NORMAL:bb[0-9]+]]
+// CHECK-SAME:        unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         destroy_addr [[ADDR_2]]
+// CHECK:         dealloc_stack [[ADDR_2]]
+// CHECK:         destroy_addr [[ADDR_1]]
+// CHECK:         dealloc_stack [[ADDR_1]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_addr [[ADDR_2]]
+// CHECK:         dealloc_stack [[ADDR_2]]
+// CHECK:         destroy_addr [[ADDR_1]]
+// CHECK:         dealloc_stack [[ADDR_1]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field5x_q_tvyTwd'
+    read {
+      Builtin.int_trap()
+    }
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseC05ownedC6Field5x_q_tvxTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1>
+// CHECK-SAME:         (
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
+// CHECK-SAME:         @yields @inout (τ_0_0, τ_0_1)
+// CHECK-SAME:  {
+// CHECK:       {{bb[0-9]+}}(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]], #OpenBase.ownedOpenField5!modify
+// CHECK:             <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK:             $@yield_once @convention(method) <τ_0_0, τ_0_1> (@guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout (τ_0_0, τ_0_1)
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1>([[SELF]])
+// CHECK:         yield [[ADDR]]
+// CHECK:             resume [[NORMAL:bb[0-9]+]]
+// CHECK:             unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[NORMAL]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseC05ownedC6Field5x_q_tvxTwd'
+    modify {
+      Builtin.int_trap()
+    }
+  }
+  open subscript<V>(_ v: V, _ _: Open.Type) -> T {
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluiyTwd
+// CHECK-SAME:      : $@yield_once_2
+// CHECK-SAME:         @convention(method)
+// CHECK-SAME:         <τ_0_0, τ_0_1><τ_1_0>
 // CHECK-SAME:         (
 // CHECK-SAME:             @in_guaranteed τ_1_0
 // CHECK-SAME:             @thin Open.Type
-// CHECK-SAME:             @guaranteed OpenBase<τ_0_0>
-// CHECK-SAME:         ) 
-// CHECK-SAME:             -> 
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
 // CHECK-SAME:         @yields @in_guaranteed τ_0_0
 // CHECK-SAME:  {
 // CHECK:       {{bb[0-9]+}}(
@@ -106,19 +714,22 @@ open class OpenBase<T> {
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]]
-// CHECK:             #OpenBase.subscript!read
-// CHECK:             <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
-// CHECK:             $@yield_once @convention(method) <τ_0_0><τ_1_0> (@in_guaranteed τ_1_0, @thin Open.Type, @guaranteed OpenBase<τ_0_0>) -> @yields @in_guaranteed τ_0_0
-// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_1_0>([[KEY]], [[OPEN_TY]], [[SELF]])
+// CHECK:             #OpenBase.subscript!getter
+// CHECK:             <T, U><V> (OpenBase<T, U>) -> (V, Open.Type) -> T
+// CHECK:             $@convention(method) <τ_0_0, τ_0_1><τ_1_0> (@in_guaranteed τ_1_0, @thin Open.Type, @guaranteed OpenBase<τ_0_0, τ_0_1>) -> @out τ_0_0
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack
+// CHECK:         [[EMPTY:%[^,]+]] = apply [[ORIGINAL]]<τ_0_0, τ_0_1, τ_1_0>([[ADDR]], [[KEY]], [[OPEN_TY]], [[SELF]])
 // CHECK:         yield [[ADDR]]
 // CHECK:             resume bb1
 // CHECK:             unwind bb2
 // CHECK:       bb1:
-// CHECK:         end_apply [[TOKEN]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
 // CHECK:       bb2:
-// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s16default_override8OpenBaseCyxqd___AA0C0OmtcluiyTwd'
     read {
@@ -127,13 +738,13 @@ open class OpenBase<T> {
 // CHECK-LABEL: sil shared [serialized] [ossa] @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluixTwd
 // CHECK-SAME:      : $@yield_once_2
 // CHECK-SAME:         @convention(method)
-// CHECK-SAME:         <τ_0_0><τ_1_0>
+// CHECK-SAME:         <τ_0_0, τ_0_1><τ_1_0>
 // CHECK-SAME:         (
 // CHECK-SAME:             @in_guaranteed τ_1_0
 // CHECK-SAME:             @thin Open.Type
-// CHECK-SAME:             @guaranteed OpenBase<τ_0_0>
-// CHECK-SAME:         ) 
-// CHECK-SAME:             -> 
+// CHECK-SAME:             @guaranteed OpenBase<τ_0_0, τ_0_1>
+// CHECK-SAME:         )
+// CHECK-SAME:             ->
 // CHECK-SAME:         @yields @inout τ_0_0
 // CHECK-SAME:  {
 // CHECK:       {{bb[0-9]+}}(
@@ -143,9 +754,9 @@ open class OpenBase<T> {
 // CHECK-SAME:  ):
 // CHECK:         [[ORIGINAL:%[^,]+]] = class_method [[SELF]]
 // CHECK-SAME:        #OpenBase.subscript!modify
-// CHECK-SAME:        <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
-// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0><τ_1_0> (@in_guaranteed τ_1_0, @thin Open.Type, @guaranteed OpenBase<τ_0_0>) -> @yields @inout τ_0_0
-// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_1_0>([[KEY]], [[OPEN_TY]], [[SELF]])
+// CHECK-SAME:        <T, U><V> (OpenBase<T, U>) -> (V, Open.Type) -> ()
+// CHECK-SAME:        $@yield_once @convention(method) <τ_0_0, τ_0_1><τ_1_0> (@in_guaranteed τ_1_0, @thin Open.Type, @guaranteed OpenBase<τ_0_0, τ_0_1>) -> @yields @inout τ_0_0
+// CHECK:         ([[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[ORIGINAL]]<τ_0_0, τ_0_1, τ_1_0>([[KEY]], [[OPEN_TY]], [[SELF]])
 // CHECK:         yield [[ADDR]]
 // CHECK:             resume [[NORMAL:bb[0-9]+]]
 // CHECK:             unwind [[UNWIND:bb[0-9]+]]
@@ -169,7 +780,7 @@ open class OpenBase<T> {
       Builtin.int_trap()
     }
   }
-  public subscript<U>(_ u: U, _ _: Public.Type) -> T {
+  public subscript<V>(_ v: V, _ _: Public.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -185,7 +796,7 @@ open class OpenBase<T> {
       Builtin.int_trap()
     }
   }
-  subscript<U>(_ u: U, _ _: Internal.Type) -> T {
+  subscript<V>(_ v: V, _ _: Internal.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -195,7 +806,7 @@ open class OpenBase<T> {
   }
 }
 
-public class PublicBase<T> {
+public class PublicBase<T, U> {
   open var openField: T {
     read {
       Builtin.int_trap()
@@ -204,7 +815,7 @@ public class PublicBase<T> {
       Builtin.int_trap()
     }
   }
-  open subscript<U>(_ u: U, _ _: Open.Type) -> T {
+  open subscript<V>(_ v: V, _ _: Open.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -220,7 +831,7 @@ public class PublicBase<T> {
       Builtin.int_trap()
     }
   }
-  public subscript<U>(_ u: U, _ _: Public.Type) -> T {
+  public subscript<V>(_ v: V, _ _: Public.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -236,7 +847,7 @@ public class PublicBase<T> {
       Builtin.int_trap()
     }
   }
-  subscript<U>(_ u: U, _ _: Internal.Type) -> T {
+  subscript<V>(_ v: V, _ _: Internal.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -246,7 +857,7 @@ public class PublicBase<T> {
   }
 }
 
-class InternalBase<T> {
+class InternalBase<T, U> {
   open var openField: T {
     read {
       Builtin.int_trap()
@@ -255,7 +866,7 @@ class InternalBase<T> {
       Builtin.int_trap()
     }
   }
-  open subscript<U>(_ u: U, _ _: Open.Type) -> T {
+  open subscript<V>(_ v: V, _ _: Open.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -271,7 +882,7 @@ class InternalBase<T> {
       Builtin.int_trap()
     }
   }
-  public subscript<U>(_ u: U, _ _: Public.Type) -> T {
+  public subscript<V>(_ v: V, _ _: Public.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -287,7 +898,7 @@ class InternalBase<T> {
       Builtin.int_trap()
     }
   }
-  subscript<U>(_ u: U, _ _: Internal.Type) -> T {
+  subscript<V>(_ v: V, _ _: Internal.Type) -> T {
     read {
       Builtin.int_trap()
     }
@@ -300,24 +911,78 @@ class InternalBase<T> {
 // CHECK-LABEL: sil_default_override_table OpenBase {
 // CHECK-NEXT:    #OpenBase.openField!read2
 // CHECK-SAME:        #OpenBase.openField!read
-// CHECK-SAME:        <T> (OpenBase<T>) -> () -> ()
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseC9openFieldxvyTwd
 // CHECK-NEXT:    #OpenBase.openField!modify2
 // CHECK-SAME:        #OpenBase.openField!modify
-// CHECK-SAME:        <T> (OpenBase<T>) -> () -> ()
+// CHECK-SAME:        <T, U> (OpenBase<T, U>) -> () -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseC9openFieldxvxTwd
+// CHECK-NEXT:    #OpenBase.openField2!read2
+// CHECK-SAME:        #OpenBase.openField2!read: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField2x_xtvyTwd
+// CHECK-NEXT:    #OpenBase.openField2!modify2
+// CHECK-SAME:        #OpenBase.openField2!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField2x_xtvxTwd
+// CHECK-NEXT:    #OpenBase.openField3!read2
+// CHECK-SAME:        #OpenBase.openField3!read: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField3x_SitvyTwd
+// CHECK-NEXT:    #OpenBase.openField3!modify2
+// CHECK-SAME:        #OpenBase.openField3!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField3x_SitvxTwd
+// CHECK-NEXT:    #OpenBase.openField4!read2
+// CHECK-SAME:        #OpenBase.openField4!read: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField4SS_xtvyTwd
+// CHECK-NEXT:    #OpenBase.openField4!modify2
+// CHECK-SAME:        #OpenBase.openField4!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField4SS_xtvxTwd
+// CHECK-NEXT:    #OpenBase.openField5!read2
+// CHECK-SAME:        #OpenBase.openField5!read: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField5x_q_tvyTwd
+// CHECK-NEXT:    #OpenBase.openField5!modify2
+// CHECK-SAME:        #OpenBase.openField5!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC10openField5x_q_tvxTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField!read2
+// CHECK-SAME:        #OpenBase.ownedOpenField!getter: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC5FieldxvyTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField!modify2
+// CHECK-SAME:        #OpenBase.ownedOpenField!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC5FieldxvxTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField2!read2
+// CHECK-SAME:        #OpenBase.ownedOpenField2!getter: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field2x_xtvyTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField2!modify2
+// CHECK-SAME:        #OpenBase.ownedOpenField2!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field2x_xtvxTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField3!read2
+// CHECK-SAME:        #OpenBase.ownedOpenField3!getter: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field3x_SitvyTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField3!modify2
+// CHECK-SAME:        #OpenBase.ownedOpenField3!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field3x_SitvxTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField4!read2
+// CHECK-SAME:        #OpenBase.ownedOpenField4!getter: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field4SS_xtvyTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField4!modify2
+// CHECK-SAME:        #OpenBase.ownedOpenField4!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field4SS_xtvxTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField5!read2
+// CHECK-SAME:        #OpenBase.ownedOpenField5!getter: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field5x_q_tvyTwd
+// CHECK-NEXT:    #OpenBase.ownedOpenField5!modify2
+// CHECK-SAME:        #OpenBase.ownedOpenField5!modify: <T, U> (OpenBase<T, U>) -> () -> ()
+// CHECK-SAME:        @$s16default_override8OpenBaseC05ownedC6Field5x_q_tvxTwd
 // CHECK-NEXT:    #OpenBase.subscript!read2
-// CHECK-SAME:        #OpenBase.subscript!read
-// CHECK-SAME:        <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
+// CHECK-SAME:        #OpenBase.subscript!getter
+// CHECK-SAME:        <T, U><V> (OpenBase<T, U>) -> (V, Open.Type) -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluiyTwd
 // CHECK-NEXT:    #OpenBase.subscript!modify2
 // CHECK-SAME:        #OpenBase.subscript!modify
-// CHECK-SAME:        <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
+// CHECK-SAME:        <T, U><V> (OpenBase<T, U>) -> (V, Open.Type) -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluixTwd
 // CHECK-NOT:     #OpenBase.publicField!read2
 // CHECK-NOT:     #OpenBase.publicField!modify2
-// CHECK-NOT:     #OpenBase.subscript!read2: #OpenBase.subscript!read: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
-// CHECK-NOT:     #OpenBase.subscript!modify2: #OpenBase.subscript!modify: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
+// CHECK-NOT:     #OpenBase.subscript!read2: #OpenBase.subscript!read: <T, U><V> (OpenBase<T, U>) -> (U, Public.Type) -> ()
+// CHECK-NOT:     #OpenBase.subscript!modify2: #OpenBase.subscript!modify: <T, U><V> (OpenBase<T, U>) -> (U, Public.Type) -> ()
 // CHECK-NEXT:  }
 
 // CHECK-NOT: sil_default_override_table PublicBase {


### PR DESCRIPTION
Based on https://github.com/swiftlang/swift/pull/84472 .

Before the feature is enabled, a var decl for which a reading accessor is implemented via `_read` still had as its opaque accessor a getter (unless it's marked `@_borrowed`, it's noncopyable, or it has a lifetime dependency).  So when that `_read` is replaced with a `read`/`yielding borrow`, it is still necessary to emit a getter.  And for back deployment it is still necessary to provide a default override of the getter in terms of the `read`.

rdar://149352519

