### PR TITLE
build.ps1: set SDKROOT when testing

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2282,6 +2282,7 @@ function Build-Compilers([Hashtable] $Platform, [string] $Variant) {
 function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $TestClang, [switch] $TestLLD, [switch] $TestLLDB, [switch] $TestLLVM, [switch] $TestSwift) {
   Invoke-IsolatingEnvVars {
     $env:Path = "$(Get-CMarkBinaryCache $Platform)\src;$(Get-ProjectBinaryCache $BuildPlatform Compilers)\tools\swift\libdispatch-windows-$($Platform.Architecture.LLVMName)-prefix\bin;$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostPlatform.Architecture.VSName);$UnixToolsBinDir"
+    $env:SDKROOT = (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)
     $TestingDefines = Get-CompilersDefines $Platform $Variant -Test
     if ($TestLLVM) { $Targets += @("check-llvm") }
     if ($TestClang) { $Targets += @("check-clang") }


### PR DESCRIPTION
While adding a new LLDB test, I realized *every* LLDB test that runs Swift is disabled or xfailed. In the case of my test and at least one other one (see https://github.com/swiftlang/llvm-project/issues/9620), this is due to `SDKROOT` being unset. This manifests as a "unable to load standard library for target" error.

When paired with a forthcoming change (either https://github.com/swiftlang/llvm-project/pull/11717 or https://github.com/swiftlang/swift/pull/85202), I'm hopeful that we can re-enable many of the disabled tests.