### PR TITLE
Only print SIL before sub-passes of selected passes with -sil-print-every-subpass

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -487,7 +487,8 @@ bool SILPassManager::continueWithNextSubpassRun(
 
   unsigned subPass = numSubpassesRun++;
 
-  if (isFunctionSelectedForPrinting(function) && SILPrintEverySubpass) {
+  if (SILPrintEverySubpass && isFunctionSelectedForPrinting(function) &&
+      doPrintBefore(trans, function)) {
     dumpPassInfo("*** SIL function before ", trans, function);
     llvm::dbgs() << "  *** sub-pass " << subPass << " for ";
     if (forTransformee) {


### PR DESCRIPTION
rdar://164256638

Problem:
I’ve recently been fixing bugs that cause debug info to be lost in optimized Swift builds. Several of these were in the SILCombine and Simplification optimization passes, which have many unrelated sub-passes. To narrow down which sub-pass dropped debug info, I had to rely on the -sil-print-every-subpass option.

With this option, the SIL for each selected function is printed before every sub-pass of every pass. This includes passes that may not be relevant to what the developer is investigating, and the resulting output can easily exceed 100MB of text, due to the large number of sub-passes in passes like SimplifyCFG.

To fix this, I would suggest making -sil-print-every-subpass respect the -sil-print-before and -sil-print-around options.

Positive Case:
```
sil-opt -O -sil-print-before=SILCombine -sil-print-every-subpass any-sil-file.sil
sil-opt -O -sil-print-around=SILCombine -sil-print-every-subpass any-sil-file.sil
```
Expected result: SIL is only printed before sub-passes of SILCombine
Actual result: SIL is printed before sub-passes of every pass.

Negative Case:
```
sil-opt -O -sil-print-every-subpass any-sil-file.sil
```
Expected result: No "pre-subpass" SIL is printed.
Actual result: SIL is printed before sub-passes of every pass.