### PR TITLE
[Docs] Improve abstract & flow for Sendable

### DIFF
--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -66,10 +66,6 @@
 /// A thread-safe type whose values can be shared across arbitrary concurrent
 /// contexts without introducing a risk of data races.
 ///
-/// Values of the type may have no shared mutable state,
-/// or they may protect that state with a lock
-/// or by forcing it to only be accessed from a specific actor.
-///
 /// You can safely pass values of a sendable type
 /// from one concurrency domain to another ---
 /// for example, you can pass a sendable value as the argument
@@ -83,6 +79,14 @@
 /// - Reference types that internally manage access to their state
 ///
 /// - Functions and closures (by marking them with `@Sendable`)
+///
+/// To make a type sendable, you do one of the following:
+///
+/// - Ensure that values of the type don't have any shared mutable state.
+///
+/// - Protect shared mutable state with a lock
+///
+/// - Isolate shared mutable state to a specific actor
 ///
 /// Although this protocol doesn't have any required methods or properties,
 /// it does have semantic requirements that are enforced at compile time.

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -64,9 +64,11 @@
 @_marker public protocol SendableMetatype: ~Copyable, ~Escapable { }
 
 /// A thread-safe type whose values can be shared across arbitrary concurrent
-/// contexts without introducing a risk of data races. Values of the type may
-/// have no shared mutable state, or they may protect that state with a lock or
-/// by forcing it to only be accessed from a specific actor.
+/// contexts without introducing a risk of data races.
+///
+/// Values of the type may have no shared mutable state,
+/// or they may protect that state with a lock
+/// or by forcing it to only be accessed from a specific actor.
 ///
 /// You can safely pass values of a sendable type
 /// from one concurrency domain to another ---

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type whose metatype can be shared across arbitrary concurrent contexts
+/// A type whose metatype can be shared across arbitrary isolation domains
 /// without introducing a risk of data races.
 ///
 /// When a generic type `T` conforms
@@ -63,8 +63,8 @@
 /// `T: SendableMetatype`.
 @_marker public protocol SendableMetatype: ~Copyable, ~Escapable { }
 
-/// A thread-safe type whose values can be shared across arbitrary concurrent
-/// contexts without introducing a risk of data races.
+/// A thread-safe type whose values can be shared across arbitrary isolation
+/// domains without introducing a risk of data races.
 ///
 /// You can safely pass values of a sendable type
 /// from one concurrency domain to another ---


### PR DESCRIPTION
Limited the abstract to one sentence, per API reference style guide.  Avoided "may" because it's ambiguous between permission (the types are allowed to do this) and possibility (this is one way the types can be sendable).  Moved the list of ways to make a type sendable a little lower, after the docs have framed what sendability is more.

Fixes: rdar://129033829