### PR TITLE
[RemoteMirrors] Add hook for resolving indirect addresses

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -121,6 +121,20 @@ public:
     return ReadObjResult<T>(reinterpret_cast<const T *>(ptr), deleter);
   }
 
+  /// Resolves an indirect address at the given relative offset.
+  ///
+  /// \param address The base address which contains the relative offset.
+  /// \param offset The offset read.
+  /// \param directnessEncodedInOffset Whether the relative offset encodes the
+  /// directness as the last bit. Note that this is not the offset passed in as
+  /// a parameter, but whether the offset read at address would have the last
+  /// bit set.
+  virtual RemoteAddress
+  resolveIndirectAddressAtOffset(RemoteAddress address, uint64_t offset,
+                                 bool directnessEncodedInOffset) {
+    return address + offset;
+  }
+
   /// Attempts to read 'size' bytes from the given address in the remote process.
   ///
   /// Returns a pointer to the requested data and a function that must be called to

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -461,18 +461,20 @@ public:
         swift::Demangle::NodePointer {
       // Resolve the reference to a remote address.
       auto offsetInMangledName =
-            (const char *)base - mangledName.getLocalBuffer();
-      auto remoteAddress =
-          mangledName.getRemoteAddress() + offsetInMangledName + offset;
+          (const char *)base - mangledName.getLocalBuffer();
+      auto offsetAddress = mangledName.getRemoteAddress() + offsetInMangledName;
 
       RemoteAbsolutePointer resolved;
       if (directness == Directness::Indirect) {
+        auto remoteAddress = Reader->resolveIndirectAddressAtOffset(
+            offsetAddress, offset, /*directnessEncodedInOffset=*/false);
         if (auto indirectAddress = readPointer(remoteAddress)) {
           resolved = stripSignedPointer(*indirectAddress);
         } else {
           return nullptr;
         }
       } else {
+        auto remoteAddress = offsetAddress + offset;
         resolved = Reader->getSymbol(remoteAddress);
       }
 
@@ -2078,17 +2080,19 @@ protected:
     
     using SignedPointer = typename std::make_signed<StoredPointer>::type;
 
-    RemoteAddress resultAddress = getAddress(fieldRef) + (SignedPointer)offset;
-
     // Low bit set in the offset indicates that the offset leads to the absolute
     // address in memory.
     if (indirect) {
+      RemoteAddress resultAddress = Reader->resolveIndirectAddressAtOffset(
+          getAddress(fieldRef), (SignedPointer)offset,
+          /*directnessEncodedInOffset=*/true);
       if (auto ptr = readPointer(resultAddress)) {
         return stripSignedPointer(*ptr);
       }
       return std::nullopt;
     }
 
+    RemoteAddress resultAddress = getAddress(fieldRef) + (SignedPointer)offset;
     return RemoteAbsolutePointer(resultAddress);
   }
 


### PR DESCRIPTION
- **Explanation:** Adds a hook so implementations of memory reader can add logic to resolving remote addresses. This is needed because of an interaction between LLDB, which tries to read memory from files instead of process memory whenever possible and the DYLD shared cache.
- **Scope:** Only affects remote mirrors clients. The default implementation of the new function should behave exactly the same as before this patch, so only LLDB, which overrides the function, should se any difference in behavior.
- **Issue/Radar:** rdar://163652093 
- **Original PR:** https://github.com/swiftlang/swift/pull/85091
- **Risk:** Low. Only LLDB should be affected.
- **Testing:** Since this is specific to LLDB and the shared cache, there's no test I could add here, besides manual testing.
- **Reviewer:** @mikeash  