### PR TITLE
[CoroutineAccessors] Ptrauth improvements.

### DIFF
--- a/lib/IRGen/GenCoro.cpp
+++ b/lib/IRGen/GenCoro.cpp
@@ -1083,6 +1083,13 @@ static llvm::Constant *getAddrOfGlobalCoroAllocator(
   return taskAllocator;
 }
 
+static llvm::Constant *getAddrOfGlobalCoroAllocator(
+    IRGenModule &IGM, CoroAllocatorKind kind, bool shouldDeallocateImmediately,
+    llvm::Constant *allocFn, llvm::Constant *deallocFn) {
+  return getAddrOfGlobalCoroAllocator(IGM, kind, shouldDeallocateImmediately,
+                                      allocFn, deallocFn, allocFn, deallocFn);
+}
+
 static llvm::Constant *getAddrOfSwiftCoroMalloc(
                                                 IRGenModule &IGM) {
   return getAddrOfSwiftCoroAllocThunk("_swift_coro_malloc",
@@ -1098,13 +1105,10 @@ static llvm::Constant *getAddrOfSwiftCoroFree(
 }
 
 llvm::Constant *IRGenModule::getAddrOfGlobalCoroMallocAllocator() {
-  return getAddrOfGlobalCoroAllocator(
-      *this, CoroAllocatorKind::Malloc,
-      /*shouldDeallocateImmediately=*/true,
-      getAddrOfSwiftCoroMalloc(*this),
-      getAddrOfSwiftCoroFree(*this),
-      getAddrOfSwiftCoroMalloc(*this),
-      getAddrOfSwiftCoroFree(*this));
+  return getAddrOfGlobalCoroAllocator(*this, CoroAllocatorKind::Malloc,
+                                      /*shouldDeallocateImmediately=*/true,
+                                      getAddrOfSwiftCoroMalloc(*this),
+                                      getAddrOfSwiftCoroFree(*this));
 }
 
 static llvm::Constant *
@@ -1122,13 +1126,10 @@ getAddrOfSwiftCoroTaskDealloc(IRGenModule &IGM) {
 }
 
 llvm::Constant *IRGenModule::getAddrOfGlobalCoroAsyncTaskAllocator() {
-  return getAddrOfGlobalCoroAllocator(
-      *this, CoroAllocatorKind::Async,
-      /*shouldDeallocateImmediately=*/false,
-      getAddrOfSwiftCoroTaskAlloc(*this),
-      getAddrOfSwiftCoroTaskDealloc(*this),
-      getAddrOfSwiftCoroTaskAlloc(*this),
-      getAddrOfSwiftCoroTaskDealloc(*this));
+  return getAddrOfGlobalCoroAllocator(*this, CoroAllocatorKind::Async,
+                                      /*shouldDeallocateImmediately=*/false,
+                                      getAddrOfSwiftCoroTaskAlloc(*this),
+                                      getAddrOfSwiftCoroTaskDealloc(*this));
 }
 
 llvm::Value *

--- a/lib/IRGen/GenCoro.cpp
+++ b/lib/IRGen/GenCoro.cpp
@@ -1090,15 +1090,13 @@ static llvm::Constant *getAddrOfGlobalCoroAllocator(
                                       allocFn, deallocFn, allocFn, deallocFn);
 }
 
-static llvm::Constant *getAddrOfSwiftCoroMalloc(
-                                                IRGenModule &IGM) {
+static llvm::Constant *getAddrOfSwiftCoroMalloc(IRGenModule &IGM) {
   return getAddrOfSwiftCoroAllocThunk("_swift_coro_malloc",
                                       &IRGenModule::getMallocFunctionPointer,
                                       IGM);
 }
 
-static llvm::Constant *getAddrOfSwiftCoroFree(
-                                              IRGenModule &IGM) {
+static llvm::Constant *getAddrOfSwiftCoroFree(IRGenModule &IGM) {
   return getAddrOfSwiftCoroDeallocThunk("_swift_coro_free",
                                         &IRGenModule::getFreeFunctionPointer,
                                         IGM);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1094,11 +1094,11 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
       codeKey, /*address*/ false, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroDeallocationFunction);
 
-  opts.CoroAllocationFunction = PointerAuthSchema(
+  opts.CoroFrameAllocationFunction = PointerAuthSchema(
       codeKey, /*address*/ false, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroFrameAllocationFunction);
 
-  opts.CoroDeallocationFunction = PointerAuthSchema(
+  opts.CoroFrameDeallocationFunction = PointerAuthSchema(
       codeKey, /*address*/ false, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroFrameDeallocationFunction);
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1087,19 +1087,19 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
       PointerAuthSchema(nonABIDataKey, /*address*/ true, Discrimination::Decl);
 
   opts.CoroAllocationFunction = PointerAuthSchema(
-      codeKey, /*address*/ false, Discrimination::Constant,
+      codeKey, /*address*/ true, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroAllocationFunction);
 
   opts.CoroDeallocationFunction = PointerAuthSchema(
-      codeKey, /*address*/ false, Discrimination::Constant,
+      codeKey, /*address*/ true, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroDeallocationFunction);
 
   opts.CoroFrameAllocationFunction = PointerAuthSchema(
-      codeKey, /*address*/ false, Discrimination::Constant,
+      codeKey, /*address*/ true, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroFrameAllocationFunction);
 
   opts.CoroFrameDeallocationFunction = PointerAuthSchema(
-      codeKey, /*address*/ false, Discrimination::Constant,
+      codeKey, /*address*/ true, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::CoroFrameDeallocationFunction);
 }
 

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -37,10 +37,30 @@
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
+// CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth.1 = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 53841 }
+// CHECK-arm64e-SAME:  section "llvm.ptrauth"
+// CHECK-arm64e-SAME:  align 8
+// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth.2 = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 23464 },
+// CHECK-arm64e-SAME:  section "llvm.ptrauth",
+// CHECK-arm64e-SAME:  align 8
 // CHECK-LABEL: _swift_coro_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
 // CHECK-SAME:       i32 258,
-// CHECK-SAME:       malloc
-// CHECK-SAME:       free
+// CHECK-SAME:       _swift_coro_malloc
+// CHECK-ar64e-SAME:     .ptrauth
+// CHECK-SAME:       _swift_coro_free
+// CHECK-ar64e-SAME:     .ptrauth
+// CHECK-SAME:       _swift_coro_malloc
+// CHECK-ar64e-SAME:     .ptrauth.1
+// CHECK-SAME:       _swift_coro_free
+// CHECK-ar64e-SAME:     .ptrauth.2
 // CHECK-SAME:  }
 // CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
@@ -56,10 +76,30 @@
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
+// CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth.3 = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 53841 }
+// CHECK-arm64e-SAME:  section "llvm.ptrauth"
+// CHECK-arm64e-SAME:  align 8
+// CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth.4 = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 23464 },
+// CHECK-arm64e-SAME:  section "llvm.ptrauth",
+// CHECK-arm64e-SAME:  align 8
 // CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
 // CHECK-SAME:      i32 1,
 // CHECK-SAME:      _swift_coro_task_alloc
+// CHECK-ar64e-SAME:     .ptrauth
 // CHECK-SAME:      _swift_coro_task_dealloc
+// CHECK-ar64e-SAME:     .ptrauth
+// CHECK-SAME:      _swift_coro_task_alloc
+// CHECK-ar64e-SAME:     .ptrauth.3
+// CHECK-SAME:      _swift_coro_task_dealloc
+// CHECK-ar64e-SAME:     .ptrauth.4
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -26,28 +26,52 @@
 // CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_malloc_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 1
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_free,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_malloc_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 2
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth.1 = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_malloc_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 3
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 53841 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: _swift_coro_free.ptrauth.2 = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_free,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_malloc_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 4
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 23464 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
@@ -65,28 +89,52 @@
 // CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 1
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 2
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: _swift_coro_task_alloc.ptrauth.3 = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_task_alloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 3
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 53841 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
 // CHECK-arm64e-SAME:  align 8
 // CHECK-arm64e-LABEL: @_swift_coro_task_dealloc.ptrauth.4 = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_task_dealloc,
 // CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_async_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 4
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 23464 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
@@ -114,8 +162,10 @@
 // CHECK-SAME:        i32 0
 // CHECK-SAME:        i32 1
 // CHECK:         [[ALLOCATE_FN:%[^,]+]] = load ptr, ptr [[ALLOCATE_FN_PTR]]
+// CHECK-arm64e:  [[ALLOCATE_FN_PTR_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN_PTR]] to i64
+// CHECK-arm64e:  [[ALLOCATE_FN_DISCRIMINATOR:%[^,]+]] = call i64 @llvm.ptrauth.blend(i64 [[ALLOCATE_FN_PTR_BITS]], i64 24469)
 // CHECK-arm64e:  [[ALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[ALLOCATE_FN]] to i64
-// CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 24469)
+// CHECK-arm64e:  [[ALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[ALLOCATE_FN_BITS]], i32 0, i64 [[ALLOCATE_FN_DISCRIMINATOR]])
 // CHECK-arm64e:  [[ALLOCATE_FN:%[^,]+]] = inttoptr i64 [[ALLOCATE_FN_BITS_AUTHED]]
 // CHECK:         [[ALLOCATION:%[^,]+]] = call swiftcc ptr [[ALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], [[INT]] [[SIZE]])
 // CHECK:         ret ptr [[ALLOCATION]]
@@ -146,8 +196,10 @@
 // CHECK-SAME:          i32 0
 // CHECK-SAME:          i32 2
 // CHECK:           [[DEALLOCATE_FN:%[^,]+]] = load ptr, ptr [[DEALLOCATE_FN_PTR]]
+// CHECK-arm64e:    [[DEALLOCATE_FN_PTR_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN_PTR]] to i64
+// CHECK-arm64e:    [[DEALLOCATE_FN_DISCRIMINATOR:%[^,]+]] = call i64 @llvm.ptrauth.blend(i64 [[DEALLOCATE_FN_PTR_BITS]], i64 40879)
 // CHECK-arm64e:    [[DEALLOCATE_FN_BITS:%[^,]+]] = ptrtoint ptr [[DEALLOCATE_FN]] to i64
-// CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 40879)
+// CHECK-arm64e:    [[DEALLOCATE_FN_BITS_AUTHED:%[^,]+]] = call i64 @llvm.ptrauth.auth(i64 [[DEALLOCATE_FN_BITS]], i32 0, i64 [[DEALLOCATE_FN_DISCRIMINATOR]])
 // CHECK-arm64e:    [[DEALLOCATE_FN:%[^,]+]] = inttoptr i64 [[DEALLOCATE_FN_BITS_AUTHED]]
 // CHECK:           call swiftcc void [[DEALLOCATE_FN]](ptr [[FRAME]], ptr swiftcoro [[ALLOCATOR]], ptr [[ADDRESS]])
 // CHECK:         ret void


### PR DESCRIPTION
Fix the schema used for the functions in the frame de/alloc slots.  Address-discriminate all functions stored in the allocator.

rdar://163330882
