### PR TITLE
Avoid unnecessary insertion of mark_unresolved_noncopyable_value

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -807,10 +807,15 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         // If we have a mutable binding for a 'let', such as 'self' in an
         // 'init' method, load it.
         if (val->getType().isMoveOnly()) {
-          val = B.createMarkUnresolvedNonCopyableValueInst(
-              loc, val,
-              MarkUnresolvedNonCopyableValueInst::CheckKind::
-                  NoConsumeOrAssign);
+          auto *moveOnlyIntroducer = dyn_cast_or_null<MarkUnresolvedNonCopyableValueInst>(val);
+          if (!moveOnlyIntroducer || moveOnlyIntroducer->getCheckKind() !=
+                                         MarkUnresolvedNonCopyableValueInst::
+                                             CheckKind::NoConsumeOrAssign) {
+            val = B.createMarkUnresolvedNonCopyableValueInst(
+                loc, val,
+                MarkUnresolvedNonCopyableValueInst::CheckKind::
+                    NoConsumeOrAssign);
+          }
         }
         val = emitLoad(loc, val, tl, SGFContext(), IsNotTake).forward(*this);
       }

--- a/test/SILGen/addressable_read.swift
+++ b/test/SILGen/addressable_read.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -verify  -enable-experimental-feature AddressableParameters %s
+
+public struct Container<Element: ~Copyable >: ~Copyable {
+  var _storage: UnsafeMutableBufferPointer<Element>
+  var _count: Int
+
+  public subscript(index: Int) -> Element {
+    @_addressableSelf
+    _read {
+      precondition(index >= 0 && index < _count, "Index out of bounds")
+      yield _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+    }
+    _modify {
+      precondition(index >= 0 && index < _count, "Index out of bounds")
+      yield &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+    }
+  }
+}
+
+extension Container: Copyable where Element: Copyable {}
+


### PR DESCRIPTION
SILGen inserts mark_unresolved_noncopyable_value at the introducer in some cases and at uses in other cases. This inconsistency can causes insertion of a redundant mark* instruction which crashes the move-only checker.

This PR avoids inserting a redundant mark* instruction.

