### PR TITLE
[xcodegen] Remove buildable folder caveat

### DIFF
--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -307,13 +307,6 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
     guard log.logLevel <= .note else { return }
 
     var notes: [String] = []
-    if projectOpts.useBuildableFolders {
-      notes.append("""
-        - Buildable folders are enabled by default, which requires Xcode 16. You
-          can pass '--no-buildable-folders' to disable this. See the '--help'
-          entry for more info.
-        """)
-    }
 
     if !projectOpts.addStdlibSwift {
       notes.append("""


### PR DESCRIPTION
With the release of Xcode 26, I think it's pretty likely that folks working on Swift will be using at least Xcode 16 now.