### PR TITLE
Support 'as UInt8' in @section expressions

### DIFF
--- a/lib/Sema/LegalConstExprVerifier.cpp
+++ b/lib/Sema/LegalConstExprVerifier.cpp
@@ -176,6 +176,16 @@ checkSupportedWithSectionAttribute(const Expr *expr,
       // Non-InlineArray arrays are not allowed
       return std::make_pair(expr, TypeNotSupported);
     }
+    
+    // Coerce expressions to UInt8 are allowed (to support @DebugDescription)
+    if (const CoerceExpr *coerceExpr = dyn_cast<CoerceExpr>(expr)) {
+      auto coerceType = coerceExpr->getType();
+      if (coerceType && coerceType->isUInt8()) {
+        expressionsToCheck.push_back(coerceExpr->getSubExpr());
+        continue;
+      }
+      return std::make_pair(expr, TypeNotSupported);
+    }
 
     // Operators are not allowed in @section expressions
     if (isa<BinaryExpr>(expr)) {

--- a/test/ConstValues/SectionSyntactic.swift
+++ b/test/ConstValues/SectionSyntactic.swift
@@ -35,8 +35,8 @@
 // non-literal expressions (should be rejected)
 @section("mysection") let invalidNonLiteral1 = Int.max
 // expected-error@-1{{not supported in a constant expression}}
-@section("mysection") let invalidNonLiteral2 = UInt8(42)
-// expected-error@-1{{not supported in a constant expression}}
+@section("mysection") let invalidNonLiteral2 = UInt64(42)
+// expected-error@-1{{unsupported type in a constant expression}}
 @section("mysection") let invalidNonLiteral3 = true.hashValue
 // expected-error@-1{{not supported in a constant expression}}
 
@@ -85,6 +85,7 @@ enum E { case a }
 @section("mysection") let tuple1 = (1, 2, 3, 2.718, true) // ok
 @section("mysection") let tuple2: (Int, Float, Bool) = (42, 3.14, false) // ok
 @section("mysection") let tuple3 = (foo, bar) // ok (function references in tuple)
+@section("mysection") let tuple4 = (1 as UInt8, 2 as UInt8, 3 as UInt8) // ok
 
 // invalid tuples (should be rejected)
 @section("mysection") let invalidTuple1 = (1, 2, Int.max)


### PR DESCRIPTION
Because some SDKs contain an implementation of `@DebugDescription` macro that still expands to `(... as UInt8, ...)`, we need to allow it in the new strict/stable `@section` expressions.

rdar://164052997
