### PR TITLE
Supply -z,nobtcfi on x86_64 as well.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -995,7 +995,7 @@ function(add_swift_host_tool executable)
   endif()
 
   # Opt-out of OpenBSD BTCFI if instructed where it is enforced by default.
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL "OPENBSD" AND SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND NOT SWIFT_OPENBSD_BTCFI)
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL "OPENBSD" AND SWIFT_HOST_VARIANT_ARCH MATCHES "aarch64|x86_64" AND NOT SWIFT_OPENBSD_BTCFI)
     target_link_options(${executable} PRIVATE "LINKER:-z,nobtcfi")
   endif()
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -150,7 +150,10 @@ bool swift::tripleRequiresRPathForSwiftLibrariesInOS(
 }
 
 bool swift::tripleBTCFIByDefaultInOpenBSD(const llvm::Triple &triple) {
-  return triple.isOSOpenBSD() && triple.getArch() == llvm::Triple::aarch64;
+  return triple.isOSOpenBSD() && (
+     triple.getArch() == llvm::Triple::aarch64 ||
+     triple.getArch() == llvm::Triple::x86_64);
+
 }
 
 DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {


### PR DESCRIPTION
On older x86_64 hardware, this isn't a problem since CET IBT hardware support may not have been available. However, newer x86_64 hardware supports the feature, which will lead to BTCFI failures. Therefore ensure the same BTCFI disabling logic applies on x86_64 as well as aarch64.