### PR TITLE
[Sema] Fix crash in `CheckRedeclarationRequest` for IUO mismatch check

### DIFF
--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -402,6 +402,16 @@ class optionalOverloads {
 func optional_3() -> Int? { } // expected-note{{previously declared}}
 func optional_3() -> Int! { } // expected-error{{invalid redeclaration of 'optional_3()'}}
 
+var optionalFnVar: (Int?) -> Void // expected-note {{previously declared}}
+var optionalFnVar: (Int?) -> Void // expected-error {{invalid redeclaration of 'optionalFnVar'}}
+
+enum IUORedeclarationCaseConstructor {
+  case foo(Int?) // expected-note{{previously declared}}
+  static func foo(_ x: Int!) -> Self {}
+  // expected-error@-1 {{invalid redeclaration of 'foo'}}
+  // expected-note@-2 {{implicitly unwrapped optional parameter is of same type as optional parameter}}
+}
+
 // mutating / nonmutating
 protocol ProtocolWithMutating {
   mutating func test1() // expected-note {{previously declared}}


### PR DESCRIPTION
Make sure we only check this if both declarations have parameter lists. While here, clean up the logic a bit such that we just iterate over the parameter lists.

rdar://156874925