### PR TITLE
[NFC][Diagnostics]: remove a number of unused diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -219,9 +219,6 @@ NOTE(scanner_find_cycle_swift_overlay_path, none,
 NOTE(scanner_cycle_source_target_shadow_module, none,
      "source target '%0' shadowing a%select{ |n SDK }2Swift module with the same name at: '%1'", (StringRef, StringRef, bool))
 
-ERROR(scanner_arguments_invalid, none,
-      "dependencies scanner cannot be configured with arguments: '%0'", (StringRef))
-
 ERROR(error_scanner_extra, none,
       "failed inside dependency scanner: '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -68,11 +68,6 @@ ERROR(error_unknown_library_level, none,
       "unknown library level '%0', "
       "expected one of 'api', 'spi', 'ipi', or 'other'", (StringRef))
 
-ERROR(error_old_spi_only_import_unsupported, none,
-      "'-experimental-spi-imports' is unsupported in Swift 6, "
-      "use '@_spiOnly' instead",
-      ())
-
 ERROR(error_unknown_require_explicit_availability, none,
       "unknown argument '%0', passed to -require-explicit-availability, "
       "expected 'error', 'warn' or 'ignore'",
@@ -305,26 +300,9 @@ REMARK(remark_indexing_system_module,none,
        "%select{|; skipping because of a broken swiftinterface}1",
        (StringRef, bool))
 
-ERROR(error_create_symbolic_interfaces_dir,none,
-      "creating symbolic interfaces directory: %0", (StringRef))
-ERROR(error_symbolic_interfaces_failed_status_check,none,
-      "failed file status check: %0", (StringRef))
-ERROR(error_write_symbolic_interface,none,
-      "writing symbolic interface file: %0", (StringRef))
-REMARK(remark_emitting_symbolic_interface_module,none,
-       "emitting symbolic interface at %0"
-       "%select{|; skipping because it's up to date}1",
-       (StringRef, bool))
-
 ERROR(error_wrong_number_of_arguments,none,
       "wrong number of '%0' arguments (expected %1, got %2)",
       (StringRef, int, int))
-
-ERROR(error_formatting_multiple_file_ranges,none,
-      "file ranges don't support multiple input files", ())
-
-ERROR(error_formatting_invalid_range,none,
-      "file range is invalid", ())
 
 WARNING(stats_disabled,none,
         "compiler was not built with support for collecting statistics", ())
@@ -517,7 +495,6 @@ REMARK(matching_output_produced,none,
 // Caching related diagnostics
 GROUPED_ERROR(error_caching_no_cas_fs, CompilationCaching, none,
     "caching is enabled without CAS file-system options, input is not immutable", ())
-ERROR(error_prefix_mapping, none, "cannot create scanner prefix mapping: '%0'", (StringRef))
 
 REMARK(replay_output, none, "replay output file '%0': key '%1'", (StringRef, StringRef))
 REMARK(output_cache_miss, none, "cache miss for input file '%0': key '%1'", (StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1752,8 +1752,6 @@ ERROR(opened_attribute_expected_rparen,none,
 // pack_element
 ERROR(pack_element_attribute_expected_lparen,none,
       "expected '(' after 'pack_element' attribute", ())
-ERROR(pack_element_attribute_expected_rparen,none,
-      "expected ')' after id value for 'pack_element' attribute", ())
 ERROR(multiple_open_pack_element,none,
       "multiple 'open_pack_element' instructions with same UUID", ())
 ERROR(opened_shape_class_not_pack_param,none,
@@ -1837,8 +1835,6 @@ ERROR(sil_autodiff_expected_lsquare,PointsToFirstBadToken,
       "expected '[' to start the %0", (StringRef))
 ERROR(sil_autodiff_expected_rsquare,PointsToFirstBadToken,
       "expected ']' to complete the %0", (StringRef))
-ERROR(sil_autodiff_expected_index_list,PointsToFirstBadToken,
-      "expected a space-separated list of indices, e.g. '0 1'", ())
 ERROR(sil_autodiff_expected_index_list_label,PointsToFirstBadToken,
       "expected label '%0' in index list", (StringRef))
 ERROR(sil_autodiff_expected_parameter_index,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -686,9 +686,6 @@ ERROR(expr_keypath_mutating_getter,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %0, "
       "which has a mutating getter",
       (const ValueDecl *, bool))
-ERROR(expr_keypath_static_member,none,
-      "%select{key path|dynamic key path member lookup}1 cannot refer to static member %0",
-      (const ValueDecl *, bool))
 ERROR(keypath_static_member_access_from_unsupported_module,none,
      "%select{key path|dynamic key path member lookup}3 cannot refer "
      "to static member %1 of type %0 from module %2",
@@ -1318,10 +1315,6 @@ REMARK(transitive_dependency_behavior,none,
        "%1 has %select{a required|an optional|an ignored}2 "
        "transitive dependency on '%0'",
        (StringRef, Identifier, unsigned))
-       
-REMARK(explicit_interface_build_skipped,none,
-       "Skipped rebuilding module at %0 - up-to-date",
-       (StringRef))
 
 GROUPED_WARNING(cannot_find_module_version,ModuleVersionMissing,none,
         "cannot find user version number for%select{| Clang}1 module '%0';"
@@ -2223,8 +2216,6 @@ ERROR(expose_protocol_to_cxx_unsupported,none,
       "protocol %0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_move_only_to_cxx,none,
       "noncopyable %kind0 can not yet be represented in C++", (ValueDecl *))
-ERROR(expose_nested_type_to_cxx,none,
-      "nested %kind0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_macro_to_cxx,none,
       "Swift macro can not yet be represented in C++", (ValueDecl *))
 GROUPED_WARNING(warn_unannotated_cxx_func_returning_frt, ForeignReferenceType, none,
@@ -5984,11 +5975,6 @@ ERROR(non_sendable_result_in_objc,none,
       "actor boundary",
       (Type, const ValueDecl *, ActorIsolation))
 
-ERROR(non_sendable_call_result_type,none,
-      "non-Sendable result type %0 cannot be sent from %1 context in call "
-      "to async function",
-      (Type, ActorIsolation))
-
 ERROR(non_sendable_property_exits_actor,none,
       "non-Sendable type %0 of %kind1 cannot exit %2 context",
       (Type, const ValueDecl *, ActorIsolation))
@@ -6408,9 +6394,6 @@ ERROR(invalid_ownership_with_optional,none,
 ERROR(invalid_ownership_not_optional,none,
       "%0 variable should have optional type %1",
       (ReferenceOwnership, Type))
-ERROR(invalid_ownership_is_let,none,
-      "%0 must be a mutable variable, because it may change at runtime",
-      (ReferenceOwnership))
 ERROR(ownership_invalid_in_protocols,none,
       "%0 cannot be applied to a property declaration in a protocol",
       (ReferenceOwnership))
@@ -8329,11 +8312,6 @@ ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
       none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
 ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a noncopyable type", ())
-ERROR(noncopyable_types_cannot_be_resilient, none,
-      "noncopyable %kind0 must be '@frozen' in library evolution mode; "
-      "non-'@frozen' public and '@usableFromInline' noncopyable types are not "
-      "supported",
-      (const ValueDecl *))
 ERROR(noncopyable_cannot_have_read_set_accessor,none,
       "noncopyable %select{variable|subscript}0 cannot provide a read and set accessor",
       (unsigned))


### PR DESCRIPTION
did a pass through the diagnostics to identify potentially-unused ones. criteria for inclusion was roughly:

1. The diagnostic was added over 1 year ago but is no longer referenced
2. The diagnostic didn't appear to be associated with a possibly-still-in-development feature (e.g. lifetime dependence, performance hints, etc)
