### PR TITLE
[SE-0491] Support module selectors in ParsedDeclNames

### DIFF
--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -41,11 +41,11 @@ class AccessNoteDeclName {
 public:
   /// The names of the parent/contextual declarations containing the declaration
   /// the access note should apply to.
-  std::vector<Identifier> parentNames;
+  std::vector<DeclNameRef> parentNames;
 
   /// The name of the declaration the access note should be applied to. (For
   /// accessors, this is actually the name of the storage it's attached to.)
-  DeclName name;
+  DeclNameRef name;
 
   /// For accessors, the kind of accessor; for non-accessors, \c None.
   std::optional<AccessorKind> accessorKind;

--- a/include/swift/Parse/ParseDeclName.h
+++ b/include/swift/Parse/ParseDeclName.h
@@ -76,6 +76,10 @@ struct ParsedDeclName {
   /// Form a declaration name from this parsed declaration name.
   DeclNameRef formDeclNameRef(ASTContext &ctx, bool isSubscript = false,
                               bool isCxxClassTemplateSpec = false) const;
+
+  /// Form a list of context names from this parsed declaration name.
+  void formContextNames(ASTContext &ctx,
+                        llvm::SmallVectorImpl<DeclNameRef> &out);
 };
 
 /// Parse a stringified Swift declaration name,
@@ -89,7 +93,8 @@ DeclName formDeclName(ASTContext &ctx, StringRef baseName,
                       bool isCxxClassTemplateSpec = false);
 
 /// Form a Swift declaration name reference from its constituent parts.
-DeclNameRef formDeclNameRef(ASTContext &ctx, StringRef baseName,
+DeclNameRef formDeclNameRef(ASTContext &ctx,
+                            StringRef moduleSelectorAndBaseName,
                             ArrayRef<StringRef> argumentLabels,
                             bool isFunctionName, bool isInitializer,
                             bool isSubscript = false,


### PR DESCRIPTION
Some constructs that use a `ParsedDeclName`, like `@available(renamed:)`, ought to support module selectors. Add this support.

Draft: Need to re-assess support in access notes, add tests.
