### PR TITLE
[draft – dnm] Add a defaulting version of `index(forKey:)` to `Dictionary`

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -920,13 +920,6 @@ extension Dictionary {
     forKey key: Key,
     default defaultValue: @autoclosure () -> Value
   ) -> Index {
-#if SILLY // silly inefficient implementation
-    if let index = _variant.index(forKey: key) {
-      return index
-    }
-    _variant[key] = defaultValue()
-    return _variant.index(forKey: key)!
-#else
     let (bucket, found) = _variant.mutatingFind(key)
     if !found {
       _variant.asNative._insert(at: bucket, key: key, value: defaultValue())
@@ -934,7 +927,6 @@ extension Dictionary {
     return unsafe Index(
       _native: _HashTable.Index(bucket: bucket, age: _variant.asNative.age)
     )
-#endif
   }
 
   public mutating func _addValue(_ value: Value, forKey key: Key) -> Bool {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -916,6 +916,7 @@ extension Dictionary {
     }
   }
 
+  @available(SwiftStdlib 9999, *)
   public mutating func _index(
     forKey key: Key,
     default defaultValue: @autoclosure () -> Value
@@ -929,6 +930,7 @@ extension Dictionary {
     )
   }
 
+  @available(SwiftStdlib 9999, *)
   public mutating func _addValue(_ value: Value, forKey key: Key) -> Bool {
     let (bucket, found) = _variant.mutatingFind(key)
     if !found {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -937,6 +937,16 @@ extension Dictionary {
 #endif
   }
 
+  public mutating func _addValue(_ value: Value, forKey key: Key) -> Bool {
+    let (bucket, found) = _variant.mutatingFind(key)
+    if !found {
+      _variant.asNative._insert(at: bucket, key: key, value: value)
+      return true
+    } else {
+      return false
+    }
+  }
+
   /// Returns a new dictionary containing the keys of this dictionary with the
   /// values transformed by the given closure.
   ///

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1140,8 +1140,9 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 
-// Dictionary._index(forKey:defaultValue:)
+// Dictionary "insert if key is absent" functions
 Added: _$sSD6_index6forKey7defaultSD5IndexVyxq__Gx_q_yXKtF
+Added: _$sSD9_addValue_6forKeySbq__xtF
 
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1140,6 +1140,9 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 
+// Dictionary._index(forKey:defaultValue:)
+Added: _$sSD6_index6forKey7defaultSD5IndexVyxq__Gx_q_yXKtF
+
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize
 Added: __swift_debug_metadataAllocatorPageSize

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1140,8 +1140,9 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 
-// Dictionary._index(forKey:defaultValue:)
+// Dictionary "insert if key is absent" functions
 Added: _$sSD6_index6forKey7defaultSD5IndexVyxq__Gx_q_yXKtF
+Added: _$sSD9_addValue_6forKeySbq__xtF
 
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1140,6 +1140,9 @@ Added: _$ss7UnicodeO27_RandomAccessWordRecognizerVN
 Removed: _$sSS17_nearestWordIndex9atOrBelowSS0C0VAD_tF
 Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 
+// Dictionary._index(forKey:defaultValue:)
+Added: _$sSD6_index6forKey7defaultSD5IndexVyxq__Gx_q_yXKtF
+
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize
 Added: __swift_debug_metadataAllocatorPageSize

--- a/test/stdlib/DictionaryIndexDefault.swift
+++ b/test/stdlib/DictionaryIndexDefault.swift
@@ -21,4 +21,24 @@ tests.test("DefaultValueIndexForKey") {
   let i = d._index(forKey: "b", default: [])
   d.values[i].append(r)
   expectEqual([r], d["b"])
+
+  let j = d._index(forKey: "b", default: [])
+  d.values[j].append(r)
+  expectNotEqual([r], d["b"])
+}
+
+tests.test("DictionaryInsertIfNil") {
+  var d = ["a": [1], "c": [3]]
+  var inserted: Bool
+  let r = Int.random(in: 0..<1000)
+
+  inserted = d._addValue([r], forKey: "b")
+  expectTrue(inserted)
+  expectEqual([r], d["b"])
+
+  inserted = d._addValue([], forKey: "c")
+  expectFalse(inserted)
+  if let value = expectNotNil(d["c"]) {
+    expectFalse(value.isEmpty)
+  }
 }

--- a/test/stdlib/DictionaryIndexDefault.swift
+++ b/test/stdlib/DictionaryIndexDefault.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+var tests = TestSuite("DictionaryIndexDefault")
+defer { runAllTests() }
+
+tests.test("DefaultValueSubscript") {
+  var d = ["a": [1], "c": [3]]
+  let r = Int.random(in: 0..<1000)
+  d["b", default: []].append(r)
+  expectEqual([r], d["b"])
+}
+
+tests.test("DefaultValueIndexForKey") {
+  var d = ["a": [1], "c": [3]]
+  let r = Int.random(in: 0..<1000)
+  let i = d._index(forKey: "b", default: [])
+  d.values[i].append(r)
+  expectEqual([r], d["b"])
+}

--- a/test/stdlib/DictionaryIndexDefault.swift
+++ b/test/stdlib/DictionaryIndexDefault.swift
@@ -16,6 +16,8 @@ tests.test("DefaultValueSubscript") {
 }
 
 tests.test("DefaultValueIndexForKey") {
+  guard #available(SwiftStdlib 9999, *) else { return }
+
   var d = ["a": [1], "c": [3]]
   let r = Int.random(in: 0..<1000)
   let i = d._index(forKey: "b", default: [])
@@ -28,6 +30,8 @@ tests.test("DefaultValueIndexForKey") {
 }
 
 tests.test("DictionaryInsertIfNil") {
+  guard #available(SwiftStdlib 9999, *) else { return }
+
   var d = ["a": [1], "c": [3]]
   var inserted: Bool
   let r = Int.random(in: 0..<1000)


### PR DESCRIPTION
For an application where a wrapped `Dictionary`'s `Value` needs to be updated in place while also returning the updated value, this function appears to be missing for best efficiency.
```
extension Dictionary {
  public mutating func _index(
    forKey key: Key,
    default defaultValue: @autoclosure () -> Value
  ) -> Index {...}
}
```

This would enable the following pattern:
```
var dictionary = [String: [String: String]]
let index = dictionary.index(forKey: "a", default: [:])
dictionary.values[index].merge(otherValues)
return dictionary.values[index]
```
where only one hash table lookup would be needed.

First thing to do is discover whether this actually fulfills the need.

Also adds
```
extension Dictionary {
  public mutating func _addValue(_: Value, forKey: Key) -> Bool { ... }
}
```
which is more discoverable than the alternative.