### PR TITLE
Define CALL_IMPL_SWIFT_REFCOUNT_CC when retain/release aren't overridden

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -186,6 +186,9 @@ static HeapObject *_swift_tryRetain_(HeapObject *object)
 #define CALL_IMPL(name, args) \
     return _ ## name ## _ args;
 
+#define CALL_IMPL_SWIFT_REFCOUNT_CC(name, args) \
+    return _ ## name ## _ args;
+
 #define CALL_IMPL_CHECK(name, args) \
     return _ ## name ## _ args;
 


### PR DESCRIPTION
This is currently missing when `SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE` is undefined, but it's called unconditionally, breaking Android :(