### PR TITLE
AST: Rename Swift runtime availability domain to `StandaloneSwiftRuntime`

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -51,8 +51,9 @@ public:
     /// Represents availability with respect to Swift language mode.
     SwiftLanguageMode,
 
-    /// Represents availability with respect to the Swift runtime.
-    SwiftRuntime,
+    /// Represents availability with respect to the Swift runtime when it is not
+    /// built-in to the target platform.
+    StandaloneSwiftRuntime,
 
     /// Represents PackageDescription availability.
     PackageDescription,
@@ -147,8 +148,8 @@ public:
     return AvailabilityDomain(Kind::SwiftLanguageMode);
   }
 
-  static AvailabilityDomain forSwiftRuntime() {
-    return AvailabilityDomain(Kind::SwiftRuntime);
+  static AvailabilityDomain forStandaloneSwiftRuntime() {
+    return AvailabilityDomain(Kind::StandaloneSwiftRuntime);
   }
 
   static AvailabilityDomain forPackageDescription() {
@@ -192,7 +193,9 @@ public:
     return getKind() == Kind::SwiftLanguageMode;
   }
 
-  bool isSwiftRuntime() const { return getKind() == Kind::SwiftRuntime; }
+  bool isStandaloneSwiftRuntime() const {
+    return getKind() == Kind::StandaloneSwiftRuntime;
+  }
 
   bool isPackageDescription() const {
     return getKind() == Kind::PackageDescription;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -555,6 +555,10 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(InlineAlways, false)
 /// Allow use of 'Swift' (Swift runtime version) in @available attributes
 EXPERIMENTAL_FEATURE(SwiftRuntimeAvailability, true)
 
+/// 'Swift' availability is always standalone, even when targeting platforms
+/// that have a built-in Swift runtime. Implies 'SwiftRuntimeAvailability'.
+EXPERIMENTAL_FEATURE(StandaloneSwiftAvailability, true)
+
 /// Allow use of `~Sendable`.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(TildeSendable, false)
 

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -343,7 +343,7 @@ domainCanBeUnconditionallyUnavailableAtRuntime(AvailabilityDomain domain,
     return domain.isActive(ctx);
 
   case AvailabilityDomain::Kind::SwiftLanguageMode:
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
     return false;
 
@@ -371,7 +371,7 @@ domainIsUnavailableAtRuntimeIfUnintroduced(AvailabilityDomain domain,
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::Platform:
   case AvailabilityDomain::Kind::SwiftLanguageMode:
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
     return false;
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -101,18 +101,27 @@ AvailabilityDomain::forCustom(ValueDecl *decl) {
                            AvailabilityDomainForDeclRequest{decl}, {});
 }
 
+static AvailabilityDomain getSwiftRuntimeDomain(ASTContext &ctx) {
+  // If -enable-experimental-feature StandaloneSwiftAvailability is specified
+  // then forcibly separate platform and Swift runtime availability.
+  if (ctx.LangOpts.hasFeature(Feature::StandaloneSwiftAvailability))
+    return AvailabilityDomain::forStandaloneSwiftRuntime();
+
+  // FIXME: [runtime availability] Return the platform Swift runtime domain.
+
+  return AvailabilityDomain::forStandaloneSwiftRuntime();
+}
+
 std::optional<AvailabilityDomain>
 AvailabilityDomain::builtinDomainForString(StringRef string,
                                            const DeclContext *declContext) {
-  // This parameter is used in downstream forks, do not remove.
-  (void)declContext;
-
+  auto &ctx = declContext->getASTContext();
   auto domain =
       llvm::StringSwitch<std::optional<AvailabilityDomain>>(string)
           .Case("*", AvailabilityDomain::forUniversal())
           .Case("swift", AvailabilityDomain::forSwiftLanguageMode())
           .Case("SwiftLanguageMode", AvailabilityDomain::forSwiftLanguageMode())
-          .Case("Swift", AvailabilityDomain::forSwiftRuntime())
+          .Case("Swift", getSwiftRuntimeDomain(ctx))
           .Case("_PackageDescription",
                 AvailabilityDomain::forPackageDescription())
           .Default(std::nullopt);
@@ -132,7 +141,7 @@ bool AvailabilityDomain::isVersioned() const {
   case Kind::Embedded:
     return false;
   case Kind::SwiftLanguageMode:
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::PackageDescription:
   case Kind::Platform:
     return true;
@@ -153,7 +162,7 @@ bool AvailabilityDomain::isVersionValid(
   case Kind::SwiftLanguageMode:
   case Kind::PackageDescription:
     return true;
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
     // Swift 5.0 is the first ABI stable Swift runtime version.
     if (version.getMajor() < 5)
       return false;
@@ -175,7 +184,7 @@ bool AvailabilityDomain::supportsContextRefinement() const {
   case Kind::SwiftLanguageMode:
   case Kind::PackageDescription:
     return false;
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::Platform:
   case Kind::Custom:
     return true;
@@ -189,7 +198,7 @@ bool AvailabilityDomain::supportsQueries() const {
   case Kind::SwiftLanguageMode:
   case Kind::PackageDescription:
     return false;
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::Platform:
   case Kind::Custom:
     return true;
@@ -204,7 +213,10 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx,
   case Kind::PackageDescription:
   case Kind::Embedded:
     return true;
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
+    // FIXME: [runtime availability] Active either when
+    // StandaloneSwiftAvailability is enabled or the target supports a
+    // standalone Swift runtime.
     return ctx.LangOpts.hasFeature(Feature::SwiftRuntimeAvailability);
   case Kind::Platform:
     return isPlatformActive(getPlatformKind(), ctx.LangOpts, forTargetVariant);
@@ -231,7 +243,7 @@ bool AvailabilityDomain::mustBeSpecifiedAlone() const {
   case Kind::Embedded:
   case Kind::Custom:
     return true;
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::Platform:
     // Platform and Swift runtime availability specifications can appear
     // together, e.g. `@available(Swift 6, macOS 15, iOS 18, *)`.
@@ -252,7 +264,7 @@ getDeploymentVersion(const AvailabilityDomain &domain, const ASTContext &ctx) {
     return ctx.LangOpts.EffectiveLanguageVersion;
   case AvailabilityDomain::Kind::PackageDescription:
     return ctx.LangOpts.PackageDescriptionVersion;
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
     if (!ctx.LangOpts.hasFeature(Feature::SwiftRuntimeAvailability))
       return std::nullopt;
     return ctx.LangOpts.MinSwiftRuntimeVersion;
@@ -292,7 +304,7 @@ llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
   case Kind::SwiftLanguageMode:
     // FIXME: [runtime availability] Render language mode diags differently.
     return "Swift";
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
     return "Swift";
   case Kind::PackageDescription:
     return "PackageDescription";
@@ -311,7 +323,7 @@ llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
     return "*";
   case Kind::SwiftLanguageMode:
     return "swift";
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
     return "Swift";
   case Kind::PackageDescription:
     return "_PackageDescription";
@@ -343,12 +355,11 @@ bool AvailabilityDomain::contains(const AvailabilityDomain &other) const {
   case Kind::Universal:
     return true;
   case Kind::SwiftLanguageMode:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::PackageDescription:
   case Kind::Embedded:
   case Kind::Custom:
     return other == *this;
-  case Kind::SwiftRuntime:
-    return other.isPlatform() || other == *this;
   case Kind::Platform:
     if (getPlatformKind() == other.getPlatformKind())
       return true;
@@ -362,7 +373,7 @@ bool AvailabilityDomain::isRoot() const {
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::Embedded:
   case AvailabilityDomain::Kind::SwiftLanguageMode:
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
     return true;
   case AvailabilityDomain::Kind::Platform:
@@ -448,7 +459,7 @@ AvailabilityDomain AvailabilityDomain::copy(ASTContext &ctx) const {
   switch (getKind()) {
   case Kind::Universal:
   case Kind::SwiftLanguageMode:
-  case Kind::SwiftRuntime:
+  case Kind::StandaloneSwiftRuntime:
   case Kind::PackageDescription:
   case Kind::Embedded:
   case Kind::Platform:
@@ -471,7 +482,7 @@ bool StableAvailabilityDomainComparator::operator()(
   switch (lhsKind) {
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::SwiftLanguageMode:
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
   case AvailabilityDomain::Kind::Embedded:
     return false;
@@ -560,7 +571,7 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
   }
 
   // Use of the 'Swift' domain requires the 'SwiftRuntimeAvailability' feature.
-  if (!hasSwiftRuntimeAvailability && domain->isSwiftRuntime()) {
+  if (!hasSwiftRuntimeAvailability && domain->isStandaloneSwiftRuntime()) {
     diags.diagnose(loc, diag::availability_domain_requires_feature, *domain,
                    "SwiftRuntimeAvailability");
     return std::nullopt;

--- a/lib/AST/AvailabilityQuery.cpp
+++ b/lib/AST/AvailabilityQuery.cpp
@@ -37,7 +37,7 @@ AvailabilityQuery::AvailabilityQuery(
     DEBUG_ASSERT(kind != ResultKind::Dynamic);
     break;
 
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
     // Dynamic Swift runtime queries take just a primary version argument.
     if (kind == ResultKind::Dynamic) {
       DEBUG_ASSERT(primaryRange);
@@ -186,7 +186,7 @@ FuncDecl *AvailabilityQuery::getDynamicQueryDeclAndArguments(
     // These domains don't support dynamic queries.
     return nullptr;
 
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
     unpackVersion(getPrimaryArgument().value(), arguments);
     return ctx.getIsSwiftRuntimeVersionAtLeast();
   case AvailabilityDomain::Kind::Platform:

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -869,7 +869,7 @@ private:
       return AvailabilityQuery::dynamic(variantSpec->getDomain(), primaryRange,
                                         variantRange);
 
-    case AvailabilityDomain::Kind::SwiftRuntime:
+    case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
       return AvailabilityQuery::dynamic(domain, primaryRange, std::nullopt);
 
     case AvailabilityDomain::Kind::Platform:

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -448,6 +448,7 @@ static bool usesFeatureInlineAlways(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(SwiftRuntimeAvailability)
+UNINTERESTING_FEATURE(StandaloneSwiftAvailability)
 
 static bool usesFeatureTildeSendable(Decl *decl) {
   auto *TD = dyn_cast<TypeDecl>(decl);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -939,9 +939,15 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
     if (!seenFeatures.insert(*feature).second)
       continue;
 
+    bool forMigration = featureMode.has_value();
+
     // Enable the feature if requested.
     if (isEnableFeatureFlag)
-      Opts.enableFeature(*feature, /*forMigration=*/featureMode.has_value());
+      Opts.enableFeature(*feature, forMigration);
+
+    // 'StandaloneSwiftAvailability' implies 'SwiftRuntimeAvailability'
+    if (*feature == Feature::StandaloneSwiftAvailability)
+      Opts.enableFeature(Feature::SwiftRuntimeAvailability, forMigration);
   }
 
   // Since pseudo-features don't have a boolean on/off state, process them in

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1699,7 +1699,7 @@ bool shouldHideDomainNameForConstraintDiagnostic(
   case AvailabilityDomain::Kind::Custom:
   case AvailabilityDomain::Kind::PackageDescription:
     return true;
-  case AvailabilityDomain::Kind::SwiftRuntime:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::Platform:
     return false;
   case AvailabilityDomain::Kind::SwiftLanguageMode:

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2197,7 +2197,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     switch (domain.getKind()) {
     case AvailabilityDomain::Kind::Universal:
     case AvailabilityDomain::Kind::SwiftLanguageMode:
-    case AvailabilityDomain::Kind::SwiftRuntime:
+    case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
     case AvailabilityDomain::Kind::PackageDescription:
     case AvailabilityDomain::Kind::Platform:
       // FIXME: [availability] Diagnose as an error in a future Swift version.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5259,10 +5259,10 @@ diagnoseTypeWitnessAvailability(NormalProtocolConformance *conformance,
   switch (domain.getKind()) {
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::SwiftLanguageMode:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
   case AvailabilityDomain::Kind::Platform:
     break;
-  case AvailabilityDomain::Kind::SwiftRuntime:
   case AvailabilityDomain::Kind::Embedded:
   case AvailabilityDomain::Kind::Custom:
     shouldError = true;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5821,8 +5821,8 @@ decodeDomainKind(uint8_t kind) {
       return AvailabilityDomainKind::Universal;
     case static_cast<uint8_t>(AvailabilityDomainKind::SwiftLanguageMode):
       return AvailabilityDomainKind::SwiftLanguageMode;
-    case static_cast<uint8_t>(AvailabilityDomainKind::SwiftRuntime):
-      return AvailabilityDomainKind::SwiftRuntime;
+    case static_cast<uint8_t>(AvailabilityDomainKind::StandaloneSwiftRuntime):
+      return AvailabilityDomainKind::StandaloneSwiftRuntime;
     case static_cast<uint8_t>(AvailabilityDomainKind::PackageDescription):
       return AvailabilityDomainKind::PackageDescription;
     case static_cast<uint8_t>(AvailabilityDomainKind::Embedded):
@@ -5844,8 +5844,8 @@ decodeAvailabilityDomain(AvailabilityDomainKind domainKind,
     return AvailabilityDomain::forUniversal();
   case AvailabilityDomainKind::SwiftLanguageMode:
     return AvailabilityDomain::forSwiftLanguageMode();
-  case AvailabilityDomainKind::SwiftRuntime:
-    return AvailabilityDomain::forSwiftRuntime();
+  case AvailabilityDomainKind::StandaloneSwiftRuntime:
+    return AvailabilityDomain::forStandaloneSwiftRuntime();
   case AvailabilityDomainKind::PackageDescription:
     return AvailabilityDomain::forPackageDescription();
   case AvailabilityDomainKind::Embedded:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -786,7 +786,7 @@ enum class AvailabilityDomainKind : uint8_t {
   Embedded,
   Platform,
   Custom,
-  SwiftRuntime,
+  StandaloneSwiftRuntime,
 };
 using AvailabilityDomainKindField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3134,8 +3134,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
             return AvailabilityDomainKind::Universal;
           case AvailabilityDomain::Kind::SwiftLanguageMode:
             return AvailabilityDomainKind::SwiftLanguageMode;
-          case AvailabilityDomain::Kind::SwiftRuntime:
-            return AvailabilityDomainKind::SwiftRuntime;
+          case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+            return AvailabilityDomainKind::StandaloneSwiftRuntime;
           case AvailabilityDomain::Kind::PackageDescription:
             return AvailabilityDomainKind::PackageDescription;
           case AvailabilityDomain::Kind::Embedded:

--- a/test/Availability/availability_swift_runtime.swift
+++ b/test/Availability/availability_swift_runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library -enable-experimental-feature SwiftRuntimeAvailability -min-swift-runtime-version 5.5
+// RUN: %target-typecheck-verify-swift -parse-as-library -enable-experimental-feature StandaloneSwiftAvailability -min-swift-runtime-version 5.5
 
-// REQUIRES: swift_feature_SwiftRuntimeAvailability
+// REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 @available(Swift 5.0, *)
 func availableInSwift5_0Runtime() { }

--- a/test/IRGen/availability_swift_runtime.swift
+++ b/test/IRGen/availability_swift_runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-ir %s -min-swift-runtime-version 5.0 -O -enable-experimental-feature SwiftRuntimeAvailability | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -min-swift-runtime-version 5.0 -O -enable-experimental-feature StandaloneSwiftAvailability | %FileCheck %s
 
-// REQUIRES: swift_feature_SwiftRuntimeAvailability
+// REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 @_silgen_name("callMeMaybe")
 public func callMeMaybe()

--- a/test/SILGen/availability_query_swift_runtime.swift
+++ b/test/SILGen/availability_query_swift_runtime.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-emit-sil %s -min-swift-runtime-version 5.0 -verify -enable-experimental-feature SwiftRuntimeAvailability
-// RUN: %target-swift-emit-silgen %s -min-swift-runtime-version 5.0 -enable-experimental-feature SwiftRuntimeAvailability | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -min-swift-runtime-version 5.0 -verify -enable-experimental-feature StandaloneSwiftAvailability
+// RUN: %target-swift-emit-silgen %s -min-swift-runtime-version 5.0 -enable-experimental-feature StandaloneSwiftAvailability | %FileCheck %s
 
-// REQUIRES: swift_feature_SwiftRuntimeAvailability
+// REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 // CHECK-LABEL: sil [ossa] @$s32availability_query_swift_runtime15testIfAvailableyyF : $@convention(thin) () -> () {
 // CHECK:         [[MAJOR:%.*]] = integer_literal $Builtin.Word, 6

--- a/test/SILGen/availability_query_swift_runtime_maccatalyst_zippered.swift
+++ b/test/SILGen/availability_query_swift_runtime_maccatalyst_zippered.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-sil %s -target %target-cpu-apple-macosx11 -target-variant %target-cpu-apple-ios14-macabi -min-swift-runtime-version 5.0 -verify -enable-experimental-feature SwiftRuntimeAvailability
-// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx11 -target-variant %target-cpu-apple-ios14-macabi -min-swift-runtime-version 5.0 -enable-experimental-feature SwiftRuntimeAvailability | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -target %target-cpu-apple-macosx11 -target-variant %target-cpu-apple-ios14-macabi -min-swift-runtime-version 5.0 -verify -enable-experimental-feature StandaloneSwiftAvailability
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx11 -target-variant %target-cpu-apple-ios14-macabi -min-swift-runtime-version 5.0 -enable-experimental-feature StandaloneSwiftAvailability | %FileCheck %s
 
 // REQUIRES: OS=macosx || OS=maccatalyst
-// REQUIRES: swift_feature_SwiftRuntimeAvailability
+// REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 // CHECK-LABEL: sil [ossa] @$s53availability_query_swift_runtime_maccatalyst_zippered15testIfAvailableyyF : $@convention(thin) () -> () {
 // CHECK:         [[MAJOR:%.*]] = integer_literal $Builtin.Word, 6

--- a/test/attr/attr_availability_swift_runtime.swift
+++ b/test/attr/attr_availability_swift_runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library -enable-experimental-feature SwiftRuntimeAvailability
+// RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library -enable-experimental-feature StandaloneSwiftAvailability
 
-// REQUIRES: swift_feature_SwiftRuntimeAvailability
+// REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 @available(Swift 6, *)
 func availableInSwiftRuntime6Short() { }

--- a/test/attr/attr_availability_swift_runtime.swift
+++ b/test/attr/attr_availability_swift_runtime.swift
@@ -1,5 +1,7 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library -enable-experimental-feature SwiftRuntimeAvailability
 // RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library -enable-experimental-feature StandaloneSwiftAvailability
 
+// REQUIRES: swift_feature_SwiftRuntimeAvailability
 // REQUIRES: swift_feature_StandaloneSwiftAvailability
 
 @available(Swift 6, *)


### PR DESCRIPTION
This name will distinguish the standalone Swift runtime availability domain from the domain for the built-in Swift runtime on supported targets.

Also, introduce the `StandaloneSwiftAvailability` experimental feature which can be used by tests (or the standard library) to force the compiler to treat `Swift` runtime availability as separate from platform availability when compiling for targets that have the Swift runtime built-in.
