### PR TITLE
[6.2] [Test] Don't expect IRGen/typed_throws_abi.swift to fail

### DIFF
--- a/test/IRGen/typed_throws_abi.swift
+++ b/test/IRGen/typed_throws_abi.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-irgen -enable-library-evolution | %FileCheck %s
 
-// XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
 struct Empty: Error {}


### PR DESCRIPTION
Since this test was introduced, code gen has changed and it is now passing on arm64e as well

Cherry-pick of #85022 to 6.2

rdar://163168020
