### PR TITLE
[IRGen] Fix call generation to respect C calling conventions.

### DIFF
--- a/docs/SIL/Types.md
+++ b/docs/SIL/Types.md
@@ -240,6 +240,10 @@ number of ways:
     -   An `@in_constant` parameter is indirect. The address must be of
         an initialized object; the function will treat the value held
         there as read-only.
+    -   An `@in_cxx` parameter is indirect. The address must be of an
+        initialized object; the callee may mutate the object, but is
+        not responsible for destroying it.  This corresponds to the
+        parameter-passing convention of the Itanium C++ ABI.
     -   A `@pack_owned` parameter is indirect. The parameter must be of
         pack type and is always an address. Whether the pack elements
         are direct values or addresses of values is encoded in the pack

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -221,6 +221,8 @@ def crosscheck_unqualified_lookup : Flag<["-"], "crosscheck-unqualified-lookup">
 
 def use_clang_function_types : Flag<["-"], "use-clang-function-types">,
   HelpText<"Use stored Clang function types for computing canonical types.">;
+def no_use_clang_function_types : Flag<["-"], "no-use-clang-function-types">,
+  HelpText<"Do not use stored Clang function types.">;
 
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -866,12 +866,16 @@ clang::QualType ClangTypeConverter::visit(Type type) {
 }
 
 clang::QualType ClangTypeConverter::convert(Type type) {
+  // We have to do this first, otherwise we will fail to locate
+  // ObjC protocol types in the cache, and instead create a new one
+  // every time (which is bad).
+  if (auto existential = type->getAs<ExistentialType>())
+    type = existential->getConstraintType();
+
+  // Now search the cache
   auto it = Cache.find(type);
   if (it != Cache.end())
     return it->second;
-
-  if (auto existential = type->getAs<ExistentialType>())
-    type = existential->getConstraintType();
 
   // Try to do this without making cache entries for obvious cases.
   if (auto nominal = type->getAs<NominalType>()) {

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -25,11 +25,16 @@
 namespace swift {
 
 // MARK: - ClangTypeInfo
+const clang::Type *ClangTypeInfo::makeCanonical(const clang::Type *type) {
+  if (!type)
+    return nullptr;
+  return type->getCanonicalTypeInternal().getTypePtr();
+}
 
 bool operator==(ClangTypeInfo lhs, ClangTypeInfo rhs) {
   if (lhs.type == rhs.type)
     return true;
-  if (lhs.type && rhs.type)
+  if (lhs.type && rhs.type && lhs.equivalentType == rhs.equivalentType)
     return lhs.type->getCanonicalTypeInternal() ==
            rhs.type->getCanonicalTypeInternal();
   return false;
@@ -39,10 +44,15 @@ bool operator!=(ClangTypeInfo lhs, ClangTypeInfo rhs) {
   return !(lhs == rhs);
 }
 
+bool ClangTypeInfo::isEquivalentType(const ClangTypeInfo &other) const {
+  return equivalentType == other.equivalentType;
+}
+
 ClangTypeInfo ClangTypeInfo::getCanonical() const {
   if (!type)
     return ClangTypeInfo();
-  return ClangTypeInfo(type->getCanonicalTypeInternal().getTypePtr());
+  return ClangTypeInfo(type->getCanonicalTypeInternal().getTypePtr(),
+                       equivalentType->getCanonicalTypeInternal().getTypePtr());
 }
 
 void ClangTypeInfo::printType(ClangModuleLoader *cml,

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -86,7 +86,8 @@ UnexpectedClangTypeError::checkClangType(SILFunctionTypeRepresentation silRep,
     if (isBlock && !type->isBlockPointerType())
       return {{Kind::NotBlockPointer, type}};
     if (!isBlock && !(type->isFunctionPointerType()
-                      || type->isFunctionReferenceType()))
+                      || type->isFunctionReferenceType()
+                      || type->isFunctionType()))
       return {{Kind::NotFunctionPointerOrReference, type}};
     return std::nullopt;
   }
@@ -121,8 +122,8 @@ void UnexpectedClangTypeError::dump() {
     return;
   }
   case Kind::NotFunctionPointerOrReference: {
-    e << ("Expected function pointer/reference type for @convention(c) function"
-          " but found:\n");
+    e << ("Expected function or function pointer/reference type for "
+          "@convention(c) function but found:\n");
     type->dump();
     return;
   }

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -268,7 +268,17 @@ ClangImporter::resolveStableSerializationPath(
       // Ignore unacceptable declarations.
       if (!isAcceptable(lookupDecl, step.first))
         continue;
-  
+
+      // If lookupDecl is the ObjC "id" type, return it directly; we can
+      // end up here if we find the `typedef objc_object *id` declaration,
+      // in which case we always want to use the built-in `id` type;
+      // we don't care about multiple matching declarations in this case...
+      // we just want to use the built-in `id` type.
+      if (auto typedefDecl = dyn_cast<clang::TypedefDecl>(lookupDecl)) {
+        if (typedefDecl->getUnderlyingType()->isObjCIdType())
+          return typedefDecl;
+      }
+
       // Bail out if we find multiple matching declarations.
       // TODO: make an effort to filter by the target module?
       if (resultDecl && !isSameDecl(resultDecl, lookupDecl))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1212,7 +1212,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableNewOperatorLookup = Args.hasFlag(OPT_enable_new_operator_lookup,
                                               OPT_disable_new_operator_lookup,
                                               /*default*/ false);
-  Opts.UseClangFunctionTypes |= Args.hasArg(OPT_use_clang_function_types);
+
+  // Clang function types should be enabled by default, but can be
+  // disabled if need be with -no-use-clang-function-types
+  Opts.UseClangFunctionTypes
+    = Args.hasFlag(options::OPT_use_clang_function_types,
+                   options::OPT_no_use_clang_function_types,
+                   /*default*/ true);
 
   if (Args.hasArg(OPT_emit_fine_grained_dependency_sourcefile_dot_files))
     Opts.EmitFineGrainedDependencySourcefileDotFiles = true;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -5352,9 +5352,15 @@ SILFunctionType::isABICompatibleWith(CanSILFunctionType other,
     auto param1 = getParameters()[i];
     auto param2 = other->getParameters()[i];
 
-    if (param1.getConvention() != param2.getConvention())
+    // Special case for C++: it's OK to pass things to an @in_guaranteed
+    // function where @in_cxx would be OK, since the callee behaves in
+    // a compatible manner.
+    if (param1.getConvention() != param2.getConvention()
+        && (param1.getConvention() != ParameterConvention::Indirect_In_CXX
+            || (param2.getConvention()
+                != ParameterConvention::Indirect_In_Guaranteed)))
       return {ABICompatibilityCheckResult::DifferingParameterConvention, i};
-    // Note that the diretionality here is reversed from the other cases
+    // Note that the directionality here is reversed from the other cases
     // because of contravariance: parameters of the *second* type will be
     // trivially converted to be parameters of the *first* type.
     if (!areABICompatibleParamsOrReturns(

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4054,6 +4054,13 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
 
   if (auto func = dyn_cast<clang::FunctionDecl>(clangDecl)) {
     auto clangType = func->getType().getTypePtr();
+
+    if (clangType) {
+      // Pass the Clang type through, so we can extract information from it
+      // later on.
+      extInfoBuilder = extInfoBuilder.withClangFunctionType(clangType);
+    }
+
     AbstractionPattern origPattern =
         foreignInfo.self.isImportAsMember()
             ? AbstractionPattern::getCFunctionAsMethod(origType, clangType,

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -5173,8 +5173,14 @@ TypeConverter::checkFunctionForABIDifferences(SILModule &M,
 
   for (unsigned i = 0, e = fnTy1->getParameters().size(); i < e; ++i) {
     auto param1 = fnTy1->getParameters()[i], param2 = fnTy2->getParameters()[i];
-    
-    if (param1.getConvention() != param2.getConvention())
+
+    // Special case for C++: it's OK to pass things to an @in_guaranteed
+    // function where @in_cxx would be OK, since the callee behaves in
+    // a compatible manner.
+    if (param1.getConvention() != param2.getConvention()
+        && (param1.getConvention() != ParameterConvention::Indirect_In_CXX
+            || (param2.getConvention()
+                != ParameterConvention::Indirect_In_Guaranteed)))
       return ABIDifference::NeedsThunk;
 
     // Parameters are contravariant and our relation is not symmetric, so

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2476,7 +2476,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   auto rep2 = einfo2.getRepresentation();
   bool clangTypeMismatch =
       (options.contains(ConstraintSystemFlags::UseClangFunctionTypes) &&
-       (einfo1.getClangTypeInfo() != einfo2.getClangTypeInfo()));
+       !einfo1.getClangTypeInfo().isEquivalentType(einfo2.getClangTypeInfo()));
   switch (kind) {
   case ConstraintKind::Bind:
   case ConstraintKind::BindParam:

--- a/test/ClangImporter/blocks_returning_bool.swift
+++ b/test/ClangImporter/blocks_returning_bool.swift
@@ -11,7 +11,7 @@ import BlocksReturningBool
 
 // rdar://43656704
 
-// CHECK-LABEL: sil {{.*}} @$sSo9Aggregatea13takePredicateABySbSicSgXCSg_tcfC
+// CHECK-LABEL: sil {{.*}} @$sSo9Aggregatea13takePredicateABySbSicSgXzC28_ZTSPFvU13block_pointerFbmEESg_tcfC
 // CHECK-SAME: Optional<@convention(c) (Optional<@convention(block) (Int) -> Bool>) -> ()>
 func foo() -> Aggregate {
   return Aggregate(takePredicate: nil)

--- a/test/ClangImporter/clang-function-types.swift
+++ b/test/ClangImporter/clang-function-types.swift
@@ -7,7 +7,7 @@ import ctypes
 // CHECK: f1: (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?
 public let f1 = getFunctionPointer_()
 
-// CHECK: f2: (@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?)?
+// CHECK: f2: (@convention(c, cType: "size_t (*(*)(size_t (*)(size_t)))(size_t)") ((@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?)?
 public let f2 = getHigherOrderFunctionPointer()
 
 // CHECK: f3: () -> (@convention(c) (Swift.UnsafeMutablePointer<ctypes.Dummy>?) -> Swift.UnsafeMutablePointer<ctypes.Dummy>?)?

--- a/test/IRGen/Inputs/calling_conventions.h
+++ b/test/IRGen/Inputs/calling_conventions.h
@@ -1,0 +1,16 @@
+#ifndef CALLING_CONVENTIONS_H_
+#define CALLING_CONVENTIONS_H_
+
+int cdecl_fn(int a, int b, int c);
+
+typedef int (*cdecl_fn_ptr_t)(int a, int b, int c);
+
+extern cdecl_fn_ptr_t cdecl_fn_ptr;
+
+int __attribute__((swiftcall)) swiftcc_fn(int a, int b, int c);
+
+typedef int (__attribute__((swiftcall)) *swiftcc_fn_ptr_t)(int a, int b, int c);
+
+extern swiftcc_fn_ptr_t swiftcc_fn_ptr;
+
+#endif /* CALLING_CONVENTIONS_H_ */

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -43,3 +43,11 @@ module CFBridgedType {
 module RawLayoutCXX {
   header "raw_layout_cxx.h"
 }
+
+module Win32CallingConventions {
+  header "win32_calling_conventions.h"
+}
+
+module CallingConventions {
+  header "calling_conventions.h"
+}

--- a/test/IRGen/Inputs/win32_calling_conventions.h
+++ b/test/IRGen/Inputs/win32_calling_conventions.h
@@ -1,0 +1,22 @@
+#ifndef STDCALL_FUNCTION_H_
+#define STDCALL_FUNCTION_H_
+
+int __stdcall stdcall_fn(int a, int b, int c);
+
+typedef int (__stdcall *stdcall_fn_ptr_t)(int a, int b, int c);
+
+extern stdcall_fn_ptr_t stdcall_fn_ptr;
+
+int __fastcall fastcall_fn(int a, int b, int c);
+
+typedef int (__fastcall *fastcall_fn_ptr_t)(int a, int b, int c);
+
+extern fastcall_fn_ptr_t fastcall_fn_ptr;
+
+int __vectorcall vectorcall_fn(int a, int b, int c);
+
+typedef int (__vectorcall *vectorcall_fn_ptr_t)(int a, int b, int c);
+
+extern vectorcall_fn_ptr_t vectorcall_fn_ptr;
+
+#endif /* STDCALL_FUNCTION_H_ */

--- a/test/IRGen/calling_conventions.swift
+++ b/test/IRGen/calling_conventions.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -module-name calling_conventions -use-clang-function-types -parse-as-library -I %S/Inputs -emit-ir %s | %FileCheck %s
+
+import CallingConventions
+
+func foo() {
+  // CHECK: call i32 @cdecl_fn(i32 1, i32 2, i32 3)
+  _ = cdecl_fn(1, 2, 3)
+
+  // CHECK: call i32 %{{[0-9]+}}(i32 4, i32 5, i32 6)
+  _ = cdecl_fn_ptr(4, 5, 6)
+
+  // CHECK: call swiftcc i32 @swiftcc_fn(i32 1, i32 2, i32 3)
+  _ = swiftcc_fn(1, 2, 3)
+
+  // CHECK: call swiftcc i32 %{{[0-9]+}}(i32 4, i32 5, i32 6)
+  _ = swiftcc_fn_ptr(4, 5, 6)
+}

--- a/test/IRGen/unexploded-calls.swift
+++ b/test/IRGen/unexploded-calls.swift
@@ -28,6 +28,6 @@ public func g(_ s : S) {
 // CHECK:   [[ALLOCA]].g._value = getelementptr inbounds{{.*}} %TSf, ptr [[ALLOCA]].g, i32 0, i32 0
 // CHECK:   store float %1, ptr [[ALLOCA]].g._value, align 4
 // CHECK:   %[[LOAD:.*]] = load %struct.S, ptr [[ALLOCA]], align 4
-// CHECK:   call void @f(%struct.S %[[LOAD]])
+// CHECK:   call {{.*}}void @f(%struct.S %[[LOAD]])
 // CHECK: }
 

--- a/test/IRGen/win32_calling_conventions.swift
+++ b/test/IRGen/win32_calling_conventions.swift
@@ -1,0 +1,25 @@
+// RUN: %swift-frontend-plain -target i686-unknown-windows-msvc -module-name win32_calling_conventions -use-clang-function-types -parse-as-library -I %S/Inputs -emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+import Win32CallingConventions
+
+func foo() {
+  // CHECK: call x86_stdcallcc i32 @cdecl_fn(i32 1, i32 2, i32 3)
+  stdcall_fn(1, 2, 3)
+
+  // CHECK: call x86_stdcallcc i32 %{{[0-9]+}}(i32 4, i32 5, i32 6)
+  stdcall_fn_ptr(4, 5, 6)
+
+  // CHECK: call x86_fastcallcc i32 @cdecl_fn(i32 1, i32 2, i32 3)
+  fastcall_fn(1, 2, 3)
+
+  // CHECK: call x86_fastcallcc i32 %{{[0-9]+}}(i32 4, i32 5, i32 6)
+  fastcall_fn_ptr(4, 5, 6)
+
+  // CHECK: call x86_vectorcallcc i32 @cdecl_fn(i32 1, i32 2, i32 3)
+  vectorcall_fn(1, 2, 3)
+
+  // CHECK: call x86_vectorcallcc i32 %{{[0-9]+}}(i32 4, i32 5, i32 6)
+  vectorcall_fn_ptr(4, 5, 6)
+}

--- a/test/Interop/Cxx/class/closure-thunk-irgen.swift
+++ b/test/Interop/Cxx/class/closure-thunk-irgen.swift
@@ -41,10 +41,10 @@ public func testClosureToFuncPtrReturnNonTrivial() {
 // CHECK: %[[V1:.*]] = call noalias ptr @swift_allocObject(ptr getelementptr inbounds (%{{.*}}, ptr @{{.*}}, i32 0, i32 2), i64 24, i64 7)
 // CHECK: %[[V2:.*]] = getelementptr inbounds{{.*}} <{ %{{.*}}, ptr }>, ptr %[[V1]], i32 0, i32 1
 // CHECK: store ptr %[[V0]], ptr %[[V2]], align 8
-// CHECK: %[[V3:.*]] = insertvalue { ptr, ptr } { ptr @"$sSo10NonTrivialVIetCX_ABIegn_TRTA{{(\.ptrauth)?}}", ptr undef }, ptr %[[V1]], 1
+// CHECK: %[[V3:.*]] = insertvalue { ptr, ptr } { ptr @"$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TRTA{{(\.ptrauth)?}}", ptr undef }, ptr %[[V1]], 1
 // CHECK: ret { ptr, ptr } %[[V3]]
 
-// CHECK: define linkonce_odr hidden swiftcc void @"$sSo10NonTrivialVIetCX_ABIegn_TR"(ptr noalias dereferenceable(8) %[[V0:.*]], ptr %[[V1:.*]])
+// CHECK: define linkonce_odr hidden swiftcc void @"$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TR"(ptr noalias dereferenceable(8) %[[V0:.*]], ptr %[[V1:.*]])
 // CHECK: %[[V2:.*]] = alloca %{{.*}}, align 8
 // CHECK: call void @llvm.lifetime.start.p0(i64 8, ptr %[[V2]])
 // CHECK: call {{(void|ptr)}} @_ZN10NonTrivialC{{1|2}}ERKS_(ptr %[[V2]], ptr %[[V0]])
@@ -56,10 +56,10 @@ public func testClosureToFuncPtrReturnNonTrivial() {
 // CHECK-NEXT: call void @llvm.lifetime.end.p0(i64 8, ptr %[[V2]])
 // CHECK-NEXT: ret void
 
-// CHECK: define internal swiftcc void @"$sSo10NonTrivialVIetCX_ABIegn_TRTA"(ptr noalias dereferenceable(8) %[[V0]], ptr swiftself %[[V1]])
+// CHECK: define internal swiftcc void @"$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TRTA"(ptr noalias dereferenceable(8) %[[V0]], ptr swiftself %[[V1]])
 // CHECK: %[[V2]] = getelementptr inbounds{{.*}} <{ %{{.*}}, ptr }>, ptr %[[V1]], i32 0, i32 1
 // CHECK-NEXT: %[[V3]] = load ptr, ptr %[[V2]], align 8
-// CHECK-NEXT: tail call swiftcc void @"$sSo10NonTrivialVIetCX_ABIegn_TR"(ptr noalias dereferenceable(8) %[[V0]], ptr %[[V3]])
+// CHECK-NEXT: tail call swiftcc void @"$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TR"(ptr noalias dereferenceable(8) %[[V0]], ptr %[[V3]])
 // CHECK-NEXT: ret void
 
 public func returnFuncPtr() -> (NonTrivial) -> () {

--- a/test/Interop/Cxx/class/closure-thunk-macosx-sil.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx-sil.swift
@@ -10,7 +10,7 @@ import Closure
 // CHECK: %[[V2:.*]] = alloc_stack $@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> ()
 // CHECK: %[[V3:.*]] = project_block_storage %[[V2]] : $*@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> ()
 // CHECK: store %[[V1]] to %[[V3]] : $*@callee_guaranteed (@in_guaranteed ARCWeak) -> ()
-// CHECK: %[[V7:.*]] = function_ref @$sSo7ARCWeakVIegn_ABIeyBi_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), @in ARCWeak) -> ()
+// CHECK: %[[V7:.*]] = function_ref @$sSo7ARCWeakVIegn_ABIeyzB31_ZTSU13block_pointerFv7ARCWeakEi_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), @in ARCWeak) -> ()
 // CHECK: %[[V6:.*]] = init_block_storage_header %[[V2]] : $*@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), invoke %[[V7]] : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), @in ARCWeak) -> (), type $@convention(block) (@in ARCWeak) -> ()
 // CHECK: %[[V8:.*]] = copy_block %[[V6]] : $@convention(block) (@in ARCWeak) -> ()
 // CHECK: dealloc_stack %[[V2]] : $*@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> ()
@@ -20,7 +20,7 @@ import Closure
 // CHECK: %[[V12:.*]] = tuple ()
 // CHECK: return %[[V12]] : $()
 
-// CHECK: sil shared [transparent] [reabstraction_thunk] @$sSo7ARCWeakVIegn_ABIeyBi_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), @in ARCWeak) -> () {
+// CHECK: sil shared [transparent] [reabstraction_thunk] @$sSo7ARCWeakVIegn_ABIeyzB31_ZTSU13block_pointerFv7ARCWeakEi_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), @in ARCWeak) -> () {
 // CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> (), %[[V1:.*]] : $*ARCWeak):
 // CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (@in_guaranteed ARCWeak) -> ()
 // CHECK: %[[V3:.*]] = load %[[V2]] : $*@callee_guaranteed (@in_guaranteed ARCWeak) -> ()

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -36,7 +36,7 @@ public func testClosureToBlockReturnNonTrivial() {
   cfuncReturnNonTrivial({() -> NonTrivial in return NonTrivial() })
 }
 
-// CHECK-LABEL: sil private [thunk] [ossa] @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_To : $@convention(c) (@in_cxx NonTrivial) -> () {
 // CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
 // CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
 // CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial
@@ -50,7 +50,7 @@ public func testConstRefNonTrivial() {
   cfuncConstRefNonTrivial({S in });
 }
 
-// CHECK-LABEL: sil private [thunk] [ossa] @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_To : $@convention(c) (@in_cxx NonTrivial) -> () {
 // CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
 // CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
 // CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial

--- a/test/Interop/Cxx/class/closure-thunk-opaque-values.swift
+++ b/test/Interop/Cxx/class/closure-thunk-opaque-values.swift
@@ -4,7 +4,7 @@
 
 import Closure
 
-// CHECK: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo7ARCWeakVIetCi_ABIegn_TR : $@convention(thin) (@in_guaranteed ARCWeak, @convention(c) (@in ARCWeak) -> ()) -> () {
+// CHECK: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo7ARCWeakVIetzC18_ZTSPDoFv7ARCWeakEi_ABIegn_TR : $@convention(thin) (@in_guaranteed ARCWeak, @convention(c) (@in ARCWeak) -> ()) -> () {
 // CHECK: bb0(%[[V0:.*]] : @guaranteed $ARCWeak, %[[V1:.*]] : $@convention(c) (@in ARCWeak) -> ()):
 // CHECK: %[[V2:.*]] = copy_value %[[V0]] : $ARCWeak
 // CHECK: apply %[[V1]](%[[V2]]) : $@convention(c) (@in ARCWeak) -> ()

--- a/test/Interop/Cxx/class/closure-thunk.swift
+++ b/test/Interop/Cxx/class/closure-thunk.swift
@@ -54,11 +54,11 @@ public func testClosureToFuncPtr() {
 // CHECK: sil @$s4main13returnFuncPtrySo10NonTrivialVcyF : $@convention(thin) () -> @owned @callee_guaranteed (@in_guaranteed NonTrivial) -> () {
 // CHECK: %[[V0:.*]] = function_ref @$sSo8getFnPtrySo10NonTrivialVXCyFTo : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
 // CHECK: %[[V1:.*]] = apply %[[V0]]() : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
-// CHECK: %[[V2:.*]] = function_ref @$sSo10NonTrivialVIetCX_ABIegn_TR : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> ()
+// CHECK: %[[V2:.*]] = function_ref @$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TR : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> ()
 // CHECK: %[[V3:.*]] = partial_apply [callee_guaranteed] %[[V2]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> ()
 // CHECK: return %[[V3]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
 
-// CHECK: sil shared [transparent] [reabstraction_thunk] @$sSo10NonTrivialVIetCX_ABIegn_TR : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> () {
+// CHECK: sil shared [transparent] [reabstraction_thunk] @$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TR : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> () {
 // CHECK: bb0(%[[V0:.*]] : $*NonTrivial, %[[V1:.*]] : $@convention(c) (@in_cxx NonTrivial) -> ()):
 // CHECK: %[[V2:.*]] = alloc_stack $NonTrivial
 // CHECK: copy_addr %[[V0]] to [init] %[[V2]] : $*NonTrivial

--- a/test/Interop/Cxx/class/closure-thunk.swift
+++ b/test/Interop/Cxx/class/closure-thunk.swift
@@ -52,7 +52,7 @@ public func testClosureToFuncPtr() {
 }
 
 // CHECK: sil @$s4main13returnFuncPtrySo10NonTrivialVcyF : $@convention(thin) () -> @owned @callee_guaranteed (@in_guaranteed NonTrivial) -> () {
-// CHECK: %[[V0:.*]] = function_ref @$sSo8getFnPtrySo10NonTrivialVXCyFTo : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
+// CHECK: %[[V0:.*]] = function_ref @$sSo8getFnPtrySo10NonTrivialVXzC22_ZTSPDoFv10NonTrivialEyFTo : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
 // CHECK: %[[V1:.*]] = apply %[[V0]]() : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
 // CHECK: %[[V2:.*]] = function_ref @$sSo10NonTrivialVIetzC22_ZTSPDoFv10NonTrivialEX_ABIegn_TR : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> ()
 // CHECK: %[[V3:.*]] = partial_apply [callee_guaranteed] %[[V2]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial, @convention(c) (@in_cxx NonTrivial) -> ()) -> ()

--- a/test/Interop/Cxx/class/function-call-macosx.swift
+++ b/test/Interop/Cxx/class/function-call-macosx.swift
@@ -18,7 +18,7 @@ public func testARCWeak() {
 }
 
 // CHECK: sil [ossa] @$s4main26testARCWeakFunctionPointeryyF : $@convention(thin) () -> () {
-// CHECK: %[[V0:.*]] = function_ref @$sSo9getFnPtr2ySo7ARCWeakVXCyFTo : $@convention(c) () -> @convention(c) (@in ARCWeak) -> ()
+// CHECK: %[[V0:.*]] = function_ref @$sSo9getFnPtr2ySo7ARCWeakVXzC18_ZTSPDoFv7ARCWeakEyFTo : $@convention(c) () -> @convention(c) (@in ARCWeak) -> ()
 // CHECK: %[[V1:.*]] = apply %[[V0]]() : $@convention(c) () -> @convention(c) (@in ARCWeak) -> ()
 // CHECK: %[[MV1:.*]] = move_value [var_decl] %[[V1]] : $@convention(c) (@in ARCWeak) -> ()
 // CHECK: %[[V3:.*]] = alloc_stack $ARCWeak

--- a/test/Interop/Cxx/class/function-call.swift
+++ b/test/Interop/Cxx/class/function-call.swift
@@ -44,7 +44,7 @@ public func testDestroyAddr() {
 }
 
 // CHECK: sil @$s4main29testNonTrivialFunctionPointeryyF : $@convention(thin) () -> () {
-// CHECK: %[[V0:.*]] = function_ref @$sSo8getFnPtrySo10NonTrivialVXCyFTo : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
+// CHECK: %[[V0:.*]] = function_ref @$sSo8getFnPtrySo10NonTrivialVXzC22_ZTSPDoFv10NonTrivialEyFTo : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
 // CHECK: %[[V1:.*]] = apply %[[V0]]() : $@convention(c) () -> @convention(c) (@in_cxx NonTrivial) -> ()
 // CHECK: %[[V3:.*]] = alloc_stack $NonTrivial
 // CHECK: %[[V7:.*]] = function_ref @$sSo10NonTrivialVABycfCTo : $@convention(c) () -> @out NonTrivial

--- a/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
+++ b/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
@@ -58,3 +58,9 @@ public struct OpaquePointer {
     self._rawValue = v
   }
 }
+
+@frozen
+public enum Optional<Wrapped> {
+  case none
+  case some(Wrapped)
+}

--- a/test/Interpreter/cdecl_implementation_run.swift
+++ b/test/Interpreter/cdecl_implementation_run.swift
@@ -33,7 +33,7 @@ extern int simple(int x, int y);
 
 extern void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b);
 
-extern void sameName();
+extern void sameName(void);
 
 __attribute__((swift_name("renamed_swiftSide(_:)")))
 extern void renamed_clangSide(ptrdiff_t arg);

--- a/test/SILGen/default_arguments_imported.swift
+++ b/test/SILGen/default_arguments_imported.swift
@@ -8,7 +8,7 @@ import gizmo
 
 // CHECK-LABEL: sil hidden [ossa] @$s26default_arguments_imported9testGizmo{{[_0-9a-zA-Z]*}}F
 func testGizmo(gizmo: Gizmo) {
-  // CHECK: enum $Optional<@callee_guaranteed (@guaranteed Optional<Gizmo>) -> ()>, #Optional.none!enumelt
+  // CHECK: enum $Optional<@convention(block) (Optional<Gizmo>) -> ()>, #Optional.none!enumelt
   // CHECK: objc_method [[SELF:%[0-9]+]] : $Gizmo, #Gizmo.enumerateSubGizmos!foreign
   gizmo.enumerateSubGizmos()
 } // CHECK: } // end sil function '$s26default_arguments_imported9testGizmo5gizmoySo0E0C_tF'

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -99,6 +99,13 @@ func cFuncPtrConversion(_ x: @escaping @convention(c) (A) -> ()) -> @convention(
   return x
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s24function_conversion_objc19cFuncPtrConversion2yAA1ACyXCAA1BCyXCF
+func cFuncPtrConversion2(_ x: @escaping @convention(c) () -> B) -> @convention(c) () -> A {
+// CHECK:         convert_function %0 : $@convention(c) () -> @autoreleased B to $@convention(c) () -> @autoreleased A
+// CHECK:         return
+  return x
+}
+
 func cFuncPtr(_ a: A) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s24function_conversion_objc19cFuncDeclConversionyAA1BCXCyF
@@ -107,9 +114,4 @@ func cFuncDeclConversion() -> @convention(c) (B) -> () {
 // CHECK:         convert_function %0 : $@convention(c) (A) -> () to $@convention(c) (B) -> ()
 // CHECK:         return
   return cFuncPtr
-}
-
-func cFuncPtrConversionUnsupported(_ x: @escaping @convention(c) (@convention(block) () -> ()) -> ())
-    -> @convention(c) (@convention(c) () -> ()) -> () {
-  return x  // expected-error{{C function pointer signature '@convention(c) (@convention(block) () -> ()) -> ()' is not compatible with expected type '@convention(c) (@convention(c) () -> ()) -> ()'}}
 }

--- a/test/SILGen/function_conversion_objc2.swift
+++ b/test/SILGen/function_conversion_objc2.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name function_conversion_objc -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -enable-objc-interop -verify
+
+// We can't put these in function_conversion_objc.swift, because the error that's
+// picked up below happens before we get to SILGen, so we then don't output the
+// SIL.  Hence this has been moved to its own separate file.
+
+import Foundation
+
+func cFuncPtrConversionUnsupported(_ x: @escaping @convention(c) (@convention(block) () -> ()) -> ())
+    -> @convention(c) (@convention(c) () -> ()) -> () {
+  return x  // expected-error{{cannot convert return expression of type '@convention(c) (@convention(block) () -> ()) -> ()' to return type '@convention(c) (@convention(c) () -> ()) -> ()'}}
+}
+
+class A : NSObject {}
+class B : A {}
+
+// Can't convert a function taking a B to a function taking an A, because it
+// expects a B, not an A.
+func cFuncPtrConversionWrong(_ x: @escaping @convention(c) (B) -> ()) -> @convention(c) (A) -> () {
+  return x  // expected-error{{cannot convert return expression of type '@convention(c) (B) -> ()' to return type '@convention(c) (A) -> ()'}}
+}
+
+// Can't convert a function returning an A to a function returning a B, because
+// not all 'A's are 'B's
+func cFuncPtrConversionWrong2(_ x: @escaping @convention(c) () -> A) -> @convention(c) () -> B {
+  return x  // expected-error{{cannot convert return expression of type '@convention(c) () -> A' to return type '@convention(c) () -> B'}}
+}


### PR DESCRIPTION
On 32-bit Windows, a number of different calling conventions are in use, but Swift ignores them when generating call instructions in IRGen, and generates calls that always use the default calling convention, `cdecl`.  This results in stack corruption, because `stdcall` uses the `ret <nn>` instruction, which adds its argument to the stack pointer on return.

rdar://163178024
