### PR TITLE
[Custom availability] Fix conformance availability diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7282,6 +7282,10 @@ ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
       (Type, Type, AvailabilityDomain, AvailabilityRange))
 
+ERROR(conformance_availability_not_available, none,
+      "conformance of %0 to %1 is only available in %2",
+      (Type, Type, AvailabilityDomain))
+
 //------------------------------------------------------------------------------
 // MARK: if #available(...)
 //------------------------------------------------------------------------------

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1465,6 +1465,21 @@ static void configureAvailabilityDomains(const ASTContext &ctx,
   for (auto dynamic : opts.AvailabilityDomains.DynamicDomains)
     createAndInsertDomain(dynamic, CustomAvailabilityDomain::Kind::Dynamic);
 
+  // If we didn't see the UnicodeNormalization availability domain, set it
+  // appropriately.
+  if (domainMap.count(ctx.getIdentifier("UnicodeNormalization")) == 0) {
+    if (ctx.LangOpts.hasFeature(Feature::Embedded)) {
+      // Embedded Swift disables this domain by default.
+      createAndInsertDomain("UnicodeNormalization",
+                            CustomAvailabilityDomain::Kind::Enabled);
+    } else {
+      // Non-Embedded Swift always enables the Unicode tables.
+      createAndInsertDomain("UnicodeNormalization",
+                            CustomAvailabilityDomain::Kind::AlwaysEnabled);
+    }
+  }
+
+
   mainModule->setAvailabilityDomains(std::move(domainMap));
 }
 

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -58,8 +58,6 @@ void SILGenFunction::emitDistributedRemoteActorDeinit(
 
     auto cleanupLoc = CleanupLocation(loc);
 
-    auto &C = cd->getASTContext();
-
     {
       FullExpr CleanupScope(Cleanups, cleanupLoc);
       ManagedValue borrowedSelf = emitManagedBeginBorrow(loc, selfValue);

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -568,3 +568,31 @@ class DerivedUnavailable2: BaseAvailableInEnabledDomain { } // expected-error {{
 @available(DisabledDomain, unavailable)
 class DerivedUnavailable3: BaseAvailableInEnabledDomain { }
 
+
+// Protocol conformance availability.
+protocol P { }
+
+struct MyType1 { }
+
+@available(EnabledDomain)
+extension MyType1: P { }
+
+struct MyType2 { }
+
+@available(AlwaysEnabledDomain)
+extension MyType2: P { }
+
+struct MyType3 { }
+
+@available(DisabledDomain)
+extension MyType3: P { }
+
+func acceptP<T: P>(_: T.Type) { }
+
+func testP() { // expected-note 2{{add '@available' attribute to enclosing global function}}
+  acceptP(MyType1.self) // expected-error{{conformance of 'MyType1' to 'P' is only available in EnabledDomain}}
+  // expected-note@-1{{add 'if #available' version check}}
+  acceptP(MyType2.self) // okay
+  acceptP(MyType3.self)  // expected-error{{conformance of 'MyType3' to 'P' is only available in DisabledDomain}}
+  // expected-note@-1{{add 'if #available' version check}}
+}


### PR DESCRIPTION
Emit a proper diagnostic for a conformance that is not available due to custom availability that doesn't have version information, eliminating an assertion.