### PR TITLE
Fix Issue #68212: Preserve type specialization in typealias extensions

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3068,10 +3068,10 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(unboundGeneric->getDecl())) {
       auto underlyingType = aliasDecl->getUnderlyingType();
       if (auto extendedNominal = underlyingType->getAnyNominal()) {
-        return TypeChecker::isPassThroughTypealias(
-                   aliasDecl, extendedNominal)
-                   ? extendedType
-                   : extendedNominal->getDeclaredType();
+        // Return the typealias type itself to preserve specialization info.
+        // Previously we returned the nominal's declared type which lost
+        // information about partial type specialization. See Issue #68212.
+        return extendedType;
       }
 
       if (underlyingType->is<TupleType>()) {


### PR DESCRIPTION
When extending a partially specialized generic typealias (e.g., 'typealias IntField<Tag> = Field<Tag, Int>'), the compiler was losing type specialization information and returning only the base nominal type (Field<Tag, Value>), causing type checker errors when trying to use specialized type information in the extension body.

This fix ensures that we return the typealias type itself, which properly preserves the partial specialization constraints.

The previous logic used isPassThroughTypealias() to decide between returning extendedType or extendedNominal->getDeclaredType(). When the latter was returned, it lost the specialization information (e.g., that Value == Int in IntField<Tag>).

By always returning extendedType for typealias extensions, we preserve the full type information and allow the type checker to correctly resolve types in the extension body.

Fixes: https://github.com/swiftlang/swift/issues/68212

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
