### PR TITLE
[cxx-interop] Fix-up `-emit-clang-header-min-access` flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -816,9 +816,9 @@ def emit_clang_header_path : Separate<["-"], "emit-clang-header-path">,
   Alias<emit_objc_header_path>;
 
 def emit_clang_header_min_access : Separate<["-"], "emit-clang-header-min-access">,
-  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath, CacheInvariant]>,
+  Flags<[FrontendOption, NoInteractiveOption, CacheInvariant]>,
   MetaVarName<"<access-level>">,
-  HelpText<"The minimum access level of declarations to include in the emitted header.>">;
+  HelpText<"The minimum access level of declarations to include in the emitted header">;
 
 def static : Flag<["-"], "static">,
   Flags<[FrontendOption, ModuleInterfaceOption, NoInteractiveOption]>,


### PR DESCRIPTION
This fixes a minor issue with the flag: its argument is not a actually a file system path (`ArgumentIsPath`).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
