### PR TITLE
SIL: Fix a `-Wimplicit-fallthrough` warning

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2550,7 +2550,8 @@ public:
   case BuiltinValueKind::id:                                                   \
     require(false,                                                             \
             "this builtin should never show up as builtin inst. It should "    \
-            "only result in other SIL instructions being emitted by SILGen");
+            "only result in other SIL instructions being emitted by SILGen");  \
+    break;
 #define BUILTIN(ID, Name, Attrs)                                               \
   case BuiltinValueKind::ID:                                                   \
     break;

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -681,7 +681,7 @@ enable-new-runtime-build
 
 # Escalate certain C++ warnings to errors for Swift.
 extra-swift-cmake-options=
-   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized"
+   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx


### PR DESCRIPTION
Warning introduced by https://github.com/swiftlang/swift/pull/85118.
