### PR TITLE
[Compile Time Constant Extraction] Extraction support for force unwrapped optionals

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -519,6 +519,11 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       return extractCompileTimeValue(openExistentialExpr->getExistentialValue(), declContext);
     }
 
+    case ExprKind::ForceValue: {
+      auto forceValueExpr = cast<ForceValueExpr>(expr);
+      return extractCompileTimeValue(forceValueExpr->getSubExpr(), declContext);
+    }
+
     default: {
       break;
     }

--- a/test/ConstExtraction/ExtractForceValue.swift
+++ b/test/ConstExtraction/ExtractForceValue.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractForceValue.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractForceValue.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+class CustomKey {
+  init?() {
+
+  }
+}
+struct MyStruct: MyProto {
+  let prop1: CustomKey = CustomKey()!
+  let prop2: CustomKey! = CustomKey()
+}
+
+// CHECK:          "properties": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "prop1",
+// CHECK-NEXT:         "type": "ExtractForceValue.CustomKey",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "false",
+// CHECK-NEXT:         "isComputed": "false",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractForceValue.swift",
+// CHECK-NEXT:         "line": 15,
+// CHECK-NEXT:         "valueKind": "InitCall",
+// CHECK-NEXT:         "value": {
+// CHECK-NEXT:           "type": "Swift.Optional<ExtractForceValue.CustomKey>",
+// CHECK-NEXT:           "arguments": []
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "prop2",
+// CHECK-NEXT:         "type": "Swift.Optional<ExtractForceValue.CustomKey>",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "false",
+// CHECK-NEXT:         "isComputed": "false",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractForceValue.swift",
+// CHECK-NEXT:         "line": 16,
+// CHECK-NEXT:         "valueKind": "InitCall",
+// CHECK-NEXT:         "value": {
+// CHECK-NEXT:           "type": "Swift.Optional<ExtractForceValue.CustomKey>",
+// CHECK-NEXT:           "arguments": []
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]


### PR DESCRIPTION
Adds support for extracting force unwrapped optionals. 

```
let prop: MyType = MyType()! 
```

In this case the value kind was being extracted as a Runtime value. 

resolves rdar://146046727
