### PR TITLE
Sema: Fix a fuzzer crash

### DIFF
--- a/validation-test/compiler_crashers_fixed/Solution-getFixedType-98b9c4.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFixedType-98b9c4.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::Solution::getFixedType(swift::TypeVariableType*) const","signatureAssert":"Assertion failed: (knownBinding != typeBindings.end()), function getFixedType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 class a {
   static
 b {


### PR DESCRIPTION
This test case crashes when prepared overloads are disabled, but passes when enabled. To avoid messing up tests if we have to turn the flag on and off, fix the crash.