### PR TITLE
[NFC][update-checkout] run the black formatter on update-checkout

### DIFF
--- a/utils/update_checkout/__init__.py
+++ b/utils/update_checkout/__init__.py
@@ -1,4 +1,3 @@
-
 from .update_checkout import main
 
 __all__ = ["main"]

--- a/utils/update_checkout/run_tests.py
+++ b/utils/update_checkout/run_tests.py
@@ -24,13 +24,13 @@ MODULE_DIR = os.path.abspath(os.path.dirname(__file__))
 UTILS_DIR = os.path.abspath(os.path.join(MODULE_DIR, os.pardir))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Add the swift/utils directory to the Python path.
     sys.path.append(UTILS_DIR)
 
     # Create temp directory and export it for the test suite.
     temp_dir = tempfile.mkdtemp()
-    os.environ['UPDATECHECKOUT_TEST_WORKSPACE_DIR'] = temp_dir
+    os.environ["UPDATECHECKOUT_TEST_WORKSPACE_DIR"] = temp_dir
 
     # Discover all tests for the module.
     module_tests = unittest.defaultTestLoader.discover(MODULE_DIR)

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -21,17 +21,17 @@ import unittest
 # For now we only use a config with a single scheme. We should add support for
 # handling multiple schemes.
 MOCK_REMOTE = {
-    'repo1': [
+    "repo1": [
         # This is a series of changes to repo1. (File, NewContents)
-        ('A.txt', 'A'),
-        ('B.txt', 'B'),
-        ('A.txt', 'a'),
+        ("A.txt", "A"),
+        ("B.txt", "B"),
+        ("A.txt", "a"),
     ],
-    'repo2': [
+    "repo2": [
         # This is a series of changes to repo2. (File, NewContents)
-        ('X.txt', 'X'),
-        ('Y.txt', 'Y'),
-        ('X.txt', 'z'),
+        ("X.txt", "X"),
+        ("Y.txt", "Y"),
+        ("X.txt", "z"),
     ],
 }
 
@@ -39,40 +39,40 @@ MOCK_CONFIG = {
     # This is here just b/c we expect it. We should consider consolidating
     # clone-patterns into a dictionary where we map protocols (i.e. ['ssh,
     # 'https'] to patterns). Then we can define this issue.
-    'ssh-clone-pattern': 'DO_NOT_USE',
+    "ssh-clone-pattern": "DO_NOT_USE",
     # We reset this value with our remote path when we process
-    'https-clone-pattern': '',
-    'repos': {
-        'repo1': {
-            'remote': {'id': 'repo1'},
+    "https-clone-pattern": "",
+    "repos": {
+        "repo1": {
+            "remote": {"id": "repo1"},
         },
-        'repo2': {
-            'remote': {'id': 'repo2'},
+        "repo2": {
+            "remote": {"id": "repo2"},
         },
     },
-    'default-branch-scheme': 'main',
-    'branch-schemes': {
-        'main': {
-            'aliases': ['main'],
-            'repos': {
-                'repo1': 'main',
-                'repo2': 'main',
-            }
+    "default-branch-scheme": "main",
+    "branch-schemes": {
+        "main": {
+            "aliases": ["main"],
+            "repos": {
+                "repo1": "main",
+                "repo2": "main",
+            },
         }
-    }
+    },
 }
 
 MOCK_ADDITIONAL_SCHEME = {
-    'branch-schemes': {
-        'extra': {
-            'aliases': ['extra'],
-            'repos': {
+    "branch-schemes": {
+        "extra": {
+            "aliases": ["extra"],
+            "repos": {
                 # Spell this differently just to make it distinguishable in
                 # test output, even though we only have one branch.
                 # TODO: Support multiple test branches in the repo instead.
-                'repo1': 'refs/heads/main',
-                'repo2': 'refs/heads/main',
-            }
+                "repo1": "refs/heads/main",
+                "repo2": "refs/heads/main",
+            },
         }
     }
 }
@@ -85,18 +85,21 @@ class CallQuietlyException(Exception):
         self.output = output
 
     def __str__(self):
-        return f"Command returned a non-zero exit status {self.returncode}:\n"\
-               f"Command: {' '.join(self.command)}\n" \
-               f"Output: {self.output.decode('utf-8')}"
+        return (
+            f"Command returned a non-zero exit status {self.returncode}:\n"
+            f"Command: {' '.join(self.command)}\n"
+            f"Output: {self.output.decode('utf-8')}"
+        )
 
 
 def call_quietly(*args, **kwargs):
-    kwargs['stderr'] = subprocess.STDOUT
+    kwargs["stderr"] = subprocess.STDOUT
     try:
         return subprocess.check_output(*args, **kwargs)
     except subprocess.CalledProcessError as e:
-        raise CallQuietlyException(command=e.cmd, returncode=e.returncode,
-                                   output=e.stdout) from e
+        raise CallQuietlyException(
+            command=e.cmd, returncode=e.returncode, output=e.stdout
+        ) from e
 
 
 def create_dir(d):
@@ -105,75 +108,82 @@ def create_dir(d):
 
 
 def teardown_mock_remote(base_dir):
-    call_quietly(['rm', '-rf', base_dir])
+    call_quietly(["rm", "-rf", base_dir])
 
 
 def get_config_path(base_dir):
-    return os.path.join(base_dir, 'test-config.json')
+    return os.path.join(base_dir, "test-config.json")
 
 
 def get_additional_config_path(base_dir):
-    return os.path.join(base_dir, 'test-additional-config.json')
+    return os.path.join(base_dir, "test-additional-config.json")
 
 
 def setup_mock_remote(base_dir, base_config):
     create_dir(base_dir)
 
     # We use local as a workspace for creating commits.
-    LOCAL_PATH = os.path.join(base_dir, 'local')
+    LOCAL_PATH = os.path.join(base_dir, "local")
     # We use remote as a directory that simulates our remote unchecked out
     # repo.
-    REMOTE_PATH = os.path.join(base_dir, 'remote')
+    REMOTE_PATH = os.path.join(base_dir, "remote")
 
     create_dir(REMOTE_PATH)
     create_dir(LOCAL_PATH)
 
-    for (k, v) in MOCK_REMOTE.items():
+    for k, v in MOCK_REMOTE.items():
         local_repo_path = os.path.join(LOCAL_PATH, k)
         remote_repo_path = os.path.join(REMOTE_PATH, k)
         create_dir(remote_repo_path)
         create_dir(local_repo_path)
-        call_quietly(['git', 'init', '--bare', remote_repo_path])
-        call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
-                     cwd=remote_repo_path)
-        call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
-        call_quietly(['git', 'config', '--local', 'user.name', 'swift_test'],
-                     cwd=local_repo_path)
-        call_quietly(['git', 'config', '--local', 'user.email', 'no-reply@swift.org'],
-                     cwd=local_repo_path)
-        call_quietly(['git', 'config', '--local', 'commit.gpgsign', 'false'],
-                     cwd=local_repo_path)
-        call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
-                     cwd=local_repo_path)
-        for (i, (filename, contents)) in enumerate(v):
+        call_quietly(["git", "init", "--bare", remote_repo_path])
+        call_quietly(
+            ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=remote_repo_path
+        )
+        call_quietly(["git", "clone", "-l", remote_repo_path, local_repo_path])
+        call_quietly(
+            ["git", "config", "--local", "user.name", "swift_test"], cwd=local_repo_path
+        )
+        call_quietly(
+            ["git", "config", "--local", "user.email", "no-reply@swift.org"],
+            cwd=local_repo_path,
+        )
+        call_quietly(
+            ["git", "config", "--local", "commit.gpgsign", "false"], cwd=local_repo_path
+        )
+        call_quietly(
+            ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
+        )
+        for i, (filename, contents) in enumerate(v):
             filename_path = os.path.join(local_repo_path, filename)
-            with open(filename_path, 'w') as f:
+            with open(filename_path, "w") as f:
                 f.write(contents)
-            call_quietly(['git', 'add', filename], cwd=local_repo_path)
-            call_quietly(['git', 'commit', '-m', 'Commit %d' % i],
-                         cwd=local_repo_path)
-            call_quietly(['git', 'push', 'origin', 'main'],
-                         cwd=local_repo_path)
+            call_quietly(["git", "add", filename], cwd=local_repo_path)
+            call_quietly(["git", "commit", "-m", "Commit %d" % i], cwd=local_repo_path)
+            call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
 
-    https_clone_pattern = os.path.join('file://%s' % REMOTE_PATH, '%s')
-    base_config['https-clone-pattern'] = https_clone_pattern
+    https_clone_pattern = os.path.join("file://%s" % REMOTE_PATH, "%s")
+    base_config["https-clone-pattern"] = https_clone_pattern
 
-    with open(get_config_path(base_dir), 'w') as f:
+    with open(get_config_path(base_dir), "w") as f:
         json.dump(base_config, f)
 
-    with open(get_additional_config_path(base_dir), 'w') as f:
+    with open(get_additional_config_path(base_dir), "w") as f:
         json.dump(MOCK_ADDITIONAL_SCHEME, f)
 
     return (LOCAL_PATH, REMOTE_PATH)
 
 
-BASEDIR_ENV_VAR = 'UPDATECHECKOUT_TEST_WORKSPACE_DIR'
+BASEDIR_ENV_VAR = "UPDATECHECKOUT_TEST_WORKSPACE_DIR"
 CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-UPDATE_CHECKOUT_EXECUTABLE = 'update-checkout.cmd' if os.name == 'nt' else 'update-checkout'
-UPDATE_CHECKOUT_PATH = os.path.abspath(os.path.join(CURRENT_FILE_DIR,
-                                                    os.path.pardir,
-                                                    os.path.pardir,
-                                                    UPDATE_CHECKOUT_EXECUTABLE))
+UPDATE_CHECKOUT_EXECUTABLE = (
+    "update-checkout.cmd" if os.name == "nt" else "update-checkout"
+)
+UPDATE_CHECKOUT_PATH = os.path.abspath(
+    os.path.join(
+        CURRENT_FILE_DIR, os.path.pardir, os.path.pardir, UPDATE_CHECKOUT_EXECUTABLE
+    )
+)
 
 
 class SchemeMockTestCase(unittest.TestCase):
@@ -184,16 +194,19 @@ class SchemeMockTestCase(unittest.TestCase):
         self.config = MOCK_CONFIG.copy()
         self.workspace = os.getenv(BASEDIR_ENV_VAR)
         if self.workspace is None:
-            raise RuntimeError('Misconfigured test suite! Environment '
-                               'variable %s must be set!' % BASEDIR_ENV_VAR)
+            raise RuntimeError(
+                "Misconfigured test suite! Environment "
+                "variable %s must be set!" % BASEDIR_ENV_VAR
+            )
         self.config_path = get_config_path(self.workspace)
         self.additional_config_path = get_additional_config_path(self.workspace)
         self.update_checkout_path = UPDATE_CHECKOUT_PATH
         if not os.access(self.update_checkout_path, os.X_OK):
-            raise RuntimeError('Error! Could not find executable '
-                               'update-checkout at path: %s'
-                               % self.update_checkout_path)
-        self.source_root = os.path.join(self.workspace, 'source_root')
+            raise RuntimeError(
+                "Error! Could not find executable "
+                "update-checkout at path: %s" % self.update_checkout_path
+            )
+        self.source_root = os.path.join(self.workspace, "source_root")
 
     def setUp(self):
         create_dir(self.source_root)
@@ -205,7 +218,7 @@ class SchemeMockTestCase(unittest.TestCase):
         teardown_mock_remote(self.workspace)
 
     def call(self, *args, **kwargs):
-        kwargs['cwd'] = self.source_root
+        kwargs["cwd"] = self.source_root
         return call_quietly(*args, **kwargs)
 
     def get_all_repos(self):

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -22,37 +22,58 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
         super(CloneTestCase, self).__init__(*args, **kwargs)
 
     def test_simple_clone(self):
-        self.call([self.update_checkout_path,
-                   '--config', self.config_path,
-                   '--source-root', self.source_root,
-                   '--clone'])
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+            ]
+        )
 
         for repo in self.get_all_repos():
             repo_path = os.path.join(self.source_root, repo)
             self.assertTrue(os.path.isdir(repo_path))
 
     def test_clone_with_additional_scheme(self):
-        output = self.call([self.update_checkout_path,
-                            '--config', self.config_path,
-                            '--config', self.additional_config_path,
-                            '--source-root', self.source_root,
-                            '--clone',
-                            '--scheme', 'extra',
-                            '--verbose'])
+        output = self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--config",
+                self.additional_config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "extra",
+                "--verbose",
+            ]
+        )
 
         # Test that we're actually checking out the 'extra' scheme based on the output
         self.assertIn("git checkout refs/heads/main", output.decode("utf-8"))
 
     def test_manager_not_called_on_long_socket(self):
-        fake_tmpdir = '/tmp/very/' + '/long' * 20 + '/tmp'
+        fake_tmpdir = "/tmp/very/" + "/long" * 20 + "/tmp"
 
-        with mock.patch('tempfile.gettempdir', return_value=fake_tmpdir), \
-            mock.patch('multiprocessing.Manager') as mock_manager:
+        with mock.patch("tempfile.gettempdir", return_value=fake_tmpdir), mock.patch(
+            "multiprocessing.Manager"
+        ) as mock_manager:
 
-            self.call([self.update_checkout_path,
-                    '--config', self.config_path,
-                    '--source-root', self.source_root,
-                    '--clone'])
+            self.call(
+                [
+                    self.update_checkout_path,
+                    "--config",
+                    self.config_path,
+                    "--source-root",
+                    self.source_root,
+                    "--clone",
+                ]
+            )
             # Ensure that we do not try to create a Manager when the tempdir
             # is too long.
             mock_manager.assert_not_called()
@@ -85,9 +106,7 @@ class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
     def test_clone(self):
         self.call(self.base_args + ["--scheme", self.scheme_name, "--clone"])
 
-        missing_repo_path = os.path.join(
-            self.source_root, self.get_all_repos().pop()
-        )
+        missing_repo_path = os.path.join(self.source_root, self.get_all_repos().pop())
         self.assertFalse(os.path.isdir(missing_repo_path))
 
     # Test that we do not update a repository that is not listed in the given

--- a/utils/update_checkout/tests/test_dump.py
+++ b/utils/update_checkout/tests/test_dump.py
@@ -22,16 +22,28 @@ class DumpTestCase(scheme_mock.SchemeMockTestCase):
 
     def test_dump_hashes_json(self):
         # First do the clone.
-        self.call([self.update_checkout_path,
-                   '--config', self.config_path,
-                   '--source-root', self.source_root,
-                   '--clone'])
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+            ]
+        )
 
         # Then dump the hashes.
-        output = self.call([self.update_checkout_path,
-                            '--config', self.config_path,
-                            '--source-root', self.source_root,
-                            '--dump-hashes'])
+        output = self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--dump-hashes",
+            ]
+        )
         # The output should be valid JSON
         result = json.loads(output)
 

--- a/utils/update_checkout/tests/test_merge_config.py
+++ b/utils/update_checkout/tests/test_merge_config.py
@@ -38,38 +38,44 @@ class MergeTestCase(unittest.TestCase):
             },
         }
 
-        self.assertEqual(merge_config(default_config, {
-            "note": "this is machine generated or something",
-            "ssh-clone-pattern": "git@2",
-            "repos": {
-                "llvm-project": {"remote": {"id": "blah/llvm-project"}},
-                "swift-syntax": {"remote": {"id": "swiftlang/swift-syntax"}},
-            },
-            "default-branch-scheme": "bonus",
-            "branch-schemes": {
-                "bonus": {
-                    "aliases": ["bonus", "also-bonus"],
+        self.assertEqual(
+            merge_config(
+                default_config,
+                {
+                    "note": "this is machine generated or something",
+                    "ssh-clone-pattern": "git@2",
+                    "repos": {
+                        "llvm-project": {"remote": {"id": "blah/llvm-project"}},
+                        "swift-syntax": {"remote": {"id": "swiftlang/swift-syntax"}},
+                    },
+                    "default-branch-scheme": "bonus",
+                    "branch-schemes": {
+                        "bonus": {
+                            "aliases": ["bonus", "also-bonus"],
+                        },
+                    },
                 },
-            },
-        }), {
-            "ssh-clone-pattern": "git@2",
-            "https-clone-pattern": "https://1",
-            "repos": {
-                "swift": {"remote": {"id": "swiftlang/swift"}},
-                "llvm-project": {"remote": {"id": "blah/llvm-project"}},
-                "swift-syntax": {"remote": {"id": "swiftlang/swift-syntax"}},
-            },
-            "default-branch-scheme": "bonus",
-            "branch-schemes": {
-                "main": {
-                    "aliases": ["swift/main", "main", "stable/20240723"],
+            ),
+            {
+                "ssh-clone-pattern": "git@2",
+                "https-clone-pattern": "https://1",
+                "repos": {
+                    "swift": {"remote": {"id": "swiftlang/swift"}},
+                    "llvm-project": {"remote": {"id": "blah/llvm-project"}},
+                    "swift-syntax": {"remote": {"id": "swiftlang/swift-syntax"}},
                 },
-                "bonus": {
-                    "aliases": ["bonus", "also-bonus"],
+                "default-branch-scheme": "bonus",
+                "branch-schemes": {
+                    "main": {
+                        "aliases": ["swift/main", "main", "stable/20240723"],
+                    },
+                    "bonus": {
+                        "aliases": ["bonus", "also-bonus"],
+                    },
                 },
+                "note": "this is machine generated or something",
             },
-            "note": "this is machine generated or something",
-        })
+        )
 
         with self.assertRaises(ValueError):
             merge_config(default_config, default_config)

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -29,9 +29,9 @@ def setup_worktree(workspace_path, local_path, worktree_name):
     for project in os.listdir(local_path):
         local_project_path = os.path.join(local_path, project)
         worktree_project_path = os.path.join(worktree_path, project)
-        call_quietly(['git',
-                      '-C', local_project_path,
-                      'worktree', 'add', worktree_project_path])
+        call_quietly(
+            ["git", "-C", local_project_path, "worktree", "add", worktree_project_path]
+        )
 
 
 def teardown_worktree(workspace_path, local_path, worktree_name):
@@ -39,9 +39,16 @@ def teardown_worktree(workspace_path, local_path, worktree_name):
     for project in os.listdir(local_path):
         local_project_path = os.path.join(local_path, project)
         worktree_project_path = os.path.join(worktree_path, project)
-        call_quietly(['git',
-                      '-C', local_project_path,
-                      'worktree', 'remove', worktree_project_path])
+        call_quietly(
+            [
+                "git",
+                "-C",
+                local_project_path,
+                "worktree",
+                "remove",
+                worktree_project_path,
+            ]
+        )
 
 
 class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
@@ -50,10 +57,17 @@ class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
         super(WorktreeTestCase, self).__init__(*args, **kwargs)
 
     def test_worktree(self):
-        self.call([self.update_checkout_path,
-                   '--config', self.config_path,
-                   '--source-root', self.worktree_path,
-                   '--scheme', 'main'])
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.worktree_path,
+                "--scheme",
+                "main",
+            ]
+        )
 
     def setUp(self):
         super(WorktreeTestCase, self).setUp()

--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -8,7 +8,11 @@ import shutil
 
 from .git_command import GitException
 
-from .runner_arguments import RunnerArguments, AdditionalSwiftSourcesArguments, UpdateArguments
+from .runner_arguments import (
+    RunnerArguments,
+    AdditionalSwiftSourcesArguments,
+    UpdateArguments,
+)
 
 
 class TaskTracker:
@@ -71,7 +75,7 @@ class MonitoredFunction:
             return result
 
 
-class ParallelRunner():
+class ParallelRunner:
     def __init__(
         self,
         fn: Callable[..., None],
@@ -111,7 +115,9 @@ class ParallelRunner():
             monitor_thread = Thread(target=self._monitor, daemon=True)
             monitor_thread.start()
             with ThreadPoolExecutor(max_workers=self._n_threads) as pool:
-                results = list(pool.map(self._monitored_fn, self._pool_args, timeout=1800))
+                results = list(
+                    pool.map(self._monitored_fn, self._pool_args, timeout=1800)
+                )
             self._stop_event.set()
             monitor_thread.join()
         return results
@@ -121,7 +127,10 @@ class ParallelRunner():
         while not self._stop_event.is_set():
             current_line, updated_repos = self._task_tracker.status()
             if current_line != last_output:
-                truncated = f"{self._output_prefix} [{updated_repos}/{self._nb_repos}] ({current_line})"
+                truncated = (
+                    f"{self._output_prefix} [{updated_repos}/{self._nb_repos}] "
+                    f"({current_line})"
+                )
                 if len(truncated) > self._terminal_width:
                     ellipsis_marker = " ..."
                     truncated = (

--- a/utils/update_checkout/update_checkout/runner_arguments.py
+++ b/utils/update_checkout/update_checkout/runner_arguments.py
@@ -3,12 +3,14 @@ from typing import Any, Dict, List, Optional
 
 from .cli_arguments import CliArguments
 
+
 @dataclass
 class RunnerArguments:
     repo_name: str
     scheme_name: str
     output_prefix: str
     verbose: bool
+
 
 @dataclass
 class UpdateArguments(RunnerArguments):
@@ -21,6 +23,7 @@ class UpdateArguments(RunnerArguments):
     clean: bool
     stash: bool
     cross_repos_pr: Dict[str, str]
+
 
 @dataclass
 class AdditionalSwiftSourcesArguments(RunnerArguments):


### PR DESCRIPTION
This NFC patch is the result of running the black formatter on the `update_checkout` directory to fix the [`Python-Lint` bot](https://ci.swift.org/view/all/job/swift-PR-python-lint/).

This results in a large diff, however, I figured that since update-checkout is undergoing feature work, this is a good occasion to reformat all the files.