### PR TITLE
[utils] mark update-verify-tests tests unsupported with old Python

### DIFF
--- a/test/Utils/update-verify-tests/lit.local.cfg
+++ b/test/Utils/update-verify-tests/lit.local.cfg
@@ -1,0 +1,4 @@
+import sys
+
+if sys.version_info < (3, 9):
+    config.unsupported = True


### PR DESCRIPTION
This utility uses the walrus operator introduced in Python 3.8, but this causes tests to fail in Amazon Linux 2 CI, which uses Python 3.7. Since this is not a shipped product, that doesn't really matter, and 3.7 is an ancient EOL version anyways. The premerge CI uses Python 3.9 and later, so use that as a basis, just to avoid the same issue in the future in case some Python 3.9 feature sneaks in.

rdar://164151931