### PR TITLE
Update swift-subprocess to 0.2.1

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -191,7 +191,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.2"
+                "swift-subprocess": "0.2.1"
             }
         },
         "release/6.2": {
@@ -623,7 +623,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.2"
+                "swift-subprocess": "0.2.1"
             }
         },
         "next" : {
@@ -684,7 +684,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.1.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.2"
+                "swift-subprocess": "0.2.1"
             }
         }
     }


### PR DESCRIPTION
This tag includes a CMake bugfix, https://github.com/swiftlang/swift-subprocess/pull/201