### PR TITLE
Modularize signal.h on FreeBSD

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -49,6 +49,14 @@ module SwiftGlibc [system] {
   export *
 }
 
+% if CMAKE_SDK == "FREEBSD":
+module signal_h [system] {
+  config_macros _BSD_VISIBLE, _POSIX_VISIBLE
+  header "signal.h"
+  export *
+}
+% end
+
 module CUUID [system] {
   header "uuid/uuid.h"
   link "uuid"


### PR DESCRIPTION
This nudges the Glibc modulemap just enough to get SwiftPM and later targets building. Without it, Swift tries to import the signal hander APIs through CDispatch instead of Glibc. CDispatch shouldn't be directly imported, so recommending that is nonsensical.

This is not a full solution for all headers, but meant to perturb the module machinery sufficiently that it pulls signal.h into glibc correctly.

Works around:
```
Swift-Project/swiftpm/Sources/Basics/Cancellator.swift:79:24:
error: property '__sigaction_u' is not available due to missing import of defining module 'CDispatch' [#MemberImportVisibility]
```