### PR TITLE
[SE-0494][stdlib] Add `isTriviallyIdentical` for unicode views

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -418,6 +418,13 @@ extension _StringGuts {
   }
 }
 
+extension _StringGuts {
+  @inline(__always) // Performance
+  internal func isTriviallyIdentical(to other: Self) -> Bool {
+    self.rawBits == other.rawBits
+  }
+}
+
 #if _runtime(_ObjC)
 extension _StringGuts {
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -1056,3 +1056,14 @@ extension String.UTF16View {
     }
   }
 }
+
+extension String.UTF16View {
+  /// Returns a boolean value indicating whether this UTF16 view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._guts.rawBits == other._guts.rawBits
+  }
+}

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -1062,7 +1062,7 @@ extension String.UTF16View {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._guts.rawBits == other._guts.rawBits
   }

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -1064,6 +1064,6 @@ extension String.UTF16View {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
-    self._guts.rawBits == other._guts.rawBits
+    self._guts.isTriviallyIdentical(to: other._guts)
   }
 }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -690,7 +690,7 @@ extension String.UTF8View {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._guts.rawBits == other._guts.rawBits
   }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -692,6 +692,6 @@ extension String.UTF8View {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
-    self._guts.rawBits == other._guts.rawBits
+    self._guts.isTriviallyIdentical(to: other._guts)
   }
 }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -684,3 +684,14 @@ extension String.UTF8View {
     return unsafe try _guts.withFastUTF8(body)
   }
 }
+
+extension String.UTF8View {
+  /// Returns a boolean value indicating whether this UTF8 view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._guts.rawBits == other._guts.rawBits
+  }
+}

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -527,3 +527,14 @@ extension String.UnicodeScalarView {
     return r._knownUTF16
   }
 }
+
+extension String.UnicodeScalarView {
+  /// Returns a boolean value indicating whether this unicode scalar view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._guts.rawBits == other._guts.rawBits
+  }
+}

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -533,7 +533,7 @@ extension String.UnicodeScalarView {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._guts.rawBits == other._guts.rawBits
   }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -535,6 +535,6 @@ extension String.UnicodeScalarView {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
-    self._guts.rawBits == other._guts.rawBits
+    self._guts.isTriviallyIdentical(to: other._guts)
   }
 }

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -882,6 +882,18 @@ extension Substring.UTF8View {
 #endif // !(os(watchOS) && _pointerBitWidth(_32))
 }
 
+extension Substring.UTF8View {
+  /// Returns a boolean value indicating whether this UTF8 view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._base.isTriviallyIdentical(to: other._base)
+    && self._bounds == other._bounds
+  }
+}
+
 extension Substring {
   @inlinable
   public var utf8: UTF8View {
@@ -1034,6 +1046,18 @@ extension Substring.UTF16View: BidirectionalCollection {
   public subscript(r: Range<Index>) -> Substring.UTF16View {
     let r = _wholeGuts.validateSubscalarRange(r, in: _bounds)
     return Substring.UTF16View(_slice.base, _bounds: r)
+  }
+}
+
+extension Substring.UTF16View {
+  /// Returns a boolean value indicating whether this UTF16 view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._base.isTriviallyIdentical(to: other._base)
+    && self._bounds == other._bounds
   }
 }
 
@@ -1278,6 +1302,18 @@ extension Substring.UnicodeScalarView: RangeReplaceableCollection {
       with: { $0.replaceSubrange(subrange, with: replacement) })
 
     _invariantCheck()
+  }
+}
+
+extension Substring.UnicodeScalarView {
+  /// Returns a boolean value indicating whether this unicode scalar view
+  /// is trivially identical to `other`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    self._slice._base.isTriviallyIdentical(to: other._slice._base)
+    && self._bounds == other._bounds
   }
 }
 

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -887,7 +887,7 @@ extension Substring.UTF8View {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._base.isTriviallyIdentical(to: other._base)
     && self._bounds == other._bounds
@@ -1054,7 +1054,7 @@ extension Substring.UTF16View {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._base.isTriviallyIdentical(to: other._base)
     && self._bounds == other._bounds
@@ -1310,7 +1310,7 @@ extension Substring.UnicodeScalarView {
   /// is trivially identical to `other`.
   ///
   /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 6.3, *)
   public func isTriviallyIdentical(to other: Self) -> Bool {
     self._slice._base.isTriviallyIdentical(to: other._slice._base)
     && self._bounds == other._bounds

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -522,6 +522,94 @@ StringTests.test("_isIdentical(to:)") {
   expectTrue(g._isIdentical(to: g))
 }
 
+StringTests.test("String.UnicodeScalarView.isTriviallyIdentical(to:)") {
+  let a = "Hello".unicodeScalars
+  let b = "Hello".unicodeScalars
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  let c = "Abcde".unicodeScalars
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+StringTests.test("String.UTF8View.isTriviallyIdentical(to:)") {
+  let a = "Hello".utf8
+  let b = "Hello".utf8
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  
+  let c = "Abcde".utf8
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+StringTests.test("String.UTF16View.isTriviallyIdentical(to:)") {
+  let a = "Hello".utf16
+  let b = "Hello".utf16
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  
+  let c = "Abcde".utf16
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+
+StringTests.test("Substring.UnicodeScalarView.isTriviallyIdentical(to:)") {
+  let base1 = "Test String"
+  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .unicodeScalars
+  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .unicodeScalars
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+    .unicodeScalars
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+StringTests.test("Substring.UTF8View.isTriviallyIdentical(to:)") {
+  let base1 = "Test String"
+  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .utf8
+  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .utf8
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+    .utf8
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+StringTests.test("Substring.UTF16View.isTriviallyIdentical(to:)") {
+  let base1 = "Test String"
+  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .utf16
+  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+    .utf16
+  expectTrue(a.isTriviallyIdentical(to: a))
+  expectTrue(b.isTriviallyIdentical(to: b))
+  expectTrue(a.isTriviallyIdentical(to: b))
+  expectTrue(b.isTriviallyIdentical(to: a))
+  
+  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+    .utf16
+  expectFalse(a.isTriviallyIdentical(to: c))
+  expectFalse(c.isTriviallyIdentical(to: a))
+}
+
 StringTests.test("hasPrefix/hasSuffix vs Character boundaries") {
   // https://github.com/apple/swift/issues/67427
   let s1 = "\r\n"

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -522,93 +522,129 @@ StringTests.test("_isIdentical(to:)") {
   expectTrue(g._isIdentical(to: g))
 }
 
-StringTests.test("String.UnicodeScalarView.isTriviallyIdentical(to:)") {
-  let a = "Hello".unicodeScalars
-  let b = "Hello".unicodeScalars
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  let c = "Abcde".unicodeScalars
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
-StringTests.test("String.UTF8View.isTriviallyIdentical(to:)") {
-  let a = "Hello".utf8
-  let b = "Hello".utf8
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  
-  let c = "Abcde".utf8
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
-StringTests.test("String.UTF16View.isTriviallyIdentical(to:)") {
-  let a = "Hello".utf16
-  let b = "Hello".utf16
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  
-  let c = "Abcde".utf16
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
+StringTests.test("String.UnicodeScalarView.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let a = "Hello".unicodeScalars
+    let b = "Hello".unicodeScalars
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    let c = "Abcde".unicodeScalars
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
+StringTests.test("String.UTF8View.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let a = "Hello".utf8
+    let b = "Hello".utf8
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    
+    let c = "Abcde".utf8
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
+StringTests.test("String.UTF16View.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let a = "Hello".utf16
+    let b = "Hello".utf16
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    
+    let c = "Abcde".utf16
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
 
-StringTests.test("Substring.UnicodeScalarView.isTriviallyIdentical(to:)") {
-  let base1 = "Test String"
-  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .unicodeScalars
-  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .unicodeScalars
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
-    .unicodeScalars
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
-StringTests.test("Substring.UTF8View.isTriviallyIdentical(to:)") {
-  let base1 = "Test String"
-  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .utf8
-  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .utf8
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
-    .utf8
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
-StringTests.test("Substring.UTF16View.isTriviallyIdentical(to:)") {
-  let base1 = "Test String"
-  let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .utf16
-  let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
-    .utf16
-  expectTrue(a.isTriviallyIdentical(to: a))
-  expectTrue(b.isTriviallyIdentical(to: b))
-  expectTrue(a.isTriviallyIdentical(to: b))
-  expectTrue(b.isTriviallyIdentical(to: a))
-  
-  let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
-    .utf16
-  expectFalse(a.isTriviallyIdentical(to: c))
-  expectFalse(c.isTriviallyIdentical(to: a))
-}
+StringTests.test("Substring.UnicodeScalarView.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let base1 = "Test String"
+    let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .unicodeScalars
+    let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .unicodeScalars
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+      .unicodeScalars
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
+StringTests.test("Substring.UTF8View.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let base1 = "Test String"
+    let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .utf8
+    let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .utf8
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+      .utf8
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
+StringTests.test("Substring.UTF16View.isTriviallyIdentical(to:)")
+  .skip(.custom({
+    if #available(SwiftStdlib 6.3, *) { false } else { true }
+  }, reason: "Requires Swift stdlib 6.3"))
+  .code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    
+    let base1 = "Test String"
+    let a = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .utf16
+    let b = base1[base1.index(base1.startIndex, offsetBy: 5)..<base1.endIndex]
+      .utf16
+    expectTrue(a.isTriviallyIdentical(to: a))
+    expectTrue(b.isTriviallyIdentical(to: b))
+    expectTrue(a.isTriviallyIdentical(to: b))
+    expectTrue(b.isTriviallyIdentical(to: a))
+    
+    let c = base1[base1.startIndex..<base1.index(base1.startIndex, offsetBy: 5)]
+      .utf16
+    expectFalse(a.isTriviallyIdentical(to: c))
+    expectFalse(c.isTriviallyIdentical(to: a))
+  }
 
 StringTests.test("hasPrefix/hasSuffix vs Character boundaries") {
   // https://github.com/apple/swift/issues/67427


### PR DESCRIPTION
Adds `isTriviallyIdentical(to:)` to the types below:

- `String.UnicodeScalarView`
- `String.UTF16View`
- `String.UTF8View`
- `Substring.UnicodeScalarView`
- `Substring.UTF16View`
- `Substring.UTF8View`

Part of issue #84991 