### PR TITLE
[stdlib] Minor clean-up and new fast path for larger (e.g. 128-bit) integer printing

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1724,7 +1724,7 @@ extension BinaryInteger {
       //   `i + 2` to the power of `j`; or, if `i + 2` is a power of 2, the
       //   exponent `k` such that `1 << k` is the result of raising `i + 2` to
       //   the power of `j`.
-      let lookup: InlineArray<35, UInt64> = [
+      let lookup: _InlineArray<35, UInt64> = [
         0x40_00000000000040, 0x23_b1bf6cd930979b, 0x20_00000000000040,
         0x18_d3c21bcecceda1, 0x15_4def8a56600000, 0x13_287f3c1a5b27d7,
         0x15_0000000000003f, 0x11_3b3fcef3103289, 0x10_2386f26fc10000,

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1755,7 +1755,7 @@ extension BinaryInteger {
           offset &-= chunkByteCount
           (value, remainder) = value.quotientAndRemainder(dividingBy: divisor)
 
-          precondition(offset >= chunkSafetyMargin, "Insufficient buffer size")
+          _precondition(offset >= chunkSafetyMargin, "Insufficient buffer size")
           let buffer_ =
             unsafe UnsafeMutableBufferPointer<UTF8.CodeUnit>(
               _uncheckedStart: buffer.baseAddress! + offset,
@@ -1778,7 +1778,7 @@ extension BinaryInteger {
           remainder = UInt64(truncatingIfNeeded: value) & mask
           value >>= divisorOrRightShiftCount
 
-          precondition(offset >= chunkSafetyMargin, "Insufficient buffer size")
+          _precondition(offset >= chunkSafetyMargin, "Insufficient buffer size")
           let buffer_ =
             unsafe UnsafeMutableBufferPointer<UTF8.CodeUnit>(
               _uncheckedStart: buffer.baseAddress! + offset,
@@ -1793,7 +1793,7 @@ extension BinaryInteger {
         }
       }
 
-      precondition(offset >= safetyMargin, "Insufficient buffer size")
+      _precondition(offset >= safetyMargin, "Insufficient buffer size")
       let buffer_ =
         unsafe UnsafeMutableBufferPointer<UTF8.CodeUnit>(
           _uncheckedStart: buffer.baseAddress!,

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1645,7 +1645,7 @@ extension BinaryInteger {
   internal func _description(radix: Int, uppercase: Bool) -> String {
     _precondition(radix >= 2 && radix <= 36, "Radix must be between 2 and 36")
 
-    if _fastPath(bitWidth <= 64 || magnitude < UInt64.max) {
+    if _fastPath(bitWidth <= 64 || magnitude <= UInt64.max) {
       if radix >= 10 {
         var buffer = _InlineArray<21, UTF8.CodeUnit>(repeating: 0x30)
         var span = buffer.mutableSpan


### PR DESCRIPTION
A follow-up to #85180.

First, make the guarantee that our Swift-native implementation of integer-to-ASCII conversion always fills the _suffix_ of the given mutable span.

(Some minor swift-format corrections interspersed.)

Then, use that guarantee to work in 64-bit (or rather, for most bases, 56-bit) chunks for larger integers.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
