### PR TITLE
[Test] Fix ABI and symbol visibility tests for client retain/release.

### DIFF
--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1143,3 +1143,9 @@ Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize
 Added: __swift_debug_metadataAllocatorPageSize
+
+// New symbols to support emit-into-client retain/release.
+Added: __swift_retainRelease_slowpath_mask_v1
+Added: _swift_release_preservemost
+Added: _swift_release_preservemost_weak_placeholder
+Added: _swift_retain_preservemost

--- a/test/stdlib/symbol-visibility-darwin.test-sh
+++ b/test/stdlib/symbol-visibility-darwin.test-sh
@@ -1,14 +1,20 @@
-// Ensure that we do not export any weak symbols from the dylibs.
+// Ensure that we do not export any unwanted weak symbols from the dylibs.
 //
 // Weak symbols require additional work from the loader to resolve the symbol at
 // load time and can cause ODR violations as well as unexpected symbol
 // satisfaction because the weak symbol may be used from a separate module.
+//
+// The _swift_release_preservemost_weak_placeholder symbol is present to allow
+// strong symbols from swiftCore to override weak symbols in other libraries,
+// to allow back-deployment usage of the swift_retain_preservemost and
+// swift_release_preservemost entrypoints.
 
 // RUN: %empty-directory(%t)
 
 // RUN: %llvm-nm --defined-only --extern-only --demangle %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak --demangle %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
-// RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
+// RUN: grep -v _swift_release_preservemost_weak_placeholder < %t/swiftCore-all.txt > %t/swiftCore-all-filtered.txt
+// RUN: diff -u %t/swiftCore-all-filtered.txt %t/swiftCore-no-weak.txt
 
 // RUN: %llvm-nm --defined-only --extern-only --demangle %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak --demangle %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
The client retain/release changes introduced new symbols which need to be added to these tests.

rdar://163578648