### PR TITLE
Fix various warnings

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -31,21 +31,21 @@ extension BridgedNullable {
   }
 }
 
-extension SourceLoc: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension Identifier: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableDecl: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableExpr: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableStmt: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableTypeRepr: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullablePattern: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableGenericParamList: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableTrailingWhereClause: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableParameterList: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullablePatternBindingInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableDefaultArgumentInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableCustomAttributeInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableArgumentList: /*@retroactive*/ swiftASTGen.BridgedNullable {}
-extension BridgedNullableVarDecl: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension SourceLoc: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension Identifier: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableDecl: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableExpr: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableStmt: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableTypeRepr: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullablePattern: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableGenericParamList: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableTrailingWhereClause: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableParameterList: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullablePatternBindingInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableDefaultArgumentInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableCustomAttributeInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableArgumentList: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
+extension BridgedNullableVarDecl: /*@retroactive*/ swiftASTGen.BridgedNullable, Swift.ExpressibleByNilLiteral {}
 
 extension Identifier: /*@retroactive*/ Swift.Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2774,7 +2774,8 @@ swift::swift_distributedActor_remote_initialize(const Metadata *actorType) {
 
   // TODO: remove this memset eventually, today we only do this to not have
   //       to modify the destructor logic, as releasing zeroes is no-op
-  memset(alloc + 1, 0, metadata->getInstanceSize() - sizeof(HeapObject));
+  memset((void *)(alloc + 1), 0,
+         metadata->getInstanceSize() - sizeof(HeapObject));
 
   // TODO(distributed): a remote one does not have to have the "real"
   //  default actor body, e.g. we don't need an executor at all; so

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -624,7 +624,7 @@ extension String {
     _connectOrphanedFoundationSubclassesIfNeeded()
 
     if _guts.isSmall {
-      return unsafe _guts.asSmall.withUTF8 { bufPtr in
+      return _guts.asSmall.withUTF8 { bufPtr in
         // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
         if _guts.isSmallASCII, let result = unsafe _createCFString(
           bufPtr.baseAddress._unsafelyUnwrappedUnchecked,


### PR DESCRIPTION
- Suppress a `-Wnontrivial-memcall` warning in Actor.cpp.
- Remove an unnecessary 'unsafe' expression in StringBridge.swift.
- Suppress spurious retroactive conformance warnings emitted by the Swift 6.2 compiler.