### PR TITLE
AST: Refactor availability version remapping

### DIFF
--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -25,7 +25,6 @@
 namespace swift {
 class ASTContext;
 class AvailabilityDomain;
-class BackDeployedAttr;
 class Decl;
 class SemanticAvailableAttr;
 
@@ -49,37 +48,8 @@ public:
   static std::optional<AvailabilityRange>
   annotatedAvailableRange(const Decl *D);
 
-  static AvailabilityRange
-  annotatedAvailableRangeForAttr(const Decl *D, const AbstractSpecializeAttr *attr,
-                                 ASTContext &ctx);
-
-  /// For the attribute's introduction version, update the platform and version
-  /// values to the re-mapped platform's, if using a fallback platform.
-  /// Returns `true` if a remap occured.
-  static bool updateIntroducedAvailabilityDomainForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &ctx,
-      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
-
-  /// For the attribute's deprecation version, update the platform and version
-  /// values to the re-mapped platform's, if using a fallback platform.
-  /// Returns `true` if a remap occured.
-  static bool updateDeprecatedAvailabilityDomainForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &ctx,
-      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
-
-  /// For the attribute's obsoletion version, update the platform and version
-  /// values to the re-mapped platform's, if using a fallback platform.
-  /// Returns `true` if a remap occured.
-  static bool updateObsoletedAvailabilityDomainForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &ctx,
-      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
-
-  /// For the attribute's before version, update the platform and version
-  /// values to the re-mapped platform's, if using a fallback platform.
-  /// Returns `true` if a remap occured.
-  static bool updateBeforeAvailabilityDomainForFallback(
-      const BackDeployedAttr *attr, const ASTContext &ctx,
-      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
+  static AvailabilityRange annotatedAvailableRangeForAttr(
+      const Decl *D, const AbstractSpecializeAttr *attr, ASTContext &ctx);
 };
 
 } // end namespace swift

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1134,8 +1134,7 @@ public:
   /// Returns the active `@backDeployed` attribute and the `AvailabilityRange`
   /// in which the decl is available as ABI.
   std::optional<std::pair<const BackDeployedAttr *, AvailabilityRange>>
-  getBackDeployedAttrAndRange(ASTContext &Ctx,
-                              bool forTargetVariant = false) const;
+  getBackDeployedAttrAndRange(bool forTargetVariant = false) const;
 
   /// Returns true if the decl has a valid and active `@backDeployed` attribute.
   bool isBackDeployed() const;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -18,7 +18,6 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/AvailabilityDomain.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -256,128 +256,6 @@ static bool isBetterThan(const SemanticAvailableAttr &newAttr,
                                           prevAttr->getPlatform());
 }
 
-static const clang::DarwinSDKInfo::RelatedTargetVersionMapping *
-getFallbackVersionMapping(const ASTContext &Ctx,
-                          clang::DarwinSDKInfo::OSEnvPair Kind) {
-  auto *SDKInfo = Ctx.getDarwinSDKInfo();
-  if (SDKInfo)
-    return SDKInfo->getVersionMapping(Kind);
-
-  return Ctx.getAuxiliaryDarwinPlatformRemapInfo(Kind);
-}
-
-static std::optional<clang::VersionTuple>
-getRemappedIntroducedVersionForFallbackPlatform(
-    const ASTContext &Ctx, const llvm::VersionTuple &Version) {
-  const auto *Mapping = getFallbackVersionMapping(
-      Ctx, clang::DarwinSDKInfo::OSEnvPair(
-               llvm::Triple::IOS, llvm::Triple::UnknownEnvironment,
-               llvm::Triple::XROS, llvm::Triple::UnknownEnvironment));
-  if (!Mapping)
-    return std::nullopt;
-  return Mapping->mapIntroducedAvailabilityVersion(Version);
-}
-
-static std::optional<clang::VersionTuple>
-getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
-    const ASTContext &Ctx, const llvm::VersionTuple &Version) {
-  const auto *Mapping = getFallbackVersionMapping(
-      Ctx, clang::DarwinSDKInfo::OSEnvPair(
-               llvm::Triple::IOS, llvm::Triple::UnknownEnvironment,
-               llvm::Triple::XROS, llvm::Triple::UnknownEnvironment));
-  if (!Mapping)
-    return std::nullopt;
-  return Mapping->mapDeprecatedObsoletedAvailabilityVersion(Version);
-}
-
-bool AvailabilityInference::updateIntroducedAvailabilityDomainForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &ctx,
-    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
-  std::optional<llvm::VersionTuple> introducedVersion = attr.getIntroduced();
-  if (!introducedVersion.has_value())
-    return false;
-
-  bool hasRemap = false;
-  auto remappedDomain = attr.getDomain().getRemappedDomain(ctx, hasRemap);
-  if (!hasRemap)
-    return false;
-
-  auto potentiallyRemappedIntroducedVersion =
-      getRemappedIntroducedVersionForFallbackPlatform(ctx, *introducedVersion);
-  if (potentiallyRemappedIntroducedVersion.has_value()) {
-    domain = remappedDomain;
-    platformVer = potentiallyRemappedIntroducedVersion.value();
-    return true;
-  }
-  return false;
-}
-
-bool AvailabilityInference::updateDeprecatedAvailabilityDomainForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &ctx,
-    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
-  std::optional<llvm::VersionTuple> deprecatedVersion = attr.getDeprecated();
-  if (!deprecatedVersion.has_value())
-    return false;
-
-  bool hasRemap = false;
-  auto remappedDomain = attr.getDomain().getRemappedDomain(ctx, hasRemap);
-  if (!hasRemap)
-    return false;
-
-  auto potentiallyRemappedDeprecatedVersion =
-      getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
-          ctx, *deprecatedVersion);
-  if (potentiallyRemappedDeprecatedVersion.has_value()) {
-    domain = remappedDomain;
-    platformVer = potentiallyRemappedDeprecatedVersion.value();
-    return true;
-  }
-  return false;
-}
-
-bool AvailabilityInference::updateObsoletedAvailabilityDomainForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &ctx,
-    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
-  std::optional<llvm::VersionTuple> obsoletedVersion = attr.getObsoleted();
-  if (!obsoletedVersion.has_value())
-    return false;
-
-  bool hasRemap = false;
-  auto remappedDomain = attr.getDomain().getRemappedDomain(ctx, hasRemap);
-  if (!hasRemap)
-    return false;
-
-  auto potentiallyRemappedObsoletedVersion =
-      getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
-          ctx, *obsoletedVersion);
-  if (potentiallyRemappedObsoletedVersion.has_value()) {
-    domain = remappedDomain;
-    platformVer = potentiallyRemappedObsoletedVersion.value();
-    return true;
-  }
-  return false;
-}
-
-bool AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
-    const BackDeployedAttr *attr, const ASTContext &ctx,
-    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
-  bool hasRemap = false;
-  auto remappedDomain =
-      attr->getAvailabilityDomain().getRemappedDomain(ctx, hasRemap);
-  if (!hasRemap)
-    return false;
-
-  auto beforeVersion = attr->getVersion();
-  auto potentiallyRemappedIntroducedVersion =
-      getRemappedIntroducedVersionForFallbackPlatform(ctx, beforeVersion);
-  if (potentiallyRemappedIntroducedVersion.has_value()) {
-    domain = remappedDomain;
-    platformVer = potentiallyRemappedIntroducedVersion.value();
-    return true;
-  }
-  return false;
-}
-
 static std::optional<SemanticAvailableAttr>
 getDeclAvailableAttrForPlatformIntroduction(const Decl *D) {
   std::optional<SemanticAvailableAttr> bestAvailAttr;
@@ -917,40 +795,31 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getIntroduced() const {
 std::optional<AvailabilityDomainAndRange>
 SemanticAvailableAttr::getIntroducedDomainAndRange(
     const ASTContext &Ctx) const {
-  auto *attr = getParsedAttr();
   auto domain = getDomain();
-
   if (domain.isUniversal())
     return std::nullopt;
 
-  if (!attr->getRawIntroduced().has_value()) {
-    // For versioned domains, an "introduced:" version is always required to
-    // indicate introduction.
-    if (domain.isVersioned())
-      return std::nullopt;
+  if (auto introduced = getIntroduced())
+    return domain.getRemappedDomainAndRange(
+        *introduced, AvailabilityVersionKind::Introduced, Ctx);
 
-    // For version-less domains, an attribute that does not indicate some other
-    // kind of unconditional availability constraint implicitly specifies that
-    // the decl is available in all versions of the domain.
-    switch (attr->getKind()) {
-    case AvailableAttr::Kind::Default:
-      return AvailabilityDomainAndRange(domain.getRemappedDomain(Ctx),
-                                        AvailabilityRange::alwaysAvailable());
-    case AvailableAttr::Kind::Deprecated:
-    case AvailableAttr::Kind::Unavailable:
-    case AvailableAttr::Kind::NoAsync:
-      return std::nullopt;
-    }
+  // For versioned domains, an "introduced:" version is always required to
+  // indicate introduction.
+  if (domain.isVersioned())
+    return std::nullopt;
+
+  // For version-less domains, an attribute that does not indicate some other
+  // kind of unconditional availability constraint implicitly specifies that
+  // the decl is available in all versions of the domain.
+  switch (attr->getKind()) {
+  case AvailableAttr::Kind::Default:
+    return AvailabilityDomainAndRange(domain.getRemappedDomain(Ctx),
+                                      AvailabilityRange::alwaysAvailable());
+  case AvailableAttr::Kind::Deprecated:
+  case AvailableAttr::Kind::Unavailable:
+  case AvailableAttr::Kind::NoAsync:
+    return std::nullopt;
   }
-
-  llvm::VersionTuple introducedVersion = getIntroduced().value();
-  llvm::VersionTuple remappedVersion;
-  if (AvailabilityInference::updateIntroducedAvailabilityDomainForFallback(
-          *this, Ctx, domain, remappedVersion))
-    introducedVersion = remappedVersion;
-
-  return AvailabilityDomainAndRange(domain,
-                                    AvailabilityRange{introducedVersion});
 }
 
 std::optional<llvm::VersionTuple> SemanticAvailableAttr::getDeprecated() const {
@@ -962,28 +831,18 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getDeprecated() const {
 std::optional<AvailabilityDomainAndRange>
 SemanticAvailableAttr::getDeprecatedDomainAndRange(
     const ASTContext &Ctx) const {
-  auto *attr = getParsedAttr();
-  AvailabilityDomain domain = getDomain();
+  if (auto deprecated = getDeprecated())
+    return getDomain().getRemappedDomainAndRange(
+        *deprecated, AvailabilityVersionKind::Deprecated, Ctx);
 
-  if (!attr->getRawDeprecated().has_value()) {
-    // Regardless of the whether the domain supports versions or not, an
-    // unconditional deprecation attribute indicates the decl is always
-    // deprecated.
-    if (isUnconditionallyDeprecated())
-      return AvailabilityDomainAndRange(domain.getRemappedDomain(Ctx),
-                                        AvailabilityRange::alwaysAvailable());
+  // Regardless of the whether the domain supports versions or not, an
+  // unconditional deprecation attribute indicates the decl is always
+  // deprecated.
+  if (isUnconditionallyDeprecated())
+    return AvailabilityDomainAndRange(getDomain().getRemappedDomain(Ctx),
+                                      AvailabilityRange::alwaysAvailable());
 
-    return std::nullopt;
-  }
-
-  llvm::VersionTuple deprecatedVersion = getDeprecated().value();
-  llvm::VersionTuple remappedVersion;
-  if (AvailabilityInference::updateDeprecatedAvailabilityDomainForFallback(
-          *this, Ctx, domain, remappedVersion))
-    deprecatedVersion = remappedVersion;
-
-  return AvailabilityDomainAndRange(domain,
-                                    AvailabilityRange{deprecatedVersion});
+  return std::nullopt;
 }
 
 std::optional<llvm::VersionTuple> SemanticAvailableAttr::getObsoleted() const {
@@ -994,26 +853,16 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getObsoleted() const {
 
 std::optional<AvailabilityDomainAndRange>
 SemanticAvailableAttr::getObsoletedDomainAndRange(const ASTContext &Ctx) const {
-  auto *attr = getParsedAttr();
-  AvailabilityDomain domain = getDomain();
+  if (auto obsoleted = getObsoleted())
+    return getDomain().getRemappedDomainAndRange(
+        *obsoleted, AvailabilityVersionKind::Obsoleted, Ctx);
 
-  if (!attr->getRawObsoleted().has_value()) {
-    // An "unavailable" attribute effectively means obsolete in all versions.
-    if (attr->isUnconditionallyUnavailable())
-      return AvailabilityDomainAndRange(domain.getRemappedDomain(Ctx),
-                                        AvailabilityRange::alwaysAvailable());
+  // An "unavailable" attribute effectively means obsolete in all versions.
+  if (isUnconditionallyUnavailable())
+    return AvailabilityDomainAndRange(getDomain().getRemappedDomain(Ctx),
+                                      AvailabilityRange::alwaysAvailable());
 
-    return std::nullopt;
-  }
-
-  llvm::VersionTuple obsoletedVersion = getObsoleted().value();
-  llvm::VersionTuple remappedVersion;
-  if (AvailabilityInference::updateObsoletedAvailabilityDomainForFallback(
-          *this, Ctx, domain, remappedVersion))
-    obsoletedVersion = remappedVersion;
-
-  return AvailabilityDomainAndRange(domain,
-                                    AvailabilityRange{obsoletedVersion});
+  return std::nullopt;
 }
 
 namespace {

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -14,7 +14,6 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContextStorage.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -18,7 +18,6 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityConstraint.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -13,7 +13,6 @@
 #include "CodeCompletionDiagnostics.h"
 
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsIDE.h"

--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -113,9 +113,9 @@ static std::optional<AvailabilityQuery>
 getAvailabilityQueryForBackDeployment(AbstractFunctionDecl *AFD) {
   auto &ctx = AFD->getASTContext();
   if (ctx.LangOpts.TargetVariant) {
-    auto primaryAttrAndRange = AFD->getBackDeployedAttrAndRange(ctx);
+    auto primaryAttrAndRange = AFD->getBackDeployedAttrAndRange();
     auto variantAttrAndRange =
-        AFD->getBackDeployedAttrAndRange(ctx, /*forTargetVariant=*/true);
+        AFD->getBackDeployedAttrAndRange(/*forTargetVariant=*/true);
 
     if (!primaryAttrAndRange && !variantAttrAndRange)
       return std::nullopt;
@@ -134,7 +134,7 @@ getAvailabilityQueryForBackDeployment(AbstractFunctionDecl *AFD) {
                                       primaryRange, variantRange);
   }
 
-  if (auto primaryAttrAndRange = AFD->getBackDeployedAttrAndRange(ctx))
+  if (auto primaryAttrAndRange = AFD->getBackDeployedAttrAndRange())
     return AvailabilityQuery::dynamic(
         primaryAttrAndRange->first->getAvailabilityDomain(),
         primaryAttrAndRange->second, std::nullopt);
@@ -284,7 +284,7 @@ SILGenFunction::emitIfAvailableQuery(SILLocation loc,
 bool SILGenModule::requiresBackDeploymentThunk(ValueDecl *decl,
                                                ResilienceExpansion expansion) {
   auto &ctx = getASTContext();
-  auto attrAndRange = decl->getBackDeployedAttrAndRange(ctx);
+  auto attrAndRange = decl->getBackDeployedAttrAndRange();
   if (!attrAndRange)
     return false;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -27,7 +27,6 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/AttrKind.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -5366,14 +5365,8 @@ void AttributeChecker::checkBackDeployedAttrs(
 
     // Unavailable decls cannot be back deployed.
     if (availability.containsUnavailableDomain(Domain)) {
-      auto domainForDiagnostics = Domain;
-      llvm::VersionTuple ignoredVersion;
-
-      AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
-          Attr, Ctx, domainForDiagnostics, ignoredVersion);
-
       diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr, VD,
-               domainForDiagnostics);
+               Domain.getRemappedDomain(Ctx));
 
       // Find the attribute that makes the declaration unavailable.
       const Decl *attrDecl = D;
@@ -5396,23 +5389,22 @@ void AttributeChecker::checkBackDeployedAttrs(
     // fallback could never be executed at runtime.
     if (auto availableRangeAttrPair =
             getSemanticAvailableRangeDeclAndAttr(VD, Domain)) {
-      auto beforeDomain = Domain;
-      auto beforeVersion = Attr->getVersion();
-      auto availableAttr = availableRangeAttrPair.value().first;
-      auto introVersion = availableAttr.getIntroduced().value();
-      AvailabilityDomain introDomain = availableAttr.getDomain();
+      auto availableAttr = availableRangeAttrPair->first;
+      auto introDomainAndRange = availableAttr.getIntroducedDomainAndRange(Ctx);
+      if (!introDomainAndRange)
+        continue;
 
-      AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
-          Attr, Ctx, beforeDomain, beforeVersion);
-      AvailabilityInference::updateIntroducedAvailabilityDomainForFallback(
-          availableAttr, Ctx, introDomain, introVersion);
+      auto beforeDomainAndRange = Domain.getRemappedDomainAndRange(
+          Attr->getVersion(), AvailabilityVersionKind::Introduced, Ctx);
 
-      if (beforeVersion <= introVersion) {
+      auto introRange = introDomainAndRange->getRange();
+      auto beforeRange = beforeDomainAndRange.getRange();
+      if (introRange.isContainedIn(beforeRange)) {
         diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,
-                 Attr, VD, beforeDomain, AvailabilityRange(beforeVersion));
+                 Attr, VD, beforeDomainAndRange.getDomain(), beforeRange);
         diagnose(availableAttr.getParsedAttr()->AtLoc,
-                 diag::availability_introduced_in_version, VD, introDomain,
-                 AvailabilityRange(introVersion))
+                 diag::availability_introduced_in_version, VD,
+                 introDomainAndRange->getDomain(), introRange)
             .highlight(availableAttr.getParsedAttr()->getRange());
         continue;
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5266,7 +5266,7 @@ void AttributeChecker::checkBackDeployedAttrs(
   std::map<PlatformKind, SourceLoc> seenPlatforms;
 
   const BackDeployedAttr *ActiveAttr = nullptr;
-  if (auto AttrAndRange = D->getBackDeployedAttrAndRange(Ctx))
+  if (auto AttrAndRange = D->getBackDeployedAttrAndRange())
     ActiveAttr = AttrAndRange->first;
 
   for (auto *Attr : Attrs) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -32,7 +32,6 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"


### PR DESCRIPTION
Availability version remapping currently only applies to code built for visionOS. We plan to introduce more platform kinds and standalone availability domains that will require version remapping, though, so it's time to rearchitect and simplify the code to make it easier to generalize.

`AvailabilityDomain` is now responsible for version remapping and much of the previously duplicated utilities have been consolidated.