### PR TITLE
[AST/Sema] Add a diagnostic group `ExplicitSendable` to replace `-require-explicit-sendable`

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -87,6 +87,7 @@ GROUP(TemporaryPointers,none,"temporary-pointers")
 GROUP(TrailingClosureMatching,none,"trailing-closure-matching")
 GROUP(UnknownWarningGroup,none,"unknown-warning-group")
 GROUP(WeakMutability,none,"weak-mutability")
+GROUP(ExplicitSendable,DefaultIgnoreWarnings,"explicit-sendable-annotations")
 
 GROUP_LINK(PerformanceHints,ExistentialType)
 GROUP_LINK(PerformanceHints,ReturnTypeImplicitCopy)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2857,9 +2857,9 @@ WARNING(remove_public_import,none,
 WARNING(remove_package_import,none,
         "package import of %0 was not used in package declarations",
         (Identifier))
-WARNING(public_decl_needs_sendable,none,
-        "public %kind0 does not specify whether it is 'Sendable' or not",
-        (const ValueDecl *))
+GROUPED_WARNING(public_decl_needs_sendable,ExplicitSendable,none,
+                "public %kind0 does not specify whether it is 'Sendable' or not",
+                (const ValueDecl *))
 NOTE(explicit_disable_sendable,none,
      "make %kind0 explicitly non-Sendable to suppress this warning",
      (const ValueDecl *))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -245,9 +245,6 @@ namespace swift {
     // Availability macros definitions to be expanded at parsing.
     SmallVector<std::string, 4> AvailabilityMacros;
 
-    /// Require public declarations to declare that they are Sendable (or not).
-    bool RequireExplicitSendable = false;
-
     /// Detect and automatically import modules' cross-import overlays.
     bool EnableCrossImportOverlays = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1272,7 +1272,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.getLastArg(OPT_debug_cycles))
     Opts.DebugDumpCycles = true;
 
-  Opts.RequireExplicitSendable |= Args.hasArg(OPT_require_explicit_sendable);
   for (const Arg *A : Args.filtered(OPT_define_availability)) {
     Opts.AvailabilityMacros.push_back(A->getValue());
   }
@@ -2724,6 +2723,14 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       }
     }());
   }
+
+  // `-require-explicit-sendable` is an alias to `-Wwarning ExplicitSendable`.
+  if (Args.hasArg(OPT_require_explicit_sendable) &&
+      !Args.hasArg(OPT_suppress_warnings)) {
+    Opts.WarningsAsErrorsRules.push_back(WarningAsErrorRule(
+        WarningAsErrorRule::Action::Disable, "ExplicitSendable"));
+  }
+
   if (Args.hasArg(OPT_debug_diagnostic_names)) {
     Opts.PrintDiagnosticNames = PrintDiagnosticNamesMode::Identifier;
   }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Concurrency.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/DiagnosticGroups.h"
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -1376,7 +1377,7 @@ static bool checkSendableInstanceStorage(
 void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
   // Only diagnose when explicitly requested.
   ASTContext &ctx = nominal->getASTContext();
-  if (!ctx.LangOpts.RequireExplicitSendable)
+  if (ctx.Diags.isIgnoredDiagnosticGroupTree(DiagGroupID::ExplicitSendable))
     return;
 
   if (nominal->getLoc().isInvalid())

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=targeted
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable -strict-concurrency=targeted
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable -strict-concurrency=complete
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -Wwarning ExplicitSendable -strict-concurrency=complete
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=targeted
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Wwarning ExplicitSendable -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
-
+// RUN: %target-swift-frontend -require-explicit-sendable -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
 
 public protocol P { }
 

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -require-explicit-sendable -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -Wwarning ExplicitSendable -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
 
 
 public protocol P { }

--- a/userdocs/diagnostics/explicit-sendable-annotations.md
+++ b/userdocs/diagnostics/explicit-sendable-annotations.md
@@ -1,0 +1,30 @@
+# Explicit Sendable annotations on public type declarations
+
+If a public type doesn't have an explicit Sendable or non-Sendable annotation it is sometimes hard to discern whether that is intentional or not, especially if a type could be Sendable.
+
+## Overview
+
+The Swift compiler would emit a warning if a public type has none of the following:
+
+  - A conformance to `Sendable` protocol;
+  - An unavailable conformance to `Sendable` protocol;
+  - `~Sendable` conformance to suppress the inference.
+
+Let's consider a simple public type without any Senable annotations:
+
+```
+public struct S {
+    let x: Int
+}
+```
+
+When compiling with `-Wwarning ExplicitSendable` the following warning is going to be produced by the Swift compiler:
+
+```
+1 | public struct S {
+  |               |- warning: public struct 'S' does not specify whether it is 'Sendable' or not [#ExplicitSendable]
+  |               |- note: consider making struct 'S' conform to the 'Sendable' protocol
+  |               `- note: make struct 'S' explicitly non-Sendable to suppress this warning
+2 |     let x: Int
+3 | }
+```


### PR DESCRIPTION
Always run explicit `Sendable` checks on public types and suppress
warning printing by default instead of using a special compiler argument.

Resolves: rdar://162394810

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
