### PR TITLE
IRGen: Narrow fix for type equivalence problem in searchNominalTypeMetadata()

### DIFF
--- a/test/IRGen/fulfillment_map_key_equality.swift
+++ b/test/IRGen/fulfillment_map_key_equality.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-library-evolution | %FileCheck %s
+
+// rdar://160649141
+
+public protocol P1 {}
+
+public protocol P2 {
+  associatedtype A1
+}
+
+public protocol P5 {
+  associatedtype A2: P2
+}
+
+public protocol P3 where A4.A1 == A3.A2.A1 {
+  associatedtype A3: P5
+  associatedtype A4: P2
+
+  var x: Int { get }
+}
+
+public protocol P6: P3 {}
+
+public protocol P4 {
+  associatedtype A4: P2
+}
+
+public struct G1<A1>: P2 {}
+
+public struct G2<A2: P2>: P5  {}
+
+public struct G3<T: P6 & P4>: P3 where T.A4.A1: P1 {
+  public typealias A4 = G1<T.A3.A2.A1>
+  public typealias A3 = G2<T.A3.A2>
+
+  // Make sure this witness thunk doesn't have any additional bogus parameters.
+
+  // CHECK-LABEL: define internal swiftcc i64 @"$s28fulfillment_map_key_equality2G3VyxGAA2P3A2aEP1xSivgTW"(ptr noalias swiftself captures(none) %0, ptr %Self, ptr %SelfWitnessTable) {{.*}} {
+  public var x: Int { fatalError() }
+}


### PR DESCRIPTION
This fixes a regression introduced by e3c8f423bc0d2fac9998c2b60da793921fc69ad4, but the root cause was actually a subtle invariant violation in IRGen.

FulfillmentMap's use of canonical types as keys assumes that canonical type equality is sufficient for checking if two types "are the same". However, this is not true when those types contain type parameters, because two distinct type parameters might belong to the same equivalence class.

Thus, when we take the type's context substitution map, and apply it to each type parameter in our given list of requirements, the substitution operation could output a different but equivalent type parameter.

However, it turns out that in practice, we only end up here with a type that is either fully substituted, or is exactly the declared interface type of their nominal.

In the latter case, the type's substitution map is the identity substitution map, so we can just detect this case and skip the call to subst(). This avoids the problem.

I added an assertion that will fire if this assumption is ever violated in the future. To support the general case, we will need to pass down a generic signature that describes the type parameters that appear in the given type, and use this signature to reduce the type of each lookup key before we proceed.

Fixes rdar://160649141.