### PR TITLE
FreeBSD: Disable libxml2 in tools

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1374,6 +1374,9 @@ xctest
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
 llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
 
+extra-llvm-cmake-options=
+  -DLLVM_ENABLE_LIBXML2=OFF
+
 install-foundation
 install-libdispatch
 install-llbuild

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2126,6 +2126,33 @@ for host in "${ALL_HOSTS[@]}"; do
                     DOTEST_EXTRA="${DOTEST_EXTRA} -Xlinker -rpath -Xlinker ${FOUNDATION_BUILD_DIR}/lib"
                 fi
 
+                if [[ ! "${SKIP_BUILD_LIBXML2}" ]]; then
+                  # Note: This is wrong when cross-compiling. LLDB is part of
+                  # the toolchain while the built libxml2 is built for the
+                  # runtime environment for use in FoundationXML.
+                  # Build-Script does not separate the toolchain and runtime
+                  # build, so this is already broken.
+                  BASE_INSTALL_DIR="$(get_host_install_destdir ${host})"
+                  LIBXML2_HEADERS="${BASE_INSTALL_DIR}/usr/include/libxml2"
+                  LIBXML2_LIBRARY="${BASE_INSTALL_DIR}/usr/lib/libxml2.a"
+
+                  if [[ -z "${DRY_RUN}" && ! -d "${LIBXML2_HEADERS}" ]]; then
+                      echo "Error: '${LIBXML2_HEADERS}' does not exist" 1>&2
+                      exit 1
+                  fi
+
+                  if [[ -z "${DRY_RUN}" && ! -e "${LIBXML2_LIBRARY}" ]]; then
+                      echo "Error: '${LIBXML2_LIBRARY}' does not exist" 1>&2
+                      exit 1
+                  fi
+
+                  cmake_options+=(
+                    -DLIBXML2_INCLUDE_DIR:PATH="${LIBXML2_HEADERS}"
+                    -DLIBXML2_LIBRARY:PATH="${LIBXML2_LIBRARY}"
+                    -DLIBXML2_DEFINITIONS="-DLIBXML_STATIC"
+                  )
+                fi
+
                 # Watchpoint testing is currently disabled: see rdar://38566150.
                 LLDB_TEST_CATEGORIES="--skip-category=watchpoint"
 


### PR DESCRIPTION
Removing the dependency on libxml2 from the tools. This is disabling it in LLVM, so lld won't depend on it, and in lldb.

libxml2 is updated pretty frequently on FreeBSD as it is a user-installed package. If folks have a different version of libxml2 installed from what is installed on the CI nodes, the resulting products won't launch.

Edit: Updated PR to statically link the runtime libxml2 static archive for FoundationXML into LLDB while leaving it disabled for lld, which uses it for the Windows manifest parsing.
