### PR TITLE
[SE-0491] Conditionally emit module selectors into swiftinterfaces

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -580,6 +580,9 @@ public:
   /// with types sharing a name with a module.
   bool AliasModuleNames = false;
 
+  /// Use module selectors when printing names.
+  bool UseModuleSelectors = false;
+
   /// Name of the modules that have been aliased in AliasModuleNames mode.
   /// Ideally we would use something other than a string to identify a module,
   /// but since one alias can apply to more than one module, strings happen
@@ -769,6 +772,7 @@ public:
   ///
   /// \see swift::emitSwiftInterface
   static PrintOptions printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
+                                              bool useModuleSelectors,
                                               bool preferTypeRepr,
                                               bool printFullConvention,
                                               InterfaceMode interfaceMode,

--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -27,5 +27,6 @@ BLOCKLIST_ACTION(ShouldDisableOwnershipVerification)
 BLOCKLIST_ACTION(SkipEmittingFineModuleTrace)
 BLOCKLIST_ACTION(SkipIndexingModule)
 BLOCKLIST_ACTION(ShouldUseTypeCheckerPerfHacks)
+BLOCKLIST_ACTION(DisableModuleSelectorsInModuleInterface)
 
 #undef BLOCKLIST_ACTION

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -646,7 +646,8 @@ private:
                                      const LangOptions &LangOpts,
                                      const ClangImporterOptions &clangImporterOpts,
                                      const CASOptions &casOpts,
-                                     bool suppressNotes, bool suppressRemarks);
+                                     bool suppressNotes, bool suppressRemarks,
+                                     PrintDiagnosticNamesMode diagnosticNamesMode);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
                                            DiagnosticEngine &subInstanceDiags,
                                            SwiftInterfaceInfo &interfaceInfo,

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -40,6 +40,9 @@ struct ModuleInterfaceOptions {
   /// with types sharing a name with a module.
   bool AliasModuleNames = false;
 
+  /// Should we emit module selectors into the module interface?
+  bool UseModuleSelectors = false;
+
   /// See \ref FrontendOptions.PrintFullConvention.
   /// [TODO: Clang-type-plumbing] This check should go away.
   bool PrintFullConvention = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -736,6 +736,16 @@ def emit_variant_package_module_interface_path :
   MetaVarName<"<path>">,
   HelpText<"Output package module interface file for the target variant to <path>">;
 
+def enable_module_selectors_in_module_interface :
+  Flag<["-"], "enable-module-selectors-in-module-interface">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"When emitting module interface files, use module selectors to avoid name collisions">;
+
+def disable_module_selectors_in_module_interface :
+  Flag<["-"], "disable-module-selectors-in-module-interface">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"When emitting module interface files, do not use module selectors to avoid name collisions">;
+
 def verify_emitted_module_interface :
   Flag<["-"], "verify-emitted-module-interface">,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -263,6 +263,7 @@ private:
 };
 
 PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
+                                                   bool useModuleSelectors,
                                                    bool preferTypeRepr,
                                                    bool printFullConvention,
                                                    InterfaceMode interfaceMode,
@@ -276,6 +277,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   result.PrintLongAttrsOnSeparateLines = true;
   result.TypeDefinitions = true;
   result.CurrentModule = ModuleToPrint;
+  result.UseModuleSelectors = useModuleSelectors;
   result.FullyQualifiedTypes = true;
   result.FullyQualifiedTypesIfAmbiguous = true;
   result.FullyQualifiedExtendedTypesIfAmbiguous = true;
@@ -6058,9 +6060,8 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  template <typename T>
-  void printModuleContext(T *Ty) {
-    FileUnit *File = cast<FileUnit>(Ty->getDecl()->getModuleScopeContext());
+  void printModuleContext(GenericTypeDecl *TyDecl) {
+    FileUnit *File = cast<FileUnit>(TyDecl->getModuleScopeContext());
     ModuleDecl *Mod = File->getParentModule();
     StringRef ExportedModuleName = File->getExportedModuleName();
 
@@ -6069,7 +6070,7 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     // all of these modules may be visible. We therefore need to make sure we
     // choose a module that is visible from the current module. This is possible
     // only if we know what the current module is.
-    const clang::Decl *ClangDecl = Ty->getDecl()->getClangDecl();
+    const clang::Decl *ClangDecl = TyDecl->getClangDecl();
     if (ClangDecl && Options.CurrentModule) {
       for (auto *Redecl : ClangDecl->redecls()) {
         auto *owningModule = Redecl->getOwningModule();
@@ -6106,12 +6107,10 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     }
 
     if (Options.UseOriginallyDefinedInModuleNames) {
-      Decl *D = Ty->getDecl();
-      for (auto attr: D->getAttrs().getAttributes<OriginallyDefinedInAttr>()) {
+      if (auto attr =
+            TyDecl->getAttrs().getAttribute<OriginallyDefinedInAttr>()) {
         Name = Mod->getASTContext().getIdentifier(
-            const_cast<OriginallyDefinedInAttr *>(attr)
-                ->getManglingModuleName());
-        break;
+            attr->getManglingModuleName());
       }
     }
 
@@ -6122,7 +6121,6 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     }
 
     Printer.printModuleRef(Mod, Name);
-    Printer << ".";
   }
 
   template <typename T>
@@ -6140,7 +6138,42 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return M->getRealName().str().starts_with(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX);
   }
 
+  bool isMemberOfGenericParameter(TypeBase *T) {
+    Type parent = nullptr;
+    if (auto alias = dyn_cast<TypeAliasType>(T))
+      parent = alias->getParent();
+    else if (auto generic = T->getAs<AnyGenericType>())
+      parent = generic->getParent();
+    return parent && parent->isTypeParameter();
+  }
+
+  bool shouldPrintModuleSelector(TypeBase *T) {
+    if (!Options.UseModuleSelectors)
+      return false;
+
+    GenericTypeDecl *GTD = T->getAnyGeneric();
+    if (!GTD && isa<TypeAliasType>(T))
+      GTD = cast<TypeAliasType>(T)->getDecl();
+    if (!GTD)
+      return false;
+
+    // Builtin types must always be qualified somehow.
+    ModuleDecl *M = GTD->getDeclContext()->getParentModule();
+    if (M->isBuiltinModule())
+      return true;
+
+    // A member of a generic parameter can't be qualified by a module selector.
+    if (isMemberOfGenericParameter(T))
+      return false;
+
+    // Module selectors skip over local types, so don't add one.
+    return GTD->getLocalContext() == nullptr;
+  }
+
   bool shouldPrintFullyQualified(TypeBase *T) {
+    if (Options.UseModuleSelectors)
+      return false;
+
     if (Options.FullyQualifiedTypes)
       return true;
 
@@ -6197,7 +6230,15 @@ public:
       printParentType(parent);
       NameContext = PrintNameContext::TypeMember;
     } else if (shouldPrintFullyQualified(Ty)) {
-      printModuleContext(Ty);
+      printModuleContext(Ty->getDecl());
+      Printer << ".";
+      NameContext = PrintNameContext::TypeMember;
+    }
+
+    // We print module selectors whether or not we printed a parent type.
+    if (shouldPrintModuleSelector(Ty)) {
+      printModuleContext(Ty->getDecl());
+      Printer << "::";
       NameContext = PrintNameContext::TypeMember;
     }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -316,6 +316,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_module_cache_path);
   inputArgs.AddLastArg(arguments, options::OPT_module_link_name);
   inputArgs.AddLastArg(arguments, options::OPT_module_abi_name);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_module_selectors_in_module_interface,
+                       options::OPT_disable_module_selectors_in_module_interface);
   inputArgs.AddLastArg(arguments, options::OPT_package_name);
   inputArgs.AddLastArg(arguments, options::OPT_export_as);
   inputArgs.AddLastArg(arguments, options::OPT_nostdimport);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -536,7 +536,8 @@ static void PrintArg(raw_ostream &OS, const char *Arg, StringRef TempDir) {
 }
 
 static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
-                                     ArgList &Args) {
+                                     ArgList &Args,
+                                     DiagnosticEngine &diags) {
   using namespace options;
 
   Opts.PreserveTypesAsWritten |=
@@ -545,6 +546,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasFlag(OPT_alias_module_names_in_module_interface,
                  OPT_disable_alias_module_names_in_module_interface,
                  ::getenv("SWIFT_ALIAS_MODULE_NAMES_IN_INTERFACES"));
+
   Opts.PrintFullConvention |=
     Args.hasArg(OPT_experimental_print_full_convention);
   Opts.DebugPrintInvalidSyntax |=
@@ -557,6 +559,21 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     if (contents == "spi") {
       Opts.setInterfaceMode(PrintOptions::InterfaceMode::Private);
     }
+  }
+
+  if (Args.hasArgNoClaim(OPT_enable_module_selectors_in_module_interface)
+      || Args.hasArgNoClaim(OPT_disable_module_selectors_in_module_interface)) {
+    Opts.UseModuleSelectors =
+      Args.hasFlag(OPT_enable_module_selectors_in_module_interface,
+                   OPT_disable_module_selectors_in_module_interface,
+                   false);
+  } else if (auto envValue = ::getenv("SWIFT_MODULE_SELECTORS_IN_INTERFACES")) {
+    Opts.UseModuleSelectors = llvm::StringSwitch<bool>(envValue)
+        .CasesLower("false", "no", "off", "0", false)
+        .Default(true);
+  } else {
+    // Any heuristics we might add would go here.
+    Opts.UseModuleSelectors = false;
   }
 }
 
@@ -4169,7 +4186,7 @@ bool CompilerInvocation::parseArgs(
     setMainExecutablePath(mainExecutablePath);
   }
 
-  ParseModuleInterfaceArgs(ModuleInterfaceOpts, ParsedArgs);
+  ParseModuleInterfaceArgs(ModuleInterfaceOpts, ParsedArgs, Diags);
   SaveModuleInterfaceArgs(ModuleInterfaceOpts, FrontendOpts, ParsedArgs, Diags);
 
   if (ParseCASArgs(CASOpts, ParsedArgs, Diags, FrontendOpts)) {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1663,7 +1663,8 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     FrontendOptions::ActionType requestedAction,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
     const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
-    bool suppressNotes, bool suppressRemarks) {
+    bool suppressNotes, bool suppressRemarks,
+    PrintDiagnosticNamesMode printDiagnosticNames) {
   GenericArgs.push_back("-frontend");
   // Start with a genericSubInvocation that copies various state from our
   // invoking ASTContext.
@@ -1762,6 +1763,20 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   if (suppressRemarks) {
     genericSubInvocation.getDiagnosticOptions().SuppressRemarks = true;
     GenericArgs.push_back("-suppress-remarks");
+  }
+
+  // Inherit the parent invocation's setting for printing diagnostic IDs.
+  genericSubInvocation.getDiagnosticOptions().PrintDiagnosticNames =
+      printDiagnosticNames;
+  switch (printDiagnosticNames) {
+  case PrintDiagnosticNamesMode::None:
+    break;
+  case PrintDiagnosticNamesMode::Identifier:
+    GenericArgs.push_back("-debug-diagnostic-names");
+    break;
+  case PrintDiagnosticNamesMode::Group:
+    // FIXME: Currently no flag for Group mode
+    break;
   }
 
   // Inherit this setting down so that it can affect error diagnostics (mostly
@@ -1870,7 +1885,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   inheritOptionsForBuildingInterface(LoaderOpts.requestedAction, searchPathOpts,
                                      langOpts, clangImporterOpts, casOpts,
                                      Diags->getSuppressNotes(),
-                                     Diags->getSuppressRemarks());
+                                     Diags->getSuppressRemarks(),
+                                     Diags->getPrintDiagnosticNamesMode());
   // Configure front-end input.
   auto &SubFEOpts = genericSubInvocation.getFrontendOptions();
   SubFEOpts.RequestedAction = LoaderOpts.requestedAction;

--- a/test/ModuleInterface/Inputs/module_selector/blocklist.yml
+++ b/test/ModuleInterface/Inputs/module_selector/blocklist.yml
@@ -1,0 +1,4 @@
+---
+DisableModuleSelectorsInModuleInterface:
+    ModuleName:
+        - TestCase

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -1,0 +1,137 @@
+// RUN: %empty-directory(%t)
+
+// Test with -enable-module-selectors-in-module-interface
+// RUN: %empty-directory(%t/enabled)
+// RUN: %target-swift-emit-module-interface(%t/enabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface
+// RUN: %FileCheck --input-file %t/enabled/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-ENABLED
+// RUN: %target-swift-typecheck-module-from-interface(%t/enabled/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// Test with -disable-module-selectors-in-module-interface
+// RUN: %empty-directory(%t/disabled)
+// RUN: %target-swift-emit-module-interface(%t/disabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -disable-module-selectors-in-module-interface
+// RUN: %FileCheck --input-file %t/disabled/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %target-swift-typecheck-module-from-interface(%t/disabled/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// Test default behavior
+// RUN: %empty-directory(%t/default)
+// RUN: %target-swift-emit-module-interface(%t/default/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+// RUN: %FileCheck --input-file %t/default/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %target-swift-typecheck-module-from-interface(%t/default/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// Test with -enable-module-selectors-in-module-interface and blocklist
+// RUN: %empty-directory(%t/blocked)
+// RUN: %target-swift-emit-module-interface(%t/blocked/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface -blocklist-file %S/Inputs/module_selector/blocklist.yml
+// RUN: %FileCheck --input-file %t/blocked/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %target-swift-typecheck-module-from-interface(%t/blocked/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// CHECK: import enums_using_attributes
+import enums_using_attributes
+
+// CHECK-LABEL: public struct Struct<T> :
+// CHECK-ENABLED-SAME: Swift::Hashable where T : Swift::Hashable {
+// CHECK-DISABLED-SAME: Swift.Hashable where T : Swift.Hashable {
+public struct Struct<T: Hashable>: Hashable {
+  // CHECK: public let integer:
+  // CHECK-ENABLED-SAME: Swift::Int
+  // CHECK-DISABLED-SAME: Swift.Int
+  public let integer: Int = 42
+
+  // CHECK: public let enumeration:
+  // CHECK-ENABLED-SAME: enums_using_attributes::CFEnumWithAttr
+  // CHECK-DISABLED-SAME: enums_using_attributes.CFEnumWithAttr
+  public let enumeration: CFEnumWithAttr = CFEnumWithAttr.first
+
+  // CHECK: public let t: T?
+  public let t: T? = nil
+
+  // CHECK: public static func ==
+  // CHECK-ENABLED-SAME: (a: TestCase::Struct<T>, b: TestCase::Struct<T>) -> Swift::Bool
+  // CHECK-DISABLED-SAME: (a: TestCase.Struct<T>, b: TestCase.Struct<T>) -> Swift.Bool
+
+  // CHECK: public func hash
+  // CHECK-ENABLED-SAME: (into hasher: inout Swift::Hasher)
+  // CHECK-DISABLED-SAME: (into hasher: inout Swift.Hasher)
+
+  // CHECK: public var hashValue:
+  // CHECK-ENABLED-SAME: Swift::Int {
+  // CHECK-DISABLED-SAME: Swift.Int {
+
+  // CHECK: }
+}
+
+// CHECK-ENABLED: extension TestCase::Struct {
+// CHECK-DISABLED: extension TestCase.Struct {
+extension Struct {
+  // CHECK-LABEL: public enum Nested {
+  public enum Nested {
+    // CHECK: case integer
+    // CHECK-ENABLED-SAME: (Swift::Int)
+    // CHECK-DISABLED-SAME: (Swift.Int)
+    case integer(Int)
+
+    // CHECK: case enumeration
+    // CHECK-ENABLED-SAME: (enums_using_attributes::CFEnumWithAttr)
+    // CHECK-DISABLED-SAME: (enums_using_attributes.CFEnumWithAttr)
+    case enumeration(CFEnumWithAttr)
+
+    // CHECK: case t(T)
+    case t(T)
+
+    // CHECK: case `struct`
+    // CHECK-ENABLED-SAME: (TestCase::Struct<T>)
+    // CHECK-DISABLED-SAME: (TestCase.Struct<T>)
+    case `struct`(Struct)
+
+    // CHECK: }
+  }
+
+  // CHECK: }
+}
+
+// CHECK-ENABLED: extension Swift::Int {
+// CHECK-DISABLED: extension Swift.Int {
+extension Swift::Int {
+  // CHECK-LABEL: public enum RetroactiveNested {
+  public enum RetroactiveNested {}
+}
+
+// CHECK-ENABLED: extension Swift::Int.TestCase::RetroactiveNested {
+// CHECK-DISABLED: extension Swift.Int.RetroactiveNested {
+extension Int.RetroactiveNested {
+  public func anchor() {}
+}
+
+// CHECK-LABEL: public func fn<T>
+// CHECK-ENABLED-SAME: (_: TestCase::Struct<T>, _: TestCase::Struct<T>.TestCase::Nested)
+// CHECK-DISABLED-SAME: (_: TestCase.Struct<T>, _:  TestCase.Struct<T>.Nested)
+public func fn<T: Hashable>(_: Struct<T>, _: Struct<T>.Nested) {}
+
+// CHECK-LABEL: public func fn2<T>
+// CHECK-ENABLED-SAME: (_: T) where T : Swift::Identifiable, T.ID == TestCase::Struct<Swift::Int>
+// CHECK-DISABLED-SAME: (_: T) where T : Swift.Identifiable, T.ID == TestCase.Struct<Swift.Int>
+@available(SwiftStdlib 5.1, *)
+public func fn2<T: Identifiable>(_: T) where T.ID == Struct<Int> {}
+
+// CHECK-LABEL: public protocol Proto {
+@available(SwiftStdlib 5.1, *)
+public protocol Proto {
+  // CHECK: associatedtype AssocType :
+  // CHECK-ENABLED-SAME: Swift::Identifiable
+  // CHECK-DISABLED-SAME: Swift.Identifiable
+  associatedtype AssocType: Identifiable
+
+  // CHECK: typealias TypeAlias =
+  // CHECK-ENABLED-SAME: TestCase::Struct<Swift::Int>
+  // CHECK-DISABLED-SAME: TestCase.Struct<Swift.Int>
+  typealias TypeAlias = Struct<Int>
+
+  // CHECK: func requirement() -> Self.AssocType.ID
+  func requirement() -> AssocType.ID
+
+  // CHECK: func requirement2() ->
+  // CHECK-ENABLED: Self.TypeAlias.TestCase::Nested
+  // CHECK-DISABLED: Self.TypeAlias.Nested
+  func requirement2() -> TypeAlias.Nested
+
+  // CHECK: }
+}


### PR DESCRIPTION
Adds a new frontend and legacy driver flag, `-{enable,disable}-module-selectors-in-module-interface`, to control whether decl references in module interfaces are qualified using member syntax (the previous behavior) or module selectors:

```swift
// Using `-disable-module-selectors-in-module-interface`
extension XCTest.XCTestCase {}

// Using `-enable-module-selectors-in-module-interface`
extension XCTest::XCTestCase {}
```

Currently, `disable` is the default; in the future, it will become `enable`. Also includes support for disabling using the blocklist action `DisableModuleSelectorsInModuleInterface`.

Continuation of #34556.