### PR TITLE
[CAS] Support legacy prefix map option

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2343,7 +2343,7 @@ def scanner_prefix_map_paths : MultiArg<["-"], "scanner-prefix-map-paths", 2>,
   HelpText<"Remap paths reported by dependency scanner">, MetaVarName<"<prefix> <replacement>">;
 
 def scanner_prefix_map : Separate<["-"], "scanner-prefix-map">,
-  Flags<[NewDriverOnlyOption]>,
+  Flags<[FrontendOption, NewDriverOnlyOption]>,
   HelpText<"Remap paths reported by dependency scanner">, MetaVarName<"<prefix=replacement>">;
 
 def scanner_prefix_map_sdk : Separate<["-"], "scanner-prefix-map-sdk">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2519,6 +2519,12 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
     Opts.ScannerPrefixMapper.push_back({A->getValue(0), A->getValue(1)});
   }
 
+  // Handle legacy prefix map option.
+  for (StringRef Opt : Args.getAllArgValues(OPT_scanner_prefix_map)) {
+    if (auto Mapping = llvm::MappedPrefix::getFromJoined(Opt))
+      Opts.ScannerPrefixMapper.push_back({Mapping->Old, Mapping->New});
+  }
+
   Opts.ResolvedPluginVerification |=
       Args.hasArg(OPT_resolved_plugin_verification);
 

--- a/test/CAS/module_path_remap.swift
+++ b/test/CAS/module_path_remap.swift
@@ -31,4 +31,11 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F commandLine | %FileCheck %s -check-prefix CLANG-CMD
 // CLANG-CMD: /^src/test/ScanDependencies/Inputs/CHeaders/module.modulemap
 
+/// Check the legacy option.
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps2.json \
+// RUN:  -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -emit-dependencies \
+// RUN:  -import-objc-header %S/../ScanDependencies/Inputs/CHeaders/Bridging.h -swift-version 4 -cache-compile-job \
+// RUN:  -cas-path %t/cas -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-output-dir %t -auto-bridging-header-chaining
 
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps2.json deps2 casFSRootID > %t/deps2.fs.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/deps2.fs.casid | %FileCheck %s -check-prefix DEPS-FS


### PR DESCRIPTION
Bring back legacy prefix map option to allow an older swift-driver to work with newer swift-frontend. For old swift-driver, it will always send the old style prefix map option, so the new compiler needs to support that.

rdar://164208526

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
