### PR TITLE
Fix ASAN stack-use-after-scope errors `Basic/TaskQueueTest.cpp`

### DIFF
--- a/unittests/Basic/TaskQueueTest.cpp
+++ b/unittests/Basic/TaskQueueTest.cpp
@@ -149,8 +149,8 @@ TEST(TaskQueueTest, HighConcurrency) {
     return TaskFinishedResponse::ContinueExecution;
   };
 
+  const char *Args[] = {"test", nullptr};
   for (int i = 0; i < 50; i++) {
-    const char *Args[] = {"test", nullptr};
     TQ.addTask("/bin/echo", Args, llvm::ArrayRef<const char *>(), nullptr, false);
   }
 
@@ -182,8 +182,8 @@ TEST(TaskQueueTest, TaskBeganCallback) {
     return TaskFinishedResponse::ContinueExecution;
   };
 
+  const char *Args[] = {"echo", "test", nullptr};
   for (int i = 0; i < 3; i++) {
-    const char *Args[] = {"echo", "test", nullptr};
     TQ.addTask("/bin/echo", Args, llvm::ArrayRef<const char *>(), nullptr, false);
   }
 
@@ -219,8 +219,8 @@ TEST(TaskQueueTest, StopExecutionOnFailure) {
     return TaskFinishedResponse::ContinueExecution;
   };
 
+  const char *Args[] = {"test", nullptr};
   for (int i = 0; i < 10; i++) {
-    const char *Args[] = {"test", nullptr};
     TQ.addTask("/bin/echo", Args, llvm::ArrayRef<const char *>(), nullptr, false);
   }
 


### PR DESCRIPTION
The issue was that in three tests, the `Args` arrays were being declared inside for loops.

When `TQ.addTask()` was called, it stored a pointer to the `Args` array. As the `Args` array was declared in the loop, it would go out of scope at the end of each iteration whilst `TaskQueue` held a pointer to it.