### PR TITLE
[Observation] Refine performance from metrics for observations' hotpaths

### DIFF
--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -99,6 +99,8 @@ add_library(swiftObservation
   Sources/Observation/ObservationRegistrar.swift
   Sources/Observation/ObservationTracking.swift
   Sources/Observation/Observations.swift
+  Sources/Observation/OptimizedSet.swift
+  Sources/Observation/Table.swift
   Sources/Observation/ThreadLocal.swift
   Sources/Observation/ThreadLocal.cpp)
 set_target_properties(swiftObservation PROPERTIES

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -18,6 +18,8 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   ObservationRegistrar.swift
   ObservationTracking.swift
   Observations.swift
+  OptimizedSet.swift
+  Table.swift
   ThreadLocal.cpp
   ThreadLocal.swift
 

--- a/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
@@ -21,9 +21,9 @@ public struct ObservationTracking: Sendable {
   struct Entry: @unchecked Sendable {
     let context: ObservationRegistrar.Context
     
-    var properties: Set<AnyKeyPath>
+    var properties: OptimizedSet<AnyKeyPath>
     
-    init(_ context: ObservationRegistrar.Context, properties: Set<AnyKeyPath> = []) {
+    init(_ context: ObservationRegistrar.Context, properties: OptimizedSet<AnyKeyPath> = .empty) {
       self.context = context
       self.properties = properties
     }
@@ -78,21 +78,21 @@ public struct ObservationTracking: Sendable {
     let values = tracking.list.entries.mapValues { 
       switch (willSet, didSet) {
       case (.some(let willSetObserver), .some(let didSetObserver)):
-        return Id.full($0.addWillSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
+        return Id.full($0.addWillSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
           willSetObserver(tracking)
-        }, $0.addDidSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
+        }, $0.addDidSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
           didSetObserver(tracking)
         })
       case (.some(let willSetObserver), .none):
-        return Id.willSet($0.addWillSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
+        return Id.willSet($0.addWillSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
           willSetObserver(tracking)
         })
       case (.none, .some(let didSetObserver)):
-        return Id.didSet($0.addDidSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
+        return Id.didSet($0.addDidSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
           didSetObserver(tracking)
         })
       case (.none, .none):

--- a/stdlib/public/Observation/Sources/Observation/OptimizedSet.swift
+++ b/stdlib/public/Observation/Sources/Observation/OptimizedSet.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// Observation favors sets with either 1 or 0 elements; this prevents some of 
+// the extra traffic of retains/releases and hashes by specializing the
+// storage to a enumeration for holding those values and falling back to a 
+// standard Set.
+
+enum OptimizedSet<Element: Hashable> {
+	case empty
+	case single(Element)
+	case many(Set<Element>)
+}
+
+extension OptimizedSet {
+	var isEmpty: Bool {
+		switch self {
+		case .empty: return true
+		case .single: return false
+		case .many(let elements): return elements.isEmpty
+		}
+	}
+
+	mutating func insert(_ element: Element) {
+		switch self {
+		case .empty: 
+			self = .single(element)
+		case .single(let existing):
+			guard element != existing else {
+				return
+			}
+			self = .many([existing, element])
+		case .many(var existing):
+			self = .empty // avoid CoW
+			existing.insert(element)
+			self = .many(existing)
+		}
+	}
+
+	mutating func remove(_ element: Element) {
+		switch self {
+		case .empty:
+			break
+		case .single(let existing):
+			if existing == element {
+				self = .empty
+			}
+		case .many(var existing):
+			self = .empty
+			existing.remove(element)
+			let count = existing.count
+			if count == 1 {
+				self = .single(existing.first!)
+			} else {
+				self = .many(existing)
+			}
+		}
+	}
+
+	func union(_ other: OptimizedSet<Element>) -> OptimizedSet<Element> {
+		switch (self, other) {
+		case (.empty, .empty): return .empty
+		case (.single(let lhsElement), .empty): return .single(lhsElement)
+		case (.empty, .single(let rhsElement)): return .single(rhsElement)
+		case (.single(let lhsElement), .single(let rhsElement)):
+			if lhsElement == rhsElement {
+				return .single(lhsElement)
+			} else {
+				return .many([lhsElement, rhsElement])
+			}
+		case (.many(let lhsElements), .empty): return .many(lhsElements)
+		case (.empty, .many(let rhsElements)): return .many(rhsElements)
+		case (.single(let lhsElement), .many(var rhsElements)):
+			rhsElements.insert(lhsElement)
+			return .many(rhsElements)
+		case (.many(var lhsElements), .single(let rhsElement)):
+			lhsElements.insert(rhsElement)
+			return .many(lhsElements)
+		case (.many(let lhsElements), .many(let rhsElements)):
+			return .many(lhsElements.union(rhsElements))
+		}
+	}
+}
+
+extension OptimizedSet: Sequence {
+	enum Iterator: IteratorProtocol {
+		case empty
+		case single(Element)
+		case many(Set<Element>.Iterator)
+
+		mutating func next() -> Element? {
+			switch self {
+			case .empty: return nil
+			case .single(let element):
+				self = .empty
+				return element
+			case .many(var iterator):
+				self = .empty
+				guard let element = iterator.next() else {
+					return nil
+				}
+				self = .many(iterator)
+				return element
+			}
+		}
+	}
+
+	func makeIterator() -> Iterator {
+		switch self {
+		case .empty: .empty
+		case .single(let element): .single(element)
+		case .many(let elements): .many(elements.makeIterator())
+		}
+	}
+}

--- a/stdlib/public/Observation/Sources/Observation/Table.swift
+++ b/stdlib/public/Observation/Sources/Observation/Table.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+struct Table<Element> {
+  var elements: UnsafeMutableBufferPointer<Element?>?
+  var overflow: [Int: Element]?
+  let capacity: Int
+  
+  init(capacity: Int) {
+    self.capacity = capacity
+  }
+  
+  subscript(_ index: Int) -> Element? {
+    get {
+      if index < capacity {
+        return elements?[index]
+      } else {
+        return overflow?[index]
+      }
+    }
+    set {
+      if index < capacity {
+        if let elements {
+          elements[index] = newValue
+        } else {
+          let newElements = UnsafeMutableBufferPointer<Element?>.allocate(capacity: capacity)
+          newElements.initialize(repeating: nil)
+          newElements[index] = newValue
+          elements = newElements
+        }
+      } else {
+        if let newValue, overflow == nil {
+          overflow = [index : newValue]
+        } else {
+          overflow?[index] = newValue
+        }
+      }
+    }
+  }
+  
+  mutating func removeValue(forKey index: Int) -> Element? {
+    if index < capacity {
+      if let elements {
+        defer { elements[index] = nil }
+        return elements[index]
+      }
+    } else {
+      return overflow?.removeValue(forKey: index)
+    }
+    return nil
+  }
+  
+  mutating func removeAll() {
+    elements?.deinitialize()
+    elements?.deallocate()
+    elements = nil
+    overflow?.removeAll()
+  }
+}


### PR DESCRIPTION
Performance profiles showed that many of the hot sections of observation are around cancellation and impactful regions were also located around the hashing and lookup into the storage of sets and dictionaries. Observation has specific behavioral characteristics that a specialized a pair of storages (with fallback) would dramatically positively impact the performance of applications using Observation.

Some benchmarks of SwfitUI show up to a 30% performance improvement of the contributions of Observation itself from these changes.