### PR TITLE
[Compile Time Constant Extraction] Add the location of the extracted value

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -50,20 +50,23 @@ public:
   };
 
   ValueKind getKind() const { return Kind; }
+  SourceLoc getLoc() const { return Loc; }
 
 protected:
-  CompileTimeValue(ValueKind ValueKind) : Kind(ValueKind) {}
+  CompileTimeValue(ValueKind ValueKind, SourceLoc L = {})
+      : Kind(ValueKind), Loc(L) {}
 
 private:
   ValueKind Kind;
+  SourceLoc Loc;
 };
 
 /// A string representation of a raw literal value,
 /// for example an integer or string or float literal.
 class RawLiteralValue : public CompileTimeValue {
 public:
-  RawLiteralValue(std::string Value)
-  : CompileTimeValue(ValueKind::RawLiteral), Value(Value) {}
+  RawLiteralValue(std::string Value, SourceLoc Loc)
+      : CompileTimeValue(ValueKind::RawLiteral, Loc), Value(Value) {}
 
   std::string getValue() const { return Value; }
 
@@ -84,7 +87,8 @@ private:
 
 class NilLiteralValue : public CompileTimeValue {
 public:
-  NilLiteralValue() : CompileTimeValue(ValueKind::NilLiteral) {}
+  NilLiteralValue(SourceLoc Loc)
+      : CompileTimeValue(ValueKind::NilLiteral, Loc) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::NilLiteral;
@@ -101,8 +105,9 @@ struct FunctionParameter {
 /// with a collection of (potentially compile-time-known) parameters
 class InitCallValue : public CompileTimeValue {
 public:
-  InitCallValue(swift::Type Type, std::vector<FunctionParameter> Parameters)
-      : CompileTimeValue(ValueKind::InitCall), Type(Type),
+  InitCallValue(swift::Type Type, std::vector<FunctionParameter> Parameters,
+                SourceLoc Loc)
+      : CompileTimeValue(ValueKind::InitCall, Loc), Type(Type),
         Parameters(Parameters) {}
 
   static bool classof(const CompileTimeValue *T) {
@@ -301,8 +306,8 @@ struct TupleElement {
 /// A representation of a tuple and each tuple-element
 class TupleValue : public CompileTimeValue {
 public:
-  TupleValue(std::vector<TupleElement> Elements)
-      : CompileTimeValue(ValueKind::Tuple), Elements(Elements) {}
+  TupleValue(std::vector<TupleElement> Elements, SourceLoc Loc)
+      : CompileTimeValue(ValueKind::Tuple, Loc), Elements(Elements) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Tuple;
@@ -317,8 +322,9 @@ private:
 /// An array literal value representation
 class ArrayValue : public CompileTimeValue {
 public:
-  ArrayValue(std::vector<std::shared_ptr<CompileTimeValue>> Elements)
-      : CompileTimeValue(ValueKind::Array), Elements(Elements) {}
+  ArrayValue(std::vector<std::shared_ptr<CompileTimeValue>> Elements,
+             SourceLoc Loc)
+      : CompileTimeValue(ValueKind::Array, Loc), Elements(Elements) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Array;
@@ -334,8 +340,9 @@ private:
 /// A dictionary literal value representation
 class DictionaryValue : public CompileTimeValue {
 public:
-  DictionaryValue(std::vector<std::shared_ptr<TupleValue>> elements)
-      : CompileTimeValue(ValueKind::Dictionary), Elements(elements) {}
+  DictionaryValue(std::vector<std::shared_ptr<TupleValue>> elements,
+                  SourceLoc Loc)
+      : CompileTimeValue(ValueKind::Dictionary, Loc), Elements(elements) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Dictionary;
@@ -353,8 +360,9 @@ private:
 class EnumValue : public CompileTimeValue {
 public:
   EnumValue(std::string Identifier,
-            std::optional<std::vector<FunctionParameter>> Parameters)
-      : CompileTimeValue(ValueKind::Enum), Identifier(Identifier),
+            std::optional<std::vector<FunctionParameter>> Parameters,
+            SourceLoc Loc)
+      : CompileTimeValue(ValueKind::Enum, Loc), Identifier(Identifier),
         Parameters(Parameters) {}
 
   std::string getIdentifier() const { return Identifier; }
@@ -374,7 +382,8 @@ private:
 /// A type value representation
 class TypeValue : public CompileTimeValue {
 public:
-  TypeValue(swift::Type Type) : CompileTimeValue(ValueKind::Type), Type(Type) {}
+  TypeValue(swift::Type Type, SourceLoc Loc)
+      : CompileTimeValue(ValueKind::Type, Loc), Type(Type) {}
 
   swift::Type getType() const { return Type; }
 
@@ -393,10 +402,10 @@ public:
     std::string Label;
     swift::Type Type;
   };
-  KeyPathValue(std::string Path,
-               swift::Type RootType,
-               std::vector<Component> Components)
-  : CompileTimeValue(ValueKind::KeyPath), Path(Path), RootType(RootType), Components(Components) {}
+  KeyPathValue(std::string Path, swift::Type RootType,
+               std::vector<Component> Components, SourceLoc Loc)
+      : CompileTimeValue(ValueKind::KeyPath, Loc), Path(Path),
+        RootType(RootType), Components(Components) {}
 
   std::string getPath() const { return Path; }
   swift::Type getRootType() const { return RootType; }
@@ -419,8 +428,9 @@ private:
 class FunctionCallValue : public CompileTimeValue {
 public:
   FunctionCallValue(std::string Identifier,
-                    std::optional<std::vector<FunctionParameter>> Parameters)
-      : CompileTimeValue(ValueKind::FunctionCall), Identifier(Identifier),
+                    std::optional<std::vector<FunctionParameter>> Parameters,
+                    SourceLoc Loc)
+      : CompileTimeValue(ValueKind::FunctionCall, Loc), Identifier(Identifier),
         Parameters(Parameters) {}
 
   std::string getIdentifier() const { return Identifier; }
@@ -443,8 +453,9 @@ private:
 class StaticFunctionCallValue : public CompileTimeValue {
 public:
   StaticFunctionCallValue(std::string Label, swift::Type Type,
-                          std::vector<FunctionParameter> Parameters)
-      : CompileTimeValue(ValueKind::StaticFunctionCall), Label(Label),
+                          std::vector<FunctionParameter> Parameters,
+                          SourceLoc Loc)
+      : CompileTimeValue(ValueKind::StaticFunctionCall, Loc), Label(Label),
         Type(Type), Parameters(Parameters) {}
 
   static bool classof(const CompileTimeValue *T) {
@@ -468,8 +479,9 @@ class MemberFunctionCallValue : public CompileTimeValue {
 public:
   MemberFunctionCallValue(std::string Label,
                           std::shared_ptr<CompileTimeValue> BaseValue,
-                          std::vector<FunctionParameter> Parameters)
-      : CompileTimeValue(ValueKind::MemberFunctionCall), Label(Label),
+                          std::vector<FunctionParameter> Parameters,
+                          SourceLoc Loc)
+      : CompileTimeValue(ValueKind::MemberFunctionCall, Loc), Label(Label),
         BaseValue(BaseValue), Parameters(Parameters) {}
 
   static bool classof(const CompileTimeValue *T) {
@@ -490,8 +502,9 @@ private:
 /// let foo = MyStruct.bar
 class MemberReferenceValue : public CompileTimeValue {
 public:
-  MemberReferenceValue(swift::Type BaseType, std::string MemberLabel)
-      : CompileTimeValue(ValueKind::MemberReference), BaseType(BaseType),
+  MemberReferenceValue(swift::Type BaseType, std::string MemberLabel,
+                       SourceLoc Loc)
+      : CompileTimeValue(ValueKind::MemberReference, Loc), BaseType(BaseType),
         MemberLabel(MemberLabel) {}
 
   std::string getMemberLabel() const { return MemberLabel; }
@@ -510,8 +523,9 @@ private:
 class InterpolatedStringLiteralValue : public CompileTimeValue {
 public:
   InterpolatedStringLiteralValue(
-      std::vector<std::shared_ptr<CompileTimeValue>> Segments)
-      : CompileTimeValue(ValueKind::InterpolatedString), Segments(Segments) {}
+      std::vector<std::shared_ptr<CompileTimeValue>> Segments, SourceLoc Loc)
+      : CompileTimeValue(ValueKind::InterpolatedString, Loc),
+        Segments(Segments) {}
 
   std::vector<std::shared_ptr<CompileTimeValue>> getSegments() const {
     return Segments;

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -241,14 +241,15 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
     case ExprKind::StringLiteral: {
       auto rawLiteral = extractRawLiteral(expr);
       if (rawLiteral.has_value()) {
-        return std::make_shared<RawLiteralValue>(rawLiteral.value());
+        return std::make_shared<RawLiteralValue>(rawLiteral.value(),
+                                                 expr->getStartLoc());
       }
 
       break;
     }
 
     case ExprKind::NilLiteral: {
-      return std::make_shared<NilLiteralValue>();
+      return std::make_shared<NilLiteralValue>(expr->getStartLoc());
     }
 
     case ExprKind::Array: {
@@ -258,7 +259,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         elementValues.push_back(
             extractCompileTimeValue(elementExpr, declContext));
       }
-      return std::make_shared<ArrayValue>(elementValues);
+      return std::make_shared<ArrayValue>(elementValues, expr->getStartLoc());
     }
 
     case ExprKind::Dictionary: {
@@ -270,7 +271,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
           tuples.push_back(std::static_pointer_cast<TupleValue>(elementValue));
         }
       }
-      return std::make_shared<DictionaryValue>(tuples);
+      return std::make_shared<DictionaryValue>(tuples, expr->getStartLoc());
     }
 
     case ExprKind::Tuple: {
@@ -299,7 +300,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
                extractCompileTimeValue(elementExpr, declContext)});
         }
       }
-      return std::make_shared<TupleValue>(elements);
+      return std::make_shared<TupleValue>(elements, expr->getStartLoc());
     }
 
     case ExprKind::Call: {
@@ -311,13 +312,15 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
         std::vector<FunctionParameter> parameters =
             extractFunctionArguments(callExpr->getArgs(), declContext);
-        return std::make_shared<FunctionCallValue>(identifier, parameters);
+        return std::make_shared<FunctionCallValue>(identifier, parameters,
+                                                   expr->getStartLoc());
       }
 
       if (isa<ConstructorRefCallExpr>(callExpr->getFn())) {
         std::vector<FunctionParameter> parameters =
             extractFunctionArguments(callExpr->getArgs(), declContext);
-        return std::make_shared<InitCallValue>(callExpr->getType(), parameters);
+        return std::make_shared<InitCallValue>(callExpr->getType(), parameters,
+                                               expr->getStartLoc());
       }
 
       if (auto dotSyntaxCallExpr = dyn_cast<DotSyntaxCallExpr>(callExpr->getFn())) {
@@ -332,21 +335,23 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
           auto declRef = dotSyntaxCallExpr->getFn()->getReferencedDecl();
           switch (declRef.getDecl()->getKind()) {
           case DeclKind::EnumElement: {
-            return std::make_shared<EnumValue>(baseIdentifierName, parameters);
+            return std::make_shared<EnumValue>(baseIdentifierName, parameters,
+                                               expr->getStartLoc());
           }
 
           case DeclKind::Func: {
             auto funcDecl = cast<FuncDecl>(declRef.getDecl());
             if (funcDecl->isStatic()) {
               return std::make_shared<StaticFunctionCallValue>(
-                  baseIdentifierName, callExpr->getType(), parameters);
+                  baseIdentifierName, callExpr->getType(), parameters,
+                  callExpr->getStartLoc());
             }
 
             return std::make_shared<MemberFunctionCallValue>(
                 baseIdentifierName,
                 extractCompileTimeValue(dotSyntaxCallExpr->getBase(),
                                         declContext),
-                parameters);
+                parameters, dotSyntaxCallExpr->getStartLoc());
           }
 
           default: {
@@ -363,7 +368,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
           std::vector<FunctionParameter> parameters =
               extractFunctionArguments(callExpr->getArgs(), declContext);
-          return std::make_shared<FunctionCallValue>(identifier, parameters);
+          return std::make_shared<FunctionCallValue>(identifier, parameters,
+                                                     expr->getStartLoc());
         }
       }
 
@@ -376,7 +382,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       if (auto declRefExpr = dyn_cast<DeclRefExpr>(fn)) {
         auto caseName =
             declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
-        return std::make_shared<EnumValue>(caseName, std::nullopt);
+        return std::make_shared<EnumValue>(caseName, std::nullopt,
+                                           expr->getStartLoc());
       }
 
       break;
@@ -407,7 +414,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       auto dotSelfExpr = cast<DotSelfExpr>(expr);
       auto dotSelfMetaType = dotSelfExpr->getType()->getAs<AnyMetatypeType>();
       if (dotSelfMetaType)
-        return std::make_shared<TypeValue>(dotSelfMetaType->getInstanceType());
+        return std::make_shared<TypeValue>(dotSelfMetaType->getInstanceType(),
+                                           expr->getStartLoc());
       else
         break;
     }
@@ -425,13 +433,14 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       assert(!decl->hasDefaultExpr());
       switch (decl->getDefaultArgumentKind()) {
       case DefaultArgumentKind::NilLiteral:
-        return std::make_shared<NilLiteralValue>();
+        return std::make_shared<NilLiteralValue>(expr->getStartLoc());
       case DefaultArgumentKind::EmptyArray:
         return std::make_shared<ArrayValue>(
-            std::vector<std::shared_ptr<CompileTimeValue>>());
+            std::vector<std::shared_ptr<CompileTimeValue>>(),
+            expr->getStartLoc());
       case DefaultArgumentKind::EmptyDictionary:
         return std::make_shared<DictionaryValue>(
-            std::vector<std::shared_ptr<TupleValue>>());
+            std::vector<std::shared_ptr<TupleValue>>(), expr->getStartLoc());
       default:
         break;
       }
@@ -461,7 +470,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
             path += components[i].Label;
         }
 
-        return std::make_shared<KeyPathValue>(path, rootType, components);
+        return std::make_shared<KeyPathValue>(path, rootType, components,
+                                              expr->getStartLoc());
     }
 
     case ExprKind::InjectIntoOptional: {
@@ -481,7 +491,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         auto baseTypeExpr = cast<TypeExpr>(memberExpr->getBase());
         auto label = memberExpr->getDecl().getDecl()->getBaseIdentifier().str();
         return std::make_shared<MemberReferenceValue>(
-            baseTypeExpr->getInstanceType(), label.str());
+            baseTypeExpr->getInstanceType(), label.str(), expr->getStartLoc());
       }
       break;
     }
@@ -499,7 +509,8 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
             segments.push_back(extractCompileTimeValue(expr, declContext));
           });
 
-      return std::make_shared<InterpolatedStringLiteralValue>(segments);
+      return std::make_shared<InterpolatedStringLiteralValue>(
+          segments, expr->getStartLoc());
     }
 
     case ExprKind::Closure: {
@@ -750,11 +761,17 @@ void writeLocationInformation(llvm::json::OStream &JSON, SourceLoc Loc,
 
 // Take BuilderValue, which is a representation of a result builder
 // and write the values
-void writeBuilderValue(llvm::json::OStream &JSON, BuilderValue *Value);
+void writeBuilderValue(llvm::json::OStream &JSON, BuilderValue *Value,
+                       const ASTContext &ctx);
 
 void writeValue(llvm::json::OStream &JSON,
-                std::shared_ptr<CompileTimeValue> Value) {
+                std::shared_ptr<CompileTimeValue> Value, const ASTContext &ctx,
+                SourceLoc FallbackLoc = {}) {
   auto value = Value.get();
+  auto valueLoc = value->getLoc();
+  if (valueLoc.isInvalid())
+    valueLoc = FallbackLoc;
+  writeLocationInformation(JSON, valueLoc, ctx);
   switch (value->getKind()) {
   case CompileTimeValue::ValueKind::RawLiteral: {
     JSON.attribute("valueKind", "RawLiteral");
@@ -779,7 +796,7 @@ void writeValue(llvm::json::OStream &JSON,
           JSON.object([&] {
             JSON.attribute("label", FP.Label);
             JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
-            writeValue(JSON, FP.Value);
+            writeValue(JSON, FP.Value, ctx);
           });
         }
       });
@@ -798,7 +815,7 @@ void writeValue(llvm::json::OStream &JSON,
             JSON.attribute("label", Label);
           }
           JSON.attribute("type", toFullyQualifiedTypeNameString(TV.Type));
-          writeValue(JSON, TV.Value);
+          writeValue(JSON, TV.Value, ctx);
         });
       }
     });
@@ -807,7 +824,7 @@ void writeValue(llvm::json::OStream &JSON,
 
   case CompileTimeValue::ValueKind::Builder: {
     auto builderValue = cast<BuilderValue>(value);
-    writeBuilderValue(JSON, builderValue);
+    writeBuilderValue(JSON, builderValue, ctx);
     break;
   }
 
@@ -818,9 +835,9 @@ void writeValue(llvm::json::OStream &JSON,
         auto tupleElements = tupleValue.get()->getElements();
         JSON.object([&] {
           JSON.attributeObject(
-              "key", [&] { writeValue(JSON, tupleElements[0].Value); });
+              "key", [&] { writeValue(JSON, tupleElements[0].Value, ctx); });
           JSON.attributeObject(
-              "value", [&] { writeValue(JSON, tupleElements[1].Value); });
+              "value", [&] { writeValue(JSON, tupleElements[1].Value, ctx); });
         });
       }
     });
@@ -833,7 +850,7 @@ void writeValue(llvm::json::OStream &JSON,
     JSON.attribute("valueKind", "Array");
     JSON.attributeArray("value", [&] {
       for (auto CTP : arrayValue->getElements()) {
-        JSON.object([&] { writeValue(JSON, CTP); });
+        JSON.object([&] { writeValue(JSON, CTP, ctx); });
       }
     });
     break;
@@ -851,7 +868,7 @@ void writeValue(llvm::json::OStream &JSON,
             JSON.object([&] {
               JSON.attribute("label", FP.Label);
               JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
-              writeValue(JSON, FP.Value);
+              writeValue(JSON, FP.Value, ctx);
             });
           }
         });
@@ -905,7 +922,7 @@ void writeValue(llvm::json::OStream &JSON,
             JSON.object([&] {
               JSON.attribute("label", FP.Label);
               JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
-              writeValue(JSON, FP.Value);
+              writeValue(JSON, FP.Value, ctx);
             });
           }
         });
@@ -927,7 +944,7 @@ void writeValue(llvm::json::OStream &JSON,
           JSON.object([&] {
             JSON.attribute("label", FP.Label);
             JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
-            writeValue(JSON, FP.Value);
+            writeValue(JSON, FP.Value, ctx);
           });
         }
       });
@@ -956,7 +973,7 @@ void writeValue(llvm::json::OStream &JSON,
     JSON.attribute("valueKind", "MemberFunctionCall");
     JSON.attributeObject("value", [&]() {
       // Write the root (non-MemberFunctionCall) base once
-      JSON.attributeObject("baseValue", [&] { writeValue(JSON, cursor); });
+      JSON.attributeObject("baseValue", [&] { writeValue(JSON, cursor, ctx); });
       // Flat list of call steps in order
       JSON.attributeArray("calls", [&] {
         for (auto &step : chain) {
@@ -968,7 +985,7 @@ void writeValue(llvm::json::OStream &JSON,
                   JSON.attribute("label", FP.Label);
                   JSON.attribute("type",
                                  toFullyQualifiedTypeNameString(FP.Type));
-                  writeValue(JSON, FP.Value);
+                  writeValue(JSON, FP.Value, ctx);
                 });
               }
             });
@@ -997,7 +1014,7 @@ void writeValue(llvm::json::OStream &JSON,
       JSON.attributeArray("segments", [&] {
         auto segments = interpolatedStringValue->getSegments();
         for (auto s : segments) {
-          JSON.object([&] { writeValue(JSON, s); });
+          JSON.object([&] { writeValue(JSON, s, ctx); });
         }
       });
     });
@@ -1012,7 +1029,7 @@ void writeValue(llvm::json::OStream &JSON,
 }
 
 void writeAttributeInfo(llvm::json::OStream &JSON,
-                        const CustomAttrValue &AttrVal,
+                        const CustomAttrValue &AttrVal, const Decl &decl,
                         const ASTContext &ctx) {
   JSON.object([&] {
     JSON.attribute("type",
@@ -1023,7 +1040,7 @@ void writeAttributeInfo(llvm::json::OStream &JSON,
         JSON.object([&] {
           JSON.attribute("label", FP.Label);
           JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
-          writeValue(JSON, FP.Value);
+          writeValue(JSON, FP.Value, ctx);
         });
       }
     });
@@ -1032,14 +1049,14 @@ void writeAttributeInfo(llvm::json::OStream &JSON,
 
 void writePropertyWrapperAttributes(
     llvm::json::OStream &JSON, std::optional<AttrValueVector> PropertyWrappers,
-    const ASTContext &ctx) {
+    const Decl &decl, const ASTContext &ctx) {
   if (!PropertyWrappers.has_value()) {
     return;
   }
 
   JSON.attributeArray("propertyWrappers", [&] {
     for (auto PW : PropertyWrappers.value())
-      writeAttributeInfo(JSON, PW, ctx);
+      writeAttributeInfo(JSON, PW, decl, ctx);
   });
 }
 
@@ -1210,20 +1227,21 @@ createBuilderCompileTimeValue(CustomAttr *AttachedResultBuilder,
                                         ResultBuilderMembers);
 }
 
-void writeSingleBuilderMemberElement(
-    llvm::json::OStream &JSON, std::shared_ptr<CompileTimeValue> Element) {
+void writeSingleBuilderMemberElement(llvm::json::OStream &JSON,
+                                     std::shared_ptr<CompileTimeValue> Element,
+                                     const ASTContext &ctx) {
   switch (Element.get()->getKind()) {
   case CompileTimeValue::ValueKind::StaticFunctionCall: {
     auto staticFunctionCallValue = cast<StaticFunctionCallValue>(Element.get());
     if (staticFunctionCallValue->getLabel() == "buildExpression") {
       for (auto FP : staticFunctionCallValue->getParameters()) {
-        writeValue(JSON, FP.Value);
+        writeValue(JSON, FP.Value, ctx);
       }
     }
     break;
   }
   default: {
-    writeValue(JSON, Element);
+    writeValue(JSON, Element, ctx);
     break;
   }
   }
@@ -1231,13 +1249,14 @@ void writeSingleBuilderMemberElement(
 
 void writeBuilderMember(
     llvm::json::OStream &JSON,
-    std::shared_ptr<BuilderValue::BuilderMember> BuilderMember) {
+    std::shared_ptr<BuilderValue::BuilderMember> BuilderMember,
+    const ASTContext &ctx) {
   auto Member = BuilderMember.get();
   switch (Member->getKind()) {
   case BuilderValue::Expression: {
     auto member = cast<BuilderValue::SingleMember>(Member);
     JSON.attributeObject("element", [&] {
-      writeSingleBuilderMemberElement(JSON, member->getElement());
+      writeSingleBuilderMemberElement(JSON, member->getElement(), ctx);
     });
 
     break;
@@ -1247,7 +1266,7 @@ void writeBuilderMember(
     auto member = cast<BuilderValue::ArrayMember>(Member);
     JSON.attributeArray("elements", [&] {
       for (auto elem : member->getElements()) {
-        JSON.object([&] { writeBuilderMember(JSON, elem); });
+        JSON.object([&] { writeBuilderMember(JSON, elem, ctx); });
       }
     });
     break;
@@ -1269,12 +1288,12 @@ void writeBuilderMember(
     }
     JSON.attributeArray("ifElements", [&] {
       for (auto elem : member->getIfElements()) {
-        JSON.object([&] { writeBuilderMember(JSON, elem); });
+        JSON.object([&] { writeBuilderMember(JSON, elem, ctx); });
       }
     });
     JSON.attributeArray("elseElements", [&] {
       for (auto elem : member->getElseElements()) {
-        JSON.object([&] { writeBuilderMember(JSON, elem); });
+        JSON.object([&] { writeBuilderMember(JSON, elem, ctx); });
       }
     });
     break;
@@ -1282,7 +1301,8 @@ void writeBuilderMember(
   }
 }
 
-void writeBuilderValue(llvm::json::OStream &JSON, BuilderValue *Value) {
+void writeBuilderValue(llvm::json::OStream &JSON, BuilderValue *Value,
+                       const ASTContext &ctx) {
   JSON.attribute("valueKind", "Builder");
   JSON.attributeObject("value", [&] {
     if (auto resultBuilderType = Value->getResultBuilderType()) {
@@ -1315,8 +1335,7 @@ void writeBuilderValue(llvm::json::OStream &JSON, BuilderValue *Value) {
             JSON.attribute("kind", "Unknown");
             break;
           }
-
-          writeBuilderMember(JSON, member);
+          writeBuilderMember(JSON, member, ctx);
         });
       }
     });
@@ -1470,9 +1489,6 @@ void writeProperties(llvm::json::OStream &JSON,
         JSON.attribute("mangledTypeName", "n/a - deprecated");
         JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
         JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
-        writeLocationInformation(JSON, decl->getLoc(),
-                                 decl->getDeclContext()->getASTContext());
-
         if (value.get()->getKind() == CompileTimeValue::ValueKind::Runtime) {
           // Extract result builder information only if the variable has not
           // used a different kind of initializer
@@ -1482,9 +1498,10 @@ void writeProperties(llvm::json::OStream &JSON,
           }
         }
 
-        writeValue(JSON, value);
+        writeValue(JSON, value, decl->getDeclContext()->getASTContext(),
+                   decl->getLoc());
         writePropertyWrapperAttributes(JSON, PropertyInfo.PropertyWrappers,
-                                       decl->getASTContext());
+                                       *decl, decl->getASTContext());
         writeAvailabilityAttributes(JSON, *decl);
       });
     }

--- a/test/ConstExtraction/ExtractArchetype.swift
+++ b/test/ConstExtraction/ExtractArchetype.swift
@@ -26,6 +26,8 @@ public struct ArchetypalConformance<T>: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "bar",
 // CHECK-NEXT:              "type": "Any",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractArchetype.swift",
+// CHECK-NEXT:              "line": 15,
 // CHECK-NEXT:              "valueKind": "Type",
 // CHECK-NEXT:              "value": {
 // CHECK-NEXT:                "type": "T",

--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -89,11 +89,15 @@ public class Hux: Bat {}
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
 // CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 37
 // CHECK-NEXT:              "valueKind": "NilLiteral"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "fuz",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 37
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "0"
 // CHECK-NEXT:            }
@@ -115,12 +119,16 @@ public class Hux: Bat {}
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
 // CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 12
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "hello"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "fuz",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 12
 // CHECK-NEXT:              "valueKind": "FunctionCall",
 // CHECK-NEXT:              "value": {
 // CHECK-NEXT:              "name": "adder",
@@ -128,12 +136,16 @@ public class Hux: Bat {}
 // CHECK-NEXT:                {
 // CHECK-NEXT:                   "label": "",
 // CHECK-NEXT:                   "type": "Swift.Int",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:                   "line": 12,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "2"
 // CHECK-NEXT:                 },
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "label": "",
 // CHECK-NEXT:                   "type": "Swift.Int",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:                   "line": 12,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "3"
 // CHECK-NEXT:                 }
@@ -158,11 +170,15 @@ public class Hux: Bat {}
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
 // CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 15
 // CHECK-NEXT:              "valueKind": "NilLiteral"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "fuz",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 37
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "0"
 // CHECK-NEXT:            }
@@ -184,11 +200,15 @@ public class Hux: Bat {}
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
 // CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 16
 // CHECK-NEXT:              "valueKind": "NilLiteral"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "fuz",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 16
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "42"
 // CHECK-NEXT:            }
@@ -210,12 +230,16 @@ public class Hux: Bat {}
 // CHECK-NEXT:            {
 // CHECK-NEXT:               "label": "",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 18
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": "2"
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "label": "",
 // CHECK-NEXT:               "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:              "line": 18
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": "3"
 // CHECK-NEXT:             }

--- a/test/ConstExtraction/ExtractEnums.swift
+++ b/test/ConstExtraction/ExtractEnums.swift
@@ -232,12 +232,16 @@ public struct Enums: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "title",
 // CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
+// CHECK-NEXT:              "line": 27,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "the_title"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "subtitle",
 // CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
+// CHECK-NEXT:              "line": 27,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "the_subtitle"
 // CHECK-NEXT:            }
@@ -272,6 +276,8 @@ public struct Enums: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
+// CHECK-NEXT:              "line": 28,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "42"
 // CHECK-NEXT:            }

--- a/test/ConstExtraction/ExtractFromExtension.swift
+++ b/test/ConstExtraction/ExtractFromExtension.swift
@@ -24,6 +24,8 @@ extension MyType {
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "",
 // CHECK-NEXT:            "type": "Swift.String",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractFromExtension.swift",
+// CHECK-NEXT:            "line": 8,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "it is doable"
 // CHECK-NEXT:          }

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -64,14 +64,20 @@ extension String: Foo {}
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 10,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "1"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 10,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "2"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 10,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "3"
 // CHECK-NEXT:          }
@@ -88,6 +94,8 @@ extension String: Foo {}
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 11,
 // CHECK-NEXT:            "valueKind": "InitCall",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractGroups.Bar",
@@ -95,10 +103,14 @@ extension String: Foo {}
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 11,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "1"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 11,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "hi"
 // CHECK-NEXT:          }
@@ -115,6 +127,8 @@ extension String: Foo {}
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 12,
 // CHECK-NEXT:            "valueKind": "InitCall",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractGroups.Bar",
@@ -154,30 +168,42 @@ extension String: Foo {}
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "One"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "1"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Two"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "2"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Three"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "3"
 // CHECK-NEXT:            }
@@ -196,21 +222,31 @@ extension String: Foo {}
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 18,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "1"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 18,
 // CHECK-NEXT:              "valueKind": "Array",
 // CHECK-NEXT:              "value": [
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:                  "line": 18,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "a"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:                  "line": 18,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "b"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:                  "line": 18,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "c"
 // CHECK-NEXT:                }
@@ -219,13 +255,19 @@ extension String: Foo {}
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 19,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "2"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 19,
 // CHECK-NEXT:              "valueKind": "Array",
 // CHECK-NEXT:              "value": [
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:                  "line": 19,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "z"
 // CHECK-NEXT:                }
@@ -246,10 +288,14 @@ extension String: Foo {}
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 22,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Bar"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 22,
 // CHECK-NEXT:              "valueKind": "InitCall",
 // CHECK-NEXT:              "value": {
 // CHECK-NEXT:                "type": "ExtractGroups.Bar",
@@ -259,10 +305,14 @@ extension String: Foo {}
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 23,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Int"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:              "line": 23,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "42"
 // CHECK-NEXT:            }
@@ -300,11 +350,15 @@ extension String: Foo {}
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "Swift.String",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 28,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "foo"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "ExtractGroups.Bar",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 28,
 // CHECK-NEXT:            "valueKind": "InitCall",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractGroups.Bar",
@@ -326,12 +380,16 @@ extension String: Foo {}
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "lat",
 // CHECK-NEXT:            "type": "Swift.Float",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 29,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "42.7"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "lng",
 // CHECK-NEXT:            "type": "Swift.Float",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:            "line": 29,
 // CHECK-NEXT:            "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "-73.9"
 // CHECK-NEXT:          }

--- a/test/ConstExtraction/ExtractInjectOptional.swift
+++ b/test/ConstExtraction/ExtractInjectOptional.swift
@@ -23,12 +23,16 @@ public struct Bat {
 // CHECK-NEXT: {
 // CHECK-NEXT:   "label": "buz",
 // CHECK-NEXT:   "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInjectOptional.swift",
+// CHECK-NEXT:   "line": 9,
 // CHECK-NEXT:   "valueKind": "RawLiteral",
 // CHECK-NEXT:   "value": "hello"
 // CHECK-NEXT: },
 // CHECK-NEXT: {
 // CHECK-NEXT:   "label": "fuz",
 // CHECK-NEXT:   "type": "Swift.Int",
+// CHECK-NEXT:   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInjectOptional.swift",
+// CHECK-NEXT:   "line": 9,
 // CHECK-NEXT:   "valueKind": "RawLiteral",
 // CHECK-NEXT:   "value": "4"
 // CHECK-NEXT: }

--- a/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
+++ b/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
@@ -86,10 +86,14 @@ public struct External: MyProto {
 // CHECK-NEXT:         "value": {
 // CHECK-NEXT:           "segments": [
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": "Start Interpolation with Member Reference: "
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "MemberReference",
 // CHECK-NEXT:               "value": {
 // CHECK-NEXT:                 "baseType": "ExtractInterpolatedStringLiterals.Internal",
@@ -97,10 +101,14 @@ public struct External: MyProto {
 // CHECK-NEXT:               }
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": ". Followed By Function Call: "
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "FunctionCall",
 // CHECK-NEXT:               "value": {
 // CHECK-NEXT:                 "name": "generateString",
@@ -108,6 +116,8 @@ public struct External: MyProto {
 // CHECK-NEXT:                   {
 // CHECK-NEXT:                     "label": "input",
 // CHECK-NEXT:                     "type": "Swift.String",
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:                     "line": 26,
 // CHECK-NEXT:                     "valueKind": "RawLiteral",
 // CHECK-NEXT:                     "value": "test"
 // CHECK-NEXT:                   }
@@ -115,10 +125,14 @@ public struct External: MyProto {
 // CHECK-NEXT:               }
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": ". End with KeyPath: "
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "KeyPath",
 // CHECK-NEXT:               "value": {
 // CHECK-NEXT:                 "path": "nested.foo",
@@ -136,6 +150,8 @@ public struct External: MyProto {
 // CHECK-NEXT:               }
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractInterpolatedStringLiterals.swift",
+// CHECK-NEXT:               "line": 26,
 // CHECK-NEXT:               "valueKind": "RawLiteral",
 // CHECK-NEXT:               "value": "."
 // CHECK-NEXT:             }

--- a/test/ConstExtraction/ExtractKeyPaths.swift
+++ b/test/ConstExtraction/ExtractKeyPaths.swift
@@ -61,7 +61,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:       "line": 33,
+// CHECK-NEXT:        "line": 33,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "path": "foo",

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -100,6 +100,14 @@ public struct Optionals: MyProto {
     static var float1: Float?
 }
 
+// Optional properties with no explicit initializer
+// are default-initialized to nil by the compiler, which creates
+// a NilLiteralExpr with an invalid SourceLoc. The location must
+// fall back to the declaration site.
+public struct StaticNilLocation: MyProto {
+    static var nilProp: Int?
+}
+
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.Bools",
@@ -268,7 +276,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 27,
+// CHECK-NEXT:        "line": 28,
 // CHECK-NEXT:        "valueKind": "RawLiteral",
 // CHECK-NEXT:        "value": "First \"string\"\nSecond \\ string"
 // CHECK-NEXT:      },
@@ -320,7 +328,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 39,
+// CHECK-NEXT:        "line": 38,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Buffered<Swift.String>",
@@ -328,6 +336,8 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 39,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Hello"
 // CHECK-NEXT:            }
@@ -341,7 +351,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 42,
+// CHECK-NEXT:        "line": 41,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Clamping<Swift.Int>",
@@ -349,18 +359,24 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 42,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "128"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "min",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 41,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "0"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "max",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 41,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "255"
 // CHECK-NEXT:            }
@@ -374,7 +390,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 45,
+// CHECK-NEXT:        "line": 44,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
@@ -382,6 +398,8 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "ExtractLiterals.Clamping<Swift.Int>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 44,
 // CHECK-NEXT:              "valueKind": "InitCall",
 // CHECK-NEXT:              "value": {
 // CHECK-NEXT:                "type": "ExtractLiterals.Clamping<Swift.Int>",
@@ -389,18 +407,24 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "wrappedValue",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 45,
 // CHECK-NEXT:                    "valueKind": "RawLiteral"
 // CHECK-NEXT:                    "value": "128"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "min",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 44,
 // CHECK-NEXT:                    "valueKind": "RawLiteral",
 // CHECK-NEXT:                    "value": "0"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "max",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 44,
 // CHECK-NEXT:                    "valueKind": "RawLiteral",
 // CHECK-NEXT:                    "value": "255"
 // CHECK-NEXT:                  }
@@ -427,7 +451,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 39,
+// CHECK-NEXT:        "line": 38,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Buffered<Swift.String>",
@@ -435,6 +459,8 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 39,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "Hello"
 // CHECK-NEXT:            }
@@ -466,7 +492,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 42,
+// CHECK-NEXT:        "line": 41,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Clamping<Swift.Int>",
@@ -474,18 +500,24 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 42,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "128"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "min",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 41,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "0"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "max",
 // CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 41,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "255"
 // CHECK-NEXT:            }
@@ -500,12 +532,16 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "min",
 // CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                "line": 41,
 // CHECK-NEXT:                "valueKind": "RawLiteral",
 // CHECK-NEXT:                "value": "0"
 // CHECK-NEXT:              },
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "max",
 // CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                "line": 41,
 // CHECK-NEXT:                "valueKind": "RawLiteral",
 // CHECK-NEXT:                "value": "255"
 // CHECK-NEXT:              }
@@ -520,7 +556,7 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:        "line": 45,
+// CHECK-NEXT:        "line": 44,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
@@ -528,6 +564,8 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "wrappedValue",
 // CHECK-NEXT:              "type": "ExtractLiterals.Clamping<Swift.Int>",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:              "line": 44,
 // CHECK-NEXT:              "valueKind": "InitCall",
 // CHECK-NEXT:              "value": {
 // CHECK-NEXT:                "type": "ExtractLiterals.Clamping<Swift.Int>",
@@ -535,18 +573,24 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "wrappedValue",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 45,
 // CHECK-NEXT:                    "valueKind": "RawLiteral",
 // CHECK-NEXT:                    "value": "128"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "min",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 44,
 // CHECK-NEXT:                    "valueKind": "RawLiteral",
 // CHECK-NEXT:                    "value": "0"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                    "label": "max",
 // CHECK-NEXT:                    "type": "Swift.Int",
+// CHECK-NEXT:                    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                    "line": 44,
 // CHECK-NEXT:                    "valueKind": "RawLiteral",
 // CHECK-NEXT:                    "value": "255"
 // CHECK-NEXT:                  }
@@ -570,12 +614,16 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "min",
 // CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                "line": 44,
 // CHECK-NEXT:                "valueKind": "RawLiteral",
 // CHECK-NEXT:                "value": "0"
 // CHECK-NEXT:              },
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "max",
 // CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:                "line": 44,
 // CHECK-NEXT:                "valueKind": "RawLiteral",
 // CHECK-NEXT:                "value": "255"
 // CHECK-NEXT:              }
@@ -667,7 +715,26 @@ public struct Optionals: MyProto {
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:       "line": 100,
+// CHECK-NEXT:        "line": 100,
+// CHECK-NEXT:        "valueKind": "NilLiteral"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.StaticNilLocation",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals17StaticNilLocationV",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 107,
+// CHECK:         "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "nilProp",
+// CHECK-NEXT:        "type": "Swift.Optional<Swift.Int>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 108,
 // CHECK-NEXT:        "valueKind": "NilLiteral"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]

--- a/test/ConstExtraction/ExtractMemberFunctions.swift
+++ b/test/ConstExtraction/ExtractMemberFunctions.swift
@@ -36,7 +36,8 @@ struct Statics: MyProto {
 // CHECK:       "valueKind": "MemberFunctionCall",
 // CHECK-NEXT:  "value": {
 // CHECK-NEXT:    "baseValue": {
-// CHECK-NEXT:      "valueKind": "InitCall",
+// CHECK:           "line": 28,
+// CHECK:           "valueKind": "InitCall",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractMemberFunctions.MyStruct",
 // CHECK-NEXT:        "arguments": []
@@ -49,7 +50,7 @@ struct Statics: MyProto {
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "arg",
 // CHECK-NEXT:            "type": "Swift.String",
-// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK:                 "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "struct arg"
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]
@@ -62,7 +63,7 @@ struct Statics: MyProto {
 // CHECK:       "valueKind": "MemberFunctionCall",
 // CHECK-NEXT:  "value": {
 // CHECK-NEXT:    "baseValue": {
-// CHECK-NEXT:      "valueKind": "InitCall",
+// CHECK:           "valueKind": "InitCall",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractMemberFunctions.MyClass",
 // CHECK-NEXT:        "arguments": []
@@ -75,7 +76,7 @@ struct Statics: MyProto {
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "arg",
 // CHECK-NEXT:            "type": "Swift.String",
-// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK:                 "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "class arg"
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]
@@ -88,7 +89,7 @@ struct Statics: MyProto {
 // CHECK:       "valueKind": "MemberFunctionCall",
 // CHECK-NEXT:  "value": {
 // CHECK-NEXT:    "baseValue": {
-// CHECK-NEXT:      "valueKind": "InitCall",
+// CHECK:           "valueKind": "InitCall",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractMemberFunctions.MyStruct",
 // CHECK-NEXT:        "arguments": []
@@ -101,7 +102,7 @@ struct Statics: MyProto {
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "label": "arg",
 // CHECK-NEXT:            "type": "Swift.String",
-// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK:                 "valueKind": "RawLiteral",
 // CHECK-NEXT:            "value": "second struct"
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]
@@ -118,7 +119,7 @@ struct Statics: MyProto {
 // CHECK:       "valueKind": "MemberFunctionCall",
 // CHECK-NEXT:  "value": {
 // CHECK-NEXT:    "baseValue": {
-// CHECK-NEXT:      "valueKind": "StaticFunctionCall",
+// CHECK:           "valueKind": "StaticFunctionCall",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractMemberFunctions.MyStruct",
 // CHECK-NEXT:        "memberLabel": "myStaticFunc",

--- a/test/ConstExtraction/ExtractOpenExistential.swift
+++ b/test/ConstExtraction/ExtractOpenExistential.swift
@@ -56,6 +56,8 @@ public struct External: MyProto {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "label": "",
 // CHECK-NEXT:               "type": "any ExtractOpenExistential.ExampleProtocol",
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractOpenExistential.swift",
+// CHECK-NEXT:               "line": 22,
 // CHECK-NEXT:               "valueKind": "InitCall",
 // CHECK-NEXT:               "value": {
 // CHECK-NEXT:                 "type": "ExtractOpenExistential.ConcreteType",

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -178,6 +178,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:               "line": 78,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -185,6 +187,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 78,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProvider.foos.1"
 // CHECK-NEXT:                     }
@@ -195,6 +199,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 79,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -202,6 +208,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 79,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProvider.foos.2"
 // CHECK-NEXT:                     }
@@ -227,6 +235,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 84,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -234,6 +244,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 84,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProvider.bars.1"
 // CHECK-NEXT:                     }
@@ -244,6 +256,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 85,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -251,6 +265,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 85,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProvider.bars.2"
 // CHECK-NEXT:                     }
@@ -276,9 +292,13 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 90,
 // CHECK-NEXT:                 "valueKind": "MemberFunctionCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "baseValue": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 90,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -286,6 +306,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 90,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProvider.bars.1"
 // CHECK-NEXT:                         }
@@ -338,6 +360,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 98,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -345,6 +369,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 98,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProviderInferred.foos.1"
 // CHECK-NEXT:                     },
@@ -358,6 +384,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                           {
 // CHECK-NEXT:                             "kind": "buildExpression",
 // CHECK-NEXT:                             "element": {
+// CHECK-NEXT:                               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                               "line": 99,
 // CHECK-NEXT:                               "valueKind": "RawLiteral",
 // CHECK-NEXT:                               "value": "Nested.Builder.1"
 // CHECK-NEXT:                             }
@@ -365,6 +393,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                           {
 // CHECK-NEXT:                             "kind": "buildExpression",
 // CHECK-NEXT:                             "element": {
+// CHECK-NEXT:                               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                               "line": 100,
 // CHECK-NEXT:                               "valueKind": "RawLiteral",
 // CHECK-NEXT:                               "value": "Nested.Builder.2"
 // CHECK-NEXT:                             }
@@ -379,6 +409,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildExpression",
 // CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                 "line": 102,
 // CHECK-NEXT:                 "valueKind": "InitCall",
 // CHECK-NEXT:                 "value": {
 // CHECK-NEXT:                   "type": "ExtractResultBuilders.Foo",
@@ -386,6 +418,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "label": "name",
 // CHECK-NEXT:                       "type": "Swift.String",
+// CHECK-NEXT:                       "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                       "line": 102,
 // CHECK-NEXT:                       "valueKind": "RawLiteral",
 // CHECK-NEXT:                       "value": "MyFooProviderInferred.foos.2"
 // CHECK-NEXT:                     }
@@ -398,6 +432,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:               "ifElements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 105,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -405,6 +441,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 105,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProviderInferred.foos.if.LessThan3"
 // CHECK-NEXT:                         }
@@ -421,6 +459,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                   "ifElements": [
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "element": {
+// CHECK-NEXT:                         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                         "line": 107,
 // CHECK-NEXT:                         "valueKind": "InitCall",
 // CHECK-NEXT:                         "value": {
 // CHECK-NEXT:                           "type": "ExtractResultBuilders.Foo",
@@ -428,6 +468,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                               "label": "name",
 // CHECK-NEXT:                               "type": "Swift.String",
+// CHECK-NEXT:                               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                               "line": 107,
 // CHECK-NEXT:                               "valueKind": "RawLiteral",
 // CHECK-NEXT:                               "value": "MyFooProviderInferred.foos.elseif.Between3And6"
 // CHECK-NEXT:                             }
@@ -442,6 +484,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                   "elseElements": [
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       "element": {
+// CHECK-NEXT:                         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                         "line": 109,
 // CHECK-NEXT:                         "valueKind": "InitCall",
 // CHECK-NEXT:                         "value": {
 // CHECK-NEXT:                           "type": "ExtractResultBuilders.Foo",
@@ -449,6 +493,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                               "label": "name",
 // CHECK-NEXT:                               "type": "Swift.String",
+// CHECK-NEXT:                               "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                               "line": 109,
 // CHECK-NEXT:                               "valueKind": "RawLiteral",
 // CHECK-NEXT:                               "value": "MyFooProviderInferred.foos.else.Between7And10"
 // CHECK-NEXT:                             }
@@ -468,6 +514,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:               "elements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 113,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -475,10 +523,14 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 113,
 // CHECK-NEXT:                           "valueKind": "InterpolatedStringLiteral",
 // CHECK-NEXT:                           "value": {
 // CHECK-NEXT:                             "segments": [
 // CHECK-NEXT:                               {
+// CHECK-NEXT:                                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                                 "line": 113,
 // CHECK-NEXT:                                 "valueKind": "RawLiteral",
 // CHECK-NEXT:                                 "value": "MyFooProviderInferred.foos.Array."
 // CHECK-NEXT:                               },
@@ -486,6 +538,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                                 "valueKind": "Runtime"
 // CHECK-NEXT:                               },
 // CHECK-NEXT:                               {
+// CHECK-NEXT:                                 "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                                 "line": 113,
 // CHECK-NEXT:                                 "valueKind": "RawLiteral",
 // CHECK-NEXT:                                 "value": ""
 // CHECK-NEXT:                               }
@@ -503,6 +557,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:               "ifElements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 117,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -510,6 +566,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 117,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProviderInferred.foos.Optional"
 // CHECK-NEXT:                         }
@@ -550,6 +608,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:               "ifElements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 121,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -557,6 +617,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 121,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProviderInferred.foos.limitedAvailability.1"
 // CHECK-NEXT:                         }
@@ -566,6 +628,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                 },
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 122,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -573,6 +637,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 122,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProviderInferred.foos.limitedAvailability.2"
 // CHECK-NEXT:                         }
@@ -590,6 +656,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:               "elseElements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {
+// CHECK-NEXT:                     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                     "line": 124,
 // CHECK-NEXT:                     "valueKind": "InitCall",
 // CHECK-NEXT:                     "value": {
 // CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
@@ -597,6 +665,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                           "label": "name",
 // CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 124,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "MyFooProviderInferred.foos.limitedAvailability.else"
 // CHECK-NEXT:                         }
@@ -642,6 +712,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "valueKind": "Array",
 // CHECK-NEXT:         "value": [
 // CHECK-NEXT:           {
+// CHECK-NEXT:             "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:             "line": 131,
 // CHECK-NEXT:             "valueKind": "InitCall",
 // CHECK-NEXT:             "value": {
 // CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
@@ -649,6 +721,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "label": "name",
 // CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                   "line": 131,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.1"
 // CHECK-NEXT:                 },
@@ -662,6 +736,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                       {
 // CHECK-NEXT:                         "kind": "buildExpression",
 // CHECK-NEXT:                         "element": {
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 132,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "Nested.Builder.1"
 // CHECK-NEXT:                         }
@@ -669,6 +745,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                       {
 // CHECK-NEXT:                         "kind": "buildExpression",
 // CHECK-NEXT:                         "element": {
+// CHECK-NEXT:                           "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                           "line": 133,
 // CHECK-NEXT:                           "valueKind": "RawLiteral",
 // CHECK-NEXT:                           "value": "Nested.Builder.2"
 // CHECK-NEXT:                         }
@@ -680,6 +758,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             }
 // CHECK-NEXT:           },
 // CHECK-NEXT:           {
+// CHECK-NEXT:             "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:             "line": 135,
 // CHECK-NEXT:             "valueKind": "InitCall",
 // CHECK-NEXT:             "value": {
 // CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
@@ -687,6 +767,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "label": "name",
 // CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                   "line": 135,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.2"
 // CHECK-NEXT:                 }
@@ -721,10 +803,12 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "true",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 140,
+// CHECK-NEXT:         "line": 141,
 // CHECK-NEXT:         "valueKind": "Array",
 // CHECK-NEXT:         "value": [
 // CHECK-NEXT:           {
+// CHECK-NEXT:             "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:             "line": 142,
 // CHECK-NEXT:             "valueKind": "InitCall",
 // CHECK-NEXT:             "value": {
 // CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
@@ -732,6 +816,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "label": "name",
 // CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                   "line": 142,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayReturn.foos.1"
 // CHECK-NEXT:                 }
@@ -739,6 +825,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             }
 // CHECK-NEXT:           },
 // CHECK-NEXT:           {
+// CHECK-NEXT:             "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:             "line": 143,
 // CHECK-NEXT:             "valueKind": "InitCall",
 // CHECK-NEXT:             "value": {
 // CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
@@ -746,6 +834,8 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "label": "name",
 // CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:                   "line": 143,
 // CHECK-NEXT:                   "valueKind": "RawLiteral",
 // CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.2"
 // CHECK-NEXT:                 }

--- a/test/ConstExtraction/ExtractStaticFunctions.swift
+++ b/test/ConstExtraction/ExtractStaticFunctions.swift
@@ -48,6 +48,8 @@ struct Statics: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "item",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractStaticFunctions.swift",
+// CHECK-NEXT:        "line": 30,
 // CHECK-NEXT:        "valueKind": "RawLiteral",
 // CHECK-NEXT:        "value": "bar"
 // CHECK-NEXT:      }
@@ -70,6 +72,8 @@ struct Statics: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "item",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractStaticFunctions.swift",
+// CHECK-NEXT:        "line": 32,
 // CHECK-NEXT:        "valueKind": "RawLiteral",
 // CHECK-NEXT:        "value": "baz"
 // CHECK-NEXT:      }

--- a/test/ConstExtraction/ExtractTypeValue.swift
+++ b/test/ConstExtraction/ExtractTypeValue.swift
@@ -25,6 +25,8 @@ struct TypeValuePropertyStruct : MyProto {
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypeValue.swift",
+// CHECK-NEXT:            "line": 15,
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractTypeValue.Warbler<Swift.String>",
@@ -32,6 +34,8 @@ struct TypeValuePropertyStruct : MyProto {
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypeValue.swift",
+// CHECK-NEXT:            "line": 15,
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractTypeValue.Avocet",
@@ -39,6 +43,8 @@ struct TypeValuePropertyStruct : MyProto {
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypeValue.swift",
+// CHECK-NEXT:            "line": 15,
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
 // CHECK-NEXT:              "type": "ExtractTypeValue.RainbowLorikeet",

--- a/test/ConstExtraction/ExtractTypes.swift
+++ b/test/ConstExtraction/ExtractTypes.swift
@@ -24,6 +24,8 @@ public struct Types : MyProto {
 // CHECK:       "valueKind": "Array",
 // CHECK-NEXT:  "value": [
 // CHECK-NEXT:    {
+// CHECK-NEXT:      "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypes.swift",
+// CHECK-NEXT:      "line": 16,
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractTypes.TypeA"
@@ -31,6 +33,8 @@ public struct Types : MyProto {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
+// CHECK-NEXT:      "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypes.swift",
+// CHECK-NEXT:      "line": 17,
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractTypes.TypeB"
@@ -38,6 +42,8 @@ public struct Types : MyProto {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
+// CHECK-NEXT:      "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractTypes.swift",
+// CHECK-NEXT:      "line": 18,
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
 // CHECK-NEXT:        "type": "ExtractTypes.TypeC"

--- a/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
+++ b/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
@@ -29,6 +29,8 @@ public struct Warbler : Bird {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "",
 // CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractUnderlyingToOpaque.swift",
+// CHECK-NEXT:              "line": 14,
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "blue"
 // CHECK-NEXT:            }

--- a/test/ConstExtraction/ExtractVariadicArgs.swift
+++ b/test/ConstExtraction/ExtractVariadicArgs.swift
@@ -35,25 +35,37 @@ public struct Driver: MyProto {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "args",
 // CHECK-NEXT:              "type": "Swift.Int...",
+// CHECK-NEXT:              "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:              "line": 16,
 // CHECK-NEXT:              "valueKind": "Array",
 // CHECK-NEXT:              "value": [
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:                  "line": 16,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "1"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:                  "line": 16,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "2"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:                  "line": 16,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "3"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:                  "line": 16,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "4"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                {
+// CHECK-NEXT:                  "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractVariadicArgs.swift",
+// CHECK-NEXT:                  "line": 16,
 // CHECK-NEXT:                  "valueKind": "RawLiteral",
 // CHECK-NEXT:                  "value": "5"
 // CHECK-NEXT:                }


### PR DESCRIPTION
Adding location information to the extracted value. This should help provide exact diagnostics for statements across multiple lines.

```
let types = [
  UTType.pdf, 
  Self.someInvalidType(),
]
```

resolves: rdar://155246454