### PR TITLE
NFC: use -Werror flags in CI only in asserts builds on Darwin

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -347,11 +347,6 @@ skip-test-cmark
 
 build-embedded-stdlib-cross-compiling
 
-# Escalate certain C++ warnings to errors for Swift.
-extra-swift-cmake-options=
-   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
-
-
 [preset: buildbot_incremental_base_all_platforms]
 mixin-preset=buildbot_incremental_base
 
@@ -683,6 +678,10 @@ skip-test-swiftpm
 skip-test-llbuild
 
 enable-new-runtime-build
+
+# Escalate certain C++ warnings to errors for Swift.
+extra-swift-cmake-options=
+   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -680,6 +680,7 @@ skip-test-llbuild
 enable-new-runtime-build
 
 # Escalate certain C++ warnings to errors for Swift.
+# NOTE: -Werror=unused is not yet working in non-asserts builds.
 extra-swift-cmake-options=
    -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
 
@@ -1876,6 +1877,12 @@ skip-test-xros-host
 # Skip LLBuild test until GitHub issue is fixed:
 # https://github.com/apple/swift-llbuild/issues/894
 skip-test-llbuild
+
+# Escalate certain C++ warnings to errors for Swift.
+# NOTE: -Werror=unused is not yet working in non-asserts builds.
+extra-swift-cmake-options=
+   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
+
 
 [preset: llvm_project_pull_request]
 mixin-preset=buildbot_all_platforms,tools=RA,stdlib=RA


### PR DESCRIPTION
When compiling without asserts, there's a quite a high chance of unused variables appearing. In my prior PR (https://github.com/swiftlang/swift/pull/85311) I hadn't realized this. So this is a correction to help avoid issues in non-asserts CI configurations using the `buildbot_incremental_base` preset.

So far, I haven't seen any configurations downstream of that preset building without asserts. So this is a just-in-case PR.