### PR TITLE
[AST/Sema] Allow `Sendable` suppression on Objective-C class declarations

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -256,8 +256,9 @@ protected:
       kind : NumExternKindBits
     );
 
-    SWIFT_INLINE_BITFIELD(SynthesizedProtocolAttr, DeclAttribute, 1,
-      isUnchecked : 1
+    SWIFT_INLINE_BITFIELD(SynthesizedProtocolAttr, DeclAttribute, 2,
+      isUnchecked : 1,
+      isSuppressed: 1
     );
 
     SWIFT_INLINE_BITFIELD(ObjCImplementationAttr, DeclAttribute, 3,
@@ -1754,12 +1755,13 @@ class SynthesizedProtocolAttr : public DeclAttribute {
 
 public:
   SynthesizedProtocolAttr(ProtocolDecl *protocol, LazyConformanceLoader *Loader,
-                          bool isUnchecked)
+                          bool isUnchecked, bool isSuppressed)
       : DeclAttribute(DeclAttrKind::SynthesizedProtocol, SourceLoc(),
                       SourceRange(),
                       /*Implicit=*/true),
         Loader(Loader), protocol(protocol) {
     Bits.SynthesizedProtocolAttr.isUnchecked = unsigned(isUnchecked);
+    Bits.SynthesizedProtocolAttr.isSuppressed = unsigned(isSuppressed);
   }
 
   /// Retrieve the known protocol kind naming the protocol to be
@@ -1772,6 +1774,10 @@ public:
     return bool(Bits.SynthesizedProtocolAttr.isUnchecked);
   }
 
+  bool isSuppressed() const {
+    return bool(Bits.SynthesizedProtocolAttr.isSuppressed);
+  }
+
   /// Retrieve the lazy loader that will be used to populate the
   /// synthesized conformance.
   LazyConformanceLoader *getLazyLoader() const { return Loader; }
@@ -1782,12 +1788,13 @@ public:
 
   SynthesizedProtocolAttr *clone(ASTContext &ctx) const {
     return new (ctx) SynthesizedProtocolAttr(
-        protocol, getLazyLoader(), isUnchecked());
+        protocol, getLazyLoader(), isUnchecked(), isSuppressed());
   }
 
   bool isEquivalent(const SynthesizedProtocolAttr *other,
                     Decl *attachedTo) const {
     return isUnchecked() == other->isUnchecked()
+            && isSuppressed() == other->isSuppressed()
             && getProtocol() == other->getProtocol()
             && getLazyLoader() == other->getLazyLoader();
   }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -3306,6 +3306,13 @@ DeclAttributes::getEffectiveSendableAttr() const {
   if (auto sendableAttr = getAttribute<SendableAttr>())
     return sendableAttr;
 
+  // ~Sendable on declarations imported from Objective-C.
+  for (auto *attr : getAttributes<SynthesizedProtocolAttr>()) {
+    if (attr->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable) &&
+        attr->isSuppressed())
+      return nullptr;
+  }
+
   return assumedAttr;
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -4168,7 +4168,7 @@ swift::getDirectlyInheritedNominalTypeDecls(
     if (attr->isUnchecked())
       attributes.uncheckedLoc = loc;
     result.push_back({attr->getProtocol(), loc, /*inheritedTypeRepr=*/nullptr,
-                      attributes, /*isSuppressed=*/false});
+                      attributes, attr->isSuppressed()});
   }
 
   // Else we have access to this information on the where clause.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1248,6 +1248,8 @@ void NominalTypeDecl::prepareConformanceTable() const {
 
   // Add protocols for any synthesized protocol attributes.
   for (auto attr : getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
+    if (attr->isSuppressed())
+      continue;
     addSynthesized(attr->getProtocol());
   }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -503,7 +503,8 @@ void ClangImporter::Implementation::addSynthesizedTypealias(
 
 void ClangImporter::Implementation::addSynthesizedProtocolAttrs(
     NominalTypeDecl *nominal,
-    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs, bool isUnchecked) {
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs, bool isUnchecked,
+    bool isSuppressed) {
   auto &ctx = nominal->getASTContext();
 
   for (auto kind : synthesizedProtocolAttrs) {
@@ -512,7 +513,7 @@ void ClangImporter::Implementation::addSynthesizedProtocolAttrs(
     // ctx.getProtocol(kind) != nulltpr which would be nice.
     if (auto proto = ctx.getProtocol(kind))
       nominal->addAttribute(
-          new (ctx) SynthesizedProtocolAttr(proto, this, isUnchecked));
+        new (ctx) SynthesizedProtocolAttr(proto, this, isUnchecked, isSuppressed));
   }
 }
 
@@ -9470,8 +9471,8 @@ void ClangImporter::Implementation::addExplicitProtocolConformance(
                decl->getDeclaredInterfaceType(), conformsToValue);
     }
 
-    decl->addAttribute(new (SwiftContext)
-                           SynthesizedProtocolAttr(protocol, this, false));
+    decl->addAttribute(new (SwiftContext) SynthesizedProtocolAttr(
+        protocol, this, /*isUnchecked=*/false, /*isSuppressed=*/false));
   } else {
     HeaderLoc attrLoc((conformsToAttr)->getLocation());
     diagnose(attrLoc, diag::conforms_to_not_protocol, result,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1264,7 +1264,8 @@ public:
   void addSynthesizedProtocolAttrs(
       NominalTypeDecl *nominal,
       ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-      bool isUnchecked = false);
+      bool isUnchecked = false,
+      bool isSuppressed = false);
 
   void makeComputed(AbstractStorageDecl *storage, AccessorDecl *getter,
                     AccessorDecl *setter);

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -172,6 +172,13 @@ bool SuppressesConformanceRequest::evaluate(Evaluator &evaluator,
     if (other == kp)
       return true;
   }
+
+  for (auto *attr :
+       nominal->getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
+    if (attr->getProtocol()->isSpecificProtocol(kp) && attr->isSuppressed())
+      return true;
+  }
+
   return false;
 }
 

--- a/test/Concurrency/tilde_sendable_objc.swift
+++ b/test/Concurrency/tilde_sendable_objc.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature TildeSendable \
+// RUN:   -module-name main -I %t -verify -verify-ignore-unrelated
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_TildeSendable
+
+//--- Test.h
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+#define SWIFT_NONSENDABLE_ASSUMED __attribute__((__swift_attr__("@_nonSendable(_assumed)")))
+#define SWIFT_SUPPRESS_SENDABLE __attribute__((__swift_attr__("~Sendable")))
+
+@import Foundation;
+
+// Test that `~Sendable` superseeds `@_nonSendable(_assumed)` on classes.
+
+SWIFT_NONSENDABLE_ASSUMED
+SWIFT_SUPPRESS_SENDABLE
+@interface Parent : NSObject
+@end
+
+// Test that `Sendable` superseeds `@_nonSendable(_assumed)` and `~Sendable` from the parent.
+
+SWIFT_NONSENDABLE_ASSUMED
+SWIFT_SENDABLE
+@interface SendableValue : Parent
+@end
+
+SWIFT_NONSENDABLE_ASSUMED
+@interface NonSendableValue : Parent
+@end
+
+//--- main.swift
+func testSendable<T: Sendable>(_: T) {}
+
+public func test(p: Parent, v: SendableValue, ns: NonSendableValue) {
+  testSendable(p) // expected-error {{type 'Parent' does not conform to the 'Sendable' protocol}}
+  testSendable(v) // Ok (no diagnostics unable unavailable conformance associated with `Parent`).
+  testSendable(ns) // expected-error {{conformance of 'NonSendableValue' to 'Sendable' is unavailable}}
+}
+


### PR DESCRIPTION
Expressed as `__swift_attr__("~Sendable")` this acts like `: ~Sendable`
on Swift type declarations and supersedes `@_nonSendable(_assumed)`.

Resolves: rdar://140928937

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
