### PR TITLE
[CoroutineAccessors] Provide frame to de/allocation functions.

### DIFF
--- a/include/swift/ABI/Coro.h
+++ b/include/swift/ABI/Coro.h
@@ -61,11 +61,15 @@ struct CoroAllocator;
 using CoroAllocation = void *;
 using CoroAllocateFn = CoroAllocation (*)(CoroAllocator *, size_t);
 using CoroDealllocateFn = void (*)(CoroAllocator *, CoroAllocation);
+using CoroAllocateFrameFn = CoroAllocation (*)(CoroAllocator *, size_t);
+using CoroDealllocateFrameFn = void (*)(CoroAllocator *, CoroAllocation);
 
 struct CoroAllocator {
   CoroAllocatorFlags flags;
   CoroAllocateFn allocate;
   CoroDealllocateFn deallocate;
+  CoroAllocateFrameFn allocateFrame;
+  CoroDealllocateFrameFn deallocateFrame;
 
   /// Whether the allocator should deallocate memory on calls to
   /// swift_coro_dealloc.

--- a/include/swift/ABI/Coro.h
+++ b/include/swift/ABI/Coro.h
@@ -56,9 +56,11 @@ public:
                                 setShouldDeallocateImmediately)
 };
 
+struct CoroAllocator;
+
 using CoroAllocation = void *;
-using CoroAllocateFn = CoroAllocation (*)(size_t);
-using CoroDealllocateFn = void (*)(CoroAllocation);
+using CoroAllocateFn = CoroAllocation (*)(CoroAllocator *, size_t);
+using CoroDealllocateFn = void (*)(CoroAllocator *, CoroAllocation);
 
 struct CoroAllocator {
   CoroAllocatorFlags flags;

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1797,6 +1797,8 @@ namespace SpecialPointerAuthDiscriminators {
   /// Function pointers stored in the coro allocator struct.
   const uint16_t CoroAllocationFunction = 0x5f95;   // = 24469
   const uint16_t CoroDeallocationFunction = 0x9faf; // = 40879
+  const uint16_t CoroFrameAllocationFunction = 0xd251;   // = 53841
+  const uint16_t CoroFrameDeallocationFunction = 0x5ba8; // = 23464
 }
 
 /// The number of arguments that will be passed directly to a generic

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -257,6 +257,14 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
 
   /// Stored in a coro allocator struct, the function used to deallocate memory.
   PointerAuthSchema CoroDeallocationFunction;
+
+  /// Stored in a coro allocator struct, the function used to allocate a callee
+  /// coroutine's fixed-size frame.
+  PointerAuthSchema CoroFrameAllocationFunction;
+
+  /// Stored in a coro allocator struct, the function used to deallocate a
+  /// callee coroutine's fixed-size frame.
+  PointerAuthSchema CoroFrameDeallocationFunction;
 };
 
 enum class JITDebugArtifact : unsigned {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5269,7 +5269,7 @@ StackAddress irgen::emitAllocCoroStaticFrame(IRGenFunction &IGF,
   //       respectively.
   auto retval =
       IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, size, Alignment(MaximumAlignment),
-                            /*allowTaskAlloc*/ true, "caller-coro-frame");
+                            AllowsTaskAlloc, "caller-coro-frame");
   IGF.Builder.CreateLifetimeStart(retval.getAddress(),
                                   Size(-1) /*dynamic size*/);
   return retval;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5178,10 +5178,12 @@ void irgen::emitYieldOnce2CoroutineEntry(IRGenFunction &IGF,
   IGF.setCoroutineAllocator(allocator);
   auto allocFn = IGF.IGM.getOpaquePtr(getCoroAllocFn(IGF.IGM));
   auto deallocFn = IGF.IGM.getOpaquePtr(getCoroDeallocFn(IGF.IGM));
+  auto allocFrameFn = IGF.IGM.getOpaquePtr(getCoroAllocFrameFn(IGF.IGM));
+  auto deallocFrameFn = IGF.IGM.getOpaquePtr(getCoroDeallocFrameFn(IGF.IGM));
   emitRetconCoroutineEntry(
       IGF, fnType, buffer, llvm::Intrinsic::coro_id_retcon_once_dynamic,
       Size(-1) /*dynamic-to-IRGen size*/, IGF.IGM.getCoroStaticFrameAlignment(),
-      {cfp, allocator}, allocFn, deallocFn, {});
+      {cfp, allocator}, allocFn, deallocFn, {allocFrameFn, deallocFrameFn});
 }
 void irgen::emitYieldOnce2CoroutineEntry(
     IRGenFunction &IGF, LinkEntity coroFunction, CanSILFunctionType fnType,
@@ -5267,9 +5269,10 @@ StackAddress irgen::emitAllocCoroStaticFrame(IRGenFunction &IGF,
   // TODO: Avoid swift_task_alloc (async) and malloc (yield_once) if the
   //       suspension doesn't span an apply of an async function or a yield
   //       respectively.
-  auto retval =
-      IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, size, Alignment(MaximumAlignment),
-                            AllowsTaskAlloc, "caller-coro-frame");
+  auto retval = IGF.emitDynamicAlloca(
+      IGF.IGM.Int8Ty, size, Alignment(MaximumAlignment), AllowsTaskAlloc,
+      IsForCalleeCoroutineFrame_t(IGF.isCalleeAllocatedCoroutine()),
+      "callee-coro-frame");
   IGF.Builder.CreateLifetimeStart(retval.getAddress(),
                                   Size(-1) /*dynamic size*/);
   return retval;
@@ -5277,7 +5280,8 @@ StackAddress irgen::emitAllocCoroStaticFrame(IRGenFunction &IGF,
 void irgen::emitDeallocCoroStaticFrame(IRGenFunction &IGF, StackAddress frame) {
   IGF.Builder.CreateLifetimeEnd(frame.getAddress(), Size(-1) /*dynamic size*/);
   IGF.emitDeallocateDynamicAlloca(frame, /*allowTaskAlloc*/ true,
-                                  /*useTaskDeallocThrough*/ true);
+                                  /*useTaskDeallocThrough*/ true,
+                                  /*forCalleeCoroutineFrame*/ true);
 }
 
 llvm::Value *irgen::emitYield(IRGenFunction &IGF,

--- a/lib/IRGen/GenCoro.h
+++ b/lib/IRGen/GenCoro.h
@@ -16,7 +16,9 @@ namespace irgen {
 class IRGenModule;
 
 llvm::Constant *getCoroAllocFn(IRGenModule &IGM);
+llvm::Constant *getCoroAllocFrameFn(IRGenModule &IGM);
 llvm::Constant *getCoroDeallocFn(IRGenModule &IGM);
+llvm::Constant *getCoroDeallocFrameFn(IRGenModule &IGM);
 
 llvm::Value *
 emitYieldOnce2CoroutineAllocator(IRGenFunction &IGF,

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -560,14 +560,14 @@ StackAddress IRGenFunction::emitDynamicAlloca(SILType T,
                                               const llvm::Twine &name) {
   llvm::Value *size = emitLoadOfSize(*this, T);
   return emitDynamicAlloca(IGM.Int8Ty, size, Alignment(16), AllowsTaskAlloc,
-                           name);
+                           IsNotForCalleeCoroutineFrame, name);
 }
 
-StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
-                                              llvm::Value *arraySize,
-                                              Alignment align,
-                                              AllowsTaskAlloc_t allowTaskAlloc,
-                                              const llvm::Twine &name) {
+StackAddress IRGenFunction::emitDynamicAlloca(
+    llvm::Type *eltTy, llvm::Value *arraySize, Alignment align,
+    AllowsTaskAlloc_t allowTaskAlloc,
+    IsForCalleeCoroutineFrame_t forCalleeCoroutineFrame,
+    const llvm::Twine &name) {
   // Async functions call task alloc.
   if (allowTaskAlloc && isAsync()) {
     llvm::Value *byteCount;
@@ -601,9 +601,10 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
     auto alignment = llvm::ConstantInt::get(IGM.Int32Ty, align.getValue());
 
     // Allocate memory.  This produces an abstract token.
-    auto allocToken =
-        Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_alloc,
-                                    {IGM.SizeTy}, {byteCount, alignment});
+    auto *allocToken = Builder.CreateIntrinsicCall(
+        forCalleeCoroutineFrame ? llvm::Intrinsic::coro_alloca_alloc_frame
+                                : llvm::Intrinsic::coro_alloca_alloc,
+        {IGM.SizeTy}, {byteCount, alignment});
 
     // Get the allocation result.
     auto ptr = Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_get,
@@ -643,7 +644,8 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
 /// location before the dynamic alloca's call.
 void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
                                                 bool allowTaskDealloc,
-                                                bool useTaskDeallocThrough) {
+                                                bool useTaskDeallocThrough,
+                                                bool forCalleeCoroutineFrame) {
   // Async function use taskDealloc.
   if (allowTaskDealloc && isAsync() && address.getAddress().isValid()) {
     if (useTaskDeallocThrough) {
@@ -671,7 +673,10 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
 #endif
       return;
     }
-    Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_free, allocToken);
+    Builder.CreateIntrinsicCall(forCalleeCoroutineFrame
+                                    ? llvm::Intrinsic::coro_alloca_free_frame
+                                    : llvm::Intrinsic::coro_alloca_free,
+                                allocToken);
     return;
   }
   // Otherwise, call llvm.stackrestore if an address was saved.

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -559,13 +559,14 @@ irgen::emitInitializeBufferWithCopyOfBufferCall(IRGenFunction &IGF,
 StackAddress IRGenFunction::emitDynamicAlloca(SILType T,
                                               const llvm::Twine &name) {
   llvm::Value *size = emitLoadOfSize(*this, T);
-  return emitDynamicAlloca(IGM.Int8Ty, size, Alignment(16), true, name);
+  return emitDynamicAlloca(IGM.Int8Ty, size, Alignment(16), AllowsTaskAlloc,
+                           name);
 }
 
 StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
                                               llvm::Value *arraySize,
                                               Alignment align,
-                                              bool allowTaskAlloc,
+                                              AllowsTaskAlloc_t allowTaskAlloc,
                                               const llvm::Twine &name) {
   // Async functions call task alloc.
   if (allowTaskAlloc && isAsync()) {

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -467,9 +467,9 @@ irgen::emitTypeMetadataPack(IRGenFunction &IGF, CanPackType packType,
   }
 
   assert(packType->containsPackExpansionType());
-  auto pack = IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
-                                    IGF.IGM.getPointerAlignment(),
-                                    /*allowTaskAlloc=*/true);
+  auto pack =
+      IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
+                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
 
   auto visitFn =
     [&](CanType eltTy, unsigned staticIndex,
@@ -612,9 +612,9 @@ irgen::emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
   }
 
   assert(packType->containsPackExpansionType());
-  auto pack = IGF.emitDynamicAlloca(IGF.IGM.WitnessTablePtrTy, shape,
-                                    IGF.IGM.getPointerAlignment(),
-                                    /*allowTaskAlloc=*/true);
+  auto pack =
+      IGF.emitDynamicAlloca(IGF.IGM.WitnessTablePtrTy, shape,
+                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
 
   auto index = 0;
   auto visitFn = [&](CanType eltTy, unsigned staticIndex,
@@ -1184,9 +1184,9 @@ StackAddress irgen::allocatePack(IRGenFunction &IGF, CanSILPackType packType) {
   }
 
   assert(packType->containsPackExpansionType());
-  auto addr = IGF.emitDynamicAlloca(IGF.IGM.OpaquePtrTy, shape,
-                                    IGF.IGM.getPointerAlignment(),
-                                    /*allowTaskAlloc=*/true);
+  auto addr =
+      IGF.emitDynamicAlloca(IGF.IGM.OpaquePtrTy, shape,
+                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
 
   return addr;
 }
@@ -1255,10 +1255,9 @@ irgen::emitDynamicTupleTypeLabels(IRGenFunction &IGF, CanTupleType type,
       llvm::ConstantInt::get(IGF.IGM.SizeTy, 1));
 
   // Allocate space for the label string; we fill it in below.
-  StackAddress labelString = IGF.emitDynamicAlloca(
-                                IGF.IGM.Int8Ty, labelLength,
-                                IGF.IGM.getPointerAlignment(),
-                                /*allowTaskAlloc=*/true);
+  StackAddress labelString =
+      IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, labelLength,
+                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
 
   // Get the static label string, where each pack expansion is one element.
   auto *staticLabelString = getTupleLabelsString(IGF.IGM, type);
@@ -1371,9 +1370,8 @@ irgen::emitDynamicFunctionParameterFlags(IRGenFunction &IGF,
                                          AnyFunctionType::CanParamArrayRef params,
                                          CanPackType packType,
                                          llvm::Value *shapeExpression) {
-  auto array =
-      IGF.emitDynamicAlloca(IGF.IGM.Int32Ty, shapeExpression,
-                            Alignment(4), /*allowTaskAlloc=*/true);
+  auto array = IGF.emitDynamicAlloca(IGF.IGM.Int32Ty, shapeExpression,
+                                     Alignment(4), AllowsTaskAlloc);
 
   unsigned numExpansions = 0;
 
@@ -1431,9 +1429,9 @@ irgen::emitInducedTupleTypeMetadataPack(
     IRGenFunction &IGF, llvm::Value *tupleMetadata) {
   auto *shape = emitTupleTypeMetadataLength(IGF, tupleMetadata);
 
-  auto pack = IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
-                                    IGF.IGM.getPointerAlignment(),
-                                    /*allowTaskAlloc=*/true);
+  auto pack =
+      IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
+                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
   auto elementForIndex =
     [&](llvm::Value *index) -> llvm::Value * {
       return irgen::emitTupleTypeMetadataElementType(IGF, tupleMetadata, index);

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -399,6 +399,10 @@ PointerAuthEntity::getDeclDiscriminator(IRGenModule &IGM) const {
         return SpecialPointerAuthDiscriminators::CoroAllocationFunction;
       case Special::CoroDeallocationFunction:
         return SpecialPointerAuthDiscriminators::CoroDeallocationFunction;
+      case Special::CoroFrameAllocationFunction:
+        return SpecialPointerAuthDiscriminators::CoroFrameAllocationFunction;
+      case Special::CoroFrameDeallocationFunction:
+        return SpecialPointerAuthDiscriminators::CoroFrameDeallocationFunction;
       }
       llvm_unreachable("bad kind");
     };

--- a/lib/IRGen/GenPointerAuth.h
+++ b/lib/IRGen/GenPointerAuth.h
@@ -70,6 +70,8 @@ public:
     TypeLayoutString,
     CoroAllocationFunction,
     CoroDeallocationFunction,
+    CoroFrameAllocationFunction,
+    CoroFrameDeallocationFunction,
   };
 
 private:

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1098,6 +1098,14 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
   opts.CoroDeallocationFunction = PointerAuthSchema(
       codeKey, /*address*/ false, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroDeallocationFunction);
+
+  opts.CoroAllocationFunction = PointerAuthSchema(
+      codeKey, /*address*/ false, Discrimination::Constant,
+      SpecialPointerAuthDiscriminators::CoroFrameAllocationFunction);
+
+  opts.CoroDeallocationFunction = PointerAuthSchema(
+      codeKey, /*address*/ false, Discrimination::Constant,
+      SpecialPointerAuthDiscriminators::CoroFrameDeallocationFunction);
 }
 
 std::unique_ptr<llvm::TargetMachine>

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -71,6 +71,11 @@ enum AllowsTaskAlloc_t : bool {
   AllowsTaskAlloc = true,
 };
 
+enum IsForCalleeCoroutineFrame_t : bool {
+  IsNotForCalleeCoroutineFrame,
+  IsForCalleeCoroutineFrame,
+};
+
 /// IRGenFunction - Primary class for emitting LLVM instructions for a
 /// specific function.
 class IRGenFunction {
@@ -310,10 +315,13 @@ public:
   StackAddress
   emitDynamicAlloca(llvm::Type *eltTy, llvm::Value *arraySize, Alignment align,
                     AllowsTaskAlloc_t allowTaskAlloc = AllowsTaskAlloc,
+                    IsForCalleeCoroutineFrame_t forCalleeCoroutineFrame =
+                        IsNotForCalleeCoroutineFrame,
                     const llvm::Twine &name = "");
   void emitDeallocateDynamicAlloca(StackAddress address,
                                    bool allowTaskDealloc = true,
-                                   bool useTaskDeallocThrough = false);
+                                   bool useTaskDeallocThrough = false,
+                                   bool forCalleeCoroutineFrame = false);
 
   llvm::BasicBlock *createBasicBlock(const llvm::Twine &Name);
   const TypeInfo &getTypeInfoForUnlowered(Type subst);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -66,6 +66,11 @@ namespace irgen {
   class TypeInfo;
   enum class ValueWitness : unsigned;
 
+enum AllowsTaskAlloc_t : bool {
+  DoesNotAllowTaskAlloc = false,
+  AllowsTaskAlloc = true,
+};
+
 /// IRGenFunction - Primary class for emitting LLVM instructions for a
 /// specific function.
 class IRGenFunction {
@@ -302,9 +307,10 @@ public:
                        const llvm::Twine &name = "");
 
   StackAddress emitDynamicAlloca(SILType type, const llvm::Twine &name = "");
-  StackAddress emitDynamicAlloca(llvm::Type *eltTy, llvm::Value *arraySize,
-                                 Alignment align, bool allowTaskAlloc = true,
-                                 const llvm::Twine &name = "");
+  StackAddress
+  emitDynamicAlloca(llvm::Type *eltTy, llvm::Value *arraySize, Alignment align,
+                    AllowsTaskAlloc_t allowTaskAlloc = AllowsTaskAlloc,
+                    const llvm::Twine &name = "");
   void emitDeallocateDynamicAlloca(StackAddress address,
                                    bool allowTaskDealloc = true,
                                    bool useTaskDeallocThrough = false);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -783,6 +783,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
                                          Int32Ty, // CoroAllocator.Flags
                                          PtrTy, // allocate
                                          PtrTy, // deallocate
+                                         PtrTy, // allocateFrame
+                                         PtrTy, // deallocateFrame
                                      });
   SwiftImplicitActorType =
       createStructType(*this, "swift.implicit_isolated_actor_type",

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -773,9 +773,9 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   CoroFunctionPointerTy = createStructType(*this, "swift.coro_func_pointer",
                                            {RelativeAddressTy, Int32Ty}, true);
   CoroAllocateFnTy = llvm::FunctionType::get(
-      CoroAllocationTy, {CoroAllocatorPtrTy, SizeTy}, /*isVarArg*/ false);
+      CoroAllocationTy, {CoroAllocationTy, CoroAllocatorPtrTy, SizeTy}, /*isVarArg*/ false);
   CoroDeallocateFnTy = llvm::FunctionType::get(
-      VoidTy, {CoroAllocatorPtrTy, CoroAllocationTy}, /*isVarArg*/ false);
+      VoidTy, {CoroAllocationTy, CoroAllocatorPtrTy, CoroAllocationTy}, /*isVarArg*/ false);
   CoroAllocatorFlagsTy = Int32Ty;
   // swift/ABI/Coro.h : CoroAllocator
   CoroAllocatorTy = createStructType(*this, "swift.coro_allocator",

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -781,8 +781,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   CoroAllocatorTy = createStructType(*this, "swift.coro_allocator",
                                      {
                                          Int32Ty, // CoroAllocator.Flags
-                                         PtrTy,
-                                         PtrTy,
+                                         PtrTy, // allocate
+                                         PtrTy, // deallocate
                                      });
   SwiftImplicitActorType =
       createStructType(*this, "swift.implicit_isolated_actor_type",

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -772,10 +772,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   CoroFunctionPointerTy = createStructType(*this, "swift.coro_func_pointer",
                                            {RelativeAddressTy, Int32Ty}, true);
-  CoroAllocateFnTy =
-      llvm::FunctionType::get(CoroAllocationTy, SizeTy, /*isVarArg*/ false);
-  CoroDeallocateFnTy =
-      llvm::FunctionType::get(VoidTy, CoroAllocationTy, /*isVarArg*/ false);
+  CoroAllocateFnTy = llvm::FunctionType::get(
+      CoroAllocationTy, {CoroAllocatorPtrTy, SizeTy}, /*isVarArg*/ false);
+  CoroDeallocateFnTy = llvm::FunctionType::get(
+      VoidTy, {CoroAllocatorPtrTy, CoroAllocationTy}, /*isVarArg*/ false);
   CoroAllocatorFlagsTy = Int32Ty;
   // swift/ABI/Coro.h : CoroAllocator
   CoroAllocatorTy = createStructType(*this, "swift.coro_allocator",

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3721,8 +3721,8 @@ static void emitBuiltinStackAlloc(IRGenSILFunction &IGF,
     return;
   }
 
-  auto stackAddress = IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, size, align,
-                                            false, "temp_alloc");
+  auto stackAddress = IGF.emitDynamicAlloca(
+      IGF.IGM.Int8Ty, size, align, DoesNotAllowTaskAlloc, "temp_alloc");
   IGF.setLoweredStackAddress(i, stackAddress);
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3721,8 +3721,9 @@ static void emitBuiltinStackAlloc(IRGenSILFunction &IGF,
     return;
   }
 
-  auto stackAddress = IGF.emitDynamicAlloca(
-      IGF.IGM.Int8Ty, size, align, DoesNotAllowTaskAlloc, "temp_alloc");
+  auto stackAddress =
+      IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, size, align, DoesNotAllowTaskAlloc,
+                            IsNotForCalleeCoroutineFrame, "temp_alloc");
   IGF.setLoweredStackAddress(i, stackAddress);
 }
 

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -63,6 +63,7 @@
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(
+// CHECK-SAME:      ptr [[FRAME:%[^,]+]]
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
 // CHECK-SAME:      [[INT]] [[SIZE:%[^)]+]]
 // CHECK-SAME:  )
@@ -76,11 +77,12 @@
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN]] to i64
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 24469)
 // CHECK-arm64e:  [[ALLOCATE_FN:%[^,]+]] = inttoptr i64 [[ALLOCATE_FN_BITS_AUTHED]]
-// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
+// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
 // CHECK:         ret ptr [[ALLOCATION]]
 // CHECK:       }
 
 // CHECK-LABEL: @_swift_coro_dealloc(
+// CHECK-SAME:      ptr [[FRAME:%[^,]+]]
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
 // CHECK-SAME:      ptr [[ADDRESS:%[^)]+]]
 // CHECK-SAME:  )
@@ -107,7 +109,7 @@
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN]] to i64
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 40879)
 // CHECK-arm64e:    [[DEALLOCATE_FN:%[^,]+]] = inttoptr i64 [[DEALLOCATE_FN_BITS_AUTHED]]
-// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
+// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
 // CHECK:         ret void
 // CHECK:       }
 

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -23,15 +23,15 @@
 // CHECK-SAME:    i32 0
 // CHECK-SAME:  }>
 
-// CHECK-arm64e-LABEL: _swift_malloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_malloc,
+// CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: _swift_free.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_free,
+// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 40879 },
@@ -42,15 +42,15 @@
 // CHECK-SAME:       malloc
 // CHECK-SAME:       free
 // CHECK-SAME:  }
-// CHECK-arm64e-LABEL: swift_task_alloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @swift_task_alloc,
+// CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: @swift_task_dealloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @swift_task_dealloc,
+// CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 40879 },
@@ -58,8 +58,8 @@
 // CHECK-arm64e-SAME:  align 8
 // CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
 // CHECK-SAME:      i32 1,
-// CHECK-SAME:      swift_task_alloc
-// CHECK-SAME:      swift_task_dealloc
+// CHECK-SAME:      _swift_coro_task_alloc
+// CHECK-SAME:      _swift_coro_task_dealloc
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(
@@ -76,7 +76,7 @@
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN]] to i64
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 24469)
 // CHECK-arm64e:  [[ALLOCATE_FN:%[^,]+]] = inttoptr i64 [[ALLOCATE_FN_BITS_AUTHED]]
-// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]]([[INT]] [[SIZE]])
+// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
 // CHECK:         ret ptr [[ALLOCATION]]
 // CHECK:       }
 
@@ -107,7 +107,7 @@
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN]] to i64
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 40879)
 // CHECK-arm64e:    [[DEALLOCATE_FN:%[^,]+]] = inttoptr i64 [[DEALLOCATE_FN_BITS_AUTHED]]
-// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr [[ADDRESS]])
+// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
 // CHECK:         ret void
 // CHECK:       }
 

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -308,7 +308,7 @@ public var force_yield_once_convention : () {
 // CHECK-SAME:        _swift_coro_malloc_allocator
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
-// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
   @_silgen_name("increment_irm_yield_once")
   _modify {
@@ -338,8 +338,8 @@ public var force_yield_once_2_convention : () {
 //           :            i32 1
 //           :        )
 // CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
-// CHECK-64:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE_64]], i32 16)
-// CHECK-32:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i32(i32 {{%[^,]+}}, i32 16)
+// CHECK-64:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.frame.i64(i64 [[SIZE_64]], i32 16)
+// CHECK-32:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.frame.i32(i32 {{%[^,]+}}, i32 16)
 // CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
 // CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
 // CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
@@ -357,7 +357,7 @@ public var force_yield_once_2_convention : () {
 // CHECK-SAME:        [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
-// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
   @_silgen_name("increment_irm_yield_once_2")
   modify {

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -255,7 +255,7 @@ public var force_yield_once_convention : () {
 // CHECK-SAME:        _swift_coro_malloc_allocator
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
-// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
   @_silgen_name("increment_i_yield_once")
   _modify {
@@ -284,7 +284,7 @@ public var force_yield_once_2_convention : () {
 //           :            i32 1
 //           :        )
 // CHECK:         [[SIZE:%[^,]+]] = zext i32 {{%[^,]+}} to i64
-// CHECK:         [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE]], i32 16)
+// CHECK:         [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.frame.i64(i64 [[SIZE]], i32 16)
 // CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
 // CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
 // CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
@@ -302,7 +302,7 @@ public var force_yield_once_2_convention : () {
 // CHECK-SAME:        [[ALLOCATOR]]
 // CHECK-SAME:    )
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
-// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:         call void @llvm.coro.alloca.free.frame(token [[ALLOCATION]])
 // CHECK:       }
   @_silgen_name("increment_i_yield_once_2")
   modify {

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -65,7 +65,8 @@
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(
-// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
+// CHECK-SAME:      ptr [[FRAME:%[^,]+]]
+// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]],
 // CHECK-SAME:      i64 [[SIZE:%[^)]+]]
 // CHECK-SAME:  )
 // CHECK-SAME:  {
@@ -87,12 +88,13 @@
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN]] to i64
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 24469)
 // CHECK-arm64e:  [[ALLOCATE_FN:%[^,]+]] = inttoptr i64 [[ALLOCATE_FN_BITS_AUTHED]]
-// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
+// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
 // CHECK:         ret ptr [[ALLOCATION]]
 // CHECK:       }
 
 // CHECK-LABEL: @_swift_coro_dealloc(
-// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
+// CHECK-SAME:      ptr [[FRAME:%[^,]+]]
+// CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]],
 // CHECK-SAME:      ptr [[ADDRESS:%[^)]+]]
 // CHECK-SAME:  )
 // CHECK-SAME:  {
@@ -125,7 +127,7 @@
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN]] to i64
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 40879)
 // CHECK-arm64e:    [[DEALLOCATE_FN:%[^,]+]] = inttoptr i64 [[DEALLOCATE_FN_BITS_AUTHED]]
-// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
+// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
 // CHECK:         ret void
 // CHECK:       }
 

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -25,15 +25,15 @@
 // CHECK-SAME:    i32 0
 // CHECK-SAME:  }>
 
-// CHECK-arm64e-LABEL: swift_task_alloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @swift_task_alloc,
+// CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: @swift_task_dealloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @swift_task_dealloc,
+// CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 40879 },
@@ -41,18 +41,18 @@
 // CHECK-arm64e-SAME:  align 8
 // CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
 // CHECK-SAME:      i32 1,
-// CHECK-SAME:      swift_task_alloc
-// CHECK-SAME:      swift_task_dealloc
+// CHECK-SAME:      _swift_coro_task_alloc
+// CHECK-SAME:      _swift_coro_task_dealloc
 // CHECK-SAME:  }
-// CHECK-arm64e-LABEL: _swift_malloc.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_malloc,
+// CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
-// CHECK-arm64e-LABEL: _swift_free.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_free,
+// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
 // CHECK-arm64e-SAME:    i32 0,
 // CHECK-arm64e-SAME:    i64 0,
 // CHECK-arm64e-SAME:    i64 40879 },
@@ -87,7 +87,7 @@
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN]] to i64
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 24469)
 // CHECK-arm64e:  [[ALLOCATE_FN:%[^,]+]] = inttoptr i64 [[ALLOCATE_FN_BITS_AUTHED]]
-// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]]([[INT]] [[SIZE]])
+// CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
 // CHECK:         ret ptr [[ALLOCATION]]
 // CHECK:       }
 
@@ -125,7 +125,7 @@
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN]] to i64
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 40879)
 // CHECK-arm64e:    [[DEALLOCATE_FN:%[^,]+]] = inttoptr i64 [[DEALLOCATE_FN_BITS_AUTHED]]
-// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr [[ADDRESS]])
+// CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
 // CHECK:         ret void
 // CHECK:       }
 


### PR DESCRIPTION
Distinguish between de/allocations for a callee frame by making a different function call.  Pass the frame from the caller to its allocation functions.  Together, this enables an allocator that stores contextual information in a header of the frame.
