### PR TITLE
AST: Introduce the `Swift`, `anyAppleOS`, and `DriverKit` platform kinds

### DIFF
--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -34,6 +34,11 @@ AVAILABILITY_PLATFORM(visionOSApplicationExtension, "application extensions for 
 AVAILABILITY_PLATFORM(macOSApplicationExtension, "application extensions for macOS")
 AVAILABILITY_PLATFORM(macCatalyst, "Mac Catalyst")
 AVAILABILITY_PLATFORM(macCatalystApplicationExtension, "application extensions for Mac Catalyst")
+AVAILABILITY_PLATFORM(DriverKit, "DriverKit")
+/// A meta-platform representing the built-in Swift runtime.
+AVAILABILITY_PLATFORM(Swift, "Swift")
+/// A meta-platform for Apple operating systems with unified versioning.
+AVAILABILITY_PLATFORM(anyAppleOS, "any Apple OS")
 AVAILABILITY_PLATFORM(FreeBSD, "FreeBSD")
 AVAILABILITY_PLATFORM(OpenBSD, "OpenBSD")
 AVAILABILITY_PLATFORM(Windows, "Windows")

--- a/lib/AST/PlatformKindUtils.cpp
+++ b/lib/AST/PlatformKindUtils.cpp
@@ -115,6 +115,9 @@ swift::basePlatformForExtensionPlatform(PlatformKind Platform) {
   case PlatformKind::tvOS:
   case PlatformKind::watchOS:
   case PlatformKind::visionOS:
+  case PlatformKind::DriverKit:
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
   case PlatformKind::FreeBSD:
   case PlatformKind::OpenBSD:
   case PlatformKind::Windows:
@@ -159,6 +162,11 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
     case PlatformKind::visionOS:
     case PlatformKind::visionOSApplicationExtension:
       return Target.isXROS();
+    case PlatformKind::DriverKit:
+      return Target.isDriverKit();
+    case PlatformKind::Swift:
+    case PlatformKind::anyAppleOS:
+      return Target.isOSDarwin();
     case PlatformKind::OpenBSD:
       return Target.isOSOpenBSD();
     case PlatformKind::FreeBSD:
@@ -292,6 +300,11 @@ swift::tripleOSTypeForPlatform(PlatformKind platform) {
   case PlatformKind::visionOS:
   case PlatformKind::visionOSApplicationExtension:
     return llvm::Triple::XROS;
+  case PlatformKind::DriverKit:
+    return llvm::Triple::DriverKit;
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
+      return std::nullopt;
   case PlatformKind::FreeBSD:
     return llvm::Triple::FreeBSD;
   case PlatformKind::OpenBSD:
@@ -332,6 +345,9 @@ bool swift::isPlatformSPI(PlatformKind Platform) {
   case PlatformKind::watchOSApplicationExtension:
   case PlatformKind::visionOS:
   case PlatformKind::visionOSApplicationExtension:
+  case PlatformKind::DriverKit:
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
   case PlatformKind::OpenBSD:
   case PlatformKind::FreeBSD:
   case PlatformKind::Windows:

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2561,6 +2561,14 @@ PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
   case PlatformKind::visionOSApplicationExtension:
     break;
 
+  case PlatformKind::DriverKit:
+    deprecatedAsUnavailableMessage = "";
+    break;
+
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
+    llvm_unreachable("Unexpected platform");
+
   case PlatformKind::FreeBSD:
     deprecatedAsUnavailableMessage = "";
     break;
@@ -2615,6 +2623,13 @@ bool PlatformAvailability::isPlatformRelevant(StringRef name) const {
   case PlatformKind::visionOSApplicationExtension:
     return name == "xros" || name == "xros_app_extension" ||
            name == "visionos" || name == "visionos_app_extension";
+
+  case PlatformKind::DriverKit:
+    return name == "driverkit";
+
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
+    break; // Unexpected
 
   case PlatformKind::FreeBSD:
     return name == "freebsd";
@@ -2692,6 +2707,15 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::visionOSApplicationExtension:
     // No deprecation filter on xrOS
     return false;
+
+  case PlatformKind::DriverKit:
+    // No deprecation filter on DriverKit
+    // FIXME: [availability] This should probably have a value.
+    return false;
+
+  case PlatformKind::Swift:
+  case PlatformKind::anyAppleOS:
+    break; // Unexpected
 
   case PlatformKind::FreeBSD:
     // No deprecation filter on FreeBSD

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -245,6 +245,12 @@ getLinkerPlatformId(OriginallyDefinedInAttr::ActiveVersion Ver,
   switch(Ver.Platform) {
   case swift::PlatformKind::none:
     llvm_unreachable("cannot find platform kind");
+  case swift::PlatformKind::DriverKit:
+    llvm_unreachable("not used for this platform");
+  case swift::PlatformKind::Swift:
+    llvm_unreachable("not used for this platform");
+  case PlatformKind::anyAppleOS:
+    llvm_unreachable("not used for this platform");
   case swift::PlatformKind::FreeBSD:
     llvm_unreachable("not used for this platform");
   case swift::PlatformKind::OpenBSD:
@@ -253,6 +259,7 @@ getLinkerPlatformId(OriginallyDefinedInAttr::ActiveVersion Ver,
     llvm_unreachable("not used for this platform");
   case swift::PlatformKind::Android:
     llvm_unreachable("not used for this platform");
+
   case swift::PlatformKind::iOS:
   case swift::PlatformKind::iOSApplicationExtension:
     if (target && target->isMacCatalystEnvironment())

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1821,6 +1821,14 @@ public:
       case PlatformKind::visionOSApplicationExtension:
         plat = "visionos_app_extension";
         break;
+      case PlatformKind::DriverKit:
+        plat = "driverkit";
+        break;
+      case PlatformKind::Swift:
+      case PlatformKind::anyAppleOS:
+        // FIXME: [runtime availability] Figure out how to support this.
+        ASSERT(0);
+        break;
       case PlatformKind::FreeBSD:
         plat = "freebsd";
         break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 970; // return_borrow
+const uint16_t SWIFTMODULE_VERSION_MINOR = 971; // new platform kinds
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -54,6 +54,12 @@ StringRef getDomain(const SemanticAvailableAttr &AvAttr) {
       return { "watchOSAppExtension" };
     case swift::PlatformKind::visionOSApplicationExtension:
       return { "visionOSAppExtension" };
+    case PlatformKind::DriverKit:
+      return { "DriverKit" };
+    case swift::PlatformKind::Swift:
+      return { "Swift" };
+    case PlatformKind::anyAppleOS:
+      return { "Any Apple OS" };
     case swift::PlatformKind::FreeBSD:
       return { "FreeBSD" };
     case swift::PlatformKind::OpenBSD:

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -83,6 +83,9 @@ actor MyGenericGlobalActor<T> {
 // AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
+// AVAILABILITY1-NEXT: Keyword/None:                       DriverKit[#Platform#]; name=DriverKit{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       Swift[#Platform#]; name=Swift{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       anyAppleOS[#Platform#]; name=anyAppleOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       FreeBSD[#Platform#]; name=FreeBSD{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       OpenBSD[#Platform#]; name=OpenBSD{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       Windows[#Platform#]; name=Windows{{$}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -693,6 +693,9 @@ static void reportAvailabilityAttributes(ASTContext &Ctx, const Decl *D,
   static UIdent PlatformOSXAppExt("source.availability.platform.osx_app_extension");
   static UIdent PlatformtvOSAppExt("source.availability.platform.tvos_app_extension");
   static UIdent PlatformWatchOSAppExt("source.availability.platform.watchos_app_extension");
+  static UIdent PlatformDriverKit("source.availability.platform.driverkit");
+  static UIdent PlatformSwift("source.availability.platform.swift");
+  static UIdent PlatformAnyAppleOS("source.availability.platform.any_apple_os");
   static UIdent PlatformFreeBSD("source.availability.platform.freebsd");
   static UIdent PlatformOpenBSD("source.availability.platform.openbsd");
   static UIdent PlatformWindows("source.availability.platform.windows");
@@ -743,6 +746,15 @@ static void reportAvailabilityAttributes(ASTContext &Ctx, const Decl *D,
       // FIXME: Formal platform support in SourceKit is needed.
       PlatformUID = UIdent();
       break;
+    case PlatformKind::DriverKit:
+      PlatformUID = PlatformDriverKit;
+      break;
+    case PlatformKind::Swift:
+      PlatformUID = PlatformSwift;
+      break;
+    case PlatformKind::anyAppleOS:
+      PlatformUID = PlatformAnyAppleOS;
+      break;
     case PlatformKind::OpenBSD:
       PlatformUID = PlatformOpenBSD;
       break;
@@ -756,7 +768,7 @@ static void reportAvailabilityAttributes(ASTContext &Ctx, const Decl *D,
       PlatformUID = PlatformAndroid;
       break;
     }
-    // FIXME: [availability] Handle other availability domains?
+    // FIXME: [availability] Handle non-platform availability domains?
 
     AvailableAttrInfo Info;
     Info.AttrKind = AvailableAttrKind;


### PR DESCRIPTION
This change just stages in a few new platform kinds, without fully adding support for them yet.

- The `Swift` platform represents availability of the Swift runtime across all platforms that support an ABI stable Swift runtime (see the pitch at https://forums.swift.org/t/pitch-swift-runtime-availability/82742).
- The `anyAppleOS` platform is an experimental platform that represents all of Apple's operating systems. This is intended to simplify writing availability for Apple's platforms by taking advantage of the new unified OS versioning system announced at WWDC 2025.
- The `DriverKit` platform corresponds to Apple DriverKit which is already supported by LLVM.
