### PR TITLE
Extend @_extern to global and static variables

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6071,9 +6071,7 @@ public:
 
   /// Return true if this is a property that either has storage
   /// or init accessor associated with it.
-  bool supportsInitialization() const {
-    return hasStorage() || hasInitAccessor();
-  }
+  bool supportsInitialization() const;
 
   /// Return true if this storage has the basic accessors/capability
   /// to be mutated.  This is generally constant after the accessors are

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -774,7 +774,7 @@ DECL_ATTR(_rawLayout, RawLayout,
   146)
 
 DECL_ATTR(_extern, Extern,
-  OnFunc,
+  OnFunc | OnVar,
   AllowMultipleAttributes | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   147)
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2123,8 +2123,8 @@ WARNING(reserved_runtime_symbol_name,none,
 // @_extern
 ERROR(attr_extern_experimental,none,
       "'@_extern' requires '-enable-experimental-feature Extern'", ())
-ERROR(extern_not_at_top_level_func,none,
-      "'@_extern' can only be applied to global functions", ())
+ERROR(extern_not_at_top_level,none,
+      "'@_extern' can only be applied to globals", ())
 ERROR(extern_empty_c_name,none,
       "expected non-empty C name in '@_extern'", ())
 ERROR(extern_only_non_other_attr,none,
@@ -2134,6 +2134,8 @@ WARNING(extern_c_maybe_invalid_name, none,
         "C name '%0' may be invalid; explicitly specify the name in "
         "'@_extern(c)' to suppress this warning",
         (StringRef))
+ERROR(extern_variable_initializer, none,
+      "'@_extern' variable cannot have an initializer", ())
 
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,
@@ -2170,13 +2172,14 @@ ERROR(c_func_variadic, none,
 ERROR(c_func_unsupported_specifier, none,
       "cannot declare '%0' argument %1 in %kind2",
       (StringRef, DeclName, const ValueDecl *))
-ERROR(c_func_unsupported_type, none, "%0 cannot be represented in C",
+ERROR(c_unsupported_type, none, "%0 cannot be represented in C",
       (Type))
 ERROR(c_func_async,none,
       "async functions cannot be represented in C", ())
 ERROR(c_func_throws,none,
       "raising errors from C functions is not supported", ())
-
+ERROR(c_var_computed,none,
+      "computed variable cannot be represented in C", ())
 ERROR(expose_wasm_not_at_top_level_func,none,
       "'@_expose' with 'wasm' can only be applied to global "
       "functions", ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -276,9 +276,9 @@ public:
 
 /// Determine whether the given declaration has
 /// a C-compatible interface.
-class IsCCompatibleFuncDeclRequest :
-    public SimpleRequest<IsCCompatibleFuncDeclRequest,
-                         bool(FuncDecl *),
+class IsCCompatibleDeclRequest :
+    public SimpleRequest<IsCCompatibleDeclRequest,
+                         bool(ValueDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -287,7 +287,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, FuncDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -581,8 +581,8 @@ SWIFT_REQUEST(TypeChecker, SerializeAttrGenericSignatureRequest,
 SWIFT_REQUEST(TypeChecker, IsFunctionBodySkippedRequest,
               bool(const AbstractFunctionDecl *),
               SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsCCompatibleFuncDeclRequest,
-              bool(const FuncDecl *),
+SWIFT_REQUEST(TypeChecker, IsCCompatibleDeclRequest,
+              bool(const ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SemanticDeclAttrsRequest,
               DeclAttributes(const Decl *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7977,6 +7977,13 @@ bool AbstractStorageDecl::hasInitAccessor() const {
       HasInitAccessorRequest{const_cast<AbstractStorageDecl *>(this)}, false);
 }
 
+bool AbstractStorageDecl::supportsInitialization() const {
+  if (getAttrs().hasAttribute<ExternAttr>())
+    return false;
+
+  return hasStorage() || hasInitAccessor();
+}
+
 VarDecl::VarDecl(DeclKind kind, bool isStatic, VarDecl::Introducer introducer,
                  SourceLoc nameLoc, Identifier name,
                  DeclContext *dc, StorageIsMutable_t supportsMutation)
@@ -8143,6 +8150,10 @@ bool VarDecl::isLazilyInitializedGlobal() const {
     return false;
 
   if (getAttrs().hasAttribute<SILGenNameAttr>())
+    return false;
+
+  // @_extern declarations are not initialized.
+  if (getAttrs().hasAttribute<ExternAttr>())
     return false;
 
   // Top-level global variables in the main source file and in the REPL are not

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -612,7 +612,10 @@ extension ASTGenVisitor {
     }
 
     // @const/@section globals are not top-level, per SE-0492.
-    let isConst = attrs.attributes.hasAttribute(.Section) || attrs.attributes.hasAttribute(.ConstVal)
+    // We follow the same rule for @_extern.
+    let isConst = attrs.attributes.hasAttribute(.Section)
+      || attrs.attributes.hasAttribute(.ConstVal)
+      || attrs.attributes.hasAttribute(.Extern)
 
     let topLevelDecl: BridgedTopLevelCodeDecl?
     if self.declContext.isModuleScopeContext, self.declContext.parentSourceFile.isScriptMode, !isConst {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8747,12 +8747,14 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
   SourceLoc VarLoc = newBindingContext.getIntroducer() ? consumeToken() : Tok.getLoc();
 
   bool IsConst = Attributes.hasAttribute<SectionAttr>() ||
-                 Attributes.hasAttribute<ConstValAttr>();
+                 Attributes.hasAttribute<ConstValAttr>() ||
+                 Attributes.hasAttribute<ExternAttr>();
 
   // If this is a var in the top-level of script/repl source file, wrap the
   // PatternBindingDecl in a TopLevelCodeDecl, since it represents executable
   // code.  The VarDecl and any accessor decls (for computed properties) go in
   // CurDeclContext.  @const/@section globals are not top-level, per SE-0492.
+  // We follow the same rule for @_extern.
   TopLevelCodeDecl *topLevelDecl = nullptr;
   if (allowTopLevelCode() && CurDeclContext->isModuleScopeContext() &&
       !IsConst) {

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -50,7 +50,8 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
     formalLinkage = getDeclLinkage(gDecl);
   auto silLinkage = getSILLinkage(formalLinkage, forDef);
 
-  if (gDecl->getAttrs().hasAttribute<SILGenNameAttr>()) {
+  auto cExternAttr = ExternAttr::find(gDecl->getAttrs(), ExternKind::C);
+  if (gDecl->getAttrs().hasAttribute<SILGenNameAttr>() || cExternAttr) {
     silLinkage = SILLinkage::DefaultForDeclaration;
     if (! gDecl->hasInitialValue()) {
       forDef = NotForDefinition;
@@ -76,6 +77,10 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
 
   if (auto sectionAttr = gDecl->getAttrs().getAttribute<SectionAttr>())
     silGlobal->setSection(sectionAttr->Name);
+
+  if (cExternAttr) {
+    silGlobal->setAsmName(cExternAttr->getCName(gDecl));
+  }
 
   return silGlobal;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2589,6 +2589,10 @@ public:
         if (!var->hasStorage())
           return;
 
+        // If the variable is @_extern, it never needs an initializer.
+        if (var->getAttrs().hasAttribute<ExternAttr>())
+          return;
+
         if (var->getAttrs().hasAttribute<SILGenNameAttr>()
               || !ABIRoleInfo(var).providesAPI())
           return;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -514,16 +514,16 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     }
   }
 
-  auto isInitAccessorProperty = [](Pattern *pattern) {
-    auto *var = pattern->getSingleVar();
-    return var && var->getAccessor(AccessorKind::Init);
+  auto supportsInitialization = [&] {
+    auto *var = binding->getSingleVar();
+    return var && var->supportsInitialization();
   };
 
   // If we have a type but no initializer, check whether the type is
   // default-initializable. If so, do it.
   if (!pbe.isInitialized() &&
       binding->isDefaultInitializable(entryNumber) &&
-      (pattern->hasStorage() || isInitAccessorProperty(pattern))) {
+      supportsInitialization()) {
     if (auto defaultInit = TypeChecker::buildDefaultInitializer(patternType)) {
       // If we got a default initializer, install it and re-type-check it
       // to make sure it is properly coerced to the pattern type.
@@ -598,7 +598,16 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     Context.Diags.diagnose(binding->getPattern(entryNumber)->getLoc(),
                            diag::destructuring_let_struct_stored_property_unsupported);
   }
-  
+
+  // Extern declarations are not permitted to have initializers.
+  if (auto singleVar = binding->getSingleVar()) {
+    if (singleVar->getAttrs().hasAttribute<ExternAttr>() &&
+        pbe.isInitialized()) {
+      singleVar->diagnose(diag::extern_variable_initializer)
+          .highlight(pbe.getOriginalInitRange());
+    }
+  }
+
   return &pbe;
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -515,8 +515,14 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
   }
 
   auto supportsInitialization = [&] {
-    auto *var = binding->getSingleVar();
-    return var && var->supportsInitialization();
+    bool anySupportsInitialization = false;
+    pattern->forEachVariable([&](VarDecl *var) {
+      if (var->supportsInitialization()) {
+        anySupportsInitialization = true;
+      }
+    });
+
+    return anySupportsInitialization;
   };
 
   // If we have a type but no initializer, check whether the type is

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -2,6 +2,17 @@
 
 // REQUIRES: swift_feature_Extern
 
+
+// CHECK: @pointer_c = external global
+@_extern(c)
+var pointer_c: UnsafeMutablePointer<Int>
+
+// CHECK: @nullable_pointer_c = external global
+@_extern(c)
+var nullable_pointer_c: UnsafeMutablePointer<Int>?
+
+func acceptInt(_: Int) { }
+
 func test() {
   // CHECK: call void @explicit_extern_c()
   explicit_extern_c()
@@ -12,6 +23,11 @@ func test() {
   default_arg_value()
   // CHECK: call void @default_arg_value(i32 24)
   default_arg_value(24)
+
+  // CHECK: call void @swift_beginAccess(ptr @pointer_c
+  // CHECK-NEXT: [[POINTEE_VAL:%[0-9]+]] = load ptr, ptr @pointer_c
+  // CHECK-NEXT: call void @swift_endAccess
+  acceptInt(pointer_c.pointee)
 }
 
 test()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -disable-availability-checking
 
-// https://github.com/apple/swift/issues/70776
-// REQUIRES: github70776
 // REQUIRES: swift_feature_Extern
 
 @_extern(wasm, module: "m1", name: "f1")
@@ -13,7 +11,7 @@ func f2ErrorOnMissingNameLiteral(x: Int) -> Int // expected-error{{expected '{' 
 @_extern(wasm, module: "m3", name) // expected-error  {{expected ':' after label 'name'}}
 func f3ErrorOnMissingNameColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m4",) // expected-error  {{expected name argument to @_extern attribute}}
+@_extern(wasm, module: "m4",) // expected-error  {{expected name argument to '@_extern'}}
 func f4ErrorOnMissingNameLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
 @_extern(wasm, module: "m5") // expected-error {{expected ',' in '_extern' attribute}}
@@ -25,19 +23,19 @@ func f6ErrorOnMissingModuleLiteral(x: Int) -> Int // expected-error{{expected '{
 @_extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in '_extern' attribute}}
 func f7ErrorOnMissingModuleColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm,) // expected-error {{expected module argument to @_extern attribute}} expected-error {{expected ',' in '_extern' attribute}}
+@_extern(wasm,) // expected-error {{expected module argument to '@_extern'}} expected-error {{expected ',' in '_extern' attribute}}
 func f8ErrorOnMissingModuleLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
 @_extern(wasm, module: "m9", name: "f9")
 func f9WithBody() {} // expected-error {{unexpected body of function declaration}}
 
 struct S {
-    @_extern(wasm, module: "m10", name: "f10") // expected-error {{@_extern attribute can only be applied to global functions}}
+    @_extern(wasm, module: "m10", name: "f10") // expected-error {{'@_extern' can only be applied to globals}}
     func f10Member()
 }
 
 func f11Scope() {
-    @_extern(wasm, module: "m11", name: "f11")
+    @_extern(wasm, module: "m11", name: "f11") // expected-error{{'@_extern' can only be applied to globals}}
     func f11Inner()
 }
 
@@ -50,7 +48,7 @@ func externCValid()
 @_extern(c, "_start_with_underscore")
 func underscoredValid()
 
-@_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
+@_extern(c, "") // expected-error {{expected non-empty C name in '@_extern'}}
 func emptyCName()
 
 // Allow specifying any identifier explicitly
@@ -70,20 +68,25 @@ func omitCName()
 func editingCName() // expected-error {{expected '{' in body of function declaration}}
 
 struct StructScopeC {
-    @_extern(c, "member_decl") // expected-error {{@_extern attribute can only be applied to global functions}}
+    @_extern(c, "member_decl") // expected-error {{'@_extern' can only be applied to globals}}
     func memberDecl()
 
     @_extern(c, "static_member_decl")
     static func staticMemberDecl()
 }
 
+struct GenericStruct<T> {
+  @_extern(c, "static_member_decl") // expected-error{{'@_extern' can only be applied to globals}}
+  static func genericStaticMemberDecl()
+}
+
 func funcScopeC() {
-    @_extern(c, "func_scope_inner")
+    @_extern(c, "func_scope_inner") // expected-error {{'@_extern' can only be applied to globals}}
     func inner()
 }
 
-@_extern(c, "c_value") // expected-error {{@_extern may only be used on 'func' declarations}}
-var nonFunc: Int = 0
+@_extern(c, "c_value")
+var nonFunc: Int = 0 // expected-error{{'@_extern' variable cannot have an initializer}}
 
 @_extern(c, "with_body")
 func withInvalidBody() {} // expected-error {{unexpected body of function declaration}}
@@ -134,23 +137,23 @@ func throwsFuncC() throws // expected-error {{raising errors from C functions is
 @_extern(c)
 func genericFuncC<T>(_: T) // expected-error {{'T' cannot be represented in C}}
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_Wasm()
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_Wasm()
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}} expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
 @_cdecl("another_c_name")
 @_silgen_name("another_sil_name")
 func withAtSILGenName_CDecl_C()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -73,6 +73,9 @@ struct StructScopeC {
 
     @_extern(c, "static_member_decl")
     static func staticMemberDecl()
+
+    @_extern(c, "global_static_variable")
+    static var globalVariable: Int
 }
 
 struct GenericStruct<T> {


### PR DESCRIPTION
Allow external declaration of global variables via `@_extern(c)`. Such variables need to have types represented in C (of course), have only storage (no accessors), and cannot have initializers. At the SIL level, we use the SIL asmname attribute to get the appropriate C name.

While here, slightly shore up the `@_extern(c)` checking, which should fix issue #70776 / rdar://153515764.
