### PR TITLE
[SIL] Use mangled names + asmname for `@c` functions

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -333,6 +333,10 @@ struct SILDeclRef {
   /// Produce a mangled form of this constant.
   std::string mangle(ManglingKind MKind = ManglingKind::Default) const;
 
+  /// If the symbol has a specific name for use at the LLVM IR level,
+  /// produce that name. This may be different than the mangled name in SIL.
+  std::optional<StringRef> getAsmName() const;
+
   /// True if the SILDeclRef references a function.
   bool isFunc() const {
     return kind == Kind::Func;

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -450,6 +450,15 @@ void TBDGenVisitor::didVisitDecl(Decl *D) {
 }
 
 void TBDGenVisitor::addFunction(SILDeclRef declRef) {
+  // If there is a specific symbol name this should have at the IR level,
+  // use it instead.
+  if (auto asmName = declRef.getAsmName()) {
+    addSymbol(*asmName, SymbolSource::forSILDeclRef(declRef),
+              SymbolFlags::Text);
+    return;
+  }
+
+
   addSymbol(declRef.mangle(), SymbolSource::forSILDeclRef(declRef),
             SymbolFlags::Text);
 }

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -127,10 +127,8 @@ void SILFunctionBuilder::addFunctionAttributes(
       }
     }
 
-    if (constant.isFunc() && constant.hasFuncDecl()) {
-      auto func = constant.getFuncDecl();
-      if (auto *EA = ExternAttr::find(Attrs, ExternKind::C))
-        F->setAsmName(EA->getCName(func));
+    if (auto asmName = constant.getAsmName()) {
+      F->setAsmName(*asmName);
     }
   }
 

--- a/test/SILGen/cdecl-official.swift
+++ b/test/SILGen/cdecl-official.swift
@@ -6,21 +6,21 @@
 
 // REQUIRES: swift_feature_CDecl
 
-// CHECK-LABEL: sil hidden [ossa] @pear : $@convention(c) (@convention(c) (Int) -> Int) -> () {
+// CHECK-LABEL: sil hidden [asmname "pear"] [ossa] @$s5cdecl5appleyyS2iXCFTo : $@convention(c) (@convention(c) (Int) -> Int) -> () {
 @c(pear)
 func apple(_ f: @convention(c) (Int) -> Int) { }
 
 func acceptSwiftFunc(_ f: (Int) -> Int) { }
 
 // CHECK-LABEL: sil hidden [ossa] @$s5cdecl16forceCEntryPoint{{[_0-9a-zA-Z]*}}F
-// CHECK: [[GRAPEFRUIT:%[0-9]+]] = function_ref @grapefruit : $@convention(c) (Int) -> Int
-// CHECK: [[PEAR:%[0-9]+]] = function_ref @pear : $@convention(c) (@convention(c) (Int) -> Int) -> ()
+// CHECK: [[GRAPEFRUIT:%[0-9]+]] = function_ref @$s5cdecl6orangeyS2iFTo : $@convention(c) (Int) -> Int
+// CHECK: [[PEAR:%[0-9]+]] = function_ref @$s5cdecl5appleyyS2iXCFTo : $@convention(c) (@convention(c) (Int) -> Int) -> ()
 // CHECK: apply [[PEAR]]([[GRAPEFRUIT]])
 func forceCEntryPoint() {
   apple(orange)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @grapefruit : $@convention(c) (Int) -> Int {
+// CHECK-LABEL: sil hidden [asmname "grapefruit"] [ossa] @$s5cdecl6orangeyS2iFTo : $@convention(c) (Int) -> Int {
 @c(grapefruit)
 func orange(_ x: Int) -> Int {
   return x
@@ -36,7 +36,7 @@ func requiresThunk() {
   acceptSwiftFunc(orange)
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @cauliflower : $@convention(c) (Int) -> Int {
+// CHECK-LABEL: sil [serialized] [asmname "cauliflower"] [ossa] @$s5cdecl8broccoliyS2iFTo : $@convention(c) (Int) -> Int {
 // CHECK-NOT: apply
 // CHECK: return
 @c(cauliflower)
@@ -44,7 +44,7 @@ public func broccoli(_ x: Int) -> Int {
   return x
 }
 
-// CHECK-LABEL: sil private [ossa] @collard_greens : $@convention(c) (Int) -> Int {
+// CHECK-LABEL: sil private [asmname "collard_greens"] [ossa] @$s5cdecl4kale33_{{.*}}FTo : $@convention(c) (Int) -> Int {
 // CHECK-NOT: apply
 // CHECK: return
 @c(collard_greens)
@@ -52,7 +52,7 @@ private func kale(_ x: Int) -> Int {
   return x
 }
 
-// CHECK-LABEL: sil private [ossa] @defaultName : $@convention(c) (Int) -> Int {
+// CHECK-LABEL: sil private [asmname "defaultName"] [ossa] @$s5cdecl11defaultName33{{.*}}iFTo : $@convention(c) (Int) -> Int {
 // CHECK-NOT: apply
 // CHECK: return
 @c


### PR DESCRIPTION
Instead of using the C name for `@c` functions in SIL, retain mangled names and apply the `asmname` attribute, so we retain more type information until later in the pipeline and avoid collisions.

Another part of rdar://137014448.
