### PR TITLE
Revert "AST: Add assertion to BuiltinLiteralExpr::setBuiltinInitializer()"

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -697,7 +697,9 @@ public:
 
   /// Set the builtin initializer that will be used to construct the
   /// literal.
-  void setBuiltinInitializer(ConcreteDeclRef builtinInitializer);
+  void setBuiltinInitializer(ConcreteDeclRef builtinInitializer) {
+    BuiltinInitializer = builtinInitializer;
+  }
 };
 
 /// The 'nil' literal.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1086,14 +1086,7 @@ StringRef LiteralExpr::getLiteralKindDescription() const {
   llvm_unreachable("Unhandled literal");
 }
 
-void BuiltinLiteralExpr::setBuiltinInitializer(
-    ConcreteDeclRef builtinInitializer) {
-  ASSERT(builtinInitializer);
-  BuiltinInitializer = builtinInitializer;
-}
-
-IntegerLiteralExpr * IntegerLiteralExpr::createFromUnsigned(
-    ASTContext &C, unsigned value, SourceLoc loc) {
+IntegerLiteralExpr * IntegerLiteralExpr::createFromUnsigned(ASTContext &C, unsigned value, SourceLoc loc) {
   llvm::SmallString<8> Scratch;
   llvm::APInt(sizeof(unsigned)*8, value).toString(Scratch, 10, /*signed*/ false);
   auto Text = C.AllocateCopy(StringRef(Scratch));


### PR DESCRIPTION
This reverts commit d7d564148725de3b7cc8dcf3d3cb6c2b88cb117a.

rdar://163596214

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
