### PR TITLE
[CSApply] NFC: Simplify solution application to `try` expressions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3752,26 +3752,12 @@ namespace {
       return expr;
     }
 
-    Expr *visitTryExpr(TryExpr *expr) {
-      return simplifyExprType(expr);
-    }
+    Expr *visitAnyTryExpr(AnyTryExpr *expr) {
+      simplifyExprType(expr);
 
-    Expr *visitForceTryExpr(ForceTryExpr *expr) {
       auto *subExpr = expr->getSubExpr();
-      auto type = simplifyType(cs.getType(subExpr));
-
-      // Let's load the value associated with this try.
-      if (type->hasLValueType()) {
-        subExpr = coerceToType(subExpr, type->getRValueType(),
-                               cs.getConstraintLocator(subExpr));
-
-        if (!subExpr)
-          return nullptr;
-      }
-
-      cs.setType(expr, cs.getType(subExpr));
-      expr->setSubExpr(subExpr);
-
+      expr->setSubExpr(coerceToType(subExpr, cs.getType(expr),
+                                    cs.getConstraintLocator(subExpr)));
       return expr;
     }
 


### PR DESCRIPTION
Since `try!` now forces l-value -> r-value conversion during CSGen, let's simplify solution application to `try` expressions by coercing sub-expression to a type of a `try` itself which would introduce all necessary loads.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
