### PR TITLE
[CAS] Don't leak `-iapinotes-modules` clang flag in caching build

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4363,6 +4363,9 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   FEOpts.IncludeTimestamps = false;
   FEOpts.ModuleMapFiles.clear();
 
+  // APINotesOptions.
+  instance.getAPINotesOpts().ModuleSearchPaths.clear();
+
   // IndexStorePath is forwarded from swift.
   FEOpts.IndexStorePath.clear();
 

--- a/test/CAS/apinotes.swift
+++ b/test/CAS/apinotes.swift
@@ -1,0 +1,29 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t
+
+// RUN: %FileCheck --input-file=%t/deps.json %s
+
+// CHECK-NOT: -iapinotes-modules
+
+//--- main.swift
+import A
+
+//--- module.modulemap
+module A { header "A.h" export *}
+
+//--- A.h
+#pragma once
+void a(void);
+
+//--- A.apinotes
+Name: A
+Functions:
+  - Name: a
+    Availability: none
+    AvailabilityMsg: "don't use this"


### PR DESCRIPTION
The search paths for apinotes are leaked when using compilation caching but they are not needed like other search path because the apinotes are found and stored inside include-tree.

rdar://164205657

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
