### PR TITLE
[Observation] Add threading fatal error handler.

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   ObservationRegistrar.swift
   ObservationTracking.swift
   Observations.swift
+  ThreadingError.cpp
   ThreadLocal.cpp
   ThreadLocal.swift
 

--- a/stdlib/public/Observation/Sources/Observation/ThreadingError.cpp
+++ b/stdlib/public/Observation/Sources/Observation/ThreadingError.cpp
@@ -1,0 +1,26 @@
+//===--- ThreadingError.cpp - Error handling support code -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Threading/Errors.h"
+#include <cstdio>
+#include <cstdlib>
+
+// Handle fatal errors from the threading library
+SWIFT_ATTRIBUTE_NORETURN
+SWIFT_FORMAT(1, 2)
+void swift::threading::fatal(const char *format, ...) {
+  va_list val;
+
+  va_start(val, format);
+  vfprintf(stderr, format, val);
+  abort();
+}


### PR DESCRIPTION
When the Threading library experiences a fatal error, we need to tell it what to do.
