### PR TITLE
Platform: correct `posix_spawn` API nullability

### DIFF
--- a/stdlib/public/Platform/spawn.apinotes
+++ b/stdlib/public/Platform/spawn.apinotes
@@ -11,3 +11,7 @@ Functions:
     Type: "const posix_spawn_file_actions_t _Nonnull * _Nullable"
   - Position: 3
     Type: "const posix_spawnattr_t _Nonnull * _Nullable"
+- Name: posix_spawn_file_actions_init
+  Parameters:
+  - Position: 0
+    Type: "posix_spawn_file_actions_t _Nullable * _Nonnull"

--- a/stdlib/public/Platform/spawn.apinotes
+++ b/stdlib/public/Platform/spawn.apinotes
@@ -5,3 +5,9 @@ Functions:
   Parameters:
   - Position: 0
     Type: "posix_spawnattr_t _Nullable * _Nonnull"
+- Name: posix_spawn
+  Parameters:
+  - Position: 2
+    Type: "const posix_spawn_file_actions_t _Nonnull * _Nullable"
+  - Position: 3
+    Type: "const posix_spawnattr_t _Nonnull * _Nullable"


### PR DESCRIPTION
The `posix_spawn` API is not annotated appropriately for nullability. Adjust the signature to allow proper usage with older NDKs.