### PR TITLE
LoopInvariantCodeMotion: don't extend "read" access scopes over memory writes to the same address

### DIFF
--- a/test/SIL/OwnershipVerifier/load_borrow_invalidation_partial_apply.sil
+++ b/test/SIL/OwnershipVerifier/load_borrow_invalidation_partial_apply.sil
@@ -55,7 +55,7 @@ bb0(%0 :  @owned $WrapperStruct):
 //       we run sil-opt with -dont-abort-on-memory-lifetime-error.
 
 // CHECK-LABEL: Begin Error in function caller2
-// CHECK: SIL verification failed: Load borrow invalidated by a local write
+// CHECK: SIL verification failed: read-only scope invalidated by a local write
 // CHECK-LABEL: End Error in function caller2
 sil [ossa] @caller2 : $@convention(thin) (@owned WrapperStruct) -> () {
 bb0(%0 :  @owned $WrapperStruct):

--- a/test/SIL/OwnershipVerifier/load_borrow_verify_errors.sil
+++ b/test/SIL/OwnershipVerifier/load_borrow_verify_errors.sil
@@ -8,7 +8,7 @@ sil @use_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
 
 // Write:   store {{.*}} [assign] {{.*}}
 // CHECK: Begin Error in function test_write_reborrow
-// CHECK: SIL verification failed: Load borrow invalidated by a local write
+// CHECK: SIL verification failed: read-only scope invalidated by a local write
 // CHECK: End Error in function test_write_reborrow
 sil [ossa] @test_write_reborrow : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
@@ -30,7 +30,7 @@ bb2(%ldarg : @guaranteed $Klass):
 }
 
 // CHECK: Begin Error in function test_multiple_loadborrows
-// CHECK: SIL verification failed: Load borrow invalidated by a local write
+// CHECK: SIL verification failed: read-only scope invalidated by a local write
 // CHECK: Verifying instruction:
 // CHECK: ->  destroy_addr
 // CHECK: End Error in function test_multiple_loadborrows
@@ -84,7 +84,7 @@ struct MyStruct {
 }
 
 // CHECK: Begin Error in function test_is_unique
-// CHECK: SIL verification failed: Load borrow invalidated by a local write
+// CHECK: SIL verification failed: read-only scope invalidated by a local write
 // CHECK: -> %4 = is_unique %1 : $*ArrayIntBuffer
 // CHECK: End Error in function test_is_unique
 sil [ossa] @test_is_unique : $@convention(thin) (@in MyArray<MyStruct>) -> () {

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -825,7 +825,7 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
   %4 = alloc_stack $Inner
   store %1 to [init] %4
   %6 = mark_dependence %4 on %2
-  %7 = begin_access [read] [dynamic] %6
+  %7 = begin_access [modify] [dynamic] %6
   %8 = load [take] %7
   end_access %7
   dealloc_stack %4
@@ -841,7 +841,7 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
   %4 = alloc_stack $Inner
   store %1 to [init] %4
   mark_dependence_addr %4 on %2
-  %7 = begin_access [read] [dynamic] %4
+  %7 = begin_access [modify] [dynamic] %4
   %8 = load [take] %7
   end_access %7
   dealloc_stack %4

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1673,12 +1673,12 @@ bb0:
 // and the caller storage is an Argument at a different position.
 //
 // CHECK-LABEL: sil @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
-// CHECK: begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict]
 // CHECK-LABEL: } // end sil function 'testTransformArgumentCaller'
 sil @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
 bb0(%0 : $Int64, %1 : ${ var Int64 }, %2 : ${ var Int64 }):
   %boxadr = project_box %1 : $ { var Int64 }, 0
-  %access = begin_access [read] [dynamic] [no_nested_conflict] %boxadr : $*Int64
+  %access = begin_access [modify] [dynamic] [no_nested_conflict] %boxadr : $*Int64
   %f = function_ref @testTransformArgumentCallee : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
   %call = apply %f(%2) : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
   store %0 to %access : $*Int64

--- a/test/SILOptimizer/access_enforcement_opts_ossa.sil
+++ b/test/SILOptimizer/access_enforcement_opts_ossa.sil
@@ -1757,12 +1757,12 @@ bb0:
 // and the caller storage is an Argument at a different position.
 //
 // CHECK-LABEL: sil [ossa] @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
-// CHECK: begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict]
 // CHECK-LABEL: } // end sil function 'testTransformArgumentCaller'
 sil [ossa] @testTransformArgumentCaller : $@convention(thin) (Int64, @guaranteed { var Int64 }, @guaranteed { var Int64 }) -> Int64 {
 bb0(%0 : $Int64, %1 : @guaranteed ${ var Int64 }, %2 : @guaranteed ${ var Int64 }):
   %boxadr = project_box %1 : $ { var Int64 }, 0
-  %access = begin_access [read] [dynamic] [no_nested_conflict] %boxadr : $*Int64
+  %access = begin_access [modify] [dynamic] [no_nested_conflict] %boxadr : $*Int64
   %f = function_ref @testTransformArgumentCallee : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
   %call = apply %f(%2) : $@convention(thin) (@guaranteed { var Int64 }) -> Int64
   store %0 to [trivial] %access : $*Int64

--- a/test/SILOptimizer/access_storage_analysis.sil
+++ b/test/SILOptimizer/access_storage_analysis.sil
@@ -103,12 +103,12 @@ bb0(%0 : ${ var Int }, %1 : $Int):
 }
 
 // CHECK-LABEL: @writeIdentifiedBox
-// CHECK: [read] Box   %1 = alloc_box ${ var Int }
+// CHECK: [modify] Box   %1 = alloc_box ${ var Int }
 sil @writeIdentifiedBox : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %2 : $*Int
+  %3 = begin_access [modify] [dynamic] %2 : $*Int
   store %0 to %3 : $*Int
   end_access %3 : $*Int
   %6 = tuple ()
@@ -398,7 +398,7 @@ bb0(%0 : $C):
 sil @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> () {
 bb0(%0 : $C, %1 : $Int):
   %2 = ref_element_addr %0 : $C, #C.property
-  %3 = begin_access [read] [dynamic] %2 : $*Int
+  %3 = begin_access [modify] [dynamic] %2 : $*Int
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   store %1 to %4 : $*Int
   end_access %4 : $*Int

--- a/test/SILOptimizer/access_storage_analysis_ossa.sil
+++ b/test/SILOptimizer/access_storage_analysis_ossa.sil
@@ -103,12 +103,12 @@ bb0(%0 : @guaranteed ${ var Int }, %1 : $Int):
 }
 
 // CHECK-LABEL: @writeIdentifiedBox
-// CHECK: [read] Box   %1 = alloc_box ${ var Int }
+// CHECK: [modify] Box   %1 = alloc_box ${ var Int }
 sil [ossa] @writeIdentifiedBox : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %2 : $*Int
+  %3 = begin_access [modify] [dynamic] %2 : $*Int
   store %0 to [trivial] %3 : $*Int
   end_access %3 : $*Int
   destroy_value %1 : ${ var Int }
@@ -409,7 +409,7 @@ sil [ossa] @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int)
 bb0(%0 : @guaranteed $C, %1 : $Int):
   %borrow = begin_borrow %0 : $C
   %2 = ref_element_addr %borrow : $C, #C.property
-  %3 = begin_access [read] [dynamic] %2 : $*Int
+  %3 = begin_access [modify] [dynamic] %2 : $*Int
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   store %1 to [trivial] %4 : $*Int
   end_access %4 : $*Int

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -471,7 +471,7 @@ bb0:
   // def
   %def = apply %f() : $@convention(thin) () -> @owned AnyObject
   %copy = copy_value %def : $AnyObject
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   // use
   store %def to [init] %adr : $*AnyObject
   %obj = load [copy] %access : $*AnyObject
@@ -519,7 +519,7 @@ bb0:
   // def
   %def = apply %f() : $@convention(thin) () -> @owned AnyObject
   %copy = copy_value %def : $AnyObject
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   // use
   store %def to [init] %adr : $*AnyObject
   br bb1
@@ -561,7 +561,7 @@ sil [ossa] @testFullOverlapInDefBlock : $@convention(thin) () -> () {
 bb0:
   %box = alloc_box ${ var AnyObject }, var, name "x"
   %adr = project_box %box : ${ var AnyObject }, 0
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   %f = function_ref @getObject : $@convention(thin) () -> @owned AnyObject
   // def
   %def = apply %f() : $@convention(thin) () -> @owned AnyObject
@@ -609,7 +609,7 @@ sil [ossa] @testFullOverlapBeforeDefBlock : $@convention(thin) () -> () {
 bb0:
   %box = alloc_box ${ var AnyObject }, var, name "x"
   %adr = project_box %box : ${ var AnyObject }, 0
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   br bb1
 
 bb1:
@@ -657,7 +657,7 @@ bb0:
   // def
   %def = apply %f() : $@convention(thin) () -> @owned AnyObject
   %copy = copy_value %def : $AnyObject
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   // use
   store %def to [init] %adr : $*AnyObject
   destroy_value %copy : $AnyObject
@@ -692,7 +692,7 @@ bb0:
   // def
   %def = apply %f() : $@convention(thin) () -> @owned AnyObject
   %copy = copy_value %def : $AnyObject
-  %access = begin_access [read] [dynamic] %adr : $*AnyObject
+  %access = begin_access [modify] [dynamic] %adr : $*AnyObject
   // use
   store %def to [init] %adr : $*AnyObject
   br bb1

--- a/test/SILOptimizer/licm_exclusivity.sil
+++ b/test/SILOptimizer/licm_exclusivity.sil
@@ -252,3 +252,34 @@ bb2:
   %10 = tuple ()
   return %10 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_access_with_conflict_with_store :
+// CHECK:       bb1:
+// CHECK-NEXT:    begin_access
+// CHECK-LABEL: } // end sil function 'dont_hoist_access_with_conflict_with_store'
+sil [ossa] @dont_hoist_access_with_conflict_with_store : $@convention(thin) (X) -> () {
+bb0(%0 : $X):
+  %1 = global_addr @globalX: $*X
+  br bb1
+  
+bb1:
+  %3 = begin_access [read] [dynamic] %1
+  %4 = load [trivial] %3
+  fix_lifetime %4
+  end_access %3 : $*X
+  cond_br undef, bb2, bb3
+bb2:
+  store %0 to [trivial] %1
+  br bb4
+bb3:
+  br bb4
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
+  %10 = tuple ()
+  return %10
+}

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -988,7 +988,7 @@ bb0(%0 : $*Int):
 sil [ossa] @dontExtendAccessScopeOverBeginAccess : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
   %stack = alloc_stack $Klass
-  %access = begin_access [read] [static] %0 : $*Klass
+  %access = begin_access [modify] [static] %0 : $*Klass
   copy_addr [take] %access to [init] %stack : $*Klass
   end_access %access : $*Klass
   %f = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()

--- a/test/SILOptimizer/temp_rvalue_rle.sil
+++ b/test/SILOptimizer/temp_rvalue_rle.sil
@@ -499,7 +499,7 @@ sil [ossa] @unhandled_user : $@convention(thin) (@owned Klass) -> @owned Klass {
 bb0(%0 : @owned $Klass):
   %5 = alloc_stack $Klass
   store %0 to [init] %5 : $*Klass
-  %104 = begin_access [read] [static] %5 : $*Klass
+  %104 = begin_access [modify] [static] %5 : $*Klass
   %105 = load [take] %104 : $*Klass
   end_access %104 : $*Klass
   dealloc_stack %5 : $*Klass


### PR DESCRIPTION
We must not do this even if the write is _not_ in an access scope, because this would confuse alias analysis.

Fixes a mis-compile.

rdar://163891670

Also, add verification of such violations, e.g.
```
  %1 = begin_access [read] %0
  store %2 to %0
  end_access %1
```
