### PR TITLE
NFC: use -Werror flags in all Darwin tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -347,6 +347,11 @@ skip-test-cmark
 
 build-embedded-stdlib-cross-compiling
 
+# Escalate certain C++ warnings to errors for Swift.
+extra-swift-cmake-options=
+   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
+
+
 [preset: buildbot_incremental_base_all_platforms]
 mixin-preset=buildbot_incremental_base
 
@@ -678,10 +683,6 @@ skip-test-swiftpm
 skip-test-llbuild
 
 enable-new-runtime-build
-
-# Escalate certain C++ warnings to errors for Swift.
-extra-swift-cmake-options=
-   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx


### PR DESCRIPTION
Running only during smoke tests mean that a PR merged with a full test can introduce build failures.

See https://github.com/swiftlang/swift/pull/85309#issuecomment-3487060163
