### PR TITLE
[CSOptimizer] Update unary call favoring to include resolved member r…

### DIFF
--- a/test/Constraints/old_hack_related_ambiguities.swift
+++ b/test/Constraints/old_hack_related_ambiguities.swift
@@ -160,8 +160,8 @@ do {
     var p: UnsafeMutableRawPointer { get { fatalError() } }
 
     func f(_ p: UnsafeMutableRawPointer) {
-      // The old hack (which is now removed) couldn't handle member references, only direct declaration references.
       guard let x = UnsafeMutablePointer<Double>(OpaquePointer(self.p)) else {
+        // expected-error@-1 {{initializer for conditional binding must have Optional type, not 'UnsafeMutablePointer<Double>'}}
         return
       }
       _ = x

--- a/validation-test/Sema/type_checker_perf/fast/property_passed_to_single_arg_init_in_operator_context.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/property_passed_to_single_arg_init_in_operator_context.swift.gyb
@@ -1,0 +1,27 @@
+// RUN: %scale-test --begin 1 --end 16 --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+// There was a performance hack that handled calls with a single unlabeled argument
+// in a very specific way. For source compatibility reasons old behavior has to be
+// preserved in the disjunction optimizer as well, but the old hack missed a case
+// where a type of a member is known in advance (i.e. a property without overloads)
+// because there as another hack (shrink) for that. This test makes sure that
+// performance for such cases won't regress in the future.
+
+struct Test {
+  var v = 0
+
+  func test() {
+    let _ = 1.0 * (
+      1.0 * Double(v) +
+%for i in range(1, N):
+  %if i % 2 == 0:
+      1.0 * Double(v) +
+  %else:
+      1.0 * Double(self.v) +
+  %end
+%end
+      1.0 * Double(v)
+    )
+  }
+}


### PR DESCRIPTION
…eferences

Update special favoring logic for unlabeled unary calls to support non-overloads member references in argument positions.

The original hack missed a case where a type of a member is known in advance (i.e. a property without overloads) because there as another hack (shrink) for that.

This helps in situations like `Double(x)` where `x` is a property of some type that is referenced using an implicit `self.` injected by the compiler.

Resolves: rdar://161419917

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
