### PR TITLE
[6.2] Lifetime inference: fix a crash on implicit _modify for subscripts.

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1367,7 +1367,7 @@ protected:
       return std::nullopt;
     }
     if (wrappedAccessorKind) {
-      auto *var = cast<VarDecl>(accessor->getStorage());
+      auto *var = cast<AbstractStorageDecl>(accessor->getStorage());
       for (auto *wrappedAccessor : var->getAllAccessors()) {
         if (wrappedAccessor->isImplicit())
           continue;


### PR DESCRIPTION
Fixes rdar://155976839 (Compiler crash when _modify is not specified for
~Escapable type)

Related to: rdar://163133875

(cherry picked from commit 52b990a00858392a817c11d1b98a797715b99d75)
