### PR TITLE
[concurrency] Create builtins for invoking specific concurrency runtime functions.

### DIFF
--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -52,13 +52,14 @@ enum SingletonTypeSynthesizer {
   _rawUnsafeContinuation,
   _void,
   _word,
-  _swiftInt,       // Swift.Int
-  _serialExecutor, // the '_Concurrency.SerialExecutor' protocol
-  _taskExecutor,   // the '_Concurrency.TaskExecutor' protocol
-  _actor,          // the '_Concurrency.Actor' protocol
-  _distributedActor,  // the 'Distributed.DistributedActor' protocol
+  _swiftInt,               // Swift.Int
+  _serialExecutor,         // the '_Concurrency.SerialExecutor' protocol
+  _taskExecutor,           // the '_Concurrency.TaskExecutor' protocol
+  _actor,                  // the '_Concurrency.Actor' protocol
+  _distributedActor,       // the 'Distributed.DistributedActor' protocol
   _unsafeRawBufferPointer, // UnsafeRawBufferPointer
-  _unconstrainedAny, // any ~Copyable & ~Escapable
+  _unconstrainedAny,       // any ~Copyable & ~Escapable
+  _unsafeRawPointer,       // UnsafeRawPointer
 };
 inline Type synthesizeType(SynthesisContext &SC,
                            SingletonTypeSynthesizer kind) {
@@ -93,6 +94,8 @@ inline Type synthesizeType(SynthesisContext &SC,
       ->getDeclaredInterfaceType();
   case _unsafeRawBufferPointer:
     return SC.Context.getUnsafeRawBufferPointerType();
+  case _unsafeRawPointer:
+    return SC.Context.getUnsafeRawPointerType();
   case _copyable:
     return SC.Context.getProtocol(KnownProtocolKind::Copyable)
         ->getDeclaredInterfaceType();

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1174,6 +1174,42 @@ BUILTIN_TYPE_CHECKER_OPERATION(TriggerFallbackDiagnostic, trigger_fallback_diagn
 /// Maybe.
 BUILTIN_TYPE_TRAIT_OPERATION(CanBeObjCClass, canBeClass)
 
+/// Equivalent to calling swift_task_addCancellationHandler.
+///
+/// Signature: (handler: () -> Void) -> UnsafeRawPointer
+BUILTIN_MISC_OPERATION_WITH_SILGEN(TaskAddCancellationHandler,
+                                  "taskAddCancellationHandler", "",
+                                   Special)
+
+/// Equivalent to calling swift_task_removeCancellationHandler.
+///
+/// Signature: (record: UnsafeRawPointer) -> ()
+BUILTIN_MISC_OPERATION(TaskRemoveCancellationHandler,
+                       "taskRemoveCancellationHandler", "", Special)
+
+/// Equivalent to calling swift_task_addPriorityEscalationHandler.
+///
+/// Signature: (handler: (UInt8, UInt8) -> Void) -> UnsafeRawPointer
+BUILTIN_MISC_OPERATION_WITH_SILGEN(TaskAddPriorityEscalationHandler,
+                                   "taskAddPriorityEscalationHandler", "",
+                                   Special)
+
+/// Equivalent to calling swift_task_removePriorityEscalationHandler.
+///
+/// Signature: (record: UnsafeRawPointer) -> ()
+BUILTIN_MISC_OPERATION(TaskRemovePriorityEscalationHandler,
+                       "taskRemovePriorityEscalationHandler", "", Special)
+
+/// Equivalent to calling swift_task_localValuePush.
+///
+/// Signature: <Value> (key: Builtin.RawPointer, value: __owned Value) -> ()
+BUILTIN_MISC_OPERATION(TaskLocalValuePush, "taskLocalValuePush", "", Special)
+
+/// Equivalent to calling swift_task_localValuePop.
+///
+/// Signature: () -> ()
+BUILTIN_MISC_OPERATION(TaskLocalValuePop, "taskLocalValuePop", "", Special)
+
 #undef BUILTIN_TYPE_TRAIT_OPERATION
 #undef BUILTIN_UNARY_OPERATION
 #undef BUILTIN_BINARY_PREDICATE

--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -107,10 +107,21 @@ getLLVMIntrinsicIDForBuiltinWithOverflow(BuiltinValueKind ID);
 ///
 /// Returns null if the name does not identifier a known builtin value.
 ValueDecl *getBuiltinValueDecl(ASTContext &Context, Identifier Name);
-  
+
+/// Overload that takes a StringRef instead of an Identifier. We convert it to
+/// an identifier internally.
+ValueDecl *getBuiltinValueDecl(ASTContext &Context, StringRef Name);
+
 /// Returns the name of a builtin declaration given a builtin ID.
 StringRef getBuiltinName(BuiltinValueKind ID);
-  
+
+/// Namespace containing constexpr StringLiterals of BuiltinNames so that
+/// builtin names can be referred to without using raw string literals.
+namespace BuiltinNames {
+#define BUILTIN(Id, Name, Attrs) constexpr StringLiteral Id = Name;
+#include "swift/AST/Builtins.def"
+} // namespace BuiltinNames
+
 /// The information identifying the builtin - its kind and types.
 class BuiltinInfo {
 public:

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2660,6 +2660,72 @@ FUNCTION(TaskGroupDestroy,
          EFFECT(RuntimeEffect::Concurrency),
          UNKNOWN_MEMEFFECTS)
 
+// CancellationNotificationStatusRecord*
+// swift_task_addCancellationHandler(
+//     CancellationNotificationStatusRecord::FunctionType handler,
+//     void *context);
+FUNCTION(TaskAddCancellationHandler,
+        _Concurrency, swift_task_addCancellationHandler, SwiftCC,
+        ConcurrencyAvailability,
+        RETURNS(Int8PtrTy),
+        ARGS(Int8PtrTy, Int8PtrTy),
+        ATTRS(NoUnwind),
+        EFFECT(RuntimeEffect::Concurrency),
+        UNKNOWN_MEMEFFECTS)
+
+// void swift_task_removeCancellationHandler(
+//   CancellationNotificationStatusRecord *record);
+FUNCTION(TaskRemoveCancellationHandler,
+         _Concurrency, swift_task_removeCancellationHandler, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// EscalationNotificationStatusRecord*
+// swift_task_addPriorityEscalationHandler(
+//     EscalationNotificationStatusRecord::FunctionType handler,
+//     void *context);
+FUNCTION(TaskAddPriorityEscalationHandler,
+        _Concurrency, swift_task_addPriorityEscalationHandler, SwiftCC,
+        ConcurrencyAvailability,
+        RETURNS(Int8PtrTy),
+        ARGS(Int8PtrTy, Int8PtrTy),
+        ATTRS(NoUnwind),
+        EFFECT(RuntimeEffect::Concurrency),
+        UNKNOWN_MEMEFFECTS)
+
+// void swift_task_removePriorityEscalationHandler(
+//   EscalationNotificationStatusRecord *record);
+FUNCTION(TaskRemovePriorityEscalationHandler,
+         _Concurrency, swift_task_removePriorityEscalationHandler, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_task_localValuePush(const HeapObject *key,
+//                                /* +1 */ OpaqueValue *value,
+//                                const Metadata *valueType);
+FUNCTION(TaskLocalValuePush, _Concurrency, swift_task_localValuePush, SwiftCC,
+         ConcurrencyAvailability, RETURNS(),
+         ARGS(RefCountedPtrTy, OpaquePtrTy, TypeMetadataPtrTy), ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency), UNKNOWN_MEMEFFECTS)
+
+// void swift_task_localValuePop();
+FUNCTION(TaskLocalValuePop,
+         _Concurrency, swift_task_localValuePop, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(),
+         ARGS(),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
 // AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContextWithType(const Metadata *);
 FUNCTION(AutoDiffCreateLinearMapContextWithType,
          Swift, swift_autoDiffCreateLinearMapContextWithType, SwiftCC,

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -295,6 +295,7 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) {
         case BuiltinValueKind::AddressOfRawLayout:
         case BuiltinValueKind::FlowSensitiveSelfIsolation:
         case BuiltinValueKind::FlowSensitiveDistributedSelfIsolation:
+        case BuiltinValueKind::TaskLocalValuePush:
           callVisitUse(op);
           continue;
         default:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -611,6 +611,12 @@ public:
                                       Subs, Args, getInstructionContext()));
   }
 
+  BuiltinInst *createBuiltin(SILLocation Loc, StringRef Name, SILType ResultTy,
+                             SubstitutionMap Subs, ArrayRef<SILValue> Args) {
+    return createBuiltin(Loc, getASTContext().getIdentifier(Name), ResultTy,
+                         Subs, Args);
+  }
+
   /// Create a binary function with the signature: OpdTy, OpdTy -> ResultTy.
   BuiltinInst *createBuiltinBinaryFunction(SILLocation Loc, StringRef Name,
                                            SILType OpdTy, SILType ResultTy,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -1067,6 +1067,9 @@ public:
   /// Return Builtin.ImplicitActor.
   static SILType getBuiltinImplicitActorType(const ASTContext &ctx);
 
+  /// Return UnsafeRawPointer.
+  static SILType getUnsafeRawPointer(const ASTContext &ctx);
+
   //
   // Utilities for treating SILType as a pointer-like type.
   //

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -3813,3 +3813,7 @@ BuiltinFixedArrayType::isFixedNegativeSize() const {
   }
   return false;
 }
+
+ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, StringRef Name) {
+  return getBuiltinValueDecl(Context, Context.getIdentifier(Name));
+}

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2364,6 +2364,52 @@ static ValueDecl *getEmplace(ASTContext &ctx, Identifier id) {
   return builder.build(id);
 }
 
+static ValueDecl *getTaskAddCancellationHandler(ASTContext &ctx,
+                                                Identifier id) {
+  auto extInfo = ASTExtInfoBuilder().withNoEscape().build();
+  auto fnType = FunctionType::get({}, ctx.TheEmptyTupleType, extInfo);
+  return getBuiltinFunction(ctx, id, _thin,
+                            _parameters(_label("handler", fnType)),
+                            _unsafeRawPointer);
+}
+
+static ValueDecl *getTaskRemoveCancellationHandler(ASTContext &ctx,
+                                                   Identifier id) {
+  return getBuiltinFunction(
+      ctx, id, _thin, _parameters(_label("record", _unsafeRawPointer)), _void);
+}
+
+static ValueDecl *getTaskAddPriorityEscalationHandler(ASTContext &ctx,
+                                                      Identifier id) {
+  std::array<AnyFunctionType::Param, 2> params = {
+      AnyFunctionType::Param(ctx.getUInt8Type()),
+      AnyFunctionType::Param(ctx.getUInt8Type()),
+  };
+  // (UInt8, UInt8) -> ()
+  auto extInfo = ASTExtInfoBuilder().withNoEscape().build();
+  auto *functionType =
+      FunctionType::get(params, ctx.TheEmptyTupleType, extInfo);
+  return getBuiltinFunction(ctx, id, _thin,
+                            _parameters(_label("handler", functionType)),
+                            _unsafeRawPointer);
+}
+
+static ValueDecl *getTaskRemovePriorityEscalationHandler(ASTContext &ctx,
+                                                         Identifier id) {
+  return getBuiltinFunction(
+      ctx, id, _thin, _parameters(_label("record", _unsafeRawPointer)), _void);
+}
+
+static ValueDecl *getTaskLocalValuePush(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _generics(_unrestricted),
+                            _parameters(_rawPointer, _consuming(_typeparam(0))),
+                            _void);
+}
+
+static ValueDecl *getTaskLocalValuePop(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _parameters(), _void);
+}
+
 /// An array of the overloaded builtin kinds.
 static const OverloadedBuiltinKind OverloadedBuiltinKinds[] = {
   OverloadedBuiltinKind::None,
@@ -3450,6 +3496,24 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     
   case BuiltinValueKind::Emplace:
     return getEmplace(Context, Id);
+
+  case BuiltinValueKind::TaskAddCancellationHandler:
+    return getTaskAddCancellationHandler(Context, Id);
+
+  case BuiltinValueKind::TaskRemoveCancellationHandler:
+    return getTaskRemoveCancellationHandler(Context, Id);
+
+  case BuiltinValueKind::TaskAddPriorityEscalationHandler:
+    return getTaskAddPriorityEscalationHandler(Context, Id);
+
+  case BuiltinValueKind::TaskRemovePriorityEscalationHandler:
+    return getTaskRemovePriorityEscalationHandler(Context, Id);
+
+  case BuiltinValueKind::TaskLocalValuePush:
+    return getTaskLocalValuePush(Context, Id);
+
+  case BuiltinValueKind::TaskLocalValuePop:
+    return getTaskLocalValuePop(Context, Id);
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1565,6 +1565,29 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
+  case BuiltinValueKind::TaskRemovePriorityEscalationHandler:
+  case BuiltinValueKind::TaskRemoveCancellationHandler: {
+    auto rawPointer = args.claimNext();
+    emitBuiltinTaskRemoveHandler(IGF, Builtin.ID, rawPointer);
+    return;
+  }
+  case BuiltinValueKind::TaskAddCancellationHandler:
+  case BuiltinValueKind::TaskAddPriorityEscalationHandler: {
+    auto func = args.claimNext();
+    auto context = args.claimNext();
+    out.add(emitBuiltinTaskAddHandler(IGF, Builtin.ID, func, context));
+    return;
+  }
+  case BuiltinValueKind::TaskLocalValuePop:
+    return emitBuiltinTaskLocalValuePop(IGF);
+  case BuiltinValueKind::TaskLocalValuePush: {
+    auto *key = args.claimNext();
+    auto *value = args.claimNext();
+    // Grab T from the builtin.
+    auto *valueMetatype = IGF.emitTypeMetadataRef(argTypes[1].getASTType());
+    return emitBuiltinTaskLocalValuePush(IGF, key, value, valueMetatype);
+  }
+
   // Builtins without IRGen implementations.
   case BuiltinValueKind::None:
   case BuiltinValueKind::CondFailMessage:

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -115,6 +115,29 @@ emitTaskCreate(IRGenFunction &IGF, llvm::Value *flags,
 llvm::Value *clearImplicitIsolatedActorBits(IRGenFunction &IGF,
                                             llvm::Value *value);
 
+/// Emit IR for a builtin that adds a handler to the Task's task record.
+///
+/// \returns the record that can be used to refer to and cancel the handler.
+///
+/// Currently supports TaskAddCancellationHandler and
+/// TaskAddPriorityEscalationHandler.
+llvm::Value *emitBuiltinTaskAddHandler(IRGenFunction &IGF,
+                                       BuiltinValueKind kind, llvm::Value *func,
+                                       llvm::Value *context);
+
+/// Emit IR for a builtin that cancels some sort of handler by calling an ABI
+/// entry point. Record is a value that was returned by the handler creator.
+///
+/// E.x.: TaskRemoveCancellationHandler, TaskRemovePriorityEscalationHandler.
+void emitBuiltinTaskRemoveHandler(IRGenFunction &IGF, BuiltinValueKind kind,
+                                  llvm::Value *record);
+
+void emitBuiltinTaskLocalValuePush(IRGenFunction &IGF, llvm::Value *key,
+                                   llvm::Value *value,
+                                   llvm::Value *valueMetatype);
+
+void emitBuiltinTaskLocalValuePop(IRGenFunction &IGF);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1052,6 +1052,19 @@ BUILTIN_OPERAND_OWNERSHIP(BitwiseEscape, BuildDefaultActorExecutorRef)
 BUILTIN_OPERAND_OWNERSHIP(BitwiseEscape, BuildMainActorExecutorRef)
 
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, AutoDiffCreateLinearMapContextWithType)
+
+// InstantaneousUse since we take in a closure at +0.
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TaskAddCancellationHandler)
+// Trivial use since our operand is just an UnsafeRawPointer.
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemoveCancellationHandler)
+// InstantaneousUse since we take in a closure at +0.
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TaskAddPriorityEscalationHandler)
+// Trivial use since our operand is just an UnsafeRawPointer.
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemovePriorityEscalationHandler)
+// This is a trivial use since our first operand is a Builtin.RawPointer and our
+// second is an address to our generic Value.
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
+
 #undef BUILTIN_OPERAND_OWNERSHIP
 
 #define SHOULD_NEVER_VISIT_BUILTIN(ID)                                         \
@@ -1062,6 +1075,7 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, AutoDiffCreateLinearMapContextWithType)
   }
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentAsyncTask)
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentExecutor)
+SHOULD_NEVER_VISIT_BUILTIN(TaskLocalValuePop)
 #undef SHOULD_NEVER_VISIT_BUILTIN
 
 // Builtins that should be lowered to SIL instructions so we should never see

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -136,6 +136,11 @@ SILType SILType::getBuiltinImplicitActorType(const ASTContext &ctx) {
   return getPrimitiveObjectType(ctx.TheImplicitActorType->getCanonicalType());
 }
 
+SILType SILType::getUnsafeRawPointer(const ASTContext &ctx) {
+  return getPrimitiveObjectType(
+      ctx.getUnsafeRawPointerType()->getCanonicalType());
+}
+
 bool SILType::isTrivial(const SILFunction &F) const {
   auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
   

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -664,6 +664,13 @@ CONSTANT_OWNERSHIP_BUILTIN(Owned, DistributedActorAsAnyActor)
 CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, ExtractFunctionIsolation) // unreachable
 CONSTANT_OWNERSHIP_BUILTIN(None, AddressOfRawLayout)
 
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskAddCancellationHandler)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskRemoveCancellationHandler)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskAddPriorityEscalationHandler)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskRemovePriorityEscalationHandler)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePush)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePop)
+
 #undef CONSTANT_OWNERSHIP_BUILTIN
 
 // Check all of these...

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2182,6 +2182,26 @@ static ManagedValue emitBuiltinEmplace(SILGenFunction &SGF,
   return SGF.B.createLoadTake(loc, result);
 }
 
+static ManagedValue emitBuiltinTaskAddCancellationHandler(
+    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
+    ArrayRef<ManagedValue> args, SGFContext C) {
+  auto *b =
+      SGF.B.createBuiltin(loc, BuiltinNames::TaskAddCancellationHandler,
+                          SILType::getUnsafeRawPointer(SGF.getASTContext()),
+                          subs, {args[0].getValue()});
+  return ManagedValue::forRValueWithoutOwnership(b);
+}
+
+static ManagedValue emitBuiltinTaskAddPriorityEscalationHandler(
+    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
+    ArrayRef<ManagedValue> args, SGFContext C) {
+  auto *b =
+      SGF.B.createBuiltin(loc, BuiltinNames::TaskAddPriorityEscalationHandler,
+                          SILType::getUnsafeRawPointer(SGF.getASTContext()),
+                          subs, {args[0].getValue()});
+  return ManagedValue::forRValueWithoutOwnership(b);
+}
+
 std::optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -507,11 +507,9 @@ static ManagedValue emitBuiltinAddressOfBorrowBuiltins(SILGenFunction &SGF,
     auto borrow = SGF.emitRValue(argument, SGFContext::AllowGuaranteedPlusZero)
        .getAsSingleValue(SGF, argument);
     if (!SGF.F.getConventions().useLoweredAddresses()) {
-      auto &context = SGF.getASTContext();
-      auto identifier =
-          stackProtected
-              ? context.getIdentifier("addressOfBorrowOpaque")
-              : context.getIdentifier("unprotectedAddressOfBorrowOpaque");
+      auto identifier = stackProtected
+                            ? BuiltinNames::AddressOfBorrowOpaque
+                            : BuiltinNames::UnprotectedAddressOfBorrowOpaque;
       auto builtin = SGF.B.createBuiltin(loc, identifier, rawPointerType,
                                          substitutions, {borrow.getValue()});
       return ManagedValue::forObjectRValueWithoutOwnership(builtin);
@@ -1173,8 +1171,7 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
   case TypeTraitResult::CanBe: {
     auto &C = SGF.getASTContext();
     auto int8Ty = BuiltinIntegerType::get(8, C)->getCanonicalType();
-    auto apply = SGF.B.createBuiltin(loc,
-                                     C.getIdentifier(getBuiltinName(Kind)),
+    auto apply = SGF.B.createBuiltin(loc, getBuiltinName(Kind),
                                      SILType::getPrimitiveObjectType(int8Ty),
                                      substitutions, args[0].getValue());
 
@@ -1357,8 +1354,7 @@ emitBuiltinGlobalStringTablePointer(SILGenFunction &SGF, SILLocation loc,
 
   SILValue argValue = args[0].getValue();
   auto &astContext = SGF.getASTContext();
-  Identifier builtinId = astContext.getIdentifier(
-      getBuiltinName(BuiltinValueKind::GlobalStringTablePointer));
+  auto builtinId = BuiltinNames::GlobalStringTablePointer;
 
   auto resultVal = SGF.B.createBuiltin(loc, builtinId,
                                        SILType::getRawPointerType(astContext),
@@ -1479,10 +1475,9 @@ static ManagedValue emitBuiltinGetCurrentAsyncTask(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
-  auto apply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetCurrentAsyncTask)),
-      SGF.getLoweredType(ctx.TheNativeObjectType), SubstitutionMap(), { });
+  auto apply = SGF.B.createBuiltin(loc, BuiltinNames::GetCurrentAsyncTask,
+                                   SGF.getLoweredType(ctx.TheNativeObjectType),
+                                   SubstitutionMap(), {});
   return SGF.emitManagedRValueWithEndLifetimeCleanup(apply);
 }
 
@@ -1517,24 +1512,21 @@ static ManagedValue emitBuiltinSizeof(
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Sizeof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Sizeof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinStrideof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Strideof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Strideof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinAlignof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Alignof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Alignof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 
 enum class CreateTaskOptions {
@@ -1697,8 +1689,7 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
     functionValue.forward(SGF)
   };
 
-  auto builtinID =
-    ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateAsyncTask));
+  auto builtinID = BuiltinNames::CreateAsyncTask;
   auto resultTy = SGF.getLoweredType(getAsyncTaskAndContextType(ctx));
 
   auto apply = SGF.B.createBuiltin(loc, builtinID, resultTy, subs, builtinArgs);
@@ -1780,9 +1771,8 @@ static ManagedValue emitBuiltinCreateTaskGroup(SILGenFunction &SGF,
                                                SGFContext C) {
   auto &ctx = SGF.getASTContext();
   auto resultType = SILType::getRawPointerType(ctx);
-  auto value = SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateTaskGroup)),
-      resultType, subs, {});
+  auto value = SGF.B.createBuiltin(loc, BuiltinNames::CreateTaskGroup,
+                                   resultType, subs, {});
   return ManagedValue::forObjectRValueWithoutOwnership(value);
 }
 
@@ -1794,11 +1784,8 @@ static ManagedValue emitBuiltinCreateTaskGroupWithFlags(
     ArrayRef<ManagedValue> args, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   auto resultType = SILType::getRawPointerType(ctx);
-  auto value = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::CreateTaskGroupWithFlags)),
-      resultType, subs, {args[0].getValue()});
+  auto value = SGF.B.createBuiltin(loc, BuiltinNames::CreateTaskGroupWithFlags,
+                                   resultType, subs, {args[0].getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(value);
 }
 
@@ -1926,9 +1913,7 @@ static ManagedValue emitBuiltinAutoDiffCreateLinearMapContextWithType(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(getBuiltinName(
-          BuiltinValueKind::AutoDiffCreateLinearMapContextWithType)),
+      loc, BuiltinNames::AutoDiffCreateLinearMapContextWithType,
       SILType::getNativeObjectType(ctx), subs,
       /*args*/ {args[0].getValue()});
   return SGF.emitManagedRValueWithCleanup(builtinApply);
@@ -1938,13 +1923,10 @@ static ManagedValue emitBuiltinAutoDiffProjectTopLevelSubcontext(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
-  auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::AutoDiffProjectTopLevelSubcontext)),
-      SILType::getRawPointerType(ctx),
-      subs,
-      /*args*/ {args[0].borrow(SGF, loc).getValue()});
+  auto *builtinApply =
+      SGF.B.createBuiltin(loc, BuiltinNames::AutoDiffProjectTopLevelSubcontext,
+                          SILType::getRawPointerType(ctx), subs,
+                          /*args*/ {args[0].borrow(SGF, loc).getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
 }
 
@@ -1953,9 +1935,7 @@ static ManagedValue emitBuiltinAutoDiffAllocateSubcontextWithType(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::AutoDiffAllocateSubcontextWithType)),
+      loc, BuiltinNames::AutoDiffAllocateSubcontextWithType,
       SILType::getRawPointerType(ctx), subs,
       /*args*/ {args[0].borrow(SGF, loc).getValue(), args[1].getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
@@ -2034,10 +2014,9 @@ static ManagedValue emitBuiltinGetEnumTag(SILGenFunction &SGF, SILLocation loc,
                                           SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetEnumTag)),
-    SILType::getBuiltinIntegerType(32, ctx), subs,
-    { args[0].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::GetEnumTag,
+                                SILType::getBuiltinIntegerType(32, ctx), subs,
+                                {args[0].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2048,10 +2027,9 @@ static ManagedValue emitBuiltinInjectEnumTag(SILGenFunction &SGF, SILLocation lo
                                              SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::InjectEnumTag)),
-    SILType::getEmptyTupleType(ctx), subs,
-    { args[0].getValue(), args[1].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::InjectEnumTag,
+                                SILType::getEmptyTupleType(ctx), subs,
+                                {args[0].getValue(), args[1].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2081,10 +2059,9 @@ static ManagedValue emitBuiltinAddressOfRawLayout(SILGenFunction &SGF,
                                                   SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::AddressOfRawLayout)),
-    SILType::getRawPointerType(ctx), subs,
-    { args[0].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::AddressOfRawLayout,
+                                SILType::getRawPointerType(ctx), subs,
+                                {args[0].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2141,7 +2118,7 @@ static ManagedValue emitBuiltinEmplace(SILGenFunction &SGF,
   
   // Mark the buffer as initializedto communicate to DI that the memory
   // is considered initialized from this point.
-  auto markInit = getBuiltinValueDecl(Ctx, Ctx.getIdentifier("prepareInitialization"));
+  auto markInit = getBuiltinValueDecl(Ctx, BuiltinNames::PrepareInitialization);
   SGF.B.createBuiltin(loc, markInit->getBaseIdentifier(),
                        SILType::getEmptyTupleType(Ctx),
                        SubstitutionMap(),

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -214,6 +214,12 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::AddressOfBorrowOpaque:
     case BuiltinValueKind::UnprotectedAddressOfBorrowOpaque:
     case BuiltinValueKind::DistributedActorAsAnyActor:
+    case BuiltinValueKind::TaskAddCancellationHandler:
+    case BuiltinValueKind::TaskRemoveCancellationHandler:
+    case BuiltinValueKind::TaskAddPriorityEscalationHandler:
+    case BuiltinValueKind::TaskRemovePriorityEscalationHandler:
+    case BuiltinValueKind::TaskLocalValuePush:
+    case BuiltinValueKind::TaskLocalValuePop:
       return true;
     }
   }

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -125,8 +125,11 @@ func __withTaskPriorityEscalationHandler0<T, E>(
   onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void,
   isolation: isolated (any Actor)? = #isolation
 ) async throws(E) -> T {
-  let record = unsafe _taskAddPriorityEscalationHandler(handler: handler0)
-  defer { unsafe _taskRemovePriorityEscalationHandler(record: record) }
+  let record =
+    unsafe Builtin.taskAddPriorityEscalationHandler(handler: handler0)
+  defer {
+    unsafe Builtin.taskRemovePriorityEscalationHandler(record: record)
+  }
 
   return try await operation()
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -829,20 +829,6 @@ func _enqueueJobGlobalWithDeadline(_ seconds: Int64, _ nanoseconds: Int64,
                                    _ toleranceSec: Int64, _ toleranceNSec: Int64,
                                    _ clock: Int32, _ task: UnownedJob)
 
-@usableFromInline
-@available(SwiftStdlib 6.2, *)
-@_silgen_name("swift_task_addPriorityEscalationHandler")
-func _taskAddPriorityEscalationHandler(
-  handler: (UInt8, UInt8) -> Void
-) -> UnsafeRawPointer /*EscalationNotificationStatusRecord*/
-
-@usableFromInline
-@available(SwiftStdlib 6.2, *)
-@_silgen_name("swift_task_removePriorityEscalationHandler")
-func _taskRemovePriorityEscalationHandler(
-  record: UnsafeRawPointer /*EscalationNotificationStatusRecord*/
-)
-
 @available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_asyncMainDrainQueue")

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -84,8 +84,8 @@ public func withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = unsafe _taskAddCancellationHandler(handler: handler)
-  defer { unsafe _taskRemoveCancellationHandler(record: record) }
+  let record = unsafe Builtin.taskAddCancellationHandler(handler: handler)
+  defer { unsafe Builtin.taskRemoveCancellationHandler(record: record) }
 
   return try await operation()
 }
@@ -105,8 +105,8 @@ public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = unsafe _taskAddCancellationHandler(handler: handler)
-  defer { unsafe _taskRemoveCancellationHandler(record: record) }
+  let record = unsafe Builtin.taskAddCancellationHandler(handler: handler)
+  defer { unsafe Builtin.taskRemoveCancellationHandler(record: record) }
 
   return try await operation()
 }
@@ -163,15 +163,3 @@ public struct CancellationError: Error {
   // no extra information, cancellation is intended to be light-weight
   public init() {}
 }
-
-@usableFromInline
-@available(SwiftStdlib 5.1, *)
-@_silgen_name("swift_task_addCancellationHandler")
-func _taskAddCancellationHandler(handler: () -> Void) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
-
-@usableFromInline
-@available(SwiftStdlib 5.1, *)
-@_silgen_name("swift_task_removeCancellationHandler")
-func _taskRemoveCancellationHandler(
-  record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/
-)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -235,22 +235,22 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 
   /// Implementation for withValue that consumes valueDuringOperation.
   ///
-  /// Because _taskLocalValuePush and _taskLocalValuePop involve calls to
-  /// swift_task_alloc/swift_task_dealloc respectively unbeknownst to the
-  /// compiler, compiler-emitted calls to swift_task_de/alloc must be avoided
-  /// in a function that calls them.
+  /// Because Builtin.taskLocalValuePush and Builtin.taskLocalValuePop involve
+  /// calls to swift_task_alloc/swift_task_dealloc respectively unbeknownst to
+  /// the compiler, compiler-emitted calls to swift_task_de/alloc must be
+  /// avoided in a function that calls them.
   ///
   /// A copy of valueDuringOperation is required because withValue borrows its
-  /// argument but _taskLocalValuePush consumes its.  Because
+  /// argument but Builtin.taskLocalValuePush consumes its.  Because
   /// valueDuringOperation is of generic type, its size is not generally known,
   /// so such a copy entails a stack allocation and a copy to that allocation.
   /// That stack traffic gets lowered to calls to
   /// swift_task_alloc/swift_task_deallloc.
   ///
-  /// Split the calls _taskLocalValuePush/Pop from the compiler-emitted calls
+  /// Split the calls Builtin.taskLocalValuePush/Pop from the compiler-emitted calls
   /// to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
-  /// - withValueImpl contains the calls to _taskLocalValuePush/Pop
+  /// - withValueImpl contains the calls to Builtin.taskLocalValuePush/Pop
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
@@ -259,8 +259,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
                                  operation: () async throws -> R,
                                  isolation: isolated (any Actor)?,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
-    defer { _taskLocalValuePop() }
+    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
+    defer { Builtin.taskLocalValuePop() }
 
     return try await operation()
   }
@@ -275,8 +275,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     operation: () async throws -> R,
     file: String = #fileID, line: UInt = #line
   ) async rethrows -> R {
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
-    defer { _taskLocalValuePop() }
+    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
+    defer { Builtin.taskLocalValuePop() }
 
     return try await operation()
   }
@@ -299,8 +299,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #fileID, line: UInt = #line) rethrows -> R {
-    _taskLocalValuePush(key: key, value: valueDuringOperation)
-    defer { _taskLocalValuePop() }
+    Builtin.taskLocalValuePush(key, valueDuringOperation)
+    defer { Builtin.taskLocalValuePop() }
 
     return try operation()
   }
@@ -343,19 +343,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 }
 
 // ==== ------------------------------------------------------------------------
-
-@available(SwiftStdlib 5.1, *)
-@usableFromInline
-@_silgen_name("swift_task_localValuePush")
-func _taskLocalValuePush<Value>(
-  key: Builtin.RawPointer/*: Key*/,
-  value: __owned Value
-) // where Key: TaskLocal
-
-@available(SwiftStdlib 5.1, *)
-@usableFromInline
-@_silgen_name("swift_task_localValuePop")
-func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_localValueGet")

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -928,4 +928,63 @@ func allocateVector<Element>(elementType: Element.Type, capacity: Builtin.Word) 
   return Builtin.allocVector(elementType, capacity)
 }
 
+// CHECK-LABEL: define{{.*}} void @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU_", ptr null)
+// CHECK: [[CONTEXT:%.*]] = call{{.*}} @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata, i32 0, i32 2), i64 32, i64 7)
+// CHECK: [[RESULT_2:%.*]] = call {{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU0_TA", ptr [[CONTEXT]])
+// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{.*}}, ptr [[RESULT]], ptr [[RESULT_2]])
+nonisolated(nonsending) func testTaskAddCancellationHandler() async -> (UnsafeRawPointer, UnsafeRawPointer) {
+  let result = Builtin.taskAddCancellationHandler {}
+  let x = "123" 
+  let result2 = Builtin.taskAddCancellationHandler {
+    print(x)
+  }
+  return (result, result2)
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins33testTaskRemoveCancellationHandleryySVYaF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3)
+// CHECK: call{{.*}} @swift_task_removeCancellationHandler(ptr %3)
+nonisolated(nonsending) func testTaskRemoveCancellationHandler(_ x: UnsafeRawPointer) async {
+  Builtin.taskRemoveCancellationHandler(record: x)
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaFys5UInt8V_ADtXEfU_", ptr null)
+// CHECK: [[CONTEXT:%.*]] = call {{.*}}@swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata.3, i32 0, i32 2), i64 32, i64 7)
+// CHECK: [[RESULT_2:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaFys5UInt8V_ADtXEfU0_TA", ptr [[CONTEXT]])
+// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{%.*}}, ptr [[RESULT]], ptr [[RESULT_2]])
+nonisolated(nonsending) func testTaskAddPriorityEscalationHandler() async -> (UnsafeRawPointer, UnsafeRawPointer) {
+  let result = Builtin.taskAddPriorityEscalationHandler { (x: UInt8, y: UInt8) in
+    _ = x
+    _ = y
+  }
+  let str = "123"
+  let result2 = Builtin.taskAddPriorityEscalationHandler { (x: UInt8, y: UInt8) in
+    print(str)
+    _ = x
+    _ = y
+  }
+  return (result, result2)
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins39testTaskRemovePriorityEscalationHandleryySVYaF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3)
+// CHECK: call{{.*}} @swift_task_removePriorityEscalationHandler(ptr %3)
+nonisolated(nonsending) func testTaskRemovePriorityEscalationHandler(_ x: UnsafeRawPointer) async {
+  Builtin.taskRemovePriorityEscalationHandler(record: x)
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins22testTaskLocalValuePushyyBp_xntYalF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3, ptr noalias %4, ptr %Value)
+// CHECK: [[TASK_VAR:%.*]] = call swiftcc ptr @swift_task_alloc({{.*}}
+// CHECK: call ptr %InitializeWithTake(ptr noalias [[TASK_VAR]], ptr noalias {{%.*}}, ptr %Value)
+// CHECK: call swiftcc {} @swift_task_localValuePush(ptr %3, ptr [[TASK_VAR]], ptr %Value)
+nonisolated(nonsending) func testTaskLocalValuePush<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
+  Builtin.taskLocalValuePush(key, value)
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins21testTaskLocalValuePopyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: call swiftcc {} @swift_task_localValuePop()
+nonisolated(nonsending) func testTaskLocalValuePop() async {
+  Builtin.taskLocalValuePop()
+}  
+
 // CHECK: ![[R]] = !{i64 0, i64 9223372036854775807}


### PR DESCRIPTION
Specifically:

1. swift_task_addCancellationHandler
2. swift_task_removeCancellationHandler
3. swift_task_addPriorityEscalationHandler
4. swift_task_removePriorityEscalationHandler
5. swift_task_localValuePush
6. swift_task_localValuePop

rdar://109850951