### PR TITLE
[RemoteMirrors] Add hook for resolving indirect addresses

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -192,6 +192,20 @@ public:
     return ReadObjResult<T>(reinterpret_cast<const T *>(ptr), deleter);
   }
 
+  /// Resolves an indirect address at the given relative offset.
+  ///
+  /// \param address The base address which contains the relative offset.
+  /// \param offset The offset read.
+  /// \param directnessEncodedInOffset Whether the relative offset encodes the
+  /// directness as the last bit. Note that this is not the offset passed in as
+  /// a parameter, but whether the offset read at address would have the last
+  /// bit set.
+  virtual RemoteAddress
+  resolveIndirectAddressAtOffset(RemoteAddress address, uint64_t offset,
+                                 bool directnessEncodedInOffset) {
+    return address + offset;
+  }
+
   /// Attempts to read 'size' bytes from the given address in the remote process.
   ///
   /// Returns a pointer to the requested data and a function that must be called to


### PR DESCRIPTION
Adds a hook so implementations of memory reader can add logic to resolving remote addresses. This is needed because of an interaction between LLDB, which tries to read memory from files instead of process memory whenever possible and the DYLD shared cache.

The shared cache will merge pointers in the GOT sections from multiple images into one location, and update the relative offsets to point to the new location.
LLDB, will have initially read the offset pointing to the "old" location, which will be zeroed out in live memory. This gives LLDB the opportunity to re-read the relative offset, but from live memory, so it can return the right pointer in the shared cache.

rdar://160837587

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
