### PR TITLE
[evaluator] Diagnose request cycles with the request name by default

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -169,7 +169,7 @@ NOTE(note_explain_two_files_same_name,none,
 // MARK: Circular reference diagnostics
 //------------------------------------------------------------------------------
 ERROR(circular_reference, none,
-      "circular reference", ())
+      "%0: circular reference", (StringRef))
 
 NOTE(circular_reference_through, none,
      "through reference here", ())

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -318,7 +318,8 @@ public:
   }
 
   void diagnoseCycle(DiagnosticEngine &diags) const {
-    diags.diagnose(asDerived().getNearestLoc(), diag::circular_reference);
+    diags.diagnose(asDerived().getNearestLoc(), diag::circular_reference,
+                   TypeID<Derived>::getName());
   }
 
   void noteCycleStep(DiagnosticEngine &diags) const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1255,7 +1255,8 @@ void ValidatePrecedenceGroupRequest::diagnoseCycle(
   if (auto pathDir = desc.pathDirection) {
     diags.diagnose(desc.nameLoc, diag::precedence_group_cycle, (bool)*pathDir);
   } else {
-    diags.diagnose(desc.nameLoc, diag::circular_reference);
+    diags.diagnose(desc.nameLoc, diag::circular_reference,
+                   TypeID<ValidatePrecedenceGroupRequest>::getName());
   }
 }
 


### PR DESCRIPTION
The name of the request can be useful for identifying _which_ request encountered a cycle.