### PR TITLE
[test] Remove pre-rebranch `nocapture` matches

### DIFF
--- a/test/AutoDiff/IRGen/differentiable_function.sil
+++ b/test/AutoDiff/IRGen/differentiable_function.sil
@@ -33,7 +33,7 @@ bb0:
   return %result : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
 }
 
-// CHECK-LABEL: define{{.*}}test_form_diff_func(ptr noalias{{( nocapture)?}} sret(<{ %swift.function, %swift.function, %swift.function }>)
+// CHECK-LABEL: define{{.*}}test_form_diff_func(ptr noalias sret(<{ %swift.function, %swift.function, %swift.function }>) captures(none)
 // CHECK-SAME: [[OUT:%.*]])
 // CHECK:   [[OUT_ORIG:%.*]] = getelementptr{{.*}}[[OUT]], i32 0, i32 0
 // CHECK:   [[OUT_ORIG_FN:%.*]] = getelementptr{{.*}}[[OUT_ORIG]], i32 0, i32 0
@@ -60,7 +60,7 @@ bb0(%0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float):
   return %result : $(@callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
 }
 
-// CHECK-LABEL: define{{.*}}@test_extract_components(ptr noalias{{( nocapture)?}} sret(<{ %swift.function, %swift.function, %swift.function }>)
+// CHECK-LABEL: define{{.*}}@test_extract_components(ptr noalias sret(<{ %swift.function, %swift.function, %swift.function }>) captures(none)
 // CHECK-SAME: [[OUT:%.*]], ptr{{.*}}[[IN:%.*]])
 // CHECK:   [[ORIG:%.*]] = getelementptr{{.*}}[[IN]], i32 0, i32 0
 // CHECK:   [[ORIG_FN_ADDR:%.*]] = getelementptr{{.*}}[[ORIG]], i32 0, i32 0

--- a/test/DebugInfo/ErrorVar.swift
+++ b/test/DebugInfo/ErrorVar.swift
@@ -14,7 +14,7 @@ func simple(_ placeholder: Int64) throws -> () {
   // CHECK: define {{.*}}void @"$s8ErrorVar6simpleyys5Int64VKF"(
   // CHECK-SAME: i64
   // CHECK-SAME: %swift.refcounted* {{.*}}swiftself
-  // CHECK-SAME: %swift.error** noalias {{(nocapture|captures\(none\))}} dereferenceable(4)
+  // CHECK-SAME: %swift.error** noalias captures(none) dereferenceable(4)
   // CHECK: #dbg_declare
   // CHECK: #dbg_declare({{.*}}, ![[ERROR:[0-9]+]], !DIExpression(DW_OP_deref)
   // CHECK-DAG: ![[ERRTY:.*]] = !DICompositeType({{.*}}identifier: "$ss5Error_pD"

--- a/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
@@ -94,7 +94,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* {{(nocapture|captures\(none\))}} %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* captures(none) %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Read the current offset and cast an element to `Int`
 
@@ -119,7 +119,7 @@ public distributed actor MyOtherActor {
 // CHECK: missing-witness1:
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(%swift.opaque* noalias{{( nocapture)?}} sret(%swift.opaque){{( captures\(none\))?}} [[ARG_0_RES_SLOT]], %swift.type* %arg_type, i8** [[ENCODABLE_WITNESS]], i8** [[DECODABLE_WITNESS]], %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself [[DECODER]], %swift.error** noalias {{(nocapture|captures\(none\))}} dereferenceable(4) %swifterror)
+// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(%swift.opaque* noalias sret(%swift.opaque) captures(none) [[ARG_0_RES_SLOT]], %swift.type* %arg_type, i8** [[ENCODABLE_WITNESS]], i8** [[DECODABLE_WITNESS]], %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself [[DECODER]], %swift.error** noalias captures(none) dereferenceable(4) %swifterror)
 
 // CHECK: store %swift.error* null, %swift.error** %swifterror
 // CHECK-NEXT: [[ARG_0_VAL_ADDR:%.*]] = bitcast i8* [[ARG_0_VALUE_BUF]] to %TSi*
@@ -196,7 +196,7 @@ public distributed actor MyOtherActor {
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTE"
 
 /// !!! in `simple3` interesting bits are: argument value extraction (because string is exploded into N arguments) and call to distributed thunk
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* {{(nocapture|captures\(none\))}} [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* captures(none) [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 
 // CHECK: [[TYPED_RESULT_BUFF:%.*]] = bitcast i8* [[RESULT_BUFF]] to %TSi*
@@ -260,7 +260,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* {{(nocapture|captures\(none\))}} [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* captures(none) [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Let's check that the call doesn't have any arguments and returns nothing.
 
@@ -307,7 +307,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* {{(nocapture|captures\(none\))}} [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* captures(none) [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// First, let's check that all of the different argument types here are loaded correctly.
 
@@ -366,7 +366,7 @@ public distributed actor MyOtherActor {
 
 /// ---> Accessor for `genericArgs`
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  {{(nocapture|captures\(none\))}} [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  captures(none) [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// ---> Load `T`
 
@@ -422,7 +422,7 @@ public distributed actor MyOtherActor {
 
 /// Let's check that there is argument decoding since parameter list is empty
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* {{(nocapture|captures\(none\))}} [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* captures(none) [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], %swift.type* [[ACTOR_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: {{.*}} = alloca %swift.context*
 // CHECK-NEXT: %swifterror = alloca %swift.error*

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -116,7 +116,7 @@ public distributed actor MyOtherActor {
 // CHECK: missing-witness1:
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(ptr noalias sret(%swift.opaque) [[ARG_0_VALUE_BUF]], ptr %arg_type, ptr [[ENCODABLE_WITNESS]], ptr [[DECODABLE_WITNESS]], ptr swiftself [[DECODER]], ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(ptr noalias sret(%swift.opaque) [[ARG_0_VALUE_BUF]], ptr %arg_type, ptr [[ENCODABLE_WITNESS]], ptr [[DECODABLE_WITNESS]], ptr swiftself [[DECODER]], ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 
 // CHECK: store ptr null, ptr %swifterror
 // CHECK-NEXT: %._value = getelementptr inbounds{{.*}} %TSi, ptr [[ARG_0_VALUE_BUF]], i32 0, i32 0

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -302,7 +302,7 @@ func testRet3() -> MyRect2 {
 }
 
 // Returning tuple?: (Int x 6)?
-// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax2{{.*}}"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, i32 %1, i32 %2)
+// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax2{{.*}}"(ptr noalias sret({{.*}}) captures(none) %0, i32 %1, i32 %2)
 // V7K-LABEL: _$s8test_v7k7minMax2
 // We will indirectly return an optional with the address in r0, input parameters will be in r1 and r2
 // V7K: str r0, [sp, [[IDX:#[0-9]+]]]
@@ -329,7 +329,7 @@ func minMax2(x : Int, y : Int) -> (min: Int, max: Int, min2: Int, max2: Int, min
 }
 
 // Returning struct?: {Int x 6}?
-// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax3{{.*}}"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, i32 %1, i32 %2)
+// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax3{{.*}}"(ptr noalias sret({{.*}}) captures(none) %0, i32 %1, i32 %2)
 // V7K-LABEL: _$s8test_v7k7minMax3
 struct Ret {
   var min:Int

--- a/test/IRGen/abitypes_objc.swift
+++ b/test/IRGen/abitypes_objc.swift
@@ -27,20 +27,20 @@ class Foo {
   // x86_64-macosx: define internal { <2 x float>, <2 x float> } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
   // x86_64-ios: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
   // x86_64-ios: define internal { <2 x float>, <2 x float> } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
-  // i386-ios: define hidden swiftcc void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr swiftself %1) {{.*}} {
-  // i386-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // i386-ios: define hidden swiftcc void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) captures(none) %0, ptr swiftself %1) {{.*}} {
+  // i386-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   // armv7-ios: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
-  // armv7-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // armv7-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   // armv7s-ios: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
-  // armv7s-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // armv7s-ios: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   // arm64-ios: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
   // arm64-ios: define internal [[ARM64_MYRECT]] @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
   // x86_64-tvos: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
   // x86_64-tvos: define internal { <2 x float>, <2 x float> } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
   // arm64-tvos: define hidden swiftcc { float, float, float, float }  @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
   // arm64-tvos: define internal [[ARM64_MYRECT]] @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
-  // i386-watchos: define hidden swiftcc void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr swiftself %1) {{.*}} {
-  // i386-watchos: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // i386-watchos: define hidden swiftcc void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) captures(none) %0, ptr swiftself %1) {{.*}} {
+  // i386-watchos: define internal void @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   // armv7k-watchos: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
   // armv7k-watchos: define internal [[ARMV7K_MYRECT]] @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(ptr %0, ptr %1) {{[#0-9]*}} {
   // armv64_32-watchos: define hidden swiftcc { float, float, float, float } @"$s8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
@@ -157,7 +157,7 @@ class Foo {
   // armv7-ios: define hidden swiftcc float @"$s8abitypes3FooC4barc{{[_0-9a-zA-Z]*}}F"(ptr %0, ptr swiftself %1) {{.*}} {
   // armv7-ios: [[RESULT:%.*]] = alloca [[RECTTYPE:%.*MyRect.*]], align 4
   // armv7-ios: load ptr, ptr @"\01L_selector(newRect)", align 4
-  // armv7-ios: call void @objc_msgSend_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %call.aggresult
+  // armv7-ios: call void @objc_msgSend_stret(ptr noalias sret({{.*}}) captures(none) %call.aggresult
   // armv7-ios: [[GEP1:%.*]] = getelementptr inbounds [[RECTTYPE]], ptr [[RESULT]], i32 0, i32 1
   // armv7-ios: [[GEP2:%.*]] = getelementptr inbounds {{.*}}, ptr [[GEP1]], i32 0, i32 0
   // armv7-ios: [[RETVAL:%.*]] = load float, ptr [[GEP2]], align 4
@@ -167,7 +167,7 @@ class Foo {
   // armv7s-ios: define hidden swiftcc float @"$s8abitypes3FooC4barc{{[_0-9a-zA-Z]*}}F"(ptr %0, ptr swiftself %1) {{.*}} {
   // armv7s-ios: [[RESULT:%.*]] = alloca [[RECTTYPE:%.*MyRect.*]], align 4
   // armv7s-ios: load ptr, ptr @"\01L_selector(newRect)", align 4
-  // armv7s-ios: call void @objc_msgSend_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %call.aggresult
+  // armv7s-ios: call void @objc_msgSend_stret(ptr noalias sret({{.*}}) captures(none) %call.aggresult
   // armv7s-ios: [[GEP1:%.*]] = getelementptr inbounds [[RECTTYPE]], ptr [[RESULT]], i32 0, i32 1
   // armv7s-ios: [[GEP2:%.*]] = getelementptr inbounds {{.*}}, ptr [[GEP1]], i32 0, i32 0
   // armv7s-ios: [[RETVAL:%.*]] = load float, ptr [[GEP2]], align 4
@@ -185,7 +185,7 @@ class Foo {
   }
 
   // x86_64-macosx: define hidden swiftcc { double, double, double } @"$s8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}F"(ptr swiftself %0) {{.*}} {
-  // x86_64-macosx: define internal void @"$s8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // x86_64-macosx: define internal void @"$s8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   @objc dynamic func baz() -> Trio {
     return Trio(i: 1.0, j: 2.0, k: 3.0)
   }
@@ -480,17 +480,17 @@ class Foo {
     return g.invert(b)
   }
 
-  // x86_64-macosx: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2) {{.*}} {
+  // x86_64-macosx: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2) {{.*}} {
   // x86_64-macosx: [[SEL:%[0-9]+]] = load ptr, ptr @"\01L_selector(negateThrowing:error:)", align 8
   // x86_64-macosx: call signext i8 @objc_msgSend(ptr {{%[0-9]+}}, ptr [[SEL]], i8 signext {{%[0-9]+}}, ptr {{%[0-9]+}})
   // x86_64-macosx: }
 
-  // x86_64-ios: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2) {{.*}} {
+  // x86_64-ios: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2) {{.*}} {
   // x86_64-ios: [[SEL:%[0-9]+]] = load ptr, ptr @"\01L_selector(negateThrowing:error:)", align 8
   // x86_64-ios: call zeroext i1 @objc_msgSend(ptr {{%[0-9]+}}, ptr [[SEL]], i1 zeroext {{%[0-9]+}}, ptr {{%[0-9]+}})
   // x86_64-ios: }
 
-  // i386-ios: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(4) %2) {{.*}} {
+  // i386-ios: define hidden swiftcc void @"$s8abitypes3FooC10throwsTestyySbKF"(i1 %0, ptr swiftself %1, ptr noalias captures(none) dereferenceable(4) %2) {{.*}} {
   // i386-ios: [[SEL:%[0-9]+]] = load ptr, ptr @"\01L_selector(negateThrowing:error:)", align 4
   // i386-ios: call signext i8 @objc_msgSend(ptr {{%[0-9]+}}, ptr [[SEL]], i8 signext {{%[0-9]+}}, ptr {{%[0-9]+}})
   // i386-ios: }
@@ -547,18 +547,18 @@ class Foo {
   }
 
   // arm64-ios: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, ptr swiftself %5) {{.*}} {
-  // arm64-ios: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
+  // arm64-ios: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
   //
   // arm64e-ios: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, ptr swiftself %5) {{.*}} {
-  // arm64e-ios: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr %3, ptr %4) {{.*}} {
+  // arm64e-ios: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr %3, ptr %4) {{.*}} {
   //
   // arm64-tvos: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, ptr swiftself %5) {{.*}} {
-  // arm64-tvos: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
+  // arm64-tvos: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
   // arm64-macosx: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, ptr swiftself %5) {{.*}} {
-  // arm64-macosx: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr %3, ptr %4) {{.*}} {
+  // arm64-macosx: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr %3, ptr %4) {{.*}} {
   //
   // arm64-watchos: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, ptr swiftself %5) {{.*}} {
-  // arm64-watchos: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
+  // arm64-watchos: define internal void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr %3, ptr %4) {{[#0-9]*}} {
   @objc dynamic func callJustReturn(_ r: StructReturns, with v: BigStruct) -> BigStruct {
     return r.justReturn(v)
   }

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -95,13 +95,13 @@ sil @testPairedBox : $(@guaranteed { var () }) -> () {
 bb0(%0 : ${ var () }):
   // CHECK: entry:
   %2 = project_box %0 : ${ var () }, 0
-  //  CHECK-NEXT: call {{.*}}void @writeEmptyTuple(ptr {{(nocapture|captures\(none\))}} undef)
+  //  CHECK-NEXT: call {{.*}}void @writeEmptyTuple(ptr captures(none) undef)
   %3 = begin_access [modify] [dynamic] %2 : $*()
   %write_fn = function_ref @writeEmptyTuple : $@convention(thin) (@inout ()) -> ()
   apply %write_fn(%3) : $@convention(thin) (@inout ()) -> ()
   end_access %3 : $*()
 
-  // CHECK-NEXT: call {{.*}}void @readEmptyTuple(ptr noalias {{(nocapture|captures\(none\))}} undef)
+  // CHECK-NEXT: call {{.*}}void @readEmptyTuple(ptr noalias captures(none) undef)
   %5 = begin_access [read] [dynamic] %2 : $*()
   %read_fn = function_ref @readEmptyTuple : $@convention(thin) (@in_guaranteed ()) -> ()
   apply %read_fn(%5) : $@convention(thin) (@in_guaranteed ()) -> ()

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -26,7 +26,7 @@ public func calls_number() async -> Int {
 
 // CHECK-LABEL: define {{.*}}swifttailcc void @"$s25async_dynamic_replacement32indirectReturnDynamicReplaceableSi_S6ityYaKF"(ptr {{.*}}%0, ptr swiftasync %1)
 // CHECK: forward_to_replaced:
-// CHECK: musttail call swifttailcc void {{.*}}(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync {{.*}})
+// CHECK: musttail call swifttailcc void {{.*}}(ptr noalias captures(none) %0, ptr swiftasync {{.*}})
 public dynamic func indirectReturnDynamicReplaceable() async throws -> (Int, Int, Int, Int, Int, Int, Int) {
     return (0, 0, 0, 0, 0, 0, 0)
 }

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -38,7 +38,7 @@ public struct BigBigStruct {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBitfieldInBlock
-// CHECK:         call void {{%.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
+// CHECK:         call void {{%.*}}(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne
@@ -46,7 +46,7 @@ entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testTupleExtract
-// CHECK:         call void {{%.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
+// CHECK:         call void {{%.*}}(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
 sil @testTupleExtract : $@convention(thin) (@owned (BitfieldOne, @convention(block) (BitfieldOne) -> BitfieldOne), BitfieldOne) -> BitfieldOne  {
 entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x : $BitfieldOne):
   %a = tuple_extract %b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), 1
@@ -54,9 +54,9 @@ entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x
   return %r : $BitfieldOne
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBigTempStruct(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %Element)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBigTempStruct(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %Element)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases13BigTempStructV
-// CHECK: call swiftcc void @testBigTempStruct(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]], ptr %1, ptr %Element)
+// CHECK: call swiftcc void @testBigTempStruct(ptr noalias sret({{.*}}) captures(none) [[ALLOC]], ptr %1, ptr %Element)
 // CHECK: ret void
 sil @testBigTempStruct : $@convention(method) <Element> (@guaranteed _ArrayBuffer<Element>) -> @owned BigTempStruct<Element> {
 bb0(%0 : $_ArrayBuffer<Element>):
@@ -66,9 +66,9 @@ bb0(%0 : $_ArrayBuffer<Element>):
   return %9 : $BigTempStruct<Element>
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testTryApply(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr swiftself %3, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %4)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testTryApply(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr swiftself %3, ptr noalias swifterror captures(none) dereferenceable(8) %4)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
-// CHECK: call swiftcc void {{.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]]
+// CHECK: call swiftcc void {{.*}}(ptr noalias sret({{.*}}) captures(none) [[ALLOC]]
 // CHECK: ret void
 sil @testTryApply : $@convention(thin)(() -> (@owned BigStruct, @error Error)) -> (@owned BigStruct, @error Error) {
 bb0(%0 : $() -> (@owned BigStruct, @error Error)):
@@ -82,8 +82,8 @@ bb2(%err : $Error):
   throw %err : $Error
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}})
-// CHECK: call swiftcc void {{.*}}(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply(ptr captures(none) dereferenceable({{.*}}) %0, ptr noalias captures(none) dereferenceable({{.*}})
+// CHECK: call swiftcc void {{.*}}(ptr noalias captures(none) dereferenceable({{.*}}) %1
 // CHECK: ret void
 sil @testFuncWithModBlockStorageApply : $@convention(thin) (@inout_aliasable @block_storage @callee_owned (@owned BigStruct) -> (), BigStruct) -> () {
 // %0                                             // user: %5
@@ -109,7 +109,7 @@ sil public_external @c_return_func : $@convention(thin) () -> () -> @owned BigSt
 // CHECK: [[RET:%.*]] = insertvalue { ptr, ptr } { ptr @"$s17part_apply_calleeTA", ptr undef }, ptr
 // CHECK: ret { ptr, ptr } [[RET]]
 
-// CHECK-LABEL: define internal swiftcc void @"$s17part_apply_calleeTA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, i64 %1, ptr swiftself %2)
+// CHECK-LABEL: define internal swiftcc void @"$s17part_apply_calleeTA"(ptr noalias sret({{.*}}) captures(none) %0, i64 %1, ptr swiftself %2)
 // CHECK: ret void
 
 sil @part_apply_caller : $@convention(thin) () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct {
@@ -174,12 +174,12 @@ sil @get_optional_none : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.T
 sil @short_circuit_operation : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
 sil @autoclosure_partialapply : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @closure(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @closure(ptr noalias sret({{.*}}) captures(none) %0, ptr %1)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK-64: [[ALLOC4:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
-// CHECK-64: call swiftcc void @"$s22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_AFyKXKfu_TA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC1]], ptr swiftself {{.*}}, ptr{{( nocapture)?}} swifterror{{( captures\(none\))?}} %swifterror)
+// CHECK-64: call swiftcc void @"$s22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_AFyKXKfu_TA"(ptr noalias sret({{.*}}) captures(none) [[ALLOC1]], ptr swiftself {{.*}}, ptr swifterror captures(none) %swifterror)
 // CHECK: ret void
 sil @closure : $@convention(thin) (@owned SuperSub) -> BigStruct {
 bb0(%0 : $SuperSub):
@@ -218,7 +218,7 @@ sil @returnBigStruct : $@convention(thin) () -> @owned BigStruct
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @closureToConvert()
 // CHECK: entry:
 // CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
-// CHECK:   call swiftcc void @returnBigStruct(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]])
+// CHECK:   call swiftcc void @returnBigStruct(ptr noalias sret({{.*}}) captures(none) [[ALLOC]])
 // CHECK:   ret void
 // CHECK-LABEL: }
 sil @closureToConvert : $@convention(thin) () -> () {
@@ -246,11 +246,11 @@ bb0:
 
 sil @convertToThickHelper : $@convention(thin) (@owned BigStruct) -> ()
 
-// CHECK-LABAL: define {{.*}} swiftcc void @convertToThick(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABAL: define {{.*}} swiftcc void @convertToThick(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK: entry:
 // CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV, align 4
 // CHECK:   call void @llvm.memcpy.p0.p0.i64
-// CHECK:   call swiftcc void @convertToThickHelper(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[ALLOC]], ptr swiftself null)
+// CHECK:   call swiftcc void @convertToThickHelper(ptr noalias captures(none) dereferenceable({{.*}}) [[ALLOC]], ptr swiftself null)
 // CHECK:   ret void
 // CHECK-LABEL: }
 sil @convertToThick : $@convention(thin) (@in BigStruct) -> () {

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -46,7 +46,7 @@ let bigStructGlobalArray : [BigStruct] = [
   BigStruct()
 ]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr %1, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(ptr captures(none) dereferenceable({{.*}}) %0, ptr %1, ptr captures(none) dereferenceable({{.*}})
 // CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegng_SgWOe
 // CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegng_SgWOy
 // CHECK: ret void
@@ -66,9 +66,9 @@ public func f3_uses_f2() {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10f3_uses_f2yyF"()
-// CHECK: call swiftcc void @"$s22big_types_corner_cases9BigStructVACycfC"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}}
+// CHECK: call swiftcc void @"$s22big_types_corner_cases9BigStructVACycfC"(ptr noalias sret({{.*}}) captures(none)
 // CHECK: call swiftcc { ptr, ptr } @"$s22big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF"()
-// CHECK: call swiftcc void {{.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) {{.*}}, ptr swiftself {{.*}})
+// CHECK: call swiftcc void {{.*}}(ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr noalias captures(none) dereferenceable({{.*}}) {{.*}}, ptr swiftself {{.*}})
 // CHECK: ret void
 
 public func f4_tuple_use_of_f2() {
@@ -81,7 +81,7 @@ public func f4_tuple_use_of_f2() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18f4_tuple_use_of_f2yyF"()
 // CHECK: [[TUPLE:%.*]] = call swiftcc { ptr, ptr } @"$s22big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF"()
 // CHECK: [[TUPLE_EXTRACT:%.*]] = extractvalue { ptr, ptr } [[TUPLE]], 0
-// CHECK:  call swiftcc void [[TUPLE_EXTRACT]](ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) {{.*}}, ptr swiftself %{{.*}})
+// CHECK:  call swiftcc void [[TUPLE_EXTRACT]](ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr noalias captures(none) dereferenceable({{.*}}) {{.*}}, ptr swiftself %{{.*}})
 // CHECK: ret void
 
 public class BigClass {
@@ -95,8 +95,8 @@ public class BigClass {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr swiftself %1)
-// CHECK: call swiftcc void {{.*}}(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr swiftself
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr swiftself %1)
+// CHECK: call swiftcc void {{.*}}(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr swiftself
 // CHECK: ret void
 
 public struct MyStruct {
@@ -134,17 +134,17 @@ public func enumCallee(_ x: LargeEnum) {
     case .Empty2: break
   }
 }
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10enumCalleeyyAA9LargeEnumOF"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) #0 {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10enumCalleeyyAA9LargeEnumOF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) #0 {
 // CHECK-64: alloca %T22big_types_corner_cases9LargeEnumO05InnerF0O
 // CHECK-64: alloca %T22big_types_corner_cases9LargeEnumO
 // CHECK-64: $ss5print_9separator10terminatoryypd_S2StF
 // CHECK-64: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
-// CHECK-64: call swiftcc void @"$s22big_types_corner_cases9SuperBaseC4boomAA9BigStructVyF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC1]], ptr swiftself {{.*}})
+// CHECK-64: call swiftcc void @"$s22big_types_corner_cases9SuperBaseC4boomAA9BigStructVyF"(ptr noalias sret({{.*}}) captures(none) [[ALLOC1]], ptr swiftself {{.*}})
 // CHECK: ret void
 class SuperBase {
   func boom() -> BigStruct {
@@ -164,10 +164,10 @@ class SuperSub : SuperBase {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{.*}}) %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias swiftself captures(none) dereferenceable({{.*}}) %1)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK: [[LOAD:%.*]] = load ptr, ptr %.callInternalLet.data
-// CHECK: call swiftcc void %{{[0-9]+}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]], ptr swiftself [[LOAD]])
+// CHECK: call swiftcc void %{{[0-9]+}}(ptr noalias sret({{.*}}) captures(none) [[ALLOC]], ptr swiftself [[LOAD]])
 // CHECK: ret void
 public struct MUseStruct {
   var x = BigStruct()
@@ -178,8 +178,8 @@ public struct MUseStruct {
   internal let callInternalLet: () -> BigStruct?
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_SstyF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0) #0 {
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_SstyF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0) #0 {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_SstyF"(ptr noalias sret({{.*}}) captures(none) %0) #0 {
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_SstyF"(ptr noalias sret({{.*}}) captures(none) %0) #0 {
 // CHECK: alloca %TSs
 // CHECK: alloca %TSs
 // CHECK: ret void
@@ -296,9 +296,9 @@ public extension QueryHandler {
         body(query)
     }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_25query8ReturnedQyd___AA9BigStructVSgtqd___tAA0E0Rd__lF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias %1, ptr noalias %2, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_25query8ReturnedQyd___AA9BigStructVSgtqd___tAA0E0Rd__lF"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias %1, ptr noalias %2, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %3)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
-// CHECK: call swiftcc void {{.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]], ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
+// CHECK: call swiftcc void {{.*}}(ptr noalias sret({{.*}}) captures(none) [[ALLOC]], ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
 // CHECK: ret void
     func forceHandle_2<Q: Query>(query: Q) -> (Q.Returned, BigStruct?) {
         guard let body = handle_2 as? (Q) -> (Q.Returned, BigStruct?) else {
@@ -321,12 +321,12 @@ public extension QueryHandler {
         return body(query)
     }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %3)
-// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} {{.*}})
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
+// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias swifterror captures(none) {{.*}})
 // CHECK-64: ret { i64, i64 }
 
-// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %3)
-// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias{{( nocapture)?}}{{.*}}{{( captures\(none\))?}} {{.*}})
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3)
+// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias{{.*}} captures(none) {{.*}})
 // CHECK-32: ret { i32, i32 }
     func forceHandle_4<Q: Query>(query: Q) throws -> (Q.Returned, Filter?) {
         guard let body = handle_4 as? (Q) throws -> (Q.Returned, Filter?) else {

--- a/test/IRGen/big_types_corner_cases_tiny.swift
+++ b/test/IRGen/big_types_corner_cases_tiny.swift
@@ -6,6 +6,6 @@
 
 // CHECK-LABEL: define internal void @{{.*}}WZ
 // CHECK: [[ALLOC:%.*]] = alloca %T27big_types_corner_cases_tiny30LoadableStructWithBiggerStringV
-// CHECK: call swiftcc void {{.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[ALLOC]]
+// CHECK: call swiftcc void {{.*}}(ptr noalias sret({{.*}}) captures(none) [[ALLOC]]
 let model = ClassWithLoadableStructWithBiggerString().f()
 

--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -19,7 +19,7 @@ public struct BigStruct {
   var i8 : Int32 = 8
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) #0 {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(ptr noalias captures(none) dereferenceable({{.*}}) #0 {
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret void
 sil @testDestroyValue : $@convention(thin) (@owned BigStruct) -> ()  {

--- a/test/IRGen/builtin_pack_length.swift
+++ b/test/IRGen/builtin_pack_length.swift
@@ -31,7 +31,7 @@ func weirdPackCountUse1<each T>(_ x: repeat each T) -> Builtin.Word {
 }
 
 struct Pack<each T> {
-// CHECK: define {{.*}} @"$s8builtins4PackV5countBwvgZ"(i64 returned [[PACK_COUNT:%.*]], ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %"each T")
+// CHECK: define {{.*}} @"$s8builtins4PackV5countBwvgZ"(i64 returned [[PACK_COUNT:%.*]], ptr readnone captures(none) %"each T")
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i64 [[PACK_COUNT]]
   static var count: Builtin.Word {

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -696,11 +696,11 @@ func zeroInitializerEmpty() {
 // isUnique variants
 // ----------------------------------------------------------------------------
 
-// CHECK: define hidden {{.*}}void @"$s8builtins26acceptsBuiltinNativeObjectyyBoSgzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define hidden {{.*}}void @"$s8builtins26acceptsBuiltinNativeObjectyyBoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 func acceptsBuiltinNativeObject(_ ref: inout Builtin.NativeObject?) {}
 
 // native
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BoSgzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD_RC:.+]] = load ptr, ptr %0
 // CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_native(ptr %[[LD_RC]])
@@ -710,7 +710,7 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 }
 
 // native nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD_RC:.+]] = load ptr, ptr %0
 // CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(ptr %[[LD_RC]])
@@ -719,11 +719,11 @@ func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUnique(&ref)
 }
 
-// CHECK: define hidden {{.*}}void @"$s8builtins16acceptsAnyObjectyyyXlSgzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define hidden {{.*}}void @"$s8builtins16acceptsAnyObjectyyyXlSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 func acceptsAnyObject(_ ref: inout Builtin.AnyObject?) {}
 
 // ObjC
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlSgzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds{{.*}} [[OPTIONAL_ANYOBJECT_TY:%.*]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[REF:%.+]] = load ptr, ptr [[ADDR]]
@@ -736,7 +736,7 @@ func isUnique(_ ref: inout Builtin.AnyObject?) -> Bool {
 
 // ObjC nonNull
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlzF"
-// CHECK-SAME:    (ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-SAME:    (ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds{{.*}} %AnyObject, ptr %0, i32 0, i32 0
 // CHECK:      [[REF:%.+]] = load ptr, ptr [[ADDR]]
@@ -748,7 +748,7 @@ func isUnique(_ ref: inout Builtin.AnyObject) -> Bool {
 }
 
 // BridgeObject nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD:.+]] = load ptr, ptr %0
 // CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(ptr %[[LD]])
@@ -764,7 +764,7 @@ func assumeTrue(_ x: Builtin.Int1) {
   Builtin.assume_Int1(x)
 }
 // BridgeObject nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins15isUnique_nativeyBi1_BbzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins15isUnique_nativeyBi1_BbzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD:.+]] = load ptr, ptr %0
 // CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(ptr %[[LD]])
@@ -774,7 +774,7 @@ func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
 }
 
 // ImplicitlyUnwrappedOptional argument to isUnique.
-// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins11isUniqueIUOyBi1_BoSgzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins11isUniqueIUOyBi1_BoSgzF"(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK: call zeroext i1 @swift_isUniquelyReferenced_native(ptr
 // CHECK: ret i1

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -32,7 +32,7 @@ bb0:
 // CHECK-x86_64:   [[RESULT:%.*]] = alloca %TSo11BitfieldOneV, align 8
 // CHECK-x86_64:   [[ARG:%.*]] = alloca %TSo11BitfieldOneV, align 8
 //   Make the first call and pull all the values out of the indirect result.
-// CHECK-x86_64:   call void @createBitfieldOne(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[RESULT]])
+// CHECK-x86_64:   call void @createBitfieldOne(ptr noalias sret({{.*}}) captures(none) [[RESULT]])
 // CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds{{.*}} %TSo11BitfieldOneV, ptr [[RESULT]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_A_V:%.*]] = getelementptr inbounds{{.*}} %Ts6UInt32V, ptr [[ADDR_A]], i32 0, i32 0
 // CHECK-x86_64:   [[A:%.*]] = load i32, ptr [[ADDR_A_V]], align 8
@@ -102,7 +102,7 @@ sil public_external @consumeSIMDStruct : $@convention(c) (SIMDStruct) -> ()
 
 // CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testSIMDStruct()
 // CHECK-SYSV-x86_64:        call <3 x float> @createSIMDStruct
-// CHECK-WIN-x86_64:         call void @createSIMDStruct(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %
+// CHECK-WIN-x86_64:         call void @createSIMDStruct(ptr noalias sret({{.*}}) captures(none) %
 // CHECK-SYSV-x86_64:        call void @consumeSIMDStruct(<3 x float>
 // CHECK-WIN-x86_64:         call void @consumeSIMDStruct(ptr %
 sil @testSIMDStruct : $() -> () {
@@ -389,8 +389,8 @@ entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
 }
 
 // CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBitfieldInBlock
-// CHECK-SYSV-x86_64:        call void {{%.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
-// CHECK-WIN-x86_64:         call void {{%.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{%.*}}, ptr {{%.*}}, ptr {{%.*}})
+// CHECK-SYSV-x86_64:        call void {{%.*}}(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
+// CHECK-WIN-x86_64:         call void {{%.*}}(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr {{%.*}}, ptr {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -18,7 +18,7 @@ sil_vtable A {}
 sil_vtable B {}
 sil_vtable F {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_addr_cast(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @unchecked_addr_cast(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @unchecked_addr_cast : $(@in A) -> B {
 entry(%a : $*A):
   %b = unchecked_addr_cast %a : $*A to $*B

--- a/test/IRGen/class_field_other_module.swift
+++ b/test/IRGen/class_field_other_module.swift
@@ -7,7 +7,7 @@
 
 import other_class
 
-// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassXys5Int32V0c1_A00F0CF"(ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} %0)
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassXys5Int32V0c1_A00F0CF"(ptr readonly captures(none) %0)
 // CHECK-NEXT: entry:
 // An Int32 after the heap object header
 // CHECK-NEXT: [[GEP:%.*]] = getelementptr inbounds{{.*}} i8, ptr %0, i64 16
@@ -17,7 +17,7 @@ public func getSubclassX(_ o: Subclass) -> Int32 {
   return o.x
 }
 
-// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassYys5Int32V0c1_A00F0CF"(ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} %0)
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassYys5Int32V0c1_A00F0CF"(ptr readonly captures(none) %0)
 // CHECK-NEXT: entry:
 // An Int32 after an Int32 after the heap object header
 // CHECK-NEXT: [[GEP:%.*]] = getelementptr inbounds{{.*}} i8, ptr %0, i64 20

--- a/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
+++ b/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
@@ -12,4 +12,4 @@ extension Foo {
 }
 class Box<T> {}
 extension Box: Foo where T: Foo {}
-// CHECK-LABEL: define internal swiftcc void @"$s1x3BoxCyqd__GAA3FooA2aEP3baryyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{[48]}}) %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define internal swiftcc void @"$s1x3BoxCyqd__GAA3FooA2aEP3baryyFTW"(ptr noalias swiftself captures(none) dereferenceable({{[48]}}) %0, ptr %Self, ptr %SelfWitnessTable)

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -160,7 +160,7 @@ public var irm: Int {
 // CHECK-LABEL:     define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
 // CHECK-SAME:          ptr noalias [[FRAME:%[^,]+]],
 // CHECK-SAME:          ptr swiftcoro [[ALLOCATOR:%[^,]+]],
-// CHECK-SAME:          ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{8|16}}) [[SELF:%[^)]+]]
+// CHECK-SAME:          ptr swiftself captures(none) dereferenceable({{8|16}}) [[SELF:%[^)]+]]
 // CHECK-SAME:      )
 // CHECK-SAME:      {
 // CHECK:               [[ID:%[^,]+]] = call token @llvm.coro.id.retcon.once.dynamic(
@@ -327,7 +327,7 @@ public var force_yield_once_2_convention : () {
 // CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once_2(
 //                  ptr noalias %0
 // CHECK-SAME:      ptr swiftcoro [[ALLOCATOR:%[^,]+]]
-//                  ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(16) %2
+//                  ptr swiftself captures(none) dereferenceable(16) %2
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
@@ -126,7 +126,7 @@ public var i: Int {
 
 // CHECK-LABEL: define{{.*}} void @increment_i_async(
 //                  ptr swiftasync %0
-// CHECK-SAME:      ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{8|4}}) %1
+// CHECK-SAME:      ptr swiftself captures(none) dereferenceable({{8|4}}) %1
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
@@ -101,7 +101,7 @@ public var i: Int {
 
 // CHECK-LABEL: define{{.*}} void @increment_i_async(
 //                  ptr swiftasync %0
-// CHECK-SAME:      ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{8|4}}) %1
+// CHECK-SAME:      ptr swiftself captures(none) dereferenceable({{8|4}}) %1
 // CHECK-SAME:  )
 // CHECK-SAME:  {
 //      :         [[SIZE_32:%[^,]+]] = load i32

--- a/test/IRGen/dependent_reabstraction.swift
+++ b/test/IRGen/dependent_reabstraction.swift
@@ -8,7 +8,7 @@ protocol A {
 }
 
 struct X<Y> : A {
-  // CHECK-LABEL: define internal swiftcc void @"$s23dependent_reabstraction1XVyxGAA1AA2aEP1byy1BQzFTW"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+  // CHECK-LABEL: define internal swiftcc void @"$s23dependent_reabstraction1XVyxGAA1AA2aEP1byy1BQzFTW"(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
   func b(_ b: X.Type) {
     let x: Any = b
     markUsed(b as X.Type)

--- a/test/IRGen/empty_array.sil
+++ b/test/IRGen/empty_array.sil
@@ -15,11 +15,11 @@ sil_stage canonical
 
 import Builtin
 
-// CHECK-32-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias {{(nocapture|captures\(none\))}}) {{.*}} {
+// CHECK-32-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias captures(none)) {{.*}} {
 // CHECK-32:         %1 = bitcast %swift.opaque* %0 to i8*
 // CHECK-32:         %2 = getelementptr inbounds i8, i8* %1, i32 0
 
-// CHECK-64-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias {{(nocapture|captures\(none\))}}) {{.*}} {
+// CHECK-64-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias captures(none)) {{.*}} {
 // CHECK-64:         %1 = bitcast %swift.opaque* %0 to i8*
 // CHECK-64:         %2 = getelementptr inbounds i8, i8* %1, i64 0
 

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -238,7 +238,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
@@ -274,7 +274,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %2) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr captures(none) dereferenceable({{.*}}) %2) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ i64, i64 }>, ptr %2, i32 0, i32 0
 // CHECK:   store i64 %0, ptr [[DATA_0_ADDR]]
@@ -349,7 +349,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4enum10NoPayloadsO, ptr %0, i32 0, i32 0
@@ -398,7 +398,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T4enum10NoPayloadsO, ptr %0, i32 0, i32 0
 // CHECK:   store i8 2, ptr [[TAG_ADDR]]
@@ -629,7 +629,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] %0, ptr %1
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum18SinglePayloadNoXI2O, ptr %1, i32 0, i32 1
@@ -655,7 +655,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] 0, ptr %0
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum18SinglePayloadNoXI2O, ptr %0, i32 0, i32 1
@@ -992,7 +992,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
@@ -1019,7 +1019,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1304,7 +1304,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = load i8, ptr %0
 // CHECK:   ret i8 %1
@@ -1315,7 +1315,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store i8 %1, ptr %0
 // CHECK:   ret void
@@ -1440,7 +1440,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, ptr %0
@@ -1494,7 +1494,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 %0, ptr %1
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum23MultiPayloadNoSpareBitsO, ptr %1, i32 0, i32 1
@@ -1547,7 +1547,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 0, ptr %0
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T4enum23MultiPayloadNoSpareBitsO, ptr %0, i32 0, i32 1
@@ -1736,7 +1736,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -1774,7 +1774,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1824,7 +1824,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1968,7 +1968,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -2002,7 +2002,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[BYTE:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
@@ -2049,7 +2049,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0xC000_0000_0000_0000
 // CHECK-64:   store i64 -4611686018427387904, ptr %0
@@ -2254,7 +2254,7 @@ enum MultiPayloadNestedSpareBits {
   case B(MultiPayloadInnerSpareBits)
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   %1 = load [[WORD]], ptr %0
 // CHECK-64:   %2 = lshr [[WORD]] %1, 61
@@ -2326,7 +2326,7 @@ enum MultiPayloadAddressOnlyFixed {
   case Y(Builtin.Int32)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_destroy : $@convention(thin) (@in MultiPayloadAddressOnlyFixed) -> () {
 entry(%m : $*MultiPayloadAddressOnlyFixed):
   destroy_addr %m : $*MultiPayloadAddressOnlyFixed

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -48,8 +48,8 @@ extension def_enum.TrafficLight : Error {}
 
 extension def_enum.Term : Error {}
 
-// CHECK-NORMAL-LABEL: define hidden {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %T) local_unnamed_addr
-// CHECK-TESTABLE-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %T)
+// CHECK-NORMAL-LABEL: define hidden {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr readnone captures(none) %T) local_unnamed_addr
+// CHECK-TESTABLE-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr readnone captures(none) %T)
 
 enum Phantom<T> : Int64 {
   case Up

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -242,7 +242,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
@@ -278,7 +278,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %2) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, ptr captures(none) dereferenceable({{.*}}) %2) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds{{.*}} <{ i64, i64 }>, ptr %2, i32 0, i32 0
 // CHECK:   store i64 %0, ptr [[DATA_0_ADDR]]
@@ -353,7 +353,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T11enum_future10NoPayloadsO, ptr %0, i32 0, i32 0
@@ -402,7 +402,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} %T11enum_future10NoPayloadsO, ptr %0, i32 0, i32 0
 // CHECK:   store i8 2, ptr [[TAG_ADDR]]
@@ -633,7 +633,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] %0, ptr %1
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future18SinglePayloadNoXI2O, ptr %1, i32 0, i32 1
@@ -659,7 +659,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   store [[WORD]] 0, ptr %0
 // CHECK:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future18SinglePayloadNoXI2O, ptr %0, i32 0, i32 1
@@ -996,7 +996,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
@@ -1023,7 +1023,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1308,7 +1308,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = load i8, ptr %0
 // CHECK:   ret i8 %1
@@ -1319,7 +1319,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store(ptr captures(none) dereferenceable({{.*}}) %0, i8 %1) {{.*}} {
 // CHECK: entry:
 // CHECK:   store i8 %1, ptr %0
 // CHECK:   ret void
@@ -1444,7 +1444,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, ptr %0
@@ -1498,7 +1498,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 %0, ptr %1
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future23MultiPayloadNoSpareBitsO, ptr %1, i32 0, i32 1
@@ -1551,7 +1551,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   store i64 0, ptr %0
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds{{.*}} %T11enum_future23MultiPayloadNoSpareBitsO, ptr %0, i32 0, i32 1
@@ -1740,7 +1740,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -1778,7 +1778,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[VAL:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1828,7 +1828,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, ptr %0
@@ -1972,7 +1972,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -2006,7 +2006,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[VAL:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
@@ -2053,7 +2053,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // --                0xC000_0000_0000_0000
 // CHECK-64:   store i64 -4611686018427387904, ptr %0
@@ -2258,7 +2258,7 @@ enum MultiPayloadNestedSpareBits {
   case B(MultiPayloadInnerSpareBits)
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   %1 = load [[WORD]], ptr %0
 // CHECK-64:   %2 = lshr [[WORD]] %1, 61
@@ -2330,7 +2330,7 @@ enum MultiPayloadAddressOnlyFixed {
   case Y(Builtin.Int32)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_destroy : $@convention(thin) (@in MultiPayloadAddressOnlyFixed) -> () {
 entry(%m : $*MultiPayloadAddressOnlyFixed):
   destroy_addr %m : $*MultiPayloadAddressOnlyFixed

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -260,7 +260,7 @@ public func resilientEnumPartialApply(_ f: (Medium) -> Int) {
 
 }
 
-// CHECK-LABEL: define internal swiftcc void @"$s14resilient_enum6MediumOSiIgnd_ACSiIegnr_TRTA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias %1, ptr swiftself %2)
+// CHECK-LABEL: define internal swiftcc void @"$s14resilient_enum6MediumOSiIgnd_ACSiIegnr_TRTA"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias %1, ptr swiftself %2)
 
 
 // Enums with resilient payloads from a different resilience domain

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -16,15 +16,15 @@ entry:
 }
 
 // CHECK-i386-LABEL:   define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr %1) {{.*}} {
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-wasm32-LABEL:  define swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-wasm32-LABEL:  define swiftcc void @does_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
 sil @does_throw : $@convention(thin) () -> @error Error {
   // CHECK: [[T0:%.*]] = call swiftcc ptr @create_error()
   %0 = function_ref @create_error : $@convention(thin) () -> @owned Error
@@ -40,15 +40,15 @@ sil @does_throw : $@convention(thin) () -> @error Error {
 }
 
 // CHECK-i386-LABEL:   define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr %1) {{.*}} {
-// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-wasm32-LABEL: define swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
+// CHECK-wasm32-LABEL: define swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.}}) %1) {{.*}} {
 sil @doesnt_throw : $@convention(thin) () -> @error Error {
   //   We don't have to do anything here because the caller always
   //   zeroes the error slot before a call.
@@ -77,8 +77,8 @@ entry(%0 : $AnyObject):
   // CHECK-wasm32:      [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]] ptr, align
   // CHECK-NEXT: store ptr null, ptr [[ERRORSLOT]], align
 
-  // CHECK-objc-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} [[SWIFTERROR]]{{( )?}}{{(captures\(none\) )?}}dereferenceable({{.}}) [[ERRORSLOT]])
-  // CHECK-native-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} [[SWIFTERROR]]{{( )?}}{{(captures\(none\) )?}}dereferenceable({{.}}) [[ERRORSLOT]])
+  // CHECK-objc-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias [[SWIFTERROR]]{{( )?}}captures(none) dereferenceable({{.}}) [[ERRORSLOT]])
+  // CHECK-native-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias [[SWIFTERROR]]{{( )?}}captures(none) dereferenceable({{.}}) [[ERRORSLOT]])
   // CHECK-NEXT: [[ERR:%.*]] = load ptr, ptr [[ERRORSLOT]], align
   // CHECK-NEXT: [[T0:%.*]] = icmp ne ptr [[ERR]], null
   // CHECK-NEXT: ptrtoint ptr [[ERR]] to i
@@ -114,7 +114,7 @@ enum ColorError : Error {
 }
 
 // CHECK-LABEL: TestCallToWillThrowCallBack
-// CHECK: call swiftcc void @swift_willThrow(ptr swiftself undef, ptr noalias{{( nocapture)?}} readonly [[SWIFTERROR]]{{( )?}}{{(captures\(none\) )?}}dereferenceable({{.}}) %2)
+// CHECK: call swiftcc void @swift_willThrow(ptr swiftself undef, ptr noalias readonly [[SWIFTERROR]]{{( )?}}captures(none) dereferenceable({{.}}) %2)
 // CHECK: store ptr %0
 // CHECK: ret i64 undef
 sil hidden @TestCallToWillThrowCallBack : $@convention(thin) (@owned Error) -> (Int64, @error Error) {
@@ -128,8 +128,8 @@ bb0(%0 : $Error):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_single(ptr %0)
 // CHECK:       insertvalue { ptr, ptr } { ptr @"$s27partial_apply_single_helperTA{{(\.ptrauth)?}}", ptr undef },
 
-// CHECK: define internal swiftcc void @"$s27partial_apply_single_helperTA"(ptr swiftself %0, ptr noalias{{( nocapture)?}} [[SWIFTERROR]]{{( )?}}{{(captures\(none\) )?}}dereferenceable({{.}}) %1)
-// CHECK:  tail call swiftcc void @partial_apply_single_helper(ptr {{%.*}}, ptr swiftself undef, ptr noalias{{( nocapture)?}} [[SWIFTERROR]]{{( )?}}{{(captures\(none\) )?}}dereferenceable({{.}}){{( )?}}{{%.*}})
+// CHECK: define internal swiftcc void @"$s27partial_apply_single_helperTA"(ptr swiftself %0, ptr noalias [[SWIFTERROR]]{{( )?}}captures(none) dereferenceable({{.}}) %1)
+// CHECK:  tail call swiftcc void @partial_apply_single_helper(ptr {{%.*}}, ptr swiftself undef, ptr noalias [[SWIFTERROR]]{{( )?}}captures(none) dereferenceable({{.}}){{( )?}}{{%.*}})
 // CHECK-NEXT:  ret void
 sil @partial_apply_single : $@convention(thin) (@owned A) -> @callee_owned () -> @error Error {
 entry(%0 : $A):

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -22,7 +22,7 @@ bb0(%0 : $*Any, %1 : $T):
   return %3 : $()
 }
 
-// CHECK-DAG:   define{{( protected)?}} swiftcc void @init_opaque_existential(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %T) {{.*}} {
+// CHECK-DAG:   define{{( protected)?}} swiftcc void @init_opaque_existential(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %T) {{.*}} {
 // CHECK:         [[T0:%.*]] = getelementptr inbounds{{.*}} [[ANY:%Any]], ptr %0, i32 0, i32 1
 // CHECK-NEXT:    store ptr %T, ptr [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds{{.*}} [[ANY]], ptr %0, i32 0, i32 0
@@ -37,7 +37,7 @@ bb0(%0 : $*Any, %1 : $*Any):
   return %3 : $()
 }
 
-// CHECK-DAG:   define{{( protected)?}} swiftcc void @take_opaque_existential(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-DAG:   define{{( protected)?}} swiftcc void @take_opaque_existential(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: call ptr @"$sypWOb"(ptr %1, ptr %0)
 // CHECK-NEXT:    ret void
 

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -101,12 +101,12 @@ func test() {
 
   // assume %struct.c_struct and %TSo8c_structV have compatible layout
   //
-  // CHECK-x86_64: call void     @c_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}} {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
-  // CHECK-x86_64: call void @swift_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}}   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
-  // CHECK-arm64:  call void     @c_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}} {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
-  // CHECK-arm64:  call void @swift_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}}   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
-  // CHECK-wasm32: call void     @c_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}} {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
-  // CHECK-wasm32: call void @swift_roundtrip_c_struct(ptr noalias{{( nocapture)?}} sret(%TSo8c_structV){{( captures\(none\))?}}   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-x86_64: call void     @c_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-x86_64: call void @swift_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-arm64:  call void     @c_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-arm64:  call void @swift_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-wasm32: call void     @c_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-wasm32: call void @swift_roundtrip_c_struct(ptr noalias sret(%TSo8c_structV) captures(none)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
   // CHECK-armv7k: call [3 x i32]     @c_roundtrip_c_struct([3 x i32] {{.*}})
   // CHECK-armv7k: call [3 x i32] @swift_roundtrip_c_struct([3 x i32] {{.*}})
   var c_struct_val = c_struct(foo: 496, bar: 28, baz: 8)

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -8,7 +8,7 @@
 // unnecessary.
 // ONONE-NOT: @__swift_fixLifetime
 
-// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
+// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
 // CHECK-objc: entry:
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
@@ -20,7 +20,7 @@
 // CHECK-objc:  call void @__swift_fixLifetime(ptr [[TEMP]])
 // CHECK-objc:  call void @__swift_fixLifetime(ptr
 
-// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
+// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr noalias captures(none) dereferenceable({{.*}}) %5, {{(i64|i32)}} %6, {{(i64|i32)}} %7) {{.*}} {
 // CHECK-native: entry:
 // CHECK-native:  call void @__swift_fixLifetime(ptr
 // CHECK-native:  call void @__swift_fixLifetime(ptr

--- a/test/IRGen/function_param_convention.sil
+++ b/test/IRGen/function_param_convention.sil
@@ -10,7 +10,7 @@ struct X {
 // Make sure we can irgen a SIL function with various parameter attributes
 // without choking. This is just a basic reality check.
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %2, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %3, i32 %4, i32 %5, i32 %6) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr captures(none) dereferenceable({{.*}}) %2, ptr noalias captures(none) dereferenceable({{.*}}) %3, i32 %4, i32 %5, i32 %6) {{.*}} {
 
 sil @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : $X, %5 : $X, %6 : $X):

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -52,9 +52,9 @@ struct X {}
 
 sil @out_void_return : $@convention(thin) () -> @out X
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @use_void_return_value(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @use_void_return_value(ptr noalias sret({{.*}}) captures(none) %0) {{.*}} {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    call swiftcc void @out_void_return(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0)
+// CHECK-NEXT:    call swiftcc void @out_void_return(ptr noalias sret({{.*}}) captures(none) %0)
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 sil @use_void_return_value : $@convention(thin) () -> @out X {

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -58,7 +58,7 @@ func intToAll<T>(_ x: Int) -> T {
   return x as! T
 }
 
-// CHECK: define hidden swiftcc i64 @"$s13generic_casts8anyToIntySiypF"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define hidden swiftcc i64 @"$s13generic_casts8anyToIntySiypF"(ptr noalias captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 func anyToInt(_ x: Any) -> Int {
   return x as! Int
 }
@@ -104,7 +104,7 @@ func classExistentialToOpaqueArchetype<T>(_ x: ObjCProto1) -> T {
 protocol P {}
 protocol Q {}
 
-// CHECK: define hidden swiftcc void @"$s13generic_casts19compositionToMemberyAA1P_pAaC_AA1QpF{{.*}}"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define hidden swiftcc void @"$s13generic_casts19compositionToMemberyAA1P_pAaC_AA1QpF{{.*}}"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 func compositionToMember(_ a: P & Q) -> P {
   return a
 }

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -58,7 +58,7 @@ func genericMetatypes<T, U>(_ t: T.Type, _ u: U.Type) {}
 
 protocol Bas {}
 
-// CHECK: define hidden swiftcc { ptr, ptr } @"$s17generic_metatypes14protocolTypeof{{.*}}"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK: define hidden swiftcc { ptr, ptr } @"$s17generic_metatypes14protocolTypeof{{.*}}"(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 func protocolTypeof(_ x: Bas) -> Bas.Type {
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds{{.*}} %T17generic_metatypes3BasP, ptr [[X:%.*]], i32 0, i32 1
   // CHECK: [[METADATA:%.*]] = load ptr, ptr [[METADATA_ADDR]]

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -59,7 +59,7 @@ func genericMetatypes<T, U>(_ t: T.Type, _ u: U.Type) {}
 
 protocol Bas {}
 
-// CHECK: define hidden swiftcc { ptr, ptr } @"$s17generic_metatypes14protocolTypeof{{.*}}"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK: define hidden swiftcc { ptr, ptr } @"$s17generic_metatypes14protocolTypeof{{.*}}"(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 func protocolTypeof(_ x: Bas) -> Bas.Type {
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds{{.*}} %T17generic_metatypes3BasP, ptr [[X:%.*]], i32 0, i32 1
   // CHECK: [[METADATA:%.*]] = load ptr, ptr [[METADATA_ADDR]]

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -4,7 +4,7 @@
 
 // <rdar://problem/13793646>
 struct OptionalStreamAdaptor<T : IteratorProtocol> {
-  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{.*}}) %1)
+  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr swiftself captures(none) dereferenceable({{.*}}) %1)
   mutating
   func next() -> Optional<T.Element> {
     return x[0].next()

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -12,7 +12,7 @@ struct SameSizeStride { var x, y: Builtin.Int32 }
 // This type has unequal stride and size.
 struct DifferentSizeStride { var x: Builtin.Int32, y: Builtin.Int16 }
 
-// CHECK: define{{( protected)?}} {{.*}}void @same_size_stride(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
+// CHECK: define{{( protected)?}} {{.*}}void @same_size_stride(ptr noalias captures(none) dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
 // CHECK:   getelementptr inbounds %T8indexing14SameSizeStrideV, ptr %0, i64 %1
 sil @same_size_stride : $@convention(thin) (@in SameSizeStride, Builtin.Word) -> () {
 entry(%p : $*SameSizeStride, %i: $Builtin.Word):
@@ -20,7 +20,7 @@ entry(%p : $*SameSizeStride, %i: $Builtin.Word):
   return undef : $()
 }
 
-// CHECK:      define{{( protected)?}} {{.*}}void @different_size_stride(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
+// CHECK:      define{{( protected)?}} {{.*}}void @different_size_stride(ptr noalias captures(none) dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
 // CHECK:   %2 = mul nsw i64 %1, 8
 // CHECK-NEXT:   %3 = getelementptr inbounds i8, ptr %0, i64 %2
 sil @different_size_stride : $@convention(thin) (@in DifferentSizeStride, Builtin.Word) -> () {
@@ -29,7 +29,7 @@ entry(%p : $*DifferentSizeStride, %i: $Builtin.Word):
   return undef : $()
 }
 
-// CHECK:      define{{( protected)?}} {{.*}}void @zero_size(ptr noalias {{(nocapture|captures\(none\))}} %0, i64 %1) {{.*}} {
+// CHECK:      define{{( protected)?}} {{.*}}void @zero_size(ptr noalias captures(none) %0, i64 %1) {{.*}} {
 // CHECK:   %2 = mul nsw i64 %1, 1
 // CHECK-NEXT:   %3 = getelementptr inbounds i8, ptr %0, i64 %2
 sil @zero_size : $@convention(thin) (@in (), Builtin.Word) -> () {

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -15,9 +15,9 @@ struct HugeAlignment {
 }
 
 // TODO: could be the context param
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_method(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_method(ptr noalias swiftself captures(none) dereferenceable({{.*}}) %0)
 // CHECK-NOT:     alloca
-// CHECK:         call swiftcc void @huge_method(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{.*}}) %0)
+// CHECK:         call swiftcc void @huge_method(ptr noalias swiftself captures(none) dereferenceable({{.*}}) %0)
 sil @huge_method : $@convention(method) (Huge) -> () {
 entry(%x : $Huge):
   %f = function_ref @huge_method : $@convention(method) (Huge) -> ()
@@ -25,9 +25,9 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK-NOT:         alloca
-// CHECK:         call swiftcc void @huge_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK:         call swiftcc void @huge_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 sil @huge_param : $@convention(thin) (Huge) -> () {
 entry(%x : $Huge):
   %f = function_ref @huge_param : $@convention(thin) (Huge) -> ()
@@ -35,9 +35,9 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_alignment_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_alignment_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK-NOT:     alloca
-// CHECK:         call swiftcc void @huge_alignment_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK:         call swiftcc void @huge_alignment_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 sil @huge_alignment_param : $@convention(thin) (HugeAlignment) -> () {
 entry(%x : $HugeAlignment):
   %f = function_ref @huge_alignment_param : $@convention(thin) (HugeAlignment) -> ()
@@ -45,9 +45,9 @@ entry(%x : $HugeAlignment):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_return(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_return(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // CHECK:         [[TMP_RET:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_param_and_return(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[TMP_RET]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// CHECK:         call swiftcc void @huge_param_and_return(ptr noalias sret({{.*}}) captures(none) [[TMP_RET]], ptr noalias captures(none) dereferenceable({{.*}}) %1)
 sil @huge_param_and_return : $@convention(thin) (Huge) -> Huge {
 entry(%x : $Huge):
   %f = function_ref @huge_param_and_return : $@convention(thin) (Huge) -> Huge
@@ -55,9 +55,9 @@ entry(%x : $Huge):
   return %z : $Huge
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_indirect_return(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_indirect_return(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // CHECK-NOT:     alloca
-// CHECK:         call swiftcc void @huge_param_and_indirect_return(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// CHECK:         call swiftcc void @huge_param_and_indirect_return(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 sil @huge_param_and_indirect_return : $@convention(thin) (Huge) -> @out Huge {
 entry(%o : $*Huge, %x : $Huge):
   %f = function_ref @huge_param_and_indirect_return : $@convention(thin) (Huge) -> @out Huge
@@ -65,16 +65,16 @@ entry(%o : $*Huge, %x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // CHECK-NOT:     alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias ptr @swift_allocObject
-// CHECK:         call swiftcc {{.*}} @"$s24huge_partial_applicationTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr swiftself [[CLOSURE]])
-// CHECK:       define internal swiftcc void @"$s24huge_partial_applicationTA"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr swiftself %1)
+// CHECK:         call swiftcc {{.*}} @"$s24huge_partial_applicationTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr swiftself [[CLOSURE]])
+// CHECK:       define internal swiftcc void @"$s24huge_partial_applicationTA"(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr swiftself %1)
 // CHECK-NOT:     alloca
 // CHECK:         [[GEP:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T17indirect_argument4HugeV }>, ptr %1, i32 0, i32 1
 // CHECK-NOT:     alloca
 // CHECK-NOT:     tail
-// CHECK:         call swiftcc void @huge_partial_application(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[GEP]]
+// CHECK:         call swiftcc void @huge_partial_application(ptr noalias captures(none) dereferenceable({{.*}}) %0, ptr noalias captures(none) dereferenceable({{.*}}) [[GEP]]
 // CHECK:         call void @swift_release(ptr %1)
 sil @huge_partial_application : $@convention(thin) (Huge, Huge) -> () {
 entry(%x : $Huge, %y : $Huge):
@@ -84,16 +84,16 @@ entry(%x : $Huge, %y : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application_stret(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr noalias captures(none) dereferenceable({{.*}}) %2)
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias ptr @swift_allocObject
-// CHECK:         call swiftcc {{.*}} @"$s30huge_partial_application_stretTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[TMP_RET]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1, ptr swiftself [[CLOSURE]])
-// CHECK:       define internal swiftcc void @"$s30huge_partial_application_stretTA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1, ptr swiftself %2)
+// CHECK:         call swiftcc {{.*}} @"$s30huge_partial_application_stretTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias sret({{.*}}) captures(none) [[TMP_RET]], ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr swiftself [[CLOSURE]])
+// CHECK:       define internal swiftcc void @"$s30huge_partial_application_stretTA"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr swiftself %2)
 // CHECK-NOT:     alloca
 // CHECK:         [[GEP:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T17indirect_argument4HugeV }>, ptr %2, i32 0, i32 1
 // CHECK-NOT:     alloca
 // CHECK-NOT:     tail
-// CHECK:         call swiftcc void @huge_partial_application_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[GEP]])
+// CHECK:         call swiftcc void @huge_partial_application_stret(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1, ptr noalias captures(none) dereferenceable({{.*}}) [[GEP]])
 // CHECK:         call void @swift_release(ptr %2)
 sil @huge_partial_application_stret : $@convention(thin) (Huge, Huge) -> Huge {
 entry(%x : $Huge, %y : $Huge):

--- a/test/IRGen/inline_array_enum_tags.swift
+++ b/test/IRGen/inline_array_enum_tags.swift
@@ -10,7 +10,7 @@ public struct Bar {
     let y: [UInt64]
 }
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias{{( nocapture)?}} readonly{{( captures\(none\))?}} %value, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %Baz)
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias readonly captures(none) %value, ptr readnone captures(none) %Baz)
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 24
 // CHECK:   [[TAG_VAL:%.*]] = load i8, ptr [[TAG_ADDR]], align 8
 // CHECK:   [[TAG_EXT:%.*]] = zext i8 [[TAG_VAL]] to i32
@@ -27,7 +27,7 @@ public struct Padded {
 }
 
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias{{( nocapture)?}} readonly{{( captures\(none\))?}} %value, ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %WithPaddedPayload)
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias readonly captures(none) %value, ptr readnone captures(none) %WithPaddedPayload)
 // CHECK: entry:
 // CHECK:   [[ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 8
 // CHECK:   [[VAL:%.*]] = load {{i64|i32}}, ptr [[ADDR]], align 8

--- a/test/IRGen/inout_noalias.sil
+++ b/test/IRGen/inout_noalias.sil
@@ -2,7 +2,7 @@
 
 import Swift
 
-// CHECK: define{{.*}}swiftcc void @takeInoutAliasable(ptr {{(nocapture|captures\(none\))}} dereferenceable({{[0-9]+}}) %0, ptr %T)
+// CHECK: define{{.*}}swiftcc void @takeInoutAliasable(ptr captures(none) dereferenceable({{[0-9]+}}) %0, ptr %T)
 sil @takeInoutAliasable : $<T> (@inout_aliasable UnsafePointer<T>) -> () {
 entry(%ptr : $*UnsafePointer<T>):
   %retval = tuple ()

--- a/test/IRGen/keypath_accessor.sil
+++ b/test/IRGen/keypath_accessor.sil
@@ -10,7 +10,7 @@ public struct Blah {
 }
 
 // CHECK: define{{.*}} swiftcc void @"$simple_getter"(
-// CHECK-SAME: ptr{{.*}} sret(%TSi){{( captures\(none\))?}} %0,
+// CHECK-SAME: ptr{{.*}} sret(%TSi) captures(none) %0,
 // CHECK-SAME: ptr{{.*}} %1,
 // CHECK-SAME: ptr{{.*}} %2, [[INT]] %3)
 sil @$simple_getter : $@convention(keypath_accessor_getter) (@in_guaranteed Blah) -> @out Int {

--- a/test/IRGen/lazy_multi_file.swift
+++ b/test/IRGen/lazy_multi_file.swift
@@ -14,7 +14,7 @@ class Subclass : LazyContainerClass {
   // an indirect return value. When it shrinks back, remove the optional
   // indirect out.
   //
-  // CHECK-LABEL: @"$s15lazy_multi_file8SubclassC6getStrSSyF"({{(ptr noalias( nocapture)? sret( captures\(none\))?, )?}}ptr swiftself %0) {{.*}} {
+  // CHECK-LABEL: @"$s15lazy_multi_file8SubclassC6getStrSSyF"({{(ptr noalias sret captures\(none\), )?}}ptr swiftself %0) {{.*}} {
   func getStr() -> String {
     // CHECK: = getelementptr inbounds{{.*}} %T15lazy_multi_file8SubclassC, ptr %0, i32 0, i32 3
     return str

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -99,7 +99,7 @@ bb0(%x : $*Builtin.Int64):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @fixed_size(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(8) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @fixed_size(ptr noalias captures(none) dereferenceable(8) %0)
 // CHECK:         [[XBUF:%.*]] = alloca i64
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0({{(i32|i64)}} 8, ptr [[XBUF]])
 // CHECK-NEXT:    load

--- a/test/IRGen/moveonly_split_module_source_deinit.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit.swift
@@ -7,7 +7,7 @@
 
 // Make sure we call the deinit through the value witness table in the other module.
 
-// REFERRING_MODULE-LABEL: define {{.*}}swiftcc void @"$s6serverAAV4mainyyKFZ"(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{(8|4)}}) %1) {{.*}}{
+// REFERRING_MODULE-LABEL: define {{.*}}swiftcc void @"$s6serverAAV4mainyyKFZ"(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{(8|4)}}) %1) {{.*}}{
 // REFERRING_MODULE: [[SERVER:%.*]] = alloca %T6server8MoveOnlyV
 // REFERRING_MODULE: [[VALUE_WITNESS_TABLE:%.*]] = getelementptr inbounds ptr, ptr %"$s6server8MoveOnlyVN.valueWitnesses"
 // REFERRING_MODULE: [[VALUE_WITNESS:%.*]] = load ptr, ptr [[VALUE_WITNESS_TABLE]]

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -198,7 +198,7 @@ public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
 // CHECK:         [[INNER_DEINITING_RELEASABLE_NC_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
 // CHECK:         call swiftcc void @"$s24moveonly_value_functions26InnerDeinitingReleasableNCVfD"(
 // CHECK-SAME:        ptr [[INNER_DEINITING_RELEASABLE_NC_METADATA]],
-//           :        ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(64) %deinit.arg)
+//           :        ptr noalias swiftself captures(none) dereferenceable(64) %deinit.arg)
 // CHECK:       }
 public func takeOuterNC_1<T>(_ o: consuming OuterNC_1<T>) {
   external_symbol()
@@ -295,7 +295,7 @@ public func takeGenericContext_1OuterNC_1<T : P>(_ e: consuming GenericContext_1
 public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<T>) {}
 
 // CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions26takeOuterSinglePayloadNC_2yyAA0efgH2_2OyxGnlF"(
-//           :      ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(64) %0, 
+//           :      ptr noalias captures(none) dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOh"(
@@ -388,7 +388,7 @@ public func takeOuterMultiPayloadNC_1<T>(_ e: consuming OuterMultiPayloadNC_1<T>
 // CHECK:       }
 public func takeOuterMultiPayloadNC_2<T>(_ e: consuming OuterMultiPayloadNC_2<T>) {}
 // CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions25takeOuterMultiPayloadNC_3yyAA0efgH2_3OyxGnlF"(
-//           :      ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(64) %0, 
+//           :      ptr noalias captures(none) dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOh"(

--- a/test/IRGen/moveonly_value_functions_onone.swift
+++ b/test/IRGen/moveonly_value_functions_onone.swift
@@ -195,7 +195,7 @@ public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
 // CHECK:         [[INNER_DEINITING_RELEASABLE_NC_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
 // CHECK:         call swiftcc void @"$s30moveonly_value_functions_onone26InnerDeinitingReleasableNCVfD"(
 // CHECK-SAME:        ptr [[INNER_DEINITING_RELEASABLE_NC_METADATA]],
-//           :        ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(64) %deinit.arg)
+//           :        ptr noalias swiftself captures(none) dereferenceable(64) %deinit.arg)
 // CHECK:       }
 public func takeOuterNC_1<T>(_ o: consuming OuterNC_1<T>) {
   external_symbol()
@@ -288,7 +288,7 @@ public func takeGenericContext_1OuterNC_1<T : P>(_ e: consuming GenericContext_1
 public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<T>) {}
 
 // CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone26takeOuterSinglePayloadNC_2yyAA0fghI2_2OyxGnlF"(
-//           :      ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(64) %0, 
+//           :      ptr noalias captures(none) dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_2OyxGlWOh"(
@@ -305,7 +305,7 @@ public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<
 // CHECK:         [[METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
 // CHECK:         call swiftcc void @"$s30moveonly_value_functions_onone26InnerDeinitingReleasableNCVfD"(
 // CHECK-SAME:        ptr [[METADATA]],
-//           :        ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(64) %0)
+//           :        ptr noalias swiftself captures(none) dereferenceable(64) %0)
 // CHECK:       }
 public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<T>) {}
 
@@ -383,7 +383,7 @@ public func takeOuterMultiPayloadNC_1<T>(_ e: consuming OuterMultiPayloadNC_1<T>
 // CHECK:       }
 public func takeOuterMultiPayloadNC_2<T>(_ e: consuming OuterMultiPayloadNC_2<T>) {}
 // CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone25takeOuterMultiPayloadNC_3yyAA0fghI2_3OyxGnlF"(
-//           :      ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(64) %0, 
+//           :      ptr noalias captures(none) dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_3OyxGlWOh"(

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -38,7 +38,7 @@ import gizmo
 // CHECK:   ptr [[NSRECT_BLOCK_SIGNATURE]]
 // CHECK: }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @project_block_storage(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @project_block_storage(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds{{.*}} { %objc_block, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load ptr, ptr %1, align 8
@@ -51,7 +51,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %p : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc fp128 @overaligned_project_block_storage(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc fp128 @overaligned_project_block_storage(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds{{.*}} { %objc_block, fp128 }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load fp128, ptr %1, align 16
@@ -64,7 +64,7 @@ entry(%0 : $*@block_storage Builtin.FPIEEE128):
   return %p : $Builtin.FPIEEE128
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_trivial(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_trivial(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds{{.*}} { %objc_block, ptr }, ptr %0, i32 0, i32 0
 // CHECK:         [[T0:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 0
 // CHECK:         store ptr [[BLOCK_ISA]], ptr [[T0]]
@@ -109,7 +109,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer, %1 : $Int):
   return %1 : $Int
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_nontrivial(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_nontrivial(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds
 // CHECK:         [[T0:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 0
 // CHECK:         store ptr [[BLOCK_ISA]], ptr [[T0]]
@@ -147,7 +147,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 
 sil public_external @invoke_nontrivial : $@convention(c) (@inout_aliasable @block_storage Builtin.NativeObject) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_stret(ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @init_block_header_stret(ptr captures(none) dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds
 // CHECK:         [[T0:%.*]] = getelementptr inbounds{{.*}} %objc_block, ptr [[HEADER]], i32 0, i32 0
 // CHECK:         store ptr [[BLOCK_ISA]], ptr [[T0]]

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -87,13 +87,13 @@ struct BigStructWithNativeObjects {
     return NSRect(origin: NSPoint(x: 0, y: 0), 
                   size: NSSize(width: 0, height: 0))
   }
-  // CHECK: define internal void @"$s17objc_class_export3FooC6boundsSo6NSRectVyFTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2) {{[#0-9]*}} {
+  // CHECK: define internal void @"$s17objc_class_export3FooC6boundsSo6NSRectVyFTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2) {{[#0-9]*}} {
   // CHECK:   call swiftcc { double, double, double, double } @"$s17objc_class_export3FooC6boundsSo6NSRectVyF"(ptr swiftself %1)
 
   @objc func convertRectToBacking(r r: NSRect) -> NSRect {
     return r
   }
-  // CHECK: define internal void @"$s17objc_class_export3FooC20convertRectToBacking1rSo6NSRectVAG_tFTo"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr byval({{.*}} align 8 %3) {{[#0-9]*}} {
+  // CHECK: define internal void @"$s17objc_class_export3FooC20convertRectToBacking1rSo6NSRectVAG_tFTo"(ptr noalias sret({{.*}}) captures(none) %0, ptr %1, ptr %2, ptr byval({{.*}} align 8 %3) {{[#0-9]*}} {
   // CHECK:   call swiftcc { double, double, double, double } @"$s17objc_class_export3FooC20convertRectToBacking1rSo6NSRectVAG_tF"(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, ptr swiftself %1)
 
   func doStuffToSwiftSlice(f f: [Int]) {

--- a/test/IRGen/objc_generic_protocol_conformance.swift
+++ b/test/IRGen/objc_generic_protocol_conformance.swift
@@ -9,4 +9,4 @@ protocol P {
 extension Foo: P {}
 
 // SIL-LABEL: sil private [transparent] [thunk] [ossa] @$sSo3FooCyxG33objc_generic_protocol_conformance1PA2dEP3fooyyFTW {{.*}} @pseudogeneric
-// IR-LABEL: define internal swiftcc void @"$sSo3FooCyxG33objc_generic_protocol_conformance1PA2dEP3fooyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{4|8}}) %0, ptr{{( %Self)?}}, ptr{{( %SelfWitnessTable)?}})
+// IR-LABEL: define internal swiftcc void @"$sSo3FooCyxG33objc_generic_protocol_conformance1PA2dEP3fooyyFTW"(ptr noalias swiftself captures(none) dereferenceable({{4|8}}) %0, ptr{{( %Self)?}}, ptr{{( %SelfWitnessTable)?}})

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -57,15 +57,15 @@ entry(%x : $float3):
 }
 
 // x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
-// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
-// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // arm64_32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
-// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1)
+// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)

--- a/test/IRGen/objc_structs.swift
+++ b/test/IRGen/objc_structs.swift
@@ -16,7 +16,7 @@ import gizmo
 // CHECK: define hidden swiftcc { double, double, double, double } @"$s12objc_structs8getFrame{{[_0-9a-zA-Z]*}}F"(ptr %0) {{.*}} {
 func getFrame(_ g: Gizmo) -> NSRect {
   // CHECK: load ptr, ptr @"\01L_selector(frame)"
-  // CHECK: call void @objc_msgSend_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr {{.*}}, ptr {{.*}})
+  // CHECK: call void @objc_msgSend_stret(ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr {{.*}}, ptr {{.*}})
   return g.frame()
 }
 // CHECK: }
@@ -31,7 +31,7 @@ func setFrame(_ g: Gizmo, frame: NSRect) {
 
 // CHECK: define hidden swiftcc { double, double, double, double } @"$s12objc_structs8makeRect{{[_0-9a-zA-Z]*}}F"(double %0, double %1, double %2, double %3)
 func makeRect(_ a: Double, b: Double, c: Double, d: Double) -> NSRect {
-  // CHECK: call void @NSMakeRect(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}})
+  // CHECK: call void @NSMakeRect(ptr noalias sret({{.*}}) captures(none) {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}})
   return NSMakeRect(a,b,c,d)
 }
 // CHECK: }
@@ -45,7 +45,7 @@ func stringFromRect(_ r: NSRect) -> String {
 
 // CHECK: define hidden swiftcc { double, double, double, double } @"$s12objc_structs9insetRect{{[_0-9a-zA-Z]*}}F"(double %0, double %1, double %2, double %3, double %4, double %5)
 func insetRect(_ r: NSRect, x: Double, y: Double) -> NSRect {
-  // CHECK: call void @NSInsetRect(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr byval({{.*}}) align 8 {{.*}}, double {{.*}}, double {{.*}})
+  // CHECK: call void @NSInsetRect(ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr byval({{.*}}) align 8 {{.*}}, double {{.*}}, double {{.*}})
   return NSInsetRect(r, x, y)
 }
 // CHECK: }
@@ -53,13 +53,13 @@ func insetRect(_ r: NSRect, x: Double, y: Double) -> NSRect {
 // CHECK: define hidden swiftcc { double, double, double, double } @"$s12objc_structs19convertRectFromBase{{[_0-9a-zA-Z]*}}F"(ptr %0, double %1, double %2, double %3, double %4)
 func convertRectFromBase(_ v: NSView, r: NSRect) -> NSRect {
   // CHECK: load ptr, ptr @"\01L_selector(convertRectFromBase:)", align 8
-  // CHECK: call void @objc_msgSend_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr byval({{.*}}) align 8 {{.*}})
+  // CHECK: call void @objc_msgSend_stret(ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr byval({{.*}}) align 8 {{.*}})
   return v.convertRect(fromBase: r)
 }
 // CHECK: }
 
 // CHECK: define hidden swiftcc { ptr, ptr, ptr, ptr } @"$s12objc_structs20useStructOfNSStringsySo0deF0VADF"(ptr %0, ptr %1, ptr %2, ptr %3)
-// CHECK:   call void @useStructOfNSStringsInObjC(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
+// CHECK:   call void @useStructOfNSStringsInObjC(ptr noalias sret({{.*}}) captures(none) {{%.*}}, ptr byval({{.*}}) align 8 {{%.*}})
 func useStructOfNSStrings(_ s: StructOfNSStrings) -> StructOfNSStrings {
   return useStructOfNSStringsInObjC(s)
 }

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -40,7 +40,7 @@ class Hoozit : Gizmo {
     // CHECK: [[T0:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
     // CHECK: store ptr [[T0]], ptr {{.*}}, align 8
     // CHECK: load ptr, ptr @"\01L_selector(frame)"
-    // CHECK: call void @objc_msgSendSuper2_stret(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} {{.*}}, ptr {{.*}}, ptr {{.*}})
+    // CHECK: call void @objc_msgSendSuper2_stret(ptr noalias sret({{.*}}) captures(none) {{.*}}, ptr {{.*}}, ptr {{.*}})
     return NSInsetRect(super.frame(), 2.0, 2.0)
   }
   // CHECK: }

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -135,7 +135,7 @@ bb0(%x : $SwiftClass):
 
 sil public_external @indirect_guaranteed_captured_class_param : $@convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_guaranteed_class_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_guaranteed_class_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[X:%.*]] = load ptr, ptr %0
 // CHECK-NOT:     {{retain|release}}
@@ -148,7 +148,7 @@ sil public_external @indirect_guaranteed_captured_class_param : $@convention(thi
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
-// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_guaranteed_captured_class_param(i64 %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[X_TMP]]
+// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_guaranteed_captured_class_param(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) [[X_TMP]]
 // CHECK-NOT:     retain
 // CHECK:         call void @swift_release(ptr %1)
 // CHECK:         ret i64 [[RESULT]]
@@ -162,7 +162,7 @@ bb0(%x : $*SwiftClass):
 
 sil public_external @indirect_consumed_captured_class_param : $@convention(thin) (Int, @in SwiftClass) -> Int
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_consumed_class_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_consumed_class_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[CONTEXT_OBJ:%.*]] = load ptr, ptr %0
 // CHECK-NOT:     {{retain|release}}
@@ -175,7 +175,7 @@ sil public_external @indirect_consumed_captured_class_param : $@convention(thin)
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
-// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_param(i64 %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[X_TMP]])
+// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_param(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) [[X_TMP]])
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
 // CHECK:         ret i64 [[RESULT]]
@@ -227,7 +227,7 @@ bb0(%x : $SwiftClassPair):
 
 sil public_external @indirect_guaranteed_captured_class_pair_param : $@convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_guaranteed_class_pair_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_guaranteed_class_pair_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias ptr @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@"\$s[A-Za-z0-9_]+TA"]], {{.*}} [[CONTEXT_OBJ]]
@@ -237,7 +237,7 @@ sil public_external @indirect_guaranteed_captured_class_pair_param : $@conventio
 // CHECK:         [[PAIR_ADDR:%.*]] = getelementptr
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
-// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_guaranteed_captured_class_pair_param(i64 %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[PAIR_ADDR]])
+// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_guaranteed_captured_class_pair_param(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) [[PAIR_ADDR]])
 // CHECK:         release{{.*}}%1)
 // CHECK:         ret i64 [[RESULT]]
 
@@ -250,7 +250,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @indirect_consumed_captured_class_pair_param : $@convention(thin) (Int, @in SwiftClassPair) -> Int
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_consumed_class_pair_param(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_consumed_class_pair_param(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias ptr @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@"\$s[A-Za-z0-9_]+TA"]], {{.*}} [[CONTEXT_OBJ]]
@@ -260,7 +260,7 @@ sil public_external @indirect_consumed_captured_class_pair_param : $@convention(
 // CHECK:         [[X_TMP:%.*]] = alloca
 // CHECK:         call ptr @"$s13partial_apply14SwiftClassPairVWOc"
 // CHECK:         release{{.*}}%1)
-// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_pair_param(i64 %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) [[X_TMP]])
+// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_pair_param(i64 %0, ptr noalias captures(none) dereferenceable({{.*}}) [[X_TMP]])
 // CHECK:         ret i64 [[RESULT]]
 
 sil @partial_apply_indirect_consumed_class_pair_param : $@convention(thin) (@in SwiftClassPair) -> @callee_owned (Int) -> Int {
@@ -472,7 +472,7 @@ sil public_external @generic_indirect_return : $@convention(thin) <T> (Int) -> @
 // CHECK-LABEL: define{{.*}} @partial_apply_generic_indirect_return
 // CHECK: insertvalue {{.*}}$s23generic_indirect_returnTA
 
-// CHECK-LABEL: define internal swiftcc void @"$s23generic_indirect_returnTA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr swiftself
+// CHECK-LABEL: define internal swiftcc void @"$s23generic_indirect_returnTA"(ptr noalias sret({{.*}}) captures(none) %0, ptr swiftself
 // CHECK:  call swiftcc void @generic_indirect_return({{.*}} %0,
 // CHECK:  ret void
 sil @partial_apply_generic_indirect_return : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum<Int> {
@@ -500,7 +500,7 @@ sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> 
 // CHECK: [[R2:%.*]] = insertvalue { ptr, ptr } [[R1]], ptr [[CTX2]], 1
 // CHECK: ret { ptr, ptr } [[R2]]
 
-// CHECK-LABEL: define internal swiftcc void @"$s24generic_indirect_return2TA"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr swiftself %1)
+// CHECK-LABEL: define internal swiftcc void @"$s24generic_indirect_return2TA"(ptr noalias sret({{.*}}) captures(none) %0, ptr swiftself %1)
 // CHECK: call swiftcc void @generic_indirect_return2(ptr noalias sret({{.*}}) %0,
 // CHECK:  ret void
 sil @partial_apply_generic_indirect_return2 : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum2<Int> {

--- a/test/IRGen/partial_apply_coro.sil
+++ b/test/IRGen/partial_apply_coro.sil
@@ -1012,7 +1012,7 @@ bb0(%x : $SwiftClass):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @indirect_guaranteed_captured_class_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, [[ARGTYPE:i32|i64]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE:4|8]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, [[ARGTYPE:i32|i64]] %1, ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE:4|8]]) %2)
 sil public @indirect_guaranteed_captured_class_param : $@yield_once @convention(thin) (Int, @in_guaranteed SwiftClass) -> (@yields SwiftClass) {
 entry(%i : $Int, %c : $*SwiftClass):
   %0 = builtin "int_trap"() : $Never
@@ -1020,7 +1020,7 @@ entry(%i : $Int, %c : $*SwiftClass):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @partial_apply_indirect_guaranteed_class_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE]]) %[[ARGPTR:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE]]) %[[ARGPTR:.*]])
 // CHECK: entry:
 // CHECK:   %[[ARG:.*]] = load ptr, ptr %[[ARGPTR]]
 // CHECK:   %[[RET:.*]] = insertvalue { ptr, ptr } { ptr @"$s40indirect_guaranteed_captured_class_paramTA{{.*}}", ptr undef }, ptr %[[ARG]], 1
@@ -1037,7 +1037,7 @@ entry(%i : $Int, %c : $*SwiftClass):
 // CHECK:   store ptr %[[PA_CTX_BOX]], ptr %[[SELFPTR]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @indirect_guaranteed_captured_class_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE]]) %[[SELFPTR]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @indirect_guaranteed_captured_class_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE]]) %[[SELFPTR]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, ptr } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s40indirect_guaranteed_captured_class_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -1079,7 +1079,7 @@ bb0(%x : $*SwiftClass):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @indirect_consumed_captured_class_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARGTYPE:(i32|i64)]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE:(4|8)]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARGTYPE:(i32|i64)]] %1, ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE:(4|8)]]) %2)
 sil public @indirect_consumed_captured_class_param : $@yield_once @convention(thin) (Int, @in SwiftClass) -> (@yields SwiftClass) {
 entry(%i : $Int, %c : $*SwiftClass):
   %0 = builtin "int_trap"() : $Never
@@ -1087,7 +1087,7 @@ entry(%i : $Int, %c : $*SwiftClass):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @partial_apply_indirect_consumed_class_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE]]) %[[ARGPTR:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE]]) %[[ARGPTR:.*]])
 // CHECK: entry:
 // CHECK:   %[[ARG:.*]] = load ptr, ptr %[[ARGPTR]]
 // CHECK:   %[[RET:.*]] = insertvalue { ptr, ptr } { ptr @"$s38indirect_consumed_captured_class_paramTA{{.*}}", ptr undef }, ptr %[[ARG]], 1
@@ -1105,7 +1105,7 @@ entry(%i : $Int, %c : $*SwiftClass):
 // CHECK:   store ptr %[[PA_CTX_BOX]], ptr %[[SELFPTR]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @indirect_consumed_captured_class_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARGPTR_SIZE]]) %[[SELFPTR]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr } @indirect_consumed_captured_class_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable([[ARGPTR_SIZE]]) %[[SELFPTR]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, ptr } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s38indirect_consumed_captured_class_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -1231,7 +1231,7 @@ bb0(%x : $SwiftClassPair):
 
 // CHECK-64-LABEL: define {{.*}} { ptr, i64 } @indirect_guaranteed_captured_class_pair_param
 // CHECK-32-LABEL: define {{.*}} { ptr, i32 } @indirect_guaranteed_captured_class_pair_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE:(8|16)]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %1, ptr noalias captures(none) dereferenceable([[PAIR_SIZE:(8|16)]]) %2)
 sil public @indirect_guaranteed_captured_class_pair_param : $@yield_once @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> (@yields Int) {
 entry(%i : $Int, %c : $*SwiftClassPair):
   %0 = builtin "int_trap"() : $Never
@@ -1239,7 +1239,7 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @partial_apply_indirect_guaranteed_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[BOX:.*]] = call noalias ptr @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata.{{.*}}
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T18partial_apply_coro14SwiftClassPairV }>, ptr %[[BOX]], i32 0, i32 1
@@ -1258,7 +1258,7 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 // CHECK:   %[[PA_CTX:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T18partial_apply_coro14SwiftClassPairV }>, ptr %[[PA_CTX_BOX]], i32 0, i32 1
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[SPILL1]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[PA_CTX]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %1, ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[PA_CTX]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s45indirect_guaranteed_captured_class_pair_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -1301,7 +1301,7 @@ bb0(%x : $*SwiftClassPair):
 
 // CHECK-32-LABEL: define {{.*}} { ptr, i32 } @indirect_consumed_captured_class_pair_param
 // CHECK-64-LABEL: define {{.*}} { ptr, i64 } @indirect_consumed_captured_class_pair_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, [[ARG_TYPE]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %0, [[ARG_TYPE]] %1, ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %2)
 sil public @indirect_consumed_captured_class_pair_param : $@yield_once @convention(thin) (Int, @in SwiftClassPair) -> (@yields Int) {
 entry(%i : $Int, %c : $*SwiftClassPair):
   %0 = builtin "int_trap"() : $Never
@@ -1309,7 +1309,7 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @partial_apply_indirect_consumed_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[BOX:.*]] = call noalias ptr @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata.{{.*}}
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T18partial_apply_coro14SwiftClassPairV }>, ptr %[[BOX]], i32 0, i32 1
@@ -1331,7 +1331,7 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 // CHECK:   %{{.*}} = call ptr @"$s18partial_apply_coro14SwiftClassPairVWOc"(ptr %[[PA_CTX]], ptr %[[SPILL1]])
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_consumed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[SPILL1]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_consumed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %1, ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[SPILL1]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s43indirect_consumed_captured_class_pair_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 2
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -2059,7 +2059,7 @@ class  A3 {}
 sil_vtable A3 {}
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr, ptr } @amethod
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable([[SELF_SIZE:(4|8)]]) %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable([[ERROR_SIZE:(4|8)]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, ptr noalias swiftself captures(none) dereferenceable([[SELF_SIZE:(4|8)]]) %1, ptr noalias swifterror captures(none) dereferenceable([[ERROR_SIZE:(4|8)]]) %2)
 sil @amethod : $@yield_once @convention(method) (@in_guaranteed A2<A3>) -> (@yields A1, @error Error) {
 entry(%a : $*A2<A3>):
   %0 = builtin "int_trap"() : $Never
@@ -2067,13 +2067,13 @@ entry(%a : $*A2<A3>):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @repo
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[SELF_SIZE]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[SELF_SIZE]]) %[[ARG:.*]])
 // CHECK:   %[[RET:.*]] = insertvalue { ptr, ptr } { ptr @"$s7amethodTA{{.*}}", ptr undef }, ptr %{{.*}}, 1
 // CHECK:   ret { ptr, ptr } %[[RET]]
 // CHECK: }
 //
 // CHECK-LABEL: define {{.*}} { ptr, ptr, ptr } @"$s7amethodTA"
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[CTX:.*]], ptr swiftself %[[SELF:.*]], ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable([[ERROR_SIZE]]) %[[ERRORPTR:.*]])
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[CTX:.*]], ptr swiftself %[[SELF:.*]], ptr noalias swifterror captures(none) dereferenceable([[ERROR_SIZE]]) %[[ERRORPTR:.*]])
 // CHECK: entry:
 // CHECK:   %[[SELFPTR:.*]] = alloca ptr
 // CHECK:   %[[SPILL:.*]] = call ptr @malloc
@@ -2083,7 +2083,7 @@ entry(%a : $*A2<A3>):
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
 // CHECK:   store ptr null, ptr %[[ERRORPTR]]
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr, ptr } @amethod(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable([[SELF_SIZE]]) %[[SELFPTR]], ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable([[ERROR_SIZE]]) %[[ERRORPTR]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, ptr, ptr } @amethod(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], ptr noalias swiftself captures(none) dereferenceable([[SELF_SIZE]]) %[[SELFPTR]], ptr noalias swifterror captures(none) dereferenceable([[ERROR_SIZE]]) %[[ERRORPTR]])
 // CHECK:   %[[ERRORVAL:.*]] = load ptr, ptr %[[ERRORPTR]]
 // CHECK:   %[[RESUME0:.*]] = extractvalue { ptr, ptr, ptr } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s7amethodTA.Frame", ptr %[[SPILL]], i32 0, i32 1
@@ -2137,7 +2137,7 @@ bb0(%0 : $*A2<A3>):
 }
 
 // CHECK-LABEL: define {{.*}} { ptr, ptr } @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARG_SIZE:(8|16)]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[ARG_SIZE:(8|16)]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[BOX:.*]] = call noalias ptr @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T18partial_apply_coro14SwiftClassPairV }>, ptr %[[BOX]], i32 0, i32 1
@@ -2156,7 +2156,7 @@ bb0(%0 : $*A2<A3>):
 // CHECK:   %[[PA_CTX:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, %T18partial_apply_coro14SwiftClassPairV }>, ptr %[[PA_CTX_BOX]], i32 0, i32 1
 // CHECK:   %[[PA_ARG:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[PA_ARG]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[PA_ARG]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{8|16}}) %[[PA_CTX]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[PA_ARG]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable({{8|16}}) %[[PA_CTX]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]],
@@ -2201,7 +2201,7 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @use_closure2 : $@yield_once @convention(thin) (@noescape @yield_once @callee_guaranteed (Int) -> (@yields Int)) -> (@yields Int)
 
 // CHECK-LABEL: define {{.*}} @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[ARG_SIZE:(8|16)]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[ARG_SIZE:(8|16)]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8]
 // CHECK:   %[[BOX:.*]] = alloca i8
@@ -2228,7 +2228,7 @@ sil public_external @use_closure2 : $@yield_once @convention(thin) (@noescape @y
 // CHECK:   %[[PA_ARG:.*]] = load ptr, ptr %[[PA_CTX]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{8|16}}) %[[PA_ARG]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_guaranteed_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable({{8|16}}) %[[PA_ARG]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -2276,7 +2276,7 @@ bb0(%x : $*SwiftClassPair):
 
 // CHECK-32-LABEL: define {{.*}} { ptr, i32 } @indirect_in_captured_class_pair_param
 // CHECK-64-LABEL: define {{.*}} { ptr, i64 } @indirect_in_captured_class_pair_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %{{.*}}, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE:(8|16)]]) %{{.*}})
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %{{.*}}, ptr noalias captures(none) dereferenceable([[PAIR_SIZE:(8|16)]]) %{{.*}})
 sil public @indirect_in_captured_class_pair_param : $@yield_once @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> (@yields Int) {
 entry(%i : $Int, %p : $*SwiftClassPair):
   %0 = builtin "int_trap"() : $Never
@@ -2284,7 +2284,7 @@ entry(%i : $Int, %p : $*SwiftClassPair):
 }
 
 // CHECK-LABEL: define {{.*}} void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8],
 // CHECK:   %[[BOX:.*]] = alloca i8
@@ -2312,7 +2312,7 @@ entry(%i : $Int, %p : $*SwiftClassPair):
 // CHECK:   %[[PA_ARG:.*]] = load ptr, ptr %[[PA_CTX]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_in_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[PA_ARG]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_in_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[PA_ARG]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s37indirect_in_captured_class_pair_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -2477,7 +2477,7 @@ entry:
 
 // CHECK-32: define {{.*}} { ptr, i32 } @indirect_in_constant_captured_class_pair_param
 // CHECK-64: define {{.*}} { ptr, i64 } @indirect_in_constant_captured_class_pair_param
-// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %1, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE:(8|16)]]) %2)
+// CHECK-SAME: (ptr noalias dereferenceable([[BUFFER_SIZE:(16|32)]]) %0, [[ARG_TYPE:(i32|i64)]] %1, ptr noalias captures(none) dereferenceable([[PAIR_SIZE:(8|16)]]) %2)
 sil public @indirect_in_constant_captured_class_pair_param : $@yield_once @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> (@yields Int) {
 entry(%i : $Int, %ic : $*SwiftClassPair):
   %0 = builtin "int_trap"() : $Never
@@ -2485,7 +2485,7 @@ entry(%i : $Int, %ic : $*SwiftClassPair):
 }
 
 // CHECK-LABEL: define {{.*}} void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param
-// CHECK-SAME: (ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
+// CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8]
 // CHECK:   %[[BOX:.*]] = alloca i8
@@ -2513,7 +2513,7 @@ entry(%i : $Int, %ic : $*SwiftClassPair):
 // CHECK:   %[[PA_ARG:.*]] = load ptr, ptr %[[PA_CTX]]
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_in_constant_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias {{(nocapture|captures\(none\))}} dereferenceable([[PAIR_SIZE]]) %[[PA_ARG]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc { ptr, [[ARG_TYPE]] } @indirect_in_constant_captured_class_pair_param(ptr noalias dereferenceable([[BUFFER_SIZE]]) %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG0]], ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[PA_ARG]])
 // CHECK:   %[[RESUME:.*]] = extractvalue { ptr, [[ARG_TYPE]] } %[[YIELD_PAIR]], 0
 // CHECK:   %[[SPILL2:.*]] = getelementptr inbounds %"$s46indirect_in_constant_captured_class_pair_paramTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[RESUME]], ptr %[[SPILL2]]
@@ -2579,7 +2579,7 @@ bb0(%thick : $@callee_guaranteed @yield_once @convention(thick) (Int64, Int32) -
 // CHECK: }
 //
 // CHECK-LABEL: define {{.*}} ptr @"$s16external_closureTA"
-// CHECK-SAME: (ptr noalias {{.*}} %[[CTX:.*]], [[ARG_TYPE]] %[[ARG1:.*]], ptr swiftself %[[PA_CTX_BOX:.*]], ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} {{.*}} %[[ERROR:.*]])
+// CHECK-SAME: (ptr noalias {{.*}} %[[CTX:.*]], [[ARG_TYPE]] %[[ARG1:.*]], ptr swiftself %[[PA_CTX_BOX:.*]], ptr noalias swifterror captures(none) {{.*}} %[[ERROR:.*]])
 // CHECK: entry:
 // CHECK:   %[[SPILL:.*]] = call ptr @malloc
 // CHECK:   store ptr %[[SPILL]], ptr %[[CTX]]
@@ -2590,7 +2590,7 @@ bb0(%thick : $@callee_guaranteed @yield_once @convention(thick) (Int64, Int32) -
 // CHECK:   %[[FRAMEPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[FRAME]], i32 0, i32 0
 // CHECK:   call void @llvm.lifetime.start.p0(i64 [[BUFFER_SIZE]], ptr %[[FRAMEPTR]])
 // CHECK:   store ptr null, ptr %[[ERROR]]
-// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc ptr @external_closure(ptr noalias {{.*}} %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG1]], [[ARG_TYPE]] %[[ARG2]], ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} {{.*}} %[[ERROR]])
+// CHECK:   %[[YIELD_PAIR:.*]] = call swiftcc ptr @external_closure(ptr noalias {{.*}} %[[FRAMEPTR]], [[ARG_TYPE]] %[[ARG1]], [[ARG_TYPE]] %[[ARG2]], ptr swiftself undef, ptr noalias swifterror captures(none) {{.*}} %[[ERROR]])
 // CHECK:   %[[SPILL1:.*]] = getelementptr inbounds %"$s16external_closureTA.Frame", ptr %[[SPILL]], i32 0, i32 1
 // CHECK:   store ptr %[[YIELD_PAIR]], ptr %[[SPILL1]]
 // CHECK:   %[[ERRORVAL:.*]] = load ptr, ptr %[[ERROR]]

--- a/test/IRGen/partial_apply_generic.swift
+++ b/test/IRGen/partial_apply_generic.swift
@@ -37,7 +37,7 @@ var x = seq ~> split
 // Indirect return
 //
 
-// CHECK-LABEL: define internal swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}FTA"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftself %1)
+// CHECK-LABEL: define internal swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}FTA"(ptr noalias captures(none) %0, ptr swiftself %1)
 // CHECK:         tail call swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}F"(ptr noalias %0,
 
 struct HugeStruct { var a, b, c, d: Int }

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -42,11 +42,11 @@
 // specialized InternalThing.computedX.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingV9computedXxvgSi_Ts5"([[INT]]{{( returned)?}} %0)
 // specialized InternalThing.computedX.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr{{( nocapture)?}} swiftself {{(writeonly )?}}{{(captures\(none\) )?}}dereferenceable({{(4|8)}}){{.*}} %1)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
 // specialized InternalThing.subscript.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingVyxSicigSi_Ts5"([[INT]] %0, [[INT]]{{( returned)?}} %1)
 // specialized InternalThing.subscript.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr{{( nocapture)?}} swiftself {{(writeonly )?}}{{(captures\(none\) )?}}dereferenceable({{(4|8)}}){{.*}} %2)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
 
 // specialized InternalRef.compute()
 // CHECK-A-FRAG-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT:(i64|i32)]] @"$s1A11InternalRefC7computexyFAA09ResilientA10BoxedThingVySiG_Ts5"
@@ -75,13 +75,13 @@
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingV9computedXxvg1B07AnotherB0C_Ts5"(ptr{{( returned)?}} %0)
 
 // specialized InternalThing.computedX.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{(4|8)}}) %1)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %1)
 
 // specialized InternalThing.subscript.getter
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingVyxSicig1B07AnotherB0C_Ts5"([[INT:(i64|i32)]] %0, ptr{{( returned)?}} %1)
 
 // specialized InternalThing.subscript.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{(4|8)}}) %2)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %2)
 
 // specialized InternalRef.compute()
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A11InternalRefC7computexyF1B12AnotherThingC_Ts5

--- a/test/IRGen/protocol_accessor_multifile.swift
+++ b/test/IRGen/protocol_accessor_multifile.swift
@@ -8,7 +8,7 @@
 // CHECK-LABEL: define{{.*}} void @"$s27protocol_accessor_multifile14useExistentialyyF"()
 func useExistential() {
   // CHECK: [[BOX:%.+]] = alloca %T27protocol_accessor_multifile5ProtoP,
-  // CHECK: call swiftcc void @"$s27protocol_accessor_multifile17globalExistentialAA5Proto_pvg"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[BOX]])
+  // CHECK: call swiftcc void @"$s27protocol_accessor_multifile17globalExistentialAA5Proto_pvg"(ptr noalias sret({{.*}}) captures(none) [[BOX]])
   // CHECK: call swiftcc void @"$s27protocol_accessor_multifile5ProtoPAAE6methodyyF"
   globalExistential.method()
   // CHECK: call void @__swift_destroy_boxed_opaque_existential_1(ptr [[BOX]])

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -262,7 +262,7 @@ struct ConformingStruct : ResilientProtocol {
   static func defaultF()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultA(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultA(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @noDefaultA : $@convention(witness_method: ResilientProtocol) (@in_guaranteed ConformingStruct) -> () {
@@ -281,7 +281,7 @@ bb0(%0 : $*ConformingStruct):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultB(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultB(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @noDefaultB : $@convention(witness_method: ResilientProtocol) (@in_guaranteed ConformingStruct) -> () {
@@ -324,7 +324,7 @@ bb0(%0 : $*T):
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingType(ptr noalias {{(nocapture|captures\(none\))}} %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingType(ptr noalias captures(none) %0)
 sil @passConformingType : $@convention(thin) (@in ResilientConformingType) -> () {
 bb0(%0 : $*ResilientConformingType):
 
@@ -381,7 +381,7 @@ bb0(%0 : $*T):
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeRefined(ptr noalias {{(nocapture|captures\(none\))}} %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeRefined(ptr noalias captures(none) %0)
 sil @passConformingTypeRefined : $@convention(thin) (@in AnotherConformingStruct) -> () {
 bb0(%0 : $*AnotherConformingStruct):
 
@@ -424,7 +424,7 @@ bb0(%0 : $*T):
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeAssoc(ptr noalias {{(nocapture|captures\(none\))}} %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeAssoc(ptr noalias captures(none) %0)
 sil @passConformingTypeAssoc : $@convention(thin) (@in ConformsWithResilientAssoc) -> () {
 bb0(%0 : $*ConformsWithResilientAssoc):
 

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -52,20 +52,20 @@ public protocol MyResilientProtocol {
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 3
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias sret({{.*}}) captures(none) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(ptr noalias swiftself %0, ptr{{( noalias( nocapture)?( swifterror)?( captures\(none\))? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(ptr noalias swiftself %0, ptr{{( noalias( swifterror)? captures\(none\) dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 4
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias swiftself %0, ptr{{( noalias( nocapture)?( swifterror)?( captures\(none\))? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias swiftself %0, ptr{{( noalias( swifterror)? captures\(none\) dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %2, ptr noalias swiftself %3, ptr %4, ptr %5)

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -11,7 +11,7 @@ public class C {
 // Check that runtime functions use a proper calling convention.
 // CHECK-NOT: call void {{.*}} @swift_release
 
-// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s{{(27|28)}}runtime_calling_conventions3fooyyAA1CCF"(ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %0)
+// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s{{(27|28)}}runtime_calling_conventions3fooyyAA1CCF"(ptr readnone captures(none) %0)
 // Check that runtime functions use a proper calling convention.
 // OPT-CHECK-NOT: tail call void @swift_release
 

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -67,7 +67,7 @@ where Self : CodingType,
   print(Self.ValueType.self)
 }
 
-// OSIZE: define internal swiftcc ptr @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataAaEP_AA0F4TypePWT"(ptr readnone %"GenericKlazz<T, R>.Data", ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} %"GenericKlazz<T, R>", ptr{{( nocapture)?}} readnone{{( captures\(none\))?}} %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
+// OSIZE: define internal swiftcc ptr @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataAaEP_AA0F4TypePWT"(ptr readnone %"GenericKlazz<T, R>.Data", ptr readonly captures(none) %"GenericKlazz<T, R>", ptr readnone captures(none) %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
 // OSIZE: [[ATTRS]] = {{{.*}}noinline
 
 // Check that same-typing two generic parameters together lowers correctly.

--- a/test/IRGen/select_enum.sil
+++ b/test/IRGen/select_enum.sil
@@ -7,7 +7,7 @@ enum SinglePayloadSingleEmpty {
   case DataCase(Builtin.Word)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @select_enum_SinglePayloadSingleEmpty(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @select_enum_SinglePayloadSingleEmpty(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 sil @select_enum_SinglePayloadSingleEmpty : $@convention(thin) (@in SinglePayloadSingleEmpty) -> () {
 bb0(%0 : $*SinglePayloadSingleEmpty):
   %1 = load %0 : $*SinglePayloadSingleEmpty

--- a/test/IRGen/sil_generic_witness_methods.swift
+++ b/test/IRGen/sil_generic_witness_methods.swift
@@ -34,7 +34,7 @@ func call_methods<T: P, U>(_ x: T, y: S, z: U) {
   x.generic_method(z)
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s27sil_generic_witness_methods017call_existential_D0{{[_0-9a-zA-Z]*}}F"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s27sil_generic_witness_methods017call_existential_D0{{[_0-9a-zA-Z]*}}F"(ptr noalias captures(none) dereferenceable({{.*}}) %0)
 func call_existential_methods(_ x: P, y: S) {
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds{{.*}} %T27sil_generic_witness_methods1PP, ptr [[X:%0]], i32 0, i32 1
   // CHECK: [[METADATA:%.*]] = load ptr, ptr [[METADATA_ADDR]], align 8

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -28,14 +28,14 @@ struct X {}
 struct Y {}
 struct Z {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_concrete_method_witness(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_concrete_method_witness(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 sil @concrete_type_concrete_method_witness : $@convention(witness_method: P) (@in Foo) -> @thick Foo.Type {
 entry(%x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_concrete_method_witness(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{.*}}) %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_concrete_method_witness(ptr noalias swiftself captures(none) dereferenceable({{.*}}) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-objc:    [[T1:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 10
 // CHECK-native:  [[T1:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 7
 // CHECK:         %T = load ptr, ptr [[T1]], align 8
@@ -87,14 +87,14 @@ entry(%x : $@thick Bar<T, U, V>.Type):
 
 // TODO: %Self Type arg is redundant for class method witness
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 sil @concrete_type_generic_method_witness : $@convention(witness_method: P) <Z> (@in Z, @in Foo) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias swiftself captures(none) dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 sil @generic_type_generic_method_witness : $@convention(witness_method: P) <T, U, V, Z> (@in Z, @in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $*Bar<T, U, V>):
   %t = metatype $@thick T.Type

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -57,14 +57,14 @@ struct Conformer2: Q {
   func qMethod() {}
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18sil_witness_tables7erasure1cAA2QQ_pAA9ConformerV_tF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18sil_witness_tables7erasure1cAA2QQ_pAA9ConformerV_tF"(ptr noalias sret({{.*}}) captures(none) %0)
 // CHECK:         [[WITNESS_TABLE_ADDR:%.*]] = getelementptr inbounds{{.*}} %T18sil_witness_tables2QQP, ptr %0, i32 0, i32 2
 // CHECK-NEXT:    store ptr [[CONFORMER_QQ_WITNESS_TABLE:@"\$s.*WP"]], ptr [[WITNESS_TABLE_ADDR]], align 8
 func erasure(c: Conformer) -> QQ {
   return c
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18sil_witness_tables15externalErasure1c0a1_b1_c1_D12_conformance9ExternalP_pAD0G9ConformerV_tF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18sil_witness_tables15externalErasure1c0a1_b1_c1_D12_conformance9ExternalP_pAD0G9ConformerV_tF"(ptr noalias sret({{.*}}) captures(none) %0)
 // CHECK:         [[WITNESS_TABLE_ADDR:%.*]] = getelementptr inbounds{{.*}} %T39sil_witness_tables_external_conformance9ExternalPP, ptr %0, i32 0, i32 2
 // CHECK-NEXT:    store ptr [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE]], ptr %2, align 8
 func externalErasure(c: ExternalConformer) -> ExternalP {

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -80,7 +80,7 @@ public struct MySize {
   public let h: Int
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience32functionWithMyResilientTypesSize_1fAA0eH0VAEn_A2EnXEtF"(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{8|(16)}}) %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience32functionWithMyResilientTypesSize_1fAA0eH0VAEn_A2EnXEtF"(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{8|(16)}}) %1, ptr %2, ptr %3)
 public func functionWithMyResilientTypesSize(_ s: __owned MySize, f: (__owned MySize) -> MySize) -> MySize {
 
 // There's an alloca for debug info?
@@ -108,7 +108,7 @@ public func functionWithMyResilientTypesSize(_ s: __owned MySize, f: (__owned My
 // CHECK: store [[INT]] [[H]], ptr [[H_PTR]]
 
 
-// CHECK: call swiftcc void %2(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{8|16}}) [[DST]], ptr swiftself %3)
+// CHECK: call swiftcc void %2(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{8|16}}) [[DST]], ptr swiftself %3)
 // CHECK: call void @llvm.lifetime.end.p0({{i32|i64}} {{8|16}}, ptr [[DST]])
 
 // CHECK: ret void
@@ -164,7 +164,7 @@ public struct ResilientStructWithMethod {
 
 // Corner case -- type is address-only in SIL, but empty in IRGen
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience29partialApplyOfResilientMethod1ryAA0f10StructWithG0V_tF"(ptr noalias {{(nocapture|captures\(none\))}} %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience29partialApplyOfResilientMethod1ryAA0f10StructWithG0V_tF"(ptr noalias captures(none) %0)
 public func partialApplyOfResilientMethod(r: ResilientStructWithMethod) {
   _ = r.method
 }
@@ -190,7 +190,7 @@ public func resilientAny(s : ResilientWeakRef) {
 // CHECK: [[TYADDR:%.*]] = getelementptr inbounds{{.*}} %Any, ptr [[ANY]], i32 0, i32 1
 // CHECK: store ptr [[META2]], ptr [[TYADDR]]
 // CHECK: call ptr @__swift_allocate_boxed_opaque_existential_0(ptr [[ANY]])
-// CHECK: call swiftcc void @"$s17struct_resilience8wantsAnyyyypF"(ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{(32|16)}}) [[ANY]])
+// CHECK: call swiftcc void @"$s17struct_resilience8wantsAnyyyypF"(ptr noalias captures(none) dereferenceable({{(32|16)}}) [[ANY]])
 // CHECK: call void @__swift_destroy_boxed_opaque_existential_0(ptr [[ANY]])
 // CHECK: ret void
 

--- a/test/IRGen/struct_with_resilient_type.swift
+++ b/test/IRGen/struct_with_resilient_type.swift
@@ -44,7 +44,7 @@ crashCaller()
 
 // Don't use the type layout based value witness based generation (i.e we load field offsets below).
 
-// VWT-macosx: define {{.*}} ptr @"$s26struct_with_resilient_type9SomeValueVwta"(ptr noalias returned {{.*}}, ptr noalias {{.*}}, ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} [[MT:%.*]])
+// VWT-macosx: define {{.*}} ptr @"$s26struct_with_resilient_type9SomeValueVwta"(ptr noalias returned {{.*}}, ptr noalias {{.*}}, ptr readonly captures(none) [[MT:%.*]])
 // VWT-macosx:   [[VAL1:%.*]] = load i64
 // VWT-macosx:   store i64 [[VAL1]]
 // VWT-macosx:   [[T1:%.*]] = tail call swiftcc %swift.metadata_response @"$s16resilient_struct13ResilientBoolVMa"(i64 0)

--- a/test/IRGen/typed_throws.sil
+++ b/test/IRGen/typed_throws.sil
@@ -18,7 +18,7 @@ sil_vtable A {}
 
 sil @create_error : $@convention(thin) () -> @owned A
 
-// CHECK: define{{.*}} swiftcc { ptr, ptr } @throw_error(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %1)
+// CHECK: define{{.*}} swiftcc { ptr, ptr } @throw_error(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %1)
 // CHECK:   [[ERR:%.*]] = call swiftcc ptr @create_error()
 // CHECK:   call ptr @swift_retain(ptr returned [[ERR]])
 // CHECK:   store ptr inttoptr (i64 1 to ptr), ptr %1
@@ -47,7 +47,7 @@ sil @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObje
 // CHECK: entry:
 // CHECK:   %swifterror = alloca swifterror ptr
 // CHECK:   store ptr null, ptr %swifterror
-// CHECK:   [[RES:%.*]] = call swiftcc { ptr, ptr } @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %swifterror)
+// CHECK:   [[RES:%.*]] = call swiftcc { ptr, ptr } @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %swifterror)
 // CHECK:   [[RES_0:%.*]] = extractvalue { ptr, ptr } [[RES]], 0
 // CHECK:   [[RES_1:%.*]] = extractvalue { ptr, ptr } [[RES]], 1
 // CHECK:   [[ERRFLAG:%.*]] = load ptr, ptr %swifterror
@@ -209,8 +209,8 @@ bb6:
   return %7 : $()
 }
 
-// CHECK: define{{.*}} internal swiftcc { ptr, ptr } @"$s16try_apply_helperTA"(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %1)
-// CHECK:   tail call swiftcc { ptr, ptr } @try_apply_helper(ptr {{.*}}, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %1)
+// CHECK: define{{.*}} internal swiftcc { ptr, ptr } @"$s16try_apply_helperTA"(ptr swiftself %0, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %1)
+// CHECK:   tail call swiftcc { ptr, ptr } @try_apply_helper(ptr {{.*}}, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %1)
 // CHECK:   ret { ptr, ptr }
 
 sil @partial_apply_test : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed () ->(@owned AnyObject, @error S) {
@@ -234,7 +234,7 @@ entry(%0: $AnyObject):
 // CHECK:entry:
 // CHECK:  %swifterror = alloca swifterror ptr
 // CHECK:  store ptr null, ptr %swifterror
-// CHECK:  call swiftcc { ptr, ptr } %0(ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{[0-9]+}}) %swifterror)
+// CHECK:  call swiftcc { ptr, ptr } %0(ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable({{[0-9]+}}) %swifterror)
 
 sil @apply_closure : $@convention(thin) (@guaranteed @callee_guaranteed () -> (@owned AnyObject, @error S)) -> () {
 entry(%0 : $@callee_guaranteed () ->(@owned AnyObject, @error S)):
@@ -272,7 +272,7 @@ bb6:
   return %t : $()
 }
 
-// CHECK: define{{.*}} swiftcc void @throwNoError(i64 %0, ptr noalias %1, ptr %"\CF\84_0_0", ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %3, ptr %4)
+// CHECK: define{{.*}} swiftcc void @throwNoError(i64 %0, ptr noalias %1, ptr %"\CF\84_0_0", ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3, ptr %4)
 // CHECK:  ret void
 
 sil @throwNoError : $@convention(thin) <τ_0_0> (Builtin.Int64, @in τ_0_0) -> @error_indirect τ_0_0 {
@@ -281,14 +281,14 @@ bb0(%0: $*τ_0_0, %1 : $Builtin.Int64, %2 : $*τ_0_0):
   return %5 : $()
 }
 
-// CHECK: define{{.*}} swiftcc void @throwNoErrorGenericOut(ptr noalias sret(%swift.opaque) %0, i64 %1, ptr noalias %2, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr swiftself %3, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %4, ptr %5)
+// CHECK: define{{.*}} swiftcc void @throwNoErrorGenericOut(ptr noalias sret(%swift.opaque) %0, i64 %1, ptr noalias %2, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr swiftself %3, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %4, ptr %5)
 
 sil @throwNoErrorGenericOut : $@convention(thin) <τ_0_0, τ_0_1> (Builtin.Int64, @in τ_0_0) -> (@error_indirect τ_0_0, @out τ_0_1) {
 bb0(%0: $*τ_0_1, %1: $*τ_0_0, %2 : $Builtin.Int64, %3 : $*τ_0_0):
   %5 = tuple ()
   return %5 : $()
 }
-// CHECK: define{{.*}} swiftcc void @throwError(i64 %0, ptr noalias %1, ptr %"\CF\84_0_0", ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.*}}) %3, ptr %4)
+// CHECK: define{{.*}} swiftcc void @throwError(i64 %0, ptr noalias %1, ptr %"\CF\84_0_0", ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable({{.*}}) %3, ptr %4)
 // CHECK: entry:
 // CHECK:  load ptr, ptr
 // CHECK:  [[VW:%.*]] = load ptr, ptr
@@ -309,7 +309,7 @@ sil @throwError2 : $@convention(thin) <T, V> (Builtin.Int64, @in T) -> (@error_i
 // CHECK:   store ptr null, ptr %swifterror
 // CHECK:   [[SIZE:%.*]] = load i64
 // CHECK:   [[TYPEDERR:%.*]] = alloca i8, i64 [[SIZE]]
-// CHECK:   call swiftcc void @throwError2(ptr noalias sret(%swift.opaque) %0, i64 0, ptr noalias %1, ptr %T, ptr %V, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr [[TYPEDERR]])
+// CHECK:   call swiftcc void @throwError2(ptr noalias sret(%swift.opaque) %0, i64 0, ptr noalias %1, ptr %T, ptr %V, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr [[TYPEDERR]])
 // CHECK:   [[ERR_FLAG:%.*]] = load ptr, ptr %swifterror
 // CHECK:   [[ISERR:%.*]] = icmp ne ptr [[ERR_FLAG]], null
 // CHECK:   br i1 [[ISERR]]
@@ -379,8 +379,8 @@ bb3:
 
 sil @try_apply_helper_generic : $@convention(thin) <T> (@in T) -> (@out T, @error_indirect T)
 
-// CHECK: define{{.*}} internal swiftcc void @"$s24try_apply_helper_genericTA"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3)
-// CHECK:   call swiftcc void @try_apply_helper_generic(ptr noalias sret(%swift.opaque) %0, ptr noalias {{%.*}}, ptr %T, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3)
+// CHECK: define{{.*}} internal swiftcc void @"$s24try_apply_helper_genericTA"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3)
+// CHECK:   call swiftcc void @try_apply_helper_generic(ptr noalias sret(%swift.opaque) %0, ptr noalias {{%.*}}, ptr %T, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3)
 
 sil @partial_apply_test_generic : $@convention(thin) <T> (@in T) -> @owned @callee_guaranteed () ->(@out T, @error_indirect T) {
 entry(%0: $*T):
@@ -411,7 +411,7 @@ entry(%0: $*T):
 // CHECK:  [[V2:%.*]] = getelementptr inbounds{{.*}} %swift.vwtable{{.*}}
 // CHECK:  [[V3:%.*]] = load i64, ptr [[V2]]
 // CHECK:  [[V4:%.*]] = alloca i8, i64 [[V3]]
-// CHECK: call swiftcc void %0(ptr noalias sret(%swift.opaque) [[T4]], ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr [[V4]])
+// CHECK: call swiftcc void %0(ptr noalias sret(%swift.opaque) [[T4]], ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr [[V4]])
 sil @apply_closure_generic : $@convention(thin) <T, V> (@guaranteed @callee_guaranteed () ->(@out T, @error_indirect V)) -> () {
 entry(%0 : $@callee_guaranteed () ->(@out T, @error_indirect V)):
   %err = alloc_stack $V

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -75,7 +75,7 @@ func reabstractAsConcreteThrowing() throws -> Int {
   try passthroughCall(fiveOrTypedBust)
 }
 
-// CHECK-LABEL: define {{.*}} swiftcc void @"$sSi12typed_throws10MyBigErrorOIgdzo_SiACIegrzr_TR"(ptr noalias{{( nocapture)?}} sret(%TSi){{( captures\(none\))?}} %0, ptr %1, ptr %2, ptr swiftself %3, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %4, ptr %5)
+// CHECK-LABEL: define {{.*}} swiftcc void @"$sSi12typed_throws10MyBigErrorOIgdzo_SiACIegrzr_TR"(ptr noalias sret(%TSi) captures(none) %0, ptr %1, ptr %2, ptr swiftself %3, ptr noalias swifterror captures(none) dereferenceable(8) %4, ptr %5)
 // CHECK: call swiftcc {{i32|i64}} %1
 // CHECK: [[CMP:%.*]] = icmp ne ptr {{%.*}}, null
 // CHECK: br i1 [[CMP]], label %typed.error.load
@@ -107,7 +107,7 @@ func throwsSmallError() throws(SmallError) -> (Float, Int) {
 }
 
 // CHECK: define hidden swiftcc i64 @"$s12typed_throws17catchesSmallErrorSiyF"()
-// CHECK:   [[RES:%.*]] = call swiftcc { float, i64 } @"$s12typed_throws0B10SmallErrorSf_SityAA0cD0VYKF"(ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[RES:%.*]] = call swiftcc { float, i64 } @"$s12typed_throws0B10SmallErrorSf_SityAA0cD0VYKF"(ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[R0:%.*]] = extractvalue { float, i64 } [[RES]], 0
 // CHECK:   [[R1:%.*]] = extractvalue { float, i64 } [[RES]], 1
 // CHECK:   phi i64 [ [[R1]], %typed.error.load ]
@@ -316,7 +316,7 @@ func smallResultLargerError() throws(SmallError) -> Int8? {
 }
 
 // CHECK:  [[COERCED:%.*]] = alloca { i16 }, align 2
-// CHECK:  [[RES:%.*]] = call swiftcc i64 @"$s12typed_throws22smallResultLargerErrors4Int8VSgyAA05SmallF0VYKF"(ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:  [[RES:%.*]] = call swiftcc i64 @"$s12typed_throws22smallResultLargerErrors4Int8VSgyAA05SmallF0VYKF"(ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:  [[TRUNC:%.*]] = trunc i64 [[RES]] to i16
 // CHECK:  [[COERCED_PTR:%.*]] = getelementptr inbounds{{.*}} { i16 }, ptr [[COERCED]], i32 0, i32 0
 // CHECK:  store i16 [[TRUNC]], ptr [[COERCED_PTR]], align 2
@@ -335,7 +335,7 @@ func smallErrorLargerResult() throws(UInt8OptSingletonError) -> Int {
 }
 
 // CHECK:  [[COERCED:%.*]] = alloca { i16 }, align 2
-// CHECK:  [[RES:%.*]] = call swiftcc i64 @"$s12typed_throws22smallErrorLargerResultSiyAA017UInt8OptSingletonD0OYKF"(ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:  [[RES:%.*]] = call swiftcc i64 @"$s12typed_throws22smallErrorLargerResultSiyAA017UInt8OptSingletonD0OYKF"(ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:  [[TRUNC:%.*]] = trunc i64 [[RES]] to i16
 // CHECK:  [[COERCED_PTR:%.*]] = getelementptr inbounds{{.*}} { i16 }, ptr [[COERCED]], i32 0, i32 0
 // CHECK:  store i16 [[TRUNC]], ptr [[COERCED_PTR]], align 2

--- a/test/IRGen/typed_throws_abi.swift
+++ b/test/IRGen/typed_throws_abi.swift
@@ -21,7 +21,7 @@ struct ThreeWords: Error {
 }
 
 struct Impl: P {
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2f0yySbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2f0yySbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   ret void
@@ -38,7 +38,7 @@ struct Impl: P {
         }
     }
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2f1ySiSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2f1ySiSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   ret i64 1
@@ -56,7 +56,7 @@ struct Impl: P {
         return 1
     }
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2f2ySi_SitSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2f2ySi_SitSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   ret { i64, i64 } { i64 1, i64 2 }
@@ -74,7 +74,7 @@ struct Impl: P {
         return (1, 2)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f3ySi_S2itSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f3ySi_S2itSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   ret { i64, i64, i64 } { i64 1, i64 2, i64 3 }
@@ -92,7 +92,7 @@ struct Impl: P {
         return (1, 2, 3)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f4ySi_S3itSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f4ySi_S3itSbAA5EmptyVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   ret { i64, i64, i64, i64 } { i64 1, i64 2, i64 3, i64 4 }
@@ -110,7 +110,7 @@ struct Impl: P {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2f5ySi_S4itSbAA5EmptyVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2f5ySi_S4itSbAA5EmptyVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4)
     // CHECK:   br i1 %1, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
     // CHECK:   store i64 1, ptr %.elt._value, align 8
@@ -133,7 +133,7 @@ struct Impl: P {
         return (1, 2, 3, 4, 5)
     }
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2g0yySbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2g0yySbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -151,7 +151,7 @@ struct Impl: P {
         }
     }
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2g1ySiSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi4ImplV2g1ySiSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -170,7 +170,7 @@ struct Impl: P {
         return 1
     }
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2g2ySi_SitSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2g2ySi_SitSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -189,7 +189,7 @@ struct Impl: P {
         return (1, 2)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g3ySi_S2itSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g3ySi_S2itSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -208,7 +208,7 @@ struct Impl: P {
         return (1, 2, 3)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g4ySi_S3itSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g4ySi_S3itSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -227,7 +227,7 @@ struct Impl: P {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2g5ySi_S4itSbAA7OneWordVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2g5ySi_S4itSbAA7OneWordVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4)
     // CHECK: entry:
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV, align 8
     // CHECK:   br i1 %1, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -252,7 +252,7 @@ struct Impl: P {
         return (1, 2, 3, 4, 5)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h0yySbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h0yySbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -270,7 +270,7 @@ struct Impl: P {
         }
     }
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h1ySiSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h1ySiSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -289,7 +289,7 @@ struct Impl: P {
         return 1
     }
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h2ySi_SitSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h2ySi_SitSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -308,7 +308,7 @@ struct Impl: P {
         return (1, 2)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h3ySi_S2itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h3ySi_S2itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -327,7 +327,7 @@ struct Impl: P {
         return (1, 2, 3)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h4ySi_S3itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h4ySi_S3itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -346,7 +346,7 @@ struct Impl: P {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2h5ySi_S4itSbAA8TwoWordsVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2h5ySi_S4itSbAA8TwoWordsVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4)
     // CHECK: entry:
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV, align 8
     // CHECK:   br i1 %1, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -371,7 +371,7 @@ struct Impl: P {
         return (1, 2, 3, 4, 5)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i0yySbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i0yySbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -389,7 +389,7 @@ struct Impl: P {
         }
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i1ySiSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i1ySiSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -408,7 +408,7 @@ struct Impl: P {
         return 1
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i2ySi_SitSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i2ySi_SitSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -427,7 +427,7 @@ struct Impl: P {
         return (1, 2)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i3ySi_S2itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i3ySi_S2itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -446,7 +446,7 @@ struct Impl: P {
         return (1, 2, 3)
     }
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i4ySi_S3itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i4ySi_S3itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV
     // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -465,7 +465,7 @@ struct Impl: P {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2i5ySi_S4itSbAA10ThreeWordsVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi4ImplV2i5ySi_S4itSbAA10ThreeWordsVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4)
     // CHECK: entry:
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV, align 8
     // CHECK:   br i1 %1, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -494,7 +494,7 @@ struct Impl: P {
 // CHECK: define hidden swiftcc i1 @"$s16typed_throws_abi11callImpl_f0ySbAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2f0yySbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2f0yySbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
 // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
 // CHECK:   br i1 [[ISERROR]], label %typed.error.load, label %[[SUCCESS:.*]]
@@ -521,7 +521,7 @@ func callImpl_f0(_ impl: Impl, _ b: Bool) -> Bool {
 // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi11callImpl_f1ySiAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2f1ySiSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2f1ySiSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
 // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
 // CHECK:   br i1 [[ISERROR]], label %typed.error.load, label %[[SUCCESS:.*]]
@@ -548,7 +548,7 @@ func callImpl_f1(_ impl: Impl, _ b: Bool) -> Int {
 // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi11callImpl_f2ySi_SitAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2f2ySi_SitSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2f2ySi_SitSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
@@ -581,7 +581,7 @@ func callImpl_f2(_ impl: Impl, _ b: Bool) -> (Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_f3ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f3ySi_S2itSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f3ySi_S2itSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -618,7 +618,7 @@ func callImpl_f3(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi11callImpl_f4ySi_S3itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f4ySi_S3itSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2f4ySi_S3itSbAA5EmptyVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 2
@@ -656,12 +656,12 @@ func callImpl_f4(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int) {
     }
 }
 
-// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_f5ySi_S4itAA0E0V_SbtF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1)
+// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_f5ySi_S4itAA0E0V_SbtF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
 // CHECK:   %swifterror1 = alloca ptr, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
-// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2f5ySi_S4itSbAA5EmptyVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr %swifterror1)
+// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2f5ySi_S4itSbAA5EmptyVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr %swifterror1)
 // CHECK:   [[CALL_RES0:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES1:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES2:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
@@ -706,7 +706,7 @@ func callImpl_f5(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int, Int) {
 // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi11callImpl_g0ySiAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2g0yySbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2g0yySbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
 // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
 // CHECK:   br i1 [[ISERROR]], label %typed.error.load, label %[[SUCCESS:.*]]
@@ -734,7 +734,7 @@ func callImpl_g0(_ impl: Impl, _ b: Bool) -> Int {
 // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi11callImpl_g1ySiAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2g1ySiSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc i64 @"$s16typed_throws_abi4ImplV2g1ySiSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
 // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
 // CHECK:   br i1 [[ISERROR]], label %typed.error.load, label %[[SUCCESS:.*]]
@@ -762,7 +762,7 @@ func callImpl_g1(_ impl: Impl, _ b: Bool) -> Int {
 // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi11callImpl_g2ySi_SitAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2g2ySi_SitSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2g2ySi_SitSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
@@ -796,7 +796,7 @@ func callImpl_g2(_ impl: Impl, _ b: Bool) -> (Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_g3ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g3ySi_S2itSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g3ySi_S2itSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -834,7 +834,7 @@ func callImpl_g3(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi11callImpl_g4ySi_S3itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g4ySi_S3itSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2g4ySi_S3itSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 2
@@ -873,12 +873,12 @@ func callImpl_g4(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int) {
     }
 }
 
-// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_g5ySi_S4itAA0E0V_SbtF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1)
+// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_g5ySi_S4itAA0E0V_SbtF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
 // CHECK:   %swifterror1 = alloca %T16typed_throws_abi7OneWordV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
-// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2g5ySi_S4itSbAA7OneWordVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr %swifterror1)
+// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2g5ySi_S4itSbAA7OneWordVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr %swifterror1)
 // CHECK:   [[CALL_RES0:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES1:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES2:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
@@ -927,7 +927,7 @@ func callImpl_g5(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi11callImpl_h0ySi_SitAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h0yySbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h0yySbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
@@ -961,7 +961,7 @@ func callImpl_h0(_ impl: Impl, _ b: Bool) -> (Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi11callImpl_h1ySi_SitAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h1ySiSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h1ySiSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
@@ -995,7 +995,7 @@ func callImpl_h1(_ impl: Impl, _ b: Bool) -> (Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi11callImpl_h2ySi_SitAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h2ySi_SitSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64 } @"$s16typed_throws_abi4ImplV2h2ySi_SitSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[ERROR:%.*]] = load ptr, ptr %swifterror, align 8
@@ -1030,7 +1030,7 @@ func callImpl_h2(_ impl: Impl, _ b: Bool) -> (Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_h3ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h3ySi_S2itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h3ySi_S2itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -1069,7 +1069,7 @@ func callImpl_h3(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi11callImpl_h4ySi_S3itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h4ySi_S3itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2h4ySi_S3itSbAA8TwoWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 2
@@ -1109,12 +1109,12 @@ func callImpl_h4(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int) {
     }
 }
 
-// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_h5ySi_S4itAA0E0V_SbtF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1)
+// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_h5ySi_S4itAA0E0V_SbtF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
 // CHECK:   %swifterror1 = alloca %T16typed_throws_abi8TwoWordsV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
-// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2h5ySi_S4itSbAA8TwoWordsVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr %swifterror1)
+// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2h5ySi_S4itSbAA8TwoWordsVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr %swifterror1)
 // CHECK:   [[CALL_RES0:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES1:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES2:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
@@ -1165,7 +1165,7 @@ func callImpl_h5(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_i0ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i0yySbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i0yySbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -1203,7 +1203,7 @@ func callImpl_i0(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_i1ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i1ySiSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i1ySiSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -1241,7 +1241,7 @@ func callImpl_i1(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_i2ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i2ySi_SitSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i2ySi_SitSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -1281,7 +1281,7 @@ func callImpl_i2(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi11callImpl_i3ySi_S2itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i3ySi_S2itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i3ySi_S2itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64 } [[CALL_RES]], 2
@@ -1321,7 +1321,7 @@ func callImpl_i3(_ impl: Impl, _ b: Bool) -> (Int, Int, Int) {
 // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi11callImpl_i4ySi_S3itAA0E0V_SbtF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i4ySi_S3itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi4ImplV2i4ySi_S3itSbAA10ThreeWordsVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { i64, i64, i64, i64 } [[CALL_RES]], 2
@@ -1362,12 +1362,12 @@ func callImpl_i4(_ impl: Impl, _ b: Bool) -> (Int, Int, Int, Int) {
     }
 }
 
-// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_i5ySi_S4itAA0E0V_SbtF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1)
+// CHECK: define hidden swiftcc void @"$s16typed_throws_abi11callImpl_i5ySi_S4itAA0E0V_SbtF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
 // CHECK:   %swifterror1 = alloca %T16typed_throws_abi10ThreeWordsV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
-// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2i5ySi_S4itSbAA10ThreeWordsVYKF"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror, ptr %swifterror1)
+// CHECK:   call swiftcc void @"$s16typed_throws_abi4ImplV2i5ySi_S4itSbAA10ThreeWordsVYKF"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %call.aggresult, i1 %1, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror, ptr %swifterror1)
 // CHECK:   [[CALL_RES0:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES1:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
 // CHECK:   [[CALL_RES2:%.*]] = load i64, ptr {{%call.aggresult.*}}, align 8
@@ -1519,7 +1519,7 @@ struct ImplAsync: PAsync {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2f5ySi_S4itSbYaAA5EmptyVYKF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr %3)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2f5ySi_S4itSbYaAA5EmptyVYKF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3)
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   br i1 %2, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
     // CHECK: [[SUCCESS]]:
@@ -1648,7 +1648,7 @@ struct ImplAsync: PAsync {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2g5ySi_S4itSbYaAA7OneWordVYKF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr %3)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2g5ySi_S4itSbYaAA7OneWordVYKF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi7OneWordV, align 8
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   br i1 %2, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -1778,7 +1778,7 @@ struct ImplAsync: PAsync {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2h5ySi_S4itSbYaAA8TwoWordsVYKF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr %3)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2h5ySi_S4itSbYaAA8TwoWordsVYKF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi8TwoWordsV, align 8
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   br i1 %2, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -1908,7 +1908,7 @@ struct ImplAsync: PAsync {
         return (1, 2, 3, 4)
     }
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2i5ySi_S4itSbYaAA10ThreeWordsVYKF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr %3)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi9ImplAsyncV2i5ySi_S4itSbYaAA10ThreeWordsVYKF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr %3)
     // CHECK:   [[ERROR:%.*]] = alloca %T16typed_throws_abi10ThreeWordsV, align 8
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   br i1 %2, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
@@ -2127,7 +2127,7 @@ func callImplAsync_f4(_ impl: ImplAsync, _ b: Bool) async -> (Int, Int, Int, Int
     }
 }
 
-// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_f5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2)
+// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_f5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2)
 // CHECK:   %swifterror = alloca ptr, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
 // CHECK:   %swifterror1 = alloca swifterror ptr, align 8
@@ -2381,7 +2381,7 @@ func callImplAsync_g4(_ impl: ImplAsync, _ b: Bool) async -> (Int, Int, Int, Int
 }
 
 
-// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_g5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2)
+// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_g5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2)
 // CHECK:   %swifterror = alloca %T16typed_throws_abi7OneWordV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
 // CHECK:   %swifterror1 = alloca swifterror ptr, align 8
@@ -2647,7 +2647,7 @@ func callImplAsync_h4(_ impl: ImplAsync, _ b: Bool) async -> (Int, Int, Int, Int
 }
 
 
-// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_h5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2)
+// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_h5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2)
 // CHECK:   %swifterror = alloca %T16typed_throws_abi8TwoWordsV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
 // CHECK:   %swifterror1 = alloca swifterror ptr, align 8
@@ -2927,7 +2927,7 @@ func callImplAsync_i4(_ impl: ImplAsync, _ b: Bool) async -> (Int, Int, Int, Int
 }
 
 
-// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_i5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2)
+// CHECK: define hidden swifttailcc void @"$s16typed_throws_abi16callImplAsync_i5ySi_S4itAA0eF0V_SbtYaF"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2)
 // CHECK:   %swifterror = alloca %T16typed_throws_abi10ThreeWordsV, align 8
 // CHECK:   %call.aggresult = alloca <{ %TSi, %TSi, %TSi, %TSi, %TSi }>, align 8
 // CHECK:   %swifterror1 = alloca swifterror ptr, align 8
@@ -2989,7 +2989,7 @@ func callImplAsync_i5(_ impl: ImplAsync, _ b: Bool) async -> (Int, Int, Int, Int
     }
 }
 
-// CHECK: define hidden swiftcc { float, float, i64 } @"$s16typed_throws_abi14nonMatching_f0ySf_SftSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+// CHECK: define hidden swiftcc { float, float, i64 } @"$s16typed_throws_abi14nonMatching_f0ySf_SftSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
 // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
 // CHECK: [[SUCCESS]]:
 // CHECK:   ret { float, float, i64 } { float 1.000000e+00, float 2.000000e+00, i64 undef }
@@ -3009,7 +3009,7 @@ func nonMatching_f0(_ b: Bool) throws(OneWord) -> (Float, Float) {
 // CHECK: define hidden swiftcc { i64, float, float } @"$s16typed_throws_abi18callNonMatching_f0ySi_S2ftSbF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
 // CHECK:   store ptr null, ptr %swifterror, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { float, float, i64 } @"$s16typed_throws_abi14nonMatching_f0ySf_SftSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { float, float, i64 } @"$s16typed_throws_abi14nonMatching_f0ySf_SftSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { float, float, i64 } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { float, float, i64 } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { float, float, i64 } [[CALL_RES]], 2
@@ -3044,7 +3044,7 @@ func callNonMatching_f0(_ b: Bool) -> (Int, Float, Float) {
     }
 }
 
-// define hidden swiftcc { float, i64, float } @"$s16typed_throws_abi14nonMatching_f1ySf_SbSftSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2)
+// define hidden swiftcc { float, i64, float } @"$s16typed_throws_abi14nonMatching_f1ySf_SbSftSbAA7OneWordVYKF"(i1 %0, ptr swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2)
 // CHECK:   br i1 %0, label %[[SUCCESS:.*]], label %[[FAIL:.*]]
 // CHECK: [[SUCCESS]]:
 // CHECK:   ret { float, i64, float } { float 1.000000e+00, i64 1, float 2.000000e+00 }
@@ -3063,7 +3063,7 @@ func nonMatching_f1(_ b: Bool) throws(OneWord) -> (Float, Bool, Float) {
 
 // CHECK: define hidden swiftcc { i64, float, i1, float } @"$s16typed_throws_abi18callNonMatching_f1ySi_SfSbSftSbF"(i1 %0)
 // CHECK:   %swifterror = alloca swifterror ptr, align 8
-// CHECK:   [[CALL_RES:%.*]] = call swiftcc { float, i64, float } @"$s16typed_throws_abi14nonMatching_f1ySf_SbSftSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %swifterror)
+// CHECK:   [[CALL_RES:%.*]] = call swiftcc { float, i64, float } @"$s16typed_throws_abi14nonMatching_f1ySf_SbSftSbAA7OneWordVYKF"(i1 %0, ptr swiftself undef, ptr noalias swifterror captures(none) dereferenceable(8) %swifterror)
 // CHECK:   [[CALL_RES0:%.*]] = extractvalue { float, i64, float } [[CALL_RES]], 0
 // CHECK:   [[CALL_RES1:%.*]] = extractvalue { float, i64, float } [[CALL_RES]], 1
 // CHECK:   [[CALL_RES2:%.*]] = extractvalue { float, i64, float } [[CALL_RES]], 2
@@ -3225,7 +3225,7 @@ func callNonMatching_f1_async(_ b: Bool) async -> (Int, Float, Bool, Float) {
 }
 
 protocol P {
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2f0yySbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2f0yySbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3236,7 +3236,7 @@ protocol P {
     // CHECK: }
     func f0(_ b: Bool) throws(Empty)
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2f1ySiSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2f1ySiSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3247,7 +3247,7 @@ protocol P {
     // CHECK: }
     func f1(_ b: Bool) throws(Empty) -> Int
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2f2ySi_SitSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2f2ySi_SitSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3258,7 +3258,7 @@ protocol P {
     // CHECK: }
     func f2(_ b: Bool) throws(Empty) -> (Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2f3ySi_S2itSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2f3ySi_S2itSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3269,7 +3269,7 @@ protocol P {
     // CHECK: }
     func f3(_ b: Bool) throws(Empty) -> (Int, Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2f4ySi_S3itSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2f4ySi_S3itSbAA5EmptyVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3280,13 +3280,13 @@ protocol P {
     // CHECK: }
     func f4(_ b: Bool) throws(Empty) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2f5ySi_S4itSbAA5EmptyVYKFTj"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
-    // CHECK:   call swiftcc void {{%.*}}(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2f5ySi_S4itSbAA5EmptyVYKFTj"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK:   call swiftcc void {{%.*}}(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   ret void
     // CHECK: }
     func f5(_ b: Bool) throws(Empty) -> (Int, Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2g0yySbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2g0yySbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3297,7 +3297,7 @@ protocol P {
     // CHECK: }
     func g0(_ b: Bool) throws(OneWord)
 
-    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2g1ySiSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc i64 @"$s16typed_throws_abi1PP2g1ySiSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3308,7 +3308,7 @@ protocol P {
     // CHECK: }
     func g1(_ b: Bool) throws(OneWord) -> Int
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2g2ySi_SitSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2g2ySi_SitSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3319,7 +3319,7 @@ protocol P {
     // CHECK: }
     func g2(_ b: Bool) throws(OneWord) -> (Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2g3ySi_S2itSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2g3ySi_S2itSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3330,7 +3330,7 @@ protocol P {
     // CHECK: }
     func g3(_ b: Bool) throws(OneWord) -> (Int, Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2g4ySi_S3itSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2g4ySi_S3itSbAA7OneWordVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3341,13 +3341,13 @@ protocol P {
     // CHECK: }
     func g4(_ b: Bool) throws(OneWord) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2g5ySi_S4itSbAA7OneWordVYKFTj"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
-    // CHECK:   call swiftcc void {{%.*}}(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2g5ySi_S4itSbAA7OneWordVYKFTj"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK:   call swiftcc void {{%.*}}(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   ret void
     // CHECK: }
     func g5(_ b: Bool) throws(OneWord) -> (Int, Int, Int, Int, Int)
 
-    // CHECK:  define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h0yySbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK:  define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h0yySbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3358,7 +3358,7 @@ protocol P {
     // CHECK: }
     func h0(_ b: Bool) throws(TwoWords)
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h1ySiSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h1ySiSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3369,7 +3369,7 @@ protocol P {
     // CHECK: }
     func h1(_ b: Bool) throws(TwoWords) -> Int
 
-    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h2ySi_SitSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64 } @"$s16typed_throws_abi1PP2h2ySi_SitSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3380,7 +3380,7 @@ protocol P {
     // CHECK: }
     func h2(_ b: Bool) throws(TwoWords) -> (Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2h3ySi_S2itSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2h3ySi_S2itSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3391,7 +3391,7 @@ protocol P {
     // CHECK: }
     func h3(_ b: Bool) throws(TwoWords) -> (Int, Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2h4ySi_S3itSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2h4ySi_S3itSbAA8TwoWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3402,13 +3402,13 @@ protocol P {
     // CHECK: }
     func h4(_ b: Bool) throws(TwoWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2h5ySi_S4itSbAA8TwoWordsVYKFTj"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
-    // CHECK:   call swiftcc void {{%.*}}(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2h5ySi_S4itSbAA8TwoWordsVYKFTj"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK:   call swiftcc void {{%.*}}(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   ret void
     // CHECK: }
     func h5(_ b: Bool) throws(TwoWords) -> (Int, Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i0yySbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i0yySbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3419,7 +3419,7 @@ protocol P {
     // CHECK: }
     func i0(_ b: Bool) throws(ThreeWords)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i1ySiSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i1ySiSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3430,7 +3430,7 @@ protocol P {
     // CHECK: }
     func i1(_ b: Bool) throws(ThreeWords) -> Int
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i2ySi_SitSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i2ySi_SitSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3441,7 +3441,7 @@ protocol P {
     // CHECK: }
     func i2(_ b: Bool) throws(ThreeWords) -> (Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i3ySi_S2itSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64 } @"$s16typed_throws_abi1PP2i3ySi_S2itSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3452,7 +3452,7 @@ protocol P {
     // CHECK: }
     func i3(_ b: Bool) throws(ThreeWords) -> (Int, Int, Int)
 
-    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2i4ySi_S3itSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %2, ptr %3, ptr %4)
+    // CHECK: define hidden swiftcc { i64, i64, i64, i64 } @"$s16typed_throws_abi1PP2i4ySi_S3itSbAA10ThreeWordsVYKFTj"(i1 %0, ptr noalias swiftself %1, ptr noalias swifterror captures(none) dereferenceable(8) %2, ptr %3, ptr %4)
     // CHECK:   [[ERROR:%.*]] = load ptr, ptr %2
     // CHECK:   [[ISERROR:%.*]] = icmp ne ptr [[ERROR]], null
     // CHECK:   br i1 [[ISERROR]], label %failure, label %success
@@ -3463,8 +3463,8 @@ protocol P {
     // CHECK: }
     func i4(_ b: Bool) throws(ThreeWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2i5ySi_S4itSbAA10ThreeWordsVYKFTj"(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
-    // CHECK:   call swiftcc void {{%.*}}(ptr noalias{{( nocapture)?}} sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>){{( captures\(none\))?}} %0, i1 %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swiftcc void @"$s16typed_throws_abi1PP2i5ySi_S4itSbAA10ThreeWordsVYKFTj"(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+    // CHECK:   call swiftcc void {{%.*}}(ptr noalias sret(<{ %TSi, %TSi, %TSi, %TSi, %TSi }>) captures(none) %0, i1 %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   ret void
     // CHECK: }
     func i5(_ b: Bool) throws(ThreeWords) -> (Int, Int, Int, Int, Int)
@@ -3542,7 +3542,7 @@ protocol PAsync {
     // CHECK: }
     func f4(_ b: Bool) async throws(Empty) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2f5ySi_S4itSbYaAA5EmptyVYKFTj"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2f5ySi_S4itSbYaAA5EmptyVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3621,7 +3621,7 @@ protocol PAsync {
     // CHECK: }
     func g4(_ b: Bool) async throws(OneWord) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2g5ySi_S4itSbYaAA7OneWordVYKFTj"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2g5ySi_S4itSbYaAA7OneWordVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3700,7 +3700,7 @@ protocol PAsync {
     // CHECK: }
     func h4(_ b: Bool) async throws(TwoWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2h5ySi_S4itSbYaAA8TwoWordsVYKFTj"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2h5ySi_S4itSbYaAA8TwoWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror
@@ -3779,7 +3779,7 @@ protocol PAsync {
     // CHECK: }
     func i4(_ b: Bool) async throws(ThreeWords) -> (Int, Int, Int, Int)
 
-    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2i5ySi_S4itSbYaAA10ThreeWordsVYKFTj"(ptr noalias {{(nocapture|captures\(none\))}} %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
+    // CHECK: define hidden swifttailcc void @"$s16typed_throws_abi6PAsyncP2i5ySi_S4itSbYaAA10ThreeWordsVYKFTj"(ptr noalias captures(none) %0, ptr swiftasync %1, i1 %2, ptr noalias swiftself %3, ptr %4, ptr %5, ptr %6)
     // CHECK:   %swifterror = alloca swifterror ptr
     // CHECK:   [[CORO:%.*]] = call ptr @llvm.coro.begin(token {{%.*}}, ptr null)
     // CHECK:   store ptr null, ptr %swifterror

--- a/test/IRGen/typed_throws_thunks.swift
+++ b/test/IRGen/typed_throws_thunks.swift
@@ -45,9 +45,9 @@ extension P {
     }
   }
 
-  // CHECK-LABEL: define{{.*}} swiftcc void @"$s19typed_throws_thunks1PP2g24bodyyyy7FailureQzYKXE_tAGYKFTj"(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+  // CHECK-LABEL: define{{.*}} swiftcc void @"$s19typed_throws_thunks1PP2g24bodyyyy7FailureQzYKXE_tAGYKFTj"(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
 	// CHECK-NOT: ret
-  // CHECK: call swiftcc void {{.*}}(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
+  // CHECK: call swiftcc void {{.*}}(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5, ptr %6)
 
   public func g2(body: () throws(Failure) -> Void) throws(Failure) {
     do {
@@ -57,9 +57,9 @@ extension P {
     }
   }
 
-  // CHECK-LABEL: define{{.*}} swiftcc { i64, i64 } @"$s19typed_throws_thunks1PP2g34bodyyyyAA9FixedSizeVYKXE_tAGYKFTj"(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5)
+  // CHECK-LABEL: define{{.*}} swiftcc { i64, i64 } @"$s19typed_throws_thunks1PP2g34bodyyyyAA9FixedSizeVYKXE_tAGYKFTj"(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5)
   // CHECK-NOT: ret
-  // CHECK:  call swiftcc { i64, i64 } {{.*}}(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %3, ptr %4, ptr %5)
+  // CHECK:  call swiftcc { i64, i64 } {{.*}}(ptr %0, ptr %1, ptr noalias swiftself %2, ptr noalias swifterror captures(none) dereferenceable(8) %3, ptr %4, ptr %5)
 
 
   public func g3(body: () throws(FixedSize) -> Void) throws(FixedSize) {
@@ -69,7 +69,7 @@ extension P {
 protocol P2 {
 // CHECK-LABEL: define{{.*}} swiftcc void @"$s19typed_throws_thunks2P2P1fyyAA1EOYKFTj"(
 // CHECK-SAME:      ptr noalias swiftself %0, 
-// CHECK-SAME:      ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %1, 
+// CHECK-SAME:      ptr noalias swifterror captures(none) dereferenceable(8) %1, 
 // CHECK-SAME:      ptr %2, ptr %3
 // CHECK-SAME:  )
 // CHECK-SAME:  {
@@ -81,7 +81,7 @@ protocol P2 {
     func f() throws(E)
 // CHECK-LABEL: define{{.*}} swiftcc i8 @"$s19typed_throws_thunks2P2P1gyys4Int8VYKFTj"(
 // CHECk-SAME:      ptr noalias swiftself %0
-// CHECK-SAME:      ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %1
+// CHECK-SAME:      ptr noalias swifterror captures(none) dereferenceable(8) %1
 // CHECK-SAME:      ptr %2
 // CHECK-SAME:      ptr %3
 // CHECK-SAME:  )
@@ -93,7 +93,7 @@ protocol P2 {
     func g() throws(Int8)
 // CHECK-LABEL: define{{.*}} swiftcc i8 @"$s19typed_throws_thunks2P2P1hs4Int8VyAA1EOYKFTj"(
 // CHECK-SAME:      ptr noalias swiftself %0
-// CHECK-SAME:      ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %1
+// CHECK-SAME:      ptr noalias swifterror captures(none) dereferenceable(8) %1
 // CHECK-SAME:      ptr %2 
 // CHECK-SAME:      ptr %3
 // CHECK-SAME:  )
@@ -105,7 +105,7 @@ protocol P2 {
     func h() throws(E) -> Int8
 // CHECK-LABEL: define{{.*}} swiftcc i8 @"$s19typed_throws_thunks2P2P1is4Int8VyAFYKFTj"(
 // CHECK-SAME:      ptr noalias swiftself %0
-// CHECK-SAME:      ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable(8) %1
+// CHECK-SAME:      ptr noalias swifterror captures(none) dereferenceable(8) %1
 // CHECK-SAME:      ptr %2
 // CHECK-SAME:      ptr %3
 // CHECK-SAME:  )

--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -81,7 +81,7 @@ public enum ForwardEnum<T> {
 // CHECK: }
 
 
-// OPT: define{{.*}} void @"$s30typelayout_based_value_witness1AVwxx"(ptr noalias %object, ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} %"A<T>")
+// OPT: define{{.*}} void @"$s30typelayout_based_value_witness1AVwxx"(ptr noalias %object, ptr readonly captures(none) %"A<T>")
 // OPT:   [[T_PARAM:%.*]] = getelementptr inbounds{{.*}} i8, ptr %"A<T>", i64 16
 // OPT:   [[T:%.*]] = load ptr, ptr [[T_PARAM]]
 // OPT:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8, ptr [[T]], {{(i64|i32)}} -8
@@ -127,7 +127,7 @@ public enum ForwardEnum<T> {
 // OPT:   ret void
 // CHECK: }
 
-// OPT: define internal void @"$s30typelayout_based_value_witness2E3Owui"(ptr noalias{{( nocapture)?}} writeonly{{( captures\(none\))?}} %value, i32 %tag, ptr{{( nocapture)?}} readonly{{( captures\(none\))?}} %"E3<T>")
+// OPT: define internal void @"$s30typelayout_based_value_witness2E3Owui"(ptr noalias writeonly captures(none) %value, i32 %tag, ptr readonly captures(none) %"E3<T>")
 // OPT:  [[IS_EMPTY:%.*]] = icmp eq i32 {{%.*}}, 0
 // OPT:  br i1 [[IS_EMPTY]], label %empty-payload, label %non-empty-payload
 // OPT: }

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -10,7 +10,7 @@ sil_vtable C {}
 class D : C {}
 sil_vtable D {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @downcast_test(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr {{(nocapture|captures\(none\))}} dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @downcast_test(ptr noalias sret({{.*}}) captures(none) %0, ptr captures(none) dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[INPUTPTR:%[0-9]+]] = load ptr, ptr [[INPUTPTRPTR:%[0-9]+]], align 8
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s26unconditional_checked_cast1DCMa"(i64 0)

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -110,7 +110,7 @@ class TPSReport<CoverSheet> : Strategy {
   func disrupt() -> GrowthHack
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable({{4|8}}) %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(ptr noalias swiftself captures(none) dereferenceable({{4|8}}) %0, ptr %Self, ptr %SelfWitnessTable)
 
 sil @classArchetypeWitnessMethod : $@convention(witness_method: Strategy) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> () {
 entry(%self : $*T):
@@ -118,7 +118,7 @@ entry(%self : $*T):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable({{4|8}}) %1, ptr %T, ptr %CoverSheet)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{4|8}}) %1, ptr %T, ptr %CoverSheet)
 // CHECK: entry:
 // CHECK:  [[WITNESS_FN:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @"$s14witness_method9TPSReportCyxGAA8StrategyAAWP", i32 3)
 // CHECK: call swiftcc void [[WITNESS_FN]](ptr noalias sret({{.*}}) %0, ptr noalias swiftself %1, ptr %T, ptr @"$s14witness_method9TPSReportCyxGAA8StrategyAAWP")

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -57,7 +57,7 @@ entry:
   %1000 = integer_literal $Builtin.Int32, 1000
   apply %marker(%1000) : $@convention(thin) (Builtin.Int32) -> ()
 
-  // CHECK-NEXT:    call swiftcc void @make_big(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[TEMP]], ptr %C)
+  // CHECK-NEXT:    call swiftcc void @make_big(ptr noalias sret({{.*}}) captures(none) [[TEMP]], ptr %C)
   %make = function_ref @make_big : $@convention(thin) <T: SomeClass> () -> (@owned Big<T>)
   %value = apply %make<C>() : $@convention(thin) <T: SomeClass> () -> (@owned Big<T>)
 
@@ -171,8 +171,8 @@ cont:
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @test_simple_guaranteed
-// CHECK-32-SAME:  (ptr noalias dereferenceable([[BUFFER_SIZE:16]]) %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(32) %1, ptr %C)
-// CHECK-64-SAME:  (ptr noalias dereferenceable([[BUFFER_SIZE:32]]) %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(64) %1, ptr %C)
+// CHECK-32-SAME:  (ptr noalias dereferenceable([[BUFFER_SIZE:16]]) %0, ptr noalias captures(none) dereferenceable(32) %1, ptr %C)
+// CHECK-64-SAME:  (ptr noalias dereferenceable([[BUFFER_SIZE:32]]) %0, ptr noalias captures(none) dereferenceable(64) %1, ptr %C)
 sil [ossa] @test_simple_guaranteed : $@yield_once <C: SomeClass> (@in_guaranteed BigWrapper<C>) -> (@yields @guaranteed Big<C>) {
 entry(%arg : $*BigWrapper<C>):
   //   Allocate space for the return value of make_big.

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -42,7 +42,7 @@ entry:
   // CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[TEMP]])
   %temp = alloc_stack $Indirect<C>
 
-  // CHECK-NEXT:    call swiftcc void @make_indirect(ptr noalias{{( nocapture)?}} sret({{.*}}){{( captures\(none\))?}} [[TEMP]], ptr %C)
+  // CHECK-NEXT:    call swiftcc void @make_indirect(ptr noalias sret({{.*}}) captures(none) [[TEMP]], ptr %C)
   %make = function_ref @make_indirect : $@convention(thin) <T: SomeClass> () -> (@out Indirect<T>)
   apply %make<C>(%temp) : $@convention(thin) <T: SomeClass> () -> (@out Indirect<T>)
 

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -18,7 +18,7 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -30,7 +30,7 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -188,7 +188,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[B_P2_i8star:%.*]] = load ptr, ptr [[B_P2_PTR]], align 8
@@ -208,7 +208,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1

--- a/test/Inputs/conditional_conformance_basic_conformances_future.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances_future.swift
@@ -18,7 +18,7 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -30,7 +30,7 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -167,7 +167,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[B_P2_i8star:%.*]] = load ptr, ptr [[B_P2_PTR]], align 8
@@ -187,7 +187,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -16,7 +16,7 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(8) %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) dereferenceable(8) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -27,7 +27,7 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8

--- a/test/Inputs/conditional_conformance_subclass_future.swift
+++ b/test/Inputs/conditional_conformance_subclass_future.swift
@@ -16,7 +16,7 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(8) %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) dereferenceable(8) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
@@ -27,7 +27,7 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -41,7 +41,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8
@@ -67,7 +67,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8

--- a/test/Inputs/conditional_conformance_with_assoc_future.swift
+++ b/test/Inputs/conditional_conformance_with_assoc_future.swift
@@ -41,7 +41,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.normal
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP6normalyyFTW"(ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP6normalyyFTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8
@@ -67,7 +67,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias{{( nocapture)?}} swiftself{{( captures\(none\))?}} %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias swiftself captures(none) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8

--- a/test/Interop/Cxx/class/method/inreg-sret.swift
+++ b/test/Interop/Cxx/class/method/inreg-sret.swift
@@ -21,8 +21,8 @@ final public class Function {
 
 // Check that inreg on the sret isn't missing
 
-// CHECK-x86_64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr noalias{{( nocapture)?}} sret(%TSo25OptionalBridgedBasicBlockV){{( captures\(none\))?}} {{.*}})
-// CHECK-aarch64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr inreg noalias{{( nocapture)?}} sret(%TSo25OptionalBridgedBasicBlockV){{( captures\(none\))?}} {{.*}})
+// CHECK-x86_64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr noalias sret(%TSo25OptionalBridgedBasicBlockV) captures(none) {{.*}})
+// CHECK-aarch64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr inreg noalias sret(%TSo25OptionalBridgedBasicBlockV) captures(none) {{.*}})
 
 // CHECK-x86_64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr {{.*}} sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})
 // CHECK-aarch64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr inreg {{.*}} sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -7,7 +7,7 @@ protocol HasReturn42 {
 }
 
 
-// CHECK: define {{.*}}i32 @"$sSo18ConformsToProtocolV4main11HasReturn42A2cDP8return42s5Int32VyFTW"(ptr{{( nocapture)?}} swiftself{{( captures\(none\))?}} dereferenceable(1) %{{.*}}, ptr %{{.*}}, ptr %{{.*}})
+// CHECK: define {{.*}}i32 @"$sSo18ConformsToProtocolV4main11HasReturn42A2cDP8return42s5Int32VyFTW"(ptr swiftself captures(none) dereferenceable(1) %{{.*}}, ptr %{{.*}}, ptr %{{.*}})
 // CHECK: [[OUT:%.*]] = call i32 @{{_ZN18ConformsToProtocol8return42Ev|"\?return42@ConformsToProtocol@@QEAAHXZ"}}(ptr
 // CHECK: ret i32 [[OUT]]
 

--- a/test/Interop/Cxx/class/returns-large-class-irgen.swift
+++ b/test/Interop/Cxx/class/returns-large-class-irgen.swift
@@ -14,7 +14,7 @@ func foo() -> LargeClass {
 
 foo()
 
-// CHECK: call swiftcc void @"$s4main3fooSo10LargeClassVyF"(ptr noalias{{( nocapture)?}} sret(%TSo10LargeClassV){{( captures\(none\))?}} %{{.*}})
+// CHECK: call swiftcc void @"$s4main3fooSo10LargeClassVyF"(ptr noalias sret(%TSo10LargeClassV) captures(none) %{{.*}})
 
 // The C++ function:
 // CHECK: define{{( dso_local)?}} void @{{_Z21funcReturnsLargeClassv|"\?funcReturnsLargeClass@@YA\?AULargeClass@@XZ"}}({{%struct.LargeClass\*|ptr}}{{.*}} sret(%struct.LargeClass){{( align .*)?}} %{{.*}})

--- a/test/Interop/Cxx/extern-var/extern-var-irgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-irgen.swift
@@ -44,4 +44,4 @@ public func passingVarAsInout() {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"() #0
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable(4) @{{counter|"\?counter@@3HA"}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{counter|"\?counter@@3HA"}})

--- a/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
@@ -28,4 +28,4 @@ public func passingVarAsInout() {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"()
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable(4) @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}})

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -85,7 +85,7 @@ public func passingVarAsInout() {
   modifyInout(&staticVar)
 }
 // CHECK: define {{.*}}void @"$s4main17passingVarAsInoutyyF"()
-// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable(4) @{{_ZL9staticVar|staticVar}})
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(ptr captures(none) dereferenceable(4) @{{_ZL9staticVar|staticVar}})
 
 // CHECK: define internal void @_GLOBAL__sub_I__swift_imported_modules_()
 // CHECK: call void @{{__cxx_global_var_init|"\?\?__EstaticVarInit@@YAXXZ"}}()

--- a/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
+++ b/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
@@ -5,7 +5,7 @@
 
 import MsvcUseVecIt
 
-// CHECK:   call void @"?begin@?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@QEBA?AV?$_Vector_const_iterator@V?$_Vector_val@U?$_Simple_types@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@@std@@@2@XZ"(ptr {{.*}}, ptr noalias{{( nocapture)?}} sret{{( captures\(none\))?}}
+// CHECK:   call void @"?begin@?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@QEBA?AV?$_Vector_const_iterator@V?$_Vector_val@U?$_Simple_types@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@@std@@@2@XZ"(ptr {{.*}}, ptr noalias sret captures(none)
 
 func test() -> Bool {
     let result = f()

--- a/test/Interop/Cxx/templates/mangling-irgen.swift
+++ b/test/Interop/Cxx/templates/mangling-irgen.swift
@@ -4,12 +4,12 @@ import Mangling
 
 public func receiveInstantiation(_ i: inout WrappedMagicBool) {}
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF"(ptr captures(none) dereferenceable(1) %0)
 
 public func receiveInstantiation(_ i: inout WrappedMagicInt) {}
 
 // Don't forget to update manglings.txt when changing s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF"(ptr {{(nocapture|captures\(none\))}} dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF"(ptr captures(none) dereferenceable(1) %0)
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()

--- a/test/SILOptimizer/devirt_witness_method_empty_conformance.swift
+++ b/test/SILOptimizer/devirt_witness_method_empty_conformance.swift
@@ -76,7 +76,7 @@ extension ApplyRegStruct {
         from space: PublicEnum, transform: RegStruct
     ) {
         transform.funcInStructAndProtAndExt(.case2, space: space) {
-// CHECK-LABEL: define hidden swiftcc void @"$sSa39devirt_witness_method_empty_conformanceAA12PublicStructVRszlE14applyTransformyyF"(ptr{{( nocapture)?}} {{.*}}swiftself{{( captures\(none\))?}} dereferenceable
+// CHECK-LABEL: define hidden swiftcc void @"$sSa39devirt_witness_method_empty_conformanceAA12PublicStructVRszlE14applyTransformyyF"(ptr {{.*}}swiftself captures(none) dereferenceable
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret void
             applyTransform()

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -698,7 +698,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(32) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias{{( nocapture)?}} sret(i32){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(4) %1, ptr {{(nocapture|captures\(none\))}} dereferenceable(4) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr captures(none) dereferenceable(4) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:       %3 = load i32, ptr %2
 // CHECK-IRGEN-NEXT:  store i32 %3, ptr %0
@@ -707,7 +707,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(64) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias{{( nocapture)?}} sret(i64){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(8) %1, ptr {{(nocapture|captures\(none\))}} dereferenceable(8) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr captures(none) dereferenceable(8) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:        %3 = load i64, ptr %2
 // CHECK-IRGEN-NEXT:   store i64 %3, ptr %0

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -886,7 +886,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(32) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias{{( nocapture)?}} sret(i32){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(4) %1, ptr {{(nocapture|captures\(none\))}} dereferenceable(4) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5"(ptr noalias sret(i32) captures(none) %0, ptr noalias captures(none) dereferenceable(4) %1, ptr captures(none) dereferenceable(4) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:       %3 = load i32, ptr %2
 // CHECK-IRGEN-NEXT:  store i32 %3, ptr %0
@@ -895,7 +895,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial(64) uses direct loads and stores
 // instead of value witness functions to load and store the value of a generic type.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias{{( nocapture)?}} sret(i64){{( captures\(none\))?}} %0, ptr noalias {{(nocapture|captures\(none\))}} dereferenceable(8) %1, ptr {{(nocapture|captures\(none\))}} dereferenceable(8) %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5"(ptr noalias sret(i64) captures(none) %0, ptr noalias captures(none) dereferenceable(8) %1, ptr captures(none) dereferenceable(8) %2, ptr %S
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:        %3 = load i64, ptr %2
 // CHECK-IRGEN-NEXT:   store i64 %3, ptr %0


### PR DESCRIPTION
These were added in https://github.com/swiftlang/swift/pull/81375 (and several other follow-up PRs because we missed a few places) and are no longer needed.