### PR TITLE
LifetimeDependenceDiagnostics: handle dynamic casting of Span<T>

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1072,6 +1072,8 @@ extension LifetimeDependenceDefUseWalker {
         return loadedAddressUse(of: localAccess.operand!, intoValue: load)
       case let copyAddr as SourceDestAddrInstruction:
         return loadedAddressUse(of: localAccess.operand!, intoAddress: copyAddr.destinationOperand)
+      case let castAddr as CheckedCastAddrBranchInst:
+        return loadedAddressUse(of: localAccess.operand!, intoAddress: castAddr.destinationOperand)
       case is SwitchEnumAddrInst:
         // switch_enum_addr does not produce any values. Subsequent uses of the address (unchecked_enum_data_addr)
         // directly use the original address.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -622,6 +622,9 @@ extension LifetimeDependence.Scope {
 ///   walkDown(dependence: LifetimeDependence)
 ///
 /// Note: this may visit values that are not dominated by `dependence` because of dependent phi operands.
+///
+/// WARNING: Do not return .abortWalk at this level or below. .abortWalk may only be returned by an overridden callback
+/// or the default implementation of unknownAddressUse().
 protocol LifetimeDependenceDefUseWalker : ForwardingDefUseWalker,
                                           OwnershipUseVisitor,
                                           AddressUseVisitor {
@@ -1074,7 +1077,7 @@ extension LifetimeDependenceDefUseWalker {
         // directly use the original address.
         return .continueWalk
       default:
-        return .abortWalk
+        return unknownAddressUse(of: localAccess.operand!)
       }
     case .dependenceSource:
       switch localAccess.instruction! {
@@ -1086,7 +1089,7 @@ extension LifetimeDependenceDefUseWalker {
       case let md as MarkDependenceAddrInst:
         return loadedAddressUse(of: localAccess.operand!, intoAddress: md.addressOperand)
       default:
-        return .abortWalk
+        return unknownAddressUse(of: localAccess.operand!)
       }
     case .dependenceDest:
       // Simply a marker that indicates the start of an in-memory dependent value. If this was a mark_dependence, uses

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -525,6 +525,13 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
       // switch_enum_addr is truly a leaf address use. It does not produce a new value. But in every other respect it is
       // like a load.
       visit(LocalVariableAccess(.load, operand))
+    case let castBr as CheckedCastAddrBranchInst:
+      if operand == castBr.sourceOperand {
+        visit(LocalVariableAccess(.load, operand))
+      } else {
+        assert(operand == castBr.destinationOperand)
+        visit(LocalVariableAccess(.store, operand))
+      }
     case is DeallocStackInst:
       break
     default:

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -2027,8 +2027,11 @@ final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
 }
 
 final public class CheckedCastAddrBranchInst : TermInst {
-  public var source: Value { operands[0].value }
-  public var destination: Value { operands[1].value }
+  public var sourceOperand: Operand { return operands[0] }
+  public var destinationOperand: Operand { return operands[1] }
+
+  public var source: Value { sourceOperand.value }
+  public var destination: Value { destinationOperand.value }
 
   public var sourceFormalType: CanonicalType {
     CanonicalType(bridged: bridged.CheckedCastAddrBranch_getSourceFormalType())

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -429,3 +429,22 @@ extension MutableSpan {
     return false
   }
 }
+
+// =============================================================================
+// Local variable analysis - address uses
+// =============================================================================
+
+func dynamicCastGood<T>(_ span: Span<T>) {
+  if let intSpan = span as? Span<Int> {
+    _ = intSpan
+  }
+}
+
+@_lifetime(immortal)
+func dynamicCastBad<T>(_ span: Span<T>) -> Span<Int> {
+  if let intSpan = span as? Span<Int> { // expected-error{{lifetime-dependent variable 'intSpan' escapes its scope}}
+    // expected-note @-2{{it depends on the lifetime of argument 'span'}}
+    return intSpan // expected-note{{this use causes the lifetime-dependent value to escape}}
+  }
+  return Span<Int>()
+}


### PR DESCRIPTION
- **LifetimeDependenceDiagnostics: diagnostic error on unknown uses**
  The common def-use walkers should not return .abortWalk without making a
  diagnostic callback.
  

- **LifetimeDependenceDiagnostics: handle dynamic casting of Span<T>**
  Add a special case for checked_cast_addr_br instruction. If it conformed to
  SourceDestAddrInstruction, then the diagnostics would already have handled it
  naturally, but the instruction's conditional semantics are strange enough that
  such a conformance might confuse other passes.
  
  rdar://159793739 (Using `as?` with non-escapable types emits faulty lifetime
  diagnostics)
  