### PR TITLE
Fix spurious "infinite conformance substitution" error with parameter packs

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1089,6 +1089,13 @@ swift::substOpaqueTypesWithUnderlyingTypes(CanType ty,
 
 ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
     ProtocolConformanceRef ref, TypeExpansionContext context) {
+  if (ref.isInvalid())
+    return ref;
+
+  if (!context.shouldLookThroughOpaqueTypeArchetypes() ||
+      !ref.getType()->hasOpaqueArchetype())
+    return ref;
+
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(
       context.getContext(), context.getResilienceExpansion(),
       context.isWholeModuleContext());

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1093,7 +1093,8 @@ ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
       context.getContext(), context.getResilienceExpansion(),
       context.isWholeModuleContext());
   InFlightSubstitution IFS(replacer, replacer,
-                           SubstFlags::SubstituteOpaqueArchetypes);
+                           SubstFlags::SubstituteOpaqueArchetypes |
+                           SubstFlags::PreservePackExpansionLevel);
 
   auto substRef = ref.subst(IFS);
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3761,8 +3761,8 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
 
   // Look through any opaque types we're allowed to.
   if (srcType->hasOpaqueArchetype()) {
-    std::tie(srcType, conformance) =
-      IGF.IGM.substOpaqueTypesWithUnderlyingTypes(srcType, conformance);
+    srcType = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(srcType);
+    conformance = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(conformance);
   }
   
   // If we don't have concrete conformance information, the type must be

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -583,8 +583,7 @@ std::pair<llvm::Constant *, unsigned>
 IRGenModule::getLoweredTypeRef(SILType loweredType,
                                CanGenericSignature genericSig,
                                MangledTypeRefRole role) {
-  auto substTy =
-    substOpaqueTypesWithUnderlyingTypes(loweredType, genericSig);
+  auto substTy = substOpaqueTypesWithUnderlyingTypes(loweredType);
   auto type = substTy.getASTType();
   return getTypeRefImpl(*this, type, genericSig, role);
 }
@@ -600,8 +599,8 @@ IRGenModule::emitWitnessTableRefString(CanType type,
                                       ProtocolConformanceRef conformance,
                                       GenericSignature origGenericSig,
                                       bool shouldSetLowBit) {
-  std::tie(type, conformance)
-    = substOpaqueTypesWithUnderlyingTypes(type, conformance);
+  type = substOpaqueTypesWithUnderlyingTypes(type);
+  conformance = substOpaqueTypesWithUnderlyingTypes(conformance);
   
   auto origType = type;
   auto genericSig = origGenericSig.getCanonicalSignature();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1162,10 +1162,9 @@ public:
   CanType getRuntimeReifiedType(CanType type);
   Type substOpaqueTypesWithUnderlyingTypes(Type type);
   CanType substOpaqueTypesWithUnderlyingTypes(CanType type);
-  SILType substOpaqueTypesWithUnderlyingTypes(SILType type, CanGenericSignature genericSig);
-  std::pair<CanType, ProtocolConformanceRef>
-  substOpaqueTypesWithUnderlyingTypes(CanType type,
-                                      ProtocolConformanceRef conformance);
+  SILType substOpaqueTypesWithUnderlyingTypes(SILType type);
+  ProtocolConformanceRef
+  substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef conformance);
 
   bool isResilient(NominalTypeDecl *decl, ResilienceExpansion expansion,
                    ClassDecl *asViewedFromRootClass = nullptr);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -494,12 +494,8 @@ CanType IRGenModule::getRuntimeReifiedType(CanType type) {
 Type IRGenModule::substOpaqueTypesWithUnderlyingTypes(Type type) {
   // Substitute away opaque types whose underlying types we're allowed to
   // assume are constant.
-  if (type->hasOpaqueArchetype()) {
-    auto context = getMaximalTypeExpansionContext();
-    return swift::substOpaqueTypesWithUnderlyingTypes(type, context);
-  }
-
-  return type;
+  auto context = getMaximalTypeExpansionContext();
+  return swift::substOpaqueTypesWithUnderlyingTypes(type, context);
 }
 
 CanType IRGenModule::substOpaqueTypesWithUnderlyingTypes(CanType type) {
@@ -507,33 +503,20 @@ CanType IRGenModule::substOpaqueTypesWithUnderlyingTypes(CanType type) {
       ->getCanonicalType();
 }
 
-SILType IRGenModule::substOpaqueTypesWithUnderlyingTypes(
-    SILType type, CanGenericSignature genericSig) {
+SILType IRGenModule::substOpaqueTypesWithUnderlyingTypes(SILType type) {
   // Substitute away opaque types whose underlying types we're allowed to
   // assume are constant.
-  if (type.getASTType()->hasOpaqueArchetype()) {
-    auto context = getMaximalTypeExpansionContext();
-    return SILType::getPrimitiveType(
-      swift::substOpaqueTypesWithUnderlyingTypes(type.getASTType(), context),
-      type.getCategory());
-  }
-
-  return type;
+  auto context = getMaximalTypeExpansionContext();
+  return SILType::getPrimitiveType(
+    swift::substOpaqueTypesWithUnderlyingTypes(type.getASTType(), context),
+    type.getCategory());
 }
 
-std::pair<CanType, ProtocolConformanceRef>
-IRGenModule::substOpaqueTypesWithUnderlyingTypes(CanType type,
-                                           ProtocolConformanceRef conformance) {
-  // Substitute away opaque types whose underlying types we're allowed to
-  // assume are constant.
-  if (type->hasOpaqueArchetype()) {
-    auto context = getMaximalTypeExpansionContext();
-    return std::make_pair(
-       swift::substOpaqueTypesWithUnderlyingTypes(type, context),
-       swift::substOpaqueTypesWithUnderlyingTypes(conformance, context));
-  }
-
-  return std::make_pair(type, conformance);
+ProtocolConformanceRef
+IRGenModule::substOpaqueTypesWithUnderlyingTypes(
+    ProtocolConformanceRef conformance) {
+  auto context = getMaximalTypeExpansionContext();
+  return swift::substOpaqueTypesWithUnderlyingTypes(conformance, context);
 }
 
 

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -68,7 +68,7 @@ void OutliningMetadataCollector::collectTypeMetadata(SILType ty) {
   }
 
   // Substitute opaque types if allowed.
-  ty = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(ty, CanGenericSignature());
+  ty = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(ty);
 
   collectTypeMetadataForLayout(ty);
   collectTypeMetadataForDeinit(ty);

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -273,9 +273,10 @@ public:
     // Substitute the underlying conformance of opaque type archetypes if we
     // should look through opaque archetypes.
     if (typeExpansionContext.shouldLookThroughOpaqueTypeArchetypes()) {
-      auto substType = IFS.withNewOptions(std::nullopt, [&] {
-        return selfType.subst(IFS)->getCanonicalType();
-      });
+      auto substType = IFS.withNewOptions(
+        SubstFlags::PreservePackExpansionLevel, [&] {
+          return selfType.subst(IFS)->getCanonicalType();
+        });
       if (substType->hasOpaqueArchetype()) {
         substConformance = substOpaqueTypesWithUnderlyingTypes(
             substConformance, typeExpansionContext);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1047,7 +1047,8 @@ findMissingGenericRequirementForSolutionFix(
 
       return env->mapTypeIntoContext(gp);
     },
-    LookUpConformanceInModule());
+    LookUpConformanceInModule(),
+    SubstFlags::PreservePackExpansionLevel);
   };
 
   type = getTypeInConformanceContext(type);

--- a/test/Generics/rdar160804717.swift
+++ b/test/Generics/rdar160804717.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple
+// REQUIRES: objc_interop
+
+// This used to trigger an infinite loop in conformance substitution
+// when emitting the opaque type descriptor in IRGen.
+
+// rdar://160804717
+
+import SwiftUI
+
+public struct CategorySplitView<each Destination: View>: View {
+    let titleKey: LocalizedStringKey
+    let groups: (repeat each Destination)
+
+    public var body: some View {
+        TupleView((repeat CategoryGroupSidebar(group: each groups))).navigationTitle(titleKey)
+    }
+}
+
+public struct CategoryGroupSidebar<Destination>: View {
+    let group: Destination
+
+    public var body: some View {
+        Text("Hi")
+    }
+}
+


### PR DESCRIPTION
The actual bug fix is just the first commit. The rest are cleanups.

Fixes rdar://160804717.