### PR TITLE
NFC: enable -debug-cycles in asserts builds

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1272,6 +1272,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.getLastArg(OPT_debug_cycles))
     Opts.DebugDumpCycles = true;
 
+  // Enable request evaluator cycle debugging in asserts builds.
+  if (CONDITIONAL_ASSERT_enabled())
+    Opts.DebugDumpCycles = true;
+
   Opts.RequireExplicitSendable |= Args.hasArg(OPT_require_explicit_sendable);
   for (const Arg *A : Args.filtered(OPT_define_availability)) {
     Opts.AvailabilityMacros.push_back(A->getValue());


### PR DESCRIPTION
There's no reason I can think of that we don't do this always, but for now let's have it on for asserts builds. Simply getting an `error: circular reference` is not helpful.