### PR TITLE
[utils]: minor improvements to find-unused-diagnostics.sh

### DIFF
--- a/utils/find-unused-diagnostics.sh
+++ b/utils/find-unused-diagnostics.sh
@@ -3,13 +3,27 @@
 # This script produces a list of all diagnostics that are defined
 # but not used in sources.
 #
+set -euo pipefail
 
 # Gather all diagnostic identifiers.
-ALL_DIAGS=$(grep -E --only-matching --no-filename 'ERROR\([a-z_]+,' include/swift/AST/Diagnostics*.def | sed -e 's/ERROR(//' -e 's/,//')
+ALL_DIAGS=$(
+    grep -Eho '(ERROR|WARNING|NOTE|REMARK)\([a-z_]+,' include/swift/AST/Diagnostics*.def \
+    | sed -E 's/(ERROR|WARNING|NOTE|REMARK)\(([a-z_]+),/\2/')
 
-# Now look for all potential identifiers in the source files.
-ALL_SOURCES=$(find lib include tools -name \*.cpp -or -name \*.h)
-DIAGS_IN_SOURCES=$(grep -E --only-matching --no-filename 'diag::[a-z_]+' $ALL_SOURCES | sed -e 's/diag:://')
+# Now look for all potential identifiers in the (C++) source files.
+CXX_SOURCES=$(find lib include tools -name \*.cpp -or -name \*.h)
+DIAGS_IN_CXX_SOURCES=$(
+    grep -Ehoz 'diag::\n?\s*[a-z_]+' $CXX_SOURCES \
+    | sed -e 's/diag:://' -e 's/[[:space:]]//g')
 
-# Print all diags that occur in the .td files but not in the source.
-comm -23 <(sort -u <<< "$ALL_DIAGS") <(sort -u <<< "$DIAGS_IN_SOURCES")
+# Get potentially unused diags from C++ sources.
+POTENTIALLY_UNUSED=$(comm -23 <(sort -u <<< "$ALL_DIAGS") <(sort -u <<< "$DIAGS_IN_CXX_SOURCES"))
+
+# Finally, check if any of the possibly-unused diags appear in Swift sources, and exclude them.
+SWIFT_SOURCES=$(find SwiftCompilerSources -name \*.swift)
+if [ -n "$SWIFT_SOURCES" ] && [ -n "$POTENTIALLY_UNUSED" ]; then
+    DIAGS_IN_SWIFT=$(grep -Fho -f <(echo "$POTENTIALLY_UNUSED") $SWIFT_SOURCES)
+    comm -23 <(echo "$POTENTIALLY_UNUSED") <(sort -u <<< "$DIAGS_IN_SWIFT")
+else
+    echo "$POTENTIALLY_UNUSED"
+fi

--- a/utils/find-unused-diagnostics.sh
+++ b/utils/find-unused-diagnostics.sh
@@ -7,13 +7,13 @@ set -euo pipefail
 
 # Gather all diagnostic identifiers.
 ALL_DIAGS=$(
-    grep -Eho '(ERROR|WARNING|NOTE|REMARK)\([a-z_]+,' include/swift/AST/Diagnostics*.def \
-    | sed -E 's/(ERROR|WARNING|NOTE|REMARK)\(([a-z_]+),/\2/')
+    grep -E --only-matching --no-filename '(ERROR|WARNING|NOTE|REMARK)\([a-zA-Z0-9_]+,' include/swift/AST/Diagnostics*.def \
+    | sed -E 's/(ERROR|WARNING|NOTE|REMARK)\(([a-zA-Z0-9_]+),/\2/')
 
 # Now look for all potential identifiers in the (C++) source files.
 CXX_SOURCES=$(find lib include tools -name \*.cpp -or -name \*.h)
 DIAGS_IN_CXX_SOURCES=$(
-    grep -Ehoz 'diag::\n?\s*[a-z_]+' $CXX_SOURCES \
+    grep -E --only-matching --no-filename --null-data 'diag::\n?\s*[a-zA-Z0-9_]+' $CXX_SOURCES \
     | sed -e 's/diag:://' -e 's/[[:space:]]//g')
 
 # Get potentially unused diags from C++ sources.
@@ -22,7 +22,7 @@ POTENTIALLY_UNUSED=$(comm -23 <(sort -u <<< "$ALL_DIAGS") <(sort -u <<< "$DIAGS_
 # Finally, check if any of the possibly-unused diags appear in Swift sources, and exclude them.
 SWIFT_SOURCES=$(find SwiftCompilerSources -name \*.swift)
 if [ -n "$SWIFT_SOURCES" ] && [ -n "$POTENTIALLY_UNUSED" ]; then
-    DIAGS_IN_SWIFT=$(grep -Fho -f <(echo "$POTENTIALLY_UNUSED") $SWIFT_SOURCES)
+    DIAGS_IN_SWIFT=$(grep --fixed-strings --only-matching --no-filename --file <(echo "$POTENTIALLY_UNUSED") $SWIFT_SOURCES)
     comm -23 <(echo "$POTENTIALLY_UNUSED") <(sort -u <<< "$DIAGS_IN_SWIFT")
 else
     echo "$POTENTIALLY_UNUSED"


### PR DESCRIPTION
This makes the following changes to the existing script:

1. Look for unused warnings, notes & remarks in the diagnostic id search (previously only matched on errors)
1. Update the pattern matching to account for more potential whitespace
1. Take usage from Swift sources into account
