### PR TITLE
Sema: Exportability check enums and classes in non-library-evolution mode

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -474,7 +474,7 @@ SIMPLE_DECL_ATTR(_alwaysEmitIntoClient, AlwaysEmitIntoClient,
   83)
 
 SIMPLE_DECL_ATTR(_implementationOnly, ImplementationOnly,
-  OnImport | OnFunc | OnConstructor | OnVar | OnSubscript | OnStruct,
+  OnImport | OnFunc | OnConstructor | OnVar | OnSubscript | OnStruct | OnClass | OnEnum,
   UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | UnreachableInABIAttr,
   84)
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3949,8 +3949,8 @@ ERROR(implementation_only_override_import_without_attr,none,
       "override of %kindonly0 imported as implementation-only must be declared "
       "'@_implementationOnly'",
       (const ValueDecl *))
-ERROR(implementation_only_on_structs_feature,none,
-      "'@_implementationOnly' on structs requires "
+ERROR(implementation_only_on_types_feature,none,
+      "'@_implementationOnly' on a type requires "
       "'-enable-experimental-feature CheckImplementationOnly'", ())
 
 ERROR(import_attr_conflict,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3848,7 +3848,7 @@ ERROR(decl_from_hidden_module,none,
       "C++ types from imported module %2 do not support library evolution|"
       "it was imported via the internal bridging header|"
       "%2 was not imported publicly|"
-      "it is a struct marked '@_implementationOnly'}3",
+      "%0 is marked '@_implementationOnly'}3",
       (const Decl *, unsigned, Identifier, unsigned))
 ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "%0 aliases '%1.%2' and cannot be used %select{here|"
@@ -3867,7 +3867,7 @@ ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "C++ types from imported module %4 do not support library evolution|"
       "it was imported via the internal bridging header|"
       "%4 was not imported publicly|"
-      "it is a struct marked '@_implementationOnly'}5",
+      "%0 is marked '@_implementationOnly'}5",
       (const TypeAliasDecl *, StringRef, StringRef, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 %select{here|as property wrapper here|"
@@ -3884,7 +3884,7 @@ ERROR(conformance_from_implementation_only_module,none,
       "C++ types from imported module %3 do not support library evolution|"
       "it was imported via the internal bridging header|"
       "%3 was not imported publicly|"
-      "it is a struct marked '@_implementationOnly'}4",
+      "%0 is marked '@_implementationOnly'}4",
       (Type, Identifier, unsigned, Identifier, unsigned))
 NOTE(assoc_conformance_from_implementation_only_module,none,
      "in associated type %0 (inferred as %1)", (Type, Type))
@@ -7353,7 +7353,7 @@ ERROR(inlinable_decl_ref_from_hidden_module,
       "C++ APIs from imported module %2 do not support library evolution|"
       "it was imported via the internal bridging header|"
       "%2 was not imported publicly|"
-      "it is a struct marked '@_implementationOnly'}3",
+      "%0 is marked '@_implementationOnly'}3",
       (const ValueDecl *, unsigned, Identifier, unsigned))
 
 ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
@@ -7366,7 +7366,7 @@ ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       "C++ types from imported module %4 do not support library evolution|"
       "it was imported via the internal bridging header|"
       "%4 was not imported publicly|"
-      "it is a struct marked '@_implementationOnly'}5",
+      "%0 is marked '@_implementationOnly'}5",
       (const TypeAliasDecl *, StringRef, StringRef, unsigned, Identifier, unsigned))
 
 NOTE(missing_import_inserted,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4995,12 +4995,12 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
     return;
   }
 
-  // @_implementationOnly on structs only applies to non-public types.
   auto *VD = cast<ValueDecl>(D);
-  if (isa<StructDecl>(VD)) {
+
+  // @_implementationOnly on types only applies to non-public types.
+  if (isa<NominalTypeDecl>(D)) {
     if (!Ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly)) {
-      diagnoseAndRemoveAttr(attr,
-          diag::implementation_only_on_structs_feature);
+      diagnoseAndRemoveAttr(attr, diag::implementation_only_on_types_feature);
       return;
     }
 

--- a/test/Sema/Inputs/implementation-only-imports/directs.swift
+++ b/test/Sema/Inputs/implementation-only-imports/directs.swift
@@ -29,3 +29,10 @@ extension StructFromIndirect {
     set {}
   }
 }
+
+public struct RawTypeFromDirect : Equatable, ExpressibleByIntegerLiteral {
+  public typealias IntegerLiteralType = Int
+  public init(integerLiteral: Int) {}
+}
+
+public protocol ProtocolFromDirect { }

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -76,7 +76,7 @@ private struct HiddenLayout {
 // expected-opt-in-note @-1 2 {{struct 'HiddenLayout' is not '@usableFromInline' or public}}
 // expected-opt-in-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-opt-in-note @-3 2 {{struct declared here}}
-// expected-opt-in-note @-4 {{struct declared here}}
+// expected-opt-in-note @-4 4 {{struct declared here}}
 }
 #else
 private struct HiddenLayout {
@@ -221,4 +221,88 @@ private struct HiddenLayoutUser {
 
 @_implementationOnly // expected-opt-in-error {{'@_implementationOnly' may not be used on public declarations}}
 public struct PublicHiddenStruct {}
+#endif
+
+/// Classes use sites
+
+public class PublicClass {
+  public init() { fatalError() }
+
+  public var publicField: StructFromDirect
+  // expected-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+
+  private var privateField: StructFromDirect
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+  private var a: ExposedLayoutPublic
+  private var aa: ExposedLayoutInternal
+  private var b: ExposedLayoutPrivate
+  private var c: HiddenLayout
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private var d: ExposedEnumPublic
+  private var e: ExposedEnumPrivate
+
+  @_neverEmitIntoClient
+  private func privateFunc(h: HiddenLayout) {}
+}
+
+internal class InternalClass {
+  public init() { fatalError() }
+
+  public var publicField: StructFromDirect
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+  private var privateField: StructFromDirect
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+
+  private var a: ExposedLayoutPublic
+  private var aa: ExposedLayoutInternal
+  private var b: ExposedLayoutPrivate
+  private var c: HiddenLayout
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private var d: ExposedEnumPublic
+  private var e: ExposedEnumPrivate
+
+  private func privateFunc(h: HiddenLayout) {} // expected-embedded-opt-in-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
+}
+
+private class PrivateClass {
+  public init() { fatalError() }
+
+  public var publicField: StructFromDirect
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+  private var privateField: StructFromDirect
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+
+  private var a: ExposedLayoutPublic
+  private var aa: ExposedLayoutInternal
+  private var b: ExposedLayoutPrivate
+  private var c: HiddenLayout
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private var d: ExposedEnumPublic
+  private var e: ExposedEnumPrivate
+
+  private func privateFunc(h: HiddenLayout) {} // expected-embedded-opt-in-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
+}
+
+#if UseImplementationOnly
+@_implementationOnly
+internal class HiddenClass {
+  public init() { fatalError() }
+
+  public var publicField: StructFromDirect
+  private var privateField: StructFromDirect
+
+  private var a: ExposedLayoutPublic
+  private var aa: ExposedLayoutInternal
+  private var b: ExposedLayoutPrivate
+  private var c: HiddenLayout
+
+  private var d: ExposedEnumPublic
+  private var e: ExposedEnumPrivate
+}
+
+@_implementationOnly // expected-opt-in-error {{'@_implementationOnly' may not be used on public declarations}}
+public enum PublicHiddenClass {}
 #endif

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -175,7 +175,7 @@ public struct ExposedLayoutPublicUser {
   // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
 }
 
-private struct ExposedLayoutInternalUser {
+internal struct ExposedLayoutInternalUser {
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -120,7 +120,7 @@ public func implicitlyInlinablePublic() {
   let _: ExposedLayoutPublic = ExposedLayoutPublic()
   let _: ExposedLayoutPrivate = ExposedLayoutPrivate()
   let _: HiddenLayout = HiddenLayout()
-  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
+  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   let _: ExposedEnumPublic = ExposedEnumPublic.A
   let _: ExposedEnumPrivate = ExposedEnumPrivate.A
@@ -130,7 +130,7 @@ private func implicitlyInlinablePrivate() {
   let _: ExposedLayoutPublic = ExposedLayoutPublic()
   let _: ExposedLayoutPrivate = ExposedLayoutPrivate()
   let _: HiddenLayout = HiddenLayout()
-  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
+  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   let _: ExposedEnumPublic = ExposedEnumPublic.A
   let _: ExposedEnumPrivate = ExposedEnumPrivate.A
@@ -169,10 +169,10 @@ public struct ExposedLayoutPublicUser {
   private var b: ExposedLayoutPrivate
 
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; it is a struct marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
+  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 internal struct ExposedLayoutInternalUser {
@@ -184,10 +184,10 @@ internal struct ExposedLayoutInternalUser {
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; it is a struct marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
+  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 private struct ExposedLayoutPrivateUser {
@@ -199,10 +199,10 @@ private struct ExposedLayoutPrivateUser {
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; it is a struct marked '@_implementationOnly'}}
+  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because it is a struct marked '@_implementationOnly'}}
+  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@_neverEmitIntoClient' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 #if UseImplementationOnly

--- a/test/attr/attr_implementation_only_on_types_feature_required.swift
+++ b/test/attr/attr_implementation_only_on_types_feature_required.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift %s
+
+@_implementationOnly struct MyStruct {}
+// expected-error@-1{{'@_implementationOnly' on a type requires '-enable-experimental-feature CheckImplementationOnly'}}


### PR DESCRIPTION
Ensure that classes and enums don't reference an implementation-only imported dependency unless they are themselves marked as `@_implementationOnly`. This is similar to the logic applied to structs in #85179, ensuring their memory layout visible to clients doesn't depend on the hidden dependency. Also extend checking for super types to structs.

This remains gated behind the experimental feature flag `CheckImplementationOnly`.