### PR TITLE
[sil] In SILGenBuiltin use a constexpr StringLiteral to reference names of Builtins instead of using raw c strings.

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -107,10 +107,21 @@ getLLVMIntrinsicIDForBuiltinWithOverflow(BuiltinValueKind ID);
 ///
 /// Returns null if the name does not identifier a known builtin value.
 ValueDecl *getBuiltinValueDecl(ASTContext &Context, Identifier Name);
-  
+
+/// Overload that takes a StringRef instead of an Identifier. We convert it to
+/// an identifier internally.
+ValueDecl *getBuiltinValueDecl(ASTContext &Context, StringRef Name);
+
 /// Returns the name of a builtin declaration given a builtin ID.
 StringRef getBuiltinName(BuiltinValueKind ID);
-  
+
+/// Namespace containing constexpr StringLiterals of BuiltinNames so that
+/// builtin names can be referred to without using raw string literals.
+namespace BuiltinNames {
+#define BUILTIN(Id, Name, Attrs) constexpr StringLiteral Id = Name;
+#include "swift/AST/Builtins.def"
+} // namespace BuiltinNames
+
 /// The information identifying the builtin - its kind and types.
 class BuiltinInfo {
 public:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -611,6 +611,12 @@ public:
                                       Subs, Args, getInstructionContext()));
   }
 
+  BuiltinInst *createBuiltin(SILLocation Loc, StringRef Name, SILType ResultTy,
+                             SubstitutionMap Subs, ArrayRef<SILValue> Args) {
+    return createBuiltin(Loc, getASTContext().getIdentifier(Name), ResultTy,
+                         Subs, Args);
+  }
+
   /// Create a binary function with the signature: OpdTy, OpdTy -> ResultTy.
   BuiltinInst *createBuiltinBinaryFunction(SILLocation Loc, StringRef Name,
                                            SILType OpdTy, SILType ResultTy,

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -3738,3 +3738,7 @@ BuiltinFixedArrayType::isFixedNegativeSize() const {
   }
   return false;
 }
+
+ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, StringRef Name) {
+  return getBuiltinValueDecl(Context, Context.getIdentifier(Name));
+}

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -507,11 +507,9 @@ static ManagedValue emitBuiltinAddressOfBorrowBuiltins(SILGenFunction &SGF,
     auto borrow = SGF.emitRValue(argument, SGFContext::AllowGuaranteedPlusZero)
        .getAsSingleValue(SGF, argument);
     if (!SGF.F.getConventions().useLoweredAddresses()) {
-      auto &context = SGF.getASTContext();
-      auto identifier =
-          stackProtected
-              ? context.getIdentifier("addressOfBorrowOpaque")
-              : context.getIdentifier("unprotectedAddressOfBorrowOpaque");
+      auto identifier = stackProtected
+                            ? BuiltinNames::AddressOfBorrowOpaque
+                            : BuiltinNames::UnprotectedAddressOfBorrowOpaque;
       auto builtin = SGF.B.createBuiltin(loc, identifier, rawPointerType,
                                          substitutions, {borrow.getValue()});
       return ManagedValue::forObjectRValueWithoutOwnership(builtin);
@@ -1173,8 +1171,7 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
   case TypeTraitResult::CanBe: {
     auto &C = SGF.getASTContext();
     auto int8Ty = BuiltinIntegerType::get(8, C)->getCanonicalType();
-    auto apply = SGF.B.createBuiltin(loc,
-                                     C.getIdentifier(getBuiltinName(Kind)),
+    auto apply = SGF.B.createBuiltin(loc, getBuiltinName(Kind),
                                      SILType::getPrimitiveObjectType(int8Ty),
                                      substitutions, args[0].getValue());
 
@@ -1357,8 +1354,7 @@ emitBuiltinGlobalStringTablePointer(SILGenFunction &SGF, SILLocation loc,
 
   SILValue argValue = args[0].getValue();
   auto &astContext = SGF.getASTContext();
-  Identifier builtinId = astContext.getIdentifier(
-      getBuiltinName(BuiltinValueKind::GlobalStringTablePointer));
+  auto builtinId = BuiltinNames::GlobalStringTablePointer;
 
   auto resultVal = SGF.B.createBuiltin(loc, builtinId,
                                        SILType::getRawPointerType(astContext),
@@ -1479,10 +1475,9 @@ static ManagedValue emitBuiltinGetCurrentAsyncTask(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
-  auto apply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetCurrentAsyncTask)),
-      SGF.getLoweredType(ctx.TheNativeObjectType), SubstitutionMap(), { });
+  auto apply = SGF.B.createBuiltin(loc, BuiltinNames::GetCurrentAsyncTask,
+                                   SGF.getLoweredType(ctx.TheNativeObjectType),
+                                   SubstitutionMap(), {});
   return SGF.emitManagedRValueWithEndLifetimeCleanup(apply);
 }
 
@@ -1524,24 +1519,21 @@ static ManagedValue emitBuiltinSizeof(
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Sizeof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Sizeof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinStrideof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Strideof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Strideof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinAlignof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Alignof)),
-      SILType::getBuiltinWordType(ctx), subs, {}));
+      loc, BuiltinNames::Alignof, SILType::getBuiltinWordType(ctx), subs, {}));
 }
 
 enum class CreateTaskOptions {
@@ -1704,8 +1696,7 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
     functionValue.forward(SGF)
   };
 
-  auto builtinID =
-    ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateAsyncTask));
+  auto builtinID = BuiltinNames::CreateAsyncTask;
   auto resultTy = SGF.getLoweredType(getAsyncTaskAndContextType(ctx));
 
   auto apply = SGF.B.createBuiltin(loc, builtinID, resultTy, subs, builtinArgs);
@@ -1787,9 +1778,8 @@ static ManagedValue emitBuiltinCreateTaskGroup(SILGenFunction &SGF,
                                                SGFContext C) {
   auto &ctx = SGF.getASTContext();
   auto resultType = SILType::getRawPointerType(ctx);
-  auto value = SGF.B.createBuiltin(
-      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateTaskGroup)),
-      resultType, subs, {});
+  auto value = SGF.B.createBuiltin(loc, BuiltinNames::CreateTaskGroup,
+                                   resultType, subs, {});
   return ManagedValue::forObjectRValueWithoutOwnership(value);
 }
 
@@ -1801,11 +1791,8 @@ static ManagedValue emitBuiltinCreateTaskGroupWithFlags(
     ArrayRef<ManagedValue> args, SGFContext C) {
   auto &ctx = SGF.getASTContext();
   auto resultType = SILType::getRawPointerType(ctx);
-  auto value = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::CreateTaskGroupWithFlags)),
-      resultType, subs, {args[0].getValue()});
+  auto value = SGF.B.createBuiltin(loc, BuiltinNames::CreateTaskGroupWithFlags,
+                                   resultType, subs, {args[0].getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(value);
 }
 
@@ -1933,9 +1920,7 @@ static ManagedValue emitBuiltinAutoDiffCreateLinearMapContextWithType(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(getBuiltinName(
-          BuiltinValueKind::AutoDiffCreateLinearMapContextWithType)),
+      loc, BuiltinNames::AutoDiffCreateLinearMapContextWithType,
       SILType::getNativeObjectType(ctx), subs,
       /*args*/ {args[0].getValue()});
   return SGF.emitManagedRValueWithCleanup(builtinApply);
@@ -1945,13 +1930,10 @@ static ManagedValue emitBuiltinAutoDiffProjectTopLevelSubcontext(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
-  auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::AutoDiffProjectTopLevelSubcontext)),
-      SILType::getRawPointerType(ctx),
-      subs,
-      /*args*/ {args[0].borrow(SGF, loc).getValue()});
+  auto *builtinApply =
+      SGF.B.createBuiltin(loc, BuiltinNames::AutoDiffProjectTopLevelSubcontext,
+                          SILType::getRawPointerType(ctx), subs,
+                          /*args*/ {args[0].borrow(SGF, loc).getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
 }
 
@@ -1960,9 +1942,7 @@ static ManagedValue emitBuiltinAutoDiffAllocateSubcontextWithType(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto *builtinApply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(
-          getBuiltinName(BuiltinValueKind::AutoDiffAllocateSubcontextWithType)),
+      loc, BuiltinNames::AutoDiffAllocateSubcontextWithType,
       SILType::getRawPointerType(ctx), subs,
       /*args*/ {args[0].borrow(SGF, loc).getValue(), args[1].getValue()});
   return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
@@ -2041,10 +2021,9 @@ static ManagedValue emitBuiltinGetEnumTag(SILGenFunction &SGF, SILLocation loc,
                                           SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetEnumTag)),
-    SILType::getBuiltinIntegerType(32, ctx), subs,
-    { args[0].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::GetEnumTag,
+                                SILType::getBuiltinIntegerType(32, ctx), subs,
+                                {args[0].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2055,10 +2034,9 @@ static ManagedValue emitBuiltinInjectEnumTag(SILGenFunction &SGF, SILLocation lo
                                              SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::InjectEnumTag)),
-    SILType::getEmptyTupleType(ctx), subs,
-    { args[0].getValue(), args[1].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::InjectEnumTag,
+                                SILType::getEmptyTupleType(ctx), subs,
+                                {args[0].getValue(), args[1].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2088,10 +2066,9 @@ static ManagedValue emitBuiltinAddressOfRawLayout(SILGenFunction &SGF,
                                                   SGFContext C) {
   auto &ctx = SGF.getASTContext();
 
-  auto bi = SGF.B.createBuiltin(
-    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::AddressOfRawLayout)),
-    SILType::getRawPointerType(ctx), subs,
-    { args[0].getValue() });
+  auto bi = SGF.B.createBuiltin(loc, BuiltinNames::AddressOfRawLayout,
+                                SILType::getRawPointerType(ctx), subs,
+                                {args[0].getValue()});
 
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
@@ -2148,7 +2125,7 @@ static ManagedValue emitBuiltinEmplace(SILGenFunction &SGF,
   
   // Mark the buffer as initializedto communicate to DI that the memory
   // is considered initialized from this point.
-  auto markInit = getBuiltinValueDecl(Ctx, Ctx.getIdentifier("prepareInitialization"));
+  auto markInit = getBuiltinValueDecl(Ctx, BuiltinNames::PrepareInitialization);
   SGF.B.createBuiltin(loc, markInit->getBaseIdentifier(),
                        SILType::getEmptyTupleType(Ctx),
                        SubstitutionMap(),


### PR DESCRIPTION
Before this patch we referred to builtin names in SILGenBuiltin using raw c strings. This can lead to potential spelling mistakes yielding bugs. Rather than doing this, I stole a technique that we use in other parts of the compiler: constexpr StringLiteral generation using CPP macros. Specifically, I defined in Builtins.h a new namespace called BuiltinNames and inside of BuiltinNames I used CPP macros to define a StringLiteral for each Builtin. Thus one can get the appropriate name for a Builtin by writing:

```
BuiltinNames::Sizeof
```

instead of writing "Sizeof". I also cleaned up the code a little by adding for functions that take identifiers an additional overload that takes a StringRef and converts the StringRef to an identifier internally. This just eliminates unnecessary code from call sites by moving them into the callee.
