### PR TITLE
[Test] Don't expect IRGen/typed_throws_abi.swift to fail

### DIFF
--- a/test/IRGen/typed_throws_abi.swift
+++ b/test/IRGen/typed_throws_abi.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-irgen -enable-library-evolution | %FileCheck %s
 
-// XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
 struct Empty: Error {}


### PR DESCRIPTION
rdar://162915553

Since this test was introduced, code gen has changed and it is now passing on arm64e as well

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
