### PR TITLE
[Runtime] Rename ClientRetainRelease library to SwiftDirectRuntime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,16 +271,16 @@ option(SWIFT_BUILD_STDLIB_CXX_MODULE
   "If not building stdlib, controls whether to build the Cxx module"
   TRUE)
 
-# The swiftClientRetainRelease library is currently only available for Darwin
+# The swiftSwiftDirectRuntime library is currently only available for Darwin
 # platforms.
 if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
   # Off by default everywhere for now.
-  option(SWIFT_BUILD_CLIENT_RETAIN_RELEASE
-    "Build the swiftClientRetainRelease library"
+  option(SWIFT_BUILD_SWIFT_DIRECT_RUNTIME
+    "Build the swiftSwiftDirectRuntime library"
     FALSE)
 else()
-  option(SWIFT_BUILD_CLIENT_RETAIN_RELEASE
-    "Build the swiftClientRetainRelease library"
+  option(SWIFT_BUILD_SWIFT_DIRECT_RUNTIME
+    "Build the swiftSwiftDirectRuntime library"
     FALSE)
 endif()
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -556,8 +556,8 @@ public:
   // Whether to emit mergeable or non-mergeable traps.
   unsigned MergeableTraps : 1;
 
-  /// Enable the use of swift_retain/releaseClient functions.
-  unsigned EnableClientRetainRelease : 1;
+  /// Enable the use of swift_retain/releaseDirect functions.
+  unsigned EnableSwiftDirectRuntime : 1;
 
   /// The number of threads for multi-threaded code generation.
   unsigned NumThreads = 0;
@@ -686,7 +686,7 @@ public:
         EmitAsyncFramePushPopMetadata(true), EmitTypeMallocForCoroFrame(true),
         AsyncFramePointerAll(false), UseProfilingMarkerThunks(false),
         UseCoroCCX8664(false), UseCoroCCArm64(false), MergeableTraps(false),
-        EnableClientRetainRelease(false),
+        EnableSwiftDirectRuntime(false),
         DebugInfoForProfiling(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1477,12 +1477,12 @@ def mergeable_traps :
   Flag<["-"], "mergeable-traps">,
   HelpText<"Emit mergeable traps even in optimized builds">;
 
-def enable_client_retain_release :
-  Flag<["-"], "enable-client-retain-release">,
-  HelpText<"Enable use of swift_retain/releaseClient functions">;
-def disable_client_retain_release :
-  Flag<["-"], "disable-client-retain-release">,
-  HelpText<"Disable use of swift_retain/releaseClient functions">;
+def enable_direct_retain_release :
+  Flag<["-"], "enable-direct-retain-release">,
+  HelpText<"Enable use of swift_retain/releaseDirect functions">;
+def disable_direct_retain_release :
+  Flag<["-"], "disable-direct-retain-release">,
+  HelpText<"Disable use of swift_retain/releaseDirect functions">;
 
 def enable_new_llvm_pass_manager :
   Flag<["-"], "enable-new-llvm-pass-manager">,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -221,7 +221,7 @@ FUNCTION(NativeStrongRelease, Swift, swift_release, C_CC, AlwaysAvailable,
          UNKNOWN_MEMEFFECTS)
 
 // void *swift_retain(void *ptr);
-FUNCTION(NativeStrongRetainClient, Swift, swift_retainClient, SwiftClientRR_CC, AlwaysAvailable,
+FUNCTION(NativeStrongRetainDirect, Swift, swift_retainDirect, SwiftDirectRR_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned, WillReturn),
@@ -229,7 +229,7 @@ FUNCTION(NativeStrongRetainClient, Swift, swift_retainClient, SwiftClientRR_CC, 
          UNKNOWN_MEMEFFECTS)
 
 // void swift_release(void *ptr);
-FUNCTION(NativeStrongReleaseClient, Swift, swift_releaseClient, SwiftClientRR_CC, AlwaysAvailable,
+FUNCTION(NativeStrongReleaseDirect, Swift, swift_releaseDirect, SwiftDirectRR_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
@@ -436,18 +436,18 @@ FUNCTION(BridgeObjectStrongRelease, Swift, swift_bridgeObjectRelease,
          EFFECT(RuntimeEffect::RefCounting, RuntimeEffect::Deallocating),
          UNKNOWN_MEMEFFECTS)
 
-// void *swift_bridgeObjectRetainClient(void *ptr);
-FUNCTION(BridgeObjectStrongRetainClient, Swift, swift_bridgeObjectRetainClient,
-         SwiftClientRR_CC, AlwaysAvailable,
+// void *swift_bridgeObjectRetainDirect(void *ptr);
+FUNCTION(BridgeObjectStrongRetainDirect, Swift, swift_bridgeObjectRetainDirect,
+         SwiftDirectRR_CC, AlwaysAvailable,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, FirstParamReturned),
          EFFECT(RuntimeEffect::RefCounting),
          UNKNOWN_MEMEFFECTS)
 
-// void *swift_bridgeObjectReleaseClient(void *ptr);
-FUNCTION(BridgeObjectStrongReleaseClient, Swift, swift_bridgeObjectReleaseClient,
-         SwiftClientRR_CC, AlwaysAvailable,
+// void *swift_bridgeObjectReleaseDirect(void *ptr);
+FUNCTION(BridgeObjectStrongReleaseDirect, Swift, swift_bridgeObjectReleaseDirect,
+         SwiftDirectRR_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3993,10 +3993,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.MergeableTraps = Args.hasArg(OPT_mergeable_traps);
 
-  Opts.EnableClientRetainRelease =
-    Args.hasFlag(OPT_enable_client_retain_release,
-                 OPT_disable_client_retain_release,
-                 Opts.EnableClientRetainRelease);
+  Opts.EnableSwiftDirectRuntime =
+    Args.hasFlag(OPT_enable_direct_retain_release,
+                 OPT_disable_direct_retain_release,
+                 Opts.EnableSwiftDirectRuntime);
 
   Opts.EnableObjectiveCProtocolSymbolicReferences =
     Args.hasFlag(OPT_enable_objective_c_protocol_symbolic_references,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -999,9 +999,9 @@ void IRGenFunction::emitNativeStrongRetain(llvm::Value *value,
   // Emit the call.
   FunctionPointer function;
   if (atomicity == Atomicity::Atomic &&
-      IGM.TargetInfo.HasSwiftClientRRLibrary &&
-      getOptions().EnableClientRetainRelease)
-    function = IGM.getNativeStrongRetainClientFunctionPointer();
+      IGM.TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
+      getOptions().EnableSwiftDirectRuntime)
+    function = IGM.getNativeStrongRetainDirectFunctionPointer();
   else if (atomicity == Atomicity::Atomic)
     function = IGM.getNativeStrongRetainFunctionPointer();
   else
@@ -1264,9 +1264,9 @@ void IRGenFunction::emitNativeStrongRelease(llvm::Value *value,
     return;
   llvm::Constant *function;
   if (atomicity == Atomicity::Atomic &&
-      IGM.TargetInfo.HasSwiftClientRRLibrary &&
-      getOptions().EnableClientRetainRelease)
-    function = IGM.getNativeStrongReleaseClientFn();
+      IGM.TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
+      getOptions().EnableSwiftDirectRuntime)
+    function = IGM.getNativeStrongReleaseDirectFn();
   else if (atomicity == Atomicity::Atomic)
     function = IGM.getNativeStrongReleaseFn();
   else
@@ -1366,9 +1366,9 @@ void IRGenFunction::emitBridgeStrongRetain(llvm::Value *value,
                                            Atomicity atomicity) {
   llvm::Constant *function;
   if (atomicity == Atomicity::Atomic &&
-      IGM.TargetInfo.HasSwiftClientRRLibrary &&
-      getOptions().EnableClientRetainRelease)
-    function = IGM.getBridgeObjectStrongRetainClientFn();
+      IGM.TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
+      getOptions().EnableSwiftDirectRuntime)
+    function = IGM.getBridgeObjectStrongRetainDirectFn();
   else if (atomicity == Atomicity::Atomic)
     function = IGM.getBridgeObjectStrongRetainFn();
   else
@@ -1380,9 +1380,9 @@ void IRGenFunction::emitBridgeStrongRelease(llvm::Value *value,
                                             Atomicity atomicity) {
   llvm::Constant *function;
   if (atomicity == Atomicity::Atomic &&
-      IGM.TargetInfo.HasSwiftClientRRLibrary &&
-      getOptions().EnableClientRetainRelease)
-    function = IGM.getBridgeObjectStrongReleaseClientFn();
+      IGM.TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
+      getOptions().EnableSwiftDirectRuntime)
+    function = IGM.getBridgeObjectStrongReleaseDirectFn();
   else if (atomicity == Atomicity::Atomic)
     function = IGM.getBridgeObjectStrongReleaseFn();
   else

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -566,7 +566,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   DereferenceableID = getLLVMContext().getMDKindID("dereferenceable");
 
   C_CC = getOptions().PlatformCCallingConvention;
-  SwiftClientRR_CC = llvm::CallingConv::PreserveMost;
+  SwiftDirectRR_CC = llvm::CallingConv::PreserveMost;
   // TODO: use "tinycc" on platforms that support it
   DefaultCC = SWIFT_DEFAULT_LLVM_CC;
 
@@ -1733,9 +1733,9 @@ void IRGenModule::addLinkLibraries() {
     registerLinkLibrary(
         LinkLibrary{"objc", LibraryKind::Library, /*static=*/false});
 
-  if (TargetInfo.HasSwiftClientRRLibrary &&
-      getOptions().EnableClientRetainRelease)
-    registerLinkLibrary(LinkLibrary{"swiftClientRetainRelease",
+  if (TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
+      getOptions().EnableSwiftDirectRuntime)
+    registerLinkLibrary(LinkLibrary{"swiftSwiftDirectRuntime",
                                     LibraryKind::Library, /*static=*/true});
 
   // If C++ interop is enabled, add -lc++ on Darwin and -lstdc++ on linux.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -921,7 +921,7 @@ public:
   llvm::CallingConv::ID SwiftCC;       /// swift calling convention
   llvm::CallingConv::ID SwiftAsyncCC;  /// swift calling convention for async
   llvm::CallingConv::ID SwiftCoroCC;   /// swift calling convention for callee-allocated coroutines
-  llvm::CallingConv::ID SwiftClientRR_CC; /// swift client retain/release calling convention
+  llvm::CallingConv::ID SwiftDirectRR_CC; /// swift direct retain/release calling convention
 
   /// What kind of tail call should be used for async->async calls.
   llvm::CallInst::TailCallKind AsyncTailCallKind;

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -71,13 +71,13 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
   // half for the kernel.
   target.SwiftRetainIgnoresNegativeValues = true;
 
-  // ARM64 Darwin has swiftClientRetainRelease, but not in Embedded mode. JIT
+  // ARM64 Darwin has swiftSwiftDirectRuntime, but not in Embedded mode. JIT
   // mode can't load the static library, so disable it there as well.
   if (triple.isOSDarwin() &&
       !IGM.getSwiftModule()->getASTContext().LangOpts.hasFeature(
           Feature::Embedded) &&
       !IGM.getOptions().UseJIT)
-    target.HasSwiftClientRRLibrary = true;
+    target.HasSwiftSwiftDirectRuntimeLibrary = true;
 
   target.UsableSwiftAsyncContextAddrIntrinsic = true;
 }

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -114,8 +114,8 @@ public:
   /// "negative" pointer values.
   bool SwiftRetainIgnoresNegativeValues = false;
 
-  /// True if the swiftClientRetainRelease static library is available.
-  bool HasSwiftClientRRLibrary = false;
+  /// True if the swiftSwiftDirectRuntime static library is available.
+  bool HasSwiftSwiftDirectRuntimeLibrary = false;
 
   bool UsableSwiftAsyncContextAddrIntrinsic = false;
 };

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -320,8 +320,8 @@ endif()
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.
-  if(SWIFT_BUILD_CLIENT_RETAIN_RELEASE)
-    add_subdirectory(ClientRetainRelease)
+  if(SWIFT_BUILD_SWIFT_DIRECT_RUNTIME)
+    add_subdirectory(SwiftDirectRuntime)
   endif()
 
   add_subdirectory(runtime)

--- a/stdlib/public/SwiftDirectRuntime/CMakeLists.txt
+++ b/stdlib/public/SwiftDirectRuntime/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_swift_target_library(swiftClientRetainRelease
+# swiftSwiftDirectRuntime is a static library that provides implementations of the
+# fast paths of Swift runtime functions that are suitable for being embedded
+# directly into clients.
+
+add_swift_target_library(swiftSwiftDirectRuntime
   STATIC DONT_EMBED_BITCODE NOSWIFTRT
   RetainRelease.s
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}

--- a/stdlib/public/SwiftDirectRuntime/RetainRelease.s
+++ b/stdlib/public/SwiftDirectRuntime/RetainRelease.s
@@ -92,23 +92,23 @@ ret
 // limits, in addition to the usual x19 and up. Any calls to functions that use
 // the standard calling convention need to save/restore x9-x15.
 
-.private_extern _swift_bridgeObjectReleaseClient
+.private_extern _swift_bridgeObjectReleaseDirect
 #if SWIFT_OBJC_INTEROP
-_swift_bridgeObjectReleaseClient:
+_swift_bridgeObjectReleaseDirect:
   tbz  x0, #63, LbridgeObjectReleaseNotTagged
   ret
 LbridgeObjectReleaseNotTagged:
-  tbnz  x0, #62, LbridgeObjectReleaseClientObjC
+  tbnz  x0, #62, LbridgeObjectReleaseDirectObjC
   and   x0, x0, 0x0ffffffffffffff8
 
 #else
-_swift_bridgeObjectReleaseClient:
+_swift_bridgeObjectReleaseDirect:
   and   x0, x0, 0x0ffffffffffffff8
 #endif
 
-.alt_entry _swift_releaseClient
-.private_extern _swift_releaseClient
-_swift_releaseClient:
+.alt_entry _swift_releaseDirect
+.private_extern _swift_releaseDirect
+_swift_releaseDirect:
 // RR of NULL or values with high bit set is a no-op.
   cmp   x0, #0
   b.le  Lrelease_ret
@@ -210,7 +210,7 @@ Lcall_swift_release:
   ldr   x9, [sp], #0x50
   ret_maybe_ab
 
-LbridgeObjectReleaseClientObjC:
+LbridgeObjectReleaseDirectObjC:
   maybe_pacibsp
   stp   x0, x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]
@@ -232,21 +232,21 @@ LbridgeObjectReleaseObjCRet:
   ret_maybe_ab
 
 
-.private_extern _swift_bridgeObjectRetainClient
+.private_extern _swift_bridgeObjectRetainDirect
 #if SWIFT_OBJC_INTEROP
-_swift_bridgeObjectRetainClient:
+_swift_bridgeObjectRetainDirect:
   tbz  x0, #63, LbridgeObjectRetainNotTagged
   ret
 LbridgeObjectRetainNotTagged:
-  tbnz  x0, #62, Lswift_bridgeObjectRetainClientObjC
+  tbnz  x0, #62, Lswift_bridgeObjectRetainDirectObjC
 
-.alt_entry _swift_retainClient
+.alt_entry _swift_retainDirect
 #else
-.set _swift_bridgeObjectRetainClient, _swift_retainClient
+.set _swift_bridgeObjectRetainDirect, _swift_retainDirect
 #endif
 
-.private_extern _swift_retainClient
-_swift_retainClient:
+.private_extern _swift_retainDirect
+_swift_retainDirect:
 // RR of NULL or values with high bit set is a no-op.
   cmp   x0, #0
   b.le  Lretain_ret
@@ -348,7 +348,7 @@ Lcall_swift_retain:
   ldp   x0, x9, [sp], #0x50
   ret_maybe_ab
 
-Lswift_bridgeObjectRetainClientObjC:
+Lswift_bridgeObjectRetainDirectObjC:
   maybe_pacibsp
   stp   x0, x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -448,8 +448,8 @@ if(TARGET libSwiftScan)
 endif()
 
 set(stdlib_link_libraries)
-if(SWIFT_BUILD_CLIENT_RETAIN_RELEASE)
-  list(APPEND stdlib_link_libraries swiftClientRetainRelease)
+if(SWIFT_BUILD_SWIFT_DIRECT_RUNTIME)
+  list(APPEND stdlib_link_libraries swiftSwiftDirectRuntime)
 endif()
 
 add_swift_target_library(swiftCore

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -62,26 +62,26 @@ using namespace swift;
 #endif
 
 #if SWIFT_REFCOUNT_CC_PRESERVEMOST
-// These assembly definitions support the swiftClientRetainRelease library which
-// is currently implemented for ARM64 Mach-O.
+// These assembly definitions support the retain/release fast paths in the
+// swiftSwiftDirectRuntime library which is currently implemented for ARM64 Mach-O.
 #if __arm64__ && __LP64__ && defined(__APPLE__) && defined(__MACH__)
 asm(R"(
-// Define a mask used by ClientRetainRelease to determine when it must call into
-// the runtime. The symbol's address is used as the mask, rather than its
-// contents, to eliminate one load instruction when using it. This is imported
-// weakly, which makes its address zero when running against older runtimes.
-// ClientRetainRelease references it using an addend of 0x8000000000000000,
-// which produces the appropriate mask in that case. Since the mask is still
-// unchanged in this version of the runtime, we export this symbol as zero. If a
-// different mask is ever needed, the address of this symbol needs to be set to
-// 0x8000000000000000 less than that value so that it comes out right in
-// ClientRetainRelease.
+// Define a mask used by swift_retain/releaseDirect in the SwiftDirectRuntime
+// library to determine when it must call into the runtime. The symbol's address
+// is used as the mask, rather than its contents, to eliminate one load
+// instruction when using it. This is imported weakly, which makes its address
+// zero when running against older runtimes. SwiftDirectRuntime references it using
+// an addend of 0x8000000000000000, which produces the appropriate mask in that
+// case. Since the mask is still unchanged in this version of the runtime, we
+// export this symbol as zero. If a different mask is ever needed, the address
+// of this symbol needs to be set to 0x8000000000000000 less than that value so
+// that it comes out right in SwiftDirectRuntime.
   .globl __swift_retainRelease_slowpath_mask_v1
   .set __swift_retainRelease_slowpath_mask_v1, 0
 
 // Define aliases for swift_retain/release that indicate they use preservemost.
-// ClientRetainRelease will reference these so that it can fall back to a
-// register-preserving register on older runtimes.
+// SwiftDirectRuntime will reference these so that it can fall back to a
+// register-preserving shim on older runtimes.
   .globl _swift_retain_preservemost
   .set _swift_retain_preservemost, _swift_retain
   .globl _swift_release_preservemost

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -26,8 +26,8 @@ entry(%x : $@convention(thin) () -> ()):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @thick_func_value(ptr %0, ptr %1) {{.*}} {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    call{{( preserve_mostcc)?}} ptr @swift_retain{{(Client)?}}(ptr returned %1) {{#[0-9]+}}
-// CHECK-NEXT:    call{{( preserve_mostcc)?}} void @swift_release{{(Client)?}}(ptr %1) {{#[0-9]+}}
+// CHECK-NEXT:    call{{( preserve_mostcc)?}} ptr @swift_retain{{(Direct)?}}(ptr returned %1) {{#[0-9]+}}
+// CHECK-NEXT:    call{{( preserve_mostcc)?}} void @swift_release{{(Direct)?}}(ptr %1) {{#[0-9]+}}
 // CHECK-NEXT:    %3 = insertvalue { ptr, ptr } undef, ptr %0, 0
 // CHECK-NEXT:    %4 = insertvalue { ptr, ptr } %3, ptr %1, 1
 // CHECK-NEXT:    ret { ptr, ptr } %4

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1144,7 +1144,7 @@ Removed: _$sSS10_wordIndex6beforeSS0B0VAD_tF
 Added: __swift_debug_allocationPoolSize
 Added: __swift_debug_metadataAllocatorPageSize
 
-// New symbols to support emit-into-client retain/release.
+// New symbols to support direct retain/release.
 Added: __swift_retainRelease_slowpath_mask_v1
 Added: _swift_release_preservemost
 Added: _swift_retain_preservemost


### PR DESCRIPTION
This library will likely become home to other fast-path-in-client functions, so give it a more general name.