### PR TITLE
CI: skip Test-SourceKitLSP on Windows due to instability

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4445,7 +4445,9 @@ if (-not $IsCrossCompiling) {
   if ($Test -contains "llbuild") { Invoke-BuildStep Test-LLBuild $BuildPlatform }
   if ($Test -contains "swiftpm") { Invoke-BuildStep Test-PackageManager $BuildPlatform }
   if ($Test -contains "swift-format") { Invoke-BuildStep Test-Format $BuildPlatform }
-  if ($Test -contains "sourcekit-lsp") { Invoke-BuildStep Test-SourceKitLSP $BuildPlatform}
+
+  # FIXME: https://github.com/swiftlang/swift/issues/85337
+  # if ($Test -contains "sourcekit-lsp") { Invoke-BuildStep Test-SourceKitLSP $BuildPlatform}
 
   if ($Test -contains "swift") {
     foreach ($Build in $AndroidSDKBuilds) {


### PR DESCRIPTION
Providing this as one option for working around https://github.com/swiftlang/sourcekit-lsp/issues/2360