### PR TITLE
unittests: skip some tests on AL2

### DIFF
--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -318,6 +318,9 @@ TEST(ActorTest, actorSwitch) {
 }
 
 TEST(ActorTest, actorContention) {
+  #ifdef __SKIP_RDAR163604876__
+    GTEST_SKIP() << "Skipping due to rdar://163604876";
+  #endif
   run([] {
     using Context = TupleContext<AsyncTask*, TestActor*>;
     auto actor = createActor();
@@ -387,6 +390,9 @@ TEST(ActorTest, actorContention) {
 }
 
 TEST(ActorTest, actorPriority) {
+  #ifdef __SKIP_RDAR163604876__
+    GTEST_SKIP() << "Skipping due to rdar://163604876";
+  #endif
   run([] {
     auto actor = createActor();
 
@@ -430,6 +436,9 @@ TEST(ActorTest, actorPriority) {
 }
 
 TEST(ActorTest, actorPriority2) {
+  #ifdef __SKIP_RDAR163604876__
+    GTEST_SKIP() << "Skipping due to rdar://163604876";
+  #endif
   run([] {
     auto actor = createActor();
 

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -159,4 +159,28 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     swiftThreading${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     )
+
+###
+# GTEST_SKIP conditions.
+#
+# Sometimes, we need to skip running a unit test due to some bug on a specific
+# platform. You can add a skip like this to the test:
+#
+#  #ifdef __SKIP_RDAR123__
+#    GTEST_SKIP() << "Skipping due to rdar://123";
+#  #endif
+#
+# and use CMake to detect the OS, such as via
+#  
+#  if(EXISTS "/etc/os-release")
+#    file(READ "/etc/os-release" OS_RELEASE)
+#     if(OS_RELEASE MATCHES "Amazon Linux 2")
+#       ...
+#
+# and use 
+#   
+#    target_compile_definitions(SwiftRuntimeTests PRIVATE __SKIP_RDAR123__)
+#
+# to add the preprocessor definition.
+
 endif()

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -183,4 +183,13 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 #
 # to add the preprocessor definition.
 
+
+# A few unit tests with actor scheduling are failing AL2 aarch64 (rdar://163604876)
+if(EXISTS "/etc/os-release")
+    file(READ "/etc/os-release" OS_RELEASE)
+    if(OS_RELEASE MATCHES "Amazon Linux 2" AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
+        target_compile_definitions(SwiftRuntimeTests PRIVATE __SKIP_RDAR163604876__)
+    endif()
+endif()
+
 endif()


### PR DESCRIPTION
It's blocking the Swift CI job https://ci.swift.org/job/oss-swift-package-amazon-linux-2-aarch64/