### PR TITLE
CI: run Test-SourceKitLSP tests serially to workaround instability

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3924,8 +3924,9 @@ function Test-SourceKitLSP {
     # Tell the tests where to find the just-built plugins.
     $env:SOURCEKIT_LSP_TEST_PLUGIN_PATHS="$($HostPlatform.ToolchainInstallRoot)\usr\lib"
 
+    # FIXME: TestParallel has issues: https://github.com/swiftlang/swift/issues/85337
     Build-SPMProject `
-      -Action TestParallel `
+      -Action Test `
       -Src "$SourceCache\sourcekit-lsp" `
       -Bin "$BinaryCache\$($HostPlatform.Triple)\SourceKitLSPTests" `
       -Platform $BuildPlatform `


### PR DESCRIPTION
Providing this as one option for working around https://github.com/swiftlang/sourcekit-lsp/issues/2360

It keeps the tests running, but without running them in parallel.