### PR TITLE
[Sema]: ban the use of 'nonisolated' on actor declarations

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7982,6 +7982,15 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     }
   }
 
+  // `nonisolated` on an actor declaration is contradictory.
+  if (auto *classDecl = dyn_cast<ClassDecl>(D);
+      classDecl && classDecl->isExplicitActor()) {
+    diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr)
+        .warnUntilFutureSwiftVersion()
+        .fixItRemove(attr->getRange());
+    return;
+  }
+
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     //'nonisolated(unsafe)' is meaningless for computed properties, functions etc.
     auto var = dyn_cast<VarDecl>(VD);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7986,7 +7986,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   if (auto *classDecl = dyn_cast<ClassDecl>(D);
       classDecl && classDecl->isExplicitActor()) {
     diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr)
-        .warnUntilFutureSwiftVersion()
         .fixItRemove(attr->getRange());
     return;
   }

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -53,3 +53,5 @@ extension A2 {
 
   init(doesNotDelegate: ()) {} // expected-error {{designated initializer cannot be declared in an extension of 'A2'}}
 }
+
+nonisolated actor A3 {} // expected-warning {{'nonisolated' modifier cannot be applied to this declaration; this will be an error in a future Swift language mode}}{{1-13=}}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -54,4 +54,4 @@ extension A2 {
   init(doesNotDelegate: ()) {} // expected-error {{designated initializer cannot be declared in an extension of 'A2'}}
 }
 
-nonisolated actor A3 {} // expected-warning {{'nonisolated' modifier cannot be applied to this declaration; this will be an error in a future Swift language mode}}{{1-13=}}
+nonisolated actor A3 {} // expected-error {{'nonisolated' modifier cannot be applied to this declaration}}{{1-13=}}

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -65,6 +65,8 @@ distributed actor D5: P1 {
   // expected-note@-1{{non-distributed instance method 'dist()'}}
 }
 
+nonisolated distributed actor D6 {} // expected-warning {{'nonisolated' modifier cannot be applied to this declaration; this will be an error in a future Swift language mode}}{{1-13=}}
+
 // ==== Tests ------------------------------------------------------------------
 
 // Make sure the conformances have been added implicitly.

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -65,7 +65,7 @@ distributed actor D5: P1 {
   // expected-note@-1{{non-distributed instance method 'dist()'}}
 }
 
-nonisolated distributed actor D6 {} // expected-warning {{'nonisolated' modifier cannot be applied to this declaration; this will be an error in a future Swift language mode}}{{1-13=}}
+nonisolated distributed actor D6 {} // expected-error {{'nonisolated' modifier cannot be applied to this declaration}}{{1-13=}}
 
 // ==== Tests ------------------------------------------------------------------
 


### PR DESCRIPTION
The combination doesn't make sense, so don't allow it.

Resolves: https://github.com/swiftlang/swift/issues/85174