### PR TITLE
Fix crash when accessing span of empty InlineArray  

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -587,6 +587,10 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(borrow self)
     @_transparent
     borrowing get {
+      guard count > 0 else {
+        let span = Span<Element>()
+        return unsafe _overrideLifetime(span, borrowing: self)
+      }
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
@@ -598,6 +602,10 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(&self)
     @_transparent
     mutating get {
+      guard count > 0 else {
+        let span = MutableSpan<Element>()
+        return unsafe _overrideLifetime(span, mutating: &self)
+      }
       let span = unsafe MutableSpan(
         _unsafeStart: _protectedMutableAddress,
         count: count

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -120,11 +120,7 @@ suite.test("InlineArray.span property (String)")
 }
 
 suite.test("InlineArray.span property (empty, aligned)")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
-.code {
+.require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let empty: InlineArray<0, Padded> = []

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -119,6 +119,20 @@ suite.test("InlineArray.span property (String)")
   }    
 }
 
+suite.test("InlineArray.span property (empty, aligned)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let empty: InlineArray<0, Padded> = []
+  let span = empty.span
+  expectTrue(span.isEmpty)
+  expectEqual(span.count, 0)
+}
+
 suite.test("InlineArray.mutableSpan property")
 .require(.stdlib_6_2).code
 {
@@ -145,4 +159,15 @@ suite.test("InlineArray.mutableSpan property (String)")
   span[3] = String(repeating: "0", count: Int.random(in: 100..<500))
   let s = span[3]
   expectTrue(s._isIdentical(to: v[3]))
+}
+
+suite.test("InlineArray.mutableSpan property (empty, aligned)")
+.require(.stdlib_6_2).code
+{
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var empty: InlineArray<0, Padded> = []
+  var span = empty.mutableSpan
+  expectTrue(span.isEmpty)
+  expectEqual(span.count, 0)
 }


### PR DESCRIPTION
Fix crash when creating a Span from an empty InlineArray whose storage is only byte-aligned. Resolves #85265.