### PR TITLE
[Diagnostics] Add missing fix-its for unexpected/expected comma in attribute arguments

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1423,7 +1423,8 @@ bool Parser::parseDifferentiableAttributeArguments(
     if (!consumeIf(tok::comma)) return false;
     // Diagnose trailing comma before 'where' or ')'.
     if (Tok.is(tok::kw_where) || Tok.is(tok::r_paren)) {
-      diagnose(Tok, diag::unexpected_separator, ",");
+      diagnose(Tok, diag::unexpected_separator, ",")
+        .fixItRemove(PreviousLoc);
       return true;
     }
     // Check that token after comma is 'wrt'.
@@ -1665,14 +1666,16 @@ ParserResult<DerivativeAttr> Parser::parseDerivativeAttribute(SourceLoc atLoc,
       // If comma is required but does not exist and ')' has not been reached,
       // diagnose missing comma.
       if (requireComma && !Tok.is(tok::r_paren)) {
-        diagnose(getEndOfPreviousLoc(), diag::expected_separator, ",");
+        diagnose(getEndOfPreviousLoc(), diag::expected_separator, ",")
+          .fixItInsertAfter(PreviousLoc, ",");
         return true;
       }
       return false;
     }
     // Diagnose trailing comma before ')'.
     if (Tok.is(tok::r_paren)) {
-      diagnose(Tok, diag::unexpected_separator, ",");
+      diagnose(Tok, diag::unexpected_separator, ",")
+        .fixItRemove(PreviousLoc);
       return errorAndSkipUntilConsumeRightParen(*this, AttrName);
     }
     // Check that token after comma is 'wrt:'.
@@ -1745,14 +1748,16 @@ ParserResult<TransposeAttr> Parser::parseTransposeAttribute(SourceLoc atLoc,
       // If comma is required but does not exist and ')' has not been reached,
       // diagnose missing comma.
       if (requireComma && !Tok.is(tok::r_paren)) {
-        diagnose(Tok, diag::expected_separator, ",");
+        diagnose(Tok, diag::expected_separator, ",")
+          .fixItInsertAfter(PreviousLoc, ",");
         return true;
       }
       return false;
     }
     // Diagnose trailing comma before ')'.
     if (Tok.is(tok::r_paren)) {
-      diagnose(Tok, diag::unexpected_separator, ",");
+      diagnose(Tok, diag::unexpected_separator, ",")
+        .fixItRemove(PreviousLoc);
       return errorAndSkipUntilConsumeRightParen(*this, AttrName);
     }
     // Check that token after comma is 'wrt:'.

--- a/test/AutoDiff/Parse/derivative_attr_parse.swift
+++ b/test/AutoDiff/Parse/derivative_attr_parse.swift
@@ -81,7 +81,7 @@ func dfoo(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
     return (x, { $0 })
 }
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{20-21=}}
 @derivative(of: foo,)
 func dfoo(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })
@@ -100,14 +100,14 @@ func dfoo(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })
 }
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{20-21=}}
 @derivative(of: foo,)
 func dfoo(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })
 }
 
 // TF-1168: missing comma before `wrt:`.
-// expected-error @+2 {{expected ',' separator}}
+// expected-error @+2 {{expected ',' separator}} {{20-20=,}}
 // expected-error @+1 {{expected declaration}}
 @derivative(of: foo wrt: x)
 func dfoo(x: Float) -> (value: Float, differential: (Float) -> (Float)) {

--- a/test/AutoDiff/Parse/differentiable_attr_parse.swift
+++ b/test/AutoDiff/Parse/differentiable_attr_parse.swift
@@ -149,7 +149,7 @@ func two(x: Float, y: Float) -> Float {
   return x + y
 }
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{32-33=}}
 @differentiable(reverse, wrt: 0,)
 func two(x: Float, y: Float) -> Float {
   return x + y
@@ -173,13 +173,13 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{34-35=}}
 @differentiable(reverse, wrt: (x),)
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{34-35=}}
 @differentiable(reverse, wrt: (x), where T)
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x

--- a/test/AutoDiff/Parse/transpose_attr_parse.swift
+++ b/test/AutoDiff/Parse/transpose_attr_parse.swift
@@ -61,7 +61,7 @@ func transpose(v: Float) -> Float
 @transpose(of: foo, wrt)
 func transpose(v: Float) -> Float
 
-// expected-error @+1 {{unexpected ',' separator}}
+// expected-error @+1 {{unexpected ',' separator}} {{19-20=}}
 @transpose(of: foo,)
 func transpose(v: Float) -> Float
 
@@ -95,7 +95,7 @@ func transpose(v: Float) -> Float
 func transpose(v: Float) -> Float
 
 // TF-1168: missing comma before `wrt:`.
-// expected-error @+2 {{expected ',' separator}}
+// expected-error @+2 {{expected ',' separator}} {{19-19=,}}
 // expected-error @+1 {{expected declaration}}
 @transpose(of: foo wrt: x)
 func transpose(v: Float) -> Float

--- a/test/Parse/trailing-comma.swift
+++ b/test/Parse/trailing-comma.swift
@@ -74,7 +74,7 @@ if #available(iOS 15,) { }  // expected-error {{expected platform name}}
 
 // Built-in Attributes
 
-@attached(extension, conformances: OptionSet,)  // expected-error {{unexpected ',' separator}}
+@attached(extension, conformances: OptionSet,)  // expected-error {{unexpected ',' separator}} {{45-46=}}
 macro OptionSet<RawType>() = #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 
 @inline(never,) // expected-error {{expected declaration}} expected-error {{expected ')' in 'inline' attribute}} 
@@ -83,7 +83,7 @@ func foo() { }
 @available(iOS 15,) // expected-error {{expected platform name}} expected-error {{expected declaration}} 
 func foo() { }
 
-@backDeployed(before: SwiftStdlib 6.0,) // expected-error {{unexpected ',' separator}}
+@backDeployed(before: SwiftStdlib 6.0,) // expected-error {{unexpected ',' separator}} {{38-39=}}
 func foo() { }
 
 struct Foo {
@@ -104,10 +104,10 @@ struct Foo {
 
 func f(in: @differentiable(reverse,) (Int) -> Int) { } // expected-warning {{@differentiable' has been renamed to '@differentiable(reverse)' and will be removed in the next release}} expected-error {{expected ',' separator}} expected-error {{unnamed parameters must be written with the empty name '_'}}
 
-@derivative(of: Self.other,) // expected-error {{unexpected ',' separator}}
+@derivative(of: Self.other,) // expected-error {{unexpected ',' separator}} {{27-28=}}
 func foo() {}
 
-@transpose(of: S.instanceMethod,) // expected-error {{unexpected ',' separator}}
+@transpose(of: S.instanceMethod,) // expected-error {{unexpected ',' separator}} {{32-33=}}
 func transposeInstanceMethodWrtSelf(_ other: S, t: S) -> S {
     other + t
 }
@@ -145,6 +145,6 @@ if #available(OSX 51,) { // expected-error {{expected platform name}}
 }
 
 @available(OSX 10.7, iOS 7.0, *,) // expected-error {{expected platform name}} expected-error {{expected declaration}}
-@_originallyDefinedIn(module: "HighLevel", OSX 10.9, iOS 13.0,) // expected-error {{unexpected ',' separator}}
-@backDeployed(before: OSX 10.9,) // expected-error {{unexpected ',' separator}}
+@_originallyDefinedIn(module: "HighLevel", OSX 10.9, iOS 13.0,) // expected-error {{unexpected ',' separator}} {{62-63=}}
+@backDeployed(before: OSX 10.9,) // expected-error {{unexpected ',' separator}} {{31-32=}}
 public struct StructWithAvailability {}

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -452,7 +452,7 @@ public func missingVersionFunc3() {}
 @backDeployed(before: macOS 0) // expected-warning {{expected version number in '@backDeployed' attribute; this is an error in the Swift 6 language mode}}
 public func missingVersionFunc4() {}
 
-@backDeployed(before: macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}}
+@backDeployed(before: macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}} {{43-44=}}
 public func unexpectedSeparatorFunc() {}
 
 @backDeployed(before: macOS 12.0.1) // expected-warning {{'@backDeployed' only uses major and minor version number}}


### PR DESCRIPTION
1. Add fix-its for unexpected or expected comma in `@differentiable`, `@derivative`, and `@transpose` arguments.
2. Assert on fix-its for unexpected/expected comma in tests.