### PR TITLE
[Test][C++ Interop] XFAIL some tests.

### DIFF
--- a/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
+++ b/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
@@ -6,6 +6,9 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 //--- Inputs/swiftify-non-public.h
 #pragma once
 

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -3,6 +3,9 @@
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 //--- Inputs/module.modulemap
 module Test {
     header "noncopyable.h"

--- a/test/Interop/Cxx/class/safe-interop-mode-darwin.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode-darwin.swift
@@ -6,6 +6,9 @@
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: OS=macosx
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 //--- Inputs/module.modulemap
 module Test {
     header "nonescapable.h"

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -7,6 +7,9 @@
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 //--- Inputs/module.modulemap
 module Test {
     header "nonescapable.h"

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -4,6 +4,9 @@
 //
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import MemberInline
 import StdlibUnittest
 

--- a/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
@@ -9,6 +9,9 @@
 
 // RUN: ls -R %/t | %FileCheck %s
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -9,6 +9,9 @@
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 #if !BRIDGING_HEADER
 import StdSpan
 #endif

--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -9,6 +9,9 @@
 // REQUIRES: executable_test
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 #if !BRIDGING_HEADER
 import StdSpan
 #endif

--- a/test/Interop/Cxx/stdlib/use-std-any.swift
+++ b/test/Interop/Cxx/stdlib/use-std-any.swift
@@ -8,6 +8,9 @@
 // type, which Swift isn't able to instantiate. 
 // UNSUPPORTED: OS=windows-msvc
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import StdAny
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-chrono.swift
+++ b/test/Interop/Cxx/stdlib/use-std-chrono.swift
@@ -8,6 +8,9 @@
 
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import CxxStdlib
 

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import StdFunction
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -11,6 +11,9 @@
 // rdar://121551667
 // XFAIL: OS=freebsd
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import StdOptional
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import StdPair
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -18,6 +18,9 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 // UNSUPPORTED: LinuxDistribution=fedora-41
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 #if !BRIDGING_HEADER
 import StdSet

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,6 +1,9 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdSpan
 
 let arr: [Int32] = [1, 2, 3]

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -10,6 +10,9 @@
 // REQUIRES: executable_test
 // REQUIRES: std_span
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 #if !BRIDGING_HEADER
 import StdSpan

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import CxxStdlib
 import StdStringView

--- a/test/Interop/Cxx/stdlib/use-std-string-with-opts.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-with-opts.swift
@@ -4,6 +4,9 @@
 
 // Tests optimizations related to CxxStdlib.
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import CxxStdlib
 import StdStringAndVector

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -8,6 +8,9 @@
 //
 // REQUIRES: executable_test
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 import StdlibUnittest
 import CxxStdlib
 #if USE_CUSTOM_STRING_API

--- a/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
@@ -7,6 +7,9 @@
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20 -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -cxx-interoperability-mode=default -Xcc -std=c++20 -dump-macro-expansions 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --implicit-check-not __swiftmacro
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
+
 //--- test.swift
 import Instance
 

--- a/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
+++ b/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
@@ -10,6 +10,8 @@
 // CHECK:    unsafe self.init(IntSpan(sp))
 // CHECK: }
 
+// rdar://163511959 error: circular reference
+// XFAIL: *
 
 //--- Inputs/module.modulemap
 module Method {


### PR DESCRIPTION
For some reason we're seeing
```
<unknown>:0: error: circular reference
```
from a number of C++ interop tests.

This triggers everywhere, so XFAIL it while the problem is looked at.

rdar://163511959
