### PR TITLE
SIL Verifier: don't run read-only access scope verification in lowered SIL

### DIFF
--- a/test/SIL/verifier-fail-access-scope.sil
+++ b/test/SIL/verifier-fail-access-scope.sil
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-sil-opt %s -o /dev/null
+
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil [ossa] @write_in_read_only_scope : $@convention(thin) (@inout Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = begin_access [read] [static] %0
+  store %1 to [trivial] %0
+  end_access %2
+  %5 = tuple()
+  return %5
+}

--- a/test/SIL/verifier-no-fail-access-scope1.sil
+++ b/test/SIL/verifier-no-fail-access-scope1.sil
@@ -1,0 +1,19 @@
+// RUN: %target-sil-opt %s -o /dev/null
+
+// REQUIRES: asserts
+
+sil_stage raw
+
+// Need to complete mandatory passes until we can verify that there are no stores in read-only access scopes.
+
+import Builtin
+import Swift
+
+sil [ossa] @write_in_read_only_scope : $@convention(thin) (@inout Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = begin_access [read] [static] %0
+  store %1 to [trivial] %0
+  end_access %2
+  %5 = tuple()
+  return %5
+}

--- a/test/SIL/verifier-no-fail-access-scope2.sil
+++ b/test/SIL/verifier-no-fail-access-scope2.sil
@@ -1,0 +1,19 @@
+// RUN: %target-sil-opt %s -o /dev/null
+
+// REQUIRES: asserts
+
+sil_stage lowered
+
+// LoadableByAddress in lowered SIL can insert copy_addrs inside read-only access scope.
+
+import Builtin
+import Swift
+
+sil [ossa] @write_in_read_only_scope : $@convention(thin) (@inout Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = begin_access [read] [static] %0
+  store %1 to [trivial] %0
+  end_access %2
+  %5 = tuple()
+  return %5
+}


### PR DESCRIPTION
LoadableByAddress in lowered SIL can insert `copy_addr`s inside read-only access scope.

rdar://163248403
