### PR TITLE
Windows: use derived SDK path when looking for resource dir

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -214,7 +214,8 @@ protected:
   /// Get the resource dir link path, which is platform-specific and found
   /// relative to the compiler.
   void getResourceDirPath(SmallVectorImpl<char> &runtimeLibPath,
-                          const llvm::opt::ArgList &args, bool shared) const;
+                          const llvm::opt::ArgList &args, bool shared,
+                          StringRef SDKPath) const;
 
   /// Get the secondary runtime library link path given the primary path.
   void getSecondaryResourceDirPath(

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -349,7 +349,8 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
   // Link compatibility libraries, if we're deploying back to OSes that
   // have an older Swift runtime.
   SmallString<128> SharedResourceDirPath;
-  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
+  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true,
+                     context.OI.SDKPath);
   std::optional<llvm::VersionTuple> runtimeCompatibilityVersion;
 
   if (context.Args.hasArg(options::OPT_runtime_compatibility_version)) {

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -232,7 +232,8 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   SmallString<128> SharedResourceDirPath;
   getResourceDirPath(SharedResourceDirPath, context.Args,
-                     /*Shared=*/!(staticExecutable || staticStdlib));
+                     /*Shared=*/!(staticExecutable || staticStdlib),
+                     context.OI.SDKPath);
 
   if (!context.Args.hasArg(options::OPT_nostartfiles)) {
     SmallString<128> swiftrtPath = SharedResourceDirPath;
@@ -294,7 +295,8 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   // if we're going that route, we'll set `linkFilePath` to the path to that
   // file.
   SmallString<128> linkFilePath;
-  getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false);
+  getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false,
+                     context.OI.SDKPath);
 
   if (staticExecutable) {
     llvm::sys::path::append(linkFilePath, "static-executable-args.lnk");

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -115,7 +115,8 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
                          /*Shared=*/false);
 
   SmallString<128> SharedResourceDirPath;
-  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/false);
+  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/false,
+                     context.OI.SDKPath);
 
   if (!context.Args.hasArg(options::OPT_nostartfiles)) {
     SmallString<128> swiftrtPath = SharedResourceDirPath;
@@ -152,7 +153,8 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   // if we're going that route, we'll set `linkFilePath` to the path to that
   // file.
   SmallString<128> linkFilePath;
-  getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false);
+  getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false,
+                     context.OI.SDKPath);
   llvm::sys::path::append(linkFilePath, "static-executable-args.lnk");
 
   auto linkFile = linkFilePath.str();

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -147,7 +147,8 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   if (!context.Args.hasArg(options::OPT_nostartfiles)) {
     SmallString<128> SharedResourceDirPath;
-    getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
+    getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true,
+                       context.OI.SDKPath);
 
     SmallString<128> swiftrtPath = SharedResourceDirPath;
     llvm::sys::path::append(swiftrtPath,


### PR DESCRIPTION
Setting `SDKROOT` is [documented](https://github.com/swiftlang/swift/blob/a6cae4acd6039ea2bf87d6b4d8ef9b05860f49a3/docs/WindowsToolchain.md?plain=1#L37) to set `-sdk` if it's not set separately, but `getResourceDirPath` uses the option directly instead of the derived value.

Unfortunately, fixing this requires some churn from changing the signature.