### PR TITLE
[StrictExhaustiveSwitches] Replace default switch case with known enumerated cases

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -115,6 +115,7 @@ GROUP(UselessAvailabilityCheck,none,"useless-availability-check")
 GROUP(UselessConditionalStatement,none,"useless-conditional-statement")
 GROUP(WeakMutability,none,"weak-mutability")
 GROUP(OldSuppressedAssociatedTypes,none,"old-suppressed-associatedtypes")
+GROUP(StrictExhaustiveSwitches,DefaultIgnoreWarnings,"strict-exhaustive-switches")
 
 GROUP_LINK(PerformanceHints,ExistentialType)
 GROUP_LINK(PerformanceHints,ReturnTypeImplicitCopy)

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -346,6 +346,8 @@ WARNING(unreachable_code_after_stmt,none,
         "be executed", (unsigned))
 WARNING(unreachable_case,none,
         "%select{case|default}0 will never be executed", (bool))
+NOTE(default_after_catchall,none,
+     "a 'default' case is equivalent to a catch-all case; remove one", ())
 WARNING(switch_on_a_constant,none,
         "switch condition evaluates to a constant", ())
 NOTE(unreachable_code_note,none, "will never be executed", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7797,6 +7797,9 @@ NOTE(missing_several_cases,none,
 NOTE(missing_unknown_case,none,
      "handle unknown values using \"@unknown default\"", ())
 
+GROUPED_WARNING(decompose_default_case,StrictExhaustiveSwitches,none,
+  "switch can be made exhaustive without use of 'default'; replace with known cases", ())
+
 NOTE(non_exhaustive_switch_drop_unknown,none,
      "remove '@unknown' to handle remaining values", ())
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1418,6 +1418,9 @@ public:
 
   bool isDefault() { return getCaseLabelItems()[0].isDefault(); }
 
+  /// True if this case matches any pattern ('case _:' or 'case(_, _):')
+  bool isCatchAll();
+
   bool hasUnknownAttr() const {
     // Note: This representation doesn't allow for synthesized @unknown cases.
     // However, that's probably sensible; the purpose of @unknown is for

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -1008,6 +1008,32 @@ CaseStmt *findNextCaseStmt(
 
 }
 
+static bool isCatchAllPattern(const Pattern *pattern) {
+  switch (pattern->getKind()) {
+  case PatternKind::Any:
+    return true;
+  case PatternKind::Tuple:
+    return llvm::all_of(cast<TuplePattern>(pattern)->getElements(),
+                        [&](const TuplePatternElt element) {
+                          return isCatchAllPattern(element.getPattern());
+                        });
+  case PatternKind::OptionalSome:
+    return isCatchAllPattern(
+        cast<OptionalSomePattern>(pattern)->getSubPattern());
+  case PatternKind::Paren:
+    return isCatchAllPattern(cast<ParenPattern>(pattern)->getSubPattern());
+  default:
+    return false;
+  }
+}
+
+bool CaseStmt::isCatchAll() {
+  return !isDefault() &&
+         llvm::all_of(getCaseLabelItems(), [](const CaseLabelItem &item) {
+           return !item.getGuardExpr() && isCatchAllPattern(item.getPattern());
+         });
+}
+
 CaseStmt *CaseStmt::findNextCaseStmt() const {
   auto parent = getParentStmt();
   if (!parent)

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1151,6 +1151,19 @@ void PatternMatchEmission::emitDispatch(ClauseMatrix &clauses, ArgArray args,
         }
         if (isParentDoCatch || isDefault || caseHasExprPattern) {
           SGF.SGM.diagnose(Loc, diag::unreachable_case, isDefault);
+
+          // When a default is unreachable because a catch-all case already
+          // covers the space, also diagnose the catch-all case.
+          if (isDefault) {
+            if (auto *switchStmt = dyn_cast<SwitchStmt>(PatternMatchStmt)) {
+              for (auto *caseBlock : switchStmt->getCases()) {
+                if (caseBlock->isCatchAll()) {
+                  SGF.SGM.diagnose(caseBlock->getLoc(),
+                                   diag::default_after_catchall);
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -16,6 +16,7 @@
 
 #include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/DiagnosticGroups.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Pattern.h"
 #include "swift/Basic/Assertions.h"
@@ -973,6 +974,11 @@ namespace {
       }
     }
 
+    bool hasStrictExhaustiveChecksEnabled() {
+      auto SF = DC->getParentSourceFile();
+      return Context.Diags.isDiagnosticGroupEnabled(SF, DiagGroupID::StrictExhaustiveSwitches);
+    }
+
     void checkExhaustiveness(bool limitedChecking) {
       // If the type of the scrutinee is uninhabited, we're already dead.
       // Allow any well-typed patterns through.
@@ -985,11 +991,14 @@ namespace {
       if (limitedChecking) {
         // Reject switch statements with empty blocks.
         if (Switch->getCases().empty())
-          diagnoseMissingCases(RequiresDefault::EmptySwitchBody, Space());
+          diagnoseMissingCases(RequiresDefault::EmptySwitchBody, Space(),
+                               nullptr /* unknown default */,
+                               nullptr /* default */);
         return;
       }
 
       const CaseStmt *unknownCase = nullptr;
+      const CaseStmt *defaultCase = nullptr;
       SmallVector<Space, 4> spaces;
       auto &DE = Context.Diags;
       for (auto *caseBlock : Switch->getCases()) {
@@ -1006,8 +1015,14 @@ namespace {
             continue;
 
           // Space is trivially covered with a default clause.
-          if (caseItem.isDefault())
-            return;
+          if (caseItem.isDefault()) {
+            if (!hasStrictExhaustiveChecksEnabled()) {
+              return;
+            }
+            assert(defaultCase == nullptr && "multiple default cases");
+            defaultCase = caseBlock;
+            continue;
+          }
 
           Space projection = projectPattern(caseItem.getPattern());
           bool isRedundant = !projection.isEmpty() &&
@@ -1046,7 +1061,7 @@ namespace {
       auto diff = totalSpace.minus(coveredSpace, DC, &minusCount);
       if (!diff) {
         diagnoseMissingCases(RequiresDefault::SpaceTooLarge, Space(),
-                             unknownCase);
+                             unknownCase, defaultCase);
         return;
       }
 
@@ -1060,34 +1075,44 @@ namespace {
       // uncovered space is empty because we trust that if the developer went to
       // the trouble of writing @unknown that it was for a good reason, like
       // addressing diagnostics in another build configuration where there are
-      // potentially unknown cases.
+      // potentially unknown cases, like a dependency built with resilience.
       uncovered = *uncovered.minus(Space::forUnknown(unknownCase == nullptr),
                                    DC, /*&minusCount*/ nullptr);
 
-      if (uncovered.isEmpty())
+      if (uncovered.isEmpty()) {
         return;
+      }
 
       // If the entire space is left uncovered we have two choices: We can
       // decompose the type space and offer them as fixits, or simply offer
       // to insert a `default` clause.
+      //
+      // If a strictly exhaustive switch is requested
+      // (see hasStrictExhaustiveChecksEnabled), a default case will be
+      // suggested to be decomposed into the remaining cases if they are
+      // statically possible to determine.
+      //
+      // As well, if the type space is resilient, the default case may also
+      // be converted to an unknown default to exhaust known and future cases
       if (uncovered.getKind() == SpaceKind::Type) {
         if (Space::canDecompose(uncovered.getType())) {
           SmallVector<Space, 4> spaces;
           Space::decomposeDisjuncts(DC, uncovered.getType(), {}, spaces);
           diagnoseMissingCases(RequiresDefault::No, Space::forDisjunct(spaces),
-                               unknownCase);
-        } else {
+                               unknownCase, defaultCase);
+        } else if (!defaultCase) {
           diagnoseMissingCases(Switch->getCases().empty()
                                  ? RequiresDefault::EmptySwitchBody
                                  : RequiresDefault::UncoveredSwitch,
-                               uncovered, unknownCase);
+                               uncovered, unknownCase, nullptr /*defaultCase*/);
         }
         return;
       }
 
-      diagnoseMissingCases(RequiresDefault::No, uncovered, unknownCase);
+      diagnoseMissingCases(RequiresDefault::No, uncovered, unknownCase,
+                           defaultCase);
     }
-    
+
     enum class RequiresDefault {
       No,
       EmptySwitchBody,
@@ -1096,14 +1121,40 @@ namespace {
     };
 
     void diagnoseMissingCases(RequiresDefault defaultReason, Space uncovered,
-                              const CaseStmt *unknownCase = nullptr) {
+                              const CaseStmt *unknownCase,
+                              const CaseStmt *defaultCase) {
+      assert(!(unknownCase && defaultCase) &&
+             "both @unknown default and default should be caught earlier");
       if (!Switch->getLBraceLoc().isValid()) {
         // There is no '{' in the switch statement, which we already diagnosed
         // in the parser. So there's no real body to speak of and it doesn't
         // make sense to emit diagnostics about missing cases.
         return;
       }
+
+      std::optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
+          diag::non_exhaustive_switch;
+
+      // Decide whether we want an error or a warning.
+      bool downgrade = false;
+
+      // We either replace default with unknown default or known cases
+      // based on resilience and StrictExhaustiveSwitches
+      bool hasEmittedUnnecessaryDefaultDiagnostic = false;
+
       auto &DE = Context.Diags;
+      if (defaultCase) {
+        if (defaultReason != RequiresDefault::No) {
+          // We actually do need the default,
+          // so it does handle the space, do not emit diagnostics
+          return;
+        }
+
+        // Switch actually is exhaustive with known cases,
+        // so don't emit exhaustive diagnostic
+        mainDiagType.reset();
+      }
+
       SourceLoc startLoc = Switch->getStartLoc();
       SourceLoc insertLoc;
       if (unknownCase)
@@ -1114,10 +1165,6 @@ namespace {
       llvm::SmallString<128> buffer;
       llvm::raw_svector_ostream OS(buffer);
 
-      // Decide whether we want an error or a warning.
-      std::optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
-          diag::non_exhaustive_switch;
-      bool downgrade = false;
       if (unknownCase) {
         switch (defaultReason) {
         case RequiresDefault::EmptySwitchBody:
@@ -1182,9 +1229,18 @@ namespace {
 
         diag.warnUntilLanguageMode(languageModeForError());
 
-        mainDiagType = std::nullopt;
-      }
+        mainDiagType.reset();
         break;
+      }
+      }
+
+      if (defaultCase && !hasEmittedUnnecessaryDefaultDiagnostic) {
+        // Warn that the default case is not needed, remove the
+        // default case and enumerate the cases below
+        hasEmittedUnnecessaryDefaultDiagnostic = true;
+        DE.diagnose(defaultCase->getStartLoc(), diag::decompose_default_case)
+            .fixItRemoveChars(defaultCase->getStartLoc(),
+                              defaultCase->getEndLoc());
       }
 
       switch (defaultReason) {
@@ -1224,8 +1280,7 @@ namespace {
 
       // Add notes to explain what's missing.
       auto processUncoveredSpaces =
-          [&](llvm::function_ref<void(const Space &space,
-                                      bool onlyOneUncoveredSpace)> process) {
+          [&](llvm::function_ref<void(const Space &space)> process) {
 
         // Flatten away all disjunctions.
         SmallVector<Space, 4> flats;
@@ -1279,7 +1334,7 @@ namespace {
               continue;
           }
 
-          process(flat, flats.size() == 1);
+          process(flat);
         }
       };
 
@@ -1300,14 +1355,16 @@ namespace {
       SmallString<128> missingSeveralCasesFixIt;
       int diagnosedCases = 0;
 
-      processUncoveredSpaces([&](const Space &space,
-                                 bool onlyOneUncoveredSpace) {
+      processUncoveredSpaces([&](const Space &space) {
         llvm::SmallString<64> fixItBuffer;
         llvm::raw_svector_ostream fixItOS(fixItBuffer);
         if (space.getKind() == SpaceKind::UnknownCase) {
-          fixItOS << "@unknown " << tok::kw_default << ":\n<#fatalError()#>\n";
+          if (!hasEmittedUnnecessaryDefaultDiagnostic) {
+            fixItOS << "@unknown " << tok::kw_default
+                    << ":\n<#fatalError()#>\n";
           DE.diagnose(startLoc, diag::missing_unknown_case)
               .fixItInsert(insertLoc, fixItBuffer.str());
+          }
         } else {
           llvm::SmallString<64> spaceBuffer;
           llvm::raw_svector_ostream spaceOS(spaceBuffer);

--- a/test/stmt/strict_exhaustive_switches.swift
+++ b/test/stmt/strict_exhaustive_switches.swift
@@ -1,0 +1,175 @@
+// RUN: split-file %s %t
+
+// Use fragile enums
+// RUN: %target-swift-frontend %t/Enums.swift -emit-module -module-name enums -o %t/enums.swiftmodule
+// RUN: %target-swift-frontend    -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/WithError.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -typecheck
+// RUN: %target-swift-emit-silgen -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/SILVerify.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -o /dev/null
+
+//--- Enums.swift
+
+public enum ReasonableEnum {
+  case zero
+  case one
+}
+
+public enum OverlyLargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+  case case11
+}
+
+//--- NewDiagnostics.swift
+
+import enums
+
+func testMissingKnownCases(enum o: OverlyLargeSpaceEnum) -> Bool {
+  switch o {
+    // expected-note@-1 {{add missing cases}}
+    // expected-note@-2 11 {{add missing case}}
+    case .case0: return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) { // expected-note {{add missing cases}}
+    // expected-note@-1 {{add missing case: '(.one, _)'}}
+    // expected-note@-2 {{add missing case: '(_, .one)'}}
+    case (.zero, .zero): return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(o1: OverlyLargeSpaceEnum, o2: OverlyLargeSpaceEnum) -> Bool {
+  switch (o1, o2) { // expected-note {{add missing case: '(.case11, _)'}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+//--- SILVerify.swift
+
+import enums
+
+func testExhaustiveWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one: return true
+    default: return false // expected-warning {{default will never be executed}}
+  }
+}
+
+func testWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case _: // expected-note {{a 'default' case is equivalent to a catch-all case; remove one}}
+      return true
+    default: // expected-warning {{default will never be executed}}
+      return false
+  }
+}
+
+func testTupleWildcardWithDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) {
+  case (_, _): // expected-note {{a 'default' case is equivalent to a catch-all case; remove one}}
+    return true
+  default: // expected-warning {{default will never be executed}}
+    return false
+  }
+}
+
+func testParensWildcardWithDefault(e1: ReasonableEnum) -> Bool {
+  switch (e1) {
+  case ((_)): // expected-note {{a 'default' case is equivalent to a catch-all case; remove one}}
+      return true
+    default: // expected-warning {{default will never be executed}}
+      return false
+  }
+}
+
+func testGuardedWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one:
+      return true
+    case _ where e == .one:
+      return true
+    default:
+      return false
+  }
+}
+
+//--- PreventRegressions.swift
+
+import enums
+
+func testWellFormedExhaustive(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one: return true
+  }
+}
+
+func testExhaustiveOpen(value: Int) -> Bool {
+  switch value {
+  case 1: return true
+  case 2...10: return true
+  default: return false
+  }
+}
+
+func testExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch e {
+  case .zero, .one: return true
+  @unknown default: return false
+  }
+}
+
+func testNonExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch ReasonableEnum.zero { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.one'}}
+  case .zero: return true
+  @unknown default: return false
+  }
+}
+
+func testExhaustiveTupleWithUnknownDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) {
+  case (.zero, _), (.one, _): return true
+  @unknown default: return false
+  }
+}
+
+func nonExhaustiveTupleWithUnknownDeafult(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.one, _)'}}
+  case (.zero, _): return true
+  @unknown default: return false
+  }
+}
+
+//--- WithError.swift
+
+// split file to verify type-checking but can't get to sil with error
+func testNonExhaustiveOpen(value: Int) -> Bool {
+  switch value { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add a default clause}}
+  case 1: return true
+  case 2...10: return true
+  }
+}


### PR DESCRIPTION
Implementing the default behavior from [this forum thread](https://forums.swift.org/t/anything-similar-to-wswitch-enum-for-swift/82542/38), similar to -Wswitch-enum

Optionally (with -enable-experimental-feature StrictExhaustiveSwitches) replace a default case label with the known set of exhaustive cases if the compiler is able to determine that set of cases. This works great for the simple case of an enum, with @unknown default able to still handle the resilient (or NS_ENUM) case.