### PR TITLE
DI: Place cleanups for partially-initialized non-`Copyable` values on the `mark_unresolved_noncopyable` marker.

### DIFF
--- a/test/Interpreter/moveonly_throw_partial_init.swift
+++ b/test/Interpreter/moveonly_throw_partial_init.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+struct Butt: Error {}
+
+struct Inside: ~Copyable {
+	init() throws { throw Butt() }
+}
+
+class C {
+	deinit { print("destroying") }
+}
+
+struct Outside: ~Copyable {
+    let instance: Inside
+	var c: C
+
+    init() throws {
+		c = C()
+        let instance = try Inside()
+        self.instance = instance
+    }
+}
+
+// CHECK: begin
+// CHECK-NEXT: destroying
+// CHECK-NEXT: caught
+// CHECK-NEXT: end
+
+func test() {
+	print("begin")
+	do {
+		_ = try Outside()
+	} catch {
+		print("caught")
+	}
+	print("end")
+}
+test()
+

--- a/test/SILOptimizer/definite_init_moveonly.sil
+++ b/test/SILOptimizer/definite_init_moveonly.sil
@@ -1,0 +1,40 @@
+// RUN: %target-sil-opt -module-name definite_init_moveonly -enable-sil-verify-all -definite-init %s | %FileCheck %s
+
+import Swift
+
+class C {
+	init()
+}
+
+struct S: ~Copyable {
+	var c1: C
+	var c2: C
+}
+
+// Ensure that, when DI introduces cleanups for partially initialized move-
+// only values, the cleanups are applied under the `mark_unresolved`
+// instruction, so that the move checker properly accounts for the cleanups.
+// #85063 | rdar://163194098
+
+// CHECK-LABEL: sil [ossa] @$test
+sil [ossa] @$test : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+	%s = alloc_stack [lexical] [var_decl] $S, var, name "butts", type $S
+	%s_marked = mark_uninitialized [rootself] %s
+	// CHECK: [[S_MOVEONLY:%.*]] = mark_unresolved_non_copyable_value
+	%s_moveonly = mark_unresolved_non_copyable_value [consumable_and_assignable] %s_marked
+	%s_access = begin_access [modify] [static] %s_moveonly
+	%c1 = struct_element_addr %s_access, #S.c1
+	assign %c to %c1
+	end_access %s_access
+	// CHECK: br [[NEXT:bb[0-9]+]]
+	br next
+
+	// CHECK: [[NEXT]]:
+	// CHECK: [[FIELD_TO_DESTROY:%.*]] = struct_element_addr [[S_MOVEONLY]], #S.c1
+	// CHECK: destroy_addr [[FIELD_TO_DESTROY]]
+next:
+	destroy_addr %s_moveonly
+	dealloc_stack %s
+	return undef : $()
+}

--- a/test/SILOptimizer/moveonly_partial_consumption_inlinable.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption_inlinable.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -enable-library-evolution -emit-sil -verify %s
+
+public struct Consumable: ~Copyable {}
+
+public func consume(_: consuming Consumable) {}
+
+public struct NotFrozen: ~Copyable {
+	public var field: Consumable
+
+	public consuming func notInlinable() {
+		consume(field)
+	}
+
+	@inlinable
+	public consuming func inlinable() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+
+	@_alwaysEmitIntoClient
+	public consuming func aeic() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+
+	@_transparent
+	public consuming func transparent() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+}
+
+@frozen
+public struct Frozen: ~Copyable {
+	public var field: Consumable
+
+	public consuming func notInlinable() {
+		consume(field)
+	}
+
+	@inlinable
+	public consuming func inlinable() {
+		consume(field)
+	}
+}
+
+@usableFromInline
+internal struct NotFrozenUFI: ~Copyable {
+	public var field: Consumable
+
+	public consuming func notInlinable() {
+		consume(field)
+	}
+
+	@inlinable
+	public consuming func inlinable() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+
+	@_alwaysEmitIntoClient
+	public consuming func aeic() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+
+	@_transparent
+	public consuming func transparent() {
+		// expected-error @+1 {{consumed but not reinitialized}}
+		consume(field) // expected-note{{}}
+	}
+}
+


### PR DESCRIPTION
… the `mark_unresolved_noncopyable` marker.

This ensures that move checking sees the cleanups when determining a value's lifetime and doesn't try to insert its own cleanup leading to a double destroy. Fixes #85063 | rdar://163194098.