### PR TITLE
[update-checkout] Use `basename` to get repo name for Git failures

### DIFF
--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -78,7 +78,7 @@ class Git:
                     f"status {str(e.returncode)}, aborting"
                 )
             raise GitException(
-                e.returncode, command, os.path.dirname(repo_path), output
+                e.returncode, command, os.path.basename(repo_path), output
             )
         except OSError as e:
             if fatal:


### PR DESCRIPTION
`os.path.dirname` removes the last path component of a path. If there was a git failure in `~/src/swift`, this means that we show `~/src` as the repo name, which isn’t very helpful. Use `os.path.basename`, which returns the last path component, ie. `swift`.
