### PR TITLE
Fix missing null terminator in runtime path resolution on Linux

### DIFF
--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -548,8 +548,9 @@ _swift_initRuntimePath(void *) {
     // this is needed with Musl when statically linking because in that case
     // dladdr() does nothing.
     char pathBuf[4096];
-    ssize_t len = readlink("/proc/self/exe", pathBuf, sizeof(pathBuf));
-    if (len > 0 && len < sizeof(pathBuf)) {
+    ssize_t len = readlink("/proc/self/exe", pathBuf, sizeof(pathBuf)-1);
+    if (len > 0 ) {
+      pathBuf[len] = '\0';
       runtimePath = ::strdup(pathBuf);
       return;
     }


### PR DESCRIPTION
readlink does not null terminate the output buffer.  The existing code passed the full buffer size to readlink, which did not leave any space to append a terminator.

This change passes size -1 to readlink and terminates the buffer with a '\0' after a successful read to avoid reading past the end of the buffer.

This change is consistent with the usage pattern seen in swift-foundation-icu / icuSources / common / putil.cpp


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
