### PR TITLE
Fix warnings

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -157,7 +157,11 @@ public func freeBridgedString(bridged: BridgedStringRef) {
   bridged.data?.deallocate()
 }
 
-extension BridgedStringRef: /*@retroactive*/ Swift.ExpressibleByStringLiteral {
+extension BridgedStringRef:
+  /*@retroactive*/ Swift.ExpressibleByStringLiteral,
+                   Swift.ExpressibleByExtendedGraphemeClusterLiteral,
+                   Swift.ExpressibleByUnicodeScalarLiteral
+{
   public init(stringLiteral str: StaticString) {
     self.init(data: str.utf8Start, count: str.utf8CodeUnitCount)
   }

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -121,7 +121,7 @@ struct CompilerBuildConfiguration: BuildConfiguration {
   }
 
   func isActiveTargetObjectFormat(name: String) throws -> Bool {
-    try staticBuildConfiguration.isActiveTargetObjectFormat(name: name)
+    staticBuildConfiguration.isActiveTargetObjectFormat(name: name)
   }
 
   var targetAtomicBitWidths: [Int] {

--- a/lib/ASTGen/Sources/BasicSwift/StaticBuildConfiguration+LangOptions.swift
+++ b/lib/ASTGen/Sources/BasicSwift/StaticBuildConfiguration+LangOptions.swift
@@ -35,27 +35,29 @@ extension StaticBuildConfiguration {
   init(langOptions: BridgedLangOptions) {
     var entries = ConfigurationEntries()
 
-    langOptions.enumerateBuildConfigurationEntries(callbackContext: &entries) { cContext, entries, key, value in
-      let entries = entries.assumingMemoryBound(to: ConfigurationEntries.self)
-      switch key {
-      case .BCKAttribute:
-        entries.pointee.attributes.insert(String(bridged: value))
-      case .BCKCustomCondition:
-        entries.pointee.customConditions.insert(String(bridged: value))
-      case .BCKFeature:
-        entries.pointee.features.insert(String(bridged: value))
-      case .BCKTargetOSName:
-        entries.pointee.targetOSNames.insert(String(bridged: value))
-      case .BCKTargetArchitecture:
-        entries.pointee.targetArchitectures.insert(String(bridged: value))
-      case .BCKTargetEnvironment:
-        entries.pointee.targetEnvironments.insert(String(bridged: value))
-      case .BCKTargetRuntime:
-        entries.pointee.targetRuntimes.insert(String(bridged: value))
-      case .BCKTargetPointerAuthenticationScheme:
-        entries.pointee.targetPointerAuthenticationSchemes.insert(String(bridged: value))
-      case .BCKTargetObjectFileFormat:
-        entries.pointee.targetObjectFileFormats.insert(String(bridged: value))
+    withUnsafeMutablePointer(to: &entries) {
+      langOptions.enumerateBuildConfigurationEntries(callbackContext: $0) { cContext, entries, key, value in
+        let entries = entries.assumingMemoryBound(to: ConfigurationEntries.self)
+        switch key {
+        case .BCKAttribute:
+          entries.pointee.attributes.insert(String(bridged: value))
+        case .BCKCustomCondition:
+          entries.pointee.customConditions.insert(String(bridged: value))
+        case .BCKFeature:
+          entries.pointee.features.insert(String(bridged: value))
+        case .BCKTargetOSName:
+          entries.pointee.targetOSNames.insert(String(bridged: value))
+        case .BCKTargetArchitecture:
+          entries.pointee.targetArchitectures.insert(String(bridged: value))
+        case .BCKTargetEnvironment:
+          entries.pointee.targetEnvironments.insert(String(bridged: value))
+        case .BCKTargetRuntime:
+          entries.pointee.targetRuntimes.insert(String(bridged: value))
+        case .BCKTargetPointerAuthenticationScheme:
+          entries.pointee.targetPointerAuthenticationSchemes.insert(String(bridged: value))
+        case .BCKTargetObjectFileFormat:
+          entries.pointee.targetObjectFileFormats.insert(String(bridged: value))
+        }
       }
     }
 

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1758,7 +1758,7 @@ func parseProtocolMacroParam(
     if let methodSyntax = DeclSyntax("\(raw: methodSignature)").as(FunctionDeclSyntax.self) {
       name = methodSyntax.name.trimmed.text
     }
-    for (tmp, method) in methods where method.name.trimmed.text == name {
+    for (_, method) in methods where method.name.trimmed.text == name {
       notes.append(Note(node: Syntax(method.name), message: MacroExpansionNoteMessage("did you mean '\(method.trimmed.description)'?")))
     }
     throw DiagnosticError(


### PR DESCRIPTION
- Swiftify: Fix an unused variable warning
- ASTGen: Work around a retroactive conformance bug in Swift 6.2
- ASTGen: Fix an implicit pointer conversion warning
- ASTGen: Remove an unnecessary try