### PR TITLE
Lifetimes: handle MutableSpan reassignment and 'inout' arguments

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -557,9 +557,9 @@ extension DiagnoseDependenceWalker : LifetimeDependenceDefUseWalker {
     return .abortWalk
   }
 
-  mutating func inoutDependence(argument: FunctionArgument, on operand: Operand) -> WalkResult {
+  mutating func inoutDependence(argument: FunctionArgument, functionExit: Instruction) -> WalkResult {
     if diagnostics.checkInoutResult(argument: argument) == .abortWalk {
-      diagnostics.reportEscaping(operand: operand)
+      diagnostics.reportEscaping(value: argument, user: functionExit)
       return .abortWalk
     }
     return .continueWalk

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -184,7 +184,8 @@ private struct DiagnoseDependence {
       if inoutArg == sourceArg {
         return .continueWalk
       }
-      if function.argumentConventions.getDependence(target: inoutArg.index, source: sourceArg.index) != nil {
+      if function.argumentConventions.parameterDependence(targetArgumentIndex: inoutArg.index,
+                                                          sourceArgumentIndex: sourceArg.index) != nil {
         // The inout result depends on a lifetime that is inherited or borrowed in the caller.
         log("  has dependent inout argument: \(inoutArg)")
         return .continueWalk

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -685,7 +685,7 @@ extension ScopeExtension {
     do {
       // The innermost scope that must be extended must dominate all uses.
       var walker = LifetimeDependentUseWalker(function, localReachabilityCache, context) {
-        inRangeUses.append($0.instruction)
+        inRangeUses.append($0)
         return .continueWalk
       }
       defer {walker.deinitialize()}
@@ -1064,7 +1064,7 @@ private extension BeginApplyInst {
 private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   let function: Function
   let context: Context
-  let visitor: (Operand) -> WalkResult
+  let visitor: (Instruction) -> WalkResult
   let localReachabilityCache: LocalVariableReachabilityCache
   var visitedValues: ValueSet
 
@@ -1072,7 +1072,7 @@ private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   var dependsOnCaller = false
 
   init(_ function: Function, _ localReachabilityCache: LocalVariableReachabilityCache, _ context: Context,
-       visitor: @escaping (Operand) -> WalkResult) {
+       visitor: @escaping (Instruction) -> WalkResult) {
     self.function = function
     self.context = context
     self.visitor = visitor
@@ -1091,42 +1091,42 @@ private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   mutating func deadValue(_ value: Value, using operand: Operand?)
   -> WalkResult {
     if let operand {
-      return visitor(operand)
+      return visitor(operand.instruction)
     }
     return .continueWalk
   }
 
   mutating func leafUse(of operand: Operand) -> WalkResult {
-    return visitor(operand)
+    return visitor(operand.instruction)
   }
 
   mutating func escapingDependence(on operand: Operand) -> WalkResult {
     log(">>> Escaping dependence: \(operand)")
-    _ = visitor(operand)
+    _ = visitor(operand.instruction)
     // Make a best-effort attempt to extend the access scope regardless of escapes. It is possible that some mandatory
     // pass between scope fixup and diagnostics will make it possible for the LifetimeDependenceDefUseWalker to analyze
     // this use.
     return .continueWalk
   }
 
-  mutating func inoutDependence(argument: FunctionArgument, on operand: Operand) -> WalkResult {
+  mutating func inoutDependence(argument: FunctionArgument, functionExit: Instruction) -> WalkResult {
     dependsOnCaller = true
-    return visitor(operand)
+    return visitor(functionExit)
   }
 
   mutating func returnedDependence(result operand: Operand) -> WalkResult {
     dependsOnCaller = true
-    return visitor(operand)
+    return visitor(operand.instruction)
   }
 
   mutating func returnedDependence(address: FunctionArgument,
                                    on operand: Operand) -> WalkResult {
     dependsOnCaller = true
-    return visitor(operand)
+    return visitor(operand.instruction)
   }
 
   mutating func yieldedDependence(result: Operand) -> WalkResult {
-    return visitor(result)
+    return visitor(result.instruction)
   }
 
   mutating func storeToYieldDependence(address: Value, of operand: Operand) -> WalkResult {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -649,7 +649,7 @@ extension AddressOwnershipLiveRange {
     var reachableUses = Stack<LocalVariableAccess>(context)
     defer { reachableUses.deinitialize() }
 
-    localReachability.gatherKnownLifetimeUses(from: assignment, in: &reachableUses)
+    localReachability.gatherKnownLivenessUses(from: assignment, in: &reachableUses)
 
     let assignmentInst = assignment.instruction ?? allocation.parentFunction.entryBlock.instructions.first!
     var range = InstructionRange(begin: assignmentInst, context)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
@@ -26,7 +26,7 @@ private extension ArgumentConventions {
 
     // Check if `argIndex` is a lifetime source in parameterDependencies
     for targetIndex in firstParameterIndex..<self.count {
-      if getDependence(target: targetIndex, source: argIndex) != nil {
+      if parameterDependence(targetArgumentIndex: targetIndex, sourceArgumentIndex: argIndex) != nil {
         return true
       }
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -168,7 +168,7 @@ struct LocalVariableAccess: CustomStringConvertible {
 class LocalVariableAccessInfo: CustomStringConvertible {
   let access: LocalVariableAccess
 
-  private var _isFullyAssigned: Bool?
+  private var _isFullyAssigned: IsFullyAssigned?
 
   /// Cache whether the allocation has escaped prior to this access.
   /// This returns `nil` until reachability is computed.
@@ -180,30 +180,36 @@ class LocalVariableAccessInfo: CustomStringConvertible {
     case .beginAccess:
       switch (localAccess.instruction as! BeginAccessInst).accessKind {
       case .read, .deinit:
-        self._isFullyAssigned = false
+        _isFullyAssigned = .no
       case .`init`, .modify:
         break // lazily compute full assignment
       }
     case .load, .dependenceSource, .dependenceDest:
-      self._isFullyAssigned = false
+      _isFullyAssigned = .no
     case .store, .storeBorrow:
       if let store = localAccess.instruction as? StoringInstruction {
-        self._isFullyAssigned = LocalVariableAccessInfo.isBase(address: store.destination)
+        self._isFullyAssigned = LocalVariableAccessInfo.isBase(address: store.destination) ? .value : .no
+
       } else {
-        self._isFullyAssigned = true
+        self._isFullyAssigned = .value
       }
     case .apply:
+      // This logic is consistent with AddressInitializationWalker.appliedAddressUse()
       let apply = localAccess.instruction as! FullApplySite
       if let convention = apply.convention(of: localAccess.operand!) {
-        self._isFullyAssigned = convention.isIndirectOut
-      } else {
-        self._isFullyAssigned = false
+        if convention.isIndirectOut {
+          self._isFullyAssigned = .value
+        }
+        if convention.isInout {
+          self._isFullyAssigned = apply.fullyAssigns(operand: localAccess.operand!)
+        }
       }
+      _isFullyAssigned = .no
     case .escape:
-      self._isFullyAssigned = false
+      _isFullyAssigned = .no
       self.hasEscaped = true
     case .inoutYield:
-      self._isFullyAssigned = false
+      _isFullyAssigned = .no
     case .incomingArgument, .outgoingArgument, .deadEnd:
       fatalError("Function arguments are never mapped to LocalVariableAccessInfo")
     }
@@ -217,7 +223,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
 
   /// Is this access a full assignment such that none of the variable's components are reachable from a previous
   /// access.
-  func isFullyAssigned(_ context: Context) -> Bool {
+  func isFullyAssigned(_ context: Context) -> IsFullyAssigned {
     if let cached = _isFullyAssigned {
       return cached
     }
@@ -226,8 +232,15 @@ class LocalVariableAccessInfo: CustomStringConvertible {
     }
     assert(isModify)
     let beginAccess = access.instruction as! BeginAccessInst
-    let initializer = AddressInitializationWalker.findSingleInitializer(ofAddress: beginAccess, context: context)
-    _isFullyAssigned = (initializer != nil) ? true : false
+    if AddressInitializationWalker.findSingleInitializer(ofAddress: beginAccess, requireFullyAssigned: .value, context)
+         != nil {
+      _isFullyAssigned = .value
+    } else if AddressInitializationWalker.findSingleInitializer(ofAddress: beginAccess,
+                                                                requireFullyAssigned: .lifetime, context) != nil {
+      _isFullyAssigned = .lifetime
+    } else {
+      _isFullyAssigned = .no
+    }
     return _isFullyAssigned!
   }
 
@@ -553,12 +566,13 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
 /// it as an analysis. We expect a very small number of accesses per local variable.
 struct LocalVariableAccessBlockMap {
   // Lattice, from most information to least information:
-  // none -> read -> modify -> escape -> assign
+  // none -> read -> modify -> escape -> assignLifetime -> assignValue
   enum BlockEffect: Int {
     case read    // no modification or escape
     case modify  // no full assignment or escape
     case escape  // no full assignment
-    case assign  // full assignment, other accesses may be before or after it.
+    case assignLifetime // lifetime assignment, other accesses may be before or after it.
+    case assignValue    // full value assignment, other accesses may be before or after it.
 
     /// Return a merged lattice state such that the result has strictly less information.
     func meet(_ other: BlockEffect?) -> BlockEffect {
@@ -607,8 +621,13 @@ extension LocalVariableAccessBlockMap.BlockEffect {
     if accessInfo.isEscape {
       self = .escape
     }
-    if accessInfo.isFullyAssigned(context) {
-      self = .assign
+    switch accessInfo.isFullyAssigned(context) {
+    case .no:
+      break
+    case .lifetime:
+      self = .assignLifetime
+    case .value:
+      self = .assignValue
     }
   }
 }
@@ -647,6 +666,52 @@ struct LocalVariableReachableAccess {
   }
 }
 
+extension LocalVariableReachableAccess {
+  enum ForwardDataFlowEffect: Int {
+    case read   // no modification or escape
+    case modify // no full assignment or escape
+    case escape // no full assignment
+    case assign // lifetime or value assignment, other accesses may be before or after it.
+
+    /// Return a merged lattice state such that the result has strictly less information.
+    func meet(_ other: ForwardDataFlowEffect?) -> ForwardDataFlowEffect {
+      guard let other else {
+        return self
+      }
+      return other.rawValue > self.rawValue ? other : self
+    }
+  }
+
+  enum DataFlowMode {
+    /// Find the known live range, which may safely enclose dependent uses. Records escapes and continues walking.
+    /// Record the destroy or reassignment access of the local before the walk stops.
+    case livenessUses
+
+    // Find all dependent uses, stop at escapes, stop before recording the destroy or reassignment.
+    case dependentUses
+
+    func getForwardEffect(_ effect: BlockEffect) -> ForwardDataFlowEffect {
+      switch effect {
+      case .read:
+        .read
+      case .modify:
+        .modify
+      case .escape:
+        .escape
+      case .assignLifetime:
+        switch self {
+        case .livenessUses:
+          .modify
+        case .dependentUses:
+          .assign
+        }
+      case .assignValue:
+        .assign
+      }
+    }
+  }
+}
+
 // Find reaching assignments...
 extension LocalVariableReachableAccess {
   // Gather all fully assigned accesses that reach 'instruction'. If 'instruction' is itself a modify access, it is
@@ -672,9 +737,9 @@ extension LocalVariableReachableAccess {
       // `blockInfo.effect` is the same as `currentEffect` returned by backwardScanAccesses, except when an early escape
       // happens below an assign, in which case we report the escape here.
       switch currentEffect {
-      case .none, .read, .modify, .escape:
+      case .none, .read, .modify, .escape, .assignLifetime:
         break
-      case .assign:
+      case .assignValue:
         currentEffect = backwardScanAccesses(before: block.instructions.reversed().first!, accessStack: &accessStack)
       }
       if !backwardPropagateEffect(in: block, effect: currentEffect, blockList: &blockList, accessStack: &accessStack) {
@@ -689,13 +754,13 @@ extension LocalVariableReachableAccess {
                                        accessStack: inout Stack<LocalVariableAccess>)
     -> Bool {
     switch effect {
-    case .none, .read, .modify:
+    case .none, .read, .modify, .assignLifetime:
       if block != accessMap.allocation.parentBlock {
         for predecessor in block.predecessors { blockList.pushIfNotVisited(predecessor) }
       } else if block == accessMap.function.entryBlock {
         accessStack.push(accessMap.liveInAccess!)
       }
-    case .assign:
+    case .assignValue:
       break
     case .escape:
       return false
@@ -704,7 +769,7 @@ extension LocalVariableReachableAccess {
   }
 
   // Check all instructions in this block before and including `first`. Return a BlockEffect indicating the combined
-  // effects seen before stopping the scan. A .escape or .assign stops the scan.
+  // effects seen before stopping the scan. A .escape or .assignValue stops the scan.
   private func backwardScanAccesses(before first: Instruction, accessStack: inout Stack<LocalVariableAccess>)
     -> BlockEffect? {
     var currentEffect: BlockEffect?
@@ -714,9 +779,9 @@ extension LocalVariableReachableAccess {
       }
       currentEffect = BlockEffect(for: accessInfo, accessMap.context).meet(currentEffect)
       switch currentEffect! {
-      case .read, .modify:
+      case .read, .modify, .assignLifetime:
         continue
-      case .assign:
+      case .assignValue:
         accessStack.push(accessInfo.access)
       case .escape:
         break
@@ -729,30 +794,27 @@ extension LocalVariableReachableAccess {
 
 // Find reachable accesses...
 extension LocalVariableReachableAccess {
-  /// This performs a forward CFG walk to find known reachable uses from `assignment`. This ignores aliasing and
-  /// escapes.
-  ///
-  /// The known live range is the range in which the assigned value is valid and may be used by dependent values. It
-  /// includes the destroy or reassignment of the local.
-  func gatherKnownLifetimeUses(from assignment: LocalVariableAccess,
+  /// This performs a forward CFG walk to find known reachable uses from `assignment` that guarantee liveness and may
+  /// safely enclose dependent uses.
+  func gatherKnownLivenessUses(from assignment: LocalVariableAccess,
                                 in accessStack: inout Stack<LocalVariableAccess>) {
     if let modifyInst = assignment.instruction {
-      _ = gatherReachableUses(after: modifyInst, in: &accessStack, lifetime: true)
+      _ = gatherReachableUses(after: modifyInst, in: &accessStack, mode: .livenessUses)
       return
     }
-    gatherKnownLifetimeUsesFromEntry(in: &accessStack)
+    gatherKnownLivenessUsesFromEntry(in: &accessStack)
   }
 
-  /// This performs a forward CFG walk to find known reachable uses from the function entry. This ignores aliasing and
-  /// escapes.
-  private func gatherKnownLifetimeUsesFromEntry(in accessStack: inout Stack<LocalVariableAccess>) {
+  /// This performs a forward CFG walk to find known reachable uses from the function entry that guarantee liveness and
+  /// may safely enclose dependent uses.
+  private func gatherKnownLivenessUsesFromEntry(in accessStack: inout Stack<LocalVariableAccess>) {
     assert(accessMap.liveInAccess!.kind == .incomingArgument, "only an argument access is live in to the function")
     let firstInst = accessMap.function.entryBlock.instructions.first!
-    _ = gatherReachableUses(onOrAfter: firstInst, in: &accessStack, lifetime: true)
+    _ = gatherReachableUses(onOrAfter: firstInst, in: &accessStack, mode: .livenessUses)
   }
 
-  /// This performs a forward CFG walk to find all reachable uses of `modifyInst`. `modifyInst` may be a `begin_access
-  /// [modify]` or instruction that initializes the local variable.
+  /// This performs a forward CFG walk to find all reachable lifetime dependent uses of `modifyInst`. `modifyInst` may
+  /// be a `begin_access [modify]` or instruction that initializes the local variable.
   ///
   /// This does not include the destroy or reassignment of the value set by `modifyInst`.
   ///
@@ -762,12 +824,16 @@ extension LocalVariableReachableAccess {
   /// This does not gather the escaping accesses themselves. When escapes are reachable, it also does not guarantee that
   /// previously reachable accesses are gathered.
   ///
+  /// The walk stops at any variable assignment that does not propagate the lifetime dependency; for example, at an
+  /// @inout argument that does not depend on itself (apply.fullyAssigns(arg) == .lifetime).
+  ///
   /// This computes reachability separately for each store. If this store is a fully assigned access, then
   /// this never repeats work (it is a linear-time analysis over all assignments), because the walk always stops at the
   /// next fully-assigned access. Field assignment can result in an analysis that is quadratic in the number
   /// stores. Nonetheless, the analysis is highly efficient because it maintains no block state other than the
   /// block's intrusive bit set.
-  func gatherAllReachableUses(of modifyInst: Instruction, in accessStack: inout Stack<LocalVariableAccess>) -> Bool {
+  func gatherAllReachableDependentUses(of modifyInst: Instruction,
+                                       in accessStack: inout Stack<LocalVariableAccess>) -> Bool {
     guard let accessInfo = accessMap[modifyInst] else {
       return false
     }
@@ -777,64 +843,72 @@ extension LocalVariableReachableAccess {
     if accessInfo.hasEscaped! {
       return false
     }
-    return gatherReachableUses(after: modifyInst, in: &accessStack, lifetime: false)
+    return gatherReachableUses(after: modifyInst, in: &accessStack, mode: .dependentUses)
+  }
+
+  func gatherAllReachableDependentUsesFromEntry(in accessStack: inout Stack<LocalVariableAccess>) -> Bool {
+    return gatherReachableUses(onOrAfter: accessMap.function.entryBlock.instructions.first!, in: &accessStack,
+                               mode: .dependentUses)
   }
 
   /// This performs a forward CFG walk to find all uses of this local variable reachable after `begin`.
   ///
-  /// If `lifetime` is true, then this gathers the full known lifetime, including destroys and reassignments ignoring
-  /// escapes.
+  /// For DataFlowMode.livenessUses, this gathers the full known live range, including destroys and reassignments
+  /// continuing past escapes.
   ///
-  /// If `lifetime` is false, then this returns `false` if the walk ended early because of a reachable escape.
+  /// For DataFlowMode.dependentUses, this returns `false` if the walk ended early because of a reachable escape.
   private func gatherReachableUses(after begin: Instruction, in accessStack: inout Stack<LocalVariableAccess>,
-                                   lifetime: Bool) -> Bool {
+                                   mode: DataFlowMode) -> Bool {
     if let term = begin as? TermInst {
       for succ in term.successors {
-        if !gatherReachableUses(onOrAfter: succ.instructions.first!, in: &accessStack, lifetime: lifetime) {
+        if !gatherReachableUses(onOrAfter: succ.instructions.first!, in: &accessStack, mode: mode) {
           return false
         }
       }
       return true
     } else {
-      return gatherReachableUses(onOrAfter: begin.next!, in: &accessStack, lifetime: lifetime)
+      return gatherReachableUses(onOrAfter: begin.next!, in: &accessStack, mode: mode)
     }
   }
 
   /// This performs a forward CFG walk to find all uses of this local variable reachable after and including `begin`.
   ///
-  /// If `lifetime` is true, then this returns false if the walk ended early because of a reachable escape.
+  /// For DataFlowMode.dependentUses, then this returns false if the walk ended early because of a reachable escape.
   private func gatherReachableUses(onOrAfter begin: Instruction, in accessStack: inout Stack<LocalVariableAccess>,
-                                   lifetime: Bool) -> Bool {
+                                   mode: DataFlowMode) -> Bool {
     var blockList = BasicBlockWorklist(context)
     defer { blockList.deinitialize() }
 
     let initialBlock = begin.parentBlock
-    let initialEffect = forwardScanAccesses(after: begin, accessStack: &accessStack, lifetime: lifetime)
-    if !lifetime, initialEffect == .escape {
+    let initialEffect = forwardScanAccesses(after: begin, accessStack: &accessStack, mode: mode)
+    if mode == .dependentUses, initialEffect == .escape {
       return false
     }
     forwardPropagateEffect(in: initialBlock, blockInfo: blockMap[initialBlock], effect: initialEffect,
                            blockList: &blockList, accessStack: &accessStack)
     while let block = blockList.pop() {
       let blockInfo = blockMap[block]
-      var currentEffect = blockInfo?.effect
-      // lattice: none -> read -> modify -> escape -> assign
+      var currentEffect: ForwardDataFlowEffect?
+      if let blockEffect = blockInfo?.effect {
+        currentEffect = mode.getForwardEffect(blockEffect)
+      }
+      // lattice: none -> read -> modify -> escape -> assignLifetime -> assignValue
       //
-      // `blockInfo.effect` is the same as `currentEffect` returned by forwardScanAccesses, except when an early
-      // disallowed escape happens before an assign.
+      // `blockInfo.effect` is the same as `currentEffect` returned by forwardScanAccesses below, except when
+      // forwardScanAccesses finds an early disallowed escape before the assign.
       switch currentEffect {
       case .none:
         break
       case .escape:
-        if !lifetime {
+        if mode == .dependentUses {
           break
         }
         fallthrough
       case .read, .modify, .assign:
         let firstInst = block.instructions.first!
-        currentEffect = forwardScanAccesses(after: firstInst, accessStack: &accessStack, lifetime: lifetime)
+        currentEffect = forwardScanAccesses(after: firstInst, accessStack: &accessStack, mode: mode)
       }
-      if !lifetime, currentEffect == .escape {
+      if mode == .dependentUses, currentEffect == .escape {
         return false
       }
       forwardPropagateEffect(in: block, blockInfo: blockInfo, effect: currentEffect, blockList: &blockList,
@@ -848,7 +922,7 @@ extension LocalVariableReachableAccess {
   typealias BlockEffect = LocalVariableAccessBlockMap.BlockEffect
   typealias BlockInfo = LocalVariableAccessBlockMap.BlockInfo
 
-  private func forwardPropagateEffect(in block: BasicBlock, blockInfo: BlockInfo?, effect: BlockEffect?,
+  private func forwardPropagateEffect(in block: BasicBlock, blockInfo: BlockInfo?, effect: ForwardDataFlowEffect?,
                                       blockList: inout BasicBlockWorklist,
                                       accessStack: inout Stack<LocalVariableAccess>) {
     switch effect {
@@ -870,24 +944,24 @@ extension LocalVariableReachableAccess {
   }
 
   // Check all instructions in this block after and including `begin`. Return a BlockEffect indicating the combined
-  // effects seen before stopping the scan. An .assign stops the scan. A .escape stops the scan if lifetime is false.
+  // effects seen before stopping the scan. An .assign stops the scan. A .escape stops the scan for .dependentUses.
   private func forwardScanAccesses(after first: Instruction, accessStack: inout Stack<LocalVariableAccess>,
-                                   lifetime: Bool)
-    -> BlockEffect? {
-    var currentEffect: BlockEffect?
+                                   mode: DataFlowMode)
+    -> ForwardDataFlowEffect? {
+    var currentEffect: ForwardDataFlowEffect?
     for inst in InstructionList(first: first) {
       guard let accessInfo = accessMap[inst] else {
         continue
       }
-      currentEffect = BlockEffect(for: accessInfo, accessMap.context).meet(currentEffect)
+      currentEffect = mode.getForwardEffect(BlockEffect(for: accessInfo, accessMap.context)).meet(currentEffect)
       switch currentEffect! {
       case .assign:
-        if lifetime {
+        if mode == .livenessUses {
           accessStack.push(accessInfo.access)
         }
         return currentEffect
       case .escape:
-        if !lifetime {
+        if mode == .dependentUses {
           log("Local variable: \(accessMap.allocation)\n    escapes at \(inst)")
           return currentEffect
         }
@@ -994,7 +1068,7 @@ let localVariableReachableUsesTest = FunctionTest("local_variable_reachable_uses
   print("### Modify: \(modify)")
   var reachableUses = Stack<LocalVariableAccess>(context)
   defer { reachableUses.deinitialize() }
-  guard localReachability.gatherAllReachableUses(of: modify, in: &reachableUses) else {
+  guard localReachability.gatherAllReachableDependentUses(of: modify, in: &reachableUses) else {
     print("!!! Reachable escape")
     return
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -857,6 +857,7 @@ extension LocalVariableReachableAccess {
         break
       }
       if block.terminator.isFunctionExiting {
+        // Record any reachable function exit as .outgoingArgument.
         accessStack.push(LocalVariableAccess(.outgoingArgument, block.terminator))
       } else if block.successors.isEmpty {
         accessStack.push(LocalVariableAccess(.deadEnd, block.terminator))

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -158,7 +158,7 @@ struct LocalVariableAccess: CustomStringConvertible {
       str += "deadEnd"
     }
     if let inst = instruction {
-      str += "\(inst)"
+      str += ", \(inst)"
     }
     return str
   }
@@ -249,6 +249,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
 
   var description: String {
     return "assign: \(_isFullyAssigned == nil ? "unknown" : String(describing: _isFullyAssigned!)), "
+      + "hasEscaped: \(hasEscaped == nil ?  "unknown" : String(describing: hasEscaped!)), "
       + "\(access)"
   }
 

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -79,6 +79,15 @@ public struct ApplyOperandConventions : Collection {
       calleeArgumentIndex(ofOperandIndex: operandIndex)!]
   }
 
+  public func parameterDependence(targetOperandIndex: Int, sourceOperandIndex: Int) -> LifetimeDependenceConvention? {
+    guard let targetArgIdx = calleeArgumentIndex(ofOperandIndex: targetOperandIndex),
+          let sourceArgIdx = calleeArgumentIndex(ofOperandIndex: sourceOperandIndex) else {
+      return nil
+    }
+    return calleeArgumentConventions.parameterDependence(targetArgumentIndex: targetArgIdx,
+                                                         sourceArgumentIndex: sourceArgIdx)
+  }
+
   public var firstParameterOperandIndex: Int {
     return ApplyOperandConventions.firstArgumentIndex +
       calleeArgumentConventions.firstParameterIndex
@@ -245,6 +254,10 @@ extension ApplySite {
     let idx = operand.index
     return idx < operandConventions.startIndex ? nil
       : operandConventions[parameterDependencies: idx]
+  }
+
+  public func parameterDependence(target: Operand, source: Operand) -> LifetimeDependenceConvention? {
+    return operandConventions.parameterDependence(targetOperandIndex: target.index, sourceOperandIndex: source.index)
   }
 
   public var yieldConventions: YieldConventions {

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -122,6 +122,22 @@ public protocol ApplySite : Instruction {
   var unappliedArgumentCount: Int { get }
 }
 
+// lattice: no -> lifetime -> value
+public enum IsFullyAssigned {
+  case no
+  case lifetime
+  case value
+
+  var reassignsLifetime: Bool {
+    switch self {
+    case .no:
+      false
+    case .lifetime, .value:
+      true
+    }
+  }
+}
+
 extension ApplySite {
   public var callee: Value { operands[ApplyOperandConventions.calleeIndex].value }
 
@@ -258,6 +274,26 @@ extension ApplySite {
 
   public func parameterDependence(target: Operand, source: Operand) -> LifetimeDependenceConvention? {
     return operandConventions.parameterDependence(targetOperandIndex: target.index, sourceOperandIndex: source.index)
+  }
+
+  /// Returns .value if this apply fully assigns 'operand' (via @out).
+  ///
+  /// Returns .lifetime if this 'operand' is a non-Escapable inout argument and its lifetime is not propagated by the
+  /// call ('@lifetime(param: copy param)' is not present).
+  public func fullyAssigns(operand: Operand) -> IsFullyAssigned {
+    switch convention(of: operand) {
+    case .indirectOut:
+      return .value
+    case .indirectInout:
+      if let argIdx = calleeArgumentIndex(of: operand),
+         calleeArgumentConventions.parameterDependence(targetArgumentIndex: argIdx, sourceArgumentIndex: argIdx) == nil
+      {
+        return .lifetime
+      }
+      return .no
+    default:
+      return .no
+    }
   }
 
   public var yieldConventions: YieldConventions {

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -318,15 +318,14 @@ public struct ArgumentConventions : Collection, CustomStringConvertible {
     return convention.parameterDependencies(for: targetParamIdx)
   }
 
+  /// Return a parameter dependence of the target argument on the source argument.
+  public func parameterDependence(targetArgumentIndex: Int, sourceArgumentIndex: Int) -> LifetimeDependenceConvention? {
+    findDependence(source: sourceArgumentIndex, in: self[parameterDependencies: targetArgumentIndex])
+  }
+
   /// Return a dependence of the function results on the indexed parameter.
   public subscript(resultDependsOn argumentIndex: Int) -> LifetimeDependenceConvention? {
     findDependence(source: argumentIndex, in: convention.resultDependencies)
-  }
-
-  /// Return a dependence of the target argument on the source argument.
-  public func getDependence(target targetArgumentIndex: Int, source sourceArgumentIndex: Int)
-    -> LifetimeDependenceConvention? {
-    findDependence(source: sourceArgumentIndex, in: self[parameterDependencies: targetArgumentIndex])
   }
 
   /// Number of SIL arguments for the function type's results

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -290,7 +290,7 @@ public struct ArgumentConventions : Collection, CustomStringConvertible {
   }
 
   public subscript(_ argumentIndex: Int) -> ArgumentConvention {
-    if let paramIdx = parameterIndex(for: argumentIndex) {
+    if let paramIdx = parameterIndex(ofArgumentIndex: argumentIndex) {
       return convention.parameters[paramIdx].convention
     }
     let resultInfo = convention.indirectSILResult(at: argumentIndex)
@@ -298,21 +298,21 @@ public struct ArgumentConventions : Collection, CustomStringConvertible {
   }
 
   public subscript(result argumentIndex: Int) -> ResultInfo? {
-    if parameterIndex(for: argumentIndex) != nil {
+    if parameterIndex(ofArgumentIndex: argumentIndex) != nil {
       return nil
     }
     return convention.indirectSILResult(at: argumentIndex)
   }
 
   public subscript(parameter argumentIndex: Int) -> ParameterInfo? {
-    guard let paramIdx = parameterIndex(for: argumentIndex) else {
+    guard let paramIdx = parameterIndex(ofArgumentIndex: argumentIndex) else {
       return nil
     }
     return convention.parameters[paramIdx]
   }
 
   public subscript(parameterDependencies targetArgumentIndex: Int) -> FunctionConvention.LifetimeDependencies? {
-    guard let targetParamIdx = parameterIndex(for: targetArgumentIndex) else {
+    guard let targetParamIdx = parameterIndex(ofArgumentIndex: targetArgumentIndex) else {
       return nil
     }
     return convention.parameterDependencies(for: targetParamIdx)
@@ -365,14 +365,14 @@ public struct ArgumentConventions : Collection, CustomStringConvertible {
 }
 
 extension ArgumentConventions {
-  private func parameterIndex(for argIdx: Int) -> Int? {
+  private func parameterIndex(ofArgumentIndex argIdx: Int) -> Int? {
     let firstParamIdx = firstParameterIndex  // bridging call
     return argIdx < firstParamIdx ? nil : argIdx - firstParamIdx
   }
 
   private func findDependence(source argumentIndex: Int, in dependencies: FunctionConvention.LifetimeDependencies?)
     -> LifetimeDependenceConvention? {
-    guard let paramIdx = parameterIndex(for: argumentIndex) else {
+    guard let paramIdx = parameterIndex(ofArgumentIndex: argumentIndex) else {
       return nil
     }
     return dependencies?[paramIdx]

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1854,13 +1854,17 @@ public class TermInst : Instruction {
 final public class UnreachableInst : TermInst {
 }
 
-final public class ReturnInst : TermInst, UnaryInstruction {
+public protocol ReturnInstruction: TermInst {
+  var returnedValue: Value { get }
+}
+
+final public class ReturnInst : TermInst, UnaryInstruction, ReturnInstruction {
   public var returnedValue: Value { operand.value }
   public override var isFunctionExiting: Bool { true }
 }
 
-final public class ReturnBorrowInst : TermInst {
-  public var returnValue: Value { operands[0].value }
+final public class ReturnBorrowInst : TermInst, ReturnInstruction {
+  public var returnedValue: Value { operands[0].value }
   public var enclosingOperands: OperandArray {
     let ops = operands
     return ops[1..<ops.count]

--- a/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
+++ b/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
@@ -17,9 +17,6 @@ public struct Resilient {
     borrowing func getSpan() -> RawSpan { fatalError() }
 }
 
-/*
-// TODO (rdar://151268401): We still get spurious errors about escaping `self`
-// in cases where the wrapped type is concretely addressable-for-dependencies.
 internal struct AFDWrapper {
     let inner: AFDResilient
 
@@ -32,4 +29,3 @@ public struct AFDResilient {
     @_lifetime(borrow self)
     borrowing func getSpan() -> RawSpan { fatalError() }
 }
-*/

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -212,6 +212,7 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D, %4 : $*D):
 // CHECK-LABEL: dependence_access: lifetime_dependence_use with: %0
 // CHECK: LifetimeDependence uses of: %0 = argument of bb0 : $*NE
 // CHECK-NEXT: Leaf use: operand #0 of   end_access %{{.*}} : $*NE
+// CHECK-NEXT: Returned inout: %0 = argument of bb0 : $*NE
 // CHECK-NEXT: dependence_access: lifetime_dependence_use with: %0
 sil [ossa] @dependence_access : $@convention(thin) (@inout NE, @owned C) -> () {
 bb0(%0 : $*NE, %1 : @owned $C):

--- a/test/SILOptimizer/lifetime_dependence/local_var_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/local_var_util.sil
@@ -18,20 +18,20 @@ sil @makeDepNE : $@convention(thin) (@inout NE) -> @lifetime(borrow address_for_
 // CHECK-LABEL: testNEInitNoEscape: local_variable_reachable_uses with: %1, @instruction
 // CHECK: ### Access map:
 // CHECK-NEXT: Access map for:   %{{.*}} = alloc_box ${ var NE }, var, name "self"
-// CHECK-NEXT: assign: true, store  destroy_value %{{.*}} : ${ var NE }
-// CHECK-NEXT: assign: false, escape  %{{.*}} = address_to_pointer %{{.*}} : $*NE to $Builtin.RawPointer
-// CHECK-NEXT: assign: true, beginAccess  %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
-// CHECK-NEXT: assign: false, load  %{{.*}} = load [copy] %{{.*}} : $*NE
-// CHECK-NEXT: assign: true, beginAccess  %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
+// CHECK-NEXT: assign: value, hasEscaped: unknown, store, destroy_value %{{.*}} : ${ var NE }
+// CHECK-NEXT: assign: no, hasEscaped: true, escape, %{{.*}} = address_to_pointer %{{.*}} : $*NE to $Builtin.RawPointer
+// CHECK-NEXT: assign: value, hasEscaped: unknown, beginAccess, %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
+// CHECK-NEXT: assign: no, hasEscaped: unknown, load, %{{.*}} = load [copy] %{{.*}} : $*NE
+// CHECK-NEXT: assign: value, hasEscaped: unknown, beginAccess, %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
 // CHECK-NEXT: ### Modify:   %{{.*}} = begin_access [modify] [unknown] %4 : $*NE
 // CHECK-NEXT: ### Reachable access:
-// CHECK-NEXT: load  %{{.*}} = load [copy] %{{.*}} : $*NE
+// CHECK-NEXT: load, %{{.*}} = load [copy] %{{.*}} : $*NE
 // CHECK-NEXT: testNEInitNoEscape: local_variable_reachable_uses with: %1, @instruction
 
 // CHECK-LABEL: testNEInitNoEscape: local_variable_reaching_assignments with: %1, @instruction
 // CHECK: ### Instruction:   end_access %{{.*}} : $*NE
 // CHECK-NEXT: ### Reachable assignments:
-// CHECK-NEXT: beginAccess  %21 = begin_access [modify] [unknown] %4 : $*NE
+// CHECK-NEXT: beginAccess, %21 = begin_access [modify] [unknown] %4 : $*NE
 // CHECK-NEXT: testNEInitNoEscape: local_variable_reaching_assignments with: %1, @instruction
 sil [ossa] @testNEInitNoEscape : $@convention(thin) (@inout NE) -> @lifetime(borrow 0) @owned NE {
 bb0(%0 : $*NE):
@@ -86,10 +86,10 @@ bb3:
 // CHECK-LABEL: testNEInitEscape: local_variable_reachable_uses with: %1, @instruction
 // CHECK: ### Access map:
 // CHECK-NEXT: Access map for:   %{{.*}} = alloc_box ${ var NE }, var, name "self"
-// CHECK-NEXT: assign: true, store  destroy_value %{{.*}} : ${ var NE }
-// CHECK-NEXT: assign: false, load  %{{.*}} = load [copy] %{{.*}} : $*NE
-// CHECK-NEXT: assign: true, beginAccess  %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
-// CHECK-NEXT: assign: false, escape  %6 = address_to_pointer %4 : $*NE to $Builtin.RawPointer
+// CHECK-NEXT: assign: value, hasEscaped: unknown, store, destroy_value %{{.*}} : ${ var NE }
+// CHECK-NEXT: assign: no, hasEscaped: unknown, load, %{{.*}} = load [copy] %{{.*}} : $*NE
+// CHECK-NEXT: assign: value, hasEscaped: unknown, beginAccess, %{{.*}} = begin_access [modify] [unknown] %{{.*}} : $*NE
+// CHECK-NEXT: assign: no, hasEscaped: true, escape, %6 = address_to_pointer %4 : $*NE to $Builtin.RawPointer
 // CHECK-NEXT: ### Modify:   %{{.*}} = begin_access [modify] [unknown] %4 : $*NE
 // CHECK-NEXT: !!! Reachable escape
 // CHECK-NEXT: testNEInitEscape: local_variable_reachable_uses with: %1, @instruction

--- a/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
@@ -54,11 +54,9 @@ func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
 
 @available(SwiftStdlib 6.2, *)
 func testUBPStorageEscape(array: [Int64]) {
-  var span = RawSpan()
-  array.withUnsafeBytes {
-    span = $0.storage // expected-error {{lifetime-dependent value escapes its scope}}
-                      // expected-note  @-2{{it depends on the lifetime of argument '$0'}}
-                      // expected-note  @-2{{this use causes the lifetime-dependent value to escape}}
-  }
+  var span = RawSpan()  // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
+  array.withUnsafeBytes {  // expected-note{{it depends on the lifetime of argument '$0'}}
+    span = $0.storage
+  } // expected-note{{this use causes the lifetime-dependent value to escape}}
   read(span)
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -409,3 +409,23 @@ func returnTempBorrow() -> Borrow<Int> {
 func test(inline: InlineInt) {
   inline.span.withUnsafeBytes { _ = $0 }
 }
+
+// =============================================================================
+// Closures
+// =============================================================================
+
+/// Test an autoclosure that invokes a mutable method where `Self: ~Escapable`.
+/// The @inout_aliasable argument has an implicit @_lifetime(capture: copy capture),
+/// and no begin_access [dynamic] is present in the closure.
+extension MutableSpan {
+  @_lifetime(self: copy self)
+  public mutating func canUpdate() -> Bool { return true }
+
+  @_lifetime(self: copy self)
+  public mutating func testAutoclosure(z: Bool) -> Bool {
+    if z && canUpdate() {
+      return true
+    }
+    return false
+  }
+}


### PR DESCRIPTION
Fix miscompilations involving MutableSpan.

- **[NFC] add a new entry point for DiagnoseDependence.reportError**
  Allow diagnosing values that have no relevant users. Such as an @inout argument.
  

- **[NFC] LifetimeDependenceDefUseWalker.inoutDependence entry point**
  Handle cases where there's no relevant operand.
  

- **[NFC] Add ApplySite.fullyAssigns(Operand) query**
  

- **Fix LifetimeDependenceDefUseWalker for @inout reassignment**
  

- **Extend AddressInitializationWalker.findSingleInitializer**
  Handle applies that reassign the lifetime of their operand vs. the value of
  their operand.
  

- **LocalVariableReachableAccess: handle lifetime reassignment**
  A ~Escapable inout apply operand that does not propagate its own lifetime can be
  treated as being assigned a new lifetime in the caller.
  
    @lifetime(arg: copy source)
    func foo<T: ~Escapable>(arg: inout T, source: T) {
      arg = source
    }
  
  A call to 'foo' initializes the lifetime of 'arg', thereby ending the lifetime
  of the previous value.
  

- **[NFC] Rename ArgumentConventions.parameterIndex(ofArgumentIndex:)**
  

- **[NFC] Add ApplySite.parameterDependence(target:source:)**
  

- **Fix LifetimeDependenceDefUseWalker to follow inout dependence**
  Fixes rdar://157796728 ([nonescapable] [miscompile] No diagnostic error when an
  inout MutableSpan is reassigned to a different lifetime source)
  

- **[NFC] LocalVariableAccessInfo.description**
  

- **LocalVariableUtils add non-escaping closure capture support**
  Don't always consider an inout_aliasable argument to have
  escaped. AccessEnforcementSelection has already done that analysis and left
  begin_access [dynamic] artifacts if the argument has escaped in any meaningful
  way. Use that information to
  
  Essential for supporting autoclosures that call mutating methods on span-like
  things. Such as UTF8Span.UnicodeScalarIterator.skipForward():
  
  e.g. while numSkipped < n && skipForward() != 0 { ... }
  

- **[NFC] extend AddressInitializationWalker to report address reads**
  

- **Fix LocalVariableReachableAccess to handle potential reassignment.**
  Define LocalAccessInfo._isFullyAssigned to mean that the access does not read
  the incoming value. Then treat any assignment that isn't full as a potential read.
  

- **LocalVariableUtils: precisely handle function live-out**
  Only record an outgoingArgument access when the current allocation is an
  outgoing argument and the function exiting instruction is ReturnInst.
  
  This avoids invalid SIL where we attempt to extend end_access up to an `unwind` but
  fail to actually materialize that end_access.
  

- **Test lifetime reassignment**
  

- **Test noescape closure capture lifetimes**
  

- **Update tests for local variable reachability for debug output**
  

- **Update lifetime tests for improved diagnostics**
  