### PR TITLE
Fix emitLoadOfLValue for +0 values produced from a physical component

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5530,9 +5530,9 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
         projection =
             emitLoad(loc, projection.getValue(), origFormalType,
                      substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);
-      } else if (isReadAccessResultOwned(src.getAccessKind()) &&
-          !projection.isPlusOneOrTrivial(*this)) {
-
+      } else if (!projection.isPlusOneOrTrivial(*this) &&
+                 (!C.isImmediatePlusZeroOk() &&
+                  !(C.isGuaranteedPlusZeroOk() && isBaseGuaranteed))) {
         // Before we copy, if we have a move only wrapped value, unwrap the
         // value using a guaranteed moveonlywrapper_to_copyable.
         if (projection.getType().isMoveOnlyWrapped()) {

--- a/test/SILGen/borrow_accessor_unit.swift
+++ b/test/SILGen/borrow_accessor_unit.swift
@@ -1,0 +1,26 @@
+// RUN:%target-swift-frontend -emit-silgen %s -enable-experimental-feature BorrowAndMutateAccessors
+
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
+public final class Klass {}
+
+public struct Wrapper {
+  var _k: Klass
+
+  var k: Klass {
+    borrow {
+      return _k
+    }
+    mutate {
+      return &_k
+    }
+  }
+}
+
+@inline(never)
+func blackhole<T>(_ t: T) { }
+
+func inoutTest(_ w: inout Wrapper) {
+  let k = w.k
+  blackhole(k) 
+}


### PR DESCRIPTION
Create a copy of the projected +0 value based on `SGFContext` instead of `src.getAccessKind()`. This is needed in cases we have a `BorrowedAddressRead` with an `SGFContext` requiring owned value.


