### PR TITLE
[SIL][Optimizer] eliminate @pack_element types

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -274,8 +274,8 @@ extension TypeProperties {
     return rawType.bridged.isSILPackElementAddress()
   }
 
-  public func getPackElementType(_ index: Int) -> Type {
-    return Type(bridged: rawType.bridged.getPackElementType(index));
+  public var packElementTypes: TypeArray {
+    return TypeArray(bridged: rawType.bridged.getPackElementTypes())
   }
 }
 

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -273,6 +273,10 @@ extension TypeProperties {
   public var isSILPackElementAddress: Bool {
     return rawType.bridged.isSILPackElementAddress()
   }
+
+  public func getPackElementType(_ index: Int) -> Type {
+    return Type(bridged: rawType.bridged.getPackElementType(index));
+  }
 }
 
 public struct TypeArray : RandomAccessCollection, CustomReflectable {

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -18,7 +18,9 @@ extension AllocStackInst : Simplifiable, SILCombineSimplifiable {
     if optimizeEnum(context) {
       return
     }
-    _ = optimizeExistential(context)
+    if optimizeExistential(context) {
+      return
+    }
     _ = optimizePackElement(context)
   }
 }
@@ -308,8 +310,10 @@ private extension AllocStackInst {
   ///
   /// For example:
   /// ```
-  ///   %0 = alloc_stack $@pack_element(...) ...
-  ///   use %1
+  ///  %1 = dynamic_pack_index %0 of $Pack{T, U}
+  ///  %2 = open_pack_element %1 of <...> at <Pack{T, U}> ...
+  ///  %3 = alloc_stack $@pack_element(...) ...
+  ///  use %3
   /// ```
   /// is transformed to
   /// ```

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -332,11 +332,10 @@ private extension AllocStackInst {
                                             isLexical: isLexical,
                                             isFromVarDecl: isFromVarDecl,
                                             usesMoveableValueDebugInfo: usesMoveableValueDebugInfo)    
-    for use in uses {
-        // FIXME: Are there any specific cases to handle?
-        use.set(to: newAlloc, context)
-    }
-    context.erase(instruction: self)
+    let builderAfter = Builder(after: self, context)
+    let addrCast = builderAfter.createUncheckedAddrCast(from: newAlloc, to: self.type.addressType)
+    uses.replaceAll(with: addrCast, context)
+    self.replace(with: newAlloc, context)
     return true
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyWitnessMethod.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyWitnessMethod.swift
@@ -15,7 +15,9 @@ import SIL
 
 extension WitnessMethodInst : Simplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
-    _ = tryReplaceExistentialArchetype(of: self, context)
+    if tryReplaceExistentialArchetype(of: self, context) {
+      return
+    }
     _ = tryReplacePackElementArchetype(of: self, context)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -560,7 +560,7 @@ extension Instruction {
        let ili = dpi.operands.first?.value as? IntegerLiteralInst,
        let index = ili.value
     {
-      return dpi.indexedPackType.getPackElementType(index).canonical
+      return dpi.indexedPackType.packElementTypes[index].canonical
     }
     return nil
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -547,6 +547,24 @@ extension Instruction {
     return nil
   }
 
+  var concreteTypeOfDependentPackElementArchetype: CanonicalType? {
+    // For simplicity only support a single type dependent operand, which is true in most of the cases anyway.
+    if let openArchetypeOp = typeDependentOperands.singleElement,
+       // Match the sequence
+       //   %1 = integer_literal $Builtin.Word, (integer value)
+       //   %2 = dynamic_pack_index %1 of $Pack{...}
+       //   %3 = open_pack_element %2 of ...
+       //   this_instruction_which_uses $*@pack_element(...)  // type-defs: %3
+       let ope = openArchetypeOp.value as? OpenPackElementInst,
+       let dpi = ope.operands.first?.value as? DynamicPackIndexInst,
+       let ili = dpi.operands.first?.value as? IntegerLiteralInst,
+       let index = ili.value
+    {
+      return dpi.indexedPackType.getPackElementType(index).canonical
+    }
+    return nil
+  }
+
   /// Returns true if a destroy of `type` must not be moved across this instruction.
   func isBarrierForDestroy(of type: Type, _ context: some Context) -> Bool {
     let instEffects = memoryEffects

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2911,6 +2911,15 @@ enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : size_t {
   BridgedBuiltinIsolationMacro,
 };
 
+struct BridgedASTTypeArray {
+  BridgedArrayRef typeArray;
+
+  SwiftInt getCount() const { return SwiftInt(typeArray.Length); }
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedASTType getAt(SwiftInt index) const;
+};
+
 struct BridgedASTType {
   enum class TraitResult {
     IsNot,
@@ -2990,7 +2999,7 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;
   BRIDGED_INLINE bool containsSILPackExpansionType() const;
   BRIDGED_INLINE bool isSILPackElementAddress() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getPackElementType(SwiftInt index) const;
+  BRIDGED_INLINE BridgedASTTypeArray getPackElementTypes() const;
 };
 
 class BridgedCanType {
@@ -3001,15 +3010,6 @@ public:
   BRIDGED_INLINE BridgedCanType(swift::CanType ty);
   BRIDGED_INLINE swift::CanType unbridged() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getRawType() const;
-};
-
-struct BridgedASTTypeArray {
-  BridgedArrayRef typeArray;
-
-  SwiftInt getCount() const { return SwiftInt(typeArray.Length); }
-
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
-  BridgedASTType getAt(SwiftInt index) const;
 };
 
 struct BridgedConformance {

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2990,6 +2990,7 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;
   BRIDGED_INLINE bool containsSILPackExpansionType() const;
   BRIDGED_INLINE bool isSILPackElementAddress() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getPackElementType(SwiftInt index) const;
 };
 
 class BridgedCanType {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -656,9 +656,8 @@ bool BridgedASTType::isSILPackElementAddress() const {
   return unbridged()->castTo<swift::SILPackType>()->isElementAddress();
 }
 
-BridgedASTType BridgedASTType::getPackElementType(SwiftInt index) const {
-    ASSERT(index >= 0);
-    return {unbridged()->castTo<swift::PackType>()->getElementType(index).getPointer()};
+BRIDGED_INLINE BridgedASTTypeArray BridgedASTType::getPackElementTypes() const {
+    return {unbridged()->castTo<swift::PackType>()->getElementTypes()};
 }
 
 static_assert((int)BridgedASTType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -656,6 +656,11 @@ bool BridgedASTType::isSILPackElementAddress() const {
   return unbridged()->castTo<swift::SILPackType>()->isElementAddress();
 }
 
+BridgedASTType BridgedASTType::getPackElementType(SwiftInt index) const {
+    ASSERT(index >= 0);
+    return {unbridged()->castTo<swift::PackType>()->getElementType(index).getPointer()};
+}
+
 static_assert((int)BridgedASTType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);
 static_assert((int)BridgedASTType::TraitResult::CanBe == (int)swift::TypeTraitResult::CanBe);
 static_assert((int)BridgedASTType::TraitResult::Is == (int)swift::TypeTraitResult::Is);


### PR DESCRIPTION
Most variadic generic functions contain loops that iterate over the elements of their Pack parameters. Since the types of the pack elements are unknown, witness table methods are used to perform operations on the current pack element in each iteration. After specialization, these loops are usually unrolled, since there is a fixed list of pack element types. In the unrolled code, it should be possible to eliminate the witness table lookups. This is not possible because of the @pack_element types introduced to refer to pack elements:

 %5 = integer_literal $Builtin.Word, 0
  %6 = dynamic_pack_index %5 of $Pack{Int, Double}
  %7 = open_pack_element %6 of <each A where repeat each A : Numeric> at <Pack{Int, Double}>, shape $each A, uuid "063BDCF4-98A3-11F0-B2E8-929C59BC796C"
  %20 = witness_method $@pack_element("063BDCF4-98A3-11F0-B2E8-929C59BC796C") each A, #Numeric."*" …
  %21 = apply %20<@pack_element("063BDCF4-98A3-11F0-B2E8-929C59BC796C") each A>(%10, %14, %18, %11) … // type-defs: %7

This simplification aims to eliminate all instances of @pack_element types from specialized functions by replacing those with the underlying concrete type. This allows the appropriate witness method, as well as other functions, to be inlined.

This computed attribute is used in the simplifications of _witness_method_, _alloc_stack_, _unchecked_addr_cast_ and _apply_.