### PR TITLE
Adjust dependencies on LLVM components

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -27,12 +27,14 @@ add_swift_host_library(swiftClangImporter STATIC
   Serializability.cpp
   SwiftifyDecl.cpp
   SwiftLookupTable.cpp
+
+  LLVM_LINK_COMPONENTS
+    BitstreamReader
 )
 target_link_libraries(swiftClangImporter PRIVATE
   swiftAST
   swiftParse
-  clangTooling
-  LLVMBitstreamReader)
+  clangTooling)
 
 target_link_libraries(swiftClangImporter INTERFACE
   clangDependencyScanning)

--- a/lib/DriverTool/CMakeLists.txt
+++ b/lib/DriverTool/CMakeLists.txt
@@ -13,14 +13,15 @@ set(driver_sources_and_options
                 swift_cache_tool_main.cpp
                 swift_symbolgraph_extract_main.cpp
                 swift_synthesize_interface_main.cpp
-                swift_parse_test_main.cpp)
+                swift_parse_test_main.cpp
+  LLVM_LINK_COMPONENTS
+                BitstreamReader)
 
 set(driver_common_libs
                 swiftAPIDigester
                 swiftDriver
                 swiftFrontendTool
-                swiftSymbolGraphGen
-                LLVMBitstreamReader)
+                swiftSymbolGraphGen)
 
 add_swift_host_library(swiftDriverTool STATIC
   ${driver_sources_and_options}


### PR DESCRIPTION
Swift host libraries should depend on LLVM libraries as part of the `LLVM_LINK_COMPONENTS` argument so the dependency graph can be properly set up. This is a problem when building LLVM as a DLL on Windows as Swift targets should depend on the LLVM DLL.

Bug: #85241