### PR TITLE
Sema: Allow more references to restricted decls from embedded code

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -98,11 +98,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   }
 
   // Embedded functions can reference non-public decls as they are visible
-  // to clients. Still report references to decls imported non-publicly
-  // to enforce access-level on imports.
-  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
-  if (fragileKind.kind == FragileFunctionKind::EmbeddedAlwaysEmitIntoClient &&
-      !problematicImport)
+  // to clients.
+  if (fragileKind.kind == FragileFunctionKind::EmbeddedAlwaysEmitIntoClient)
     return false;
 
   DowngradeToWarning downgradeToWarning = DowngradeToWarning::No;
@@ -135,6 +132,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
 
+  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
       problematicImport->accessLevel < D->getFormalAccess()) {
     Context.Diags.diagnose(problematicImport->importLoc,

--- a/test/Sema/Inputs/implementation-only-imports/indirects.swift
+++ b/test/Sema/Inputs/implementation-only-imports/indirects.swift
@@ -6,3 +6,5 @@ public typealias GenericAliasFromIndirect<T> = (StructFromIndirect, T)
 
 public func globalFunctionFromIndirect() {}
 public var globalVariableFromIndirect = 0
+
+@_spi(S) public func spiFunctionFromDirect() {}

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -11,7 +11,7 @@
 // RUN:   -enable-experimental-feature Embedded
 
 // RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated %s -I %t \
-// RUN:   -swift-version 5 -target arm64-apple-none-macho \
+// RUN:   -swift-version 6 -target arm64-apple-none-macho \
 // RUN:   -define-availability "availMacro:macOS 26.0, iOS 26.0" \
 // RUN:   -enable-experimental-feature Embedded
 
@@ -20,9 +20,11 @@
 
 @_implementationOnly import directs
 // expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
-import indirects
+@_spi(S) @_spiOnly import indirects
 
 internal func localInternalFunc() {} // expected-note {{global function 'localInternalFunc()' is not '@usableFromInline' or public}}
+
+@_spi(S) public func localSPI() {}
 
 @inlinable
 public func explicitlyInlinable(arg: StructFromDirect = StructFromDirect()) {
@@ -77,6 +79,9 @@ public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()
   explicitNonInliable()
 
   if #available(availMacro, *) { }
+
+  localSPI()
+  spiFunctionFromDirect()
 }
 
 private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {
@@ -186,6 +191,7 @@ struct Accessors {
   }
 }
 
+@_spi(S)
 public func legalAccessToIndirect(arg: StructFromIndirect = StructFromIndirect()) {
   _ = StructFromIndirect()
 


### PR DESCRIPTION
The check on functions that are implicitly always-emit-into-client from the embedded mode was too strict. Loosen some restriction so functions don't need to be marked `@_neverEmitIntoClient` to reference SPI or decls from an internally imported module.

Follow up to #84630.

rdar://163519075
rdar://163519185