### PR TITLE
[rbi] When translating a Store, make sure to require src even if the value being stored is Sendable

### DIFF
--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -2025,3 +2025,42 @@ func avoidThinkingClosureParameterIsSending() {
     }
   }
 }
+
+enum RequireSrcWhenStoringEvenWhenSendable {
+  func test<T: Sendable>(t: T) {
+    var result: T = t
+    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
+      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      result = t
+    }
+    useValue(result) // expected-note {{access can happen concurrently}}
+  }
+
+  func test2() {
+    var result: Any = 0
+    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
+      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      result = 0
+    }
+    useValue(result) // expected-note {{access can happen concurrently}}
+  }
+
+  protocol Initializable {
+    init()
+  }
+
+  func test3<T: Initializable & SendableMetatype>(type: T.Type) {
+    var result = type.init()
+    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
+      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+      result = type.init()
+    }
+    useValue(result) // expected-note {{access can happen concurrently}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -329,6 +329,18 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
   print(ns4)
 }
 
+func testNonisolatedUnsafeForwardDeclaredVar<T: Sendable>(_ body: @escaping @Sendable () async throws -> T) throws -> T {
+  nonisolated(unsafe) var result: Result<T, Error>!
+  Task {
+    do {
+      result = .success(try await body())
+    } catch {
+      result = .failure(error)
+    }
+  }
+  return try result.get()
+}
+
 ////////////////////////
 // MARK: Global Tests //
 ////////////////////////


### PR DESCRIPTION
This is important to ensure that we require the base of src if the src is non-Sendable (e.x.: a non-Sendable box).

rdar://163322459
https://github.com/swiftlang/swift/issues/85107
