### PR TITLE
enable SwiftifyImports/CxxSpan tests (NFC)

### DIFF
--- a/test/Macros/SwiftifyImport/CxxSpan/lit.local.cfg
+++ b/test/Macros/SwiftifyImport/CxxSpan/lit.local.cfg
@@ -1,0 +1,23 @@
+def get_target_os():
+    import re
+    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
+    return run_os
+
+if config.target_sdk_libcxx_path != '':
+    if os.path.exists(os.path.join(config.target_sdk_libcxx_path, "span")):
+        config.available_features.add('std_span')
+elif get_target_os() in ['linux-gnu']:
+    for p in ['/usr/include/c++/', '/usr/local/include/c++/']:
+        if not os.path.isdir(p):
+            continue
+        for subdir in os.listdir(p):
+            if not subdir.isdigit():
+                # skip paths libc++ paths like /usr/include/c++/v1, we want libstdc++ paths only (like /usr/include/c++/13)
+                continue
+            if os.path.exists(os.path.join(p, subdir, "span")):
+                config.available_features.add('std_span')
+elif get_target_os() in ['windows-msvc']:
+    # We don't test on any versions of MSVC without std::span support.
+    # FIXME: figure out where to do lookup for C++ stdlib headers on Windows - we'll probably need it eventually
+    config.available_features.add('std_span')
+


### PR DESCRIPTION
These tests require the 'std_span' feature, but that feature was previously only added in the test/Interop test suite. As a result these tests would never run.