### PR TITLE
IRGen: don't crash when emitting a statically initialized global enum with a `StaticBigInt` payload

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -269,6 +269,13 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
     strategy.emitValueInjection(IGM, builder, ei->getElement(), data, out);
     return replaceUnalignedIntegerValues(IGM, std::move(out));
   } else if (auto *ILI = dyn_cast<IntegerLiteralInst>(operand)) {
+    if (ILI->getType().is<BuiltinIntegerLiteralType>()) {
+      auto pair = emitConstantIntegerLiteral(IGM, ILI);
+      Explosion e;
+      e.add(pair.Data);
+      e.add(pair.Flags);
+      return e;
+    }
     return emitConstantInt(IGM, ILI);
   } else if (auto *FLI = dyn_cast<FloatLiteralInst>(operand)) {
     return emitConstantFP(IGM, FLI);

--- a/test/SILOptimizer/static_bigint_enums.swift
+++ b/test/SILOptimizer/static_bigint_enums.swift
@@ -1,0 +1,28 @@
+// RUN: %target-build-swift -parse-as-library -O %s -module-name=test -emit-sil | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -parse-as-library -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// UNSUPPORTED: use_os_stdlib
+
+
+@available(SwiftStdlib 5.8, *)
+public enum StaticIntStringEnum {
+  case s(StaticString)
+  case i(StaticBigInt)
+
+  // CHECK-LABEL: sil_global hidden @$s4test19StaticIntStringEnumO1xACvpZ : $StaticIntStringEnum = {
+  static var x = Self.i(27)
+}
+
+@available(SwiftStdlib 5.8, *)
+@main
+struct Main {
+  static func main() {
+    // CHECK-OUTPUT: StaticIntStringEnum: i(+0x1B)
+    print("StaticIntStringEnum:", StaticIntStringEnum.x)
+  }
+}
+


### PR DESCRIPTION
Integer literals with `BuiltinIntegerLiteralType` need a special handling.

rdar://162322558
