### PR TITLE
[ClangImporter] add implicit import of `Swift` for `__ObjC` module

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1565,21 +1565,16 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
   importer->Impl.setObjectForKeyedSubscript
     = clangContext.Selectors.getSelector(2, setObjectForKeyedSubscriptIdents);
 
-  ImplicitImportInfo implicitImportInfo;
   // Can't inherit implicit modules from main module, because it isn't loaded yet.
   // Add the Swift module, because it is important for safe interop wrappers.
-  if (auto stdlib = importer->Impl.getStdlibModule())
-    implicitImportInfo.AdditionalImports.emplace_back(ImportedModule(stdlib));
-  else {
-    Identifier stdlibName = importer->Impl.SwiftContext.getIdentifier(STDLIB_NAME);
-    ImportPath::Raw path =
-        importer->Impl.SwiftContext.AllocateCopy<Located<Identifier>>(
-            Located<Identifier>(stdlibName, SourceLoc()));
-    implicitImportInfo.AdditionalUnloadedImports.emplace_back(
-        UnloadedImportedModule(
-            ImportPath(path),
-            ImportKind::Module));
-  }
+  Identifier stdlibName =
+      importer->Impl.SwiftContext.getIdentifier(STDLIB_NAME);
+  ImportPath::Raw path =
+      importer->Impl.SwiftContext.AllocateCopy<Located<Identifier>>(
+          Located<Identifier>(stdlibName, SourceLoc()));
+  ImplicitImportInfo implicitImportInfo;
+  implicitImportInfo.AdditionalUnloadedImports.emplace_back(
+      UnloadedImportedModule(ImportPath(path), ImportKind::Module));
 
   // Set up the imported header module.
   auto *importedHeaderModule = ModuleDecl::create(

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1565,9 +1565,25 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
   importer->Impl.setObjectForKeyedSubscript
     = clangContext.Selectors.getSelector(2, setObjectForKeyedSubscriptIdents);
 
+  ImplicitImportInfo implicitImportInfo;
+  // Can't inherit implicit modules from main module, because it isn't loaded yet.
+  // Add the Swift module, because it is important for safe interop wrappers.
+  if (auto stdlib = importer->Impl.getStdlibModule())
+    implicitImportInfo.AdditionalImports.emplace_back(ImportedModule(stdlib));
+  else {
+    Identifier stdlibName = importer->Impl.SwiftContext.getIdentifier(STDLIB_NAME);
+    ImportPath::Raw path =
+        importer->Impl.SwiftContext.AllocateCopy<Located<Identifier>>(
+            Located<Identifier>(stdlibName, SourceLoc()));
+    implicitImportInfo.AdditionalUnloadedImports.emplace_back(
+        UnloadedImportedModule(
+            ImportPath(path),
+            ImportKind::Module));
+  }
+
   // Set up the imported header module.
   auto *importedHeaderModule = ModuleDecl::create(
-      ctx.getIdentifier(CLANG_HEADER_MODULE_NAME), ctx,
+      ctx.getIdentifier(CLANG_HEADER_MODULE_NAME), ctx, implicitImportInfo,
       [&](ModuleDecl *importedHeaderModule, auto addFile) {
         importer->Impl.ImportedHeaderUnit = new (ctx)
             ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
+// RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
+// RUN: %diff %t/imports.out %t/imports.expected
+
+//--- imports.expected
+imports for TMP_DIR/test.swift:
+	Swift
+	__ObjC
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+imports for __ObjC.foo:
+imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
+	__ObjC
+	Swift
+
+//--- macro-expansions.expected
+@__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeBufferPointer { _pPtr in
+      return unsafe foo(len, _pPtr.baseAddress!)
+    }
+}
+------------------------------
+
+//--- test.swift
+func test(s: Span<CInt>) {
+  foo(s)
+}
+
+//--- bridging.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+
+void foo(int len, const int * __counted_by(len) p __noescape);

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -1,3 +1,5 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
Any safe wrapper expansion originating in a bridging header would fail typechecking because the `__ObjC` module doesn't import the standard implicit imports. This is because the main module is not available to inherit implicit imports from when the `__ObjC` module is created. We don't need all of the implicit modules for safe wrappers, so import `Swift` specifically.

rdar://163078116