### PR TITLE
[Runtime] Temporarily remove swift_release_preservemost_weak_placeholder.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -86,14 +86,6 @@ asm(R"(
   .set _swift_retain_preservemost, _swift_retain
   .globl _swift_release_preservemost
   .set _swift_release_preservemost, _swift_release
-
-// A weak definition can only be overridden by a strong definition if the
-// library with the strong definition contains at least one weak definition.
-// Create a placeholder weak definition here to allow that to work.
-  .weak_definition _swift_release_preservemost_weak_placeholder
-  .globl _swift_release_preservemost_weak_placeholder
-  _swift_release_preservemost_weak_placeholder:
-    .byte 0
 )");
 #endif
 #endif


### PR DESCRIPTION
This is breaking embedded due to its use of weak definitions for embedded versions of the runtime functions. The presence of a weak export in libswiftCore allows any strong symbol in libswiftCore to override a weak symbol elsewhere. Remove while we work out how to reconcile the two.

rdar://163578646