### PR TITLE
[Concurrency] Fix MarkerItem::create to use malloc when there's no task.

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -250,7 +250,12 @@ void TaskLocal::Storage::initializeLinkParent(AsyncTask* task,
 TaskLocal::MarkerItem *TaskLocal::MarkerItem::create(AsyncTask *task,
                                                      Item *next, Kind kind) {
   size_t amountToAllocate = sizeof(MarkerItem);
-  void *allocation = _swift_task_alloc_specific(task, amountToAllocate);
+  void *allocation;
+
+  // If we have a task, allocate from that task. If not, use malloc. This must
+  // mirror the corresponding dealloc/free call in Item::destroy.
+  if (task) allocation = _swift_task_alloc_specific(task, amountToAllocate);
+  else allocation = malloc(amountToAllocate);
   return new (allocation) MarkerItem(next, kind);
 }
 


### PR DESCRIPTION
Item::destroy will call free when there's no task, so the allocation needs to match, lest we free something that wasn't malloced and crash.

rdar://162589711