### PR TITLE
[Custom availability] Add some hacky serialization

### DIFF
--- a/test/Availability/custom_domain_serialization.swift
+++ b/test/Availability/custom_domain_serialization.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Library %s -DLIBRARY \
+// RUN:  -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-always-enabled-availability-domain AlwaysEnabledDomain \
+// RUN:  -define-disabled-availability-domain DisabledDomain \
+// RUN:  -define-dynamic-availability-domain DynamicDomain
+
+// RUN: %target-typecheck-verify-swift -I %t -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-always-enabled-availability-domain AlwaysEnabledDomain \
+// RUN:  -define-disabled-availability-domain DisabledDomain \
+// RUN:  -define-dynamic-availability-domain DynamicDomain
+
+// REQUIRES: swift_feature_CustomAvailability
+
+#if LIBRARY
+
+@available(EnabledDomain)
+public func availableInEnabledDomain() { }
+
+@available(AlwaysEnabledDomain)
+public func availableInAlwaysEnabledDomain() { }
+
+#else
+import Library
+
+func test1() { // expected-note{{add '@available' attribute to enclosing global function}}
+  availableInEnabledDomain() // expected-error{{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  // expected-note@-1{{add 'if #available' version check}}
+  availableInAlwaysEnabledDomain()
+}
+
+@available(EnabledDomain)
+func test2() {
+  availableInEnabledDomain()
+  availableInAlwaysEnabledDomain()
+}
+
+#endif


### PR DESCRIPTION
Custom availability serialization is based on serializing the underlying declaration that describes the availability domain. Those don't exist yet, so conjure up a VarDecl that we use just for the name. When deserializing based on one of these declarations, do a lookup into the module. This is quite gross, but lets us do more experimentation.
