### PR TITLE
[ClangImporter] Check for builtin conformance in `importNumericLiteral`

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1698,7 +1698,6 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
   auto builtinProtocol = getProtocol(builtinProtocolKind);
   auto builtinConformance = lookupConformance(type, builtinProtocol);
   if (builtinConformance.isInvalid()) {
-    assert(false && "Missing required conformance");
     witness = ConcreteDeclRef();
     return witness;
   }
@@ -1706,7 +1705,6 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
   auto *ctx = const_cast<ASTContext *>(this);
   witness = builtinConformance.getWitnessByName(initName(*ctx));
   if (!witness) {
-    assert(false && "Missing required witness");
     witness = ConcreteDeclRef();
     return witness;
   }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -125,6 +125,11 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         return nullptr;
     }
 
+    auto &ctx = DC->getASTContext();
+    auto *constantTyNominal = constantType->getAnyNominal();
+    if (!constantTyNominal)
+      return nullptr;
+
     if (auto *integer = dyn_cast<clang::IntegerLiteral>(parsed)) {
       // Determine the value.
       llvm::APSInt value{integer->getValue(), clangTy->isUnsignedIntegerType()};
@@ -139,6 +144,16 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
           value.flipAllBits();
         }
       }
+
+      // Make sure the destination type actually conforms to the builtin literal
+      // protocol before attempting to import, otherwise we'll crash since
+      // `createConstant` expects it to.
+      // FIXME: We ought to be careful checking conformance here since it can
+      // result in cycles. Additionally we ought to consider checking for the
+      // non-builtin literal protocol to allow any ExpressibleByIntegerLiteral
+      // type to be supported.
+      if (!ctx.getIntBuiltinInitDecl(constantTyNominal))
+        return nullptr;
 
       return createMacroConstant(Impl, MI, name, DC, constantType,
                                  clang::APValue(value),
@@ -157,6 +172,16 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
       if (signTok && signTok->is(clang::tok::minus)) {
         value.changeSign();
       }
+
+      // Make sure the destination type actually conforms to the builtin literal
+      // protocol before attempting to import, otherwise we'll crash since
+      // `createConstant` expects it to.
+      // FIXME: We ought to be careful checking conformance here since it can
+      // result in cycles. Additionally we ought to consider checking for the
+      // non-builtin literal protocol to allow any ExpressibleByFloatLiteral
+      // type to be supported.
+      if (!ctx.getFloatBuiltinInitDecl(constantTyNominal))
+        return nullptr;
 
       return createMacroConstant(Impl, MI, name, DC, constantType,
                                  clang::APValue(value),

--- a/test/ClangImporter/rdar156524292.swift
+++ b/test/ClangImporter/rdar156524292.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t -verify-additional-file %t/cmodule.h
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+//--- cmodule.h
+#import <CoreGraphics/CoreGraphics.h>
+#define intLiteralCGFloat ((CGFloat)0)
+// expected-note@-1 {{invalid numeric literal}}
+// expected-note@-2 {{macro 'intLiteralCGFloat' unavailable (cannot import)}}
+#define floatLiteralCGFloat ((CGFloat)0.0)
+// expected-note@-1 {{invalid numeric literal}}
+// expected-note@-2 {{macro 'floatLiteralCGFloat' unavailable (cannot import)}}
+
+//--- module.modulemap
+module CModule [system] {
+  header "cmodule.h"
+  export *
+}
+
+//--- main.swift
+import CModule
+
+// Make sure we don't crash when attempting to import these.
+_ = intLiteralCGFloat // expected-error {{cannot find 'intLiteralCGFloat' in scope}}
+_ = floatLiteralCGFloat // expected-error {{cannot find 'floatLiteralCGFloat' in scope}}


### PR DESCRIPTION
Make sure the destination type actually conforms to the corresponding builtin literal protocol before attempting to import it. We may want to consider allowing any type that conforms to the non-builtin literal protocol, but I want to keep this patch low risk and just ensure we at least don't crash for now.

rdar://156524292