### PR TITLE
SILGen: add RValue emission for BorrowExpr

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2508,6 +2508,24 @@ public:
       verifyCheckedBase(E);
     }
 
+    void verifyChecked(BorrowExpr *E) {
+      PrettyStackTraceExpr debugStack(Ctx, "verifying BorrowExpr", E);
+
+      auto toType = E->getType();
+      auto fromType = E->getSubExpr()->getType();
+
+      // FIXME: doesStorageProduceLValue should not return false for a 'let',
+      //   so that you can borrow from it.
+      if (!fromType->hasLValueType())
+        error("borrow source must be an l-value", E);
+
+      // Result type can be either l-value or r-value.
+      // Ensure underlying type matches.
+      if (fromType->getRValueType()->getCanonicalType() !=
+          toType->getRValueType()->getCanonicalType())
+        error("borrow should not be performing a cast", E);
+    }
+
     void verifyChecked(ABISafeConversionExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verify ABISafeConversionExpr", E);
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1132,6 +1132,16 @@ bool TypeChecker::checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc) {
 }
 
 Expr *
+TypeChecker::addImplicitBorrowExpr(ASTContext &Ctx, Expr *E,
+                                 std::function<Type(Expr *)> getType,
+                                 std::function<void(Expr *, Type)> setType) {
+  auto objectType = getType(E)->getRValueType();
+  auto *BE = BorrowExpr::createImplicit(Ctx, E->getLoc(), E, objectType);
+  setType(BE, objectType);
+  return BE;
+}
+
+Expr *
 TypeChecker::addImplicitLoadExpr(ASTContext &Context, Expr *expr,
                                  std::function<Type(Expr *)> getType,
                                  std::function<void(Expr *, Type)> setType) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -882,6 +882,12 @@ Expr *addImplicitLoadExpr(
     std::function<void(Expr *, Type)> setType =
         [](Expr *E, Type type) { E->setType(type); });
 
+Expr *addImplicitBorrowExpr(
+    ASTContext &Context, Expr *expr,
+    std::function<Type(Expr *)> getType = [](Expr *E) { return E->getType(); },
+    std::function<void(Expr *, Type)> setType =
+        [](Expr *E, Type type) { E->setType(type); });
+
 /// Determine whether the given type either conforms to, or itself an
 /// existential subtype of, the given protocol.
 ///

--- a/test/ASTGen/exprs.swift
+++ b/test/ASTGen/exprs.swift
@@ -83,7 +83,7 @@ func asyncFunc(_ arg: String) async throws -> Int {
   return 1
 }
 func testUnaryExprs() async throws {
-  let str = String()
+  var str = String()
   let foo = try await asyncFunc(_borrow str)
   let bar = copy foo
   let baz = consume foo

--- a/test/Parse/borrow_expr.swift
+++ b/test/Parse/borrow_expr.swift
@@ -5,11 +5,6 @@ func testGlobal() {
     let _ = _borrow global
 }
 
-func testLet() {
-    let t = String()
-    let _ = _borrow t
-}
-
 func testVar() {
     var t = String()
     t = String()


### PR DESCRIPTION
This is some infrastructure I've factored out of a larger experimental feature to borrow more often than we currently do.

The experimental feature is not yet ready to merge, but I wanted to make the infrastructure available for others.