### PR TITLE
[Performance Hints] Disable performance hints if typechecker can skip function bodies

### DIFF
--- a/lib/Sema/PerformanceHints.cpp
+++ b/lib/Sema/PerformanceHints.cpp
@@ -31,7 +31,8 @@
 using namespace swift;
 
 bool swift::performanceHintDiagnosticsEnabled(ASTContext &ctx) {
-  return !ctx.Diags.isIgnoredDiagnosticGroupTree(DiagGroupID::PerformanceHints);
+  return !ctx.Diags.isIgnoredDiagnosticGroupTree(DiagGroupID::PerformanceHints) &&
+         (ctx.TypeCheckerOpts.SkipFunctionBodies == FunctionBodySkipping::None);
 }
 
 namespace {


### PR DESCRIPTION
If `SkipFunctionBodies` is not `None`, functions that are inlinable or not used for the result are not typechecked. The absence of type information crashes the performance hint analyzer. This change prevents the analyzer from running in these cases.