### PR TITLE
[stdlib] Use typed throws for available functions

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1422,23 +1422,41 @@ extension Array: RangeReplaceableCollection {
   }
 
   @inlinable
-  public mutating func withContiguousMutableStorageIfAvailable<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public mutating func withContiguousMutableStorageIfAvailable<R, E>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return unsafe try withUnsafeMutableBufferPointer {
-      (bufferPointer) -> R in
+      (bufferPointer) throws(E) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSa39withContiguousMutableStorageIfAvailableyqd__Sgqd__SryxGzKXEKlF")
+  mutating func __rethrows_withContiguousMutableStorageIfAvailable<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    unsafe try withContiguousMutableStorageIfAvailable(body)
+  }
 
   @inlinable
-  public func withContiguousStorageIfAvailable<R>(
-    _ body: (UnsafeBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public func withContiguousStorageIfAvailable<R, E>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return unsafe try withUnsafeBufferPointer {
-      (bufferPointer) -> R in
+      (bufferPointer) throws(E) -> R in
       return try unsafe body(bufferPointer)
     }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSa32withContiguousStorageIfAvailableyqd__Sgqd__SRyxGKXEKlF")
+  func __rethrows_withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    unsafe try withContiguousStorageIfAvailable(body)
   }
   
   @inlinable
@@ -1974,12 +1992,21 @@ extension Array {
   ///   execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public mutating func withUnsafeMutableBytes<R>(
+  public mutating func withUnsafeMutableBytes<R, E>(
+    _ body: (UnsafeMutableRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withUnsafeMutableBufferPointer { pointer throws(E) in
+      return try unsafe body(UnsafeMutableRawBufferPointer(pointer))
+    }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSa22withUnsafeMutableBytesyqd__qd__SwKXEKlF")
+  mutating func __rethrows_withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeMutableBufferPointer {
-      return try unsafe body(UnsafeMutableRawBufferPointer($0))
-    }
+    unsafe try withUnsafeMutableBytes(body)
   }
 
   /// Calls the given closure with a pointer to the underlying bytes of the
@@ -2010,12 +2037,21 @@ extension Array {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public func withUnsafeBytes<R>(
+  public func withUnsafeBytes<R, E>(
+    _ body: (UnsafeRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withUnsafeBufferPointer { pointer throws(E) in
+      try unsafe body(UnsafeRawBufferPointer(pointer))
+    }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSa15withUnsafeBytesyqd__qd__SWKXEKlF")
+  func __rethrows_withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeBufferPointer {
-      try unsafe body(UnsafeRawBufferPointer($0))
-    }
+    unsafe try withUnsafeBytes(body)
   }
 }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1422,41 +1422,23 @@ extension Array: RangeReplaceableCollection {
   }
 
   @inlinable
-  public mutating func withContiguousMutableStorageIfAvailable<R, E>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
-  ) throws(E) -> R? {
+  public mutating func withContiguousMutableStorageIfAvailable<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
     return unsafe try withUnsafeMutableBufferPointer {
-      (bufferPointer) throws(E) -> R in
+      (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
-  
-  // ABI-only
-  @inlinable
-  @_silgen_name("$sSa39withContiguousMutableStorageIfAvailableyqd__Sgqd__SryxGzKXEKlF")
-  mutating func __rethrows_withContiguousMutableStorageIfAvailable<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
-    unsafe try withContiguousMutableStorageIfAvailable(body)
-  }
 
   @inlinable
-  public func withContiguousStorageIfAvailable<R, E>(
-    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
-  ) throws(E) -> R? {
-    return unsafe try withUnsafeBufferPointer {
-      (bufferPointer) throws(E) -> R in
-      return try unsafe body(bufferPointer)
-    }
-  }
-  
-  // ABI-only
-  @inlinable
-  @_silgen_name("$sSa32withContiguousStorageIfAvailableyqd__Sgqd__SRyxGKXEKlF")
-  func __rethrows_withContiguousStorageIfAvailable<R>(
+  public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    unsafe try withContiguousStorageIfAvailable(body)
+    return unsafe try withUnsafeBufferPointer {
+      (bufferPointer) -> R in
+      return try unsafe body(bufferPointer)
+    }
   }
   
   @inlinable

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1107,23 +1107,41 @@ extension ArraySlice: RangeReplaceableCollection {
   }
 
   @inlinable
-  public mutating func withContiguousMutableStorageIfAvailable<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public mutating func withContiguousMutableStorageIfAvailable<R, E>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return unsafe try withUnsafeMutableBufferPointer {
-      (bufferPointer) -> R in
+      (bufferPointer) throws(E) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$ss10ArraySliceV39withContiguousMutableStorageIfAvailableyqd__Sgqd__SryxGzKXEKlF")
+  mutating func __rethrows_withContiguousMutableStorageIfAvailable<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    unsafe try withContiguousMutableStorageIfAvailable(body)
+  }
 
   @inlinable
-  public func withContiguousStorageIfAvailable<R>(
-    _ body: (UnsafeBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public func withContiguousStorageIfAvailable<R, E>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return unsafe try withUnsafeBufferPointer {
-      (bufferPointer) -> R in
+      (bufferPointer) throws(E) -> R in
       return try unsafe body(bufferPointer)
     }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$ss10ArraySliceV32withContiguousStorageIfAvailableyqd__Sgqd__SRyxGKXEKlF")
+  public func __rethrows_withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    unsafe try withContiguousStorageIfAvailable(body)
   }
 
   @inlinable
@@ -1533,14 +1551,23 @@ extension ArraySlice {
   ///   execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public mutating func withUnsafeMutableBytes<R>(
-    _ body: (UnsafeMutableRawBufferPointer) throws -> R
-  ) rethrows -> R {
-    return try unsafe self.withUnsafeMutableBufferPointer {
-      return try unsafe body(UnsafeMutableRawBufferPointer($0))
+  public mutating func withUnsafeMutableBytes<R, E>(
+    _ body: (UnsafeMutableRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withUnsafeMutableBufferPointer { pointer throws(E) in
+      return try unsafe body(UnsafeMutableRawBufferPointer(pointer))
     }
   }
-
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$ss10ArraySliceV22withUnsafeMutableBytesyqd__qd__SwKXEKlF")
+  public mutating func __rethrows_withUnsafeMutableBytes<R>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    unsafe try withUnsafeMutableBytes(body)
+  }
+  
   /// Calls the given closure with a pointer to the underlying bytes of the
   /// array's contiguous storage.
   ///
@@ -1569,12 +1596,21 @@ extension ArraySlice {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public func withUnsafeBytes<R>(
+  public func withUnsafeBytes<R, E>(
+    _ body: (UnsafeRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withUnsafeBufferPointer { pointer throws(E) in
+      try unsafe body(UnsafeRawBufferPointer(pointer))
+    }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$ss10ArraySliceV15withUnsafeBytesyqd__qd__SWKXEKlF")
+  public func __rethrows_withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeBufferPointer {
-      try unsafe body(UnsafeRawBufferPointer($0))
-    }
+    unsafe try withUnsafeBytes(body)
   }
 }
 

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -71,9 +71,18 @@ extension _ArrayProtocol {
   // efficient, we should make the default implementation coming from Sequence
   // preferred.
   @inlinable
-  public __consuming func filter(
+  public __consuming func filter<E>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
+    return try _filter(isIncluded)
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$ss14_ArrayProtocolPsE6filterySay7ElementQzGSbAEKXEKF")
+  __consuming func __rethrows_filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
-    return try _filter(isIncluded)
+    try filter(isIncluded)
   }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1546,11 +1546,11 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public __consuming func split(
+  public __consuming func split<E>(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    whereSeparator isSeparator: (Element) throws -> Bool
-  ) rethrows -> [SubSequence] {
+    whereSeparator isSeparator: (Element) throws(E) -> Bool
+  ) throws(E) -> [SubSequence] {
     // TODO: swift-3-indexing-model - review the following
     _precondition(maxSplits >= 0, "Must take zero or more splits")
 
@@ -1590,6 +1590,19 @@ extension Collection {
     }
 
     return result
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSlsE5split9maxSplits25omittingEmptySubsequences14whereSeparatorSay11SubSequenceQzGSi_S2b7ElementQzKXEtKF")
+  __consuming func __rethrows_split(
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true,
+    whereSeparator isSeparator: (Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    try split(maxSplits: maxSplits,
+              omittingEmptySubsequences: omittingEmptySubsequences,
+              whereSeparator: isSeparator)
   }
 }
 

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -98,9 +98,9 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func firstIndex(
-    where predicate: (Element) throws -> Bool
-  ) rethrows -> Index? {
+  public func firstIndex<E>(
+    where predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> Index? {
     var i = self.startIndex
     while i != self.endIndex {
       if try predicate(self[i]) {
@@ -109,6 +109,15 @@ extension Collection {
       self.formIndex(after: &i)
     }
     return nil
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF")
+  func __rethrows_firstIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    try firstIndex(where: predicate)
   }
 }
 
@@ -137,10 +146,19 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func last(
+  public func last<E>(
+    where predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> Element? {
+    return try lastIndex(where: predicate).map { self[$0] }
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSKsE4last5where7ElementQzSgSbADKXE_tKF")
+  func __rethrows_last(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Element? {
-    return try lastIndex(where: predicate).map { self[$0] }
+    try last(where: predicate)
   }
 
   /// Returns the index of the last element in the collection that matches the
@@ -165,9 +183,9 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func lastIndex(
-    where predicate: (Element) throws -> Bool
-  ) rethrows -> Index? {
+  public func lastIndex<E>(
+    where predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> Index? {
     var i = endIndex
     while i != startIndex {
       formIndex(before: &i)
@@ -176,6 +194,15 @@ extension BidirectionalCollection {
       }
     }
     return nil
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSKsE9lastIndex5where0B0QzSgSb7ElementQzKXE_tKF")
+  func __rethrows_lastIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    try lastIndex(where: predicate)
   }
 }
 
@@ -325,10 +352,19 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public mutating func partition(
+  public mutating func partition<E>(
+    by belongsInSecondPartition: (Element) throws(E) -> Bool
+  ) throws(E) -> Index {
+    return try _halfStablePartition(isSuffixElement: belongsInSecondPartition)
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSMsE9partition2by5IndexQzSb7ElementQzKXE_tKF")
+  mutating func __rethrows_partition(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {
-    return try _halfStablePartition(isSuffixElement: belongsInSecondPartition)
+    try partition(by: belongsInSecondPartition)
   }
 
   /// Moves all elements satisfying `isSuffixElement` into a suffix of the
@@ -336,9 +372,9 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n*) where n is the length of the collection.
   @inlinable
-  internal mutating func _halfStablePartition(
-    isSuffixElement: (Element) throws -> Bool
-  ) rethrows -> Index {
+  internal mutating func _halfStablePartition<E>(
+    isSuffixElement: (Element) throws(E) -> Bool
+  ) throws(E) -> Index {
     guard var i = try firstIndex(where: isSuffixElement)
     else { return endIndex }
     
@@ -348,7 +384,7 @@ extension MutableCollection {
       formIndex(after: &j)
     }
     return i
-  }  
+  }
 }
 
 extension MutableCollection where Self: BidirectionalCollection {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -744,9 +744,9 @@ extension Sequence {
   }
 
   @_transparent
-  public func _filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  public func _filter<E>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
 
     var result = ContiguousArray<Element>()
 
@@ -968,17 +968,32 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public __consuming func split(
+  public __consuming func split<E>(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    whereSeparator isSeparator: (Element) throws -> Bool
-  ) rethrows -> [ArraySlice<Element>] {
+    whereSeparator isSeparator: (Element) throws(E) -> Bool
+  ) throws(E) -> [ArraySlice<Element>] {
     _precondition(maxSplits >= 0, "Must take zero or more splits")
     let whole = Array(self)
     return try whole.split(
                   maxSplits: maxSplits, 
                   omittingEmptySubsequences: omittingEmptySubsequences, 
                   whereSeparator: isSeparator)
+  }
+  
+  // ABI-only
+  @inlinable
+  @_silgen_name("$sSTsE5split9maxSplits25omittingEmptySubsequences14whereSeparatorSays10ArraySliceVy7ElementQzGGSi_S2bAHKXEtKF")
+  __consuming func __rethrows_split(
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true,
+    whereSeparator isSeparator: (Element) throws -> Bool
+  ) rethrows -> [ArraySlice<Element>] {
+    try split(
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences,
+      whereSeparator: isSeparator
+    )
   }
 
   /// Returns a subsequence, up to the given maximum length, containing the


### PR DESCRIPTION
Use `throws(E)` instead of `throws`-`rethrows`