### PR TITLE
[Sema] Enforce we don't type-check bindings independently of closures

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -674,9 +674,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         target.markInvalid();
         return true;
       }
-      // FIXME: Once we ban forward references to bindings in closures, we can
-      // add this assert (https://github.com/swiftlang/swift/pull/85141).
-      // ABORT("Cannot type-check PatternBindingDecl without closure context");
+      ABORT("Cannot type-check PatternBindingDecl without closure context");
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2733,13 +2733,9 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
       // or lazy type-checking, regular type-checking should go through the
       // StmtChecker and assign types before querying this, otherwise we could
       // end up double-type-checking.
-      //
-      // FIXME: We ought to be able to enable the following assert once we've
-      // fixed cases where we currently allow forward references to variables to
-      // kick interface type requests
-      // (https://github.com/swiftlang/swift/pull/85141).
-      // ASSERT(Context.SourceMgr.hasIDEInspectionTargetBuffer() ||
-      //        Context.TypeCheckerOpts.EnableLazyTypecheck);
+      ASSERT(Context.SourceMgr.hasIDEInspectionTargetBuffer() ||
+             Context.TypeCheckerOpts.EnableLazyTypecheck &&
+             "Querying VarDecl's type before type-checking parent stmt");
 
       // Try type checking parent control statement.
       if (auto condStmt = dyn_cast<LabeledConditionalStmt>(parentStmt)) {


### PR DESCRIPTION
Bindings in closures must be type-checked together with the surrounding closure, add an assertion to make sure we don't try this. Carve out an exception for code completion which may still kick lazy type-checking, in such cases we can just decline to type-check. Also enforce that lazy type-checking on bindings in parent stmts is only done during completion or lazy type-checking.