### PR TITLE
Adopt new language features for `withTaskCancellationHandler`

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -103,12 +103,12 @@ func withTaskCancellationHandler<T>(
   nonisolated(nonsending) func withTaskCancellationHandlerNonisolatedNonsending<T, Failure: Error>(
     operation: () async throws(Failure) -> T,
     onCancel handler: @Sendable () -> Void,
-  ) async throws(Failure) -> sending T
+  ) async throws(Failure) -> T
 )
 public nonisolated(nonsending) func withTaskCancellationHandler<T, Failure: Error>(
   operation: () async throws(Failure) -> T,
   onCancel handler: @Sendable () -> Void,
-) async throws(Failure) -> sending T {
+) async throws(Failure) -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
   let record = unsafe _taskAddCancellationHandler(handler: handler)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -99,15 +99,14 @@ func withTaskCancellationHandler<T>(
 @inlinable
 @_alwaysEmitIntoClient
 @available(SwiftStdlib 5.1, *)
-// @abi(
-//   nonisolated(nonsending) func withTaskCancellationHandlerNonisolatedNonsending<T, Failure: Error>(
-//     operation: () async throws(Failure) -> sending T,
-//     onCancel handler: @Sendable () -> Void,
-//   ) async throws(Failure) -> sending T
-// )
-@_silgen_name("$s4test28withTaskCancellationHandlerN9operation8onCancelxxyYaq_YKYTXE_yyYbXEtYaq_YKs5ErrorR_r0_lF")
+@abi(
+  nonisolated(nonsending) func withTaskCancellationHandlerNonisolatedNonsending<T, Failure: Error>(
+    operation: () async throws(Failure) -> T,
+    onCancel handler: @Sendable () -> Void,
+  ) async throws(Failure) -> sending T
+)
 public nonisolated(nonsending) func withTaskCancellationHandler<T, Failure: Error>(
-  operation: () async throws(Failure) -> sending T,
+  operation: () async throws(Failure) -> T,
   onCancel handler: @Sendable () -> Void,
 ) async throws(Failure) -> sending T {
   // unconditionally add the cancellation record to the task.

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -89,8 +89,8 @@ Func withCheckedThrowingContinuation(function:_:) has parameter 0 type change fr
 Func withCheckedThrowingContinuation(function:_:) has parameter 1 type change from (_Concurrency.CheckedContinuation<τ_0_0, any Swift.Error>) -> () to Swift.String
 
 // #isolation adoption for cancellation handlers; old APIs are kept ABI compatible
-Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func withTaskCancellationHandler(operation:onCancel:isolation:)
-Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing from '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A' to '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> (), isolation: isolated Swift.Optional<Swift.Actor>) async throws -> A'
+Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func _unsafeInheritExecutor_withTaskCancellationHandler(operation:onCancel:)
+Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing from '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A' to '_Concurrency._unsafeInheritExecutor_withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A'
 
 // #isolated was adopted and the old methods kept: $ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF
 Func withCheckedContinuation(function:_:) has been renamed to Func withCheckedContinuation(isolation:function:_:)


### PR DESCRIPTION
This makes three changes to the `withTaskCancellationHandler` API.

- adopt typed throws
- return a `sending` result from the operation body
- migrate to `nonisolated(nonsending)`

This also includes an attempt at doing this in both an ABI and source-compatible way. However, I have concerns about both of these areas, so right now this is just a draft.