### PR TITLE
[TEST-ONLY] Fix CAS/legacy_layout_remap.swift on non-macos target

### DIFF
--- a/test/CAS/legacy_layout_remap.swift
+++ b/test/CAS/legacy_layout_remap.swift
@@ -1,4 +1,5 @@
 // REQUIRES: objc_interop
+// REQUIRES: platform=Darwin
 // UNSUPPORTED: swift_only_stable_abi
 
 // RUN: %empty-directory(%t)
@@ -33,8 +34,8 @@
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -c -o %t/main.o
 
 /// Now do implicit search.
-// RUN: mkdir -p %t/resource/macosx
-// RUN: cp %t/layout.yaml %t/resource/macosx/layouts-%target-arch.yaml
+// RUN: mkdir -p %t/resource/%target-os
+// RUN: cp %t/layout.yaml %t/resource/%target-os/layouts-%target-arch.yaml
 
 // RUN: %target-swift-frontend -target %target-pre-stable-abi-triple -I %t -c -enable-library-evolution \
 // RUN:   -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O -module-load-mode prefer-serialized \


### PR DESCRIPTION
Fix CAS/legacy_layout_remap test when running on non mascOS target.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
