### PR TITLE
Address GUID type definition errors

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -339,6 +339,9 @@ extension GUID: @retroactive Equatable {
   @_transparent
   @_implements(Equatable, ==(_:_:))
   public static func __equals(lhs: Self, rhs: Self) -> Bool {
+  // When C++ interop is enabled, Swift imports a == operator from guiddef.h
+  // that conflicts with the definition of == here, so we've renamed it to
+  // __equals to avoid the conflict.
     lhs.uint128Value == rhs.uint128Value
   }
 }

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -335,12 +335,12 @@ extension GUID {
 // comes from the _GUIDDef clang module rather than the WinSDK clang module.
 
 extension GUID: @retroactive Equatable {
-  @_transparent
-  @_implements(Equatable, ==(_:_:))
-  public static func __equals(lhs: Self, rhs: Self) -> Bool {
   // When C++ interop is enabled, Swift imports a == operator from guiddef.h
   // that conflicts with the definition of == here, so we've renamed it to
   // __equals to avoid the conflict.
+  @_transparent
+  @_implements(Equatable, ==(_:_:))
+  public static func __equals(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value
   }
 }

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -14,8 +14,6 @@
 @_exported import _GUIDDef
 @_exported import WinSDK // Clang module
 
-public typealias _GUID = GUID
-
 // WinBase.h
 @inlinable
 public var HANDLE_FLAG_INHERIT: DWORD {

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -335,18 +335,13 @@ extension GUID {
 
 // These conformances are marked @retroactive because the GUID type nominally
 // comes from the _GUIDDef clang module rather than the WinSDK clang module.
-
-// The C++ overlay already vends `==` when interop is enabled; avoid a redeclaration.
-#if canImport(Cxx)
-extension GUID: @retroactive Equatable {}
-#else
 extension GUID: @retroactive Equatable {
   @_transparent
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
+  @_implements(Equatable, ==(_:_:))
+  public static func __equals(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value
   }
 }
-#endif
 
 extension GUID: @retroactive Hashable {
   @_transparent

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -14,6 +14,8 @@
 @_exported import _GUIDDef
 @_exported import WinSDK // Clang module
 
+public typealias _GUID = GUID
+
 // WinBase.h
 @inlinable
 public var HANDLE_FLAG_INHERIT: DWORD {

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -333,6 +333,7 @@ extension GUID {
 
 // These conformances are marked @retroactive because the GUID type nominally
 // comes from the _GUIDDef clang module rather than the WinSDK clang module.
+
 extension GUID: @retroactive Equatable {
   @_transparent
   @_implements(Equatable, ==(_:_:))

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -336,12 +336,17 @@ extension GUID {
 // These conformances are marked @retroactive because the GUID type nominally
 // comes from the _GUIDDef clang module rather than the WinSDK clang module.
 
+// The C++ overlay already vends `==` when interop is enabled; avoid a redeclaration.
+#if canImport(Cxx)
+extension GUID: @retroactive Equatable {}
+#else
 extension GUID: @retroactive Equatable {
   @_transparent
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.uint128Value == rhs.uint128Value
   }
 }
+#endif
 
 extension GUID: @retroactive Hashable {
   @_transparent


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/84792 we have added implementation to `Equatable` and `Hashable` there are two issues with this. 
1. Uses of type `GUID` would be emitted in the `swiftinterface` file as `_GUIDDef._GUID` since it is an external type. but the type name in the imported header file is `GUID` and not `_GUID`
2. When compiling using `-cxx-interoperability-mode=default`, there are duplicate definition errors for `==` since the c++ header file defines the same operator. 

Proposed changes:
1. Add a type alias `typealias _GUID = GUID` to address the naming mismatch in the generated interface file
2. Add conditional definitions of the equatable implementation to avoid duplicate definitions.
