### PR TITLE
[Index] Record the access level of declarations in the index

### DIFF
--- a/test/Index/access_level.swift
+++ b/test/Index/access_level.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule | %FileCheck %s
+
+private func myPrivateFunc() {}
+// CHECK: [[@LINE-1]]:14 | function(fileprivate)/Swift | myPrivateFunc() | {{.*}} | Def | rel: 0
+
+fileprivate func myFileprivateFunc() {}
+// CHECK: [[@LINE-1]]:18 | function(fileprivate)/Swift | myFileprivateFunc() | {{.*}} | Def | rel: 0
+
+func myInternalFunc() {}
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | myInternalFunc() | {{.*}} | Def | rel: 0
+
+package func myPackageFunc() {}
+// CHECK: [[@LINE-1]]:14 | function(package)/Swift | myPackageFunc() | {{.*}} | Def | rel: 0
+
+public func myPublicFunc() {}
+// CHECK: [[@LINE-1]]:13 | function(public)/Swift | myPublicFunc() | {{.*}} | Def | rel: 0
+
+open class MyOpenClass {}
+// CHECK: [[@LINE-1]]:12 | class(public)/Swift | MyOpenClass | {{.*}} | Def | rel: 0
+
+@_spi(MySPI)
+public class MyPublicSPIClass {
+// CHECK: [[@LINE-1]]:14 | class(SPI)/Swift | MyPublicSPIClass | {{.*}} | Def | rel: 0
+
+  public func publicInSPI() {}
+  // CHECK: [[@LINE-1]]:15 | instance-method(SPI)/Swift | publicInSPI() | {{.*}} | Def,Dyn,RelChild | rel: 1
+}
+
+@_spi(MySPI)
+open class MyOpenSPIClass {}
+// CHECK: [[@LINE-1]]:12 | class(SPI)/Swift | MyOpenSPIClass | {{.*}} | Def | rel: 0
+
+private class Foo {
+  public func publicInPrivate() {}
+  // CHECK: [[@LINE-1]]:15 | instance-method(fileprivate)/Swift | publicInPrivate() | {{.*}} | Def,Dyn,RelChild | rel: 1
+}
+
+private enum PrivateEnum {
+  // CHECK: [[@LINE-1]]:14 | enum(fileprivate)/Swift | PrivateEnum | {{.*}} | Def | rel: 0
+  case myCase
+  // CHECK: [[@LINE-1]]:8 | enumerator(fileprivate)/Swift | myCase | {{.*}} | Def,RelChild | rel: 1
+}
+extension PrivateEnum {
+  private func f() { print("Hello") }
+  // CHECK: [[@LINE-1]]:16 | instance-method(less_than_private)/Swift | f() | {{.*}} | Def,RelChild | rel: 1
+}
+
+enum InternalEnum {
+  // CHECK: [[@LINE-1]]:6 | enum(internal)/Swift | InternalEnum | {{.*}} | Def | rel: 0
+  case myCase
+  // CHECK: [[@LINE-1]]:8 | enumerator(internal)/Swift | myCase | {{.*}} | Def,RelChild | rel: 1
+}

--- a/test/Index/async.swift
+++ b/test/Index/async.swift
@@ -3,15 +3,15 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
 func globalAsyncFunc() async {}
-// CHECK: [[@LINE-1]]:6 | function(swift_async)/Swift | globalAsyncFunc() | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(swift_async,internal)/Swift | globalAsyncFunc() | {{.*}} | Def | rel: 0
 
 struct MyStruct {
   func asyncMethod() async {}
-  // CHECK: [[@LINE-1]]:8 | instance-method(swift_async)/Swift | asyncMethod() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(swift_async,internal)/Swift | asyncMethod() |
 }
 
 class XCTestCase {}
 class MyTestCase : XCTestCase {
   func testSomeAsync() async {}
-  // CHECK: [[@LINE-1]]:8 | instance-method(test,swift_async)/Swift | testSomeAsync() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(test,swift_async,internal)/Swift | testSomeAsync() |
 }

--- a/test/Index/circular.swift
+++ b/test/Index/circular.swift
@@ -1,66 +1,66 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
 class SelfCycle : SelfCycle {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | SelfCycle | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | SelfCycle | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:19 | class/Swift | SelfCycle | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | SelfCycle | {{\W*}}
 
 class Cycle1_A: Cycle1_B {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle1_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | Cycle1_A | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:17 | class/Swift | Cycle1_B | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | Cycle1_A | {{[^ ]*}}
 class Cycle1_B: Cycle1_A {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle1_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | Cycle1_B | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:17 | class/Swift | Cycle1_A | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | Cycle1_B | {{[^ ]*}}
 
 class Cycle2_A: Cycle2_C {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | Cycle2_A | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_C | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | Cycle2_A | {{[^ ]*}}
 class Cycle2_B: Cycle2_A {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | Cycle2_B | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_A | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | Cycle2_B | {{[^ ]*}}
 class Cycle2_C: Cycle2_B {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | Cycle2_C | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | Cycle2_C | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:17 | class/Swift | Cycle2_B | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | Cycle2_C | {{[^ ]*}}
 
 class TestCase1: XCTestCase {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | TestCase1 | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | TestCase1 | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:18 | class/Swift | XCTestCase | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | TestCase1 | {{[^ ]*}}
 class XCTestCase: TestCase1 {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | XCTestCase | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | XCTestCase | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:19 | class/Swift | TestCase1 | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | XCTestCase | {{[^ ]*}}
 class TestCase2: TestCase1 {}
-// CHECK: [[@LINE-1]]:7 | class/Swift | TestCase2 | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | TestCase2 | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:18 | class/Swift | TestCase1 | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | class/Swift | TestCase2 | {{[^ ]*}}
 
 protocol SelfCycleP: SelfCycleP {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | SelfCycleP | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | SelfCycleP | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:22 | protocol/Swift | SelfCycleP | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | SelfCycleP | {{[^ ]*}}
 protocol Cycle1P_A: Cycle1P_B {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle1P_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Cycle1P_A | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle1P_B | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | Cycle1P_A | {{[^ ]*}}
 protocol Cycle1P_B: Cycle1P_A {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle1P_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Cycle1P_B | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle1P_A | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | Cycle1P_B | {{[^ ]*}}
 protocol Cycle2P_A: Cycle2P_C {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_A | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Cycle2P_A | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_C | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | Cycle2P_A | {{[^ ]*}}
 protocol Cycle2P_B: Cycle2P_A {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_B | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Cycle2P_B | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_A | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | Cycle2P_B | {{[^ ]*}}
 protocol Cycle2P_C: Cycle2P_B {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Cycle2P_C | {{[^ ]*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Cycle2P_C | {{[^ ]*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | Cycle2P_B | {{[^ ]*}} | Ref,RelBase | rel: 1
 // CHECK:   RelBase | protocol/Swift | Cycle2P_C | {{[^ ]*}}

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
-protocol P1 { // CHECK: [[@LINE]]:10 | protocol/Swift | P1 | [[P1_USR:.*]] | Def |
-  func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[P1_foo_USR:.*]] | Def
+protocol P1 { // CHECK: [[@LINE]]:10 | protocol(internal)/Swift | P1 | [[P1_USR:.*]] | Def |
+  func foo() // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[P1_foo_USR:.*]] | Def
 }
 
-struct DirectConf: P1 { // CHECK: [[@LINE]]:8 | struct/Swift | DirectConf | [[DirectConf_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[DirectConf_foo_USR:.*]] | Def,RelChild,RelOver | rel: 2
+struct DirectConf: P1 { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | DirectConf | [[DirectConf_USR:.*]] | Def
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[DirectConf_foo_USR:.*]] | Def,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
     // CHECK-NEXT: RelChild | struct/Swift | DirectConf | [[DirectConf_USR]]
 }
@@ -30,95 +30,95 @@ struct AlsoNonCopyable: NonCopyableProto & ~Copyable {}
 
 struct ConfFromExtension {}
 extension ConfFromExtension: P1 { // CHECK: [[@LINE]]:11 | extension/ext-struct/Swift | ConfFromExtension | [[ConfFromExtension_ext_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[ConfFromExtension_ext_foo_USR:.*]] | Def,RelChild,RelOver | rel: 2
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[ConfFromExtension_ext_foo_USR:.*]] | Def,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
     // CHECK-NEXT: RelChild | extension/ext-struct/Swift | ConfFromExtension | [[ConfFromExtension_ext_USR]]
 }
 
-struct ImplicitConfFromExtension { // CHECK: [[@LINE]]:8 | struct/Swift | ImplicitConfFromExtension | [[ImplicitConfFromExtension_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[ImplicitConfFromExtension_foo_USR:.*]] | Def,RelChild | rel: 1
+struct ImplicitConfFromExtension { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | ImplicitConfFromExtension | [[ImplicitConfFromExtension_USR:.*]] | Def
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[ImplicitConfFromExtension_foo_USR:.*]] | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | struct/Swift | ImplicitConfFromExtension | [[ImplicitConfFromExtension_USR]]
 }
 extension ImplicitConfFromExtension: P1 { // CHECK: [[@LINE]]:11 | extension/ext-struct/Swift | ImplicitConfFromExtension | [[ImplicitConfFromExtension_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:11 | instance-method/Swift | foo() | [[ImplicitConfFromExtension_foo_USR]] | Impl,RelOver,RelCont | rel: 2
+  // CHECK: [[@LINE-1]]:11 | instance-method(internal)/Swift | foo() | [[ImplicitConfFromExtension_foo_USR]] | Impl,RelOver,RelCont | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
   // CHECK-NEXT: RelCont | extension/ext-struct/Swift | ImplicitConfFromExtension | [[ImplicitConfFromExtension_USR]]
 }
 
-class BaseConfFromBase { // CHECK: [[@LINE]]:7 | class/Swift | BaseConfFromBase | [[BaseConfFromBase_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[BaseConfFromBase_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
+class BaseConfFromBase { // CHECK: [[@LINE]]:7 | class(internal)/Swift | BaseConfFromBase | [[BaseConfFromBase_USR:.*]] | Def
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[BaseConfFromBase_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
     // CHECK-NEXT: RelChild | class/Swift | BaseConfFromBase | [[BaseConfFromBase_USR]]
 }
-class SubConfFromBase: BaseConfFromBase, P1 { // CHECK: [[@LINE]]:7 | class/Swift | SubConfFromBase | [[SubConfFromBase_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:7 | instance-method/Swift | foo() | [[BaseConfFromBase_foo_USR]] | Impl,RelOver,RelCont | rel: 2
+class SubConfFromBase: BaseConfFromBase, P1 { // CHECK: [[@LINE]]:7 | class(internal)/Swift | SubConfFromBase | [[SubConfFromBase_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:7 | instance-method(internal)/Swift | foo() | [[BaseConfFromBase_foo_USR]] | Impl,RelOver,RelCont | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
   // CHECK-NEXT: RelCont | class/Swift | SubConfFromBase | [[SubConfFromBase_USR]]
 }
 
-protocol P2 { // CHECK: [[@LINE]]:10 | protocol/Swift | P2 | [[P2_USR:.*]] | Def |
-  func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[P2_foo_USR:.*]] | Def
+protocol P2 { // CHECK: [[@LINE]]:10 | protocol(internal)/Swift | P2 | [[P2_USR:.*]] | Def |
+  func foo() // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[P2_foo_USR:.*]] | Def
 }
 extension P2 { // CHECK: [[@LINE]]:11 | extension/ext-protocol/Swift | P2 | [[P2_ext_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[P2_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[P2_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P2_foo_USR]]
     // CHECK-NEXT: RelChild | extension/ext-protocol/Swift | P2 | [[P2_ext_USR]]
 }
 
-struct ConfFromDefaultImpl: P2 { // CHECK: [[@LINE]]:8 | struct/Swift | ConfFromDefaultImpl | [[ConfFromDefaultImpl_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
+struct ConfFromDefaultImpl: P2 { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | ConfFromDefaultImpl | [[ConfFromDefaultImpl_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P2_foo_USR]]
   // CHECK-NEXT: RelCont | struct/Swift | ConfFromDefaultImpl | [[ConfFromDefaultImpl_USR]]
 }
 
 protocol P3 {
-  func meth1() // CHECK: [[@LINE]]:8 | instance-method/Swift | meth1() | [[P3_meth1_USR:.*]] | Def
-  func meth2() // CHECK: [[@LINE]]:8 | instance-method/Swift | meth2() | [[P3_meth2_USR:.*]] | Def
+  func meth1() // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | meth1() | [[P3_meth1_USR:.*]] | Def
+  func meth2() // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | meth2() | [[P3_meth2_USR:.*]] | Def
 }
 
-class BaseMultiConf { // CHECK: [[@LINE]]:7 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR:.*]] | Def
-  func meth2() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | meth2() | [[BaseMultiConf_meth2_USR:.*]] | Def
+class BaseMultiConf { // CHECK: [[@LINE]]:7 | class(internal)/Swift | BaseMultiConf | [[BaseMultiConf_USR:.*]] | Def
+  func meth2() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | meth2() | [[BaseMultiConf_meth2_USR:.*]] | Def
 }
 extension SubMultiConf {
-  func meth1() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | meth1() | [[SubMultiConf_ext_meth1_USR:.*]] | Def
+  func meth1() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | meth1() | [[SubMultiConf_ext_meth1_USR:.*]] | Def
 }
-class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class/Swift | SubMultiConf | [[SubMultiConf_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:7 | instance-method/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
+class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class(internal)/Swift | SubMultiConf | [[SubMultiConf_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:7 | instance-method(internal)/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P2_foo_USR]]
     // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
-  // CHECK: [[@LINE-4]]:7 | instance-method/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
+  // CHECK: [[@LINE-4]]:7 | instance-method(internal)/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
     // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
-  // CHECK: [[@LINE-7]]:7 | instance-method/Swift | meth1() | [[SubMultiConf_ext_meth1_USR]] | Impl,RelOver,RelCont | rel: 2
+  // CHECK: [[@LINE-7]]:7 | instance-method(internal)/Swift | meth1() | [[SubMultiConf_ext_meth1_USR]] | Impl,RelOver,RelCont | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | meth1() | [[P3_meth1_USR]]
     // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
-  // CHECK: [[@LINE-10]]:7 | instance-method/Swift | meth2() | [[BaseMultiConf_meth2_USR]] | Impl,RelOver,RelCont | rel: 2
+  // CHECK: [[@LINE-10]]:7 | instance-method(internal)/Swift | meth2() | [[BaseMultiConf_meth2_USR]] | Impl,RelOver,RelCont | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | meth2() | [[P3_meth2_USR]]
     // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK-NOT: [[@LINE-13]]:7 | instance-method
 }
 
-class CompositionType: BaseMultiConf & P1 { // CHECK: [[@LINE]]:7 | class/Swift | CompositionType | [[CompositionType_USR:.*]] | Def
+class CompositionType: BaseMultiConf & P1 { // CHECK: [[@LINE]]:7 | class(internal)/Swift | CompositionType | [[CompositionType_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:24 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,RelBase | rel: 1
   // CHECK: [[@LINE-2]]:40 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelBase | rel: 1
   func foo() {}
 }
 
-typealias CompositionTypeAlias = BaseMultiConf & P1 // CHECK: [[@LINE]]:11 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR:.*]] | Def
+typealias CompositionTypeAlias = BaseMultiConf & P1 // CHECK: [[@LINE]]:11 | type-alias(internal)/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:50 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
 
-class CompositionTypeViaAlias: CompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionTypeViaAlias | [[CompositionTypeViaAlias_USR:.*]] | Def
+class CompositionTypeViaAlias: CompositionTypeAlias { // CHECK: [[@LINE]]:7 | class(internal)/Swift | CompositionTypeViaAlias | [[CompositionTypeViaAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:32 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:32 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,Impl,RelBase | rel: 1
   // CHECK: [[@LINE-3]]:32 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
   func foo() {}
 }
 
-typealias NestedCompositionTypeAlias = CompositionTypeAlias & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR:.*]] | Def
+typealias NestedCompositionTypeAlias = CompositionTypeAlias & P2 // CHECK: [[@LINE]]:11 | type-alias(internal)/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:40 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:63 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
 
-class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionViaNestedAlias | [[CompositionViaNestedAlias_USR:.*]] | Def
+class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]]:7 | class(internal)/Swift | CompositionViaNestedAlias | [[CompositionViaNestedAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:34 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,Impl,RelBase | rel: 1
   // CHECK: [[@LINE-3]]:34 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
@@ -126,11 +126,11 @@ class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]
   func foo() {}
 }
 
-typealias ProtocolsOnly = P1 & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR:.*]] | Def
+typealias ProtocolsOnly = P1 & P2 // CHECK: [[@LINE]]:11 | type-alias(internal)/Swift | ProtocolsOnly | [[ProtocolsOnly_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:27 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:32 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
 
-class NoInherited {} // CHECK: [[@LINE]]:7 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Def
+class NoInherited {} // CHECK: [[@LINE]]:7 | class(internal)/Swift | NoInherited | [[NoInherited_USR:.*]] | Def
 extension NoInherited: ProtocolsOnly { // CHECK: [[@LINE]]:11 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Ref
   // CHECK: [[@LINE-1]]:24 | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-2]]:24 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
@@ -140,33 +140,33 @@ extension NoInherited: ProtocolsOnly { // CHECK: [[@LINE]]:11 | class/Swift | No
 
 struct WithCodable: Codable {} // CHECK: [[@LINE]]:21 | type-alias/Swift | Codable | [[Codable_USR:.*]] | Ref | rel: 0
 
-protocol InheritingP: P1 { // CHECK: [[@LINE]]:10 | protocol/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
-  func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
+protocol InheritingP: P1 { // CHECK: [[@LINE]]:10 | protocol(internal)/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
+  func foo() // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[InheritingP_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test2P1P3fooyyF
     // CHECK-NEXT: RelChild | protocol/Swift | InheritingP | [[InheritingP_USR]]
 }
 
-struct DirectConf2: InheritingP { // CHECK: [[@LINE]]:8 | struct/Swift | DirectConf2 | [[DirectConf2_USR:.*]] | Def
+struct DirectConf2: InheritingP { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | DirectConf2 | [[DirectConf2_USR:.*]] | Def
   // FIXME: Should only override InheritingP.foo()
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[DirectConf2_foo_USR:.*]] | Def,RelChild,RelOver | rel: 3
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[DirectConf2_foo_USR:.*]] | Def,RelChild,RelOver | rel: 3
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[InheritingP_foo_USR]]
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
     // CHECK-NEXT: RelChild | struct/Swift | DirectConf2 | [[DirectConf2_USR]]
 }
 
 extension InheritingP { // CHECK: [[@LINE]]:11 | extension/ext-protocol/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method(internal)/Swift | foo() | [[InheritingP_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[InheritingP_foo_USR]]
     // CHECK-NEXT: RelChild | extension/ext-protocol/Swift | InheritingP | [[InheritingP_USR]]
 }
 
 protocol WithAssocType {
-  associatedtype T // CHECK: [[@LINE]]:18 | type-alias/associated-type/Swift | T | [[WithAssocT_USR:.*]] | Def
+  associatedtype T // CHECK: [[@LINE]]:18 | type-alias/associated-type(internal)/Swift | T | [[WithAssocT_USR:.*]] | Def
   func foo() -> T // CHECK: [[@LINE]]:17 | type-alias/associated-type/Swift | T | [[WithAssocT_USR]] | Ref
 }
 
 struct SAssocTypeAlias: WithAssocType {
-  typealias T = Int // CHECK: [[@LINE]]:13 | type-alias/Swift | T | [[SAssocT:.*]] | Def,RelChild,RelOver | rel: 2
+  typealias T = Int // CHECK: [[@LINE]]:13 | type-alias(internal)/Swift | T | [[SAssocT:.*]] | Def,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | type-alias/associated-type/Swift | T | [[WithAssocT_USR]]
     // CHECK-NEXT: RelChild | struct/Swift | SAssocTypeAlias
   func foo() -> T { return 0 } // CHECK: [[@LINE]]:17 | type-alias/Swift | T | [[SAssocT:.*]] | Ref
@@ -178,15 +178,15 @@ struct SAssocTypeInferred: WithAssocType {
 }
 
 struct AssocViaExtension {
-  struct T {} // CHECK: [[@LINE]]:10 | struct/Swift | T | [[AssocViaExtensionT_USR:.*]] | Def
+  struct T {} // CHECK: [[@LINE]]:10 | struct(internal)/Swift | T | [[AssocViaExtensionT_USR:.*]] | Def
   func foo() -> T { return T() }
 }
 
-extension AssocViaExtension: WithAssocType {} // CHECK: [[@LINE]]:11 | struct/Swift | T | [[AssocViaExtensionT_USR]] | Impl,RelOver,RelCont | rel: 2
+extension AssocViaExtension: WithAssocType {} // CHECK: [[@LINE]]:11 | struct(internal)/Swift | T | [[AssocViaExtensionT_USR]] | Impl,RelOver,RelCont | rel: 2
   // CHECK-NEXT: RelOver | type-alias/associated-type/Swift | T | [[WithAssocT_USR]]
   // CHECK-NEXT: RelCont | extension/ext-struct/Swift | AssocViaExtension
 
-func returnOpaqueResultType() -> some BaseConfFromBase & P1 & WithAssocType {} // CHECK: [[@LINE]]:6 | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF | Def | rel: 0
+func returnOpaqueResultType() -> some BaseConfFromBase & P1 & WithAssocType {} // CHECK: [[@LINE]]:6 | function(internal)/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF | Def | rel: 0
 // CHECK: [[@LINE-1]]:39 | class/Swift | BaseConfFromBase | s:14swift_ide_test012BaseConfFromD0C | Ref,RelCont | rel: 1
 // CHECK-NEXT:   RelCont | function/Swift | returnOpaqueResultType() | s:14swift_ide_test22returnOpaqueResultTypeQryF
 // CHECK: [[@LINE-3]]:58 | protocol/Swift | P1 | s:14swift_ide_test2P1P | Ref,RelCont | rel: 1

--- a/test/Index/cross_language.swift
+++ b/test/Index/cross_language.swift
@@ -16,52 +16,52 @@
 import Foundation
 
 @objc public class MyCls1 : NSObject {
-// CHECK: [[@LINE-1]]:20 | class/Swift | MyCls1 | [[MyCls1_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:20 | class(public)/Swift | MyCls1 | [[MyCls1_USR:.*]] | Def
   @objc public func someMeth() {}
-  // CHECK: [[@LINE-1]]:21 | instance-method/Swift | someMeth() | [[MyCls1_someMeth_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:21 | instance-method(public)/Swift | someMeth() | [[MyCls1_someMeth_USR:.*]] | Def
 
   @objc public var prop = 0
-  // CHECK: [[@LINE-1]]:20 | instance-property/Swift | prop | [[MyCls1_prop_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:20 | instance-property(public)/Swift | prop | [[MyCls1_prop_USR:.*]] | Def
   // CHECK: [[@LINE-2]]:20 | instance-method/acc-get/Swift | getter:prop | [[MyCls1_prop_get_USR:.*]] | Def
   // CHECK: [[@LINE-3]]:20 | instance-method/acc-set/Swift | setter:prop | [[MyCls1_prop_set_USR:.*]] | Def
 
-  // CHECK: [[@LINE-10]]:38 | constructor/Swift | init() | [[MyCls1_init_USR:.*]] | Def,Impl,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-10]]:38 | constructor(public)/Swift | init() | [[MyCls1_init_USR:.*]] | Def,Impl,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | constructor/Swift | init() | c:objc(cs)NSObject(im)init
   // CHECK-NEXT: RelChild | class/Swift | MyCls1 | [[MyCls1_USR]]
 }
 
 @objc public class MyCls2 : NSObject {
   @objc public init(withInt: Int) {}
-  // CHECK: [[@LINE-1]]:16 | constructor/Swift | init(withInt:) | [[MyCls2_initwithInt_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:16 | constructor(public)/Swift | init(withInt:) | [[MyCls2_initwithInt_USR:.*]] | Def
 }
 
 @objc public protocol MyProt {
-// CHECK: [[@LINE-1]]:23 | protocol/Swift | MyProt | [[MyProt_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:23 | protocol(public)/Swift | MyProt | [[MyProt_USR:.*]] | Def
   func someProtMeth()
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | someProtMeth() | [[MyProt_someProtMeth_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:8 | instance-method(public)/Swift | someProtMeth() | [[MyProt_someProtMeth_USR:.*]] | Def
 }
 
 public extension MyCls1 {
 // CHECK: [[@LINE-1]]:18 | extension/ext-class/Swift | MyCls1 | s:e:c:@CM@cross_language@objc(cs)MyCls1(im)someExtMeth |
 // CHECK: [[@LINE-2]]:18 | class/Swift | MyCls1 | [[MyCls1_USR]] |
   @objc public func someExtMeth() {}
-  // CHECK: [[@LINE-1]]:21 | instance-method/Swift | someExtMeth() | [[MyCls1_someExtMeth_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:21 | instance-method(public)/Swift | someExtMeth() | [[MyCls1_someExtMeth_USR:.*]] | Def
 
   @objc public var ext_prop: Int { 0 }
-  // CHECK: [[@LINE-1]]:20 | instance-property/Swift | ext_prop | [[MyCls1_ext_prop_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:20 | instance-property(public)/Swift | ext_prop | [[MyCls1_ext_prop_USR:.*]] | Def
   // CHECK: [[@LINE-2]]:34 | instance-method/acc-get/Swift | getter:ext_prop | [[MyCls1_ext_prop_get_USR:.*]] | Def
 }
 
 public extension SomeObjCClass {
   // CHECK: [[@LINE-1]]:18 | class/Swift | SomeObjCClass | [[SomeObjCClass_USR:.*]] | Ref
   @objc public func someSwiftExtMeth() {}
-  // CHECK: [[@LINE-1]]:21 | instance-method/Swift | someSwiftExtMeth() | [[SomeObjCClass_someSwiftExtMeth_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:21 | instance-method(public)/Swift | someSwiftExtMeth() | [[SomeObjCClass_someSwiftExtMeth_USR:.*]] | Def
 }
 
 @objc public enum MyEnum : Int {
-// CHECK: [[@LINE-1]]:19 | enum/Swift | MyEnum | [[MyEnum_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:19 | enum(public)/Swift | MyEnum | [[MyEnum_USR:.*]] | Def
   case someEnumConst = 1
-  // CHECK: [[@LINE-1]]:8 | enumerator/Swift | someEnumConst | [[MyEnum_someEnumConst_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:8 | enumerator(public)/Swift | someEnumConst | [[MyEnum_someEnumConst_USR:.*]] | Def
 }
 
 #endif

--- a/test/Index/enum_case_with_invalid_associated_type.swift
+++ b/test/Index/enum_case_with_invalid_associated_type.swift
@@ -1,7 +1,7 @@
 enum MyEnum {
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
   case test(artifactID: String, hostTriple: Triple)
-// CHECK: enumerator/Swift | test(artifactID:hostTriple:)
+// CHECK: enumerator(less_than_private)/Swift | test(artifactID:hostTriple:)
 // CHECK: param/Swift | artifactID
 // CHECK: param/Swift | hostTriple
 }

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
-// CHECK: [[@LINE+1]]:10 | protocol/Swift | P1 | [[P1_USR:.*]] | Def
+// CHECK: [[@LINE+1]]:10 | protocol(internal)/Swift | P1 | [[P1_USR:.*]] | Def
 protocol P1 {}
 
-// CHECK: [[@LINE+1]]:8 | struct/Swift | S1 | [[S1_USR:.*]] | Def
+// CHECK: [[@LINE+1]]:8 | struct(internal)/Swift | S1 | [[S1_USR:.*]] | Def
 struct S1 : P1 {}
 
 func test(_ o: P1?) {
   switch o {
-  // CHECK-NOT: [[@LINE+2]]:17 | enumerator/Swift | some |
+  // CHECK-NOT: [[@LINE+2]]:17 | enumerator{{.*}}/Swift | some |
   // CHECK: [[@LINE+1]]:17 | struct/Swift | S1 | [[S1_USR]] | Ref
   case let s as S1:
     test(s)
@@ -18,7 +18,7 @@ func test(_ o: P1?) {
 }
 
 protocol AP {
-  // CHECK: [[@LINE+1]]:18 | type-alias/associated-type/Swift | A | [[AP_P_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE+1]]:18 | type-alias/associated-type(internal)/Swift | A | [[AP_P_USR:.*]] | Def,RelChild | rel: 1
   associatedtype A
 }
 // CHECK: [[@LINE+1]]:19 | param/Swift | x | [[TEST2_X_USR:.*]] | Def,RelChild | rel: 1
@@ -32,7 +32,7 @@ func test2<X: AP>(x: X) {
 
 @available(*, unavailable, renamed: "test")
 func test2(_ o: S1?) {
-  // CHECK: [[@LINE-1]]:6 | function/Swift | test2(_:) | [[test2_unavailable_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:6 | function(internal)/Swift | test2(_:) | [[test2_unavailable_USR:.*]] | Def
   // CHECK: [[@LINE-2]]:17 | struct/Swift | S1 | [[S1_USR]] | Ref
   test(o) // CHECK: [[@LINE]]:3 | function/Swift | test(_:) | {{.*}} | Ref,Call,RelCall,RelCont | rel: 1
     // CHECK-NEXT: RelCall,RelCont | function/Swift | test2(_:) | [[test2_unavailable_USR]]

--- a/test/Index/implementation-only-imports.swift
+++ b/test/Index/implementation-only-imports.swift
@@ -15,34 +15,34 @@
 // CHECK: [[@LINE-1]]:{{[0-9]+}} | module/Swift | CoreFoo | c:@M@CoreFoo | Ref | rel: 0
 
 internal class SECRETSubclass : SECRETClass {}
-// CHECK: [[@LINE-1]]:{{[0-9]+}} | class/Swift | SECRETSubclass | [[SECRET_SUBCLASS_USR:s:[^|]+]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:{{[0-9]+}} | class(internal)/Swift | SECRETSubclass | [[SECRET_SUBCLASS_USR:s:[^|]+]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:{{[0-9]+}} | class/Swift | SECRETClass | [[SECRET_CLASS_USR:s:[^|]+]] | Ref,RelBase | rel: 1
 // CHECK-NEXT:  RelBase | class/Swift | SECRETSubclass | [[SECRET_SUBCLASS_USR]]{{$}}
 
 public class PublicClass {
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | class/Swift | PublicClass | [[PUBLIC_CLASS_USR:s:[^|]+]] | Def | rel: 0
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | class(public)/Swift | PublicClass | [[PUBLIC_CLASS_USR:s:[^|]+]] | Def | rel: 0
   internal var propSECRET: SECRETClass? { nil }
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property/Swift | propSECRET |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property(internal)/Swift | propSECRET |
   internal var propSECRET2: SECRETSubclass? { nil }
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property/Swift | propSECRET2 |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property(internal)/Swift | propSECRET2 |
 }
 
 extension SECRETClass {
   // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-class/Swift | SECRETClass |
   internal func testSECRET() {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method(internal)/Swift | testSECRET() |
 }
 
 extension PublicClass {
   // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR:s:[^|]+]] |
   public func extensionNamingMethod() {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | extensionNamingMethod() |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method(public)/Swift | extensionNamingMethod() |
 
   internal func testSECRET() {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method(internal)/Swift | testSECRET() |
 
   internal struct SECRETStruct: SECRETProtocol {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | struct/Swift | SECRETStruct | [[SECRET_NESTED_STRUCT_USR:s:[^|]+]] |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | struct(internal)/Swift | SECRETStruct | [[SECRET_NESTED_STRUCT_USR:s:[^|]+]] |
   // CHECK: [[@LINE-2]]:{{[0-9]+}} | protocol/Swift | SECRETProtocol | [[SECRET_PROTOCOL_USR:s:[^|]+]] | Ref,RelBase | rel: 1
   // CHECK-NEXT: RelBase | struct/Swift | SECRETStruct | [[SECRET_NESTED_STRUCT_USR]]
 }
@@ -50,16 +50,16 @@ extension PublicClass {
 extension Optional where Wrapped: SECRETProtocol {
   // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-enum/Swift | Optional |
   internal func extensionNamingMethod() {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | extensionNamingMethod() |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method(internal)/Swift | extensionNamingMethod() |
 
   internal func testSECRET() {}
-  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method(internal)/Swift | testSECRET() |
 }
 
 // CHECK-LABEL: ---FROM MODULE---
 // NEGATIVE-LABEL: ---FROM MODULE---
 
-// CHECK: 0:0 | class/Swift | PublicClass | [[PUBLIC_CLASS_USR]] | Def | rel: 0
+// CHECK: 0:0 | class(public)/Swift | PublicClass | [[PUBLIC_CLASS_USR]] | Def | rel: 0
 // CHECK: 0:0 | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR]] | Def | rel: 0
 // CHECK: 0:0 | class/Swift | PublicClass | [[PUBLIC_CLASS_USR]] | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR]]

--- a/test/Index/index_abi_attr.swift
+++ b/test/Index/index_abi_attr.swift
@@ -3,4 +3,4 @@
 // Make sure we use the API decl for mangling the USR.
 @abi(func bar())
 public func foo() {}
-// CHECK: [[@LINE-1]]:13 | function/Swift | foo() | s:14swift_ide_test3fooyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:13 | function(public)/Swift | foo() | s:14swift_ide_test3fooyyF | Def | rel: 0

--- a/test/Index/index_callasfunction.swift
+++ b/test/Index/index_callasfunction.swift
@@ -3,17 +3,17 @@
 struct Adder {
     var base: Int
     func callAsFunction(_ x: Int) -> Int {
-// CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1:.*]] | Def
+// CHECK: [[@LINE-1]]:10 | instance-method(internal)/Swift | callAsFunction(_:) | [[callAsFunc1:.*]] | Def
         return base + x
     }
     func callAsFunction(x: Int, y: Int) -> Adder {
-// CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2:.*]] | Def
+// CHECK: [[@LINE-1]]:10 | instance-method(internal)/Swift | callAsFunction(x:y:) | [[callAsFunc2:.*]] | Def
         return base + x + y
     }
 }
 
 let add3 = Adder(base: 3)
-// CHECK: [[@LINE-1]]:5 | variable/Swift | add3 | [[add3:.*]] | Def
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | add3 | [[add3:.*]] | Def
 let global = 1
 
 add3(global)
@@ -26,7 +26,7 @@ add3(x: 10, y: 11)
 // CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call | rel: 0
 
 func getAdder(_ base: Int) -> Adder { return Adder(base: base) }
-// CHECK: [[@LINE-1]]:6 | function/Swift | getAdder(_:) | [[getAdder:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | getAdder(_:) | [[getAdder:.*]] | Def | rel: 0
 
 getAdder(5)(10)
 // CHECK: [[@LINE-1]]:1 | function/Swift | getAdder(_:) | [[getAdder]] | Ref,Call | rel: 0

--- a/test/Index/index_collection_init.swift
+++ b/test/Index/index_collection_init.swift
@@ -21,7 +21,7 @@ _ = [String: Int](uniqueKeysWithValues: zip(["one", "two", "three"], 1...3))
 // CHECK: [[@LINE-1]]:5 | constructor/Swift | init(uniqueKeysWithValues:) | s:SD20uniqueKeysWithValuesSDyxq_Gqd__n_tcSTRd__x_q_t7ElementRtd__lufc | {{.*}}Ref
 
 extension Array where Element == Int {
-// CHECK: [[@LINE+1]]:3 | constructor/Swift | init(_:) | s:Sa14swift_ide_testSiRszlEySaySiGSicfc | {{.*}}Def
+// CHECK: [[@LINE+1]]:3 | constructor(internal)/Swift | init(_:) | s:Sa14swift_ide_testSiRszlEySaySiGSicfc | {{.*}}Def
   init(_ input: Int) {
     self = [input]
   }
@@ -31,7 +31,7 @@ _ = [Int](0)
 // CHECK: [[@LINE-1]]:5 | constructor/Swift | init(_:) | s:Sa14swift_ide_testSiRszlEySaySiGSicfc | {{.*}}Ref
 
 extension Dictionary {
-// CHECK: [[@LINE+1]]:3 | constructor/Swift | init(_:_:) | s:SD14swift_ide_testEySDyxq_Gx_q_tcfc | {{.*}}Def
+// CHECK: [[@LINE+1]]:3 | constructor(internal)/Swift | init(_:_:) | s:SD14swift_ide_testEySDyxq_Gx_q_tcfc | {{.*}}Def
   init(_ k: Key, _ v: Value) {
     self = [k: v]
   }

--- a/test/Index/index_comments.swift
+++ b/test/Index/index_comments.swift
@@ -6,4 +6,4 @@
 func foo() {}
 // CHECK: [[@LINE-3]]:5 | comment-tag/Swift |  | t:this_is_a_tag | Def | rel: 0
 // CHECK: [[@LINE-3]]:5 | comment-tag/Swift |  | t:and_another | Def | rel: 0
-// CHECK: [[@LINE-3]]:6 | function/Swift |
+// CHECK: [[@LINE-3]]:6 | function(internal)/Swift |

--- a/test/Index/index_curry_thunk_objc.swift
+++ b/test/Index/index_curry_thunk_objc.swift
@@ -5,11 +5,11 @@ import Foundation
 
 @objc
 class Foo: NSObject {
-  // CHECK-DAG: constructor/Swift | init(object:)
+  // CHECK-DAG: constructor(internal)/Swift | init(object:)
   init(object: Any?) {}
 }
 
 extension Foo {
-  // CHECK-DAG: static-property/Swift | boom
+  // CHECK-DAG: static-property(internal)/Swift | boom
   static let boom = Foo(object: self)
 }

--- a/test/Index/index_generic_params.swift
+++ b/test/Index/index_generic_params.swift
@@ -1,17 +1,17 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
-// CHECK: [[@LINE+1]]:10 | protocol/Swift | P1 | s:14swift_ide_test2P1P | Def |
+// CHECK: [[@LINE+1]]:10 | protocol(internal)/Swift | P1 | s:14swift_ide_test2P1P | Def |
 protocol P1 {
-  // CHECK: [[@LINE+1]]:18 | type-alias/associated-type/Swift | Assoc | s:14swift_ide_test2P1P5AssocQa | Def,RelChild |
+  // CHECK: [[@LINE+1]]:18 | type-alias/associated-type(internal)/Swift | Assoc | s:14swift_ide_test2P1P5AssocQa | Def,RelChild |
   associatedtype Assoc
 }
 
-// CHECK: [[@LINE+1]]:10 | protocol/Swift | P2 | s:14swift_ide_test2P2P | Def |
+// CHECK: [[@LINE+1]]:10 | protocol(internal)/Swift | P2 | s:14swift_ide_test2P2P | Def |
 protocol P2 {}
 
 // MARK: - Test extending a simple generic type
 
-// CHECK: [[@LINE+4]]:7 | class/Swift | Foo | s:14swift_ide_test3FooC | Def |
+// CHECK: [[@LINE+4]]:7 | class(internal)/Swift | Foo | s:14swift_ide_test3FooC | Def |
 // CHECK: [[@LINE+3]]:11 | type-alias/generic-type-param/Swift | OtherParam | s:14swift_ide_test3FooC10OtherParamxmfp | Def,RelChild |
 // CHECK: [[@LINE+2]]:23 | type-alias/generic-type-param/Swift | Bar | s:14swift_ide_test3FooC3Barq_mfp | Def,RelChild |
 // CHECK: [[@LINE+1]]:28 | protocol/Swift | P1 | s:14swift_ide_test2P1P | Ref |
@@ -34,7 +34,7 @@ extension Foo where Bar: P2 {
 
 // CHECK: [[@LINE+1]]:15 | type-alias/generic-type-param/Swift | WrapperParam | s:14swift_ide_test7WrapperC0D5Paramxmfp | Def,RelChild |
 class Wrapper<WrapperParam> {
-// CHECK: [[@LINE+2]]:9 | class/Swift | Wrapped | s:14swift_ide_test7WrapperC7WrappedC | Def,RelChild |
+// CHECK: [[@LINE+2]]:9 | class(internal)/Swift | Wrapped | s:14swift_ide_test7WrapperC7WrappedC | Def,RelChild |
 // CHECK: [[@LINE+1]]:29 | type-alias/generic-type-param/Swift | Bar | s:14swift_ide_test7WrapperC7WrappedC3Barqd_0_mfp | Def,RelChild |
   class Wrapped<OtherParam, Bar: P1> {}
 }
@@ -89,8 +89,8 @@ extension MyUnknownType where Wrapper2Param: P1 {
 
 // MARK: - Test indexing a generic initializer
 
-struct A<T> { // CHECK: [[@LINE]]:8 | struct/Swift | A | [[A_USR:.*]] | Def | rel: 0
-  init(value: T) {} // CHECK: [[@LINE]]:3 | constructor/Swift | init(value:) | [[A_init_USR:.*]] | Def,RelChild | rel: 1
+struct A<T> { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | A | [[A_USR:.*]] | Def | rel: 0
+  init(value: T) {} // CHECK: [[@LINE]]:3 | constructor(internal)/Swift | init(value:) | [[A_init_USR:.*]] | Def,RelChild | rel: 1
 }
 
 // CHECK: [[@LINE+2]]:5 | struct/Swift | A | [[A_USR]] | Ref | rel: 0
@@ -118,9 +118,9 @@ _ = ((A))(value: 1)
 // CHECK-NEXT: [[@LINE+1]]:11 | constructor/Swift | init(value:) | [[A_init_USR]] | Ref,Call | rel: 0
 _ = ((A)).init(value: 1)
 
-enum B { // CHECK: [[@LINE]]:6 | enum/Swift | B | [[B_USR:.*]] | Def | rel: 0
-  struct Nested<T> { // CHECK: [[@LINE]]:10 | struct/Swift | Nested | [[B_Nested_USR:.*]] | Def,RelChild | rel: 1
-    init(value: T) {} // CHECK: [[@LINE]]:5 | constructor/Swift | init(value:) | [[B_Nested_init_USR:.*]] | Def,RelChild | rel: 1
+enum B { // CHECK: [[@LINE]]:6 | enum(internal)/Swift | B | [[B_USR:.*]] | Def | rel: 0
+  struct Nested<T> { // CHECK: [[@LINE]]:10 | struct(internal)/Swift | Nested | [[B_Nested_USR:.*]] | Def,RelChild | rel: 1
+    init(value: T) {} // CHECK: [[@LINE]]:5 | constructor(internal)/Swift | init(value:) | [[B_Nested_init_USR:.*]] | Def,RelChild | rel: 1
   }
 }
 
@@ -150,9 +150,9 @@ _ = ((B.Nested<Int>))(value: 1)
 // CHECK-NEXT: [[@LINE+1]]:23 | constructor/Swift | init(value:) | [[B_Nested_init_USR]] | Ref,Call | rel: 0
 _ = ((B.Nested<Int>)).init(value: 1)
 
-enum C { // CHECK: [[@LINE]]:6 | enum/Swift | C | [[C_USR:.*]] | Def | rel: 0
-  struct Nested { // CHECK: [[@LINE]]:10 | struct/Swift | Nested | [[C_Nested_USR:.*]] | Def,RelChild | rel: 1
-    init(value: Int) {} // CHECK: [[@LINE]]:5 | constructor/Swift | init(value:) | [[C_Nested_init_USR:.*]] | Def,RelChild | rel: 1
+enum C { // CHECK: [[@LINE]]:6 | enum(internal)/Swift | C | [[C_USR:.*]] | Def | rel: 0
+  struct Nested { // CHECK: [[@LINE]]:10 | struct(internal)/Swift | Nested | [[C_Nested_USR:.*]] | Def,RelChild | rel: 1
+    init(value: Int) {} // CHECK: [[@LINE]]:5 | constructor(internal)/Swift | init(value:) | [[C_Nested_init_USR:.*]] | Def,RelChild | rel: 1
   }
 }
 

--- a/test/Index/index_imported_objc.swift
+++ b/test/Index/index_imported_objc.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/mods)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-ide-test -print-indexed-symbols -enable-objc-interop -source-filename %t/ObjcUser.swift -Xcc -fmodule-map-file=%t/module.modulemap | %FileCheck -dump-input=always %t/ObjcUser.swift
 
@@ -41,7 +41,7 @@ module objc_decls {
 
 //--- ObjcUser.swift
 import objc_decls
-func test() { // CHECK: [[@LINE]]:6 | function/Swift | test() | [[s:.*]] | Def | rel: 0
+func test() { // CHECK: [[@LINE]]:6 | function(internal)/Swift | test() | [[s:.*]] | Def | rel: 0
   let c = ObjCClass()
   let _ = c.baseClassProperty
   // CHECK: [[@LINE-1]]:13 | instance-property/Swift | baseClassProperty | c:objc(cs)ObjCClass(py)baseClassProperty | Ref,Read,Dyn,RelRec,RelCont | rel: 2
@@ -56,7 +56,7 @@ func test() { // CHECK: [[@LINE]]:6 | function/Swift | test() | [[s:.*]] | Def |
 }
 class SubObjCClass: ObjCClass {
   override func protocolAddedMethod() {}
-  // CHECK: [[@LINE-1]]:17 | instance-method/Swift | protocolAddedMethod() | c:@M@swift_ide_test@objc(cs)SubObjCClass(im)protocolAddedMethod | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:17 | instance-method(internal)/Swift | protocolAddedMethod() | c:@M@swift_ide_test@objc(cs)SubObjCClass(im)protocolAddedMethod | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | protocolAddedMethod() | c:objc(pl)MemberAdding(im)protocolAddedMethod
   // CHECK-NEXT: RelChild | class/Swift | SubObjCClass | c:@M@swift_ide_test@objc(cs)SubObjCClass
 }

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -1,32 +1,32 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
 struct Point {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | Point | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | Point | {{.*}} | Def | rel: 0
   var x: Int
-// CHECK: [[@LINE-1]]:7 | instance-property/Swift | x | [[PX_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | x | [[PX_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:x | [[PX_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:x | [[PX_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
   var y: Int
-// CHECK: [[@LINE-1]]:7 | instance-property/Swift | y | [[PY_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | y | [[PY_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:y | [[PY_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:y | [[PY_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 }
 
 struct Rectangle {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | Rectangle | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | Rectangle | {{.*}} | Def | rel: 0
   var topLeft: Point
-// CHECK: [[@LINE-1]]:7 | instance-property/Swift | topLeft | [[TL_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | topLeft | [[TL_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:topLeft | [[TL_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:topLeft | [[TL_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
   var bottomRight: Point
-// CHECK: [[@LINE-1]]:7 | instance-property/Swift | bottomRight | [[BR_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | bottomRight | [[BR_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:bottomRight | [[BR_GET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK: [[@LINE-3]]:7 | instance-method/acc-set/Swift | setter:bottomRight | [[BR_SET_USR:s:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 }
 
 @dynamicMemberLookup
 struct Lens<T> {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | Lens | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | Lens | {{.*}} | Def | rel: 0
   var obj: T
 
   init(_ obj: T) {
@@ -34,7 +34,7 @@ struct Lens<T> {
   }
 
   subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
-// CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR:s:.*]] | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:3 | instance-property/subscript(internal)/Swift | subscript(dynamicMember:) | [[SUB_USR:s:.*]] | Def,RelChild | rel: 1
     get { return Lens<U>(obj[keyPath: member]) }
 // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR:s:.*]] | Def,RelChild,RelAcc | rel: 1
     set { obj[keyPath: member] = newValue.obj }
@@ -145,14 +145,14 @@ func testExplicit(r: Lens<Rectangle>, a: Lens<[Int]>) {
 @dynamicMemberLookup
 protocol Foo {
   var prop: Bar {get}
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | prop | [[PROP_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | prop | [[PROP_USR:.*]] | Def,RelChild | rel: 1
 }
 struct Bar {
   let enabled = false
 }
 extension Foo {
   subscript<T>(dynamicMember keyPath: KeyPath<Bar,T>) -> T {
-  // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB2_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:3 | instance-property/subscript(internal)/Swift | subscript(dynamicMember:) | [[SUB2_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-2]]:60 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | {{.*}} | Def,Dyn,RelChild,RelAcc | rel: 1
   // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB2_USR]]
 

--- a/test/Index/index_location_directive.swift
+++ b/test/Index/index_location_directive.swift
@@ -6,5 +6,5 @@
 
 #sourceLocation(file: "some_file.swift", line: 1)
 func testFunc() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | testFunc() | s:14swift_ide_test0C4FuncyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | testFunc() | s:14swift_ide_test0C4FuncyyF | Def | rel: 0
 #sourceLocation()

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -16,51 +16,51 @@
 //--- IndexTest.swift
 @freestanding(expression)
 macro freestandingExpr<T>(arg: T) = #externalMacro(module: "IndexMacros", type: "FreestandingExprMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | freestandingExpr(arg:) |  [[EXPR_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | freestandingExpr(arg:) |  [[EXPR_USR:.*]] | Def
 
 @freestanding(declaration, names: named(TestFree))
 macro freestandingDecl<T>(arg: T) = #externalMacro(module: "IndexMacros", type: "FreestandingDeclMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | freestandingDecl(arg:) |  [[DECL_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | freestandingDecl(arg:) |  [[DECL_USR:.*]] | Def
 
 @attached(accessor)
 macro Accessor() = #externalMacro(module: "IndexMacros", type: "SomeAccessorMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | Accessor() |  [[ACCESSOR_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | Accessor() |  [[ACCESSOR_USR:.*]] | Def
 
 @attached(extension, conformances: TestProto)
 macro Conformance() = #externalMacro(module: "IndexMacros", type: "SomeConformanceMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | Conformance() |  [[CONFORMANCE_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | Conformance() |  [[CONFORMANCE_USR:.*]] | Def
 
 @attached(member, names: named(memberFunc))
 macro Member() = #externalMacro(module: "IndexMacros", type: "SomeMemberMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | Member() |  [[MEMBER_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | Member() |  [[MEMBER_USR:.*]] | Def
 
 @attached(memberAttribute)
 macro MemberAttribute() = #externalMacro(module: "IndexMacros", type: "SomeMemberAttributeMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | MemberAttribute() |  [[MEMBER_ATTRIBUTE_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | MemberAttribute() |  [[MEMBER_ATTRIBUTE_USR:.*]] | Def
 
 @attached(peer, names: named(TestPeer))
 macro Peer<T>(arg: T) = #externalMacro(module: "IndexMacros", type: "SomePeerMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | Peer(arg:) |  [[PEER_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | Peer(arg:) |  [[PEER_USR:.*]] | Def
 
 @attached(peer, names: named(peerMember))
 macro PeerMember() = #externalMacro(module: "IndexMacros", type: "SomePeerMemberMacro")
-// CHECK: [[@LINE-1]]:7 | macro/Swift | PeerMember() |  [[PEER_MEMBER_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | PeerMember() |  [[PEER_MEMBER_USR:.*]] | Def
 
 protocol TestProto {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | TestProto | [[PROTO_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | TestProto | [[PROTO_USR:.*]] | Def
 
 func accessorLog() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | accessorLog() | [[ACC_LOG_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | accessorLog() | [[ACC_LOG_USR:.*]] | Def
 func exprLog() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | exprLog() | [[EXPR_LOG_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | exprLog() | [[EXPR_LOG_USR:.*]] | Def
 func freeLog() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | freeLog() | [[FREE_LOG_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | freeLog() | [[FREE_LOG_USR:.*]] | Def
 func memberLog() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | memberLog() | [[MEMBER_LOG_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | memberLog() | [[MEMBER_LOG_USR:.*]] | Def
 func peerLog() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | peerLog() | [[PEER_LOG_USR:.*]] | Def
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | peerLog() | [[PEER_LOG_USR:.*]] | Def
 
-// CHECK: [[@LINE+2]]:8 | struct/Swift | AddOne | [[ADD_ONE_USR:.*]] | Def
+// CHECK: [[@LINE+2]]:8 | struct(internal)/Swift | AddOne | [[ADD_ONE_USR:.*]] | Def
 @propertyWrapper
 struct AddOne {
   var value: Int = 1
@@ -77,8 +77,8 @@ struct AddOne {
 // CHECK: [[@LINE+1]]:19 | struct/Swift | Double | s:Sd | Ref
 #freestandingDecl<Double>(arg: 1.0)
 // Creates a `TestFree` struct with `freeFunc` calling `freeLog`
-// CHECK: [[@LINE-2]]:1 | struct/Swift | TestFree | [[FREE_STRUCT_USR:.*]] | Def,Impl
-// CHECK: [[@LINE-3]]:1 | instance-method/Swift | freeFunc() | [[FREE_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK: [[@LINE-2]]:1 | struct(internal)/Swift | TestFree | [[FREE_STRUCT_USR:.*]] | Def,Impl
+// CHECK: [[@LINE-3]]:1 | instance-method(internal)/Swift | freeFunc() | [[FREE_FUNC_USR:.*]] | Def,Impl,RelChild
 // CHECK-NEXT: RelChild | struct/Swift | TestFree | [[FREE_STRUCT_USR]]
 // CHECK: [[@LINE-5]]:1 | function/Swift | freeLog() | [[FREE_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | freeFunc() | [[FREE_FUNC_USR]]
@@ -112,24 +112,24 @@ struct TestAttached {
 // CHECK-NEXT: RelCall,RelCont | instance-method/acc-get/Swift | getter:attachedMemberAccessors
 
 // `Member` adds a new member `memberFunc` that calls `memberLog`
-// CHECK: [[@LINE-16]]:14 | instance-method/Swift | memberFunc() | [[MEMBER_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK: [[@LINE-16]]:14 | instance-method(internal)/Swift | memberFunc() | [[MEMBER_FUNC_USR:.*]] | Def,Impl,RelChild
 // CHECK: [[@LINE-17]]:14 | function/Swift | memberLog() | [[MEMBER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | memberFunc() | [[MEMBER_FUNC_USR]]
 
 // `Peer` adds a new inner type `TestPeer` that contains `peerFunc` with a call to `peerLog`
-// CHECK: [[@LINE-21]]:39 | struct/Swift | TestPeer | [[PEER_STRUCT_USR:.*]] | Def,Impl
-// CHECK: [[@LINE-22]]:39 | instance-method/Swift | peerFunc() | [[PEER_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK: [[@LINE-21]]:39 | struct(internal)/Swift | TestPeer | [[PEER_STRUCT_USR:.*]] | Def,Impl
+// CHECK: [[@LINE-22]]:39 | instance-method(internal)/Swift | peerFunc() | [[PEER_FUNC_USR:.*]] | Def,Impl,RelChild
 // CHECK-NEXT: RelChild | struct/Swift | TestPeer | [[PEER_STRUCT_USR]]
 // CHECK: [[@LINE-24]]:39 | function/Swift | peerLog() | [[PEER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | peerFunc() | [[PEER_FUNC_USR]]
 
-// CHECK: [[@LINE+1]]:8 | struct/Swift | Outer | [[OUTER_USR:.*]] | Def
+// CHECK: [[@LINE+1]]:8 | struct(internal)/Swift | Outer | [[OUTER_USR:.*]] | Def
 struct Outer {
   // CHECK: [[@LINE+1]]:4 | macro/Swift | PeerMember() | [[PEER_MEMBER_USR]] | Ref
   @PeerMember
   var anyMember: Int
   // `PeerMember` adds a new `peerMember`
-  // CHECK: [[@LINE-3]]:3 | instance-property/Swift | peerMember | {{.*}} | Def,Impl,RelChild
+  // CHECK: [[@LINE-3]]:3 | instance-property(internal)/Swift | peerMember | {{.*}} | Def,Impl,RelChild
   // CHECK-NEXT: RelChild | struct/Swift | Outer | [[OUTER_USR]]
 
   // CHECK: [[@LINE+2]]:17 | macro/Swift | Member() | [[MEMBER_USR]] | Ref
@@ -138,7 +138,7 @@ struct Outer {
   struct TestInner {}
 }
 // `Member` adds a new member `memberFunc` that calls `memberLog`
-// CHECK: [[@LINE-4]]:16 | instance-method/Swift | memberFunc() | [[INNER_FUNC_USR:.*]] | Def,Impl
+// CHECK: [[@LINE-4]]:16 | instance-method(internal)/Swift | memberFunc() | [[INNER_FUNC_USR:.*]] | Def,Impl
 // CHECK-NEXT: RelChild | struct/Swift | TestInner
 // CHECK: [[@LINE-6]]:16 | function/Swift | memberLog() | [[MEMBER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | memberFunc() | [[INNER_FUNC_USR]]

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -6,36 +6,36 @@
 // RUN: %FileCheck %s -input-file=%t.out
 
 public var someGlobal: Int = 0
-// CHECK: [[@LINE-1]]:12 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:12 | variable(public)/Swift | someGlobal | [[SOMEGLOBAL_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:12 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 // CHECK: [[@LINE-4]]:12 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 
 public func someFunc() {}
-// CHECK: [[@LINE-1]]:13 | function/Swift | someFunc() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:13 | function(public)/Swift | someFunc() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
 
 public class CCC {}
-// CHECK: [[@LINE-1]]:14 | class/Swift | CCC | [[CCC_USR:.*]] | Def | rel: 0
-// CHECK: [[@LINE-2]]:14 | constructor/Swift | init() | [[CCC_init_USR:.*]] | Def,Impl,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:14 | class(public)/Swift | CCC | [[CCC_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-2]]:14 | constructor(internal)/Swift | init() | [[CCC_init_USR:.*]] | Def,Impl,RelChild | rel: 1
 // CHECK-NEXT:   RelChild | class/Swift | CCC | [[CCC_USR]]
 
 public typealias GenericTypealias<T> = Optional<T>
-// CHECK: [[@LINE-1]]:18 | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:18 | type-alias(public)/Swift | GenericTypealias | [[TYPEALIAS_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:35 | type-alias/generic-type-param/Swift | T | s:12index_module16GenericTypealiasa1Txmfp | Def,RelChild | rel: 1
 // CHECK-NEXT:   RelChild | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR]]
 
 // --- Check the module ---
 
-// CHECK: 0:0 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
+// CHECK: 0:0 | variable(public)/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
 // CHECK: 0:0 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 // CHECK: 0:0 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 
-// CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0
+// CHECK: 0:0 | function(public)/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0
 
-// CHECK: 0:0 | class/Swift | CCC | [[CCC_USR]] | Def | rel: 0
-// CHECK-NOT: constructor/Swift
+// CHECK: 0:0 | class(public)/Swift | CCC | [[CCC_USR]] | Def | rel: 0
+// CHECK-NOT: constructor{{.*}}/Swift
 
-// CHECK: 0:0 | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR]] | Def | rel: 0
+// CHECK: 0:0 | type-alias(public)/Swift | GenericTypealias | [[TYPEALIAS_USR]] | Def | rel: 0

--- a/test/Index/index_module_accessors.swift
+++ b/test/Index/index_module_accessors.swift
@@ -6,17 +6,17 @@
 // rdar://130775560 - Make sure the accessors are marked implicit in the index
 // data for the module.
 public struct S {
-  // CHECK-DAG: instance-property/Swift | x | s:3Mod1SV1xSivp | Def,RelChild
+  // CHECK-DAG: instance-property(public)/Swift | x | s:3Mod1SV1xSivp | Def,RelChild
   // CHECK-DAG: instance-method/acc-get/Swift | getter:x | s:3Mod1SV1xSivg | Def,Impl,RelChild,RelAcc
   public let x = 0
 
-  // CHECK-DAG: instance-property/Swift | y | s:3Mod1SV1ySivp | Def,RelChild
+  // CHECK-DAG: instance-property(public)/Swift | y | s:3Mod1SV1ySivp | Def,RelChild
   // CHECK-DAG: instance-method/acc-get/Swift | getter:y | s:3Mod1SV1ySivg | Def,Impl,RelChild,RelAcc
   public var y: Int {
     0
   }
 
-  // CHECK-DAG: instance-property/Swift | z | s:3Mod1SV1zSivp | Def,RelChild
+  // CHECK-DAG: instance-property(public)/Swift | z | s:3Mod1SV1zSivp | Def,RelChild
   // CHECK-DAG: instance-method/acc-get/Swift | getter:z | s:3Mod1SV1zSivg | Def,Impl,RelChild,RelAcc
   // CHECK-DAG: instance-method/acc-set/Swift | setter:z | s:3Mod1SV1zSivs | Def,Impl,RelChild,RelAcc
   public var z: Int {
@@ -24,7 +24,7 @@ public struct S {
     set {}
   }
 
-  // CHECK-DAG: instance-property/Swift | a | s:3Mod1SV1aSivp | Def,RelChild
+  // CHECK-DAG: instance-property(public)/Swift | a | s:3Mod1SV1aSivp | Def,RelChild
   // CHECK-DAG: instance-method/acc-get/Swift | getter:a | s:3Mod1SV1aSivg | Def,Impl,RelChild,RelAcc
   public var a: Int {
     @inlinable

--- a/test/Index/index_module_inheritance_access.swift
+++ b/test/Index/index_module_inheritance_access.swift
@@ -11,5 +11,5 @@ public class D: C {
 }
 
 // Make sure we don't report the override of the private member in the base class.
-//CHECK:      instance-method/Swift | foo() | s:3Mod1DC3fooyyF | Def,Dyn,RelChild | rel: 1
+//CHECK:      instance-method(public)/Swift | foo() | s:3Mod1DC3fooyyF | Def,Dyn,RelChild | rel: 1
 //CHECK-NEXT: RelChild | class/Swift | D | s:3Mod1DC

--- a/test/Index/index_objc_dynamic_refs.swift
+++ b/test/Index/index_objc_dynamic_refs.swift
@@ -5,15 +5,15 @@ import Foundation
 
 @objc protocol AProtocol {
     @objc optional func dynamicMethod()
-    // CHECK: [[@LINE-1]]:25 | instance-method/Swift | dynamicMethod() | [[DynamicMethod_USR:.*]] | Def
+    // CHECK: [[@LINE-1]]:25 | instance-method(internal)/Swift | dynamicMethod() | [[DynamicMethod_USR:.*]] | Def
     @objc optional var property: String { get }
-    // CHECK: [[@LINE-1]]:24 | instance-property/Swift | property | [[DynamicProperty_USR:.*]] | Def
+    // CHECK: [[@LINE-1]]:24 | instance-property(internal)/Swift | property | [[DynamicProperty_USR:.*]] | Def
 }
 
 class AClass {
 
     weak var objcDelegate: AProtocol?
-    // CHECK: [[@LINE-1]]:14 | instance-property/Swift | objcDelegate | [[Delegate_USR:.*]] | Def
+    // CHECK: [[@LINE-1]]:14 | instance-property(internal)/Swift | objcDelegate | [[Delegate_USR:.*]] | Def
 
     func doSomething() {
         objcDelegate?.dynamicMethod?()

--- a/test/Index/index_objc_impl.swift
+++ b/test/Index/index_objc_impl.swift
@@ -22,9 +22,9 @@
 // CHECK: extension/ext-class/Swift | ObjCClass | s:e:c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
 // CHECK: class/Swift | ObjCClass | c:objc(cs)ObjCClass | Ref
 @_objcImplementation public extension ObjCClass {
-  // CHECK: instance-property/Swift | someObjCDeclaredVar | c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
+  // CHECK: instance-property(public)/Swift | someObjCDeclaredVar | c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
   @objc var someObjCDeclaredVar: CInt = 1
 
   // Implicitly synthesized `override init()`:
-  // CHECK: constructor/Swift | init() | c:@CM@ObjcImpl@@objc(cs)ObjCClass(im)init | Def
+  // CHECK: constructor(public)/Swift | init() | c:@CM@ObjcImpl@@objc(cs)ObjCClass(im)init | Def
 }

--- a/test/Index/index_self.swift
+++ b/test/Index/index_self.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
-struct Foo { // CHECK: [[@LINE]]:8 | struct/Swift | Foo | [[Foo_USR:.*]] | Def | rel: 0
-  init() {} // CHECK: [[@LINE]]:3 | constructor/Swift | init() | [[Foo_init_USR:.*]] | Def,RelChild | rel: 1
+struct Foo { // CHECK: [[@LINE]]:8 | struct(internal)/Swift | Foo | [[Foo_USR:.*]] | Def | rel: 0
+  init() {} // CHECK: [[@LINE]]:3 | constructor(internal)/Swift | init() | [[Foo_init_USR:.*]] | Def,RelChild | rel: 1
 
   static func bar() -> Self {
     .init() // CHECK: [[@LINE]]:6 | constructor/Swift | init() | [[Foo_init_USR]] | Ref,Call,RelCall,RelCont | rel: 1
@@ -14,8 +14,8 @@ struct Foo { // CHECK: [[@LINE]]:8 | struct/Swift | Foo | [[Foo_USR:.*]] | Def |
   }
 }
 
-final class Final { // CHECK: [[@LINE]]:13 | class/Swift | Final | [[Final_USR:.*]] | Def | rel: 0
-  init() {} // CHECK: [[@LINE]]:3 | constructor/Swift | init() | [[Final_init_USR:.*]] | Def,RelChild | rel: 1
+final class Final { // CHECK: [[@LINE]]:13 | class(internal)/Swift | Final | [[Final_USR:.*]] | Def | rel: 0
+  init() {} // CHECK: [[@LINE]]:3 | constructor(internal)/Swift | init() | [[Final_init_USR:.*]] | Def,RelChild | rel: 1
 
   static func foo() -> Self {
     .init() // CHECK: [[@LINE]]:6 | constructor/Swift | init() | [[Final_init_USR]] | Ref,Call,RelCall,RelCont | rel: 1
@@ -28,8 +28,8 @@ final class Final { // CHECK: [[@LINE]]:13 | class/Swift | Final | [[Final_USR:.
   }
 }
 
-class Bar { // CHECK: [[@LINE]]:7 | class/Swift | Bar | [[Bar_USR:.*]] | Def | rel: 0
-  required init() {} // CHECK: [[@LINE]]:12 | constructor/Swift | init() | [[Bar_init_USR:.*]] | Def,RelChild | rel: 1
+class Bar { // CHECK: [[@LINE]]:7 | class(internal)/Swift | Bar | [[Bar_USR:.*]] | Def | rel: 0
+  required init() {} // CHECK: [[@LINE]]:12 | constructor(internal)/Swift | init() | [[Bar_init_USR:.*]] | Def,RelChild | rel: 1
 
   static func foo() -> Self {
     .init() // CHECK: [[@LINE]]:6 | constructor/Swift | init() | [[Bar_init_USR]] | Ref,Call,RelCall,RelCont | rel: 1
@@ -45,8 +45,8 @@ class Bar { // CHECK: [[@LINE]]:7 | class/Swift | Bar | [[Bar_USR:.*]] | Def | r
 
 class Baz: Bar {}
 
-protocol Proto { // CHECK: [[@LINE]]:10 | protocol/Swift | Proto | [[Proto_USR:.*]] | Def | rel: 0
-  init() // CHECK: [[@LINE]]:3 | constructor/Swift | init() | [[Proto_init_USR:.*]] | Def,RelChild | rel: 1
+protocol Proto { // CHECK: [[@LINE]]:10 | protocol(internal)/Swift | Proto | [[Proto_USR:.*]] | Def | rel: 0
+  init() // CHECK: [[@LINE]]:3 | constructor(internal)/Swift | init() | [[Proto_init_USR:.*]] | Def,RelChild | rel: 1
 }
 
 extension Proto {

--- a/test/Index/index_static_funcs.swift
+++ b/test/Index/index_static_funcs.swift
@@ -3,15 +3,15 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 
 protocol SwiftProto {
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | SwiftProto | [[Proto_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | SwiftProto | [[Proto_USR:.*]] | Def | rel: 0
   static func staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | [[ProtoStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 protocol SwiftProtoSame {
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | SwiftProtoSame | [[ProtoSame_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | SwiftProtoSame | [[ProtoSame_USR:.*]] | Def | rel: 0
   static func staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoSameStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | [[ProtoSameStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 protocol SwiftProtoOther {}
@@ -19,23 +19,23 @@ protocol SwiftProtoOther {}
 protocol SwiftProtoComposed: SwiftProtoSame, SwiftProto, SwiftProtoOther {}
 
 class SwiftClass: SwiftProtoComposed {
-// CHECK: [[@LINE-1]]:7 | class/Swift | SwiftClass | [[Class_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | SwiftClass | [[Class_USR:.*]] | Def | rel: 0
   static func staticMethod() {}
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ClassStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | [[ClassStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
   class func classMethod() {}
-  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | [[ClassClassMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | class-method(internal)/Swift | classMethod() | [[ClassClassMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 struct SwiftStruct: SwiftProtoComposed {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | SwiftStruct | [[Struct_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | SwiftStruct | [[Struct_USR:.*]] | Def | rel: 0
   static func staticMethod() {}
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[StructStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | [[StructStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
 }
 
 enum SwiftEnum: SwiftProtoComposed {
-// CHECK: [[@LINE-1]]:6 | enum/Swift | SwiftEnum | [[Enum_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | enum(internal)/Swift | SwiftEnum | [[Enum_USR:.*]] | Def | rel: 0
   static func staticMethod() {}
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[EnumStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | [[EnumStaticMethod_USR:.*]] | Def,RelChild,RelOver | rel: 3
 }
 
 func directCalls() {

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -5,14 +5,14 @@
 // RUN: %FileCheck %s -input-file=%t.out
 // RUN: %FileCheck -check-prefix NEGATIVE %s -input-file=%t.out
 
-// CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
-// CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Def | rel: 0
-// CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR:.*]] | Def,Dyn,RelChild | rel: 1
+// CHECK: function(public)/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
+// CHECK: class(public)/Swift | BaseCls | [[BASECLS_USR:.*]] | Def | rel: 0
+// CHECK: instance-method(public)/Swift | theMeth() | [[BASECLSMETH_USR:.*]] | Def,Dyn,RelChild | rel: 1
 // CHECK-NEXT: RelChild | class/Swift | BaseCls | [[BASECLS_USR]]
-// CHECK: class/Swift | SubCls | [[SUBCLS_USR:.*]] | Def | rel: 0
+// CHECK: class(public)/Swift | SubCls | [[SUBCLS_USR:.*]] | Def | rel: 0
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR]] | Ref,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | SubCls | [[SUBCLS_USR]]
-// CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
+// CHECK: instance-method(public)/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
 // CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR]]
 // CHECK-NEXT: RelChild | class/Swift | SubCls | [[SUBCLS_USR]]
 

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -19,7 +19,7 @@ class CrashTest {
 CrashTest().returnSelf(["": 0]).something
 
 class CrashTest2 {
-// CHECK: [[@LINE+1]]:8 | instance-method/Swift | bar
+// CHECK: [[@LINE+1]]:8 | instance-method(internal)/Swift | bar
   func bar() {
     someClosure { [weak self] in
       guard let sSelf = self else { return }

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -2,23 +2,23 @@
 
 // Enum
 enum AnEnumeration {
-// CHECK: [[@LINE-1]]:6 | enum/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | enum(internal)/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO | Def | rel: 0
 
   // EnumElement
   case Element
-  // CHECK: [[@LINE-1]]:8 | enumerator/Swift | Element | s:14swift_ide_test13AnEnumerationO7ElementyA2CmF | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | enumerator(internal)/Swift | Element | s:14swift_ide_test13AnEnumerationO7ElementyA2CmF | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | enum/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO
 }
 
 // Struct
 struct AStruct {
-  // CHECK: [[@LINE-1]]:8 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Def | rel: 0
+  // CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | AStruct | s:14swift_ide_test7AStructV | Def | rel: 0
   
   var base: UnsafeMutablePointer<Int>
 
   // Subscript
   subscript(index: Int) -> Int {
-    // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructVyS2icip | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:3 | instance-property/subscript(internal)/Swift | subscript(_:) | s:14swift_ide_test7AStructVyS2icip | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | struct/Swift | AStruct | s:14swift_ide_test7AStructV
 
     // Accessor + AccessorAddressor
@@ -44,11 +44,11 @@ struct AStruct {
 
 // Class
 class AClass {
-  // CHECK: [[@LINE-1]]:7 | class/Swift | AClass | s:14swift_ide_test6AClassC | Def | rel: 0
+  // CHECK: [[@LINE-1]]:7 | class(internal)/Swift | AClass | s:14swift_ide_test6AClassC | Def | rel: 0
 
   // InstanceMethod + Parameters
   func instanceMethod(a: Int, b b: Int, _ c: Int, d _: Int, _: Int) {
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethod1a1b_1d_ySi_S4itF | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethod1a1b_1d_ySi_S4itF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:23 | param/Swift | a | s:14swift_ide_test6AClassC14instanceMethod1a1b_1d_ySi_S4itFAEL_Sivp | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethod1a1b_1d_ySi_S4itF
@@ -67,17 +67,17 @@ class AClass {
 
   // ClassMethod
   class func classMethod() {}
-  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | s:14swift_ide_test6AClassC11classMethodyyFZ | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | class-method(internal)/Swift | classMethod() | s:14swift_ide_test6AClassC11classMethodyyFZ | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // StaticMethod
   static func staticMethod() {}
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | s:14swift_ide_test6AClassC12staticMethodyyFZ | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:15 | static-method(internal)/Swift | staticMethod() | s:14swift_ide_test6AClassC12staticMethodyyFZ | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // InstanceProperty
   var instanceProperty: Int {
-    // CHECK: [[@LINE-1]]:7 | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySivp | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySivp | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
     // Accessor + AccessorGetter
@@ -109,19 +109,19 @@ class AClass {
 
   // ClassProperty
   class var classProperty: Int!
-  // CHECK: [[@LINE-1]]:13 | class-property/Swift | classProperty | s:14swift_ide_test6AClassC13classPropertySiSgvpZ | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:13 | class-property(internal)/Swift | classProperty | s:14swift_ide_test6AClassC13classPropertySiSgvpZ | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:13 | class-method/acc-get/Swift | getter:classProperty | s:14swift_ide_test6AClassC13classPropertySiSgvgZ | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
 
   // StaticProperty
   static var staticProperty: Int!
-  // CHECK: [[@LINE-1]]:14 | static-property/Swift | staticProperty | s:14swift_ide_test6AClassC14staticPropertySiSgvpZ | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | static-property(internal)/Swift | staticProperty | s:14swift_ide_test6AClassC14staticPropertySiSgvpZ | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:14 | static-method/acc-get/Swift | getter:staticProperty | s:14swift_ide_test6AClassC14staticPropertySiSgvgZ | Def,Impl,RelChild,RelAcc | rel: 1
 
   // Constructor
   init() {}
-  // CHECK: [[@LINE-1]]:3 | constructor/Swift | init() | s:14swift_ide_test6AClassCACycfc | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:3 | constructor(internal)/Swift | init() | s:14swift_ide_test6AClassCACycfc | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // Destructor
@@ -132,11 +132,11 @@ class AClass {
 
 // Protocol
 protocol AProtocol {
-  // CHECK: [[@LINE-1]]:10 | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Def | rel: 0
+  // CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Def | rel: 0
 
   // AssociatedType
   associatedtype T
-  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:14swift_ide_test9AProtocolP1TQa | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type(internal)/Swift | T | s:14swift_ide_test9AProtocolP1TQa | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 
@@ -163,7 +163,7 @@ extension AProtocol { func extFn() }
 
 // TypeAlias
 typealias SomeAlias = AStruct
-// CHECK: [[@LINE-1]]:11 | type-alias/Swift | SomeAlias | s:14swift_ide_test9SomeAliasa | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | type-alias(internal)/Swift | SomeAlias | s:14swift_ide_test9SomeAliasa | Def | rel: 0
 // CHECK: [[@LINE-2]]:23 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Ref | rel: 0
 
 // GenericTypeParam
@@ -172,76 +172,76 @@ struct GenericStruct<ATypeParam> {}
 // CHECK-NEXT: RelChild | struct/Swift | GenericStruct | s:14swift_ide_test13GenericStructV
 
 func GenericFunc<ATypeParam>(_: ATypeParam) {}
-// CHECK-NOT: [[@LINE-1]]:18 | type-alias/generic-type-param/Swift | ATypeParam | {{.*}} | Def,RelChild | rel: 1
+// CHECK-NOT: [[@LINE-1]]:18 | type-alias/generic-type-param{{.*}}/Swift | ATypeParam | {{.*}} | Def,RelChild | rel: 1
 
 // Function
 func EmptyFunction() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | EmptyFunction() | s:14swift_ide_test13EmptyFunctionyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | EmptyFunction() | s:14swift_ide_test13EmptyFunctionyyF | Def | rel: 0
 
 // Variable
 var foo = 1
-// CHECK: [[@LINE-1]]:5 | variable/Swift | foo | s:14swift_ide_test3fooSivp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | foo | s:14swift_ide_test3fooSivp | Def | rel: 0
 
 // PrefixOperator
 prefix func -(a: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:13 | function/prefix-operator/Swift | -(_:) | s:14swift_ide_test1sopyAA7AStructVADF | Def | rel: 0
+// CHECK: [[@LINE-1]]:13 | function/prefix-operator(internal)/Swift | -(_:) | s:14swift_ide_test1sopyAA7AStructVADF | Def | rel: 0
 
 // PostfixOperator
 postfix operator ++
 postfix func ++(a: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:14 | function/postfix-operator/Swift | ++(_:) | s:14swift_ide_test2ppoPyAA7AStructVADF | Def | rel: 0
+// CHECK: [[@LINE-1]]:14 | function/postfix-operator(internal)/Swift | ++(_:) | s:14swift_ide_test2ppoPyAA7AStructVADF | Def | rel: 0
 
 // InfixOperator
 func +(a: AStruct, b: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:6 | function/infix-operator/Swift | +(_:_:) | s:14swift_ide_test1poiyAA7AStructVAD_ADtF | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function/infix-operator(internal)/Swift | +(_:_:) | s:14swift_ide_test1poiyAA7AStructVAD_ADtF | Def | rel: 0
 
 class XCTestCase {}
 class MyTestCase : XCTestCase {
-// CHECK: [[@LINE-1]]:7 | class(test)/Swift | MyTestCase |
+// CHECK: [[@LINE-1]]:7 | class(test,internal)/Swift | MyTestCase |
   func callit() {}
   func testMe() {
-  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,Dyn,RelChild
+  // CHECK: [[@LINE-1]]:8 | instance-method(test,internal)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,Dyn,RelChild
     callit()
     // CHECK: [[@LINE-1]]:5 | instance-method/Swift | callit() | s:14swift_ide_test10MyTestCaseC6callityyF | Ref,Call,Dyn,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR]]
   }
   func testResult() -> Int? { return nil }
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | testResult() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | testResult() |
   func test(withInt: Int) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test(withInt:) |
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | test(withInt:) |
 }
 class SubTestCase : MyTestCase {
-// CHECK: [[@LINE-1]]:7 | class(test)/Swift | SubTestCase | [[SubTestCase_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(test,internal)/Swift | SubTestCase | [[SubTestCase_USR:.*]] | Def | rel: 0
   func testIt2() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testIt2() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(test,internal)/Swift | testIt2() |
 }
 extension SubTestCase {
 // CHECK: [[@LINE-1]]:11 | extension/ext-class(test)/Swift | SubTestCase | [[SubTestCaseExt_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | class(test)/Swift | SubTestCase | [[SubTestCase_USR]] | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | extension/ext-class(test)/Swift | SubTestCase | [[SubTestCaseExt_USR]]
   func testIt3() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testIt3() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(test,internal)/Swift | testIt3() |
 }
 class NonTestCase {
   func testMeNot() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | testMeNot() |
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | testMeNot() |
 }
 
-// CHECK: [[@LINE+1]]:7 | class/Swift | C1 | [[C1_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE+1]]:7 | class(internal)/Swift | C1 | [[C1_USR:.*]] | Def | rel: 0
 class C1 {}
-// CHECK: [[@LINE+1]]:11 | type-alias/Swift | C1Alias | [[C1Alias_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE+1]]:11 | type-alias(internal)/Swift | C1Alias | [[C1Alias_USR:.*]] | Def | rel: 0
 typealias C1Alias = C1
-// CHECK: [[@LINE+4]]:7 | class/Swift | SubC1 | [[SubC1_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE+4]]:7 | class(internal)/Swift | SubC1 | [[SubC1_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE+3]]:15 | type-alias/Swift | C1Alias | [[C1Alias_USR]] | Ref | rel: 0
 // CHECK: [[@LINE+2]]:15 | class/Swift | C1 | [[C1_USR]] | Ref,Impl,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | SubC1 | [[SubC1_USR]]
 class SubC1 : C1Alias {}
 
 struct ImplCtors {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | ImplCtors | [[ImplCtors_USR:.*]] | Def | rel: 0
-  // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(x:) | [[ImplCtors_init_with_param_USR:.*]] | Def,Impl,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | ImplCtors | [[ImplCtors_USR:.*]] | Def | rel: 0
+  // CHECK: [[@LINE-2]]:8 | constructor(internal)/Swift | init(x:) | [[ImplCtors_init_with_param_USR:.*]] | Def,Impl,RelChild | rel: 1
   // CHECK-NEXT: RelChild | struct/Swift | ImplCtors | [[ImplCtors_USR]]
-  // CHECK: [[@LINE-4]]:8 | constructor/Swift | init() | [[ImplCtors_init_USR:.*]] | Def,Impl,RelChild | rel: 1
+  // CHECK: [[@LINE-4]]:8 | constructor(internal)/Swift | init() | [[ImplCtors_init_USR:.*]] | Def,Impl,RelChild | rel: 1
   // CHECK-NEXT: RelChild | struct/Swift | ImplCtors | [[ImplCtors_USR]]
   var x = 0
 }
@@ -250,10 +250,10 @@ _ = ImplCtors()
 _ = ImplCtors(x:0)
 // CHECK: [[@LINE-1]]:5 | constructor/Swift | init(x:) | [[ImplCtors_init_with_param_USR]] | Ref,Call | rel: 0
 
-var globalCompProp: Int // CHECK: [[@LINE]]:5 | variable/Swift | [[globalCompProp:.*]] | Def
+var globalCompProp: Int // CHECK: [[@LINE]]:5 | variable(internal)/Swift | [[globalCompProp:.*]] | Def
 { // CHECK: [[@LINE]]:1 | function/acc-get/Swift | getter:globalCompProp |
   // CHECK-NEXT: RelChild,RelAcc | variable/Swift | [[globalCompProp]]
   // Check that the accessor def is not showing up twice.
-  // CHECK-NOT: [[@LINE-3]]:1 | function/acc-get/Swift
+  // CHECK-NOT: [[@LINE-3]]:1 | function/acc-get{{.*}}/Swift
   return 0
 }

--- a/test/Index/kinds_objc.swift
+++ b/test/Index/kinds_objc.swift
@@ -4,19 +4,19 @@
 import Foundation
 
 @objc class TargetForIBAction {}
-// CHECK: [[@LINE-1]]:13 | class/Swift | TargetForIBAction | [[TargetForIBAction_USR:.*]] | Def |
+// CHECK: [[@LINE-1]]:13 | class(internal)/Swift | TargetForIBAction | [[TargetForIBAction_USR:.*]] | Def |
 @objc class TargetForIBSegueAction {}
-// CHECK: [[@LINE-1]]:13 | class/Swift | TargetForIBSegueAction | [[TargetForIBSegueAction_USR:.*]] | Def |
+// CHECK: [[@LINE-1]]:13 | class(internal)/Swift | TargetForIBSegueAction | [[TargetForIBSegueAction_USR:.*]] | Def |
 class AttrAnnots {
   @IBOutlet var iboutletString: AnyObject?
-  // CHECK: [[@LINE-1]]:17 | instance-property(IB)/Swift | iboutletString |
+  // CHECK: [[@LINE-1]]:17 | instance-property(IB,internal)/Swift | iboutletString |
   @IBAction func someibaction(o: TargetForIBAction) {}
-  // CHECK: [[@LINE-1]]:18 | instance-method(IB)/Swift | someibaction(o:) | {{.*}} | Def,Dyn,RelChild,RelIBType | rel: 2
+  // CHECK: [[@LINE-1]]:18 | instance-method(IB,internal)/Swift | someibaction(o:) | {{.*}} | Def,Dyn,RelChild,RelIBType | rel: 2
   // CHECK-NEXT: RelIBType | class/Swift | TargetForIBAction | [[TargetForIBAction_USR]]
   @IBSegueAction func someibsegue(coder: Any, o: TargetForIBSegueAction) -> Any {}
-  // CHECK: [[@LINE-1]]:23 | instance-method(IB)/Swift | someibsegue(coder:o:) | {{.*}} | Def,Dyn,RelChild,RelIBType | rel: 2
+  // CHECK: [[@LINE-1]]:23 | instance-method(IB,internal)/Swift | someibsegue(coder:o:) | {{.*}} | Def,Dyn,RelChild,RelIBType | rel: 2
   // CHECK-NEXT: RelIBType | class/Swift | TargetForIBSegueAction | [[TargetForIBSegueAction_USR]]
   @GKInspectable var gkString = "gk"
-  // CHECK: [[@LINE-1]]:22 | instance-property(GKI)/Swift | gkString |
+  // CHECK: [[@LINE-1]]:22 | instance-property(GKI,internal)/Swift | gkString |
 }
 

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -2,13 +2,13 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -include-locals  -source-filename %s | %FileCheck -check-prefix=LOCAL %s
 
 func foo(a: Int, b: Int, c: Int) {
-  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-get/Swift | getter:a
-  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-set/Swift | setter:a
+  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-get{{.*}}/Swift | getter:a
+  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-set{{.*}}/Swift | setter:a
 
     let x = a + b
     // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
     // CHECK-NOT: [[@LINE-2]]:9 | variable(local)/Swift | x | {{.*}} | Def,RelChild | rel: 1
-    // LOCAL-NOT: [[@LINE-3]]:13 | function/acc-get/Swift | getter:a
+    // LOCAL-NOT: [[@LINE-3]]:13 | function/acc-get{{.*}}/Swift | getter:a
 
     let y = x + c
     // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1

--- a/test/Index/multifile.swift
+++ b/test/Index/multifile.swift
@@ -10,7 +10,7 @@
 
 //--- file1.swift
 
-typealias Bar = [Int] // CHECK: 2:11 | type-alias/Swift | Bar | [[Bar_USR:.*]] | Def | rel: 0
+typealias Bar = [Int] // CHECK: 2:11 | type-alias(internal)/Swift | Bar | [[Bar_USR:.*]] | Def | rel: 0
 
 //--- file2.swift
 

--- a/test/Index/objc_conformances.swift
+++ b/test/Index/objc_conformances.swift
@@ -11,7 +11,7 @@ import Foundation
 
 class C : P {
   @objc func g() {}
-  // CHECK: [[@LINE-1]]:14 | instance-method/Swift | g() | s:14swift_ide_test1CC1gyyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:14 | instance-method(internal)/Swift | g() | s:14swift_ide_test1CC1gyyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK: RelOver | instance-method/Swift | g() | c:@M@swift_ide_test@objc(pl)P(im)g
   // CHECK: RelChild | class/Swift | C | s:14swift_ide_test1CC
 }

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -2,17 +2,17 @@
 
 @propertyWrapper
 public struct Wrapper<T> {
-  // CHECK: [[@LINE-1]]:15 | struct/Swift | Wrapper | [[Wrapper_USR:.*]] | Def | rel: 0
+  // CHECK: [[@LINE-1]]:15 | struct(public)/Swift | Wrapper | [[Wrapper_USR:.*]] | Def | rel: 0
   public var wrappedValue: T
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | wrappedValue | [[wrappedValue_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | instance-property(public)/Swift | wrappedValue | [[wrappedValue_USR:.*]] | Def,RelChild | rel: 1
 
   public init(initialValue: T) {
-  // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:10 | constructor(public)/Swift | init(initialValue:) | [[WrapperInit_USR:.*]] | Def,RelChild | rel: 1
     self.wrappedValue = initialValue
   }
 
   public init(body: () -> T) {
-  // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:10 | constructor(public)/Swift | init(body:) | [[WrapperBodyInit_USR:.*]] | Def,RelChild | rel: 1
     self.wrappedValue = body()
   }
 
@@ -26,15 +26,15 @@ public struct Projection<T> {
 }
 
 var globalInt: Int { return 17 }
-// CHECK: [[@LINE-1]]:5 | variable/Swift | globalInt | [[globalInt_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | globalInt | [[globalInt_USR:.*]] | Def | rel: 0
 
 public struct HasWrappers {
   @Wrapper
   // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
   public var x: Int = globalInt
-  // CHECK-NOT: [[@LINE-1]]:23 | variable/Swift | globalInt
+  // CHECK-NOT: [[@LINE-1]]:23 | variable{{.*}}/Swift | globalInt
   // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl,RelCont | rel: 1
-  // CHECK: [[@LINE-3]]:14 | instance-property/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-3]]:14 | instance-property(public)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-4]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
 
   @Wrapper(body: { globalInt })
@@ -42,8 +42,8 @@ public struct HasWrappers {
   // CHECK: [[@LINE-2]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
   // CHECK: [[@LINE-3]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call,RelCont | rel: 1
   public var y: Int
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt
+  // CHECK: [[@LINE-1]]:14 | instance-property(public)/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK-NOT: [[@LINE-6]]:20 | variable{{.*}}/Swift | globalInt
 
   @Wrapper(body: {
   // CHECK:      [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
@@ -64,11 +64,11 @@ public struct HasWrappers {
   })
   // CHECK: [[@LINE-17]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call,RelCont | rel: 1
   public var z: Int
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | instance-property(public)/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
 
   @Wrapper
   public var `escaped identifier`: Int = globalInt
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | escaped identifier | [[escaped_identifier_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | instance-property(public)/Swift | escaped identifier | [[escaped_identifier_USR:.*]] | Def,RelChild | rel: 1
 
   func backingUse() {
     _ = _y.wrappedValue + _z.wrappedValue + x + _x.wrappedValue + $y.item

--- a/test/Index/result_builders.swift
+++ b/test/Index/result_builders.swift
@@ -36,7 +36,7 @@ enum Color {
 }
 
 func acceptColorTagged<Result>(@TaggedBuilder<Color> body: () -> Result) {
-// CHECK: [[@LINE-1]]:6 | function/Swift | acceptColorTagged(body:) | s:14swift_ide_test17acceptColorTagged4bodyyxyXE_tlF | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | acceptColorTagged(body:) | s:14swift_ide_test17acceptColorTagged4bodyyxyXE_tlF | Def | rel: 0
 // CHECK: [[@LINE-2]]:33 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref,RelCont | rel: 1
 // CHECK: [[@LINE-3]]:47 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref,RelCont | rel: 1
   print(body())
@@ -47,5 +47,5 @@ struct Context {
     // CHECK: [[@LINE-1]]:6 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref,RelCont | rel: 1
     // CHECK: [[@LINE-2]]:20 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref,RelCont | rel: 1
     func foo() -> () {}
-    // CHECK: [[@LINE-1]]:10 | instance-method/Swift | foo() | s:14swift_ide_test7ContextV3fooyyF | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:10 | instance-method(internal)/Swift | foo() | s:14swift_ide_test7ContextV3fooyyF | Def,RelChild | rel: 1
 }

--- a/test/Index/roles-contained.swift
+++ b/test/Index/roles-contained.swift
@@ -224,7 +224,7 @@ let (tupleNestedFuncSiblingElementA, (tupleNestedFuncSiblingElementB, tupleNeste
 // CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementC | {{.*}}
 
 func containingFunc(param: Int) {
-    // CHECK: [[@LINE-1]]:6 | function/Swift | containingFunc(param:) | {{.*}} | Def | rel: 0
+    // CHECK: [[@LINE-1]]:6 | function(internal)/Swift | containingFunc(param:) | {{.*}} | Def | rel: 0
     // CHECK: [[@LINE-2]]:21 | param/Swift | param | {{.*}} | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | function/Swift | containingFunc(param:) | {{.*}}
 
@@ -332,7 +332,7 @@ struct SomeStruct {
     // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
     // CHECK: [[@LINE-4]]:6 | constructor/Swift | init(wrappedValue:) | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
     // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
-    // CHECK: [[@LINE-5]]:9 | instance-property/Swift | wrappedProperty | {{.*}} | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-5]]:9 | instance-property(internal)/Swift | wrappedProperty | {{.*}} | Def,RelChild | rel: 1
     // CHECK: [[@LINE-6]]:26 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
     // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
 
@@ -342,15 +342,15 @@ struct SomeStruct {
 }
 
 let voidProperty: () = ()
-// CHECK: [[@LINE-1]]:5 | variable/Swift | voidProperty | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | voidProperty | {{.*}} | Def | rel: 0
 
 let voidAliasedProperty: Void = ()
-// CHECK: [[@LINE-1]]:5 | variable/Swift | voidAliasedProperty | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | voidAliasedProperty | {{.*}} | Def | rel: 0
 // CHECK: [[@LINE-2]]:26 | type-alias/Swift | Void | {{.*}} | Ref,RelCont | rel: 1
 // CHECK-NEXT: RelCont | variable/Swift | voidAliasedProperty | {{.*}}
 
 var computedVoidProperty: () { () }
-// CHECK: [[@LINE-1]]:5 | variable/Swift | computedVoidProperty | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | computedVoidProperty | {{.*}} | Def | rel: 0
 
 func voidFunc() -> () { () }
-// CHECK: [[@LINE-1]]:6 | function/Swift | voidFunc() | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | voidFunc() | {{.*}} | Def | rel: 0

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -10,11 +10,11 @@ import var imported_swift_module.importedGlobal
 
 // Definition
 let x = 2
-// CHECK: [[@LINE-1]]:5 | variable/Swift | x | s:14swift_ide_test1xSivp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | x | s:14swift_ide_test1xSivp | Def | rel: 0
 
 // Definition + Read of x
 var y = x + 1
-// CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:14swift_ide_test1ySivp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | y | s:14swift_ide_test1ySivp | Def | rel: 0
 // CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read,RelCont | rel: 1
 // CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelCont | rel: 1
 // CHECK-NEXT: RelCont | variable/Swift | y | s:14swift_ide_test1ySivp
@@ -33,7 +33,7 @@ y += x
 // CHECK: [[@LINE-3]]:6 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
 
 var z: Int {
-// CHECK: [[@LINE-1]]:5 | variable/Swift | z | s:14swift_ide_test1zSivp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | z | s:14swift_ide_test1zSivp | Def | rel: 0
   get {
     // CHECK: [[@LINE-1]]:3 | function/acc-get/Swift | getter:z | s:14swift_ide_test1zSivg | Def,RelChild,RelAcc | rel: 1
 
@@ -58,7 +58,7 @@ z = z + 1
 
 // Call
 func aCalledFunction(a: Int, b: inout Int) {
-// CHECK: [[@LINE-1]]:6 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Def | rel: 0
 // CHECK: [[@LINE-2]]:22 | param/Swift | a | s:{{.*}} | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF
 // CHECK: [[@LINE-4]]:30 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
@@ -86,7 +86,7 @@ aCalledFunction(a: 1, b: &z)
 // CHECK: [[@LINE-2]]:27 | variable/Swift | z | s:14swift_ide_test1zSivp | Ref,Read,Writ | rel: 0
 
 func aCaller() {
-  // CHECK: [[@LINE-1]]:6 | function/Swift | aCaller() | s:14swift_ide_test7aCalleryyF | Def | rel: 0
+  // CHECK: [[@LINE-1]]:6 | function(internal)/Swift | aCaller() | s:14swift_ide_test7aCalleryyF | Def | rel: 0
 
   aCalledFunction(a: 1, b: &z)
   // CHECK: [[@LINE-1]]:3 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Ref,Call,RelCall,RelCont | rel: 1
@@ -98,17 +98,17 @@ let aRef = aCalledFunction
 
 // RelationChildOf, Implicit
 struct AStruct {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | AStruct | [[AStruct_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | AStruct | [[AStruct_USR:.*]] | Def | rel: 0
 
   let y: Int = 2
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | y | [[AStruct_y_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | y | [[AStruct_y_USR:.*]] | Def,RelChild | rel: 1
 
   var x: Int
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | x | [[AStruct_x_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | x | [[AStruct_x_USR:.*]] | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | struct/Swift | AStruct | [[AStruct_USR]]
 
   mutating func aMethod() {
-    // CHECK: [[@LINE-1]]:17 | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:17 | instance-method(internal)/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | struct/Swift | AStruct | [[AStruct_USR]]
 
     x += 1
@@ -124,7 +124,7 @@ struct AStruct {
 
   // RelationChildOf, RelationAccessorOf
   subscript(index: Int) -> Int {
-    // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructVyS2icip | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:3 | instance-property/subscript(internal)/Swift | subscript(_:) | s:14swift_ide_test7AStructVyS2icip | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | struct/Swift | AStruct | [[AStruct_USR]]
 
     get {
@@ -143,16 +143,16 @@ struct AStruct {
 }
 
 class AClass {
-// CHECK: [[@LINE-1]]:7 | class/Swift | AClass | [[AClass_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | AClass | [[AClass_USR:.*]] | Def | rel: 0
   var y: AStruct
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | y | [[AClass_y_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | y | [[AClass_y_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR:.*]] | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | y | [[AClass_y_USR]]
   // CHECK: [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:y | [[AClass_y_set_USR:.*]] | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | y | [[AClass_y_USR]]
   var z: [Int]
   var computed_p: Int { return 0 }
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | computed_p | [[AClass_computed_p_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | computed_p | [[AClass_computed_p_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-2]]:23 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | computed_p | [[AClass_computed_p_USR]]
   // CHECK-NOT: acc-set/Swift | setter:computed_p |
@@ -164,14 +164,14 @@ class AClass {
     self.z = [1, 2, 3]
   }
   subscript(index: Int) -> Int {
-  // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:3 | instance-property/subscript(internal)/Swift | subscript(_:) | [[AClass_subscript_USR:.*]] | Def,RelChild | rel: 1
     get { return z[0] }
     // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(_:) | [[AClass_subscript_get_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
     set { z[0] = newValue }
     // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(_:) | [[AClass_subscript_set_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
   }
   func foo() -> Int { return z[0] }
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | [[AClass_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo() | [[AClass_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 let _ = AClass.foo
@@ -191,7 +191,7 @@ let _ = AClass(x: 1)[1] = 2
 
 extension AClass {
   func test_property_refs1() -> AStruct {
-    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR:.*]] | Def,Dyn,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | test_property_refs1() | [[test_property_refs1_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = y
     // CHECK: [[@LINE-1]]:9 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
     // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR]]
@@ -210,7 +210,7 @@ extension AClass {
   }
 
   func test_property_refs2() -> Int {
-    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR:.*]] | Def,Dyn,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | test_property_refs2() | [[test_property_refs2_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = computed_p
     // CHECK: [[@LINE-1]]:9 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
     // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR]]
@@ -232,24 +232,24 @@ extension AClass {
 // RelationBaseOf, RelationOverrideOf
 
 protocol X {
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | X | [[X_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | X | [[X_USR:.*]] | Def | rel: 0
 
   var reqProp: Int { get }
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | reqProp | [[reqProp_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | reqProp | [[reqProp_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-2]]:22 | instance-method/acc-get/Swift | getter:reqProp | {{.*}} | Def,Dyn,RelChild,RelAcc | rel: 1
   // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | reqProp | [[reqProp_USR]]
 }
 
 protocol Y {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Y | [[Y_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Y | [[Y_USR:.*]] | Def | rel: 0
 
 class ImplementsX : X, Y {
-// CHECK: [[@LINE-1]]:7 | class/Swift | ImplementsX | [[ImplementsX_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | ImplementsX | [[ImplementsX_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | X | [[X_USR]] | Ref,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | ImplementsX | [[ImplementsX_USR]]
 
   var reqProp: Int { return 1 }
-  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | reqProp | [[reqPropImpl_USR:.*]] | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:7 | instance-property(internal)/Swift | reqProp | [[reqPropImpl_USR:.*]] | Def,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-property/Swift | reqProp | [[reqProp_USR]]
   // CHECK-NEXT: RelChild | class/Swift | ImplementsX | [[ImplementsX_USR]]
 }
@@ -260,17 +260,17 @@ func TestX(x: X) {
 }
 
 protocol AProtocol {
-  // CHECK: [[@LINE-1]]:10 | protocol/Swift | AProtocol | [[AProtocol_USR:.*]] | Def | rel: 0
+  // CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | AProtocol | [[AProtocol_USR:.*]] | Def | rel: 0
 
   associatedtype T : X where T:Y
-  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | [[AProtocol_T_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type(internal)/Swift | T | [[AProtocol_T_USR:.*]] | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | [[AProtocol_USR]]
   // CHECK: [[@LINE-3]]:22 | protocol/Swift | X | [[X_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-4]]:30 | type-alias/associated-type/Swift | T | [[AProtocol_T_USR]] | Ref | rel: 0
   // CHECK: [[@LINE-5]]:32 | protocol/Swift | Y | [[Y_USR]] | Ref | rel: 0
 
   func foo() -> Int
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 
@@ -282,7 +282,7 @@ protocol Q : QBase where Self.A: AProtocol {}
 // CHECK: [[@LINE-1]]:34 | protocol/Swift | AProtocol | [[AProtocol_USR]] | Ref | rel: 0
 
 class ASubClass : AClass, AProtocol {
-// CHECK: [[@LINE-1]]:7 | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Def | rel: 0
+// CHECK: [[@LINE-1]]:7 | class(internal)/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Def | rel: 0
 // CHECK: [[@LINE-2]]:19 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
 // CHECK: [[@LINE-4]]:27 | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Ref,RelBase | rel: 1
@@ -291,7 +291,7 @@ class ASubClass : AClass, AProtocol {
   typealias T = ImplementsX
 
   override func foo() -> Int {
-    // CHECK: [[@LINE-1]]:17 | instance-method/Swift | foo() | s:14swift_ide_test9ASubClassC3fooSiyF | Def,Dyn,RelChild,RelOver | rel: 3
+    // CHECK: [[@LINE-1]]:17 | instance-method(internal)/Swift | foo() | s:14swift_ide_test9ASubClassC3fooSiyF | Def,Dyn,RelChild,RelOver | rel: 3
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[AClass_foo_USR]]
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF
     // CHECK-NEXT: RelChild | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
@@ -306,14 +306,14 @@ extension AClass {
   // CHECK-NEXT: RelExt | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 
   func bar() -> Int { return 2 }
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar() | s:14swift_ide_test6AClassC3barSiyF | Def,Dyn,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | bar() | s:14swift_ide_test6AClassC3barSiyF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 }
 
 struct OuterS {
-// CHECK: [[@LINE-1]]:8 | struct/Swift | OuterS | [[OUTERS_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:8 | struct(internal)/Swift | OuterS | [[OUTERS_USR:.*]] | Def | rel: 0
   struct InnerS {}
-  // CHECK: [[@LINE-1]]:10 | struct/Swift | InnerS | [[INNERS_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:10 | struct(internal)/Swift | InnerS | [[INNERS_USR:.*]] | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | struct/Swift | OuterS | [[OUTERS_USR]]
 }
 extension OuterS.InnerS : AProtocol {
@@ -330,7 +330,7 @@ extension OuterS.InnerS : AProtocol {
 
 protocol ExtendMe {}
 protocol Whatever {}
-// CHECK: [[@LINE-1]]:10 | protocol/Swift | Whatever | [[Whatever_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-1]]:10 | protocol(internal)/Swift | Whatever | [[Whatever_USR:.*]] | Def | rel: 0
 extension ExtendMe where Self: Whatever {}
 // CHECK: [[@LINE-1]]:32 | protocol/Swift | Whatever | [[Whatever_USR]] | Ref | rel: 0
 
@@ -375,7 +375,7 @@ let _ = anInstance[0]
 // CHECK: [[@LINE-2]]:19 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Read,Dyn,RelRec | rel: 1
 
 let aSubInstance: AClass = ASubClass(x: 1)
-// CHECK: [[@LINE-1]]:5 | variable/Swift | aSubInstance | s:14swift_ide_test12aSubInstanceAA6AClassCvp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | aSubInstance | s:14swift_ide_test12aSubInstanceAA6AClassCvp | Def | rel: 0
 // CHECK: [[@LINE-2]]:28 | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Ref,RelCont | rel: 1
 
 // Dynamic, RelationReceivedBy
@@ -386,7 +386,7 @@ let _ = aSubInstance.foo()
 
 // RelationContainedBy
 let contained = 2
-// CHECK: [[@LINE-1]]:5 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Def | rel: 0
+// CHECK: [[@LINE-1]]:5 | variable(internal)/Swift | contained | s:14swift_ide_test9containedSivp | Def | rel: 0
 
 protocol ProtRoot {
   func fooCommon()
@@ -398,7 +398,7 @@ protocol ProtRoot {
 
 protocol ProtDerived : ProtRoot {
   func fooCommon()
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
 
   func bar1()
   func bar2()
@@ -408,34 +408,34 @@ protocol ProtDerived : ProtRoot {
 
 extension ProtDerived {
   func fooCommon() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF
 
   func foo1() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo1() | s:14swift_ide_test11ProtDerivedPAAE4foo1yyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo1() | s:14swift_ide_test11ProtDerivedPAAE4foo1yyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo1() | s:14swift_ide_test8ProtRootP4foo1yyF
 
   func bar1() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar1() | s:14swift_ide_test11ProtDerivedPAAE4bar1yyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | bar1() | s:14swift_ide_test11ProtDerivedPAAE4bar1yyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | bar1() | s:14swift_ide_test11ProtDerivedP4bar1yyF
 
   func foo3(a : Int) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo31aySi_tF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo31aySi_tF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo3(a:) | s:14swift_ide_test8ProtRootP4foo31aySi_tF
 
   func foo3(a : String) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo31aySS_tF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo31aySS_tF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo3(a:) | s:14swift_ide_test8ProtRootP4foo31aySS_tF
 
   func bar3(_ : Int) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedPAAE4bar3yySiF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedPAAE4bar3yySiF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedP4bar3yySiF
 }
 
 enum MyEnum {
   init() {}
   func enum_func() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | enum_func() | [[MyEnum_enum_func_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | enum_func() | [[MyEnum_enum_func_USR:.*]] | Def,RelChild | rel: 1
 }
 
 MyEnum().enum_func()
@@ -448,7 +448,7 @@ class ClassWithFinals {
   // CHECK: [[@LINE-1]]:13 | instance-method/acc-get/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
   // CHECK: [[@LINE-2]]:13 | instance-method/acc-set/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
   final func foo() {}
-  // CHECK: [[@LINE-1]]:14 | instance-method/Swift | {{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | instance-method(internal)/Swift | {{.*}} | Def,RelChild | rel: 1
 }
 final class FinalClass {
   var prop : Int { get { return 0} }
@@ -457,7 +457,7 @@ final class FinalClass {
   // CHECK: [[@LINE-1]]:7 | instance-method/acc-get/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
   // CHECK: [[@LINE-2]]:7 | instance-method/acc-set/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
   func foo() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | {{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | {{.*}} | Def,RelChild | rel: 1
 }
 
 struct StructWithKeypath {
@@ -486,7 +486,7 @@ func test<M>(_: M, value: Int?) {
 }
 
 func `escapedName`(`x`: Int) {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | escapedName(x:) | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function(internal)/Swift | escapedName(x:) | {{.*}} | Def | rel: 0
 `escapedName`(`x`: 2)
 // CHECK: [[@LINE-1]]:1 | function/Swift | escapedName(x:) | {{.*}} | Ref,Call | rel: 0
 `escapedName`(`x`:)
@@ -494,15 +494,15 @@ func `escapedName`(`x`: Int) {}
 
 protocol WithPrimary<Assoc> {
 // CHECK: [[@LINE-1]]:22 | type-alias/associated-type/Swift | Assoc | {{.*}} | Ref | rel: 0
-// CHECK: [[@LINE-2]]:10 | protocol/Swift | WithPrimary | {{.*}} | Def | rel: 0
+// CHECK: [[@LINE-2]]:10 | protocol(internal)/Swift | WithPrimary | {{.*}} | Def | rel: 0
   associatedtype Assoc
-// CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | Assoc | {{.*}} | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:18 | type-alias/associated-type(internal)/Swift | Assoc | {{.*}} | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | protocol/Swift | WithPrimary | {{.*}}
 }
 
-struct Root {} // CHECK: [[@LINE]]:8 | struct/Swift | Root | [[Root_USR:.*]] | Def | rel: 0
+struct Root {} // CHECK: [[@LINE]]:8 | struct(internal)/Swift | Root | [[Root_USR:.*]] | Def | rel: 0
 
-typealias Alias = Root // CHECK: [[@LINE]]:11 | type-alias/Swift | Alias | [[Alias_USR:.*]] | Def | rel: 0
+typealias Alias = Root // CHECK: [[@LINE]]:11 | type-alias(internal)/Swift | Alias | [[Alias_USR:.*]] | Def | rel: 0
 
 extension Alias {
   // CHECK: [[@LINE-1]]:11 | type-alias/Swift | Alias | [[Alias_USR]] | Ref | rel: 0
@@ -544,7 +544,7 @@ func containerFunc() {
 // pseudo accessor for 'x'.
 class BaseClass {
   var x = 0
-  // CHECK:      [[@LINE-1]]:7 | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp | Def,RelChild | rel: 1
+  // CHECK:      [[@LINE-1]]:7 | instance-property(internal)/Swift | x | s:14swift_ide_test9BaseClassC1xSivp | Def,RelChild | rel: 1
   // CHECK:      [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test9BaseClassC1xSivg | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
   // CHECK:      [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test9BaseClassC1xSivs | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
@@ -552,7 +552,7 @@ class BaseClass {
 }
 class Subclass: BaseClass {
   override var x: Int {
-    // CHECK:      [[@LINE-1]]:16 | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp | Def,RelChild,RelOver | rel: 2
+    // CHECK:      [[@LINE-1]]:16 | instance-property(internal)/Swift | x | s:14swift_ide_test8SubclassC1xSivp | Def,RelChild,RelOver | rel: 2
     // CHECK-NEXT:   RelOver | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
     get { 0 }
     // CHECK:      [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test8SubclassC1xSivg | Def,Dyn,RelChild,RelOver,RelAcc | rel: 2

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -135,52 +135,13 @@ private:
     if (!isRef && symbol.decl) {
       uidAttrs = getDeclAttributeUIDs(symbol.decl);
       info.Attrs = uidAttrs;
-      if (auto *VD = dyn_cast<ValueDecl>(symbol.decl)) {
-        if (shouldOutputEffectiveAccessOfValueSymbol(symbol.symInfo)) {
-          AccessScope accessScope = VD->getFormalAccessScope();
-          UIdent AttrUID = SwiftLangSupport::getUIDForFormalAccessScope(accessScope);
-          info.EffectiveAccess = AttrUID;
-        }
+      if (auto accessLevel = clang::index::getSwiftAccessLevelFromSymbolPropertySet(
+              symbol.symInfo.Properties)) {
+        info.EffectiveAccess =
+            SwiftLangSupport::getUIDForAccessLevel(*accessLevel);
       }
     }
     return func(info);
-  }
-
-  bool shouldOutputEffectiveAccessOfValueSymbol(SymbolInfo Info) {
-    SymbolKind Kind = Info.Kind;
-    SymbolSubKind SubKind = Info.SubKind;
-    switch (SubKind) {
-      case SymbolSubKind::AccessorGetter:
-      case SymbolSubKind::AccessorSetter:
-      case SymbolSubKind::SwiftAccessorWillSet:
-      case SymbolSubKind::SwiftAccessorDidSet:
-      case SymbolSubKind::SwiftAccessorAddressor:
-      case SymbolSubKind::SwiftAccessorMutableAddressor:
-      case SymbolSubKind::SwiftGenericTypeParam:
-        return false;
-      default:
-        break;
-    }
-    switch (Kind) {
-      case SymbolKind::Enum:
-      case SymbolKind::Struct:
-      case SymbolKind::Class:
-      case SymbolKind::Protocol:
-      case SymbolKind::Constructor:
-      case SymbolKind::EnumConstant:
-      case SymbolKind::Function:
-      case SymbolKind::StaticMethod:
-      case SymbolKind::Variable:
-      case SymbolKind::InstanceMethod:
-      case SymbolKind::ClassMethod:
-      case SymbolKind::InstanceProperty:
-      case SymbolKind::ClassProperty:
-      case SymbolKind::StaticProperty:
-      case SymbolKind::TypeAlias:
-        return true;
-     default:
-        return false;
-    }
   }
 
   template <typename F>

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -85,6 +85,8 @@ static UIdent Attr_Setter_Package("source.decl.attribute.setter_access.package")
 static UIdent Attr_Setter_Public("source.decl.attribute.setter_access.public");
 static UIdent Attr_Setter_Open("source.decl.attribute.setter_access.open");
 static UIdent EffectiveAccess_Public("source.decl.effective_access.public");
+static UIdent EffectiveAccess_SPI("source.decl.effective_access.spi");
+static UIdent EffectiveAccess_Package("source.decl.effective_access.package");
 static UIdent EffectiveAccess_Internal("source.decl.effective_access.internal");
 static UIdent EffectiveAccess_FilePrivate("source.decl.effective_access.fileprivate");
 static UIdent EffectiveAccess_LessThanFilePrivate("source.decl.effective_access.less_than_fileprivate");
@@ -864,17 +866,32 @@ SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttribute *Attr) {
   return std::nullopt;
 }
 
-UIdent SwiftLangSupport::getUIDForFormalAccessScope(const swift::AccessScope Scope) {
-  if (Scope.isPublic()) {
-    return EffectiveAccess_Public;
-  } else if (Scope.isInternal()) {
-    return EffectiveAccess_Internal;
-  } else if (Scope.isFileScope()) {
-    return EffectiveAccess_FilePrivate;
-  } else if (Scope.isPrivate()) {
+UIdent SwiftLangSupport::getUIDForAccessLevel(
+    const clang::index::SymbolProperty Scope) {
+  switch (Scope) {
+  case clang::index::SymbolProperty::Generic:
+  case clang::index::SymbolProperty::TemplatePartialSpecialization:
+  case clang::index::SymbolProperty::TemplateSpecialization:
+  case clang::index::SymbolProperty::UnitTest:
+  case clang::index::SymbolProperty::IBAnnotated:
+  case clang::index::SymbolProperty::IBOutletCollection:
+  case clang::index::SymbolProperty::GKInspectable:
+  case clang::index::SymbolProperty::Local:
+  case clang::index::SymbolProperty::ProtocolInterface:
+  case clang::index::SymbolProperty::SwiftAsync:
+    llvm_unreachable("Not an access level");
+  case clang::index::SymbolProperty::SwiftAccessControlLessThanFilePrivate:
     return EffectiveAccess_LessThanFilePrivate;
-  } else {
-    llvm_unreachable("Unsupported access scope");
+  case clang::index::SymbolProperty::SwiftAccessControlFilePrivate:
+    return EffectiveAccess_FilePrivate;
+  case clang::index::SymbolProperty::SwiftAccessControlInternal:
+    return EffectiveAccess_Internal;
+  case clang::index::SymbolProperty::SwiftAccessControlPackage:
+    return EffectiveAccess_Package;
+  case clang::index::SymbolProperty::SwiftAccessControlSPI:
+    return EffectiveAccess_SPI;
+  case clang::index::SymbolProperty::SwiftAccessControlPublic:
+    return EffectiveAccess_Public;
   }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -436,7 +436,8 @@ public:
   static std::optional<UIdent>
   getUIDForDeclAttribute(const swift::DeclAttribute *Attr);
 
-  static SourceKit::UIdent getUIDForFormalAccessScope(const swift::AccessScope Scope);
+  static SourceKit::UIdent
+  getUIDForAccessLevel(const clang::index::SymbolProperty Scope);
 
   static std::vector<UIdent> UIDsFromDeclAttributes(const swift::DeclAttributes &Attrs);
 


### PR DESCRIPTION
Depends on https://github.com/swiftlang/llvm-project/pull/11716

---

While updating the test cases, I noticed two slight oddities, for which I am happy with the current behavior, but I’m happy to be convinced by a different opinion.
- Function parameters are marked as `fileprivate`. I think we could make an argument that they should be marked as `local` instead of `fileprivate` even though they are indexed without index-locals enabled.
- Accessors such as `willSet` are marked as `fileprivate`. Since you can’t call them from anywhere else, I think this makes as much sense as anything. At least it matches the compiler’s effective access level.

rdar://163256878