### PR TITLE
[IRGen][wasm] Support ABIs with differing indirect rules for results and arguments

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -63,7 +63,8 @@ public:
 
 public:
   SILType getNewSILType(GenericEnvironment *GenericEnv, SILType storageType,
-                        irgen::IRGenModule &Mod);
+                        irgen::IRGenModule &Mod,
+                        bool useResultConvention = false);
   bool shouldTransformResults(GenericEnvironment *env,
                               CanSILFunctionType fnType,
                               irgen::IRGenModule &IGM);
@@ -72,9 +73,11 @@ public:
                                    irgen::IRGenModule &IGM);
   SILParameterInfo getNewParameter(GenericEnvironment *env,
                                    SILParameterInfo param,
-                                   irgen::IRGenModule &IGM);
+                                   irgen::IRGenModule &IGM,
+                                   bool useResultConvention);
   bool shouldTransformParameter(GenericEnvironment *env, SILParameterInfo param,
-                                irgen::IRGenModule &IGM);
+                                irgen::IRGenModule &IGM,
+                                bool useResultConvention);
   SmallVector<SILParameterInfo, 4> getNewParameters(GenericEnvironment *env,
                                                     CanSILFunctionType fnType,
                                                     irgen::IRGenModule &IGM);
@@ -95,7 +98,7 @@ public:
   SILType getNewTupleType(GenericEnvironment *GenericEnv,
                           irgen::IRGenModule &Mod,
                           const SILType &nonOptionalType,
-                          const SILType &storageType);
+                          const SILType &storageType, bool useResultConvention);
   bool newResultsDiffer(GenericEnvironment *GenericEnv,
                         ArrayRef<SILResultInfo> origResults,
                         irgen::IRGenModule &Mod);
@@ -103,17 +106,51 @@ public:
   bool containsDifferentFunctionSignature(GenericEnvironment *genEnv,
                                           irgen::IRGenModule &Mod,
                                           SILType storageType,
-                                          SILType newSILType);
+                                          SILType newSILType,
+                                          bool useResultConvention = false);
+
+  struct NewTypeCacheKey {
+    GenericEnvironment *GenericEnv;
+    SILType storageType;
+    bool useResultConvention;
+  };
 
 private:
   // Cache of already computed type transforms
-  llvm::MapVector<std::pair<GenericEnvironment *, SILType>, SILType>
-      oldToNewTypeMap;
+  llvm::MapVector<NewTypeCacheKey, SILType> oldToNewTypeMap;
 };
+
+namespace llvm {
+
+template <>
+struct DenseMapInfo<LargeSILTypeMapper::NewTypeCacheKey> {
+  static bool isEqual(const LargeSILTypeMapper::NewTypeCacheKey &lhs,
+                      const LargeSILTypeMapper::NewTypeCacheKey &rhs) {
+    return lhs.GenericEnv == rhs.GenericEnv &&
+           lhs.storageType == rhs.storageType &&
+           lhs.useResultConvention == rhs.useResultConvention;
+  }
+  static inline LargeSILTypeMapper::NewTypeCacheKey getEmptyKey() {
+    return {nullptr, SILType(), false};
+  }
+  static inline LargeSILTypeMapper::NewTypeCacheKey getTombstoneKey() {
+    return {DenseMapInfo<GenericEnvironment *>::getTombstoneKey(),
+            DenseMapInfo<SILType>::getTombstoneKey(), false};
+  }
+  static unsigned getHashValue(const LargeSILTypeMapper::NewTypeCacheKey &Val) {
+    return hash_combine(
+        DenseMapInfo<GenericEnvironment *>::getHashValue(Val.GenericEnv),
+        DenseMapInfo<SILType>::getHashValue(Val.storageType),
+        Val.useResultConvention ? 1 : 0);
+  }
+};
+
+} // end namespace llvm
 
 /// Utility to determine if this is a large loadable type
 static bool isLargeLoadableType(GenericEnvironment *GenericEnv, SILType t,
-                                irgen::IRGenModule &Mod) {
+                                irgen::IRGenModule &Mod,
+                                bool useResultConvention = false) {
   if (t.isAddress() || t.isClassOrClassMetatype()) {
     return false;
   }
@@ -128,7 +165,9 @@ static bool isLargeLoadableType(GenericEnvironment *GenericEnv, SILType t,
     assert(t.isObject() && "Expected only two categories: address and object");
     assert(!canType->hasTypeParameter());
     const TypeInfo &TI = Mod.getTypeInfoForLowered(canType);
-    auto &nativeSchemaOrigParam = TI.nativeParameterValueSchema(Mod);
+    auto &nativeSchemaOrigParam = useResultConvention
+                                      ? TI.nativeReturnValueSchema(Mod)
+                                      : TI.nativeParameterValueSchema(Mod);
     return nativeSchemaOrigParam.requiresIndirect();
   }
   return false;
@@ -144,8 +183,9 @@ static bool modifiableFunction(CanSILFunctionType funcType) {
 
 bool LargeSILTypeMapper::shouldTransformParameter(GenericEnvironment *env,
                                                   SILParameterInfo param,
-                                                  irgen::IRGenModule &IGM) {
-  auto newParam = getNewParameter(env, param, IGM);
+                                                  irgen::IRGenModule &IGM,
+                                                  bool useResultConvention) {
+  auto newParam = getNewParameter(env, param, IGM, useResultConvention);
   return (param != newParam);
 }
 
@@ -170,12 +210,13 @@ bool LargeSILTypeMapper::shouldTransformFunctionType(GenericEnvironment *env,
     return true;
 
   for (auto param : fnType->getParameters()) {
-    if (shouldTransformParameter(env, param, IGM))
+    if (shouldTransformParameter(env, param, IGM,
+                                 /*useResultConvention*/ false))
       return true;
   }
 
   for (auto yield : fnType->getYields()) {
-    if (shouldTransformParameter(env, yield, IGM))
+    if (shouldTransformParameter(env, yield, IGM, /*useResultConvention*/ true))
       return true;
   }
 
@@ -205,7 +246,7 @@ static SILType getNonOptionalType(SILType t) {
 
 bool LargeSILTypeMapper::containsDifferentFunctionSignature(
     GenericEnvironment *genEnv, irgen::IRGenModule &Mod, SILType storageType,
-    SILType newSILType) {
+    SILType newSILType, bool useResultConvention) {
   if (storageType == newSILType) {
     return false;
   }
@@ -218,8 +259,9 @@ bool LargeSILTypeMapper::containsDifferentFunctionSignature(
     for (TupleTypeElt canElem : origType->getElements()) {
       auto origCanType = CanType(canElem.getType());
       auto elem = SILType::getPrimitiveObjectType(origCanType);
-      auto newElem = getNewSILType(genEnv, elem, Mod);
-      if (containsDifferentFunctionSignature(genEnv, Mod, elem, newElem)) {
+      auto newElem = getNewSILType(genEnv, elem, Mod, useResultConvention);
+      if (containsDifferentFunctionSignature(genEnv, Mod, elem, newElem,
+                                             useResultConvention)) {
         return true;
       }
     }
@@ -384,8 +426,8 @@ static bool shouldTransformYields(GenericEnvironment *genEnv,
   for (auto &yield : loweredTy->getYields()) {
     auto yieldStorageType = yield.getSILStorageType(Mod.getSILModule(),
                                                     loweredTy, expansion);
-    auto newYieldStorageType =
-        Mapper.getNewSILType(genEnv, yieldStorageType, Mod);
+    auto newYieldStorageType = Mapper.getNewSILType(
+        genEnv, yieldStorageType, Mod, /*useResultConvention*/ true);
     if (yieldStorageType != newYieldStorageType)
       return true;
   }
@@ -403,7 +445,8 @@ static bool modYieldType(SILFunction *F, irgen::IRGenModule &Mod,
 
 SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
                                                      SILParameterInfo param,
-                                                     irgen::IRGenModule &IGM) {
+                                                     irgen::IRGenModule &IGM,
+                                                     bool useResultConvention) {
   SILType storageType = param.getSILStorageInterfaceType();
   SILType newOptFuncType =
       getNewOptionalFunctionType(env, storageType, IGM);
@@ -418,7 +461,7 @@ SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
     } else {
       return param;
     }
-  } else if (isLargeLoadableType(env, storageType, IGM)) {
+  } else if (isLargeLoadableType(env, storageType, IGM, useResultConvention)) {
     if (param.getConvention() == ParameterConvention::Direct_Owned) {
       return SILParameterInfo(storageType.getASTType(),
                               ParameterConvention::Indirect_In,
@@ -430,7 +473,7 @@ SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
                             ParameterConvention::Indirect_In_Guaranteed,
                             param.getOptions());
   } else {
-    auto newType = getNewSILType(env, storageType, IGM);
+    auto newType = getNewSILType(env, storageType, IGM, useResultConvention);
     return SILParameterInfo(newType.getASTType(), param.getConvention(),
                             param.getOptions());
   }
@@ -442,7 +485,8 @@ LargeSILTypeMapper::getNewParameters(GenericEnvironment *env,
                                      irgen::IRGenModule &IGM) {
   SmallVector<SILParameterInfo, 4> newParams;
   for (SILParameterInfo param : fnType->getParameters()) {
-    auto newParam = getNewParameter(env, param, IGM);
+    auto newParam =
+        getNewParameter(env, param, IGM, /*useResultConvention*/ false);
     newParams.push_back(newParam);
   }
   return newParams;
@@ -454,7 +498,8 @@ LargeSILTypeMapper::getNewYields(GenericEnvironment *env,
                                  irgen::IRGenModule &IGM) {
   SmallVector<SILYieldInfo, 2> newYields;
   for (auto oldYield : fnType->getYields()) {
-    auto newYieldAsParam = getNewParameter(env, oldYield, IGM);
+    auto newYieldAsParam =
+        getNewParameter(env, oldYield, IGM, /*useResultConvention*/ true);
     newYields.push_back(SILYieldInfo(newYieldAsParam.getInterfaceType(),
                                      newYieldAsParam.getConvention()));
   }
@@ -464,14 +509,15 @@ LargeSILTypeMapper::getNewYields(GenericEnvironment *env,
 SILType LargeSILTypeMapper::getNewTupleType(GenericEnvironment *GenericEnv,
                                             irgen::IRGenModule &Mod,
                                             const SILType &nonOptionalType,
-                                            const SILType &storageType) {
+                                            const SILType &storageType,
+                                            bool useResultConvention) {
   auto origType = nonOptionalType.getAs<TupleType>();
   assert(origType && "Expected a tuple type");
   SmallVector<TupleTypeElt, 2> newElems;
   for (TupleTypeElt canElem : origType->getElements()) {
     auto origCanType = CanType(canElem.getType());
     auto elem = SILType::getPrimitiveObjectType(origCanType);
-    auto newElem = getNewSILType(GenericEnv, elem, Mod);
+    auto newElem = getNewSILType(GenericEnv, elem, Mod, useResultConvention);
     newElems.emplace_back(newElem.getASTType(), canElem.getName());
   }
   auto type = TupleType::get(newElems, nonOptionalType.getASTContext());
@@ -491,9 +537,10 @@ SILType LargeSILTypeMapper::getNewTupleType(GenericEnvironment *GenericEnv,
 
 SILType LargeSILTypeMapper::getNewSILType(GenericEnvironment *GenericEnv,
                                           SILType storageType,
-                                          irgen::IRGenModule &Mod) {
+                                          irgen::IRGenModule &Mod,
+                                          bool useResultConvention) {
   // See if the type is already in the cache:
-  auto typePair = std::make_pair(GenericEnv, storageType);
+  NewTypeCacheKey typePair = {GenericEnv, storageType, useResultConvention};
   if (oldToNewTypeMap.find(typePair) != oldToNewTypeMap.end()) {
     return oldToNewTypeMap[typePair];
   }
@@ -503,11 +550,12 @@ SILType LargeSILTypeMapper::getNewSILType(GenericEnvironment *GenericEnv,
     nonOptionalType = optType;
   }
   if (nonOptionalType.getAs<TupleType>()) {
-    SILType newSILType =
-        getNewTupleType(GenericEnv, Mod, nonOptionalType, storageType);
-    auto typeToRet = isLargeLoadableType(GenericEnv, newSILType, Mod)
-                         ? newSILType.getAddressType()
-                         : newSILType;
+    SILType newSILType = getNewTupleType(GenericEnv, Mod, nonOptionalType,
+                                         storageType, useResultConvention);
+    auto typeToRet =
+        isLargeLoadableType(GenericEnv, newSILType, Mod, useResultConvention)
+            ? newSILType.getAddressType()
+            : newSILType;
     oldToNewTypeMap[typePair] = typeToRet;
     return typeToRet;
   }
@@ -522,7 +570,8 @@ SILType LargeSILTypeMapper::getNewSILType(GenericEnvironment *GenericEnv,
       newSILType = SILType::getPrimitiveType(newFnType,
                                              storageType.getCategory());
     }
-  } else if (isLargeLoadableType(GenericEnv, storageType, Mod)) {
+  } else if (isLargeLoadableType(GenericEnv, storageType, Mod,
+                                 useResultConvention)) {
     newSILType = storageType.getAddressType();
   }
   oldToNewTypeMap[typePair] = newSILType;
@@ -589,18 +638,23 @@ struct StructLoweringState {
                       LargeSILTypeMapper &Mapper)
       : F(F), Mod(Mod), Mapper(Mapper) {}
 
-  bool isLargeLoadableType(CanSILFunctionType fnTy, SILType type) {
-    return ::isLargeLoadableType(getSubstGenericEnvironment(fnTy), type, Mod);
+  bool isLargeLoadableType(CanSILFunctionType fnTy, SILType type,
+                           bool useResultConvention = false) {
+    return ::isLargeLoadableType(getSubstGenericEnvironment(fnTy), type, Mod,
+                                 useResultConvention);
   }
 
-  SILType getNewSILType(CanSILFunctionType fnTy, SILType type) {
-    return Mapper.getNewSILType(getSubstGenericEnvironment(fnTy), type, Mod);
+  SILType getNewSILType(CanSILFunctionType fnTy, SILType type,
+                        bool useResultConvention = false) {
+    return Mapper.getNewSILType(getSubstGenericEnvironment(fnTy), type, Mod,
+                                useResultConvention);
   }
 
-  bool containsDifferentFunctionSignature(CanSILFunctionType fnTy,
-                                          SILType type) {
+  bool containsDifferentFunctionSignature(CanSILFunctionType fnTy, SILType type,
+                                          bool useResultConvention = false) {
     return Mapper.containsDifferentFunctionSignature(
-        getSubstGenericEnvironment(fnTy), Mod, type, getNewSILType(fnTy, type));
+        getSubstGenericEnvironment(fnTy), Mod, type,
+        getNewSILType(fnTy, type, useResultConvention), useResultConvention);
   }
 
   bool hasLargeLoadableYields() {
@@ -609,7 +663,8 @@ struct StructLoweringState {
 
     auto env = getSubstGenericEnvironment(fnType);
     for (auto yield : fnType->getYields()) {
-      if (Mapper.shouldTransformParameter(env, yield, Mod))
+      if (Mapper.shouldTransformParameter(env, yield, Mod,
+                                          /*useResultConvention*/ true))
         return true;
     }
     return false;
@@ -1227,7 +1282,8 @@ static bool isYieldUseRewritable(StructLoweringState &pass,
                                   YieldInst *inst, Operand *operand) {
   assert(inst == operand->getUser());
   return pass.isLargeLoadableType(pass.F->getLoweredFunctionType(),
-                                  operand->get()->getType());
+                                  operand->get()->getType(),
+                                  /*useResultConvention*/ true);
 }
 
 /// Does the value's uses contain instructions that *must* be rewrites?
@@ -1914,14 +1970,15 @@ static void allocateAndSet(StructLoweringState &pass,
 static void allocateAndSetAll(StructLoweringState &pass,
                               LoadableStorageAllocation &allocator,
                               SILInstruction *user,
-                              MutableArrayRef<Operand> operands) {
+                              MutableArrayRef<Operand> operands,
+                              bool useResultConvention) {
   PrettyStackTraceSILNode backtrace("Running allocateAndSetAll on ", user);
 
   for (Operand &operand : operands) {
     SILValue value = operand.get();
     SILType silType = value->getType();
-    if (pass.isLargeLoadableType(pass.F->getLoweredFunctionType(),
-                                 silType)) {
+    if (pass.isLargeLoadableType(pass.F->getLoweredFunctionType(), silType,
+                                 useResultConvention)) {
       allocateAndSet(pass, allocator, value, user, operand);
     }
   }
@@ -2100,12 +2157,14 @@ static void rewriteFunction(StructLoweringState &pass,
       }
       ApplySite applySite = ApplySite(applyInst);
       allocateAndSetAll(pass, allocator, applyInst,
-                        applySite.getArgumentOperands());
+                        applySite.getArgumentOperands(),
+                        /*useResultConvention*/ false);
     }
 
     while (!pass.modYieldInsts.empty()) {
       YieldInst *inst = pass.modYieldInsts.pop_back_val();
-      allocateAndSetAll(pass, allocator, inst, inst->getAllOperands());
+      allocateAndSetAll(pass, allocator, inst, inst->getAllOperands(),
+                        /*useResultConvention*/ true);
     }
 
     repeat = !pass.switchEnumInstsToMod.empty() ||

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -17,12 +17,13 @@
 
 #include "SwiftTargetInfo.h"
 #include "IRGenModule.h"
-#include "llvm/TargetParser/Triple.h"
-#include "llvm/IR/DataLayout.h"
 #include "swift/ABI/System.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/Basic/Platform.h"
+#include "clang/CodeGen/SwiftCallingConv.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/TargetParser/Triple.h"
 
 using namespace swift;
 using namespace irgen;
@@ -194,6 +195,13 @@ static void configureWasm32(IRGenModule &IGM, const llvm::Triple &triple,
                             SwiftTargetInfo &target) {
   target.LeastValidPointerValue =
     SWIFT_ABI_WASM32_LEAST_VALID_POINTER;
+
+  // Determine whether the target ABI supports returning two pointers directly.
+  llvm::Type *ptrTy = llvm::PointerType::getUnqual(IGM.getLLVMContext());
+  target.SupportsDirectReturningAtLeastTwoPointers =
+      !clang::CodeGen::swiftcall::shouldPassIndirectly(IGM.getClangCGM(),
+                                                       {ptrTy, ptrTy},
+                                                       /*asReturnValue*/ true);
 }
 
 /// Configure a default target.

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -118,6 +118,9 @@ public:
   bool HasSwiftSwiftDirectRuntimeLibrary = false;
 
   bool UsableSwiftAsyncContextAddrIntrinsic = false;
+
+  /// True if the target supports directly returning at least two pointers.
+  bool SupportsDirectReturningAtLeastTwoPointers = true;
 };
 
 }

--- a/test/IRGen/async/builtin_executor.sil
+++ b/test/IRGen/async/builtin_executor.sil
@@ -3,6 +3,7 @@
 // REQUIRES: concurrency
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -606,7 +606,7 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   return %40 : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc { ptr, ptr } @create_pa_f2(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc {{{ ptr, ptr }|void}} @create_pa_f2(
 sil @create_pa_f2 : $@convention(thin) (@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64, Int32) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
 bb0(%thick : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64 , %captured : $Int32):
   %pa_f = partial_apply [callee_guaranteed] %thick(%captured) : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -disable-type-layout %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: optimized_stdlib
 // UNSUPPORTED: CPU=powerpc64le
+// UNSUPPORTED: CPU=wasm32
 
 public struct BigStruct {
   var i0 : Int32 = 0

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
+// UNSUPPORTED: CPU=wasm32
 
 import Swift
 

--- a/test/IRGen/builtin_freeze.swift
+++ b/test/IRGen/builtin_freeze.swift
@@ -27,30 +27,30 @@ func yum() -> Int32 {
 }
 // CHECK: }
 
-func fptosi(_ x: SIMD2<Float>) -> SIMD2<Int32> {
-  let maybePoison = Builtin.fptosi_Vec2xFPIEEE32_Vec2xInt32(x._storage._value)
-  var result = SIMD2<Int32>()
+func fptosi(_ x: SIMD4<Float>) -> SIMD4<Int32> {
+  let maybePoison = Builtin.fptosi_Vec4xFPIEEE32_Vec4xInt32(x._storage._value)
+  var result = SIMD4<Int32>()
   result._storage._value = maybePoison
   return result
-  // CHECK: fptosi <2 x float> %{{.+}} to <2 x i32>
+  // CHECK: fptosi <4 x float> %{{.+}} to <4 x i32>
 }
 
-func fptosiWithFreeze(_ x: SIMD2<Float>) -> SIMD2<Int32> {
-  let maybePoison = Builtin.fptosi_Vec2xFPIEEE32_Vec2xInt32(x._storage._value)
-  let frozen = Builtin.freeze_Vec2xInt32(maybePoison)
-  var result = SIMD2<Int32>()
+func fptosiWithFreeze(_ x: SIMD4<Float>) -> SIMD4<Int32> {
+  let maybePoison = Builtin.fptosi_Vec4xFPIEEE32_Vec4xInt32(x._storage._value)
+  let frozen = Builtin.freeze_Vec4xInt32(maybePoison)
+  var result = SIMD4<Int32>()
   result._storage._value = frozen
   return result
-  // CHECK: fptosi <2 x float> %{{.+}} to <2 x i32>
-  // CHECK-NEXT: freeze <2 x i32> %{{.+}}
+  // CHECK: fptosi <4 x float> %{{.+}} to <4 x i32>
+  // CHECK-NEXT: freeze <4 x i32> %{{.+}}
 }
 
-func doubleYuck(_ x: SIMD2<Float>) -> SIMD2<Int32> {
-  fptosi(SIMD2<Float>(repeating: 0x1.0p32))
+func doubleYuck(_ x: SIMD4<Float>) -> SIMD4<Int32> {
+  fptosi(SIMD4<Float>(repeating: 0x1.0p32))
   // CHECK: poison
 }
 
-func DoubleYum(_ x: SIMD2<Float>) -> SIMD2<Int32> {
-  fptosiWithFreeze(SIMD2<Float>(repeating: 0x1.0p32))
+func DoubleYum(_ x: SIMD4<Float>) -> SIMD4<Int32> {
+  fptosiWithFreeze(SIMD4<Float>(repeating: 0x1.0p32))
   // CHECK-NOT: poison
 }

--- a/test/IRGen/builtin_vector_fixed_array.sil
+++ b/test/IRGen/builtin_vector_fixed_array.sil
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-irgen -disable-availability-checking -enable-experimental-feature BuiltinModule %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BuiltinModule
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 import Swift

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -disable-type-layout %s -gnone -emit-ir -I %S/Inputs | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize --check-prefix=CHECK-%target-cpu
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -8,6 +8,7 @@
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
 // RUN: %target-swift-frontend -disable-type-layout -module-name enum_resilience -I %t -emit-ir -enable-library-evolution %s | %FileCheck %t/enum_resilience.swift -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 // RUN: %target-swift-frontend -module-name enum_resilience -I %t -emit-ir -enable-library-evolution -O %s
+// UNSUPPORTED: CPU=wasm32
 
 import resilient_enum
 import resilient_struct

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -1,6 +1,7 @@
 // XFAIL: CPU=powerpc64le
 // XFAIL: CPU=s390x
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize
+// UNSUPPORTED: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/isolated_any.sil
+++ b/test/IRGen/isolated_any.sil
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir %s | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
+// UNSUPPORTED: CPU=wasm32
 
 import Swift
 import _Concurrency

--- a/test/IRGen/meta_meta_type.swift
+++ b/test/IRGen/meta_meta_type.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECKIR %s
 // REQUIRES: executable_test
+// UNSUPPORTED: CPU=wasm32
 
 protocol Proto {
 }

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -68,7 +68,7 @@ entry(%x : $float3):
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(ptr noalias sret({{.*}}) captures(none) %0, ptr noalias captures(none) dereferenceable({{.*}}) %1)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
-// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(ptr noalias sret(%T4simd6float4V) captures(none) %0, float %1, float %2, float %3, float %4)
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4
@@ -87,7 +87,7 @@ entry(%x : $float4):
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
-// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args_float3(ptr noalias sret(%T4simd6float3V) captures(none) %0, float %1, float %2, float %3)
 sil @simd_native_args_float3 : $@convention(thin) (float3) -> float3 {
 entry(%x : $float3):
   %f = function_ref @simd_c_args_float3 : $@convention(c) (float3) -> float3

--- a/test/IRGen/package-cmo-serialize-witness-thunk.swift
+++ b/test/IRGen/package-cmo-serialize-witness-thunk.swift
@@ -21,7 +21,6 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-IR < %t/Lib-ir.ll
 // RUN: %FileCheck %s --check-prefix=CHECK-TBD < %t/Lib-tbd.tbd
 
-
 /// TEST that a public (or package) protocol witness thunk gets a shared linkage if Package CMO is enabled.
 /// It also gets [serialized] in emit-silgen.
 ///
@@ -33,8 +32,8 @@
 // CHECK-NO-PCMO-SIL-DAG: sil private [transparent] [thunk] @$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW : $@convention(witness_method: Proto) (@in_guaranteed Pub) -> @owned String {
 // CHECK-SIL-DAG:         sil shared [transparent] [thunk] @$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW : $@convention(witness_method: Proto) (@in_guaranteed Pub) -> @owned String {
 
-// CHECK-NO-PCMO-IR-DAG: define internal swiftcc { {{i64, ptr|i32, i32, i32}} } @"$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW"
-// CHECK-IR-DAG:         define linkonce_odr hidden swiftcc { {{i64, ptr|i32, i32, i32}} } @"$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW"
+// CHECK-NO-PCMO-IR-DAG: define internal swiftcc {{{ i64, ptr }|{ i32, i32, i32 }|void}} @"$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW"
+// CHECK-IR-DAG:         define linkonce_odr hidden swiftcc {{{ i64, ptr }|{ i32, i32, i32 }|void}} @"$s3Lib3PubVAA5ProtoA2aDP3fooSSvgTW"
 
 // protocol witness for Proto.bar(_:) in conformance Pub
 

--- a/test/IRGen/package_bypass_resilience_class.swift
+++ b/test/IRGen/package_bypass_resilience_class.swift
@@ -130,7 +130,7 @@ class UFIKlass {
   var varNonUfi: String?
 
   // variable initialization expression of Core.UFIKlass.varUfi
-  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc {{.*}} @"$s4Core8UFIKlassC6varUfiSSSgvpfi"()
+  // CHECK-OPT-DAG: define {{(dllexport |protected )?}}swiftcc {{.*}} @"$s4Core8UFIKlassC6varUfiSSSgvpfi"
 
   // key path getter for Core.UFIKlass.varUfi
   // CHECK-COMMON-DAG: define linkonce_odr hidden swiftcc void @"$s4Core8UFIKlassC6varUfiSSSgvpACTK"

--- a/test/IRGen/partial_apply_coro.sil
+++ b/test/IRGen/partial_apply_coro.sil
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=OnoneSimplification -I %t -emit-ir -disable-emit-type-malloc-for-coro-frame %s -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // REQUIRES: concurrency
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 import Swift

--- a/test/IRGen/simple_partial_apply.sil
+++ b/test/IRGen/simple_partial_apply.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu
+// UNSUPPORTED: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
 // RUN: %target-swift-frontend -module-name struct_resilience -Xllvm -sil-disable-pass=MandatoryARCOpts -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu
 // RUN: %target-swift-frontend -module-name struct_resilience -I %t -emit-ir -enable-library-evolution -O %s
+// UNSUPPORTED: CPU=wasm32
 
 import resilient_struct
 import resilient_enum

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-runtime --check-prefix=CHECK -DINT=i%target-ptrsize
+// UNSUPPORTED: CPU=wasm32
 
 sil_stage canonical
 

--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// UNSUPPORTED: CPU=wasm32
 
 public func takesNoEscape(_: () -> ()) {}
 

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -6,6 +6,7 @@
 // we should turn this into a REQUIRES instead.
 // UNSUPPORTED: CPU=i386
 // UNSUPPORTED: CPU=arm64_32
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 import Swift

--- a/test/IRGen/yield_result.sil
+++ b/test/IRGen/yield_result.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 

--- a/test/embedded/linkage/export_interface.swift
+++ b/test/embedded/linkage/export_interface.swift
@@ -44,7 +44,7 @@ private func throughPrivate() -> [Int] {
 // LIBRARY-IR-NOT: unnecessary
 public func unnecessary() -> Int { 5 }
 
-// LIBRARY-IR: define linkonce_odr hidden swiftcc { ptr, ptr } @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
+// LIBRARY-IR: define linkonce_odr hidden swiftcc {{{ ptr, ptr }|void}} @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
 
 // LIBRARY-SIL: sil @$e7Library5helloSaySiGyF
 // LIBRARY-SIL: sil @$e7Library8getArraySaySiGyF : $@convention(thin) () -> @owned Array<Int> {
@@ -77,5 +77,5 @@ struct Main {
   }
 }
 
-// APPLICATION-IR: define linkonce_odr hidden swiftcc { ptr, ptr } @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
+// APPLICATION-IR: define linkonce_odr hidden swiftcc {{{ ptr, ptr }|void}} @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
 

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -77,7 +77,7 @@ extension PointClass: Reflectable {
   }
 }
 
-// LIBRARY-IR: define {{.*}} @"$e7Library18createsExistentialAA11Reflectable_pyF"()
+// LIBRARY-IR: define {{.*}} @"$e7Library18createsExistentialAA11Reflectable_pyF"
 @export(interface)
 public func createsExistential() -> any Reflectable {
   return PointClass(x: 5, y: 5)
@@ -112,7 +112,7 @@ public func testMe() {
 
 // APPLICATION-IR: define {{(protected |dllexport )?}}i32 @Application_main
 
-// APPLICATION-IR: define linkonce_odr hidden swiftcc { ptr, ptr } @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
+// APPLICATION-IR: define linkonce_odr hidden swiftcc {{{ ptr, ptr }|void}} @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
 
 @main
 struct Main {

--- a/test/embedded/linkage/leaf_library.swift
+++ b/test/embedded/linkage/leaf_library.swift
@@ -40,7 +40,7 @@ private func throughPrivate() -> [Int] {
   [5, 6, 7]
 }
 
-// LIBRARY-IR: define linkonce_odr hidden swiftcc { ptr, ptr } @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
+// LIBRARY-IR: define linkonce_odr hidden swiftcc {{{ ptr, ptr }|void}} @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
 
 // LIBRARY-IR: define {{(protected |dllexport )?}}swiftcc i64 @"$e7Library11unnecessarys5Int64VyF"()
 public func unnecessary() -> Int64 { 5 }

--- a/test/stdlib/SIMDFloatInitializers.swift.gyb
+++ b/test/stdlib/SIMDFloatInitializers.swift.gyb
@@ -37,9 +37,9 @@ func repeating${n}x${bits}(_ scalar: ${scalar}) -> SIMD${n}<${scalar}> {
 %   if bits == 16:
 #endif
 %   end
-// CHECK${arch}: repeating${n}x${bits}{{.*}} {
+// CHECK${arch}: define {{.*}} @"{{.*}}repeating${n}x${bits}{{.*}}"({{(ptr noalias sret\(.+\) captures\(none\) %0, )?}}{{(.+)}} [[ARG:%[0-9]+]])
 // CHECK${arch}: entry:
-// CHECK${arch}: [[TMP:%[0-9]+]] = insertelement <${n} x ${llvm}> {{.*}} ${llvm} %0, i32 0
+// CHECK${arch}: [[TMP:%[0-9]+]] = insertelement <${n} x ${llvm}> {{.*}} ${llvm} [[ARG]], i32 0
 // CHECK${arch}-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x ${llvm}> [[TMP]], <${n} x ${llvm}> {{.*}}, <${n} x i32> zeroinitializer
 
 %  end

--- a/test/stdlib/SIMDSignedInitializers.swift.gyb
+++ b/test/stdlib/SIMDSignedInitializers.swift.gyb
@@ -23,9 +23,9 @@ import Swift
 func repeating${n}_int${bits}(_ scalar: Int${bits}) -> SIMD${n}<Int${bits}> {
   SIMD${n}(repeating: scalar)
 }
-// CHECK: repeating${n}_int${bits}{{.*}} {
+// CHECK: define {{.*}} @"{{.*}}repeating${n}_int${bits}{{.*}}"({{(ptr noalias sret\(.+\) captures\(none\) %0, )?}}{{(.+)}} [[ARG:%[0-9]+]])
 // CHECK: entry:
-// CHECK: [[TMP:%[0-9]+]] = insertelement <${n} x i${bits}> {{.*}}, i${bits} %0, i32 0
+// CHECK: [[TMP:%[0-9]+]] = insertelement <${n} x i${bits}> {{.*}}, i${bits} [[ARG]], i32 0
 // CHECK-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x i${bits}> [[TMP]], <${n} x i${bits}> {{.*}}, <${n} x i32> zeroinitializer
 
 %  end


### PR DESCRIPTION
`clang::CodeGen::swiftcall::shouldPassIndirectly` now returns true for multiple scalar values on wasm targets because the Wasm MVP does not support multiple return values. For such targets where we can't directly return two pointers, we should not attempt to indirect at this stage because the later MC lowering will also indirect the return.
