### PR TITLE
Platform: disable Linux misfeature in Swift

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -236,7 +236,14 @@ foreach(sdk ${SWIFT_SDKS})
         COMMAND
           "${CMAKE_COMMAND}" "-E" "copy"
             ${glibc_header_out} ${glibc_header_out_static}
-        OUTPUT ${glibc_modulemap_out_static} ${glibc_header_out_static}
+        COMMAND
+          ${CMAKE_COMMAND} -E make_directory "${module_dir}/apinotes"
+        COMMAND
+          ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/SwiftGlibc.apinotes" "${module_dir}/apinotes"
+        OUTPUT
+          ${glibc_modulemap_out_static}
+          ${glibc_header_out_static}
+          "${module_dir}/apinotes/SwiftGlibc.apinotes"
         DEPENDS
           "${glibc_modulemap_target}"
           "${glibc_header_target}"

--- a/stdlib/public/Platform/SwiftGlibc.apinotes
+++ b/stdlib/public/Platform/SwiftGlibc.apinotes
@@ -1,12 +1,12 @@
 ---
-Name: bionic
+Name: glibc
 Functions:
-- Name: posix_spawnattr_init
-  Parameters:
-  - Position: 0
-    Type: "posix_spawnattr_t _Nullable * _Nonnull"
 - Name: posix_spawn
   Parameters:
+  - Position: 0
+    Type: "pid_t * _Nonnull"
+  - Position: 1
+    type: "const char * _Nonnull"
   - Position: 2
     Type: "const posix_spawn_file_actions_t _Nonnull * _Nullable"
   - Position: 3
@@ -15,7 +15,3 @@ Functions:
     Type: "char * const _Nullable __argv[_Nonnull]"
   - Position: 5
     Type: "char * const _Nullable __argv[_Nonnull]"
-- Name: posix_spawn_file_actions_init
-  Parameters:
-  - Position: 0
-    Type: "posix_spawn_file_actions_t _Nullable * _Nonnull"


### PR DESCRIPTION
Linux extends the POSIX standard `posix_spawn` permitting `argv` and
`envp` to be `nullptr` as a shorthand for `&{nullptr}`. This is
incompatible with most other unices. Simply disable this extension in
Swift by disallowing the top-level `nullptr`.