### PR TITLE
[Concurrency] Add environment variable for disabling async stack slab allocator.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -14,6 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef SWIFT_RUNTIME_ENVIRONMENTVARIABLES_H
+#define SWIFT_RUNTIME_ENVIRONMENTVARIABLES_H
+
 #include "swift/Threading/Once.h"
 #include "swift/shims/Visibility.h"
 
@@ -63,6 +66,12 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride();
 
+// Wrapper around SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR that the Concurrency
+// library can call.
+SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator();
+
 } // end namespace environment
 } // end namespace runtime
 } // end namespace swift
+
+#endif // SWIFT_RUNTIME_ENVIRONMENTVARIABLES_H

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -84,3 +84,8 @@ void swift::swift_job_deallocate(Job *job, void *ptr) {
 
   allocator(static_cast<AsyncTask *>(job)).dealloc(ptr);
 }
+
+#if !SWIFT_CONCURRENCY_EMBEDDED
+std::atomic<TaskAllocatorConfiguration::EnableState>
+    TaskAllocatorConfiguration::enableState = {EnableState::Uninitialized};
+#endif

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -319,3 +319,7 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
 SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride() {
   return runtime::environment::SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE();
 }
+
+SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator() {
+  return runtime::environment::SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR();
+}

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -147,4 +147,9 @@ VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
          "record names, e.g. by the Distributed runtime to invoke distributed "
          "functions.")
 
+VARIABLE(SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR, bool, true,
+         "Use a slab allocator for the async stack. If not enabled, directly "
+         "call malloc/free. Direct use of malloc/free enables use of memory "
+         "debugging tools for async stack allocations.")
+
 #undef VARIABLE

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
@@ -25,7 +25,7 @@
 #include "swift/Runtime/Error.h"
 
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
-#include "public/runtime/StackAllocator.h"
+#include "Runtime/StackAllocator.h"
 
 namespace swift {
 

--- a/stdlib/toolchain/Compatibility56/include/Runtime/StackAllocator.h
+++ b/stdlib/toolchain/Compatibility56/include/Runtime/StackAllocator.h
@@ -57,15 +57,7 @@ namespace swift {
 ///
 /// SlabMetadataPtr specifies a fake metadata pointer to place at the beginning
 /// of slab allocations, so analysis tools can identify them.
-///
-/// SlabAllocatorConfiguration allows customizing behavior. It currently allows
-/// one customization point: bool enableSlabAllocator():
-///   returns false - the stack allocator directly calls malloc/free
-///   returns true - the slab allocator is used
-/// This function MUST return the same value throughout the lifetime the stack
-/// allocator.
-template <size_t SlabCapacity, Metadata *SlabMetadataPtr,
-          typename SlabAllocatorConfiguration>
+template <size_t SlabCapacity, Metadata *SlabMetadataPtr>
 class StackAllocator {
 private:
 
@@ -85,8 +77,6 @@ private:
   /// Used for unit testing.
   uint32_t numAllocatedSlabs:31;
 
-  /// The configuration object.
-  [[no_unique_address]] SlabAllocatorConfiguration configuration;
 
   /// The minimal alignment of allocated memory.
   static constexpr size_t alignment = MaximumAlignment;
@@ -237,10 +227,9 @@ private:
   };
 
   // Return a slab which is suitable to allocate \p size memory.
-  SWIFT_ALWAYS_INLINE
   Slab *getSlabForAllocation(size_t size) {
     Slab *slab = (lastAllocation ? lastAllocation->slab : firstSlab);
-    if (SWIFT_LIKELY(slab)) {
+    if (slab) {
       // Is there enough space in the current slab?
       if (slab->canAllocate(size))
         return slab;
@@ -260,12 +249,6 @@ private:
         size = std::max(size, alreadyAllocatedCapacity);
       }
     }
-
-    // This is only checked on the path that allocates a new slab, to minimize
-    // overhead when the slab allocator is enabled.
-    if (SWIFT_UNLIKELY(!configuration.enableSlabAllocator()))
-      return nullptr;
-
     size_t capacity = std::max(SlabCapacity,
                                Allocation::includingHeader(size));
     void *slabBuffer = malloc(Slab::includingHeader(capacity));
@@ -298,14 +281,12 @@ public:
   /// Construct a StackAllocator without a pre-allocated first slab.
   StackAllocator()
       : firstSlab(nullptr), firstSlabIsPreallocated(false),
-        numAllocatedSlabs(0), configuration() {}
+        numAllocatedSlabs(0) {}
 
   /// Construct a StackAllocator with a pre-allocated first slab.
   StackAllocator(void *firstSlabBuffer, size_t bufferCapacity) : StackAllocator() {
     // If the pre-allocated buffer can't hold a slab header, ignore it.
     if (bufferCapacity <= Slab::headerSize())
-      return;
-    if (SWIFT_UNLIKELY(!configuration.enableSlabAllocator()))
       return;
     char *start = (char *)llvm::alignAddr(firstSlabBuffer,
                                           llvm::Align(alignment));
@@ -336,17 +317,6 @@ public:
       size += sizeof(uintptr_t);
     size_t alignedSize = llvm::alignTo(size, llvm::Align(alignment));
     Slab *slab = getSlabForAllocation(alignedSize);
-
-    // If getSlabForAllocation returns null, that means that the slab allocator
-    // is disabled, and we should directly call malloc. We get this info
-    // indirectly rather than directly calling enableSlabAllocator() in order
-    // to minimize the overhead in the case where the slab allocator is enabled.
-    // When getSlabForAllocation gets inlined into this code, this ends up
-    // getting folded into its enableSlabAllocator() call, and the fast path
-    // where `slab` is non-null ends up with no extra conditionals at all.
-    if (SWIFT_UNLIKELY(!slab))
-      return malloc(size);
-
     Allocation *allocation = slab->allocate(alignedSize, lastAllocation);
     lastAllocation = allocation;
     assert(llvm::isAddrAligned(llvm::Align(alignment),
@@ -356,10 +326,7 @@ public:
 
   /// Deallocate memory \p ptr.
   void dealloc(void *ptr) {
-    if (SWIFT_UNLIKELY(!lastAllocation ||
-                       lastAllocation->getAllocatedMemory() != ptr)) {
-      if (!configuration.enableSlabAllocator())
-        return free(ptr);
+    if (!lastAllocation || lastAllocation->getAllocatedMemory() != ptr) {
       SWIFT_FATAL_ERROR(0, "freed pointer was not the last allocation");
     }
 

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1148,3 +1148,6 @@ Added: __swift_debug_metadataAllocatorPageSize
 Added: __swift_retainRelease_slowpath_mask_v1
 Added: _swift_release_preservemost
 Added: _swift_retain_preservemost
+
+// New debug environment variable for the concurrency runtime.
+Added: _concurrencyEnableTaskSlabAllocator

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1143,3 +1143,6 @@ Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 // Internal info exposed for swift-inspect.
 Added: __swift_debug_allocationPoolSize
 Added: __swift_debug_metadataAllocatorPageSize
+
+// New debug environment variable for the concurrency runtime.
+Added: _concurrencyEnableTaskSlabAllocator

--- a/unittests/runtime/StackAllocator.cpp
+++ b/unittests/runtime/StackAllocator.cpp
@@ -25,11 +25,15 @@ static constexpr size_t exceedsSlab = slabCapacity + 16;
 
 static Metadata SlabMetadata;
 
+struct SlabAllocatorConfiguration {
+  bool enableSlabAllocator() { return true; }
+};
+
 TEST(StackAllocatorTest, withPreallocatedSlab) {
 
   char firstSlab[firstSlabBufferCapacity];
-  StackAllocator<slabCapacity, &SlabMetadata> allocator(
-      firstSlab, firstSlabBufferCapacity);
+  StackAllocator<slabCapacity, &SlabMetadata, SlabAllocatorConfiguration>
+      allocator(firstSlab, firstSlabBufferCapacity);
 
   char *mem1 = (char *)allocator.alloc(fitsIntoFirstSlab);
   EXPECT_EQ(allocator.getNumAllocatedSlabs(), 0);
@@ -74,7 +78,8 @@ TEST(StackAllocatorTest, withoutPreallocatedSlab) {
 
   constexpr size_t slabCapacity = 256;
 
-  StackAllocator<slabCapacity, &SlabMetadata> allocator;
+  StackAllocator<slabCapacity, &SlabMetadata, SlabAllocatorConfiguration>
+      allocator;
 
   size_t fitsIntoSlab = slabCapacity - 16;
   size_t twoFitIntoSlab = slabCapacity / 2 - 32;


### PR DESCRIPTION
Add SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR, which is on by default. When turned off, async stack allocations call through to malloc/free. This allows memory debugging tools to be used on async stack allocations.