### PR TITLE
[cxx-interop] Avoid cycles when importing certain enums

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -273,6 +273,23 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
 
     auto literalType = getConstantLiteralType(type, convertKind);
 
+    auto findBuiltinInit = [&](NominalTypeDecl *decl,
+                               StringRef paramName) -> ValueDecl * {
+      auto memberIter =
+          llvm::find_if(decl->getCurrentMembers(), [&](Decl *member) -> bool {
+            if (auto ctorDecl = dyn_cast<ConstructorDecl>(member)) {
+              if (ctorDecl->getParameters()->size() == 1 &&
+                  ctorDecl->getParameters()->hasInternalParameter(
+                      paramName)) {
+                return true;
+              }
+            }
+            return false;
+          });
+      ASSERT(memberIter != decl->getCurrentMembers().end());
+      return cast<ValueDecl>(*memberIter);
+    };
+
     // Create the expression node.
     StringRef printedValueCopy(context.AllocateCopy(printedValue));
     if (value.getKind() == clang::APValue::Int) {
@@ -300,7 +317,8 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
                                              /*Implicit=*/true);
 
         auto *intDecl = literalType->getAnyNominal();
-        intExpr->setBuiltinInitializer(context.getIntBuiltinInitDecl(intDecl));
+        intExpr->setBuiltinInitializer(
+            findBuiltinInit(intDecl, "_builtinIntegerLiteral"));
         intExpr->setType(literalType);
 
         expr = intExpr;


### PR DESCRIPTION
This fixes an assertion failure:
```
Assertion failed: (builtinInitializer), function setBuiltinInitializer at Expr.cpp:1092
```

This was happening because of a cycle: ClangImporter tried to import an enum, which triggered a conformance lookup for `Int`, which triggered Clang module loading of the enum's owning module.

rdar://163596214

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
