### PR TITLE
[AST] Fix crash in `PrintAST::printAccessors`

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2726,8 +2726,8 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
   bool needsDisambiguationAttr = false;
   if (auto *VD = dyn_cast<VarDecl>(ASD)) {
     if (auto *PBD = VD->getParentPatternBinding()) {
-      AccessorDecl *firstAccessor = *accessorsToPrint.begin();
-      if (!firstAccessor->isObservingAccessor()) {
+      if (accessorsToPrint.empty() ||
+          !accessorsToPrint.front()->isObservingAccessor()) {
         const auto i = PBD->getPatternEntryIndexForVarDecl(VD);
         if (Options.PrintExprs) {
           needsDisambiguationAttr |= bool(PBD->getInit(i));

--- a/validation-test/compiler_crashers_fixed/PrintAST-printAccessors-74586b.swift
+++ b/validation-test/compiler_crashers_fixed/PrintAST-printAccessors-74586b.swift
@@ -1,0 +1,6 @@
+// {"kind":"typecheck","original":"29a2d7da","signature":"(anonymous namespace)::PrintAST::printAccessors(swift::AbstractStorageDecl const*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+protocol a {
+  enum b: a
+    enum c: a
+      let d: a


### PR DESCRIPTION
Make sure we check whether `accessorsToPrint` is empty.