### PR TITLE
[AST] Avoid exposing `lazy` local storage var to name lookup

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6730,9 +6730,13 @@ public:
   /// An auxiliary variable is one that is synthesized by the compiler to
   /// support this VarDecl, such as synthesized property wrapper variables.
   ///
+  /// \param forNameLookup If \c true, will only visit auxiliary variables that
+  /// may appear in name lookup results.
+  ///
   /// \note this function only visits auxiliary variables that are not part of
   /// the AST.
-  void visitAuxiliaryVars(llvm::function_ref<void(VarDecl *)>) const;
+  void visitAuxiliaryVars(bool forNameLookup,
+                          llvm::function_ref<void(VarDecl *)>) const;
 
   /// Is this the synthesized storage for a 'lazy' property?
   bool isLazyStorageProperty() const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6725,13 +6725,14 @@ public:
     Bits.VarDecl.IsDebuggerVar = IsDebuggerVar;
   }
 
-  /// Visit all auxiliary declarations to this VarDecl.
+  /// Visit all auxiliary variables for this VarDecl.
   ///
-  /// An auxiliary declaration is a declaration synthesized by the compiler to support
-  /// this VarDecl, such as synthesized property wrapper variables.
+  /// An auxiliary variable is one that is synthesized by the compiler to
+  /// support this VarDecl, such as synthesized property wrapper variables.
   ///
-  /// \note this function only visits auxiliary decls that are not part of the AST.
-  void visitAuxiliaryDecls(llvm::function_ref<void(VarDecl *)>) const;
+  /// \note this function only visits auxiliary variables that are not part of
+  /// the AST.
+  void visitAuxiliaryVars(llvm::function_ref<void(VarDecl *)>) const;
 
   /// Is this the synthesized storage for a 'lazy' property?
   bool isLazyStorageProperty() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8768,14 +8768,21 @@ bool VarDecl::hasStorageOrWrapsStorage() const {
 }
 
 void VarDecl::visitAuxiliaryVars(
-    llvm::function_ref<void(VarDecl *)> visit) const {
+    bool forNameLookup, llvm::function_ref<void(VarDecl *)> visit) const {
   if (getDeclContext()->isTypeContext() ||
       (isImplicit() && !isa<ParamDecl>(this)))
     return;
 
-  if (getAttrs().hasAttribute<LazyAttr>()) {
-    if (auto *backingVar = getLazyStorageProperty())
-      visit(backingVar);
+  // The backing storage for a lazy property is not accessible to name lookup.
+  // This is not only a matter of hiding implementation details, but also
+  // correctness since triggering LazyStoragePropertyRequest currently eagerly
+  // requests the interface type for the var, which could result in incorrectly
+  // type-checking a lazy local independently of its surrounding closure.
+  if (!forNameLookup) {
+    if (getAttrs().hasAttribute<LazyAttr>()) {
+      if (auto *backingVar = getLazyStorageProperty())
+        visit(backingVar);
+    }
   }
 
   if (getAttrs().hasAttribute<CustomAttr>() || hasImplicitPropertyWrapper()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -507,7 +507,7 @@ void Decl::visitAuxiliaryDecls(
     }
   }
 
-  // FIXME: fold VarDecl::visitAuxiliaryDecls into this.
+  // FIXME: fold VarDecl::visitAuxiliaryVars into this.
 }
 
 void Decl::forEachAttachedMacro(MacroRole role,
@@ -8767,7 +8767,8 @@ bool VarDecl::hasStorageOrWrapsStorage() const {
   return false;
 }
 
-void VarDecl::visitAuxiliaryDecls(llvm::function_ref<void(VarDecl *)> visit) const {
+void VarDecl::visitAuxiliaryVars(
+    llvm::function_ref<void(VarDecl *)> visit) const {
   if (getDeclContext()->isTypeContext() ||
       (isImplicit() && !isa<ParamDecl>(this)))
     return;

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -708,7 +708,7 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
       bool foundMatch = false;
       if (auto *varDecl = dyn_cast<VarDecl>(value)) {
         // Check if the name matches any auxiliary decls not in the AST
-        varDecl->visitAuxiliaryDecls([&](VarDecl *auxiliaryVar) {
+        varDecl->visitAuxiliaryVars([&](VarDecl *auxiliaryVar) {
           if (auxiliaryVar->ValueDecl::getName().matchesRef(fullName)) {
             value = auxiliaryVar;
             foundMatch = true;
@@ -918,7 +918,7 @@ public:
       bool foundMatch = false;
       if (auto *varDecl = dyn_cast<VarDecl>(value)) {
         // Check if the name matches any auxiliary decls not in the AST
-        varDecl->visitAuxiliaryDecls([&](VarDecl *auxiliaryVar) {
+        varDecl->visitAuxiliaryVars([&](VarDecl *auxiliaryVar) {
           if (name.isSimpleName(auxiliaryVar->getName())
                 && hasCorrectABIRole(auxiliaryVar)) {
             results.push_back(auxiliaryVar);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -708,12 +708,13 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
       bool foundMatch = false;
       if (auto *varDecl = dyn_cast<VarDecl>(value)) {
         // Check if the name matches any auxiliary decls not in the AST
-        varDecl->visitAuxiliaryVars([&](VarDecl *auxiliaryVar) {
-          if (auxiliaryVar->ValueDecl::getName().matchesRef(fullName)) {
-            value = auxiliaryVar;
-            foundMatch = true;
-          }
-        });
+        varDecl->visitAuxiliaryVars(
+            /*forNameLookup*/ true, [&](VarDecl *auxiliaryVar) {
+              if (auxiliaryVar->ValueDecl::getName().matchesRef(fullName)) {
+                value = auxiliaryVar;
+                foundMatch = true;
+              }
+            });
       }
 
       if (!foundMatch)
@@ -918,13 +919,14 @@ public:
       bool foundMatch = false;
       if (auto *varDecl = dyn_cast<VarDecl>(value)) {
         // Check if the name matches any auxiliary decls not in the AST
-        varDecl->visitAuxiliaryVars([&](VarDecl *auxiliaryVar) {
-          if (name.isSimpleName(auxiliaryVar->getName())
-                && hasCorrectABIRole(auxiliaryVar)) {
-            results.push_back(auxiliaryVar);
-            foundMatch = true;
-          }
-        });
+        varDecl->visitAuxiliaryVars(
+            /*forNameLookup*/ true, [&](VarDecl *auxiliaryVar) {
+              if (name.isSimpleName(auxiliaryVar->getName()) &&
+                  hasCorrectABIRole(auxiliaryVar)) {
+                results.push_back(auxiliaryVar);
+                foundMatch = true;
+              }
+            });
       }
 
       if (!foundMatch && value->getName().matchesRef(name)

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1716,7 +1716,7 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
   }
 
   // Emit lazy and property wrapper backing storage.
-  D->visitAuxiliaryVars([&](VarDecl *var) {
+  D->visitAuxiliaryVars(/*forNameLookup*/ false, [&](VarDecl *var) {
     if (auto *patternBinding = var->getParentPatternBinding())
       visitPatternBindingDecl(patternBinding);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1716,7 +1716,7 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
   }
 
   // Emit lazy and property wrapper backing storage.
-  D->visitAuxiliaryDecls([&](VarDecl *var) {
+  D->visitAuxiliaryVars([&](VarDecl *var) {
     if (auto *patternBinding = var->getParentPatternBinding())
       visitPatternBindingDecl(patternBinding);
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1064,7 +1064,7 @@ private:
   void emitParam(ParamDecl *PD) {
     // Register any auxiliary declarations for the parameter to be
     // visited later.
-    PD->visitAuxiliaryDecls([&](VarDecl *localVar) {
+    PD->visitAuxiliaryVars([&](VarDecl *localVar) {
       SGF.LocalAuxiliaryDecls.push_back(localVar);
     });
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1064,7 +1064,7 @@ private:
   void emitParam(ParamDecl *PD) {
     // Register any auxiliary declarations for the parameter to be
     // visited later.
-    PD->visitAuxiliaryVars([&](VarDecl *localVar) {
+    PD->visitAuxiliaryVars(/*forNameLookup*/ false, [&](VarDecl *localVar) {
       SGF.LocalAuxiliaryDecls.push_back(localVar);
     });
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1224,7 +1224,8 @@ private:
           // auxiliary variables (unless 'var' is a closure param).
           (void)var->getPropertyWrapperBackingPropertyType();
         }
-        var->visitAuxiliaryVars([&](VarDecl *auxVar) { foundDecl(auxVar); });
+        var->visitAuxiliaryVars(/*forNameLookup*/ true,
+                                [&](VarDecl *auxVar) { foundDecl(auxVar); });
       }
       // NOTE: We don't call Decl::visitAuxiliaryDecls here since peer decls of
       // local decls should not show up in lookup results.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1224,8 +1224,7 @@ private:
           // auxiliary variables (unless 'var' is a closure param).
           (void)var->getPropertyWrapperBackingPropertyType();
         }
-        var->visitAuxiliaryDecls(
-            [&](VarDecl *auxVar) { foundDecl(auxVar); });
+        var->visitAuxiliaryVars([&](VarDecl *auxVar) { foundDecl(auxVar); });
       }
       // NOTE: We don't call Decl::visitAuxiliaryDecls here since peer decls of
       // local decls should not show up in lookup results.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2382,8 +2382,9 @@ public:
     checkGlobalIsolation(VD);
 
     // Visit auxiliary decls first
-    VD->visitAuxiliaryVars(
-        [&](VarDecl *var) { this->visitBoundVariable(var); });
+    VD->visitAuxiliaryVars(/*forNameLookup*/ false, [&](VarDecl *var) {
+      this->visitBoundVariable(var);
+    });
 
     // Reject cases where this is a variable that has storage but it isn't
     // allowed.
@@ -4118,9 +4119,10 @@ void TypeChecker::checkParameterList(ParameterList *params,
 
     if (!param->isInvalid()) {
       auto *SF = owner->getParentSourceFile();
-      param->visitAuxiliaryVars([&](VarDecl *auxiliaryDecl) {
-        if (!isa<ParamDecl>(auxiliaryDecl))
-          DeclChecker(SF->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
+      auto &ctx = SF->getASTContext();
+      param->visitAuxiliaryVars(/*forNameLookup*/ false, [&](VarDecl *auxVar) {
+        if (!isa<ParamDecl>(auxVar))
+          DeclChecker(ctx, SF).visitBoundVariable(auxVar);
       });
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2382,9 +2382,8 @@ public:
     checkGlobalIsolation(VD);
 
     // Visit auxiliary decls first
-    VD->visitAuxiliaryDecls([&](VarDecl *var) {
-      this->visitBoundVariable(var);
-    });
+    VD->visitAuxiliaryVars(
+        [&](VarDecl *var) { this->visitBoundVariable(var); });
 
     // Reject cases where this is a variable that has storage but it isn't
     // allowed.
@@ -4119,7 +4118,7 @@ void TypeChecker::checkParameterList(ParameterList *params,
 
     if (!param->isInvalid()) {
       auto *SF = owner->getParentSourceFile();
-      param->visitAuxiliaryDecls([&](VarDecl *auxiliaryDecl) {
+      param->visitAuxiliaryVars([&](VarDecl *auxiliaryDecl) {
         if (!isa<ParamDecl>(auxiliaryDecl))
           DeclChecker(SF->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
       });

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -153,9 +153,8 @@ namespace {
 
       // Auxiliary decls need to have their contexts adjusted too.
       if (auto *VD = dyn_cast<VarDecl>(D)) {
-        VD->visitAuxiliaryDecls([&](VarDecl *D) {
-          D->setDeclContext(ParentDC);
-        });
+        VD->visitAuxiliaryVars(
+            [&](VarDecl *D) { D->setDeclContext(ParentDC); });
       }
 
       // We don't currently support peer macro declarations in local contexts,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -153,8 +153,9 @@ namespace {
 
       // Auxiliary decls need to have their contexts adjusted too.
       if (auto *VD = dyn_cast<VarDecl>(D)) {
-        VD->visitAuxiliaryVars(
-            [&](VarDecl *D) { D->setDeclContext(ParentDC); });
+        VD->visitAuxiliaryVars(/*forNameLookup*/ false, [&](VarDecl *D) {
+          D->setDeclContext(ParentDC);
+        });
       }
 
       // We don't currently support peer macro declarations in local contexts,

--- a/test/SILGen/lazy_locals.swift
+++ b/test/SILGen/lazy_locals.swift
@@ -50,4 +50,9 @@ func lazyLocalInClosure() {
     lazy var x = 0
     return x
   }
+  // https://github.com/swiftlang/swift/issues/83627
+  let _: (Int) -> Void = { (arg: _) in
+    lazy var val = arg
+    _ = val
+  }
 }

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -204,6 +204,12 @@ class LazyVarContainer {
   }
 }
 
+// The backing storage for lazy locals just isn't exposed through name lookup.
+func testLazyLocal() {
+  lazy var foo = 0
+  print($__lazy_storage_$_foo) // expected-error {{cannot find '$__lazy_storage_$_foo' in scope}}
+}
+
 // Make sure we can still access a synthesized variable with the same name as a lazy storage variable
 // i.e. $__lazy_storage_$_{property_name} when using property wrapper where the property name is 
 // '__lazy_storage_$_{property_name}'.

--- a/validation-test/compiler_crashers_fixed/AbstractStorageDecl-getValueInterfaceType-c9bb54.swift
+++ b/validation-test/compiler_crashers_fixed/AbstractStorageDecl-getValueInterfaceType-c9bb54.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::AbstractStorageDecl::getValueInterfaceType() const","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 class a {
 }
 {

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getClosureType-dc5f07.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getClosureType-dc5f07.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::getClosureType(swift::ClosureExpr const*) const","signatureAssert":"Assertion failed: (result), function getClosureType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   lazy var a =
     if <#expression#> {

--- a/validation-test/compiler_crashers_fixed/getParameterAt-0771c5.swift
+++ b/validation-test/compiler_crashers_fixed/getParameterAt-0771c5.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::getParameterAt(swift::ConcreteDeclRef, unsigned int)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a func b [{ lazy var c = a(d var e = b


### PR DESCRIPTION
We already reject attempts to reference this for `lazy` properties. For `lazy` locals let's just not expose it to name lookup to begin with. This ensures we don't attempt to prematurely kick the interface type computation for the var, fixing a couple of crashers.

Resolves #83627