### PR TITLE
Sema: Don't coerce subexpression of 'try' to rvalue

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3752,7 +3752,11 @@ namespace {
       return expr;
     }
 
-    Expr *visitAnyTryExpr(AnyTryExpr *expr) {
+    Expr *visitTryExpr(TryExpr *expr) {
+      return simplifyExprType(expr);
+    }
+
+    Expr *visitForceTryExpr(ForceTryExpr *expr) {
       auto *subExpr = expr->getSubExpr();
       auto type = simplifyType(cs.getType(subExpr));
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2060,8 +2060,18 @@ namespace {
       return valueTy;
     }
 
-    Type visitAnyTryExpr(AnyTryExpr *expr) {
+    Type visitTryExpr(AnyTryExpr *expr) {
       return CS.getType(expr->getSubExpr());
+    }
+
+    Type visitForceTryExpr(AnyTryExpr *expr) {
+      auto valueTy = CS.createTypeVariable(CS.getConstraintLocator(expr),
+                                           TVO_PrefersSubtypeBinding |
+                                               TVO_CanBindToNoEscape);
+      CS.addConstraint(ConstraintKind::Equal, valueTy,
+                       CS.getType(expr->getSubExpr()),
+                       CS.getConstraintLocator(expr));
+      return valueTy;
     }
 
     Type visitOptionalTryExpr(OptionalTryExpr *expr) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1192,10 +1192,7 @@ TypeChecker::coerceToRValue(ASTContext &Context, Expr *expr,
                             llvm::function_ref<Type(Expr *)> getType,
                             llvm::function_ref<void(Expr *, Type)> setType) {
   Type exprTy = getType(expr);
-
-  // If expr has no type, just assume it's the right expr.
-  if (!exprTy)
-    return expr;
+  ASSERT(exprTy);
 
   // If the type is already materializable, then we're already done.
   if (!exprTy->hasLValueType())

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1702,10 +1702,11 @@ public:
     // Type-check the subject expression.
     Expr *subjectExpr = switchStmt->getSubjectExpr();
     auto resultTy = TypeChecker::typeCheckExpression(subjectExpr, DC);
+
     auto limitExhaustivityChecks = !resultTy;
-    if (Expr *newSubjectExpr =
-            TypeChecker::coerceToRValue(getASTContext(), subjectExpr))
-      subjectExpr = newSubjectExpr;
+    if (resultTy)
+      subjectExpr = TypeChecker::coerceToRValue(getASTContext(), subjectExpr);
+
     switchStmt->setSubjectExpr(subjectExpr);
     Type subjectType = switchStmt->getSubjectExpr()->getType();
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -typecheck
+// RUN: %target-swift-emit-silgen %s
 
 struct Info {
 }

--- a/validation-test/compiler_crashers_fixed/issue-85034.swift
+++ b/validation-test/compiler_crashers_fixed/issue-85034.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-emit-silgen %s
 
 class C {
   var x = 0
@@ -7,4 +8,5 @@ class C {
 do {
   let x = C()
   let _ = (0, try x.x)  // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+  let _ = (0, try! x.x)  // expected-warning {{no calls to throwing functions occur within 'try' expression}}
 }

--- a/validation-test/compiler_crashers_fixed/issue-85034.swift
+++ b/validation-test/compiler_crashers_fixed/issue-85034.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+class C {
+  var x = 0
+}
+
+do {
+  let x = C()
+  let _ = (0, try x.x)  // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+}


### PR DESCRIPTION
Undo the change in 8ab8b2e3e9107f32ea13efd38e270ff3b45d324a, which was an incorrect fix for some other bug which has since been fixed properly.

If this becomes an rvalue even though the type of the surrounding expression is an lvalue, we can end up with infinite recursion in coerceToType(), as demonstrated by the test case.

Fixes https://github.com/swiftlang/swift/issues/85034.