### PR TITLE
[Concurrency] Fix asSerialExecutor() for complex equality.

### DIFF
--- a/test/Concurrency/Runtime/custom_executors_complex_equality.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality.swift
@@ -66,6 +66,11 @@ actor MyActor {
 
   func test(expectedExecutor: NaiveQueueExecutor, expectedQueue: DispatchQueue) {
     expectedExecutor.preconditionIsolated("Expected deep equality to trigger for \(expectedExecutor) and our \(self.executor)")
+
+    // Ensure we get a usable value from asSerialExecutor() when the executor
+    // has complex equality.
+    _ = expectedExecutor.asUnownedSerialExecutor().asSerialExecutor()!.asUnownedSerialExecutor()
+
     print("\(Self.self): [\(self.executor.name)] on same context as [\(expectedExecutor.name)]")
   }
 }


### PR DESCRIPTION
Complex equality is encoded in the low bit of the witness table pointer. We need to mask off the low bits when bitcasting to an `any SerialExecutor`.

rdar://164005854