### PR TITLE
[Distributed] Don't crash when 'open' distributed actor is declared

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5565,10 +5565,18 @@ void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,
     access = AccessLevel::FilePrivate;
 
   // Only certain declarations can be 'open'.
-  if (access == AccessLevel::Open && !isSyntacticallyOverridable()) {
-    assert(!isa<ClassDecl>(this) &&
-           "copying 'open' onto a class has complications");
-    access = AccessLevel::Public;
+  if (access == AccessLevel::Open) {
+    auto classDecl = dyn_cast<ClassDecl>(source);
+    if (classDecl && classDecl->isDistributedActor()) {
+      // don't copy 'public'; an 'open distributed actor' is illegal to begin with
+      return;
+    }
+
+    if (!isSyntacticallyOverridable()) {
+      assert(!isa<ClassDecl>(this) &&
+             "copying 'open' onto a class has complications");
+      access = AccessLevel::Public;
+    }
   }
 
   setAccess(access);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -709,6 +709,13 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   if (!swift::ensureDistributedModuleLoaded(nominal))
     return;
 
+  if (nominal->getFormalAccess() == AccessLevel::Open) {
+    // we should have outright banned 'open' for all actors, but seems we didn't.
+    // distributed actor synthesis always previously crashed if someone were to
+    // declare one as open, so we're banning it now, rather than leave it crashing.
+    (void) nominal->diagnose(diag::access_control_open_bad_decl);
+  }
+
   auto &C = nominal->getASTContext();
   auto loc = nominal->getLoc();
   recordRequiredImportAccessLevelForDecl(C.getDistributedActorDecl(), nominal,

--- a/validation-test/compiler_crashers/ValueDecl-copyFormalAccessFrom-d1e149.swift
+++ b/validation-test/compiler_crashers/ValueDecl-copyFormalAccessFrom-d1e149.swift
@@ -1,6 +1,0 @@
-// {"kind":"typecheck","original":"46f686fe","signature":"swift::ValueDecl::copyFormalAccessFrom(swift::ValueDecl const*, bool)","signatureAssert":"Assertion failed: (!hasAccess() && \"access already set\"), function setAccess"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed
-distributed open actor a {
-}

--- a/validation-test/compiler_crashers_fixed/ValueDecl-copyFormalAccessFrom-d1e149.swift
+++ b/validation-test/compiler_crashers_fixed/ValueDecl-copyFormalAccessFrom-d1e149.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed
+distributed open actor a {
+}
+
+open distributed actor DA: Comparable {}


### PR DESCRIPTION
We also take the opportunity to ban 'open distributed actor' since it does not make sense; we don't ban it outright on all actors yet since it may be breaking for adopters who did write "open actor" and we did allow that... for distributed though, that would literarily crash, so we're able to ban it explicitly.
