### PR TITLE
Introduce a custom availability domain for UnicodeNormalization

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1469,18 +1469,12 @@ static void configureAvailabilityDomains(const ASTContext &ctx,
   for (auto dynamic : opts.AvailabilityDomains.DynamicDomains)
     createAndInsertDomain(dynamic, CustomAvailabilityDomain::Kind::Dynamic);
 
-  // If we didn't see the UnicodeNormalization availability domain, set it
-  // appropriately.
-  if (domainMap.count(ctx.getIdentifier("UnicodeNormalization")) == 0) {
-    if (ctx.LangOpts.hasFeature(Feature::Embedded)) {
-      // Embedded Swift disables this domain by default.
-      createAndInsertDomain("UnicodeNormalization",
-                            CustomAvailabilityDomain::Kind::Enabled);
-    } else {
-      // Non-Embedded Swift always enables the Unicode tables.
-      createAndInsertDomain("UnicodeNormalization",
-                            CustomAvailabilityDomain::Kind::AlwaysEnabled);
-    }
+  // If we didn't see the Unicode availability domain, always
+  // enable the availability domain.
+  if (domainMap.count(ctx.getIdentifier("Unicode")) == 0) {
+    // Non-Embedded Swift always enables the Unicode tables.
+    createAndInsertDomain("Unicode",
+                          CustomAvailabilityDomain::Kind::AlwaysEnabled);
   }
 
 

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -197,6 +197,9 @@ extension Bool: Hashable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Bool: LosslessStringConvertible {
   /// Creates a new Boolean value from the given string.
   ///

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -341,6 +341,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Addressab
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AddressableTypes")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AllowUnsafeAttribute")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "CustomAvailability")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")
@@ -539,6 +540,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
         ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded
+        -Xfrontend -define-enabled-availability-domain -Xfrontend Unicode
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -211,6 +211,9 @@ extension String {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Character: Equatable {
   @inlinable @inline(__always)
   @_effects(readonly)
@@ -219,6 +222,9 @@ extension Character: Equatable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Character: Comparable {
   @inlinable @inline(__always)
   @_effects(readonly)
@@ -227,6 +233,9 @@ extension Character: Comparable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Character: Hashable {
   // not @inlinable (performance)
   /// Hashes the essential components of this value by feeding them into the

--- a/stdlib/public/core/CharacterProperties.swift
+++ b/stdlib/public/core/CharacterProperties.swift
@@ -23,6 +23,9 @@ extension Character {
   }
 
   /// A Boolean value indicating whether this is an ASCII character.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var isASCII: Bool {
     return asciiValue != nil
@@ -48,6 +51,9 @@ extension Character {
   ///     // lf.asciiValue == 10
   ///     let crlf = "\r\n" as Character
   ///     // crlf.asciiValue == 10
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var asciiValue: UInt8? {
     if _slowPath(self == "\r\n") { return 0x000A /* LINE FEED (LF) */ }
@@ -235,8 +241,15 @@ extension Character {
   ///     // 1 --> 1
   public func lowercased() -> String { return String(self).lowercased() }
 
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @usableFromInline
   internal var _isUppercased: Bool { return String(self) == self.uppercased() }
+
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @usableFromInline
   internal var _isLowercased: Bool { return String(self) == self.lowercased() }
 
@@ -248,6 +261,9 @@ extension Character {
   /// - "É" (U+0045 LATIN CAPITAL LETTER E, U+0301 COMBINING ACUTE ACCENT)
   /// - "И" (U+0418 CYRILLIC CAPITAL LETTER I)
   /// - "Π" (U+03A0 GREEK CAPITAL LETTER PI)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var isUppercase: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isUppercase) {
@@ -264,6 +280,9 @@ extension Character {
   /// - "é" (U+0065 LATIN SMALL LETTER E, U+0301 COMBINING ACUTE ACCENT)
   /// - "и" (U+0438 CYRILLIC SMALL LETTER I)
   /// - "π" (U+03C0 GREEK SMALL LETTER PI)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var isLowercase: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isLowercase) {
@@ -274,6 +293,9 @@ extension Character {
 
   /// A Boolean value indicating whether this character changes under any form
   /// of case conversion.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var isCased: Bool {
     if _fastPath(_isSingleScalar && _firstScalar.properties.isCased) {

--- a/stdlib/public/core/CharacterProperties.swift
+++ b/stdlib/public/core/CharacterProperties.swift
@@ -70,6 +70,9 @@ extension Character {
   /// - " " (U+0020 SPACE)
   /// - U+2029 PARAGRAPH SEPARATOR
   /// - U+3000 IDEOGRAPHIC SPACE
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isWhitespace: Bool {
     return _firstScalar.properties.isWhitespace
   }
@@ -106,6 +109,9 @@ extension Character {
   /// - "㊈" (U+3288 CIRCLED IDEOGRAPH NINE)
   /// - "𝟠" (U+1D7E0 MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT)
   /// - "๒" (U+0E52 THAI DIGIT TWO)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isNumber: Bool {
     return _firstScalar.properties.numericType != nil
   }
@@ -119,6 +125,9 @@ extension Character {
   /// - "५" (U+096B DEVANAGARI DIGIT FIVE) => 5
   /// - "๙" (U+0E59 THAI DIGIT NINE) => 9
   /// - "万" (U+4E07 CJK UNIFIED IDEOGRAPH-4E07) => 10_000
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public var isWholeNumber: Bool {
     return wholeNumberValue != nil
@@ -139,6 +148,9 @@ extension Character {
   ///     // ④ --> Optional(4)
   ///     // 万 --> Optional(10000)
   ///     // a --> nil
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var wholeNumberValue: Int? {
     guard _isSingleScalar else { return nil }
     guard let value = _firstScalar.properties.numericValue else { return nil }
@@ -202,6 +214,9 @@ extension Character {
   /// - "ڈ" (U+0688 ARABIC LETTER DDAL)
   /// - "日" (U+65E5 CJK UNIFIED IDEOGRAPH-65E5)
   /// - "ᚨ" (U+16A8 RUNIC LETTER ANSUZ A)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isLetter: Bool {
     return _firstScalar.properties.isAlphabetic
   }
@@ -222,6 +237,9 @@ extension Character {
   ///     // π --> Π
   ///     // ß --> SS
   ///     // 1 --> 1
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func uppercased() -> String { return String(self).uppercased() }
 
   /// Returns a lowercased version of this character.
@@ -239,6 +257,9 @@ extension Character {
   ///     // И --> и
   ///     // Π --> π
   ///     // 1 --> 1
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func lowercased() -> String { return String(self).lowercased() }
 
   #if hasFeature(CustomAvailability)
@@ -316,6 +337,9 @@ extension Character {
   /// - "®" (U+00AE REGISTERED SIGN)
   /// - "⌹" (U+2339 APL FUNCTIONAL SYMBOL QUAD DIVIDE)
   /// - "⡆" (U+2846 BRAILLE PATTERN DOTS-237)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isSymbol: Bool {
     return _firstScalar.properties.generalCategory._isSymbol
   }
@@ -337,6 +361,9 @@ extension Character {
   ///
   /// This property corresponds to the "Math" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isMathSymbol: Bool {
     return _firstScalar.properties.isMath
   }
@@ -349,6 +376,9 @@ extension Character {
   /// - "$" (U+0024 DOLLAR SIGN)
   /// - "¥" (U+00A5 YEN SIGN)
   /// - "€" (U+20AC EURO SIGN)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isCurrencySymbol: Bool {
     return _firstScalar.properties.generalCategory == .currencySymbol
   }
@@ -362,6 +392,9 @@ extension Character {
   /// - "…" (U+2026 HORIZONTAL ELLIPSIS)
   /// - "—" (U+2014 EM DASH)
   /// - "“" (U+201C LEFT DOUBLE QUOTATION MARK)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var isPunctuation: Bool {
     return _firstScalar.properties.generalCategory._isPunctuation
   }

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -28,6 +28,9 @@ import SwiftShims
 ///   or character combinations are preserved. The default is `true`.
 /// - Returns: The string of characters read from standard input. If EOF has
 ///   already been reached when `readLine()` is called, the result is `nil`.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 public func readLine(strippingNewline: Bool = true) -> String? {
   var utf8Start: UnsafeMutablePointer<UInt8>?
   let utf8Count = unsafe swift_stdlib_readLine_stdin(&utf8Start)

--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -13,6 +13,9 @@
 import SwiftShims
 
 extension Sequence where Element == Unicode.Scalar {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal var _internalNFC: Unicode._InternalNFC<Self> {
     Unicode._InternalNFC(self)
   }
@@ -24,6 +27,9 @@ extension Unicode {
   ///
   /// Normalization to NFC preserves canonical equivalence.
   ///
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal struct _InternalNFC<Source> where Source: Sequence<Unicode.Scalar> {
 
     internal let source: Source
@@ -34,6 +40,9 @@ extension Unicode {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFC: Sequence {
 
   internal consuming func makeIterator() -> Iterator {
@@ -62,9 +71,19 @@ extension Unicode._InternalNFC: Sequence {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFC: Sendable where Source: Sendable {}
+
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFC.Iterator: Sendable where Source.Iterator: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode {
 
   /// A stateful normalizer, producing a single logical stream
@@ -241,6 +260,9 @@ extension Unicode {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._NFCNormalizer {
 
   @inline(never)

--- a/stdlib/public/core/NFD.swift
+++ b/stdlib/public/core/NFD.swift
@@ -10,12 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Sequence where Element == Unicode.Scalar {
   internal var _internalNFD: Unicode._InternalNFD<Self> {
     Unicode._InternalNFD(self)
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode  {
 
   /// The contents of the source sequence, in Normalization Form D.
@@ -32,6 +38,9 @@ extension Unicode  {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFD: Sequence {
 
   internal consuming func makeIterator() -> Iterator {
@@ -54,9 +63,19 @@ extension Unicode._InternalNFD: Sequence {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFD: Sendable where Source: Sendable {}
+
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._InternalNFD.Iterator: Sendable where Source.Iterator: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode {
 
   /// A stateful normalizer, producing a single logical stream
@@ -200,6 +219,9 @@ extension Unicode {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode._NFDNormalizer {
 
   @inline(never)

--- a/stdlib/public/core/StaticBigInt.swift
+++ b/stdlib/public/core/StaticBigInt.swift
@@ -182,12 +182,23 @@ extension StaticBigInt: CustomDebugStringConvertible {
       return capacity
     }
 
+#if hasFeature(CustomAvailability)
+    if #available(Unicode) {
+      // Overwrite leading zeros with the "±0x" indicator.
+      if let upToIndex = result.firstIndex(where: { $0 != "0" }) {
+        result.replaceSubrange(..<upToIndex, with: indicator)
+      } else {
+        result = "+0x0"
+      }
+    }
+#else
     // Overwrite leading zeros with the "±0x" indicator.
     if let upToIndex = result.firstIndex(where: { $0 != "0" }) {
       result.replaceSubrange(..<upToIndex, with: indicator)
     } else {
       result = "+0x0"
     }
+#endif
     return result
   }
 }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1096,6 +1096,9 @@ extension String: CustomStringConvertible {
   public var description: String { return self }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String {
   public // @testable
   var _nfcCodeUnits: [UInt8] {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1022,6 +1022,9 @@ extension String {
   /// - Returns: A lowercase copy of the string.
   ///
   /// - Complexity: O(*n*)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @_effects(releasenone)
   public func lowercased() -> String {
     if _fastPath(_guts.isFastASCII) {
@@ -1056,6 +1059,9 @@ extension String {
   /// - Returns: An uppercase copy of the string.
   ///
   /// - Complexity: O(*n*)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @_effects(releasenone)
   public func uppercased() -> String {
     if _fastPath(_guts.isFastASCII) {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -747,6 +747,9 @@ internal class __SwiftNativeNSString {
 
 // Special-case Index <-> Offset converters for bridging and use in accelerating
 // the UTF16View in general.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension StringProtocol {
   @_specialize(where Self == String)
   @_specialize(where Self == Substring)
@@ -796,6 +799,9 @@ extension StringProtocol {
 }
 
 extension String {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public // @testable / @benchmarkable
   func _copyUTF16CodeUnits(
     into buffer: UnsafeMutableBufferPointer<UInt16>,

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -12,6 +12,9 @@
 
 import SwiftShims
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension StringProtocol {
   @inlinable
   @_specialize(where Self == String, RHS == String)
@@ -64,6 +67,9 @@ extension StringProtocol {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String: Equatable {
   @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
@@ -73,6 +79,9 @@ extension String: Equatable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String: Comparable {
   @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
@@ -81,11 +90,17 @@ extension String: Comparable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Substring: Equatable {}
 
 // TODO: Generalize `~=` over `StringProtocol` (https://github.com/apple/swift/issues/54896)
 // Below are concrete overloads to give us most of the benefit without potential
 // harm to expression type checking performance.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String {
   @_alwaysEmitIntoClient
   @inline(__always)
@@ -94,6 +109,10 @@ extension String {
     return lhs == rhs
   }
 }
+
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Substring {
   @_alwaysEmitIntoClient
   @inline(__always)

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -12,6 +12,9 @@
 
 import SwiftShims
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @inlinable @inline(__always) // top-level fastest-paths
 @_effects(readonly)
 internal func _stringCompare(
@@ -21,6 +24,9 @@ internal func _stringCompare(
   return _stringCompareWithSmolCheck(lhs, rhs, expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @usableFromInline
 @_effects(readonly)
 internal func _stringCompareWithSmolCheck(
@@ -42,6 +48,9 @@ internal func _stringCompareWithSmolCheck(
   return _stringCompareInternal(lhs, rhs, expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @inline(never) // Keep `_stringCompareWithSmolCheck` fast-path fast
 @usableFromInline
 @_effects(readonly)
@@ -61,6 +70,9 @@ internal func _stringCompareInternal(
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @inlinable @inline(__always) // top-level fastest-paths
 @_effects(readonly)
 internal func _stringCompare(
@@ -75,6 +87,9 @@ internal func _stringCompare(
     lhs, lhsRange, rhs, rhsRange, expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @usableFromInline
 @_effects(readonly)
 internal func _stringCompareInternal(
@@ -96,6 +111,9 @@ internal func _stringCompareInternal(
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 internal func _stringCompareFastUTF8(
   _ utf8Left: UnsafeBufferPointer<UInt8>,
@@ -123,6 +141,9 @@ internal func _stringCompareFastUTF8(
     utf8Left, utf8Right, expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 private func _stringCompareFastUTF8Abnormal(
   _ utf8Left: UnsafeBufferPointer<UInt8>,
@@ -177,6 +198,9 @@ private func _stringCompareFastUTF8Abnormal(
     expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 private func _stringCompareSlow(
   _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
@@ -185,6 +209,9 @@ private func _stringCompareSlow(
     lhs, 0..<lhs.count, rhs, 0..<rhs.count, expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 private func _stringCompareSlow(
   _ lhs: _StringGuts, _ lhsRange: Range<Int>,
@@ -198,6 +225,9 @@ private func _stringCompareSlow(
     expecting: expecting)
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 private func _stringCompareSlow(
   _ leftUTF8: UnsafeBufferPointer<UInt8>,
@@ -236,6 +266,9 @@ private func _lexicographicalCompare<I: FixedWidthInteger>(
   return expecting == .equal ? lhs == rhs : lhs < rhs
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_effects(readonly)
 private func _findBoundary(
   _ utf8: UnsafeBufferPointer<UInt8>, before: Int
@@ -310,6 +343,9 @@ internal func _binaryCompare<UInt8>(
 }
 
 // Double dispatch functions
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension _StringGutsSlice {
   @_effects(readonly)
   internal func compare(

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -12,6 +12,9 @@
 
 import SwiftShims
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
@@ -30,6 +33,9 @@ extension String: Hashable {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension StringProtocol {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
@@ -43,6 +49,9 @@ extension StringProtocol {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension _StringGutsSlice {
   @_effects(releasenone) @inline(never) // slow-path
   internal func _normalizedHash(into hasher: inout Hasher) {

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -80,6 +80,9 @@ extension StringProtocol {
   ///
   /// - Parameter prefix: A possible prefix to test against this string.
   /// - Returns: `true` if the string begins with `prefix`; otherwise, `false`.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public func hasPrefix<Prefix: StringProtocol>(_ prefix: Prefix) -> Bool {
     return self.starts(with: prefix)
@@ -114,6 +117,9 @@ extension StringProtocol {
   ///
   /// - Parameter suffix: A possible suffix to test against this string.
   /// - Returns: `true` if the string ends with `suffix`; otherwise, `false`.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @inlinable
   public func hasSuffix<Suffix: StringProtocol>(_ suffix: Suffix) -> Bool {
     return self.reversed().starts(with: suffix.reversed())
@@ -121,6 +127,9 @@ extension StringProtocol {
 }
 
 extension String {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func hasPrefix(_ prefix: String) -> Bool {
     if _fastPath(self._guts.isNFCFastUTF8 && prefix._guts.isNFCFastUTF8) {
       guard prefix._guts.count <= self._guts.count else { return false }
@@ -139,6 +148,9 @@ extension String {
     return starts(with: prefix)
   }
 
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func hasSuffix(_ suffix: String) -> Bool {
     if _fastPath(self._guts.isNFCFastUTF8 && suffix._guts.isNFCFastUTF8) {
       let suffixStart = self._guts.count - suffix._guts.count

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -22,6 +22,9 @@ extension Unicode.Scalar {
   // produce new sub-segments.
 
   // Quick check if a scalar is an NFC segment starter.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal var _isNFCStarter: Bool {
     // Fast path: All scalars up to U+300 are NFC_QC and have boundaries
     // before them.
@@ -31,6 +34,9 @@ extension Unicode.Scalar {
 }
 
 extension UnsafeBufferPointer where Element == UInt8 {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal func hasNormalizationBoundary(before offset: Int) -> Bool {
     if offset == 0 || offset == count {
       return true
@@ -53,6 +59,9 @@ extension UnsafeBufferPointer where Element == UInt8 {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 internal func _isScalarNFCQC(
   _ scalar: Unicode.Scalar,
   _ prevCCC: inout UInt8
@@ -71,6 +80,9 @@ internal func _isScalarNFCQC(
   return true
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension _StringGutsSlice {
   internal func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
     let substring = String(_guts)[range]
@@ -132,6 +144,9 @@ extension _StringGutsSlice {
 }
 
 /// Run the Unicode NFC quick check algorithm, returns
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 internal func _nfcQuickCheck(
   _ utf8: UnsafeBufferPointer<UInt8>,
   prevCCC: inout UInt8

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -10,6 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(Embedded)
+public typealias UnicodeStringProtocol = StringProtocol & Hashable & Comparable
+public typealias StringProtocolMixin = Any
+#else
+public typealias UnicodeStringProtocol = StringProtocol
+public typealias StringProtocolMixin = Hashable & Comparable
+#endif
+
 /// A type that can represent a string as a collection of characters.
 ///
 /// Do not declare new conformances to `StringProtocol`. Only the `String` and
@@ -18,7 +26,7 @@ public protocol StringProtocol
   : BidirectionalCollection,
   TextOutputStream, TextOutputStreamable,
   LosslessStringConvertible, ExpressibleByStringInterpolation,
-  Hashable, Comparable
+  StringProtocolMixin
   where Iterator.Element == Character,
         Index == String.Index,
         SubSequence: StringProtocol,
@@ -42,10 +50,24 @@ public protocol StringProtocol
   var utf16: UTF16View { get }
   var unicodeScalars: UnicodeScalarView { get }
 
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   func hasPrefix(_ prefix: String) -> Bool
+
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   func hasSuffix(_ suffix: String) -> Bool
 
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   func lowercased() -> String
+
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   func uppercased() -> String
 
   /// Creates a string from the given Unicode code units in the specified

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -16,6 +16,9 @@
 
 /// The compiler intrinsic which is called to lookup a string in a table
 /// of static string case values.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_semantics("findStringSwitchCase")
 public // COMPILER_INTRINSIC
 func _findStringSwitchCase(
@@ -39,8 +42,14 @@ struct _OpaqueStringSwitchCache {
   var b: Builtin.Word
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 internal typealias _StringSwitchCache = Dictionary<String, Int>
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @unsafe
 internal struct _StringSwitchContext {
   internal let cases: [StaticString]
@@ -62,6 +71,9 @@ internal struct _StringSwitchContext {
 /// in \p cache. Consecutive calls use the cache for faster lookup.
 /// The \p cases array must not change between subsequent calls with the
 /// same \p cache.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_semantics("findStringSwitchCaseWithCache")
 public // COMPILER_INTRINSIC
 func _findStringSwitchCaseWithCache(
@@ -90,6 +102,9 @@ func _findStringSwitchCaseWithCache(
 }
 
 /// Builds the string switch case.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 internal func _createStringTableCache(_ cacheRawPtr: Builtin.RawPointer) {
   let context = unsafe UnsafePointer<_StringSwitchContext>(cacheRawPtr).pointee
   var cache = _StringSwitchCache()
@@ -105,4 +120,3 @@ internal func _createStringTableCache(_ cacheRawPtr: Builtin.RawPointer) {
   }
   unsafe context.cachePtr.initialize(to: cache)
 }
-

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -95,6 +95,9 @@ extension Unicode {
   /// discards lookahead information -- some scalars will be processed multiple
   /// times. The rules are carefully constructed so that the algorithm reports
   /// the same word boundaries whether or not recognizer state is preserved.
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @available(StdlibDeploymentTarget 6.3, *)
   public // Core primitive
   struct _WordRecognizer: Sendable {
@@ -149,6 +152,9 @@ extension Unicode {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(StdlibDeploymentTarget 6.3, *)
 extension Unicode._WordRecognizer {
   /// The parts of the word recognizer state that are in addition to saved
@@ -383,6 +389,9 @@ extension Unicode._WordRecognizer {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode {
   /// A state machine for recognizing safe word boundaries in a backward
   /// sequence of Unicode scalars, based on the specification in [Unicode Annex
@@ -447,6 +456,9 @@ extension Unicode {
 }
 
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(StdlibDeploymentTarget 6.3, *)
 extension Unicode._RandomAccessWordRecognizer {
   internal enum _State: Int, Sendable {
@@ -643,6 +655,9 @@ extension Unicode._RandomAccessWordRecognizer {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String {
   /// Find and return a word boundary position at or before an arbitrary index
   /// within this string. The result may not be the closest word break to the
@@ -718,6 +733,9 @@ extension String {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension _StringGuts {
   @available(StdlibDeploymentTarget 6.3, *)
   @inline(never)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -1345,10 +1345,16 @@ extension Substring: RangeReplaceableCollection {
 }
 
 extension Substring {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func lowercased() -> String {
     return String(self).lowercased()
   }
 
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public func uppercased() -> String {
     return String(self).uppercased()
   }

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -59,6 +59,9 @@ public enum _SwiftifyInfo {
 /// Parameter paramInfo: information about how the function uses the pointer passed to it. The
 /// safety of the generated wrapper function depends on this info being extensive and accurate.
 #if hasFeature(Macros)
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @attached(peer, names: overloaded)
 public macro _SwiftifyImport(_ paramInfo: _SwiftifyInfo...,
                              spanAvailability: String? = nil,
@@ -81,6 +84,9 @@ public enum _SwiftifyProtocolMethodInfo {
 /// function, this macro supports feeding info about multiple methods and generating safe overloads
 /// for all of them at once.
 #if hasFeature(Macros)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @attached(extension, names: arbitrary)
   public macro _SwiftifyImportProtocol(
     _ methodInfo: _SwiftifyProtocolMethodInfo...,

--- a/stdlib/public/core/UTF8SpanBits.swift
+++ b/stdlib/public/core/UTF8SpanBits.swift
@@ -83,6 +83,9 @@ extension UTF8Span {
   /// Updates the `isKnownNFC` bit.
   ///
   /// - Complexity: O(n)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @_unavailableInEmbedded
   @lifetime(self: copy self)
   public mutating func checkForNFC(

--- a/stdlib/public/core/UTF8SpanComparisons.swift
+++ b/stdlib/public/core/UTF8SpanComparisons.swift
@@ -46,6 +46,9 @@ extension UTF8Span {
   /// Whether this span has the same `Character`s as `other`.
   ///
   /// - Complexity: O(n)
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   @_unavailableInEmbedded
   @_alwaysEmitIntoClient
   public func charactersEqual(
@@ -65,6 +68,9 @@ extension UTF8Span {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 6.2, *)
 extension UTF8Span {
   /// Whether `self` is equivalent to `other` under Unicode Canonical

--- a/stdlib/public/core/UnicodeBreakProperty.swift
+++ b/stdlib/public/core/UnicodeBreakProperty.swift
@@ -80,6 +80,9 @@ extension Unicode {
 }
 
 extension Unicode {
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal enum _WordBreakProperty: UInt8, Sendable {
     case aLetter
     case any

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -258,21 +258,39 @@ func _swift_stdlib_getWordBreakProperty(_ scalar: UInt32) -> UInt8
 // Unicode.Scalar.Properties
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getBinaryProperties(_ scalar: UInt32) -> UInt64
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getNumericType(_ scalar: UInt32) -> UInt8
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getNumericValue(_ scalar: UInt32) -> Double
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getNameAlias(_ scalar: UInt32) -> UnsafePointer<UInt8>?
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getMapping(_ scalar: UInt32, _ mapping: UInt8) -> Int32
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getSpecialMapping(
   _ scalar: UInt32,
@@ -280,6 +298,9 @@ func _swift_stdlib_getSpecialMapping(
   _ length: UnsafeMutablePointer<Int>
 ) -> UnsafePointer<UInt8>?
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getScalarName(
   _ scalar: UInt32,
@@ -287,21 +308,36 @@ func _swift_stdlib_getScalarName(
   _ capacity: Int
 ) -> Int
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getAge(_ scalar: UInt32) -> UInt16
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getGeneralCategory(_ scalar: UInt32) -> UInt8
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getScript(_ scalar: UInt32) -> UInt8
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getScriptExtensions(
   _ scalar: UInt32,
   _ count: UnsafeMutablePointer<UInt8>
 ) -> UnsafeMutablePointer<UInt8>?
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getCaseMapping(
   _ scalar: UInt32,

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -64,6 +64,9 @@ extension Unicode {
       rawValue & 0x1 == 0
     }
 
+    #if hasFeature(CustomAvailability)
+    @available(Unicode)
+    #endif
     init(_ scalar: Unicode.Scalar, fastUpperbound: UInt32 = 0xC0) {
       if _fastPath(scalar.value < fastUpperbound) {
         // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
@@ -159,6 +162,9 @@ extension Unicode {
   //                decomposition entry so that we can guard against scalars
   //                who happen to hash to the same index.
   //
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   internal struct _DecompositionEntry {
     let rawValue: UInt32
 
@@ -186,6 +192,9 @@ extension Unicode {
       )
     }
 
+    #if hasFeature(CustomAvailability)
+    @available(Unicode)
+    #endif
     init(_ scalar: Unicode.Scalar) {
       rawValue = _swift_stdlib_getDecompositionEntry(scalar.value)
     }
@@ -199,38 +208,29 @@ extension Unicode.Scalar {
 }
 
 //===----------------------------------------------------------------------===//
-// Utilities
-//===----------------------------------------------------------------------===//
-
-@_extern(c)
-func _swift_stdlib_getMphIdx(
-  _ scalar: UInt32,
-  _ levels: Int,
-  _ keys: UnsafePointer<UInt64>,
-  _ ranks: UnsafePointer<UInt16>,
-  _ sizes: UnsafePointer<UInt16>
-) -> Int
-
-@_extern(c)
-func _swift_stdlib_getScalarBitArrayIdx(
-  _ scalar: UInt32,
-  _ bitArrays: UnsafePointer<UInt64>,
-  _ ranks: UnsafePointer<UInt16>
-) -> Int
-
-//===----------------------------------------------------------------------===//
 // Normalization
 //===----------------------------------------------------------------------===//
-
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getNormData(_ scalar: UInt32) -> UInt16
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getDecompositionEntry(_ scalar: UInt32) -> UInt32
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getComposition(_ x: UInt32, _ y: UInt32) -> UInt32
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 var _swift_stdlib_nfd_decompositions: UnsafePointer<UInt8>?
 

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -248,6 +248,9 @@ func _swift_stdlib_isInCB_Consonant(_ scalar: UInt32) -> Bool
 // Word Breaking
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @_extern(c)
 func _swift_stdlib_getWordBreakProperty(_ scalar: UInt32) -> UInt8
 

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -27,6 +27,9 @@ extension Unicode {
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD {
   @_spi(_Unicode)
@@ -36,9 +39,15 @@ extension Unicode._NFD {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD.Iterator: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD.Iterator: IteratorProtocol {
   @_spi(_Unicode)
@@ -48,6 +57,9 @@ extension Unicode._NFD.Iterator: IteratorProtocol {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD: Sequence {
   @_spi(_Unicode)
@@ -57,6 +69,9 @@ extension Unicode._NFD: Sequence {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -65,6 +80,9 @@ extension String {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Substring {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -77,6 +95,9 @@ extension Substring {
 // Unicode.NFC
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -85,9 +106,15 @@ extension Unicode {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC {
   @_spi(_Unicode)
@@ -97,9 +124,15 @@ extension Unicode._NFC {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC.Iterator: Sendable {}
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC.Iterator: IteratorProtocol {
   @_spi(_Unicode)
@@ -109,6 +142,9 @@ extension Unicode._NFC.Iterator: IteratorProtocol {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC: Sequence {
   @_spi(_Unicode)
@@ -118,6 +154,9 @@ extension Unicode._NFC: Sequence {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension String {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -126,6 +165,9 @@ extension String {
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Substring {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -180,6 +180,9 @@ extension Substring {
 // Unicode.Script
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -220,6 +223,9 @@ extension Unicode.Scalar.Properties {
 // Case folding
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -119,6 +119,9 @@ extension Unicode.Scalar.Properties {
 }
 
 /// Boolean properties that are defined by the Unicode Standard.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
   fileprivate var _binaryProperties: _BinaryProperties {
     _BinaryProperties(
@@ -742,6 +745,9 @@ extension Unicode.Scalar.Properties {
 }
 
 /// Case mapping properties.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
   fileprivate struct _CaseMapping {
     let rawValue: UInt8
@@ -848,6 +854,9 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the "Age" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var age: Unicode.Version? {
     let age: UInt16 = _swift_stdlib_getAge(_scalar.value)
 
@@ -1147,12 +1156,18 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the "General_Category" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var generalCategory: Unicode.GeneralCategory {
     let rawValue = _swift_stdlib_getGeneralCategory(_scalar.value)
     return Unicode.GeneralCategory(rawValue: rawValue)
   }
 }
 
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
   internal func _hangulName() -> String {
     // T = Hangul tail consonants
@@ -1499,6 +1514,9 @@ extension Unicode {
 }
 
 /// Numeric properties of scalars.
+#if hasFeature(CustomAvailability)
+@available(Unicode)
+#endif
 extension Unicode.Scalar.Properties {
 
   /// The numeric type of the scalar.

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -1430,6 +1430,9 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the "Canonical_Combining_Class" property in
   /// the [Unicode Standard](http://www.unicode.org/versions/latest/).
+  #if hasFeature(CustomAvailability)
+  @available(Unicode)
+  #endif
   public var canonicalCombiningClass: Unicode.CanonicalCombiningClass {
     let normData = Unicode._NormData(_scalar)
     return Unicode.CanonicalCombiningClass(rawValue: normData.ccc)

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -12,6 +12,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_CustomAvailability
 
 //--- header.h
 enum class SomeEnum {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature CustomAvailability
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature CustomAvailability
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -13,6 +13,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_CustomAvailability
 
 //--- header.h
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -6,6 +6,7 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_CustomAvailability
 
 // CHECK: namespace swift SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("swift") {
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature CustomAvailability
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)

--- a/test/embedded/unicode-availability.swift
+++ b/test/embedded/unicode-availability.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift %s -enable-experimental-feature Embedded -wmo -enable-experimental-feature CustomAvailability -define-enabled-availability-domain Unicode -DBAD
+
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature Embedded -wmo -enable-experimental-feature CustomAvailability -define-always-enabled-availability-domain Unicode | %FileCheck -check-prefix ENABLED %s
+
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature Embedded -wmo -enable-experimental-feature CustomAvailability -define-disabled-availability-domain Unicode | %FileCheck -check-prefix DISABLED %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_CustomAvailability
+// REQUIRES: swift_feature_Embedded
+
+public func sameValue<T: Comparable>(_ x: T, _ y: T) -> Bool { x == y }
+
+// Ensure that the symbol is suppressed when the domain is disabled.
+// ENABLED: sil [ossa] @$e4main14selfComparisonySbSSF
+// DISABLED-NOT: sil [ossa] @$e4main14selfComparisonySbSSF
+
+@available(Unicode)
+@export(interface)
+public func selfComparison(_ string: String) -> Bool {
+  sameValue(string, string)
+}
+
+#if BAD
+// expected-note@+1{{add '@available' attribute to enclosing global function}}
+public func badSelfComparison(_ string: String) -> Bool {
+  sameValue(string, string) // expected-error{{conformance of 'String' to 'Comparable' is only available in Unicode}}
+  // expected-note@-1{{add 'if #available' version check}}
+}
+#endif


### PR DESCRIPTION
Tag the C functions used by the standard library for Unicode
normalization as being part of a new availability domain called
"UnicodeNormalization". Mark anything else that (transitively) depends
on those functions as requiring UnicodeNormalization, so that we get
the full surface area of the standard library that somehow depends on
the Unicode data tables (for normalization).

This availability domain is always available in non-Embedded Swift. In
Embedded Swift, this availability domain is optional: if it's enabled,
one needs to link against the swiftUnicodeDataTables library. If it's
disabled, the compiler will have rejected any code that depends on the
Unicode tables. This provides better diagnostic experience for Embedded
Swift where one does not have to work backwards from a linker failure
to determine where the Unicode normalization tables occur.

Part of rdar://151212706.