### PR TITLE
Android: disable new @available test until we get NDK 28 or newer in the CI

### DIFF
--- a/test/ClangImporter/availability_android.swift
+++ b/test/ClangImporter/availability_android.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: OS=linux-android || OS=linux-androideabi
 
+// Disable this test till we get a LTS NDK on the CI that supports it.
+// REQUIRES: NDK28
+
 import AndroidVersioning
 import Android
 


### PR DESCRIPTION
This test was only run with NDK 28 locally, so we didn't realize this feature won't work with Bionic in LTS NDK 27, which is what the CI uses. We will re-enable this with the next LTS NDK release, when we switch the Android CI to use that next LTS NDK.