### PR TITLE
[stdlib] Add the intermediate type size for every leaf component

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2925,6 +2925,10 @@ internal func calculateAppendedKeyPathSize(
 
     if isLast {
       break
+    } else {
+      // Add the intermediate type.
+      result = MemoryLayout<Int>._roundingUpToAlignment(result)
+      result &+= MemoryLayout<Int>.size
     }
   }
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1271,5 +1271,26 @@ if #available(SwiftStdlib 6.3, *) {
   }
 }
 
-runAllTests()
+struct Thingy {
+  var thingy: Thingy { self }
 
+  var a = 42
+}
+
+extension Int {
+  var subscripty: Thingy {
+    Thingy(a: 67)
+  }
+}
+
+keyPath.test("appending keypath with multiple components") {
+  var kp: KeyPath = \Thingy.self
+  kp = kp.appending(path: \.thingy)
+  kp = kp.appending(path: \.a.subscripty)
+
+  let t = Thingy()
+  let value = t[keyPath: kp]
+  expectEqual(value.a, 67)
+}
+
+runAllTests()


### PR DESCRIPTION
We were forgetting to add the intermediate type's size for every non-last leaf component during appends.

Resolves: rdar://162889199