### PR TITLE
[CS] Invalidate nested unresolved VarDecls when ignoring completion argument

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -506,6 +506,10 @@ public:
   /// walk into the body of it (unless it is single-expression).
   void forEachChildExpr(llvm::function_ref<Expr *(Expr *)> callback);
 
+  /// Apply the specified function to all variables referenced in any
+  /// child UnresolvedPatternExprs.
+  void forEachUnresolvedVariable(llvm::function_ref<void(VarDecl *)> f) const;
+
   /// Determine whether this expression refers to a type by name.
   ///
   /// This distinguishes static references to types, like Int, from metatype

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -192,7 +192,7 @@ public:
   /// Collect the set of variables referenced in the given pattern.
   void collectVariables(SmallVectorImpl<VarDecl *> &variables) const;
 
-  /// apply the specified function to all variables referenced in this
+  /// Apply the specified function to all variables referenced in this
   /// pattern.
   void forEachVariable(llvm::function_ref<void(VarDecl *)> f) const;
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -192,8 +192,7 @@ namespace {
     const std::function<void(VarDecl*)> &fn;
   public:
     
-    WalkToVarDecls(const std::function<void(VarDecl*)> &fn)
-    : fn(fn) {}
+    WalkToVarDecls(const std::function<void(VarDecl*)> &fn) : fn(fn) {}
 
     /// Walk everything that's available; there shouldn't be macro expansions
     /// that matter anyway.
@@ -239,6 +238,9 @@ namespace {
   };
 } // end anonymous namespace
 
+void Expr::forEachUnresolvedVariable(llvm::function_ref<void(VarDecl *)> f) const {
+  const_cast<Expr *>(this)->walk(WalkToVarDecls(f));
+}
 
 /// apply the specified function to all variables referenced in this
 /// pattern.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4354,6 +4354,11 @@ namespace {
       auto &CS = CG.getConstraintSystem();
 
       if (CS.isArgumentIgnoredForCodeCompletion(expr)) {
+        // Make sure we invalidate any nested VarDecls to ensure the body
+        // VarDecl for a case statement still gets a type assigned.
+        expr->forEachUnresolvedVariable([&](VarDecl *VD) {
+          CS.setType(VD, ErrorType::get(CS.getASTContext()));
+        });
         CG.setTypeForArgumentIgnoredForCompletion(expr);
         return Action::SkipNode(expr);
       }

--- a/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-64cbd4.swift
+++ b/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-64cbd4.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","signature":"swift::constraints::ConstraintSystem::getType(swift::ASTNode) const","signatureAssert":"Assertion failed: (found != NodeTypes.end() && \"Expected type to have been set!\"), function getType"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 { switch { case let c(#^COMPLETE^# b) a


### PR DESCRIPTION
Make sure we set types for any nested VarDecls in UnresolvedPatternExprs to ensure we don't crash when attempting to solve the body.
