### PR TITLE
Make sure we don't compare too many bytes if a non-native string being compared to a native one has the same utf16 count but a different utf8 count

### DIFF
--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -166,7 +166,12 @@ extension _AbstractStringStorage {
       // CFString will only give us ASCII bytes here, but that's fine.
       // We already handled non-ASCII UTF8 strings earlier since they're Swift.
       if let asciiEqual = unsafe withCocoaASCIIPointer(other, work: { (ascii) -> Bool in
-        return unsafe (start == ascii || (memcmp(start, ascii, self.count) == 0))
+        // otherUTF16Length is the same as the byte count here IFF it's ASCII
+        // self.count could still be utf8
+        if count != otherUTF16Length {
+          return 0
+        }
+        return unsafe (start == ascii || (memcmp(start, ascii, otherUTF16Length) == 0))
       }) {
         return asciiEqual ? 1 : 0
       }

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -169,7 +169,7 @@ extension _AbstractStringStorage {
         // otherUTF16Length is the same as the byte count here IFF it's ASCII
         // self.count could still be utf8
         if count != otherUTF16Length {
-          return 0
+          return false
         }
         return unsafe (start == ascii || (memcmp(start, ascii, otherUTF16Length) == 0))
       }) {

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -166,7 +166,7 @@ extension _AbstractStringStorage {
       // CFString will only give us ASCII bytes here, but that's fine.
       // We already handled non-ASCII UTF8 strings earlier since they're Swift.
       if let asciiEqual = unsafe withCocoaASCIIPointer(other, work: { (ascii) -> Bool in
-        // otherUTF16Length is the same as the byte count here IFF it's ASCII
+        // otherUTF16Length is the same as the byte count here since it's ASCII
         // self.count could still be utf8
         if count != otherUTF16Length {
           return false

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -195,4 +195,11 @@ StringBridgeTests.test("lengthOfBytes(using:)") {
   expectEqual(utf8AsMacRomanLen, 43)
 }
 
+StringBridgeTests.test("Equal UTF16 lengths but unequal UTF8") {
+  let utf8 = "aaaaaaaaaaaaaaü" //Native, UTF16 count: 31, UTF8 count: 58
+  let nsascii = "2166002315@874404110.1042078977" as NSString //Non-native, UTF16 count: 31, UTF8 count: 31
+  let nsutf8 = String(decoding: utf8.utf8, as: UTF8.self) as NSString //bridged native
+  expectTrue(nsutf8.isEqual(nsascii))
+}
+
 runAllTests()

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -199,7 +199,7 @@ StringBridgeTests.test("Equal UTF16 lengths but unequal UTF8") {
   let utf8 = "чебурашка@ящик-с-апельсинами.рф" //Native, UTF16 count: 31, UTF8 count: 58
   let nsascii = "2166002315@874404110.1042078977" as NSString //Non-native, UTF16 count: 31, UTF8 count: 31
   let nsutf8 = String(decoding: utf8.utf8, as: UTF8.self) as NSString //bridged native
-  expectTrue(nsutf8.isEqual(nsascii))
+  expectFalse(nsutf8.isEqual(nsascii))
 }
 
 runAllTests()

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -196,7 +196,7 @@ StringBridgeTests.test("lengthOfBytes(using:)") {
 }
 
 StringBridgeTests.test("Equal UTF16 lengths but unequal UTF8") {
-  let utf8 = "aaaaaaaaaaaaaaü" //Native, UTF16 count: 31, UTF8 count: 58
+  let utf8 = "чебурашка@ящик-с-апельсинами.рф" //Native, UTF16 count: 31, UTF8 count: 58
   let nsascii = "2166002315@874404110.1042078977" as NSString //Non-native, UTF16 count: 31, UTF8 count: 31
   let nsutf8 = String(decoding: utf8.utf8, as: UTF8.self) as NSString //bridged native
   expectTrue(nsutf8.isEqual(nsascii))


### PR DESCRIPTION
Fixes rdar://163960939