### PR TITLE
[Runtime] Fix the no-retain/release-overrides build.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -186,6 +186,9 @@ static HeapObject *_swift_tryRetain_(HeapObject *object)
 #define CALL_IMPL(name, args) \
     return _ ## name ## _ args;
 
+#define CALL_IMPL_SWIFT_REFCOUNT_CC(name, args) \
+    return _ ## name ## _ args;
+
 #define CALL_IMPL_CHECK(name, args) \
     return _ ## name ## _ args;
 


### PR DESCRIPTION
We need a stub version of CALL_IMPL_SWIFT_REFCOUNT_CC for the !SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE case.