### PR TITLE
[cxx-interop] Check template argument safety in ClangDeclExplicitSafety

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8709,9 +8709,14 @@ ExplicitSafety ClangTypeExplicitSafety::evaluate(
   if (auto recordDecl = clangType->getAsTagDecl()) {
     // If we reached this point the types is not imported as a shared reference,
     // so we don't need to check the bases whether they are shared references.
-    return evaluateOrDefault(evaluator,
-                             ClangDeclExplicitSafety({recordDecl, false}),
-                             ExplicitSafety::Unspecified);
+    auto req = ClangDeclExplicitSafety({recordDecl, false});
+    if (evaluator.hasActiveRequest(req))
+      // Cycles are allowed in templates, e.g.:
+      //   template <typename>   class Foo { ... }; // throws away template arg
+      //   template <typename T> class Bar : Foo<Bar<T>> { ... };
+      // We need to avoid them here.
+      return ExplicitSafety::Unspecified;
+    return evaluateOrDefault(evaluator, req, ExplicitSafety::Unspecified);
   }
 
   // Everything else is safe.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2300,40 +2300,6 @@ namespace {
         }
       }
 
-      if (const auto *ctsd =
-              dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
-        for (auto arg : ctsd->getTemplateArgs().asArray()) {
-          auto done = false;
-          auto checkUnsafe = [&](clang::TemplateArgument tyArg) {
-            if (tyArg.getKind() != clang::TemplateArgument::Type)
-              return;
-
-            auto safety =
-                evaluateOrDefault(Impl.SwiftContext.evaluator,
-                                  ClangTypeExplicitSafety({tyArg.getAsType()}),
-                                  ExplicitSafety::Unspecified);
-
-            if (safety == ExplicitSafety::Unsafe) {
-              result->addAttribute(new (Impl.SwiftContext)
-                                       UnsafeAttr(/*implicit=*/true));
-              done = true;
-            }
-          };
-
-          if (arg.getKind() == clang::TemplateArgument::Pack) {
-            for (auto pkArg : arg.getPackAsArray()) {
-              checkUnsafe(pkArg);
-              if (done)
-                break;
-            }
-          } else {
-            checkUnsafe(arg);
-          }
-          if (done)
-            break;
-        }
-      }
-
       bool isNonEscapable = false;
       if (evaluateOrDefault(
               Impl.SwiftContext.evaluator,

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -94,6 +94,16 @@ using TTakePtr = TTake<int *>;
 using TTakeSafeTuple = TTake<SafeTuple>;
 using TTakeUnsafeTuple = TTake<UnsafeTuple>;
 
+// An escapability or explicit safety annotation means a type is considered safe
+// even if it would otherwise be considered unsafe.
+template <typename> struct SWIFT_ESCAPABLE TEscape {};
+template <typename> struct __attribute__((swift_attr("safe"))) TSafe { void *ptr; };
+
+using TEscapePtr = TEscape<int *>;
+using TEscapeUnsafeTuple = TEscape<UnsafeTuple>;
+using TSafePtr = TSafe<int *>;
+using TSafeTuple = TSafe<UnsafeTuple>;
+
 struct HoldsShared {
   SharedObject* obj;
 
@@ -212,3 +222,8 @@ func useTTakeUnsafeTuple(x: TTakeUnsafeTuple) {
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
 }
+
+func useTEscapePtr(x: TEscapePtr) { _ = x }
+func useTEscapeUnsafeTuple(x: TEscapeUnsafeTuple) { _ = x }
+func useTSafePtr(x: TSafePtr) { _ = x }
+func useTSafeTuple(x: TSafeTuple) { _ = x }


### PR DESCRIPTION
Checking this upon import was overlooking annotations that explicitly mark a type as safe (or unsafe). Instead, we consolidate this logic in the ClangDeclExplicitSafety request.

rdar://163196609