### PR TITLE
[cxx-interop] Conform C++ types with `std::hash` and `std::equal_to` specialization to `Swift.Hashable`

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -455,6 +455,11 @@ ERROR(conflicting_swift_attrs, none,
 ERROR(repeating_swift_attrs, none, "multiple %0 annotations found on %1",
       (StringRef, const clang::NamedDecl *))
 
+WARNING(mismatched_equatable_semantics, none,
+        "imported C++ module exposes both equal operator and std::equal_to<>"
+        "for %0, prioritizing the equal operator. ",
+        (const NominalTypeDecl *))
+
 NOTE(annotation_here, none, "%0 annotation found here", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1650,3 +1650,64 @@ void swift::deriveAutomaticCxxConformances(
     return;
   }
 }
+static clang::ClassTemplateSpecializationDecl *
+lookupAndSpecializeFunctionObject(ClangImporter::Implementation &impl,
+                                  const clang::CXXRecordDecl *clangDecl,
+                                  std::string name) {
+  assert(clangDecl);
+  clang::ASTContext &Ctx = impl.getClangASTContext();
+  clang::Sema &clangSema = impl.getClangSema();
+
+  clang::NamespaceDecl *stdNS = clangSema.getStdNamespace();
+  // maybe the C++ header didn't include standard library?
+  if (!stdNS)
+    return nullptr;
+
+  clang::DeclarationName declName =
+      Ctx.DeclarationNames.getIdentifier(&Ctx.Idents.get(name));
+
+  clang::ClassTemplateDecl *tmplDecl =
+      stdNS->lookup(declName).find_first<clang::ClassTemplateDecl>();
+
+  if (!tmplDecl)
+    return nullptr;
+
+  // find specialization to the current clangDecl
+  void *insertPos = nullptr;
+  return tmplDecl->findSpecialization(
+      {clang::TemplateArgument(
+          clangDecl->getASTContext().getTypeDeclType(clangDecl))},
+      insertPos);
+}
+
+void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
+                                      SwiftDeclSynthesizer &synthesizer,
+                                      NominalTypeDecl *decl,
+                                      const clang::CXXRecordDecl *clangDecl) {
+  PrettyStackTraceDecl trace("conforming to Hashable", decl);
+
+  assert(decl);
+  assert(clangDecl);
+
+  auto *stdHashSpec =
+      lookupAndSpecializeFunctionObject(impl, clangDecl, "hash");
+
+  // we bail if std::hash<> couldn't be found
+  if (!stdHashSpec) {
+    return;
+  }
+
+  // we bail if we cannot find any operator==
+  if (!getEqualEqualOperator(decl))
+    return;
+
+  auto *stdHash =
+      dyn_cast<StructDecl>(impl.importDecl(stdHashSpec, impl.CurrentVersion));
+  if (!stdHash)
+    return;
+  FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHash);
+  decl->addMember(hashFunc);
+
+  impl.addSynthesizedProtocolAttrs(
+      decl, {KnownProtocolKind::Equatable, KnownProtocolKind::Hashable});
+}

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1827,10 +1827,8 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
   }
 
   // if we cannot find std::equal_to<>, we can still try operator==
-  if (!stdETSpec) {
-    if (!getEqualEqualOperator(decl))
+  if (!stdETSpec && !getEqualEqualOperator(decl))
       return;
-  }
 
   auto *stdHash =
       dyn_cast<StructDecl>(impl.importDecl(stdHashSpec, impl.CurrentVersion));

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1822,19 +1822,22 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
       lookupAndSpecializeFunctionObject(impl, clangDecl, "equal_to");
 
   // we bail if [std::hash<>] couldn't be found
-  if (!stdHashSpec) {
+  if (!stdHashSpec)
     return;
-  }
 
   if (!stdETSpec && !getEqualEqualOperator(decl))
-      return;
+    return;
 
-  auto *stdHash =
-      dyn_cast<StructDecl>(impl.importDecl(stdHashSpec, impl.CurrentVersion));
+  auto *stdHash = impl.importDecl(stdHashSpec, impl.CurrentVersion);
   if (!stdHash)
     return;
-  FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHash);
-  decl->addMember(hashFunc);
+
+  if (auto *stdHashStruct = dyn_cast<StructDecl>(stdHash)) {
+    FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHashStruct);
+    decl->addMember(hashFunc);
+  } else {
+    return;
+  }
 
   // we have two possible sources for [==(_:_:)]
   // 1. [std::equal_to<T>]
@@ -1848,9 +1851,11 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
   // custom [std::equal_to<T>] specialization that does not agree with
   // [operator==(T, T)]
   if (!getEqualEqualOperator(decl)) {
-    auto *stdET =
-        dyn_cast<StructDecl>(impl.importDecl(stdETSpec, impl.CurrentVersion));
-    if (!stdET)
+    // FIXME: I'm simply importing the [std::equal_to<T>] declaration so that
+    // it's loaded into clang context, otherwise the next
+    // [synthesizeCXXOperatorWithFunctionObject] call will fail. There is
+    // probably a more suitable function to call here.
+    if (!impl.importDecl(stdETSpec, impl.CurrentVersion))
       return;
     if (!synthesizeCXXOperatorWithFunctionObject(
             impl, clangDecl, stdETSpec, clang::BinaryOperatorKind::BO_EQ))

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1821,12 +1821,11 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
   auto *stdETSpec =
       lookupAndSpecializeFunctionObject(impl, clangDecl, "equal_to");
 
-  // we bail if std::hash<> couldn't be found
+  // we bail if [std::hash<>] couldn't be found
   if (!stdHashSpec) {
     return;
   }
 
-  // if we cannot find std::equal_to<>, we can still try operator==
   if (!stdETSpec && !getEqualEqualOperator(decl))
       return;
 
@@ -1839,8 +1838,15 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
 
   // we have two possible sources for [==(_:_:)]
   // 1. [std::equal_to<T>]
-  // 2. [bool operator==(T, T)]
-  // For backward compatibility and simplicity, 2 is prioritized over 1
+  // 2. [operator==(T, T)]
+  // The current implementation prioritize 2 over 1, which as the following
+  // effects,
+  // - the behavior of [==(_:_:)] operator in Swift will match that of
+  // [operator==(T, T)] in C++, if both exist,
+  // - the behavior of unordered containers (such as [Set]) in Swift will not
+  // match their equivalences ([unordered_set]) in C++, if the C++ type has a
+  // custom [std::equal_to<T>] specialization that does not agree with
+  // [operator==(T, T)]
   if (!getEqualEqualOperator(decl)) {
     auto *stdET =
         dyn_cast<StructDecl>(impl.importDecl(stdETSpec, impl.CurrentVersion));

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -15,6 +15,7 @@
 #include "ImporterImpl.h"
 #include "SwiftLookupTable.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/KnownProtocols.h"
@@ -31,6 +32,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DeclarationName.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Sema/DelayedDiagnostic.h"
@@ -1594,35 +1596,17 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
   decl->addMember(importedConstructor);
 }
 
-// Synthesize a [operator op(T, T)] for [T], where [T = classDecl]. The operator
-// decl is looked up earlier and passed in as [methodDecl].
+// Synthesize a [operator op(T, T)] for [T], where [T = classDecl]. The compiler
+// should have already found the default constructor and [the operator()] for
+// [fobjDecl], both of which are passed in as arguments.
 static bool synthesizeOperatorWithCxxFunctionObject(
     ClangImporter::Implementation &impl, const clang::CXXRecordDecl *classDecl,
     const clang::CXXRecordDecl *fobjDecl,
+    clang::CXXConstructorDecl *ctorDecl, // why not const??
     const clang::CXXMethodDecl *methodDecl,
     clang::BinaryOperatorKind operatorKind) {
   auto &clangCtx = impl.getClangASTContext();
   auto &clangSema = impl.getClangSema();
-
-  /// 1. lookup the constructor
-  clang::CXXConstructorDecl *ctorDecl = nullptr;
-  clang::QualType fobjTy = clangCtx.getTypeDeclType(fobjDecl);
-  clang::DeclarationName ctorName =
-      clangCtx.DeclarationNames.getCXXConstructorName(
-          clangCtx.getCanonicalType(fobjTy));
-  clang::LookupResult result(clangSema, ctorName, clang::SourceLocation(),
-                             clang::Sema::LookupOrdinaryName);
-  clangSema.LookupQualifiedName(result, fobjDecl->getDefinition());
-
-  for (clang::CXXConstructorDecl *candidate : fobjDecl->ctors()) {
-    if (candidate->param_size() == 0) {
-      ctorDecl = candidate;
-      break;
-    }
-  }
-
-  if (!ctorDecl)
-    return false;
 
   /// 2. constructor the operator
   clang::OverloadedOperatorKind opKind =
@@ -1690,7 +1674,7 @@ static bool synthesizeOperatorWithCxxFunctionObject(
   /// 3. build the constructor call
   clang::SourceLocation funcLoc = fobjDecl->getLocation();
   clang::ExprResult synthCtorExprResult = clangSema.BuildCXXConstructExpr(
-      funcLoc, fobjTy, ctorDecl,
+      funcLoc, clangCtx.getTypeDeclType(fobjDecl), ctorDecl,
       /*Elidable=*/false, {},
       /*HadMultipleCandidates=*/false,
       /*IsListInitialization=*/false,
@@ -1723,17 +1707,39 @@ static bool synthesizeOperatorWithCxxFunctionObject(
   return true;
 }
 
-// This function looks up a C++ template struct that is supposed to be a
-// function object. It further checks that there exists one operator() member
-// with the correct type signature.
-static std::pair<clang::ClassTemplateSpecializationDecl *,
-                 clang::CXXMethodDecl *>
-lookupAndSpecializeCxxFunctionObject(ClangImporter::Implementation &impl,
-                                     const clang::CXXRecordDecl *clangDecl,
-                                     std::string name, clang::QualType funTy) {
+// This function takes a C++ record [clangDecl], and finds the method of the
+// specified type, ignoring exception spec.
+static clang::CXXMethodDecl *
+lookupCxxMethodByType(ClangImporter::Implementation &impl,
+                      const clang::CXXRecordDecl *clangDecl,
+                      clang::DeclarationName methodName,
+                      clang::QualType methodTy) {
   clang::Sema &clangSema = impl.getClangSema();
   clang::ASTContext &Ctx = impl.getClangASTContext();
-  if (auto *stdNS = clangSema.getStdNamespace()) {
+  if (auto *clangDef = clangDecl->getDefinition()) {
+    clang::LookupResult result(clangSema, methodName, clang::SourceLocation(),
+                               clang::Sema::LookupOrdinaryName);
+    clangSema.LookupQualifiedName(result, clangDef);
+
+    for (clang::NamedDecl *namedDecl : result)
+      if (auto *candidate = llvm::dyn_cast<clang::CXXMethodDecl>(namedDecl))
+        if (!candidate->isDeleted() &&
+            Ctx.hasSameFunctionTypeIgnoringExceptionSpec(candidate->getType(),
+                                                         methodTy))
+          return candidate;
+  }
+
+  return nullptr;
+}
+
+// This function looks up a C++ template struct that is supposed to be a
+// function object.
+static clang::ClassTemplateSpecializationDecl *
+lookupAndSpecializeCxxFunctionObject(ClangImporter::Implementation &impl,
+                                     const clang::CXXRecordDecl *clangDecl,
+                                     std::string name) {
+  clang::ASTContext &Ctx = impl.getClangASTContext();
+  if (auto *stdNS = impl.getCxxStdNamespace()) {
     clang::DeclarationName declName =
         Ctx.DeclarationNames.getIdentifier(&Ctx.Idents.get(name));
 
@@ -1741,104 +1747,101 @@ lookupAndSpecializeCxxFunctionObject(ClangImporter::Implementation &impl,
         stdNS->lookup(declName).find_first<clang::ClassTemplateDecl>();
 
     if (!tmplDecl)
-      return {};
+      return nullptr;
 
     // find specialization of the shape [std::name<clangDecl>]
     void *insertPos = nullptr;
     auto *fobjDecl = tmplDecl->findSpecialization(
         {clang::TemplateArgument(Ctx.getTypeDeclType(clangDecl))}, insertPos);
     if (!fobjDecl)
-      return {};
+      return nullptr;
 
     // instantiate specialization for a complete definition
-    if (!fobjDecl->hasDefinition()) {
+    if (!fobjDecl->hasDefinition())
       if (impl.getClangSema().InstantiateClassTemplateSpecialization(
               clangDecl->getLocation(), fobjDecl,
               clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
               false, false))
-        return {};
-    }
+        return nullptr;
 
-    if (auto *fobjDef = fobjDecl->getDefinition()) {
-      clang::CXXMethodDecl *methodDecl = nullptr;
-      clang::DeclarationName opName =
-          Ctx.DeclarationNames.getCXXOperatorName(clang::OO_Call);
-      clang::LookupResult result(clangSema, opName, clang::SourceLocation(),
-                                 clang::Sema::LookupOrdinaryName);
-      clangSema.LookupQualifiedName(result, fobjDef);
-
-      for (clang::NamedDecl *namedDecl : result) {
-        // getUnderlyingDecl() strips away any 'using' shadows from base classes
-        if (auto *candidate = llvm::dyn_cast<clang::CXXMethodDecl>(namedDecl)) {
-          if (Ctx.hasSameFunctionTypeIgnoringExceptionSpec(candidate->getType(),
-                                                           funTy)) {
-            methodDecl = candidate;
-            break;
-          }
-        }
-      }
-
-      if (methodDecl)
-        return {fobjDecl, methodDecl};
-    }
+    return fobjDecl;
   }
 
-  return {};
+  return nullptr;
 }
 
 // Attempt at decoupling the std::equal_to<> conformance from std::hash<>
 // conformance. Because we don't want unnecessary importation, the actual import
 // is delayed as a thunk.
-static std::optional<std::function<bool()>> conformToEquatableIfNeeded(
+static std::optional<std::function<void ()>> conformToEquatableIfNeeded(
     ClangImporter::Implementation &impl, SwiftDeclSynthesizer &synthesizer,
     NominalTypeDecl *decl, const clang::CXXRecordDecl *clangDecl) {
-  clang::ASTContext &Ctx = impl.getClangASTContext();
-  // construct [const T&]
-  clang::QualType recordTy = Ctx.getTypeDeclType(clangDecl);
-  clang::QualType constRecordTy = recordTy.withConst();
-  clang::QualType constRefTy = Ctx.getLValueReferenceType(constRecordTy);
-  std::array paramsTy{constRefTy, constRefTy};
+  clang::ClassTemplateSpecializationDecl *stdETDecl = nullptr;
+  clang::CXXConstructorDecl *ctorDecl = nullptr;
+  clang::CXXMethodDecl *opDecl = nullptr;
 
-  // constant method
-  clang::FunctionProtoType::ExtProtoInfo epi;
-  epi.TypeQuals.addConst();
-  clang::QualType funTy = Ctx.getFunctionType(Ctx.BoolTy, paramsTy, epi);
+  // since operator==() is prioritized over std::equal_to, we can save some
+  // search here.
+  if (! getEqualEqualOperator(decl)) {
+    clang::ASTContext &Ctx = impl.getClangASTContext();
+    stdETDecl =
+        lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "equal_to");
 
-  auto result =
-      lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "equal_to", funTy);
-  auto *stdETDecl = result.first;
-  auto *methodDecl = result.second;
-  // check that either [std::equal_to<>] exists or [operator== ()] exists.
-  if (!stdETDecl && !getEqualEqualOperator(decl))
-    return {};
+    // check that either [std::equal_to<>] exists or [operator== ()] exists.
+    if (!stdETDecl)
+      return {};
 
-  return [&impl, decl, stdETDecl, methodDecl, clangDecl] {
-    // we have two possible sources for [==(_:_:)]
-    // 1. [std::equal_to<T>]
-    // 2. [operator==(T, T)]
-    // The current implementation prioritize 2 over 1, which as the following
-    // effects,
-    // - the behavior of [==(_:_:)] operator in Swift will match that of
-    // [operator==(T, T)] in C++, if both exist,
-    // - the behavior of unordered containers (such as [Set]) in Swift will not
-    // match their equivalences ([unordered_set]) in C++, if the C++ type has a
-    // custom [std::equal_to<T>] specialization that does not agree with
-    // [operator==(T, T)]
-    if (stdETDecl && getEqualEqualOperator(decl)) {
-      impl.diagnose(HeaderLoc{clangDecl->getLocation()},
-                    diag::mismatched_equatable_semantics, decl);
-    }
+    // lookup default constructor
+    clang::QualType ctorTy = Ctx.getFunctionType(
+      Ctx.VoidTy, {}, clang::FunctionProtoType::ExtProtoInfo());
+    clang::DeclarationName ctorName =
+        Ctx.DeclarationNames.getCXXConstructorName(
+            Ctx.getCanonicalType(Ctx.getTypeDeclType(stdETDecl)));
+    ctorDecl = dyn_cast_or_null<clang::CXXConstructorDecl>(lookupCxxMethodByType(impl, stdETDecl, ctorName, ctorTy));
+    if (!ctorDecl)
+      return {};
 
-    if (!getEqualEqualOperator(decl)) {
-      // This call will return false only when no suitable constructor is found.
-      if (!synthesizeOperatorWithCxxFunctionObject(
-              impl, clangDecl, stdETDecl, methodDecl,
-              clang::BinaryOperatorKind::BO_EQ))
-        return false;
-    }
+    // lookup operator()
+    // construct [const T&]
+    clang::QualType recordTy = Ctx.getTypeDeclType(clangDecl);
+
+    clang::QualType constRecordTy = recordTy.withConst();
+    clang::QualType constRefTy = Ctx.getLValueReferenceType(constRecordTy);
+
+    // constant method
+    clang::FunctionProtoType::ExtProtoInfo epi;
+    epi.TypeQuals.addConst();
+    clang::QualType opTy = Ctx.getFunctionType(Ctx.BoolTy, {constRefTy, constRefTy}, epi);
+    clang::DeclarationName opName =
+        Ctx.DeclarationNames.getCXXOperatorName(clang::OO_Call);
+    opDecl = lookupCxxMethodByType(impl, stdETDecl, opName, opTy);
+    if (!opDecl)
+      return {};
+  }
+
+  // we have two possible sources for [==(_:_:)]
+  // 1. [std::equal_to<T>]
+  // 2. [operator==(T, T)]
+  // The current implementation prioritize 2 over 1, which as the following
+  // effects,
+  // - the behavior of [==(_:_:)] operator in Swift will match that of
+  // [operator==(T, T)] in C++, if both exist,
+  // - the behavior of unordered containers (such as [Set]) in Swift will not
+  // match their equivalences ([unordered_set]) in C++, if the C++ type has a
+  // custom [std::equal_to<T>] specialization that does not agree with
+  // [operator==(T, T)]
+  if (stdETDecl && getEqualEqualOperator(decl))
+    impl.diagnose(HeaderLoc{clangDecl->getLocation()},
+                  diag::mismatched_equatable_semantics, decl);
+
+  return [&impl, decl, stdETDecl, ctorDecl, opDecl, clangDecl] {
+    if (!getEqualEqualOperator(decl))
+      synthesizeOperatorWithCxxFunctionObject(impl, clangDecl, stdETDecl,
+                                              ctorDecl, opDecl,
+                                              clang::BinaryOperatorKind::BO_EQ);
 
     impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::Equatable});
-    return true;
+    return;
   };
 }
 
@@ -1849,22 +1852,38 @@ static void conformToHashableIfNeeded(ClangImporter::Implementation &impl,
   PrettyStackTraceDecl trace("conforming to Hashable", decl);
 
   clang::ASTContext &Ctx = impl.getClangASTContext();
+  auto *stdHashDecl = lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "hash");
+  // we bail if [std::hash<>] doesn't exist
+  if (!stdHashDecl)
+    return;
+
+  // we won't need the constructor or [operator()] until much later, but we
+  // search for them here so that later synthesizer is guaranteed to succeed.
+  // lookup default constructor
+  clang::QualType ctorTy = Ctx.getFunctionType(
+      Ctx.VoidTy, {}, clang::FunctionProtoType::ExtProtoInfo());
+  clang::DeclarationName ctorName = Ctx.DeclarationNames.getCXXConstructorName(
+      Ctx.getCanonicalType(Ctx.getTypeDeclType(stdHashDecl)));
+  auto *ctorDecl = dyn_cast_or_null<clang::CXXConstructorDecl>(
+      lookupCxxMethodByType(impl, stdHashDecl, ctorName, ctorTy));
+
+  if (!ctorDecl)
+    return;
+
+  // lookup [operator()]
   // construct [const T&]
   clang::QualType recordTy = Ctx.getTypeDeclType(clangDecl);
   clang::QualType constRecordTy = recordTy.withConst();
   clang::QualType constRefTy = Ctx.getLValueReferenceType(constRecordTy);
-  std::array paramsTy{constRefTy};
   // constant method
   clang::FunctionProtoType::ExtProtoInfo epi;
   epi.TypeQuals.addConst();
-  clang::QualType funTy = Ctx.getFunctionType(Ctx.getSizeType(), paramsTy, epi);
-  auto [stdHashDecl, _] =
-      lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "hash", funTy);
-
-  // we bail if [std::hash<>] doesn't exist
-  if (!stdHashDecl) {
+  clang::QualType opTy = Ctx.getFunctionType(Ctx.getSizeType(), {constRefTy}, epi);
+  clang::DeclarationName opName =
+    Ctx.DeclarationNames.getCXXOperatorName(clang::OO_Call);
+  auto *opDecl = lookupCxxMethodByType(impl, stdHashDecl, opName, opTy);
+  if (!opDecl)
     return;
-  }
 
   auto *stdHash = impl.importDecl(stdHashDecl, impl.CurrentVersion);
   if (!stdHash)
@@ -1872,9 +1891,7 @@ static void conformToHashableIfNeeded(ClangImporter::Implementation &impl,
 
   if (auto conformToEquatable =
           conformToEquatableIfNeeded(impl, synthesizer, decl, clangDecl)) {
-    if (!(*conformToEquatable)()) {
-      return;
-    }
+    (*conformToEquatable)();
 
     if (auto *stdHashStruct = dyn_cast<StructDecl>(stdHash)) {
       FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHashStruct);

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1751,7 +1751,7 @@ static bool synthesizeCXXOperatorWithFunctionObject(
       /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
       clang::SourceRange(funcLoc, funcLoc));
 
-  assert(!synthCtorExprResult.isInvalid() &&
+  ASSERT(!synthCtorExprResult.isInvalid() &&
          "Unable to synthesize constructor expression for std::equal_to");
   clang::Expr *synthCtorExpr = synthCtorExprResult.get();
 
@@ -1781,7 +1781,7 @@ static clang::ClassTemplateSpecializationDecl *
 lookupAndSpecializeFunctionObject(ClangImporter::Implementation &impl,
                                   const clang::CXXRecordDecl *clangDecl,
                                   std::string name) {
-  assert(clangDecl);
+  ASSERT(clangDecl);
   clang::ASTContext &Ctx = impl.getClangASTContext();
   clang::Sema &clangSema = impl.getClangSema();
 
@@ -1813,8 +1813,8 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
                                       const clang::CXXRecordDecl *clangDecl) {
   PrettyStackTraceDecl trace("conforming to Hashable", decl);
 
-  assert(decl);
-  assert(clangDecl);
+  ASSERT(decl);
+  ASSERT(clangDecl);
 
   auto *stdHashSpec =
       lookupAndSpecializeFunctionObject(impl, clangDecl, "hash");

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1650,6 +1650,133 @@ void swift::deriveAutomaticCxxConformances(
     return;
   }
 }
+
+// applies to [operator op(T, T)] where T = classDecl
+static bool synthesizeCXXOperatorWithFunctionObject(
+    ClangImporter::Implementation &impl, const clang::CXXRecordDecl *classDecl,
+    const clang::CXXRecordDecl *funcDecl,
+    clang::BinaryOperatorKind operatorKind) {
+  auto &clangCtx = impl.getClangASTContext();
+  auto &clangSema = impl.getClangSema();
+
+  clang::OverloadedOperatorKind opKind =
+      clang::BinaryOperator::getOverloadedOperator(operatorKind);
+  const char *opSpelling = clang::getOperatorSpelling(opKind);
+
+  auto declName = clang::DeclarationName(&clangCtx.Idents.get(opSpelling));
+
+  // Determine the Clang decl context where the new operator function will be
+  // created. We use the translation unit as the decl context of the new
+  // operator, otherwise, the operator might get imported as a static member
+  // function of a different type (e.g. an operator declared inside of a C++
+  // namespace would get imported as a member function of a Swift enum), which
+  // would make the operator un-discoverable to Swift name lookup.
+  auto declContext =
+      const_cast<clang::CXXRecordDecl *>(classDecl)->getDeclContext();
+  while (!declContext->isTranslationUnit()) {
+    declContext = declContext->getParent();
+  }
+
+  clang::CXXMethodDecl *methodDecl = nullptr;
+  for (auto &&candidate : funcDecl->methods()) {
+    if (candidate->getOverloadedOperator() ==
+            clang::OverloadedOperatorKind::OO_Call &&
+        candidate->param_size() == 2) {
+      methodDecl = candidate;
+      break;
+    }
+  }
+
+  clang::QualType returnTy = methodDecl->getReturnType();
+  clang::QualType lhsTy = clangCtx.getRecordType(classDecl),
+                  rhsTy = clangCtx.getRecordType(classDecl);
+
+  auto opTy = clangCtx.getFunctionType(
+      returnTy, {lhsTy, rhsTy}, clang::FunctionProtoType::ExtProtoInfo());
+
+  // Create a `bool operator op(T, T)` function.
+  auto opDecl = clang::FunctionDecl::Create(
+      clangCtx, declContext, clang::SourceLocation(), clang::SourceLocation(),
+      declName, opTy, clangCtx.getTrivialTypeSourceInfo(returnTy),
+      clang::StorageClass::SC_Static);
+  opDecl->setImplicit();
+  opDecl->setImplicitlyInline();
+  // If this is a static member function of a class, it needs to be public.
+  opDecl->setAccess(clang::AccessSpecifier::AS_public);
+
+  // Create the parameters of the function. They are not referenced from source
+  // code, so they don't need to have a name.
+  auto lhsParamId = nullptr;
+  auto lhsTyInfo = clangCtx.getTrivialTypeSourceInfo(lhsTy);
+  auto lhsParamDecl = clang::ParmVarDecl::Create(
+      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
+      lhsParamId, lhsTy, lhsTyInfo, clang::StorageClass::SC_None,
+      /*DefArg*/ nullptr);
+  auto lhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
+      clangCtx, lhsParamDecl, false, lhsTy, clang::ExprValueKind::VK_LValue,
+      clang::SourceLocation());
+
+  auto rhsParamId = nullptr;
+  auto rhsTyInfo = clangCtx.getTrivialTypeSourceInfo(rhsTy);
+  auto rhsParamDecl = clang::ParmVarDecl::Create(
+      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
+      rhsParamId, rhsTy, rhsTyInfo, clang::StorageClass::SC_None, nullptr);
+  auto rhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
+      clangCtx, rhsParamDecl, false, rhsTy, clang::ExprValueKind::VK_LValue,
+      clang::SourceLocation());
+
+  opDecl->setParams({lhsParamDecl, rhsParamDecl});
+
+  // looking for the constructor for the function object
+  clang::CXXConstructorDecl *ctorDecl = nullptr;
+  for (clang::CXXConstructorDecl *candidate : funcDecl->ctors()) {
+    if (candidate->param_size() == 0) {
+      ctorDecl = candidate;
+      break;
+    }
+  }
+
+  if (!ctorDecl)
+    return false;
+
+  clang::QualType funcTy = clangCtx.getRecordType(funcDecl);
+  clang::SourceLocation funcLoc = funcDecl->getLocation();
+
+  clang::ExprResult synthCtorExprResult = clangSema.BuildCXXConstructExpr(
+      funcLoc, funcTy, ctorDecl,
+      /*Elidable=*/false, {},
+      /*HadMultipleCandidates=*/false,
+      /*IsListInitialization=*/false,
+      /*IsStdInitListInitialization=*/false,
+      /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
+      clang::SourceRange(funcLoc, funcLoc));
+
+  assert(!synthCtorExprResult.isInvalid() &&
+         "Unable to synthesize constructor expression for std::equal_to");
+  clang::Expr *synthCtorExpr = synthCtorExprResult.get();
+
+  SmallVector<clang::Expr *, 2> args = {lhsParamRefExpr, rhsParamRefExpr};
+  auto call =
+      clangSema.BuildCallExpr(nullptr, synthCtorExpr, clang::SourceLocation(),
+                              args, clang::SourceLocation());
+
+  if (!call.isUsable())
+    return false;
+
+  auto opBody = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
+                                          call.get(), nullptr);
+  opDecl->setBody(opBody);
+
+  impl.synthesizedAndAlwaysVisibleDecls.insert(opDecl);
+  auto lookupTable1 = impl.findLookupTable(classDecl);
+  addEntryToLookupTable(*lookupTable1, opDecl, impl.getNameImporter());
+  auto owningModule = impl.getClangOwningModule(classDecl);
+  auto lookupTable2 = impl.findLookupTable(owningModule);
+  if (lookupTable1 != lookupTable2)
+    addEntryToLookupTable(*lookupTable2, opDecl, impl.getNameImporter());
+  return true;
+}
+
 static clang::ClassTemplateSpecializationDecl *
 lookupAndSpecializeFunctionObject(ClangImporter::Implementation &impl,
                                   const clang::CXXRecordDecl *clangDecl,
@@ -1691,15 +1818,19 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
 
   auto *stdHashSpec =
       lookupAndSpecializeFunctionObject(impl, clangDecl, "hash");
+  auto *stdETSpec =
+      lookupAndSpecializeFunctionObject(impl, clangDecl, "equal_to");
 
   // we bail if std::hash<> couldn't be found
   if (!stdHashSpec) {
     return;
   }
 
-  // we bail if we cannot find any operator==
-  if (!getEqualEqualOperator(decl))
-    return;
+  // if we cannot find std::equal_to<>, we can still try operator==
+  if (!stdETSpec) {
+    if (!getEqualEqualOperator(decl))
+      return;
+  }
 
   auto *stdHash =
       dyn_cast<StructDecl>(impl.importDecl(stdHashSpec, impl.CurrentVersion));
@@ -1707,6 +1838,20 @@ void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
     return;
   FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHash);
   decl->addMember(hashFunc);
+
+  // we have two possible sources for [==(_:_:)]
+  // 1. [std::equal_to<T>]
+  // 2. [bool operator==(T, T)]
+  // For backward compatibility and simplicity, 2 is prioritized over 1
+  if (!getEqualEqualOperator(decl)) {
+    auto *stdET =
+        dyn_cast<StructDecl>(impl.importDecl(stdETSpec, impl.CurrentVersion));
+    if (!stdET)
+      return;
+    if (!synthesizeCXXOperatorWithFunctionObject(
+            impl, clangDecl, stdETSpec, clang::BinaryOperatorKind::BO_EQ))
+      return;
+  }
 
   impl.addSynthesizedProtocolAttrs(
       decl, {KnownProtocolKind::Equatable, KnownProtocolKind::Hashable});

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -15,6 +15,7 @@
 #include "ImporterImpl.h"
 #include "SwiftLookupTable.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -24,6 +25,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
+#include "swift/Localization/LocalizationFormat.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
@@ -1592,9 +1594,303 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
   decl->addMember(importedConstructor);
 }
 
+// Synthesize a [operator op(T, T)] for [T], where [T = classDecl]. The operator
+// decl is looked up earlier and passed in as [methodDecl].
+static bool synthesizeOperatorWithCxxFunctionObject(
+    ClangImporter::Implementation &impl, const clang::CXXRecordDecl *classDecl,
+    const clang::CXXRecordDecl *fobjDecl,
+    const clang::CXXMethodDecl *methodDecl,
+    clang::BinaryOperatorKind operatorKind) {
+  auto &clangCtx = impl.getClangASTContext();
+  auto &clangSema = impl.getClangSema();
+
+  /// 1. lookup the constructor
+  clang::CXXConstructorDecl *ctorDecl = nullptr;
+  clang::QualType fobjTy = clangCtx.getTypeDeclType(fobjDecl);
+  clang::DeclarationName ctorName =
+      clangCtx.DeclarationNames.getCXXConstructorName(
+          clangCtx.getCanonicalType(fobjTy));
+  clang::LookupResult result(clangSema, ctorName, clang::SourceLocation(),
+                             clang::Sema::LookupOrdinaryName);
+  clangSema.LookupQualifiedName(result, fobjDecl->getDefinition());
+
+  for (clang::CXXConstructorDecl *candidate : fobjDecl->ctors()) {
+    if (candidate->param_size() == 0) {
+      ctorDecl = candidate;
+      break;
+    }
+  }
+
+  if (!ctorDecl)
+    return false;
+
+  /// 2. constructor the operator
+  clang::OverloadedOperatorKind opKind =
+      clang::BinaryOperator::getOverloadedOperator(operatorKind);
+  const char *opSpelling = clang::getOperatorSpelling(opKind);
+  auto declName = clang::DeclarationName(&clangCtx.Idents.get(opSpelling));
+
+  // Determine the Clang decl context where the new operator function will be
+  // created. We use the translation unit as the decl context of the new
+  // operator, otherwise, the operator might get imported as a static member
+  // function of a different type (e.g. an operator declared inside of a C++
+  // namespace would get imported as a member function of a Swift enum), which
+  // would make the operator un-discoverable to Swift name lookup.
+  auto declContext =
+      const_cast<clang::CXXRecordDecl *>(classDecl)->getDeclContext();
+  while (!declContext->isTranslationUnit()) {
+    declContext = declContext->getParent();
+  }
+
+  // copying the type information
+  clang::QualType returnTy = methodDecl->getReturnType();
+  clang::QualType lhsTy = clangCtx.getTypeDeclType(classDecl),
+                  rhsTy = clangCtx.getTypeDeclType(classDecl);
+  clang::FunctionProtoType::ExtProtoInfo epi;
+  if (const auto *protoTy =
+          methodDecl->getType()->getAs<clang::FunctionProtoType>()) {
+    epi = protoTy->getExtProtoInfo();
+  } else {
+    ASSERT(false && "unexpected error when copying ExtProtoInfo");
+  }
+
+  auto opTy = clangCtx.getFunctionType(returnTy, {lhsTy, rhsTy}, epi);
+  // create a [returnTy operator op(T, T)] function.
+  auto opDecl = clang::FunctionDecl::Create(
+      clangCtx, declContext, clang::SourceLocation(), clang::SourceLocation(),
+      declName, opTy, clangCtx.getTrivialTypeSourceInfo(returnTy),
+      clang::StorageClass::SC_Static);
+  opDecl->setImplicit();
+  opDecl->setImplicitlyInline();
+  // If this is a static member function of a class, it needs to be public.
+  opDecl->setAccess(clang::AccessSpecifier::AS_public);
+
+  // insert the parameter for the [opDecl]
+  auto lhsParamId = nullptr;
+  auto lhsTyInfo = clangCtx.getTrivialTypeSourceInfo(lhsTy);
+  auto lhsParamDecl = clang::ParmVarDecl::Create(
+      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
+      lhsParamId, lhsTy, lhsTyInfo, clang::StorageClass::SC_None,
+      /*DefArg*/ nullptr);
+  auto lhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
+      clangCtx, lhsParamDecl, false, lhsTy, clang::ExprValueKind::VK_LValue,
+      clang::SourceLocation());
+
+  auto rhsParamId = nullptr;
+  auto rhsTyInfo = clangCtx.getTrivialTypeSourceInfo(rhsTy);
+  auto rhsParamDecl = clang::ParmVarDecl::Create(
+      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
+      rhsParamId, rhsTy, rhsTyInfo, clang::StorageClass::SC_None, nullptr);
+  auto rhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
+      clangCtx, rhsParamDecl, false, rhsTy, clang::ExprValueKind::VK_LValue,
+      clang::SourceLocation());
+
+  opDecl->setParams({lhsParamDecl, rhsParamDecl});
+
+  /// 3. build the constructor call
+  clang::SourceLocation funcLoc = fobjDecl->getLocation();
+  clang::ExprResult synthCtorExprResult = clangSema.BuildCXXConstructExpr(
+      funcLoc, fobjTy, ctorDecl,
+      /*Elidable=*/false, {},
+      /*HadMultipleCandidates=*/false,
+      /*IsListInitialization=*/false,
+      /*IsStdInitListInitialization=*/false,
+      /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
+      clang::SourceRange(funcLoc, funcLoc));
+
+  ASSERT(!synthCtorExprResult.isInvalid() &&
+         "Unable to synthesize constructor expression");
+  clang::Expr *synthCtorExpr = synthCtorExprResult.get();
+
+  /// 4. build the [operator()] call
+  SmallVector<clang::Expr *, 2> args = {lhsParamRefExpr, rhsParamRefExpr};
+  auto call =
+      clangSema.BuildCallExpr(nullptr, synthCtorExpr, clang::SourceLocation(),
+                              args, clang::SourceLocation());
+  ASSERT(call.isUsable() && "operator() call is not usable");
+
+  auto opBody = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
+                                          call.get(), nullptr);
+  opDecl->setBody(opBody);
+
+  impl.synthesizedAndAlwaysVisibleDecls.insert(opDecl);
+  auto lookupTable1 = impl.findLookupTable(classDecl);
+  addEntryToLookupTable(*lookupTable1, opDecl, impl.getNameImporter());
+  auto owningModule = importer::getClangOwningModule(classDecl, clangCtx);
+  auto lookupTable2 = impl.findLookupTable(owningModule);
+  if (lookupTable1 != lookupTable2)
+    addEntryToLookupTable(*lookupTable2, opDecl, impl.getNameImporter());
+  return true;
+}
+
+// This function looks up a C++ template struct that is supposed to be a
+// function object. It further checks that there exists one operator() member
+// with the correct type signature.
+static std::pair<clang::ClassTemplateSpecializationDecl *,
+                 clang::CXXMethodDecl *>
+lookupAndSpecializeCxxFunctionObject(ClangImporter::Implementation &impl,
+                                     const clang::CXXRecordDecl *clangDecl,
+                                     std::string name, clang::QualType funTy) {
+  clang::Sema &clangSema = impl.getClangSema();
+  clang::ASTContext &Ctx = impl.getClangASTContext();
+  if (auto *stdNS = clangSema.getStdNamespace()) {
+    clang::DeclarationName declName =
+        Ctx.DeclarationNames.getIdentifier(&Ctx.Idents.get(name));
+
+    clang::ClassTemplateDecl *tmplDecl =
+        stdNS->lookup(declName).find_first<clang::ClassTemplateDecl>();
+
+    if (!tmplDecl)
+      return {};
+
+    // find specialization of the shape [std::name<clangDecl>]
+    void *insertPos = nullptr;
+    auto *fobjDecl = tmplDecl->findSpecialization(
+        {clang::TemplateArgument(Ctx.getTypeDeclType(clangDecl))}, insertPos);
+    if (!fobjDecl)
+      return {};
+
+    // instantiate specialization for a complete definition
+    if (!fobjDecl->hasDefinition()) {
+      if (impl.getClangSema().InstantiateClassTemplateSpecialization(
+              clangDecl->getLocation(), fobjDecl,
+              clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+              false, false))
+        return {};
+    }
+
+    if (auto *fobjDef = fobjDecl->getDefinition()) {
+      clang::CXXMethodDecl *methodDecl = nullptr;
+      clang::DeclarationName opName =
+          Ctx.DeclarationNames.getCXXOperatorName(clang::OO_Call);
+      clang::LookupResult result(clangSema, opName, clang::SourceLocation(),
+                                 clang::Sema::LookupOrdinaryName);
+      clangSema.LookupQualifiedName(result, fobjDef);
+
+      for (clang::NamedDecl *namedDecl : result) {
+        // getUnderlyingDecl() strips away any 'using' shadows from base classes
+        if (auto *candidate = llvm::dyn_cast<clang::CXXMethodDecl>(namedDecl)) {
+          if (Ctx.hasSameFunctionTypeIgnoringExceptionSpec(candidate->getType(),
+                                                           funTy)) {
+            methodDecl = candidate;
+            break;
+          }
+        }
+      }
+
+      if (methodDecl)
+        return {fobjDecl, methodDecl};
+    }
+  }
+
+  return {};
+}
+
+// Attempt at decoupling the std::equal_to<> conformance from std::hash<>
+// conformance. Because we don't want unnecessary importation, the actual import
+// is delayed as a thunk.
+static std::optional<std::function<bool()>> conformToEquatableIfNeeded(
+    ClangImporter::Implementation &impl, SwiftDeclSynthesizer &synthesizer,
+    NominalTypeDecl *decl, const clang::CXXRecordDecl *clangDecl) {
+  clang::ASTContext &Ctx = impl.getClangASTContext();
+  // construct [const T&]
+  clang::QualType recordTy = Ctx.getTypeDeclType(clangDecl);
+  clang::QualType constRecordTy = recordTy.withConst();
+  clang::QualType constRefTy = Ctx.getLValueReferenceType(constRecordTy);
+  std::array paramsTy{constRefTy, constRefTy};
+
+  // constant method
+  clang::FunctionProtoType::ExtProtoInfo epi;
+  epi.TypeQuals.addConst();
+  clang::QualType funTy = Ctx.getFunctionType(Ctx.BoolTy, paramsTy, epi);
+
+  auto result =
+      lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "equal_to", funTy);
+  auto *stdETDecl = result.first;
+  auto *methodDecl = result.second;
+  // check that either [std::equal_to<>] exists or [operator== ()] exists.
+  if (!stdETDecl && !getEqualEqualOperator(decl))
+    return {};
+
+  return [&impl, decl, stdETDecl, methodDecl, clangDecl] {
+    // we have two possible sources for [==(_:_:)]
+    // 1. [std::equal_to<T>]
+    // 2. [operator==(T, T)]
+    // The current implementation prioritize 2 over 1, which as the following
+    // effects,
+    // - the behavior of [==(_:_:)] operator in Swift will match that of
+    // [operator==(T, T)] in C++, if both exist,
+    // - the behavior of unordered containers (such as [Set]) in Swift will not
+    // match their equivalences ([unordered_set]) in C++, if the C++ type has a
+    // custom [std::equal_to<T>] specialization that does not agree with
+    // [operator==(T, T)]
+    if (stdETDecl && getEqualEqualOperator(decl)) {
+      impl.diagnose(HeaderLoc{clangDecl->getLocation()},
+                    diag::mismatched_equatable_semantics, decl);
+    }
+
+    if (!getEqualEqualOperator(decl)) {
+      // This call will return false only when no suitable constructor is found.
+      if (!synthesizeOperatorWithCxxFunctionObject(
+              impl, clangDecl, stdETDecl, methodDecl,
+              clang::BinaryOperatorKind::BO_EQ))
+        return false;
+    }
+
+    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::Equatable});
+    return true;
+  };
+}
+
+static void conformToHashableIfNeeded(ClangImporter::Implementation &impl,
+                                      SwiftDeclSynthesizer &synthesizer,
+                                      NominalTypeDecl *decl,
+                                      const clang::CXXRecordDecl *clangDecl) {
+  PrettyStackTraceDecl trace("conforming to Hashable", decl);
+
+  clang::ASTContext &Ctx = impl.getClangASTContext();
+  // construct [const T&]
+  clang::QualType recordTy = Ctx.getTypeDeclType(clangDecl);
+  clang::QualType constRecordTy = recordTy.withConst();
+  clang::QualType constRefTy = Ctx.getLValueReferenceType(constRecordTy);
+  std::array paramsTy{constRefTy};
+  // constant method
+  clang::FunctionProtoType::ExtProtoInfo epi;
+  epi.TypeQuals.addConst();
+  clang::QualType funTy = Ctx.getFunctionType(Ctx.getSizeType(), paramsTy, epi);
+  auto [stdHashDecl, _] =
+      lookupAndSpecializeCxxFunctionObject(impl, clangDecl, "hash", funTy);
+
+  // we bail if [std::hash<>] doesn't exist
+  if (!stdHashDecl) {
+    return;
+  }
+
+  auto *stdHash = impl.importDecl(stdHashDecl, impl.CurrentVersion);
+  if (!stdHash)
+    return;
+
+  if (auto conformToEquatable =
+          conformToEquatableIfNeeded(impl, synthesizer, decl, clangDecl)) {
+    if (!(*conformToEquatable)()) {
+      return;
+    }
+
+    if (auto *stdHashStruct = dyn_cast<StructDecl>(stdHash)) {
+      FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHashStruct);
+      decl->addMember(hashFunc);
+    } else {
+      ASSERT(false);
+      return;
+    }
+
+    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::Hashable});
+  }
+}
+
 void swift::deriveAutomaticCxxConformances(
-    ClangImporter::Implementation &Impl, NominalTypeDecl *result,
-    const clang::CXXRecordDecl *clangDecl) {
+    ClangImporter::Implementation &Impl, SwiftDeclSynthesizer &synthesizer,
+    NominalTypeDecl *result, const clang::CXXRecordDecl *clangDecl) {
 
   ASSERT(result && clangDecl && "this should not be called with nullptrs");
 
@@ -1614,7 +1910,7 @@ void swift::deriveAutomaticCxxConformances(
   conformToCxxIteratorIfNeeded(Impl, result, clangDecl);
   conformToCxxSequenceIfNeeded(Impl, result, clangDecl);
   conformToCxxConvertibleToBoolIfNeeded(Impl, result);
-
+  conformToHashableIfNeeded(Impl, synthesizer, result, clangDecl);
   // CxxStdlib conformances: these should only apply to known C++ stdlib types,
   // which we determine by name and membership in the std namespace.
   if (!clangDecl->getIdentifier() || !clangDecl->isInStdNamespace())
@@ -1649,219 +1945,4 @@ void swift::deriveAutomaticCxxConformances(
     conformToCxxSpan(Impl, result, clangDecl);
     return;
   }
-}
-
-// applies to [operator op(T, T)] where T = classDecl
-static bool synthesizeCXXOperatorWithFunctionObject(
-    ClangImporter::Implementation &impl, const clang::CXXRecordDecl *classDecl,
-    const clang::CXXRecordDecl *funcDecl,
-    clang::BinaryOperatorKind operatorKind) {
-  auto &clangCtx = impl.getClangASTContext();
-  auto &clangSema = impl.getClangSema();
-
-  clang::OverloadedOperatorKind opKind =
-      clang::BinaryOperator::getOverloadedOperator(operatorKind);
-  const char *opSpelling = clang::getOperatorSpelling(opKind);
-
-  auto declName = clang::DeclarationName(&clangCtx.Idents.get(opSpelling));
-
-  // Determine the Clang decl context where the new operator function will be
-  // created. We use the translation unit as the decl context of the new
-  // operator, otherwise, the operator might get imported as a static member
-  // function of a different type (e.g. an operator declared inside of a C++
-  // namespace would get imported as a member function of a Swift enum), which
-  // would make the operator un-discoverable to Swift name lookup.
-  auto declContext =
-      const_cast<clang::CXXRecordDecl *>(classDecl)->getDeclContext();
-  while (!declContext->isTranslationUnit()) {
-    declContext = declContext->getParent();
-  }
-
-  clang::CXXMethodDecl *methodDecl = nullptr;
-  for (auto &&candidate : funcDecl->methods()) {
-    if (candidate->getOverloadedOperator() ==
-            clang::OverloadedOperatorKind::OO_Call &&
-        candidate->param_size() == 2) {
-      methodDecl = candidate;
-      break;
-    }
-  }
-
-  clang::QualType returnTy = methodDecl->getReturnType();
-  clang::QualType lhsTy = clangCtx.getRecordType(classDecl),
-                  rhsTy = clangCtx.getRecordType(classDecl);
-
-  auto opTy = clangCtx.getFunctionType(
-      returnTy, {lhsTy, rhsTy}, clang::FunctionProtoType::ExtProtoInfo());
-
-  // Create a `bool operator op(T, T)` function.
-  auto opDecl = clang::FunctionDecl::Create(
-      clangCtx, declContext, clang::SourceLocation(), clang::SourceLocation(),
-      declName, opTy, clangCtx.getTrivialTypeSourceInfo(returnTy),
-      clang::StorageClass::SC_Static);
-  opDecl->setImplicit();
-  opDecl->setImplicitlyInline();
-  // If this is a static member function of a class, it needs to be public.
-  opDecl->setAccess(clang::AccessSpecifier::AS_public);
-
-  // Create the parameters of the function. They are not referenced from source
-  // code, so they don't need to have a name.
-  auto lhsParamId = nullptr;
-  auto lhsTyInfo = clangCtx.getTrivialTypeSourceInfo(lhsTy);
-  auto lhsParamDecl = clang::ParmVarDecl::Create(
-      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
-      lhsParamId, lhsTy, lhsTyInfo, clang::StorageClass::SC_None,
-      /*DefArg*/ nullptr);
-  auto lhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, lhsParamDecl, false, lhsTy, clang::ExprValueKind::VK_LValue,
-      clang::SourceLocation());
-
-  auto rhsParamId = nullptr;
-  auto rhsTyInfo = clangCtx.getTrivialTypeSourceInfo(rhsTy);
-  auto rhsParamDecl = clang::ParmVarDecl::Create(
-      clangCtx, opDecl, clang::SourceLocation(), clang::SourceLocation(),
-      rhsParamId, rhsTy, rhsTyInfo, clang::StorageClass::SC_None, nullptr);
-  auto rhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, rhsParamDecl, false, rhsTy, clang::ExprValueKind::VK_LValue,
-      clang::SourceLocation());
-
-  opDecl->setParams({lhsParamDecl, rhsParamDecl});
-
-  // looking for the constructor for the function object
-  clang::CXXConstructorDecl *ctorDecl = nullptr;
-  for (clang::CXXConstructorDecl *candidate : funcDecl->ctors()) {
-    if (candidate->param_size() == 0) {
-      ctorDecl = candidate;
-      break;
-    }
-  }
-
-  if (!ctorDecl)
-    return false;
-
-  clang::QualType funcTy = clangCtx.getRecordType(funcDecl);
-  clang::SourceLocation funcLoc = funcDecl->getLocation();
-
-  clang::ExprResult synthCtorExprResult = clangSema.BuildCXXConstructExpr(
-      funcLoc, funcTy, ctorDecl,
-      /*Elidable=*/false, {},
-      /*HadMultipleCandidates=*/false,
-      /*IsListInitialization=*/false,
-      /*IsStdInitListInitialization=*/false,
-      /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
-      clang::SourceRange(funcLoc, funcLoc));
-
-  ASSERT(!synthCtorExprResult.isInvalid() &&
-         "Unable to synthesize constructor expression for std::equal_to");
-  clang::Expr *synthCtorExpr = synthCtorExprResult.get();
-
-  SmallVector<clang::Expr *, 2> args = {lhsParamRefExpr, rhsParamRefExpr};
-  auto call =
-      clangSema.BuildCallExpr(nullptr, synthCtorExpr, clang::SourceLocation(),
-                              args, clang::SourceLocation());
-
-  if (!call.isUsable())
-    return false;
-
-  auto opBody = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
-                                          call.get(), nullptr);
-  opDecl->setBody(opBody);
-
-  impl.synthesizedAndAlwaysVisibleDecls.insert(opDecl);
-  auto lookupTable1 = impl.findLookupTable(classDecl);
-  addEntryToLookupTable(*lookupTable1, opDecl, impl.getNameImporter());
-  auto owningModule = impl.getClangOwningModule(classDecl);
-  auto lookupTable2 = impl.findLookupTable(owningModule);
-  if (lookupTable1 != lookupTable2)
-    addEntryToLookupTable(*lookupTable2, opDecl, impl.getNameImporter());
-  return true;
-}
-
-static clang::ClassTemplateSpecializationDecl *
-lookupAndSpecializeFunctionObject(ClangImporter::Implementation &impl,
-                                  const clang::CXXRecordDecl *clangDecl,
-                                  std::string name) {
-  ASSERT(clangDecl);
-  clang::ASTContext &Ctx = impl.getClangASTContext();
-  clang::Sema &clangSema = impl.getClangSema();
-
-  clang::NamespaceDecl *stdNS = clangSema.getStdNamespace();
-  // maybe the C++ header didn't include standard library?
-  if (!stdNS)
-    return nullptr;
-
-  clang::DeclarationName declName =
-      Ctx.DeclarationNames.getIdentifier(&Ctx.Idents.get(name));
-
-  clang::ClassTemplateDecl *tmplDecl =
-      stdNS->lookup(declName).find_first<clang::ClassTemplateDecl>();
-
-  if (!tmplDecl)
-    return nullptr;
-
-  // find specialization to the current clangDecl
-  void *insertPos = nullptr;
-  return tmplDecl->findSpecialization(
-      {clang::TemplateArgument(
-          clangDecl->getASTContext().getTypeDeclType(clangDecl))},
-      insertPos);
-}
-
-void swift::conformToHashableIfNeeded(ClangImporter::Implementation &impl,
-                                      SwiftDeclSynthesizer &synthesizer,
-                                      NominalTypeDecl *decl,
-                                      const clang::CXXRecordDecl *clangDecl) {
-  PrettyStackTraceDecl trace("conforming to Hashable", decl);
-
-  ASSERT(decl);
-  ASSERT(clangDecl);
-
-  auto *stdHashSpec =
-      lookupAndSpecializeFunctionObject(impl, clangDecl, "hash");
-  auto *stdETSpec =
-      lookupAndSpecializeFunctionObject(impl, clangDecl, "equal_to");
-
-  // we bail if [std::hash<>] couldn't be found
-  if (!stdHashSpec)
-    return;
-
-  if (!stdETSpec && !getEqualEqualOperator(decl))
-    return;
-
-  auto *stdHash = impl.importDecl(stdHashSpec, impl.CurrentVersion);
-  if (!stdHash)
-    return;
-
-  if (auto *stdHashStruct = dyn_cast<StructDecl>(stdHash)) {
-    FuncDecl *hashFunc = synthesizer.makeHashFunc(decl, stdHashStruct);
-    decl->addMember(hashFunc);
-  } else {
-    return;
-  }
-
-  // we have two possible sources for [==(_:_:)]
-  // 1. [std::equal_to<T>]
-  // 2. [operator==(T, T)]
-  // The current implementation prioritize 2 over 1, which as the following
-  // effects,
-  // - the behavior of [==(_:_:)] operator in Swift will match that of
-  // [operator==(T, T)] in C++, if both exist,
-  // - the behavior of unordered containers (such as [Set]) in Swift will not
-  // match their equivalences ([unordered_set]) in C++, if the C++ type has a
-  // custom [std::equal_to<T>] specialization that does not agree with
-  // [operator==(T, T)]
-  if (!getEqualEqualOperator(decl)) {
-    // FIXME: I'm simply importing the [std::equal_to<T>] declaration so that
-    // it's loaded into clang context, otherwise the next
-    // [synthesizeCXXOperatorWithFunctionObject] call will fail. There is
-    // probably a more suitable function to call here.
-    if (!impl.importDecl(stdETSpec, impl.CurrentVersion))
-      return;
-    if (!synthesizeCXXOperatorWithFunctionObject(
-            impl, clangDecl, stdETSpec, clang::BinaryOperatorKind::BO_EQ))
-      return;
-  }
-
-  impl.addSynthesizedProtocolAttrs(
-      decl, {KnownProtocolKind::Equatable, KnownProtocolKind::Hashable});
 }

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -14,6 +14,7 @@
 #define SWIFT_CLANG_DERIVED_CONFORMANCES_H
 
 #include "ImporterImpl.h"
+#include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTContext.h"
 
 namespace swift {

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -31,6 +31,7 @@ bool hasIteratorCategory(const clang::CXXRecordDecl *clangDecl);
 bool isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl);
 
 void deriveAutomaticCxxConformances(ClangImporter::Implementation &Impl,
+                                    SwiftDeclSynthesizer &synthesizer,
                                     NominalTypeDecl *result,
                                     const clang::CXXRecordDecl *clangDecl);
 } // namespace swift

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -9442,3 +9442,10 @@ NominalType *swift::stripInlineNamespaces(NominalType *outer,
 
   return inner;
 }
+
+// cached copy of C++ [::std] namespace, accounting for the case that [::std]
+// doesn't exists.
+const clang::NamespaceDecl *
+ClangImporter::Implementation::getCxxStdNamespace() {
+  return *(stdNS ? stdNS : (stdNS = getClangSema().getStdNamespace()));
+}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3386,7 +3386,7 @@ namespace {
       validatePrivateFileIDAttributes(decl);
 
       if (auto *nominalResult = dyn_cast<NominalTypeDecl>(result)) {
-        deriveAutomaticCxxConformances(Impl, nominalResult, decl);
+        deriveAutomaticCxxConformances(Impl, synthesizer, nominalResult, decl);
 
         if (ClangImporter::Implementation::needsClosureConstructor(decl)) {
           if (auto *ctor = synthesizer.makeClosureConstructor(nominalResult))

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2027,6 +2027,12 @@ public:
   lookupImplementationFileDecls(llvm::function_ref<bool(ClangNode)> filter,
     llvm::function_ref<void(const clang::Decl*)> receiver,
     llvm::function_ref<void(const swift::ImportDecl *)> receiverImports) const;
+
+private:
+  std::optional<const clang::NamespaceDecl *> stdNS;
+
+public:
+  const clang::NamespaceDecl *getCxxStdNamespace();
 };
 
 class ImportDiagnosticAdder {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2114,7 +2114,7 @@ synthesizeHashFuncBody(AbstractFunctionDecl *afd, void *context) {
         init->getParameters()->size() == 0)
       break;
   }
-  assert(init && "did not find init() for std::hash<T>");
+  ASSERT(init && "cannot find init in Swift context for std::hash<T>");
 
   // init: (std::hash<T>.Type) -> () -> std::hash<T>
   auto initTy = init->getInterfaceType();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2188,7 +2188,7 @@ FuncDecl *SwiftDeclSynthesizer::makeHashFunc(NominalTypeDecl *decl,
       /*Throws=*/false, /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, returnType, decl);
   hashFunc->setSynthesized();
-  hashFunc->setAccess(AccessLevel::Public);
+  hashFunc->setAccess(decl->getEffectiveAccess());
   hashFunc->setBodySynthesizer(synthesizeHashFuncBody, stdHash);
 
   return hashFunc;

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2088,6 +2088,112 @@ FuncDecl *SwiftDeclSynthesizer::makeSuccessorFunc(FuncDecl *incrementFunc) {
   return result;
 }
 
+// MARK: use std::hash<> to conform to Hashable
+
+/// delayed body synthesizer for hash(into:)
+///
+/// \code
+/// hasher.combine(std::hash<T>.init()(self))
+/// \endcode
+static std::pair<BraceStmt *, bool>
+synthesizeHashFuncBody(AbstractFunctionDecl *afd, void *context) {
+  auto hashFunc = cast<FuncDecl>(afd);
+  auto stdHash = static_cast<StructDecl *>(context);
+
+  ASTContext &ctx = hashFunc->getASTContext();
+
+  // lookup init() for std::hash<T>
+  auto stdHashType =
+      TypeExpr::createImplicit(stdHash->getDeclaredInterfaceType(), ctx);
+  DeclName initName = DeclName(DeclBaseName::createConstructor());
+
+  ConstructorDecl *init = nullptr;
+  for (auto found : stdHash->lookupDirect(initName)) {
+    init = dyn_cast<ConstructorDecl>(found);
+    if (init && init->getDeclContext() == stdHash &&
+        init->getParameters()->size() == 0)
+      break;
+  }
+  assert(init && "did not find init() for std::hash<T>");
+
+  // init: (std::hash<T>.Type) -> () -> std::hash<T>
+  auto initTy = init->getInterfaceType();
+  auto initRef = new (ctx) DeclRefExpr(init, DeclNameLoc(), /*Implicit=*/true,
+                                       AccessSemantics::Ordinary, initTy);
+
+  // std::hash<T>.init: () -> std::hash<T>
+  initTy = initTy->castTo<FunctionType>()->getResult();
+  auto stdHashInitRef = DotSyntaxCallExpr::create(
+      ctx, initRef, SourceLoc(), Argument::unlabeled(stdHashType), initTy);
+
+  // std::hash<T>.init(): std::hash<T>
+  initTy = initTy->castTo<FunctionType>()->getResult();
+  auto instRef = CallExpr::createImplicitEmpty(ctx, stdHashInitRef);
+  instRef->setType(initTy);
+
+  // self: Self
+  auto selfDecl = hashFunc->getImplicitSelfDecl();
+  auto selfRefExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                           /*implicit*/ true);
+  selfRefExpr->setType(selfDecl->getInterfaceType());
+
+  // std::hash<T>.init()(self): Int
+  auto *stdHashArgs = ArgumentList::forImplicitUnlabeled(ctx, {selfRefExpr});
+  auto stdHashExpr = CallExpr::createImplicit(ctx, instRef, stdHashArgs);
+  stdHashExpr->setType(ctx.getIntType());
+
+  // hasher: Hasher
+  auto hasherParam = hashFunc->getParameters()->get(0);
+  Expr *hasherRef = new (ctx) DeclRefExpr(ConcreteDeclRef(hasherParam),
+                                          DeclNameLoc(), /*implicit*/ true);
+  hasherRef->setType(hasherParam->getInterfaceType());
+
+  // hasher.combine(_:): (Int) -> ()
+  auto *combineRef =
+      UnresolvedDotExpr::createImplicit(ctx, hasherRef, ctx.Id_combine);
+
+  // hasher.combine(hashable)
+  auto *hasherArgs = ArgumentList::forImplicitUnlabeled(ctx, {stdHashExpr});
+  auto *hasherCall = CallExpr::createImplicit(ctx, combineRef, hasherArgs);
+  hasherCall->setType(TupleType::getEmpty(ctx));
+  auto body = BraceStmt::create(ctx, SourceLoc(), {hasherCall}, SourceLoc());
+
+  return {body, /*isTypeChecked*/ false};
+}
+
+FuncDecl *SwiftDeclSynthesizer::makeHashFunc(NominalTypeDecl *decl,
+                                             StructDecl *stdHash) {
+  auto &ctx = ImporterImpl.SwiftContext;
+
+  auto hasherDecl = ctx.getHasherDecl();
+  Type hasherType = hasherDecl->getDeclaredInterfaceType();
+
+  // Params: self (implicit), into: hasher
+  auto *hasherParamDecl = new (ctx) ParamDecl(
+      SourceLoc(), SourceLoc(), ctx.Id_into, SourceLoc(), ctx.Id_hasher, decl);
+  hasherParamDecl->setSpecifier(ParamSpecifier::InOut);
+  hasherParamDecl->setInterfaceType(hasherType);
+  hasherParamDecl->setImplicit();
+
+  ParameterList *params = ParameterList::createWithoutLoc(hasherParamDecl);
+
+  // Return type: ()
+  auto returnType = TupleType::getEmpty(ctx);
+
+  // func hash(into hasher: inout Hasher) -> ()
+  DeclName name(ctx, ctx.Id_hash, params);
+  auto *const hashFunc = FuncDecl::createImplicit(
+      ctx, StaticSpellingKind::None, name, /*NameLoc=*/SourceLoc(),
+      /*Async=*/false,
+      /*Throws=*/false, /*ThrownType=*/Type(),
+      /*GenericParams=*/nullptr, params, returnType, decl);
+  hashFunc->setSynthesized();
+  hashFunc->setAccess(AccessLevel::Public);
+  hashFunc->setBodySynthesizer(synthesizeHashFuncBody, stdHash);
+
+  return hashFunc;
+}
+
 // MARK: C++ arithmetic operators
 
 static std::pair<BraceStmt *, bool>

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -311,6 +311,8 @@ public:
   /// function `successor() -> Self`.
   FuncDecl *makeSuccessorFunc(FuncDecl *incrementFunc);
 
+  FuncDecl *makeHashFunc(NominalTypeDecl *decl, StructDecl *hasherVar);
+
   FuncDecl *makeOperator(FuncDecl *operatorMethod,
                          clang::OverloadedOperatorKind opKind);
   

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -143,6 +143,10 @@ module IteratorCycleUnrelatedOperator {
 
 module StdCoroutine {
   header "std-coroutine.h"
+}
+
+module StdHash {
+  header "std-hash.h"
   requires cplusplus
   export *
 }

--- a/test/Interop/Cxx/stdlib/Inputs/std-hash.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-hash.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+using Optionalstr = std::optional<std::string>;
+using hashoptstr = std::hash<Optionalstr>;
+using eqoptstr = std::equal_to<Optionalstr>;
+
+struct A {
+  int value;
+  std::string comment;
+
+  bool operator==(const A &rhs) const { return value == rhs.value; }
+};
+
+template <>
+struct std::hash<A> {
+  size_t operator()(const A &x) const { return std::hash<int>{}(x.value); }
+};
+
+struct B {
+  int value, len;
+  char *comment;
+
+  B(int value, std::string comment) : value(value), len(comment.size()) {
+    this->comment = new char[len + 1];
+    for (int i = 0; i <= comment.size(); ++i)
+      this->comment[i] = comment[i];
+  }
+};
+
+template <>
+struct std::hash<B> {
+  size_t operator()(const B &x) const { return std::hash<int>{}(x.value); }
+};
+
+template <>
+struct std::equal_to<B> {
+  bool operator()(const B &lhs, const B &rhs) const {
+    return lhs.value == rhs.value;
+  }
+};
+
+struct C {
+  int x, y;
+};
+
+struct D {
+  int x, y;
+};
+
+template <class T>
+struct hash;
+
+template <>
+struct hash<D> {
+  size_t operator()(const D &x) const { return std::hash<int>{}(x.y); }
+};

--- a/test/Interop/Cxx/stdlib/Inputs/std-hash.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-hash.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bitset>
+#include <functional>
 #include <optional>
 #include <string>
 

--- a/test/Interop/Cxx/stdlib/Inputs/std-hash.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-hash.h
@@ -3,9 +3,12 @@
 #include <optional>
 #include <string>
 
+using Bitset = std::bitset<64>;
 using Optionalstr = std::optional<std::string>;
 using hashoptstr = std::hash<Optionalstr>;
 using eqoptstr = std::equal_to<Optionalstr>;
+
+Bitset makeBitset(uint64_t n) { return std::bitset<64>{n}; }
 
 struct A {
   int value;

--- a/test/Interop/Cxx/stdlib/Inputs/std-hash.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-hash.h
@@ -5,60 +5,85 @@
 #include <optional>
 #include <string>
 
+// === Positive Tests ===
+
+// Test Suite 1: std::bitset
 using Bitset = std::bitset<64>;
+Bitset makeBitset(uint64_t n) { return std::bitset<64>{n}; }
+
+// Test Suite 2: std::optional<std::string>
 using Optionalstr = std::optional<std::string>;
 using hashoptstr = std::hash<Optionalstr>;
 using eqoptstr = std::equal_to<Optionalstr>;
 
-Bitset makeBitset(uint64_t n) { return std::bitset<64>{n}; }
-
+// Test Suite 3: member operator==
 struct A {
   int value;
   std::string comment;
 
   bool operator==(const A &rhs) const { return value == rhs.value; }
 };
-
 template <>
 struct std::hash<A> {
   size_t operator()(const A &x) const { return std::hash<int>{}(x.value); }
 };
 
+// Test Suite 4: global operator==
 struct B {
-  int value, len;
-  char *comment;
-
-  B(int value, std::string comment) : value(value), len(comment.size()) {
-    this->comment = new char[len + 1];
-    for (int i = 0; i <= comment.size(); ++i)
-      this->comment[i] = comment[i];
-  }
+  int value;
+  std::string comment;
 };
-
+bool operator==(const B &lhs, const B &rhs) { return lhs.value == rhs.value; }
 template <>
 struct std::hash<B> {
   size_t operator()(const B &x) const { return std::hash<int>{}(x.value); }
 };
 
+// Test Suite 5: C string and std::equal_to
+struct C {
+  int value, len;
+  char *comment;
+
+  C(int value, std::string comment) : value(value), len(comment.size()) {
+    this->comment = new char[len + 1];
+    for (int i = 0; i <= comment.size(); ++i)
+      this->comment[i] = comment[i];
+  }
+};
 template <>
-struct std::equal_to<B> {
-  bool operator()(const B &lhs, const B &rhs) const {
+struct std::hash<C> {
+  size_t operator()(const C &x) const { return std::hash<int>{}(x.value); }
+};
+template <>
+struct std::equal_to<C> {
+  bool operator()(const C &lhs, const C &rhs) const {
     return lhs.value == rhs.value;
   }
 };
 
-struct C {
-  int x, y;
-};
+// === Negative Tests ===
 
+// Test Suite 1: no hash
 struct D {
   int x, y;
 };
 
-template <class T>
-struct hash;
+// Test Suite 2: no operator== or std::equal_to
+struct E {
+  int x, y;
+};
+template <>
+struct std::hash<E> {
+  size_t operator()(const E &x) const { return std::hash<int>{}(x.y); }
+};
+
+// Test Suite 3: incorrect hash specialization
+struct F {
+  int value;
+  std::string comment;
+
+  bool operator==(const F &rhs) const { return value == rhs.value; }
+};
 
 template <>
-struct hash<D> {
-  size_t operator()(const D &x) const { return std::hash<int>{}(x.y); }
-};
+struct std::hash<F> {};

--- a/test/Interop/Cxx/stdlib/Inputs/std-hash.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-hash.h
@@ -87,3 +87,16 @@ struct F {
 
 template <>
 struct std::hash<F> {};
+
+// Test Suite 4: no default constructor
+struct G {
+  int value;
+  std::string comment;
+
+  bool operator==(const G &rhs) const { return value == rhs.value; }
+};
+template <>
+struct std::hash<G> {
+  hash() = delete;
+  size_t operator()(const G &x) const { return std::hash<int>{}(x.value); }
+};

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+import StdHash
+import CxxStdlib
+
+let hash = C.hash(into:)
+// CHECK: error: type 'C' has no member 'hash(into:)'
+
+let dictC: [C : String] = [:]
+// CHECK: error: type 'C' does not conform to protocol 'Hashable'
+
+let dictD: [D : String] = [:]
+// CHECK: error: type 'D' does not conform to protocol 'Hashable'

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -1,13 +1,10 @@
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift %s -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm
 
 import StdHash
 import CxxStdlib
 
-let hash = C.hash(into:)
-// CHECK: error: type 'C' has no member 'hash(into:)'
+let hash = C.hash(into:) // expected-error {{type 'C' has no member 'hash(into:)'}}
 
-let dictC: [C : String] = [:]
-// CHECK: error: type 'C' does not conform to protocol 'Hashable'
+let dictC: [C : String] = [:] // expected-error {{type 'C' does not conform to protocol 'Hashable'}}
 
-let dictD: [D : String] = [:]
-// CHECK: error: type 'D' does not conform to protocol 'Hashable'
+let dictD: [D : String] = [:] // expected-error {{type 'D' does not conform to protocol 'Hashable'}}

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 
 import StdHash
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm
+// RUN: %target-typecheck-verify-swift %s -I %S/Inputs -cxx-interoperability-mode=default
 
 import StdHash
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -3,8 +3,10 @@
 import StdHash
 import CxxStdlib
 
-let hash = C.hash(into:) // expected-error {{type 'C' has no member 'hash(into:)'}}
+let hash = D.hash(into:) // expected-error {{type 'D' has no member 'hash(into:)'}}
 
-let dictC: [C : String] = [:] // expected-error {{type 'C' does not conform to protocol 'Hashable'}}
+let dictC: [D : String] = [:] // expected-error {{type 'D' does not conform to protocol 'Hashable'}}
 
-let dictD: [D : String] = [:] // expected-error {{type 'D' does not conform to protocol 'Hashable'}}
+let dictD: [E : String] = [:] // expected-error {{type 'E' does not conform to protocol 'Hashable'}}
+
+let dictF: [F : String] = [:] //expected-error {{type 'F' does not conform to protocol 'Hashable'}}

--- a/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash-typechecker.swift
@@ -9,4 +9,6 @@ let dictC: [D : String] = [:] // expected-error {{type 'D' does not conform to p
 
 let dictD: [E : String] = [:] // expected-error {{type 'E' does not conform to protocol 'Hashable'}}
 
-let dictF: [F : String] = [:] //expected-error {{type 'F' does not conform to protocol 'Hashable'}}
+let dictF: [F : String] = [:] // expected-error {{type 'F' does not conform to protocol 'Hashable'}}
+
+let dictG: [G : String] = [:] // expected-error {{type 'G' does not conform to protocol 'Hashable'}}

--- a/test/Interop/Cxx/stdlib/use-std-hash.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash.swift
@@ -12,22 +12,19 @@ import CxxStdlib
 
 var StdHashTestSuite = TestSuite("StdHash")
 
-StdHashTestSuite.test("StdHash.StdString") {
-  let dict: [std.string : String] = [
-    "hello" : "world",
-    "dependent": "type",
-    "swift": "cxx"]
+StdHashTestSuite.test("StdHash.stdBitset") {
+  let dict: [Bitset : String] = [
+    makeBitset(10) : "world",
+    makeBitset(21) : "type",
+    makeBitset(33) : "cxx"]
 
-  expectEqual(dict["hello"], "world")
-  expectEqual(dict["dependent"], "type")
-  expectEqual(dict["swift"], "cxx")
+  expectEqual(dict[makeBitset(10)], "world")
+  expectEqual(dict[makeBitset(21)], "type")
+  expectEqual(dict[makeBitset(33)], "cxx")
 }
 
 // we need to manually instantiate std::hash<std::optional<std::string>>
 StdHashTestSuite.test("StdHash.StdOptionalString") {
-  var hasher = Hasher()
-
-  Optionalstr.init().hash(into: &hasher)
   let dict: [Optionalstr : String] = [
     Optionalstr.init("hello") : "world",
     Optionalstr.init("dependent"): "type",

--- a/test/Interop/Cxx/stdlib/use-std-hash.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash.swift
@@ -1,0 +1,65 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdHash
+import CxxStdlib
+
+var StdHashTestSuite = TestSuite("StdHash")
+
+StdHashTestSuite.test("StdHash.StdString") {
+  let dict: [std.string : String] = [
+    "hello" : "world",
+    "dependent": "type",
+    "swift": "cxx"]
+
+  expectEqual(dict["hello"], "world")
+  expectEqual(dict["dependent"], "type")
+  expectEqual(dict["swift"], "cxx")
+}
+
+// we need to manually instantiate std::hash<std::optional<std::string>>
+StdHashTestSuite.test("StdHash.StdOptionalString") {
+  var hasher = Hasher()
+
+  Optionalstr.init().hash(into: &hasher)
+  let dict: [Optionalstr : String] = [
+    Optionalstr.init("hello") : "world",
+    Optionalstr.init("dependent"): "type",
+    Optionalstr.init("swift"): "cxx",
+    Optionalstr.init(): "nil"]
+
+  expectEqual(dict[Optionalstr.init("hello")], "world")
+  expectEqual(dict[Optionalstr.init("dependent")], "type")
+  expectEqual(dict[Optionalstr.init("swift")], "cxx")
+  expectEqual(dict[Optionalstr.init()], "nil")
+}
+
+StdHashTestSuite.test("StdHash.StructA") {
+  var dict: [A : String] = [
+    A.init(value: 10, comment: "hello") : "world",
+    A.init(value: 20, comment: "dependent"): "type"
+  ]
+
+  dict[A.init(value: 10, comment: "mare")] = "nostrum"
+
+  expectEqual(dict[A.init(value: 10, comment: "hello")], "nostrum")
+}
+
+StdHashTestSuite.test("StdHash.StructB") {
+  var dict: [B : String] = [
+    B.init(10, "hello") : "world",
+    B.init(20, "dependent"): "type"
+  ]
+
+  dict[B.init(10, "mare")] = "nostrum"
+
+  expectEqual(dict[B.init(10, "hello")], "nostrum")
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-hash.swift
+++ b/test/Interop/Cxx/stdlib/use-std-hash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
@@ -12,7 +12,7 @@ import CxxStdlib
 
 var StdHashTestSuite = TestSuite("StdHash")
 
-StdHashTestSuite.test("StdHash.stdBitset") {
+StdHashTestSuite.test("StdHash.StdBitset") {
   let dict: [Bitset : String] = [
     makeBitset(10) : "world",
     makeBitset(21) : "type",
@@ -37,7 +37,7 @@ StdHashTestSuite.test("StdHash.StdOptionalString") {
   expectEqual(dict[Optionalstr.init()], "nil")
 }
 
-StdHashTestSuite.test("StdHash.StructA") {
+StdHashTestSuite.test("StdHash.MemberEqualEqual") {
   var dict: [A : String] = [
     A.init(value: 10, comment: "hello") : "world",
     A.init(value: 20, comment: "dependent"): "type"
@@ -48,15 +48,26 @@ StdHashTestSuite.test("StdHash.StructA") {
   expectEqual(dict[A.init(value: 10, comment: "hello")], "nostrum")
 }
 
-StdHashTestSuite.test("StdHash.StructB") {
+StdHashTestSuite.test("StdHash.GlobalEqualEqual") {
   var dict: [B : String] = [
-    B.init(10, "hello") : "world",
-    B.init(20, "dependent"): "type"
+    B.init(value: 10, comment: "hello") : "world",
+    B.init(value: 20, comment: "dependent"): "type"
   ]
 
-  dict[B.init(10, "mare")] = "nostrum"
+  dict[B.init(value: 10, comment: "mare")] = "nostrum"
 
-  expectEqual(dict[B.init(10, "hello")], "nostrum")
+  expectEqual(dict[B.init(value: 10, comment: "hello")], "nostrum")
+}
+
+StdHashTestSuite.test("StdHash.StdEqualTo") {
+  var dict: [C : String] = [
+    C.init(10, "hello") : "world",
+    C.init(20, "dependent"): "type"
+  ]
+
+  dict[C.init(10, "mare")] = "nostrum"
+
+  expectEqual(dict[C.init(10, "hello")], "nostrum")
 }
 
 runAllTests()


### PR DESCRIPTION
This pull request enables the clang importer to import `std::hash<T>` and `std::equal_to<T>` when available, and use them to conform to `Hashable` protocol.

## Changes
- the importer will now conform C++ types to `Hashable` if it finds a `std::hash` specialization and some source for `func ==`,
- `func ==` can come from either `operator ==` or `std::equal_to<T>`, with the former taking precedence,
- tests for the new functionality,

## Caveats
- In current implementation, `std::hash` and `std::equal_to` needs to be specialized context. In other words, one needs to type `using _ = std::hash<std::optional<std::string>>` in order to conform `std::optional<std::string>` to `Hashable`. Maybe we can try asking clang Sema to synthesize specializations for every C++ type, but that seems costly.
- Unlike C++ containers, `operator==` is prioritized before `std::equal_to`, since Swift doesn't distinguish these two.
- Derived point-wise `func ==` is not recognized by `getEqualEqualOperator`, and thus does not contribute to `Hashable` conformance for C++ types.

Resolves https://github.com/swiftlang/swift/issues/62045