### PR TITLE
TempRValueOptimization: respect deinit-barriers when hoisting destroys

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionTest.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionTest.swift
@@ -51,7 +51,8 @@ public func registerOptimizerTests() {
     localVariableReachableUsesTest,
     localVariableReachingAssignmentsTest,
     rangeOverlapsPathTest,
-    variableIntroducerTest
+    variableIntroducerTest,
+    destroyBarrierTest
   )
 
   // Finally register the thunk they all call through.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -546,6 +546,54 @@ extension Instruction {
     // Eventually we want to replace the SILCombine implementation with this one.
     return nil
   }
+
+  /// Returns true if a destroy of `type` must not be moved across this instruction.
+  func isBarrierForDestroy(of type: Type, _ context: some Context) -> Bool {
+    let instEffects = memoryEffects
+    if instEffects == .noEffects || type.isTrivial(in: parentFunction) {
+      return false
+    }
+    guard type.isMoveOnly else {
+      // Non-trivial copyable types only have to consider deinit-barriers for classes.
+      return isDeinitBarrier(context.calleeAnalysis)
+    }
+
+    // Check side-effects of non-copyable deinits.
+
+    guard let nominal = type.nominal else {
+      return true
+    }
+    if nominal.valueTypeDestructor != nil {
+      guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
+        return true
+      }
+      let destructorEffects = deinitFunc.getSideEffects().memory
+      if instEffects.write || destructorEffects.write {
+        return true
+      }
+    }
+
+    switch nominal {
+    case is StructDecl:
+      guard let fields = type.getNominalFields(in: parentFunction) else {
+        return true
+      }
+      return fields.contains { isBarrierForDestroy(of: $0, context) }
+    case is EnumDecl:
+      guard let enumCases = type.getEnumCases(in: parentFunction) else {
+        return true
+      }
+      return enumCases.contains {
+        if let payload = $0.payload {
+          return isBarrierForDestroy(of: payload, context)
+        }
+        return false
+      }
+    default:
+      return true
+    }
+  }
+
 }
 
 // Match the pattern:
@@ -1132,4 +1180,15 @@ func cloneAndSpecializeFunction(from originalFunction: Function,
                                       substitutions: substitutions, context)
   defer { cloner.deinitialize() }
   cloner.cloneFunctionBody()
+}
+
+let destroyBarrierTest = FunctionTest("destroy_barrier") { function, arguments, context in
+  let type = arguments.takeValue().type
+  for inst in function.instructions {
+    if inst.isBarrierForDestroy(of: type, context) {
+      print("barrier: \(inst)")
+    } else {
+      print("transparent: \(inst)")
+    }
+  }
 }

--- a/test/SILOptimizer/destroy_barrier_unit.sil
+++ b/test/SILOptimizer/destroy_barrier_unit.sil
@@ -1,0 +1,183 @@
+// RUN: %target-sil-opt -test-runner %s -enable-experimental-feature MoveOnlyEnumDeinits -o /dev/null | %FileCheck %s
+
+// REQUIRES: swift_feature_MoveOnlyEnumDeinits
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct S1: ~Copyable {
+  deinit
+}
+
+struct S2: ~Copyable {
+  deinit
+}
+
+struct S3<T: ~Copyable>: ~Copyable {
+  @_hasStorage let t: T
+  deinit
+}
+
+enum E<T: ~Copyable>: ~Copyable {
+  case A(Int)
+  case B
+  case C(T)
+  deinit
+}
+
+struct StrWithoutDeinit: ~Copyable {
+  @_hasStorage var a: S1
+  @_hasStorage var b: S2
+  @_hasStorage let c: Int
+}
+
+struct S4: ~Copyable {
+  @_hasStorage var a: S1
+  @_hasStorage var b: S2
+}
+
+struct S5: ~Copyable {
+  @_hasStorage let a: Int
+  @_hasStorage let b: AnyObject
+}
+
+struct UnknownDeinit: ~Copyable {
+  deinit
+}
+
+sil @s1_deinit : $@convention(method) (@owned S1) -> () {
+[global: read]
+}
+
+sil @s2_deinit : $@convention(method) (@owned S2) -> () {
+[global: write]
+}
+
+sil @s3_deinit : $@convention(method) <T> (@in S3<T>) -> () {
+[global: read]
+}
+
+sil @e_deinit : $@convention(method) (@owned S4) -> () {
+[global: read]
+}
+
+sil_moveonlydeinit S1 {
+  @s1_deinit
+}
+
+sil_moveonlydeinit S2 {
+  @s2_deinit
+}
+
+sil_moveonlydeinit S3 {
+  @s3_deinit
+}
+
+sil_moveonlydeinit E {
+  @e_deinit
+}
+
+sil_global @g : $Int
+
+sil [ossa] @global_load_store : $@convention(thin) (@inout_aliasable Int, @guaranteed S1, @guaranteed S2, @guaranteed S3<S1>, @guaranteed S3<S2>, @guaranteed S4, @guaranteed S5, @guaranteed E<S4>, @guaranteed E<Int>, @guaranteed UnknownDeinit) -> () {
+bb0(%0 : $*Int, %1 : @guaranteed $S1, %2 : @guaranteed $S2, %3 : @guaranteed $S3<S1>, %4 : @guaranteed $S3<S2>, %5 : @guaranteed $S4, %6 : @guaranteed $S5, %7 : @guaranteed $E<S4>, %8 : @guaranteed $E<Int>, %9 : @guaranteed $UnknownDeinit):
+
+  // --- Int ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %0
+  // CHECK:       transparent:   %{{[0-9]+}} = load
+  // CHECK:       transparent:   store
+  // CHECK:       transparent:   %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %0
+  specify_test "destroy_barrier %0"
+
+  // --- S1 ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %1
+  // CHECK:       transparent:   %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %1
+  specify_test "destroy_barrier %1"
+
+  // --- S2 ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %2
+  // CHECK:       barrier:       %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %2
+  specify_test "destroy_barrier %2"
+
+  // --- S3<S1> ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %3
+  // CHECK:       transparent:   %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %3
+  specify_test "destroy_barrier %3"
+
+  // --- S3<S2> ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %4
+  // CHECK:       barrier:       %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %4
+  specify_test "destroy_barrier %4"
+
+  // --- S4 ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %5
+  // CHECK:       barrier:       %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %5
+  specify_test "destroy_barrier %5"
+
+  // --- S5 ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %6
+  // CHECK:       transparent:   %{{[0-9]+}} = load
+  // CHECK:       transparent:   store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %6
+  specify_test "destroy_barrier %6"
+
+  // --- E<S4> ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %7
+  // CHECK:       barrier:       %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %7
+  specify_test "destroy_barrier %7"
+
+  // --- E<Int> ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %8
+  // CHECK:       transparent:   %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %8
+  specify_test "destroy_barrier %8"
+
+  // --- UnknownDeinit ---
+  // CHECK-LABEL: begin running test {{.*}} on global_load_store: destroy_barrier with: %9
+  // CHECK:       barrier:       %{{[0-9]+}} = load
+  // CHECK:       barrier:       store
+  // CHECK:       barrier:       %{{[0-9]+}} = apply
+  // CHECK:       transparent:   %{{[0-9]+}} = tuple
+  // CHECK:       end running test {{.*}} on global_load_store: destroy_barrier with: %9
+  specify_test "destroy_barrier %9"
+
+  %l = load [trivial] %0
+  store %l to [trivial] %0
+  apply undef() : $() -> ()
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -66,6 +66,7 @@ sil [ossa] @inguaranteed_user_without_result_NTS : $@convention(thin) (@in_guara
 sil [ossa] @inguaranteed_user_without_result_MOS : $@convention(thin) (@in_guaranteed MOS) -> ()
 
 sil [ossa] @consuming_indirect_arg : $@convention(thin) (@in Klass) -> ()
+sil @deinit_barrier : $@convention(thin) () -> ()
 
 sil [ossa] @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
@@ -1675,5 +1676,117 @@ bb0(%0 : $*Klass):
   dealloc_stack %1 : $*Klass
   %9 = tuple ()
   return %9 : $()
+}
+
+// CHECK-LABEL:    sil [ossa] @dont_hoist_destroy :
+// CHECK-OPT-NOT:    alloc_stack
+// CHECK-OPT-NOT:    copy_addr
+// CHECK:          bb2:
+// CHECK-OPT-NEXT:   destroy_addr %0
+// CHECK-LABEL:    } // end sil function 'dont_hoist_destroy'
+sil [ossa] @dont_hoist_destroy : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = alloc_stack [lexical] [var_decl] $Klass
+  copy_addr [take] %0 to [init] %1
+  br bb1
+bb1:
+  %5 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  %6 = apply %5() : $@convention(thin) () -> ()
+  br bb2
+bb2:
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL:    sil [ossa] @hoist_destroy :
+// CHECK:          bb0(%0 : $*Klass, %1 : @owned $Klass):
+// CHECK-OPT-NEXT:   destroy_addr %0
+// CHECK-OPT-NOT:    alloc_stack
+// CHECK-OPT-NOT:    copy_addr
+// CHECK-OPT-NOT:    destroy_addr
+// CHECK-LABEL:    } // end sil function 'hoist_destroy'
+sil [ossa] @hoist_destroy : $@convention(thin) (@inout Klass, @owned Klass) -> () {
+bb0(%0 : $*Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] [var_decl] $Klass
+  copy_addr [take] %0 to [init] %2
+  br bb1
+bb1:
+  store %1 to [init] %0
+  br bb2
+bb2:
+  destroy_addr %2
+  dealloc_stack %2
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL:    sil [ossa] @hoist_destroy2 :
+// CHECK:          bb0(%0 : $*Klass, %1 : @owned $Klass, %2 : $*Int, %3 : $Int):
+// CHECK-OPT-NEXT:   destroy_addr %0
+// CHECK-OPT-NOT:    alloc_stack
+// CHECK-OPT-NOT:    copy_addr
+// CHECK-OPT-NOT:    destroy_addr
+// CHECK-LABEL:    } // end sil function 'hoist_destroy2'
+sil [ossa] @hoist_destroy2 : $@convention(thin) (@inout Klass, @owned Klass, @inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Klass, %1 : @owned $Klass, %2 : $*Int, %3 : $Int):
+  %4 = alloc_stack [lexical] [var_decl] $Klass
+  copy_addr [take] %0 to [init] %4
+  br bb1
+bb1:
+  store %1 to [init] %0
+  store %3 to [trivial] %2
+  br bb2
+bb2:
+  destroy_addr %4
+  dealloc_stack %4
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @cant_hoist_destroy :
+// CHECK:       bb0(%0 : $*Klass, %1 : @owned $Klass):
+// CHECK-NEXT:    %2 = alloc_stack
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr %2
+// CHECK-LABEL: } // end sil function 'cant_hoist_destroy'
+sil [ossa] @cant_hoist_destroy : $@convention(thin) (@inout Klass, @owned Klass) -> () {
+bb0(%0 : $*Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] [var_decl] $Klass
+  copy_addr [take] %0 to [init] %2
+  br bb1
+bb1:
+  store %1 to [init] %0
+  %5 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  %6 = apply %5() : $@convention(thin) () -> ()
+  br bb2
+bb2:
+  destroy_addr %2
+  dealloc_stack %2
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @cant_hoist_nc_destroy :
+// CHECK:       bb0(%0 : $*NCWithDeinit, %1 : @owned $NCWithDeinit, %2 : $*Int, %3 : $Int):
+// CHECK-NEXT:    %4 = alloc_stack
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr %4
+// CHECK-LABEL: } // end sil function 'cant_hoist_nc_destroy'
+sil [ossa] @cant_hoist_nc_destroy : $@convention(thin) (@inout NCWithDeinit, @owned NCWithDeinit, @inout_aliasable Int, Int) -> () {
+bb0(%0 : $*NCWithDeinit, %1 : @owned $NCWithDeinit, %2 : $*Int, %3 : $Int):
+  %4 = alloc_stack [lexical] [var_decl] $NCWithDeinit
+  copy_addr [take] %0 to [init] %4
+  br bb1
+bb1:
+  store %1 to [init] %0
+  store %3 to [trivial] %2
+  br bb2
+bb2:
+  destroy_addr %4
+  dealloc_stack %4
+  %9 = tuple ()
+  return %9
 }
 


### PR DESCRIPTION
Fixes a mis-compile which causes a deinit to be called earlier than expected.

rdar://162299994
