### PR TITLE
[Sema]: minor improvements to unused expression result diagnostics

### DIFF
--- a/test/Sema/diag_implicit_discardable.swift
+++ b/test/Sema/diag_implicit_discardable.swift
@@ -1,0 +1,73 @@
+// RUN: %target-typecheck-verify-swift
+
+struct MyError: Error {}
+enum MyNever {}
+
+func never_throws() throws -> Never { throw MyError() }
+func uninhabited_throws() throws -> (Int, MyNever) { throw MyError () }
+func almost_uninhabited_throws() throws -> (Int, Never?) { throw MyError () }
+func int_throws() throws -> Int { throw MyError() }
+func void_throws() throws {}
+
+func maybe_never() -> Never? { nil }
+func maybe_uninhabited() -> (Int, MyNever)? { nil }
+func maybe_maybe_uninhabited() -> (Int, Never)?? { nil }
+func maybe_void() -> Void? { nil }
+func maybe_maybe_void() -> Void?? { nil }
+func looks_uninhabited_if_you_squint() -> (Int, Never?)? { nil }
+
+// MARK: - Tests
+
+func test_try() throws {
+  try never_throws()
+  try uninhabited_throws()
+  try almost_uninhabited_throws()
+  // expected-warning @-1 {{result of call to 'almost_uninhabited_throws()' is unused}}
+  try int_throws()
+  // expected-warning @-1 {{result of call to 'int_throws()' is unused}}
+  try void_throws()
+}
+
+func test_force_try() throws {
+  try! never_throws()
+  try! uninhabited_throws()
+  try! almost_uninhabited_throws()
+  // expected-warning @-1 {{result of call to 'almost_uninhabited_throws()' is unused}}
+  try! int_throws()
+  // expected-warning @-1 {{result of call to 'int_throws()' is unused}}
+  try! void_throws()
+}
+
+func test_optional_try() throws {
+  try? never_throws()
+  try? uninhabited_throws()
+  try? almost_uninhabited_throws()
+  // expected-warning @-1 {{result of 'try?' is unused}}
+  try? int_throws()
+  // expected-warning @-1 {{result of 'try?' is unused}}
+  try? void_throws()
+}
+
+func test_implicitly_discardable() {
+  maybe_never()
+  maybe_uninhabited()
+  maybe_maybe_uninhabited()
+  maybe_void()
+  maybe_maybe_void()
+  looks_uninhabited_if_you_squint()
+  // expected-warning @-1 {{result of call to 'looks_uninhabited_if_you_squint()' is unused}}
+}
+
+// https://github.com/swiftlang/swift/issues/85092
+
+func test_85092() {
+  struct MyError: Error {}
+
+  func f() throws -> Never {
+    throw MyError()
+  }
+
+  func g() {
+    try? f()
+  }
+}


### PR DESCRIPTION
Previously we would emit a diagnostic in cases in which a throwing function returning a structurally-uninhabited type was called within an optional try expression. Such cases can never produce a result other than `nil`, so the existing diagnostic seemed not particularly helpful. This change attempts to address this and other minor inconsistencies by expanding the `isDiscardableType()` logic to encompass "structurally uninhabited" types (e.g. tuples that eventually bottom out in an uninhabited type in some position), and also look through any levels of optionality to find such types. This makes the unused expression result diagnostics a bit more consistent in that they will now allow 'uninteresting' unused results to be implicitly discarded. In particular, the following cases now have the same diagnostic behavior (namely, do not produce a warning for the unused results):

```swift
func maybeNever() -> Never? { nil }
func maybeVoid() -> Void? { nil }

maybeNever() // used to warn with: 'warning: result of call to 'maybeNever()' is unused'
maybeVoid()
```

Resolves: https://github.com/swiftlang/swift/issues/85092
