### PR TITLE
Don’t redundantly diagnose key path components

### DIFF
--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2642,7 +2642,9 @@ void PreCheckTarget::resolveKeyPathExpr(KeyPathExpr *KPE) {
           if (isa<ParenExpr>(expr) || isa<TupleExpr>(expr)) {
             DE.diagnose(expr->getLoc(),
                         diag::expr_string_interpolation_outside_string);
-          } else {
+          } else if (!isa<ErrorExpr>(expr)) {
+            // If we have an `ErrorExpr`, we've probably already emitted a
+            // diagnostic explaining it.
             DE.diagnose(expr->getLoc(),
                         diag::expr_swift_keypath_invalid_component);
           }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1186,8 +1186,7 @@ func f_56996() {
   _ = \Int.byteSwapped.init() // expected-error {{static member 'init()' cannot be used on instance of type 'Int'}}
   _ = \Int // expected-error {{key path must have at least one component}}
   _ = \Int? // expected-error {{key path must have at least one component}}
-  _ = \Int. // expected-error {{invalid component of Swift key path}}
-  // expected-error@-1 {{expected member name following '.'}}
+  _ = \Int. // expected-error {{expected member name following '.'}}
 }
 
 // https://github.com/apple/swift/issues/55805


### PR DESCRIPTION
A key path component that resolved to an `ErrorExpr` would be diagnosed twice: once when the `ErrorExpr` was created, then again when it was processed. Fix this redundant diagnostic.

Extracted from #34556.