### PR TITLE
AST: Skip weak linking on Windows consistently

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1525,12 +1525,15 @@ bool Decl::isAlwaysWeakImported() const {
     return clangDecl->isWeakImported(
         getASTContext().LangOpts.getMinPlatformVersion());
 
+  // FIXME: Weak linking on Windows is not yet supported
+  // https://github.com/apple/swift/issues/53303
+  if (getASTContext().LangOpts.Target.isOSWindows())
+    return false;
+
   if (getAttrs().hasAttribute<WeakLinkedAttr>())
     return true;
 
-  // FIXME: Weak linking on Windows is not yet supported
-  // https://github.com/apple/swift/issues/53303
-  if (isUnavailable() && !getASTContext().LangOpts.Target.isOSWindows())
+  if (isUnavailable())
     return true;
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))

--- a/test/SILGen/availability_windows.swift
+++ b/test/SILGen/availability_windows.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-unknown-windows-msvc | %FileCheck %s
+// REQUIRES: OS=windows-msvc
+
+@_silgen_name("windows10")
+@available(Windows 10, *)
+public func windows10()
+
+@_silgen_name("unavailable")
+@available(Windows, unavailable)
+public func unavailable()
+
+
+// CHECK-LABEL: sil [ossa] @$s20availability_windows15testIfAvailableyyF : $@convention(thin) () -> ()
+// CHECK: cond_br
+// CHECK: function_ref @windows10
+public func testIfAvailable() {
+  if #available(Windows 10, *) {
+    windows10()
+  }
+}
+// CHECK: sil [available 10] @windows10 : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [ossa] @$s20availability_windows15testUnavailableyyF : $@convention(thin) () -> ()
+// CHECK: function_ref @unavailable
+@available(*, unavailable)
+public func testUnavailable() {
+  unavailable()
+}
+
+// FIXME: Mark [weak_imported] when weak linking is supported on Windows (https://github.com/apple/swift/issues/53303)
+// CHECK: sil @unavailable : $@convention(thin) () -> ()


### PR DESCRIPTION
Always special-case Windows targets in `isAlwaysWeakImported()` instead of limiting the special case to declarations that are marked unavailable.
