### PR TITLE
[Runtime] Don't use custom retain/release calling convention in embedded Swift.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -252,7 +252,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 // differs from the standard calling convention. Currently this is only used for
 // swift_retain, swift_release, and some internal helper functions that they
 // call.
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !SWIFT_RUNTIME_EMBEDDED
 #define SWIFT_REFCOUNT_CC SWIFT_CC_PreserveMost
 #define SWIFT_REFCOUNT_CC_PRESERVEMOST 1
 #else

--- a/include/swift/Runtime/CustomRRABI.h
+++ b/include/swift/Runtime/CustomRRABI.h
@@ -59,8 +59,10 @@ namespace swift {
 template <typename Ret, typename Param>
 Param returnTypeHelper(Ret (*)(Param)) {}
 
+#if SWIFT_REFCOUNT_CC_PRESERVEMOST
 template <typename Ret, typename Param>
 Param returnTypeHelper(SWIFT_REFCOUNT_CC Ret (*)(Param)) {}
+#endif
 
 #if defined(__LP64__) || defined(_LP64)
 #define REGISTER_SUBSTITUTION_PREFIX ""


### PR DESCRIPTION
In embedded mode, some things call retain/release using the C++ declarations, but the implementations are in Swift. The Swift implementations don't use preservemost, so the C++ declarations must not declare preservemost in that context.

rdar://163940783