### PR TITLE
[Runtime] Don't use write back in EIC retain/release

### DIFF
--- a/stdlib/public/SwiftDirectRuntime/RetainRelease.s
+++ b/stdlib/public/SwiftDirectRuntime/RetainRelease.s
@@ -192,7 +192,8 @@ Lslowpath_release:
 // Save/restore the preservemost registers and call swift_retain.
 Lcall_swift_release:
   maybe_pacibsp
-  str   x9, [sp, #-0x50]!
+  sub   sp, sp, #0x50
+  str   x9, [sp]
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -207,12 +208,14 @@ Lcall_swift_release:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldr   x9, [sp], #0x50
+  ldr   x9, [sp]
+  add   sp, sp, #0x50
   ret_maybe_ab
 
 LbridgeObjectReleaseDirectObjC:
   maybe_pacibsp
-  stp   x0, x9, [sp, #-0x50]!
+  sub   sp, sp, #0x50
+  stp   x0, x9, [sp]
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -227,7 +230,8 @@ LbridgeObjectReleaseDirectObjC:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp], #0x50
+  ldp   x0, x9, [sp]
+  add   sp, sp, #0x50
 LbridgeObjectReleaseObjCRet:
   ret_maybe_ab
 
@@ -330,7 +334,8 @@ Lslowpath_retain:
 // Save/restore the preservemost registers and call swift_retain.
 Lcall_swift_retain:
   maybe_pacibsp
-  stp   x0, x9, [sp, #-0x50]!
+  sub   sp, sp, #0x50
+  stp   x0, x9, [sp]
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -345,12 +350,14 @@ Lcall_swift_retain:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp], #0x50
+  ldp   x0, x9, [sp]
+  add   sp, sp, #0x50
   ret_maybe_ab
 
 Lswift_bridgeObjectRetainDirectObjC:
   maybe_pacibsp
-  stp   x0, x9, [sp, #-0x50]!
+  sub   sp, sp, #0x50
+  stp   x0, x9, [sp]
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -365,7 +372,8 @@ Lswift_bridgeObjectRetainDirectObjC:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp], #0x50
+  ldp   x0, x9, [sp]
+  add   sp, sp, #0x50
   ret_maybe_ab
 
 #else


### PR DESCRIPTION
The write back creates a false dependency between the first and subsequent stores when creating and the last load and subsequent ops when destroying a stack frame.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
