### PR TITLE
[cxx-interop] Implicitly defined move constructors

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -611,7 +611,7 @@ namespace {
           /*invocation subs*/ SubstitutionMap(), IGF.IGM.Context);
     }
 
-    void emitCopyWithCopyConstructor(
+    void emitCopyWithCopyOrMoveConstructor(
         IRGenFunction &IGF, SILType T,
         const clang::CXXConstructorDecl *copyConstructor, llvm::Value *src,
         llvm::Value *dest) const {
@@ -625,12 +625,21 @@ namespace {
       if (copyConstructor->isDefaulted() &&
           copyConstructor->getAccess() == clang::AS_public &&
           !copyConstructor->isDeleted() &&
+          !copyConstructor->isIneligibleOrNotSelected() &&
           // Note: we use "doesThisDeclarationHaveABody" here because
           // that's what "DefineImplicitCopyConstructor" checks.
           !copyConstructor->doesThisDeclarationHaveABody()) {
-        importer->getClangSema().DefineImplicitCopyConstructor(
-            clang::SourceLocation(),
-            const_cast<clang::CXXConstructorDecl *>(copyConstructor));
+        assert(!copyConstructor->getParent()->isAnonymousStructOrUnion() &&
+               "Cannot do codegen of special member functions of anonymous "
+               "structs/unions");
+        if (copyConstructor->isCopyConstructor())
+          importer->getClangSema().DefineImplicitCopyConstructor(
+              clang::SourceLocation(),
+              const_cast<clang::CXXConstructorDecl *>(copyConstructor));
+        else
+          importer->getClangSema().DefineImplicitMoveConstructor(
+              clang::SourceLocation(),
+              const_cast<clang::CXXConstructorDecl *>(copyConstructor));
       }
 
       auto &diagEngine = importer->getClangSema().getDiagnostics();
@@ -812,9 +821,9 @@ namespace {
                             Address srcAddr, SILType T,
                             bool isOutlined) const override {
       if (auto copyConstructor = findCopyConstructor()) {
-        emitCopyWithCopyConstructor(IGF, T, copyConstructor,
-                                    srcAddr.getAddress(),
-                                    destAddr.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, copyConstructor,
+                                          srcAddr.getAddress(),
+                                          destAddr.getAddress());
         return;
       }
       StructTypeInfoBase<AddressOnlyCXXClangRecordTypeInfo, FixedTypeInfo,
@@ -827,9 +836,9 @@ namespace {
                         SILType T, bool isOutlined) const override {
       if (auto copyConstructor = findCopyConstructor()) {
         destroy(IGF, destAddr, T, isOutlined);
-        emitCopyWithCopyConstructor(IGF, T, copyConstructor,
-                                    srcAddr.getAddress(),
-                                    destAddr.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, copyConstructor,
+                                          srcAddr.getAddress(),
+                                          destAddr.getAddress());
         return;
       }
       StructTypeInfoBase<AddressOnlyCXXClangRecordTypeInfo, FixedTypeInfo,
@@ -841,17 +850,15 @@ namespace {
                             SILType T, bool isOutlined,
                             bool zeroizeIfSensitive) const override {
       if (auto moveConstructor = findMoveConstructor()) {
-        emitCopyWithCopyConstructor(IGF, T, moveConstructor,
-                                    src.getAddress(),
-                                    dest.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, moveConstructor,
+                                          src.getAddress(), dest.getAddress());
         destroy(IGF, src, T, isOutlined);
         return;
       }
 
       if (auto copyConstructor = findCopyConstructor()) {
-        emitCopyWithCopyConstructor(IGF, T, copyConstructor,
-                                    src.getAddress(),
-                                    dest.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, copyConstructor,
+                                          src.getAddress(), dest.getAddress());
         destroy(IGF, src, T, isOutlined);
         return;
       }
@@ -865,18 +872,16 @@ namespace {
                         bool isOutlined) const override {
       if (auto moveConstructor = findMoveConstructor()) {
         destroy(IGF, dest, T, isOutlined);
-        emitCopyWithCopyConstructor(IGF, T, moveConstructor,
-                                    src.getAddress(),
-                                    dest.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, moveConstructor,
+                                          src.getAddress(), dest.getAddress());
         destroy(IGF, src, T, isOutlined);
         return;
       }
 
       if (auto copyConstructor = findCopyConstructor()) {
         destroy(IGF, dest, T, isOutlined);
-        emitCopyWithCopyConstructor(IGF, T, copyConstructor,
-                                    src.getAddress(),
-                                    dest.getAddress());
+        emitCopyWithCopyOrMoveConstructor(IGF, T, copyConstructor,
+                                          src.getAddress(), dest.getAddress());
         destroy(IGF, src, T, isOutlined);
         return;
       }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -99,3 +99,9 @@ module CustomSmartPtr {
   requires cplusplus
   export *
 }
+
+module StdExpected {
+  header "std-expected.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-expected.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-expected.h
@@ -1,0 +1,23 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+
+#include <memory>
+#include <expected>
+
+using NonCopyableExpected = std::expected<std::unique_ptr<bool>, int>;
+
+template<typename T>
+class UniqueRef {
+public:
+  std::unique_ptr<T> _field;
+};
+
+struct Decoder {};
+enum Error {
+  DoomA,
+  DoomB
+};
+
+using DecoderOrError = std::expected<UniqueRef<Decoder>, Error>;
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+// TODO <expected> not yet supported with libstdc++
+// XFAIL: OS=linux-gnu
+
+// https://github.com/apple/swift/issues/70226
+// UNSUPPORTED: OS=windows-msvc
+
+import StdExpected
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let nonCopExpected = NonCopyableExpected()
+takeCopyable(nonCopExpected)
+// CHECK: error: global function 'takeCopyable' requires that 'NonCopyableExpected' (aka {{.*}}) conform to 'Copyable'
+
+let doe = DecoderOrError()
+takeCopyable(doe)
+// CHECK: error: global function 'takeCopyable' requires that 'DecoderOrError' (aka {{.*}}) conform to 'Copyable'
+
+// CHECK-NOT: error


### PR DESCRIPTION
Similar to https://github.com/swiftlang/swift/pull/84646, but for move constructors, which was preventing the use of `std::expected` of move-only types. 

rdar://152496447
