### PR TITLE
[ConstraintSystem] Type-join multiple `return` statements in a closure

### DIFF
--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -65,7 +65,7 @@ EXPR_CHANGE(AppliedPropertyWrapper)
 EXPR_CHANGE(RecordedImpliedResult)
 EXPR_CHANGE(RecordedExprPattern)
 
-CLOSURE_CHANGE(RecordedClosureType)
+CLOSURE_CHANGE(RecordedClosure)
 CLOSURE_CHANGE(RecordedPreconcurrencyClosure)
 
 CONSTRAINT_CHANGE(DisabledConstraint)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6527,6 +6527,7 @@ class TypeVarRefCollector : public ASTWalker {
   llvm::SmallVector<ReturnStmt *, 4> Returns;
 
   unsigned DCDepth = 0;
+  unsigned SVEDepth = 0;
 
 public:
   TypeVarRefCollector(ConstraintSystem &cs, DeclContext *dc,

--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -265,6 +265,15 @@ public:
   /// Form an expression target for a ReturnStmt.
   static SyntacticElementTarget forReturn(ReturnStmt *returnStmt,
                                           Expr *returnExpr, Type contextTy,
+                                          DeclContext *dc) {
+    ContextualTypeInfo context(contextTy, CTP_ReturnStmt);
+    return forReturn(returnStmt, returnExpr, context, dc);
+  }
+
+  /// Form an expression target for a ReturnStmt.
+  static SyntacticElementTarget forReturn(ReturnStmt *returnStmt,
+                                          Expr *returnExpr,
+                                          ContextualTypeInfo context,
                                           DeclContext *dc);
 
   /// Form a target for the preamble of a for-in loop, excluding its where

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3170,7 +3170,7 @@ namespace {
       if (!OuterExpansions.empty())
         CS.setCapturedExpansions(closure, OuterExpansions);
 
-      CS.setClosureType(closure, inferredType);
+      CS.setClosure(closure, {inferredType});
       return closureType;
     }
 
@@ -4314,7 +4314,7 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         FunctionType *closureTy =
             inferClosureType(closure, /*allowResultBindToHole=*/true);
-        CS.setClosureType(closure, closureTy);
+        CS.setClosure(closure, {closureTy});
         CS.setType(closure, closureTy);
       } else {
         TypeVariableType *exprType = CS.createTypeVariable(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4899,18 +4899,23 @@ bool ConstraintSystem::generateConstraints(
       target.setExprConversionType(TypeChecker::getOptionalType(expr->getLoc(), var));
     }
 
+    auto *DC = target.getDeclContext();
+
     // If we have a parent return statement, record whether it's implied.
     if (auto *RS = target.getParentReturnStmt()) {
-      if (RS->isImplied())
-        recordImpliedResult(expr, ImpliedResultKind::Regular);
+      if (RS->isImplied()) {
+        recordImpliedResult(expr, isa<AbstractClosureExpr>(DC)
+                                      ? ImpliedResultKind::ForClosure
+                                      : ImpliedResultKind::Regular);
+      }
     }
 
-    expr = buildTypeErasedExpr(expr, target.getDeclContext(),
+    expr = buildTypeErasedExpr(expr, DC,
                                target.getExprContextualType(),
                                target.getExprContextualTypePurpose());
 
     // Generate constraints for the main system.
-    expr = generateConstraints(expr, target.getDeclContext());
+    expr = generateConstraints(expr, DC);
     if (!expr)
       return true;
     target.setExpr(expr);

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -467,8 +467,8 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
     cs.removePropertyWrapper(TheExpr);
     break;
 
-  case ChangeKind::RecordedClosureType:
-    cs.removeClosureType(TheClosure);
+  case ChangeKind::RecordedClosure:
+    cs.removeClosure(TheClosure);
     break;
 
   case ChangeKind::RecordedImpliedResult:

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -853,7 +853,7 @@ ConstraintGraph::computeConnectedComponents(
 bool ConstraintGraph::contractEdges() {
   // Current constraint system doesn't have any closure expressions
   // associated with it so there is nothing to here.
-  if (CS.ClosureTypes.empty())
+  if (CS.Closures.empty())
     return false;
 
   // For a given constraint kind, decide if we should attempt to eliminate its
@@ -869,8 +869,8 @@ bool ConstraintGraph::contractEdges() {
   };
 
   SmallVector<Constraint *, 16> constraints;
-  for (const auto &closure : CS.ClosureTypes) {
-    for (const auto &param : closure.second->getParams()) {
+  for (const auto &[closure, info] : CS.Closures) {
+    for (const auto &param : info.Type->getParams()) {
       auto paramTy = param.getPlainType()->getAs<TypeVariableType>();
       if (!paramTy)
         continue;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -870,7 +870,7 @@ bool ConstraintGraph::contractEdges() {
 
   SmallVector<Constraint *, 16> constraints;
   for (const auto &[closure, info] : CS.Closures) {
-    for (const auto &param : info.Type->getParams()) {
+    for (const auto &param : info.getType()->getParams()) {
       auto paramTy = param.getPlainType()->getAs<TypeVariableType>();
       if (!paramTy)
         continue;

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -172,12 +172,11 @@ SyntacticElementTarget SyntacticElementTarget::forInitialization(
 
 SyntacticElementTarget SyntacticElementTarget::forReturn(ReturnStmt *returnStmt,
                                                          Expr *returnExpr,
-                                                         Type contextTy,
+                                                         ContextualTypeInfo context,
                                                          DeclContext *dc) {
-  assert(contextTy);
+  assert(context.getType());
   assert(returnStmt->hasResult() && "Must have result to be type-checked");
-  ContextualTypeInfo contextInfo(contextTy, CTP_ReturnStmt);
-  SyntacticElementTarget target(returnExpr, dc, contextInfo,
+  SyntacticElementTarget target(returnExpr, dc, context,
                                 /*isDiscarded*/ false);
   target.expression.parentReturnStmt = returnStmt;
   return target;

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -1171,11 +1171,12 @@ public class TestRebindingSelfIsDisallowed {
     return s.isEmpty
 }.filter { $0 }
 
-["foo"].map { s in
-    if s == "1" { return } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+// TODO(diagnostics): We need a tailored diagnostic for cases when multiple result types cannot be joined.
+["foo"].map { s in // expected-error {{cannot convert value of type '()' to closure result type 'Bool'}}
+    if s == "1" { return }
     if s == "2" { return }
     if s == "3" { return }
-    return s.isEmpty
+    return s.isEmpty // expected-error {{cannot convert value of type 'Bool' to closure result type '()'}}
 }.filter { $0 }
 
 ["foo"].map { s in

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -719,3 +719,40 @@ func test_result_builder_in_member_chaining() {
     result
   }
 }
+
+func coule_of_result_join_tests() {
+  func fn<T>(_ f: () -> T) -> T { f() }
+  func genericRes<T>() -> T { fatalError() }
+
+  let resDouble = fn { // Joins to Double
+    if true {
+      return 42
+    }
+
+    return 0.0
+  }
+
+  let _: Double = resDouble // Ok
+
+  let resOptDouble = fn { // Joins to `Double?`
+    if true {
+      return 42
+    }
+
+    if false {
+      for x in 0..<2 {
+        if x == 0 {
+          return nil
+        } else if x == 1 {
+          return genericRes()
+        } else {
+          return fn { nil }
+        }
+      }
+    }
+
+    return 0.0
+  }
+
+  let _: Double = resOptDouble! // Ok
+}

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -106,7 +106,7 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
   auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
                                      resultTy, extInfo);
 
-  cs.setClosureType(closure, defaultTy);
+  cs.setClosure(closure, {defaultTy});
 
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
   cs.setType(closure, closureTy);
@@ -191,7 +191,7 @@ TEST_F(SemaTest, TestInitializerUseDCIsSetCorrectlyInClosure) {
   auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
                                      resultTy, extInfo);
 
-  cs.setClosureType(closure, defaultTy);
+  cs.setClosure(closure, {defaultTy});
 
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
   cs.setType(closure, closureTy);

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -106,7 +106,7 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
   auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
                                      resultTy, extInfo);
 
-  cs.setClosure(closure, {defaultTy});
+  cs.setClosure(closure, {defaultTy, /*returns=*/{}});
 
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
   cs.setType(closure, closureTy);
@@ -191,7 +191,7 @@ TEST_F(SemaTest, TestInitializerUseDCIsSetCorrectlyInClosure) {
   auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
                                      resultTy, extInfo);
 
-  cs.setClosure(closure, {defaultTy});
+  cs.setClosure(closure, {defaultTy, /*returns=*/{}});
 
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
   cs.setType(closure, closureTy);

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
@@ -10,10 +10,8 @@ struct Value {
 }
 
 func test(allValues: [Value]) {
-  // Type for `return nil` cannot be inferred at the moment because there is no join for result expressions.
-  let owners = Set(allValues.compactMap { // expected-error {{generic parameter 'Element' could not be inferred}}
-      // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
-      guard let id = $0.ID else { return nil }
+  _ = Set(allValues.compactMap {
+      guard let id = $0.ID else { return nil } // Ok (result type is inferred by joining both `return` statements)
       return Description(name: "", id: id)
     })
 }


### PR DESCRIPTION
If a closure has multiple explicit return statements, solve them
as a unit via `TypeJoinExpr` after all other body elements have
been successfully solved. This strategy helps to solve situations
like when `return nil` appears before result type could be determined
from other return statements.

The method allows to solve some of the returns individually
before joining everything together (i.e. when result expression
doesn't have any literal expressions), in such cases pre-solved
return appear an "opaque value" in the final type-join operation.

All of the temporary expressions that are not going to appear
in a type-checked version of the AST are allocated in the solver
arena.

Resolves: rdar://problem/104381868
Resolves: rdar://problem/61795422

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
