### PR TITLE
Requirement Machine: Fix crash on pack + tuple type

### DIFF
--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -755,7 +755,7 @@ RequirementMachine::getReducedShapeTerm(Type type) const {
   // Get the term T', which is the reduced shape of T.
   if (term.size() != 2 ||
       term[0].getKind() != Symbol::Kind::GenericParam ||
-      term[1].getKind() != Symbol::Kind::Shape) {
+      !term.hasShape()) {
     ABORT([&](auto &out) {
       out << "Invalid reduced shape\n";
       out << "Type: " << type << "\n";
@@ -763,8 +763,8 @@ RequirementMachine::getReducedShapeTerm(Type type) const {
     });
   }
 
-  MutableTerm reducedTerm(term.begin(), term.end() - 1);
-  return reducedTerm;
+  term.removeShape();
+  return term;
 }
 
 Type RequirementMachine::getReducedShape(Type type,

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -424,7 +424,7 @@ RewriteContext::getRelativeTermForType(CanType typeWitness,
   // Get the substitution S corresponding to τ_0_n.
   unsigned index = getGenericParamIndex(typeWitness->getRootGenericParam());
   result = MutableTerm(substitutions[index]);
-  ASSERT(result.back().getKind() != Symbol::Kind::Shape);
+  ASSERT(!result.hasShape());
 
   // If the substitution is a term consisting of a single protocol symbol
   // [P], save P for later.
@@ -485,7 +485,7 @@ Type PropertyMap::getTypeFromSubstitutionSchema(
           auto substitution = substitutions[index];
 
           bool isShapePosition = (pos == TypePosition::Shape);
-          bool isShapeTerm = (substitution.back() == Symbol::forShape(Context));
+          bool isShapeTerm = substitution.hasShape();
           if (isShapePosition != isShapeTerm) {
             ABORT([&](auto &out) {
               out << "Shape vs. type mixup\n\n";
@@ -504,8 +504,8 @@ Type PropertyMap::getTypeFromSubstitutionSchema(
           // Undo the thing where the count type of a PackExpansionType
           // becomes a shape term.
           if (isShapeTerm) {
-            MutableTerm mutTerm(substitution.begin(), substitution.end() - 1);
-            substitution = Term::get(mutTerm, Context);
+            MutableTerm noShape = substitution.termWithoutShape();
+            substitution = Term::get(noShape, Context);
           }
 
           // Prepend the prefix of the lookup key to the substitution.

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -424,7 +424,12 @@ RewriteContext::getRelativeTermForType(CanType typeWitness,
   // Get the substitution S corresponding to τ_0_n.
   unsigned index = getGenericParamIndex(typeWitness->getRootGenericParam());
   result = MutableTerm(substitutions[index]);
-  ASSERT(!result.hasShape());
+  bool hasShape = false;
+
+  if (result.hasShape()) {
+    hasShape = true;
+    result.removeShape();
+  }
 
   // If the substitution is a term consisting of a single protocol symbol
   // [P], save P for later.
@@ -462,6 +467,9 @@ RewriteContext::getRelativeTermForType(CanType typeWitness,
   // Add the member type names.
   for (auto iter = symbols.rbegin(), end = symbols.rend(); iter != end; ++iter)
     result.add(*iter);
+
+  if (hasShape)
+    result.add(Symbol::forShape(*this));
 
   return result;
 }
@@ -571,8 +579,6 @@ RewriteContext::getRelativeSubstitutionSchemaFromType(
         //
         // τ_0_0 := T
         // τ_0_1 := U.[shape]
-        ASSERT(pos != TypePosition::Shape && "Not implemented");
-
         unsigned index = result.size();
 
         result.push_back(Term::get(term, *this));

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -257,11 +257,10 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
 
     ASSERT(rule.getLHS().back().getKind() != Symbol::Kind::Protocol);
 
-    if (constraintTerm.back().getKind() == Symbol::Kind::Shape) {
-      ASSERT(rule.getRHS().back().getKind() == Symbol::Kind::Shape);
+    if (constraintTerm.hasShape()) {
+      ASSERT(rule.getRHS().hasShape());
       // Strip off the shape symbol from the constraint term.
-      constraintTerm = MutableTerm(constraintTerm.begin(),
-                                   constraintTerm.end() - 1);
+      constraintTerm.removeShape();
     }
 
     if (constraintTerm.front().getKind() == Symbol::Kind::PackElement) {
@@ -332,10 +331,10 @@ void RequirementBuilder::processConnectedComponents() {
   for (auto &pair : Components) {
     MutableTerm subjectTerm(pair.first);
     RequirementKind kind;
-    if (subjectTerm.back().getKind() == Symbol::Kind::Shape) {
+    if (subjectTerm.hasShape()) {
       kind = RequirementKind::SameShape;
       // Strip off the shape symbol from the subject term.
-      subjectTerm = MutableTerm(subjectTerm.begin(), subjectTerm.end() - 1);
+      subjectTerm.removeShape();
     } else {
       kind = RequirementKind::SameType;
       if (subjectTerm.front().getKind() == Symbol::Kind::PackElement) {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -634,7 +634,7 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
 
     if (rhs.size() == 1 && rhs[0].getKind() == Symbol::Kind::Shape) {
       // We can have a rule like T.[shape] => [shape].
-      ASSERT_RULE(lhs.back().getKind() == Symbol::Kind::Shape);
+      ASSERT_RULE(lhs.hasShape());
     } else {
       // Otherwise, LHS and RHS must have the same domain.
       auto lhsDomain = lhs.getRootProtocol();

--- a/lib/AST/RequirementMachine/Term.cpp
+++ b/lib/AST/RequirementMachine/Term.cpp
@@ -68,6 +68,17 @@ Symbol Term::back() const {
   return Ptr->getElements().back();
 }
 
+bool Term::hasShape() const {
+  return back().getKind() == Symbol::Kind::Shape;
+}
+
+MutableTerm Term::termWithoutShape() const {
+  if (hasShape())
+    return MutableTerm(begin(), end() - 1);
+  else
+    return MutableTerm(begin(), end());
+}
+
 Symbol Term::operator[](size_t index) const {
   return Ptr->getElements()[index];
 }
@@ -222,6 +233,15 @@ std::optional<int> Term::compare(Term other, RewriteContext &ctx) const {
 std::optional<int> MutableTerm::compare(const MutableTerm &other,
                                         RewriteContext &ctx) const {
   return compareImpl(begin(), end(), other.begin(), other.end(), ctx);
+}
+
+bool MutableTerm::hasShape() const {
+  return back().getKind() == Symbol::Kind::Shape;
+}
+
+void MutableTerm::removeShape() {
+  if (hasShape())
+    Symbols.pop_back();
 }
 
 /// Replace the subterm in the range [from,to) of this term with \p rhs.

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -59,6 +59,9 @@ public:
 
   Symbol back() const;
 
+  bool hasShape() const;
+  MutableTerm termWithoutShape() const;
+
   Symbol operator[](size_t index) const;
 
   /// Returns an opaque pointer that uniquely identifies this term.
@@ -183,6 +186,9 @@ public:
   Symbol &back() {
     return Symbols.back();
   }
+
+  bool hasShape() const;
+  void removeShape();
 
   Symbol operator[](size_t index) const {
     return Symbols[index];

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -56,3 +56,13 @@ protocol TooManyDifferences {
   associatedtype B
   associatedtype C
 }
+
+struct G2<T> {
+    func f2<each A>()
+// expected-error@-1 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is }}
+// expected-error@-3 {{generic parameter 'A' is not used in function signature}}
+  where (repeat each A, T) == T {}
+// expected-error@-1 {{tuple with noncopyable element type 'repeat each A' is not supported}}
+
+}

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -126,3 +126,9 @@ func sameTypeMatch1<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: re
 // CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, (repeat (each U, each V)) : Any, repeat each V : PP, T.[PP]A == (/* shape: each U */ repeat ())>
 func sameTypeMatch2<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: repeat each V)
   where T.A == Shape<repeat each U>, T.A == Shape<repeat each V> {}
+
+// CHECK-LABEL: PackTupleNesting
+// CHECK-NEXT: <T, U, V, each W where T == ((repeat each W), (repeat each W)), U == (repeat each W), V == (repeat each W)>
+struct PackTupleNesting<T, U, V, each W>
+  where T == ((repeat each W), U),
+        T == (V, (repeat each W)) {} // expected-warning 3{{same-type requirement makes generic parameter}}

--- a/validation-test/compiler_crashers/RewriteContext-getRelativeTermForType-5e95d5.swift
+++ b/validation-test/compiler_crashers/RewriteContext-getRelativeTermForType-5e95d5.swift
@@ -1,5 +1,0 @@
-// {"kind":"typecheck","signature":"swift::rewriting::RewriteContext::getRelativeTermForType(swift::CanType, llvm::ArrayRef<swift::rewriting::Term>)","signatureAssert":"Assertion failed: (result.back().getKind() != Symbol::Kind::Shape), function getRelativeTermForType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-extension Result {
-  func a<each b>() where Success == (Result) -> (repeat each b)> {}
-}

--- a/validation-test/compiler_crashers/RewriteContext-getRelativeTermForType-6235b4.swift
+++ b/validation-test/compiler_crashers/RewriteContext-getRelativeTermForType-6235b4.swift
@@ -1,7 +1,0 @@
-// {"issueID":84490,"kind":"typecheck","signature":"swift::rewriting::RewriteContext::getRelativeTermForType(swift::CanType, llvm::ArrayRef<swift::rewriting::Term>)","signatureAssert":"Assertion failed: (result.back().getKind() != Symbol::Kind::Shape), function getRelativeTermForType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// https://github.com/swiftlang/swift/issues/84490
-struct a < b > {
-  func
-    c < each d where (repeat each d , b) == b>()
-}

--- a/validation-test/compiler_crashers_fixed/RewriteContext-getRelativeTermForType-5e95d5.swift
+++ b/validation-test/compiler_crashers_fixed/RewriteContext-getRelativeTermForType-5e95d5.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend -typecheck %s
+extension Result {
+  func a<each b>() where Success == (Result) -> (repeat each b)> {}
+}

--- a/validation-test/compiler_crashers_fixed/RewriteContext-getRelativeTermForType-6235b4.swift
+++ b/validation-test/compiler_crashers_fixed/RewriteContext-getRelativeTermForType-6235b4.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// https://github.com/swiftlang/swift/issues/84490
+struct a < b > {
+  func
+    c < each d where (repeat each d , b) == b>()
+}


### PR DESCRIPTION
Requirement Machine: Fix crashes on (some) pack + tuple types

Fixes issue https://github.com/swiftlang/swift/issues/84490


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
