### PR TITLE
[Sema] Fix and cleanup distributed `id`/`actorSystem` synthesis

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5442,7 +5442,6 @@ enum class KnownDerivableProtocolKind : uint8_t {
   Decodable,
   AdditiveArithmetic,
   Differentiable,
-  Identifiable,
   Actor,
   DistributedActor,
   DistributedActorSystem,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -374,6 +374,12 @@ bool conflicting(ASTContext &ctx,
                  bool *wouldConflictInSwift5 = nullptr,
                  bool skipProtocolExtensionCheck = false);
 
+/// The kind of special compiler synthesized property in a \c distributed actor,
+/// currently this includes \c id and \c actorSystem.
+enum class SpecialDistributedProperty {
+  Id, ActorSystem
+};
+
 /// The kind of artificial main to generate.
 enum class ArtificialMainKind : uint8_t {
   NSApplicationMain,
@@ -3055,6 +3061,12 @@ public:
   /// These are special accessors used by distributed thunks, implementing
   /// `distributed var get { }` accessors.
   bool isDistributedGetAccessor() const;
+
+  /// Whether this is the special synthesized 'id' or 'actorSystem' property
+  /// of a distributed actor. If \p onlyCheckName is set, then any
+  /// matching user-defined property with the name is also considered.
+  std::optional<SpecialDistributedProperty>
+  isSpecialDistributedProperty(bool onlyCheckName = false) const;
 
   bool hasName() const { return bool(Name); }
   bool isOperator() const { return Name.isOperator(); }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5710,6 +5710,8 @@ ERROR(actor_cannot_inherit_distributed_actor_protocol,none,
       (DeclName))
 ERROR(broken_distributed_actor_requirement,none,
       "DistributedActor protocol is broken: unexpected requirement", ())
+ERROR(broken_distributed_actor_system_requirement,none,
+      "DistributedActorSystem protocol is broken: unexpected requirement", ())
 ERROR(distributed_actor_system_conformance_missing_adhoc_requirement,none,
       "%kind0 is missing witness for protocol requirement %1",
       (const ValueDecl *, DeclName))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2999,7 +2999,6 @@ enum class ImplicitMemberAction : uint8_t {
   ResolveCodingKeys,
   ResolveEncodable,
   ResolveDecodable,
-  ResolveDistributedActor,
 };
 
 class ResolveImplicitMemberRequest

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3000,8 +3000,6 @@ enum class ImplicitMemberAction : uint8_t {
   ResolveEncodable,
   ResolveDecodable,
   ResolveDistributedActor,
-  ResolveDistributedActorID,
-  ResolveDistributedActorSystem,
 };
 
 class ResolveImplicitMemberRequest

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7562,8 +7562,6 @@ ProtocolDecl::getKnownDerivableProtocolKind() const {
     return KnownDerivableProtocolKind::AdditiveArithmetic;
   case KnownProtocolKind::Differentiable:
     return KnownDerivableProtocolKind::Differentiable;
-  case KnownProtocolKind::Identifiable:
-    return KnownDerivableProtocolKind::Identifiable;
   case KnownProtocolKind::Actor:
     return KnownDerivableProtocolKind::Actor;
   case KnownProtocolKind::DistributedActor:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6482,21 +6482,12 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
       if (baseName.isConstructor()) {
         if ((member.isSimpleName() || argumentNames.front() == Context.Id_from)) {
           action.emplace(ImplicitMemberAction::ResolveDecodable);
-        } else if (argumentNames.front() == Context.Id_system) {
-          action.emplace(ImplicitMemberAction::ResolveDistributedActor);
         }
       } else if (!baseName.isSpecial() &&
                  baseName.getIdentifier() == Context.Id_encode &&
                  (member.isSimpleName() ||
                   argumentNames.front() == Context.Id_to)) {
         action.emplace(ImplicitMemberAction::ResolveEncodable);
-      }
-    } else if (member.isSimpleName() || argumentNames.size() == 2) {
-      if (baseName.isConstructor()) {
-        if (argumentNames[0] == Context.Id_resolve &&
-            argumentNames[1] == Context.Id_using) {
-          action.emplace(ImplicitMemberAction::ResolveDistributedActor);
-        }
       }
     }
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6449,6 +6449,16 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
   if (isa<ProtocolDecl>(this))
     return;
 
+  auto baseName = member.getBaseName();
+  auto &Context = getASTContext();
+
+  // For a distributed actor `id` and `actorSystem` can be synthesized without
+  // causing cycles so do them above the cycle guard.
+  if (member.isSimpleName(Context.Id_id))
+    (void)getDistributedActorIDProperty();
+  if (member.isSimpleName(Context.Id_actorSystem))
+    (void)getDistributedActorSystemProperty();
+
   // Silently break cycles here because we can't be sure when and where a
   // request to synthesize will come from yet.
   // FIXME: rdar://56844567
@@ -6458,14 +6468,12 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
   Bits.NominalTypeDecl.IsComputingSemanticMembers = true;
   SWIFT_DEFER { Bits.NominalTypeDecl.IsComputingSemanticMembers = false; };
 
-  auto baseName = member.getBaseName();
-  auto &Context = getASTContext();
   std::optional<ImplicitMemberAction> action = std::nullopt;
   if (baseName.isConstructor())
     action.emplace(ImplicitMemberAction::ResolveImplicitInit);
 
   if (member.isSimpleName() && !baseName.isSpecial()) {
-    if (baseName.getIdentifier() == getASTContext().Id_CodingKeys) {
+    if (baseName.getIdentifier() == Context.Id_CodingKeys) {
       action.emplace(ImplicitMemberAction::ResolveCodingKeys);
     }
   } else {
@@ -6475,7 +6483,7 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
         if ((member.isSimpleName() || argumentNames.front() == Context.Id_from)) {
           action.emplace(ImplicitMemberAction::ResolveDecodable);
         } else if (argumentNames.front() == Context.Id_system) {
-          action.emplace(ImplicitMemberAction::ResolveDistributedActorSystem);
+          action.emplace(ImplicitMemberAction::ResolveDistributedActor);
         }
       } else if (!baseName.isSpecial() &&
                  baseName.getIdentifier() == Context.Id_encode &&

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -15,11 +15,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DistributedDecl.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessRequests.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/ASTContext.h"
-#include "swift/AST/ASTWalker.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
@@ -29,7 +29,6 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -39,9 +38,10 @@
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
-#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/SwiftNameTranslation.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Lexer.h" // FIXME: Bad dependency
 #include "clang/Lex/MacroInfo.h"
@@ -51,7 +51,6 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
-#include "swift/Basic/StringExtras.h"
 
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Module.h"

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1313,12 +1313,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveDistributedActor:
     out << "resolve DistributedActor";
     break;
-  case ImplicitMemberAction::ResolveDistributedActorID:
-    out << "resolve DistributedActor.id";
-    break;
-  case ImplicitMemberAction::ResolveDistributedActorSystem:
-    out << "resolve DistributedActor.actorSystem";
-    break;
   }
 }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1310,9 +1310,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveDecodable:
     out << "resolve Decodable.init(from:)";
     break;
-  case ImplicitMemberAction::ResolveDistributedActor:
-    out << "resolve DistributedActor";
-    break;
   }
 }
 

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -74,10 +74,8 @@ void SILGenFunction::emitDistributedRemoteActorDeinit(
           continue;
 
         // Just to double-check, we only want to destroy `id` and `actorSystem`
-        if (vd->getBaseIdentifier() == C.Id_id ||
-            vd->getBaseIdentifier() == C.Id_actorSystem) {
+        if (vd->isSpecialDistributedProperty())
           destroyClassMember(cleanupLoc, borrowedSelf, vd);
-        }
       }
 
       if (cd->isRootDefaultActor()) {

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1238,19 +1238,6 @@ private:
                 ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
                 SmallVectorImpl<InferredTypeWitnessesSolution> &solutions);
 
-  /// We may need to determine a type witness, regardless of the existence of a
-  /// default value for it, e.g. when a 'distributed actor' is looking up its
-  /// 'ID', the default defined in an extension for 'Identifiable' would be
-  /// located using the lookup resolve. This would not be correct, since the
-  /// type actually must be based on the associated 'ActorSystem'.
-  ///
-  /// TODO(distributed): perhaps there is a better way to avoid this mixup?
-  ///   Note though that this issue seems to only manifest in "real" builds
-  ///   involving multiple files/modules, and not in tests within the Swift
-  ///   project itself.
-  bool canAttemptEagerTypeWitnessDerivation(
-      DeclContext *DC, AssociatedTypeDecl *assocType);
-
 public:
   /// Describes a mapping from associated type declarations to their
   /// type witnesses (as interface types).
@@ -1667,6 +1654,17 @@ AssociatedTypeInference::getPotentialTypeWitnessesFromRequirement(
       for (auto assocTypeDecl : allUnresolved)
         assocTypeDecl->dump(out);
     });
+  }
+
+  // The `id` and `actorSystem` DistributedActor properties are never viable
+  // for type witness inference since their synthesis relies on the type
+  // witnesses already being resolved.
+  if (auto *nominal = dc->getSelfNominalTypeDecl()) {
+    if (nominal->isDistributedActor() &&
+        req->isSpecialDistributedProperty(/*onlyCheckName*/ true)) {
+      LLVM_DEBUG(llvm::dbgs() << "skipping special distributed property\n");
+      return {};
+    }
   }
 
   TypeReprCycleCheckWalker cycleCheck(dc->getASTContext(), allUnresolved);
@@ -3990,20 +3988,6 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
   return false;
 }
 
-bool AssociatedTypeInference::canAttemptEagerTypeWitnessDerivation(
-    DeclContext *DC, AssociatedTypeDecl *assocType) {
-
-  /// Rather than locating the TypeID via the default implementation of
-  /// Identifiable, we need to find the type based on the associated ActorSystem
-  if (auto *nominal = DC->getSelfNominalTypeDecl())
-    if (nominal->isDistributedActor() &&
-        assocType->getProtocol()->isSpecificProtocol(KnownProtocolKind::Identifiable)) {
-    return true;
-  }
-
-  return false;
-}
-
 auto AssociatedTypeInference::solve() -> std::optional<InferredTypeWitnesses> {
   LLVM_DEBUG(llvm::dbgs() << "============ Start " << conformance->getType()
                           << ": " << conformance->getProtocol()->getName()
@@ -4021,16 +4005,6 @@ auto AssociatedTypeInference::solve() -> std::optional<InferredTypeWitnesses> {
     // If we already have a type witness, do nothing.
     if (conformance->hasTypeWitness(assocType))
       continue;
-
-    if (canAttemptEagerTypeWitnessDerivation(dc, assocType)) {
-      auto derivedType = computeDerivedTypeWitness(assocType);
-      if (derivedType.first) {
-        recordTypeWitness(conformance, assocType,
-                          derivedType.first->mapTypeOutOfContext(),
-                          derivedType.second);
-        continue;
-      }
-    }
 
     // Try to resolve this type witness via name lookup, which is the
     // most direct mechanism, overriding all others.

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2633,12 +2633,6 @@ deriveTypeWitness(const NormalProtocolConformance *Conformance,
     return derived.deriveDifferentiable(AssocType);
   case KnownProtocolKind::DistributedActor:
     return derived.deriveDistributedActor(AssocType);
-  case KnownProtocolKind::Identifiable:
-    // Identifiable only has derivation logic for distributed actors,
-    // because how it depends on the ActorSystem the actor is associated with.
-    // If the nominal wasn't a distributed actor, we should not end up here,
-    // but either way, then we'd return null (fail derivation).
-    return derived.deriveDistributedActor(AssocType);
   default:
     return std::make_pair(nullptr, nullptr);
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1449,18 +1449,6 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     TypeChecker::addImplicitConstructors(target);
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
     (void)evaluateTargetConformanceTo(decodableProto);
-  }
-    break;
-  case ImplicitMemberAction::ResolveDistributedActor: {
-    // init(transport:) and init(resolve:using:) may be synthesized as part of
-    // derived conformance to the DistributedActor protocol.
-    // If the target should conform to the DistributedActor protocol, check the
-    // conformance here to attempt synthesis.
-    // FIXME(distributed): invoke the requirement adding explicitly here
-    TypeChecker::addImplicitConstructors(target);
-    auto *distributedActorProto =
-        Context.getProtocol(KnownProtocolKind::DistributedActor);
-    (void)evaluateTargetConformanceTo(distributedActorProto);
     break;
   }
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1451,15 +1451,13 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     (void)evaluateTargetConformanceTo(decodableProto);
   }
     break;
-  case ImplicitMemberAction::ResolveDistributedActor:
-  case ImplicitMemberAction::ResolveDistributedActorSystem:
-  case ImplicitMemberAction::ResolveDistributedActorID: {
+  case ImplicitMemberAction::ResolveDistributedActor: {
     // init(transport:) and init(resolve:using:) may be synthesized as part of
     // derived conformance to the DistributedActor protocol.
     // If the target should conform to the DistributedActor protocol, check the
     // conformance here to attempt synthesis.
     // FIXME(distributed): invoke the requirement adding explicitly here
-     TypeChecker::addImplicitConstructors(target);
+    TypeChecker::addImplicitConstructors(target);
     auto *distributedActorProto =
         Context.getProtocol(KnownProtocolKind::DistributedActor);
     (void)evaluateTargetConformanceTo(distributedActorProto);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -836,21 +836,13 @@ GetDistributedActorIDPropertyRequest::evaluate(Evaluator &evaluator,
     return lookupDistributedActorProperty(nominal, C.Id_id);
 
   // ==== Synthesize and add 'id' property to the actor decl
-  Type propertyType = getDistributedActorIDType(nominal);
-  if (propertyType->hasError())
-    return nullptr;
-
   auto *propDecl = new (C) VarDecl(/*IsStatic*/ false, VarDecl::Introducer::Let,
                                    SourceLoc(), C.Id_id, nominal);
   propDecl->setImplicit();
   propDecl->setSynthesized();
   propDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
-  propDecl->setInterfaceType(propertyType);
 
-  auto propContextTy = nominal->mapTypeIntoContext(propertyType);
-
-  Pattern *propPat = NamedPattern::createImplicit(C, propDecl, propContextTy);
-  propPat = TypedPattern::createImplicit(C, propPat, propContextTy);
+  Pattern *propPat = NamedPattern::createImplicit(C, propDecl);
 
   PatternBindingDecl *pbDecl = PatternBindingDecl::createImplicit(
       C, StaticSpellingKind::None, propPat, /*InitExpr*/ nullptr, nominal);
@@ -893,19 +885,13 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
     return lookupDistributedActorProperty(nominal, C.Id_actorSystem);
 
   // ==== Synthesize and add 'actorSystem' property to the actor decl
-  Type propertyType = getDistributedActorSystemType(nominal);
-
   auto *propDecl = new (C) VarDecl(/*IsStatic*/ false, VarDecl::Introducer::Let,
                                    SourceLoc(), C.Id_actorSystem, nominal);
   propDecl->setImplicit();
   propDecl->setSynthesized();
   propDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
-  propDecl->setInterfaceType(propertyType);
 
-  auto propContextTy = nominal->mapTypeIntoContext(propertyType);
-
-  Pattern *propPat = NamedPattern::createImplicit(C, propDecl, propContextTy);
-  propPat = TypedPattern::createImplicit(C, propPat, propContextTy);
+  Pattern *propPat = NamedPattern::createImplicit(C, propDecl);
 
   PatternBindingDecl *pbDecl = PatternBindingDecl::createImplicit(
       C, StaticSpellingKind::None, propPat, /*InitExpr*/ nullptr, nominal);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -974,8 +974,6 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *nominal) const {
   auto &C = nominal->getASTContext();
 
-  auto DAS = C.getDistributedActorSystemDecl();
-
   // not via `ensureDistributedModuleLoaded` to avoid generating a warning,
   // we won't be emitting the offending decl after all.
   if (!C.getLoadedModule(C.Id_Distributed))
@@ -983,24 +981,6 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
 
   if (!nominal->isDistributedActor())
     return nullptr;
-
-  if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
-    auto DistributedActorProto = C.getDistributedActorDecl();
-    for (auto system : DistributedActorProto->lookupDirect(C.Id_actorSystem)) {
-      if (auto var = dyn_cast<VarDecl>(system)) {
-        auto conformance = checkConformance(
-            proto->mapTypeIntoContext(var->getInterfaceType()),
-            DAS);
-
-        if (conformance.isInvalid())
-          continue;
-
-        return var;
-      }
-    }
-
-    return nullptr;
-  }
 
   auto classDecl = dyn_cast<ClassDecl>(nominal);
   if (!classDecl)

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -89,7 +89,7 @@ static VarDecl *addImplicitDistributedActorIDProperty(
 
   // ==== Synthesize and add 'id' property to the actor decl
   Type propertyType = getDistributedActorIDType(nominal);
-  if (!propertyType || propertyType->hasError())
+  if (propertyType->hasError())
     return nullptr;
 
   auto *propDecl = new (C)
@@ -879,7 +879,7 @@ static bool canSynthesizeDistributedThunk(AbstractFunctionDecl *distributedTarge
 
   auto serializationTy =
       getDistributedActorSerializationType(distributedTarget->getDeclContext());
-  return serializationTy && !serializationTy->hasDependentMember();
+  return !serializationTy->hasError() && !serializationTy->hasDependentMember();
 }
 
 /******************************************************************************/

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -99,8 +99,6 @@ bool DerivedConformance::derivesProtocolConformance(
   if (*derivableKind == KnownDerivableProtocolKind::Actor)
     return canDeriveActor(DC, Nominal);
 
-  if (*derivableKind == KnownDerivableProtocolKind::Identifiable)
-    return canDeriveIdentifiable(Nominal, DC);
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActor)
     return canDeriveDistributedActor(Nominal, DC);
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActorSystem)

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -353,14 +353,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
       }
     }
 
-    // DistributedActor.id
-    if (name.isSimpleName(ctx.Id_id))
-      return getRequirement(KnownProtocolKind::DistributedActor);
-
-    // DistributedActor.actorSystem
-    if (name.isSimpleName(ctx.Id_actorSystem))
-      return getRequirement(KnownProtocolKind::DistributedActor);
-
     return nullptr;
   }
 

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -324,10 +324,6 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveDecodable(ValueDecl *requirement);  
 
-  /// Identifiable may need to have the `ID` type witness synthesized explicitly
-  static bool canDeriveIdentifiable(NominalTypeDecl *nominal,
-                                    DeclContext *dc);
-
   /// Whether we can derive the given DistributedActor requirement in the given context.
   static bool canDeriveDistributedActor(NominalTypeDecl *nominal,
                                         DeclContext *dc);

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -90,9 +90,6 @@ static FuncDecl *deriveDistributedActor_resolve(DerivedConformance &derived) {
   auto idType = getDistributedActorIDType(decl);
   auto actorSystemType = getDistributedActorSystemType(decl);
 
-  if (!idType || !actorSystemType)
-    return nullptr;
-
   // (id: Self.ID, using system: Self.ActorSystem)
   auto *params = ParameterList::create(
       C,

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -449,19 +449,6 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
 }
 
 /******************************************************************************/
-/******************************* PROPERTIES ***********************************/
-/******************************************************************************/
-
-static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
-  return derived.Nominal->getDistributedActorIDProperty();
-}
-
-static ValueDecl *deriveDistributedActor_actorSystem(
-    DerivedConformance &derived) {
-  return derived.Nominal->getDistributedActorSystemProperty();
-}
-
-/******************************************************************************/
 /***************************** ASSOC TYPES ************************************/
 /******************************************************************************/
 
@@ -788,13 +775,8 @@ static ValueDecl *deriveDistributedActor_unownedExecutor(DerivedConformance &der
 ValueDecl *DerivedConformance::deriveDistributedActor(ValueDecl *requirement) {
   if (auto var = dyn_cast<VarDecl>(requirement)) {
     ValueDecl *derivedValue = nullptr;
-    if (var->getName() == Context.Id_id) {
-      derivedValue = deriveDistributedActor_id(*this);
-    } else if (var->getName() == Context.Id_actorSystem) {
-      derivedValue = deriveDistributedActor_actorSystem(*this);
-    } else if (var->getName() == Context.Id_unownedExecutor) {
+    if (var->getName() == Context.Id_unownedExecutor)
       derivedValue = deriveDistributedActor_unownedExecutor(*this);
-    }
 
     if (derivedValue) {
       assertRequiredSynthesizedPropertyOrder(Context, Nominal);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7852,8 +7852,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         // The synthesized "id" and "actorSystem" are the only exceptions,
         // because the implementation mirrors them.
         if (nominal->isDistributedActor() &&
-            !(var->getName() == Ctx.Id_id ||
-              var->getName() == Ctx.Id_actorSystem)) {
+            !var->isSpecialDistributedProperty()) {
           diagnoseAndRemoveAttr(attr,
                                 diag::nonisolated_distributed_actor_storage);
           return;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2905,6 +2905,10 @@ static ArrayRef<Decl *> evaluateMembersRequest(
       ResolveImplicitMemberRequest{nominal,
                  ImplicitMemberAction::ResolveCodingKeys},
       {});
+
+    // Synthesize distributed actor 'id' and 'actorSystem' if needed.
+    (void)nominal->getDistributedActorIDProperty();
+    (void)nominal->getDistributedActorSystemProperty();
   }
 
   // Expand synthesized member macros.
@@ -2940,14 +2944,11 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     if (auto *vd = dyn_cast<ValueDecl>(member)) {
       // Add synthesized members to a side table and sort them by their mangled
       // name, since they could have been added to the class in any order.
-      if (vd->isSynthesized() &&
-          // FIXME: IRGen requires the distributed actor synthesized
-          // properties to be in a specific order that is different
-          // from ordering by their mangled name, so preserve the order
-          // they were added in.
-          !(nominal &&
-            (vd == nominal->getDistributedActorIDProperty() ||
-             vd == nominal->getDistributedActorSystemProperty()))) {
+      // FIXME: IRGen requires the distributed actor synthesized properties to
+      // be in a specific order that is different from ordering by their
+      // mangled name, so preserve the order
+      // they were added in.
+      if (vd->isSynthesized() && !vd->isSpecialDistributedProperty()) {
         synthesizedMembers.add(vd);
         return;
       }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1071,8 +1071,15 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
                     return req->getName() == VD->getName();
                   });
             }
-            declToDiagnose->diagnose(diag::invalid_redecl_implicit, current,
-                                     isProtocolRequirement, other);
+            auto *conflictDecl = current == declToDiagnose ? other : current;
+            if (conflictDecl->isSpecialDistributedProperty()) {
+              declToDiagnose->diagnose(
+                  diag::distributed_actor_user_defined_special_property,
+                  other->getName());
+            } else {
+              declToDiagnose->diagnose(diag::invalid_redecl_implicit, current,
+                                       isProtocolRequirement, other);
+            }
 
             // Emit a specialized note if the one of the declarations is
             // the backing storage property ('_foo') or projected value

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -461,13 +461,6 @@ static void installCodingKeysIfNecessary(NominalTypeDecl *NTD) {
   (void)evaluateOrDefault(NTD->getASTContext().evaluator, req, {});
 }
 
-// TODO(distributed): same ugly hack as Codable does...
-static void installDistributedActorIfNecessary(NominalTypeDecl *NTD) {
-  auto req =
-    ResolveImplicitMemberRequest{NTD, ImplicitMemberAction::ResolveDistributedActor};
-  (void)evaluateOrDefault(NTD->getASTContext().evaluator, req, {});
-}
-
 // Check for static properties that produce empty option sets
 // using a rawValue initializer with a value of '0'
 static void checkForEmptyOptionSet(const VarDecl *VD) {
@@ -3089,7 +3082,6 @@ public:
     TypeChecker::addImplicitConstructors(SD);
 
     installCodingKeysIfNecessary(SD);
-    installDistributedActorIfNecessary(SD);
 
     TypeChecker::checkDeclAttributes(SD);
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -410,12 +410,8 @@ static bool checkDistributedTargetResultType(
     bool diagnose) {
   auto &C = valueDecl->getASTContext();
 
-  if (serializationRequirement && serializationRequirement->hasError()) {
-    return false;
-  }
-  if (!serializationRequirement || serializationRequirement->hasError()) {
+  if (serializationRequirement->hasError())
     return false; // error of the type would be diagnosed elsewhere
-  }
 
   Type resultType;
   if (auto func = dyn_cast<FuncDecl>(valueDecl)) {
@@ -434,11 +430,8 @@ static bool checkDistributedTargetResultType(
 
   SmallVector<ProtocolDecl *, 4> serializationRequirements;
   // Collect extra "SerializationRequirement: SomeProtocol" requirements
-  if (serializationRequirement && !serializationRequirement->hasError()) {
-    auto srl = serializationRequirement->getExistentialLayout();
-    llvm::copy(srl.getProtocols(),
-               std::back_inserter(serializationRequirements));
-  }
+  auto srl = serializationRequirement->getExistentialLayout();
+  llvm::copy(srl.getProtocols(), std::back_inserter(serializationRequirements));
 
   auto isCodableRequirement =
       checkDistributedSerializationRequirementIsExactlyCodable(
@@ -470,7 +463,7 @@ static bool checkDistributedTargetResultType(
     }
   }
 
-    return false;
+  return false;
 }
 
 bool swift::checkDistributedActorSystem(const NominalTypeDecl *system) {
@@ -551,7 +544,7 @@ bool CheckDistributedFunctionRequest::evaluate(
 
   for (auto param: *func->getParameters()) {
     // --- Check the parameter conforming to serialization requirements
-    if (serializationReqType && !serializationReqType->hasError()) {
+    if (!serializationReqType->hasError()) {
       // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
       auto serializationRequirementIsCodable =
           checkDistributedSerializationRequirementIsExactlyCodable(
@@ -861,7 +854,7 @@ GetDistributedActorInvocationDecoderRequest::evaluate(Evaluator &evaluator,
   auto &ctx = actor->getASTContext();
   auto decoderTy = getAssociatedTypeOfDistributedSystemOfActor(
       actor, ctx.Id_InvocationDecoder);
-  return decoderTy ? decoderTy->getAnyNominal() : nullptr;
+  return decoderTy->getAnyNominal();
 }
 
 FuncDecl *
@@ -886,7 +879,7 @@ GetDistributedActorConcreteArgumentDecodingMethodRequest::evaluate(
     auto serializationTy = getAssociatedTypeOfDistributedSystemOfActor(
         actor, ctx.Id_SerializationRequirement);
 
-    if (!serializationTy || !serializationTy->is<ExistentialType>())
+    if (!serializationTy->is<ExistentialType>())
       return nullptr;
 
     SmallVector<ProtocolDecl *, 4> serializationRequirements;

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -723,15 +723,6 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
       }
     }
   }
-
-  // ==== Properties
-  // --- Synthesize the 'id' property here rather than via derived conformance
-  //     because the 'DerivedConformanceDistributedActor' won't trigger for 'id'
-  //     because it has a default impl via 'Identifiable' (ObjectIdentifier)
-  //     which we do not want.
-  // Also, the 'id' var must be added before the 'actorSystem'.
-  // See NOTE (id-before-actorSystem) for more details.
-  (void)nominal->getDistributedActorIDProperty();
 }
 
 bool TypeChecker::checkDistributedFunc(FuncDecl *func) {

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -37,9 +37,6 @@ class NominalTypeDecl;
 // Diagnose an error if the Distributed module is not loaded.
 bool ensureDistributedModuleLoaded(const ValueDecl *decl);
 
-/// Check for illegal property declarations (e.g. re-declaring transport or id)
-void checkDistributedActorProperties(const NominalTypeDecl *decl);
-
 /// Type-check additional ad-hoc protocol requirements.
 /// Ad-hoc requirements are protocol requirements currently not expressible
 /// in the Swift type-system.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4712,15 +4712,6 @@ deriveProtocolRequirement(const NormalProtocolConformance *Conformance,
   case KnownDerivableProtocolKind::Differentiable:
     return derived.deriveDifferentiable(Requirement);
 
-  case KnownDerivableProtocolKind::Identifiable:
-    if (derived.Nominal->isDistributedActor()) {
-      return derived.deriveDistributedActor(Requirement);
-    } else {
-      // No synthesis is required for other types; we should only end up
-      // attempting synthesis if the nominal was a distributed actor.
-      llvm_unreachable("Identifiable is synthesized for distributed actors");
-    }
-
   case KnownDerivableProtocolKind::DistributedActor:
     return derived.deriveDistributedActor(Requirement);
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
@@ -406,16 +407,58 @@ MemberwiseInitPropertiesRequest::evaluate(Evaluator &evaluator,
   return decl->getASTContext().AllocateCopy(results);
 }
 
+static Type getLazyInterfaceTypeForSynthesizedVar(VarDecl *var) {
+  // For DistributedActor, the `id` and `actorSystem` properties have their
+  // types computed lazily.
+  if (auto distPropKind = var->isSpecialDistributedProperty()) {
+    auto *NTD = var->getDeclContext()->getSelfNominalTypeDecl();
+    ASSERT(NTD);
+    switch (distPropKind.value()) {
+    case SpecialDistributedProperty::Id:
+      return getDistributedActorIDType(NTD);
+    case SpecialDistributedProperty::ActorSystem:
+      return getDistributedActorSystemType(NTD);
+    }
+    llvm_unreachable("Unhandled case in switch!");
+  }
+  return Type();
+}
+
+static Pattern *
+getLazilySynthesizedPattern(PatternBindingDecl *PBD, Pattern *P) {
+  // Check to see if we have a pattern that binds a single synthesized var.
+  auto *NP = dyn_cast<NamedPattern>(P->getSemanticsProvidingPattern());
+  if (!NP)
+    return P;
+
+  auto *var = NP->getDecl();
+  if (!var->isSynthesized())
+    return P;
+
+  auto interfaceTy = getLazyInterfaceTypeForSynthesizedVar(var);
+  if (!interfaceTy)
+    return P;
+
+  auto *DC = var->getDeclContext();
+  auto &ctx = DC->getASTContext();
+  auto patternTy = DC->mapTypeIntoContext(interfaceTy);
+  return TypedPattern::createImplicit(ctx, P, patternTy);
+}
+
 /// Validate the \c entryNumber'th entry in \c binding.
 const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     Evaluator &eval, PatternBindingDecl *binding, unsigned entryNumber) const {
   const auto &pbe = binding->getPatternList()[entryNumber];
   auto &Context = binding->getASTContext();
 
+  // Resolve a lazily synthesized pattern if necessary.
+  auto *pattern = binding->getPattern(entryNumber);
+  pattern = getLazilySynthesizedPattern(binding, pattern);
+  binding->setPattern(entryNumber, pattern);
+
   // Resolve the pattern.
-  auto *pattern = TypeChecker::resolvePattern(binding->getPattern(entryNumber),
-                                              binding->getDeclContext(),
-                                              /*isStmtCondition*/ true);
+  pattern = TypeChecker::resolvePattern(pattern, binding->getDeclContext(),
+                                        /*isStmtCondition*/ true);
   if (!pattern) {
     binding->setInvalid();
     binding->getPattern(entryNumber)->setType(ErrorType::get(Context));

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -213,30 +213,10 @@ static void enumerateStoredPropertiesAndMissing(
   // If we have a distributed actor, find the id and actorSystem
   // properties. We always want them first, and in a specific
   // order.
-  if (decl->isDistributedActor()) {
-    VarDecl *distributedActorId = nullptr;
-    VarDecl *distributedActorSystem = nullptr;
-    ASTContext &ctx = decl->getASTContext();
-    for (auto *member : implDecl->getMembers()) {
-      if (auto *var = dyn_cast<VarDecl>(member)) {
-        if (!var->isStatic() && var->hasStorage()) {
-          if (var->getName() == ctx.Id_id) {
-            distributedActorId = var;
-          } else if (var->getName() == ctx.Id_actorSystem) {
-            distributedActorSystem = var;
-          }
-        }
-
-        if (distributedActorId && distributedActorSystem)
-          break;
-      }
-    }
-
-    if (distributedActorId)
-      addStoredProperty(distributedActorId);
-    if (distributedActorSystem)
-      addStoredProperty(distributedActorSystem);
-  }
+  if (auto idVar = decl->getDistributedActorIDProperty())
+    addStoredProperty(idVar);
+  if (auto actorSystemVar = decl->getDistributedActorSystemProperty())
+    addStoredProperty(actorSystemVar);
 
   for (auto *member : implDecl->getMembers()) {
     if (auto *var = dyn_cast<VarDecl>(member)) {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -26,7 +26,7 @@ distributed actor Caplin {
   typealias ActorSystem = FakeActorSystem
 }
 
-@Resolvable // expected-note 4{{in expansion of macro 'Resolvable' on protocol 'Fail' here}}
+@Resolvable // expected-note 5{{in expansion of macro 'Resolvable' on protocol 'Fail' here}}
 protocol Fail: DistributedActor {
   distributed func method() -> String
 }
@@ -36,6 +36,7 @@ expected-expansion@-2:2{{
   expected-note@1:13{{you can provide a module-wide default actor system by declaring:}}
   expected-error@1:19{{type '$Fail' does not conform to protocol 'DistributedActor'}}
   expected-note@1:19{{add stubs for conformance}}
+  expected-error@1:19{{type '$Fail' does not conform to protocol 'Identifiable'}}
 }}
 */
 

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -11,6 +11,7 @@ distributed actor DA {
   // expected-error@-2 {{type 'DA' does not conform to protocol 'DistributedActor'}}
   // expected-note@-3 {{add stubs for conformance}}
   // expected-note@-4{{you can provide a module-wide default actor system by declaring:}}
+  // expected-error@-5 {{type 'DA' does not conform to protocol 'Identifiable'}}
 
   // Note to add the typealias is diagnosed on the protocol:
   // _Distributed.DistributedActor:3:20: note: diagnostic produced elsewhere: protocol requires nested type 'ActorSystem'; do you want to add it?
@@ -24,6 +25,7 @@ distributed actor Server { // expected-error 2 {{distributed actor 'Server' does
   // expected-error@-1 {{type 'Server' does not conform to protocol 'DistributedActor'}}
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
   // expected-note@-3 {{add stubs for conformance}}
+  // expected-error@-4 {{type 'Server' does not conform to protocol 'Identifiable'}}
   typealias ActorSystem = DoesNotExistDataSystem
   // expected-error@-1{{cannot find type 'DoesNotExistDataSystem' in scope}}
   typealias SerializationRequirement = any Codable

--- a/test/Distributed/distributed_actor_system_missing_system_type.swift
+++ b/test/Distributed/distributed_actor_system_missing_system_type.swift
@@ -14,6 +14,7 @@ distributed actor MyActor {
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
   // expected-error@-3{{type 'MyActor' does not conform to protocol 'DistributedActor'}}
   // expected-note@-4 {{add stubs for conformance}}
+  // expected-error@-5 {{type 'MyActor' does not conform to protocol 'Identifiable'}}
 
   distributed var foo: String {
     return "xyz"
@@ -25,6 +26,7 @@ distributed actor BadSystemActor {
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
   // expected-error@-3{{type 'BadSystemActor' does not conform to protocol 'DistributedActor'}}
   // expected-note@-4 {{add stubs for conformance}}
+  // expected-error@-5 {{type 'BadSystemActor' does not conform to protocol 'Identifiable'}}
 
   // This system does not exist: but we should not crash, but just diagnose about it:
   typealias ActorSystem = ClusterSystem // expected-error{{cannot find type 'ClusterSystem' in scope}}

--- a/test/Distributed/distributed_actor_system_missing_type_no_crash.swift
+++ b/test/Distributed/distributed_actor_system_missing_type_no_crash.swift
@@ -13,6 +13,7 @@ distributed actor Fish {
   // expected-error@-3{{type 'Fish' does not conform to protocol 'DistributedActor'}}
   // expected-note@-4{{you can provide a module-wide default actor system by declaring:\ntypealias DefaultDistributedActorSystem = <#ConcreteActorSystem#>}}
   // expected-note@-5 {{add stubs for conformance}}
+  // expected-error@-6 {{type 'Fish' does not conform to protocol 'Identifiable'}}
 
   distributed func tell(_ text: String, by: Fish) {
     // What would the fish say, if it could talk?

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -54,6 +54,7 @@ distributed actor ProtocolWithChecksSeqReqDA_MissingSystem: ProtocolWithChecksSe
   //
   // expected-error@-6{{type 'ProtocolWithChecksSeqReqDA_MissingSystem' does not conform to protocol 'DistributedActor'}}
   // expected-note@-7 {{add stubs for conformance}}
+  // expected-error@-8 {{type 'ProtocolWithChecksSeqReqDA_MissingSystem' does not conform to protocol 'Identifiable'}}
 
   // Entire conformance is doomed, so we didn't proceed to checking the functions; that's fine
   distributed func testAT() async throws -> NotCodable { .init() }

--- a/test/Distributed/rdar162800185.swift
+++ b/test/Distributed/rdar162800185.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Make sure we can resolve the conformance to DistributedActor from a secondary.
+// RUN: %target-swift-frontend -c -module-name main -target %target-swift-5.7-abi-triple %t/a.swift %t/b.swift -o %/tmp
+// RUN: %target-swift-frontend -c -module-name main -target %target-swift-5.7-abi-triple -primary-file %t/a.swift %t/b.swift -o %/tmp
+// RUN: %target-swift-frontend -c -module-name main -target %target-swift-5.7-abi-triple %t/a.swift -primary-file %t/b.swift -o %/tmp
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+//--- a.swift
+import Distributed
+
+distributed actor A<ActorSystem: DistributedActorSystem> {}
+
+//--- b.swift
+import Distributed
+
+func foo<T: DistributedActor>(_: T.Type) where T.ActorSystem == LocalTestingDistributedActorSystem {}
+func bar() { foo(A.self) }

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -verify-ignore-unknown -verify-ignore-unrelated
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -66,6 +66,29 @@ distributed actor D5: P1 {
 }
 
 nonisolated distributed actor D6 {} // expected-error {{'nonisolated' modifier cannot be applied to this declaration}}{{1-13=}}
+
+// Can't define `id` and `actorSystem` in an extension either.
+distributed actor D7 {}
+extension D7 {
+  nonisolated var id: String { fatalError() }
+  // expected-error@-1 {{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
+
+  nonisolated var actorSystem: OtherActorIdentity { fatalError() }
+  // expected-error@-1 {{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
+}
+
+// FIXME: Unfortunately redeclaration checking is run after conformance checking
+// so we also get a conformace error here.
+distributed actor D8 {} // expected-error {{type 'D8' does not conform to protocol 'DistributedActor'}}
+extension D8 {
+  nonisolated var id: ID { fatalError() }
+  // expected-error@-1 {{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
+  // expected-note@-2 {{candidate exactly matches}}
+
+  nonisolated var actorSystem: DefaultDistributedActorSystem { fatalError() }
+  // expected-error@-1 {{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
+  // expected-note@-2 {{candidate exactly matches}}
+}
 
 // ==== Tests ------------------------------------------------------------------
 

--- a/validation-test/compiler_crashers_fixed/verificationFailure-94e552.swift
+++ b/validation-test/compiler_crashers_fixed/verificationFailure-94e552.swift
@@ -1,0 +1,10 @@
+// {"kind":"emit-silgen","signature":"swift::verificationFailure(llvm::Twine const&, swift::SILInstruction const*, swift::SILArgument const*, llvm::function_ref<void (swift::SILPrintContext&)>)"}
+// RUN: not %target-swift-frontend -emit-silgen %s
+// REQUIRES: OS=macosx
+import Distributed
+distributed actor a<ActorSystem: DistributedActorSystem> {
+}
+extension a {
+  nonisolated var id: ActorSystem.ActorID {
+  }
+}


### PR DESCRIPTION
- Ensure `associatedtype` inference never considers `id` and `actorSystem` properties for a distributed actor since doing so would either result in cycles or resolving using `Identifiable`'s default `id`
- Consolidate synthesis logic that was previously duplicated across witness derivation and separate requests to trigger synthesis
- Always synthesize `id` and `actorSystem` for a distributed actor, allowing redeclaration checking to diagnose user-defined versions
- Lazily compute the interface types for `id` and `actorSystem`, ensuring the synthesis logic doesn't kick semantic requests
- Install `id` and `actorSystem` as part of `synthesizeSemanticMembersIfNeeded` to ensure they're always injected into name lookup results (this is the actual fix for rdar://162800185)
- Remove `Identifiable` derivation code and `ImplicitMemberAction::ResolveDistributedActor`, neither of which should be necessary now

rdar://162800185