### PR TITLE
Runtimes: pass target variant flags when compiling assembly code

### DIFF
--- a/Runtimes/Core/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Core/cmake/modules/CatalystSupport.cmake
@@ -5,7 +5,7 @@
 
 if(SwiftCore_COMPILER_VARIANT_TARGET)
   add_compile_options(
-    "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+    "$<$<COMPILE_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with
@@ -13,7 +13,7 @@ if(SwiftCore_COMPILER_VARIANT_TARGET)
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${SwiftCore_COMPILER_VARIANT_TARGET}>")
 
   add_link_options(
-    "$<$<LINK_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+    "$<$<LINK_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
     "$<$<LINK_LANGUAGE:Swift>:SHELL:-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with

--- a/Runtimes/Overlay/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Overlay/cmake/modules/CatalystSupport.cmake
@@ -7,7 +7,7 @@ include(CheckCompilerFlag)
 
 if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
   add_compile_options(
-    "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<COMPILE_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with
@@ -15,7 +15,7 @@ if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>")
 
   add_link_options(
-    "$<$<LINK_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<LINK_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
     "$<$<LINK_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with

--- a/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
@@ -7,7 +7,7 @@ include(CheckCompilerFlag)
 
 if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
   add_compile_options(
-    "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<COMPILE_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with
@@ -15,7 +15,7 @@ if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>")
 
   add_link_options(
-    "$<$<LINK_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<LINK_LANGUAGE:ASM,C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
     "$<$<LINK_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
 
     # TODO: Remove me once we have a driver with


### PR DESCRIPTION
This ensure we build code correctly for macCatalyst.

Addresses rdar://163363796