### PR TITLE
[AST/Serialization] A few fixes for `nonisolated(nonsending)` handling

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7031,9 +7031,6 @@ class ParamDecl : public VarDecl {
 
     /// Whether or not this parameter is 'sending'.
     IsSending = 1 << 4,
-
-    /// Whether or not this parameter is isolated to a caller.
-    IsCallerIsolated = 1 << 5,
   };
 
   /// The type repr and 3 bits used for flags.
@@ -7332,18 +7329,6 @@ public:
       addFlag(Flag::IsSending);
     else
       removeFlag(Flag::IsSending);
-  }
-
-  /// Whether or not this parameter is marked with 'nonisolated(nonsending)'.
-  bool isCallerIsolated() const {
-    return getOptions().contains(Flag::IsCallerIsolated);
-  }
-
-  void setCallerIsolated(bool value = true) {
-    if (value)
-      addFlag(Flag::IsCallerIsolated);
-    else
-      removeFlag(Flag::IsCallerIsolated);
   }
 
   /// Whether or not this parameter is marked with '@_addressable'.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -127,9 +127,11 @@ struct ShouldPrintChecker {
 
 /// Type-printing options which should only be applied to the outermost
 /// type.
-enum class NonRecursivePrintOption: uint32_t {
+enum class NonRecursivePrintOption : uint32_t {
   /// Print `Optional<T>` as `T!`.
   ImplicitlyUnwrappedOptional = 1 << 0,
+  /// Avoid printing `nonisolated(nonsending)` modifier.
+  SkipNonisolatedNonsending = 1 << 1,
 };
 using NonRecursivePrintOptions = OptionSet<NonRecursivePrintOption>;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9206,6 +9206,7 @@ void ParamDecl::setTypeRepr(TypeRepr *repr) {
               dyn_cast<CallerIsolatedTypeRepr>(unwrappedType)) {
         setCallerIsolated(true);
         unwrappedType = callerIsolated->getBase();
+        continue;
       }
 
       break;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9204,7 +9204,6 @@ void ParamDecl::setTypeRepr(TypeRepr *repr) {
 
       if (auto *callerIsolated =
               dyn_cast<CallerIsolatedTypeRepr>(unwrappedType)) {
-        setCallerIsolated(true);
         unwrappedType = callerIsolated->getBase();
         continue;
       }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4222,7 +4222,6 @@ public:
     bool isIsolated;
     bool isCompileTimeLiteral, isConstValue;
     bool isSending;
-    bool isCallerIsolated;
     bool isAddressable;
     uint8_t rawDefaultArg;
     TypeID defaultExprType;
@@ -4236,7 +4235,6 @@ public:
                                          isCompileTimeLiteral,
                                          isConstValue,
                                          isSending,
-                                         isCallerIsolated,
                                          isAddressable,
                                          rawDefaultArg,
                                          defaultExprType,
@@ -4283,7 +4281,6 @@ public:
     param->setCompileTimeLiteral(isCompileTimeLiteral);
     param->setConstValue(isConstValue);
     param->setSending(isSending);
-    param->setCallerIsolated(isCallerIsolated);
     param->setAddressable(isAddressable);
 
     // Decode the default argument kind.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 973; // @export attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 974; // remove 'isCallerIsolated' bit from ParamDecl
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1763,7 +1763,6 @@ namespace decls_block {
     BCFixed<1>,              // isCompileTimeLiteral?
     BCFixed<1>,              // isConst?
     BCFixed<1>,              // isSending?
-    BCFixed<1>,              // isCallerIsolated?
     BCFixed<1>,              // isAddressable?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4808,7 +4808,6 @@ public:
         param->isCompileTimeLiteral(),
         param->isConstVal(),
         param->isSending(),
-        param->isCallerIsolated(),
         param->isAddressable(),
         getRawStableDefaultArgumentKind(argKind),
         S.addTypeRef(defaultExprType),

--- a/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
+++ b/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
@@ -10,6 +10,8 @@
 // RUN:   -emit-module-path %t/A.swiftmodule \
 // RUN:   -emit-module-interface-path %t/A.swiftinterface
 
+// RUN: %FileCheck %t/src/A.swift --input-file %t/A.swiftinterface
+
 // RUN: %target-swift-typecheck-module-from-interface(%t/A.swiftinterface) -module-name A
 
 // Build the client using module
@@ -22,9 +24,22 @@
 
 //--- A.swift
 @MainActor
-
 public final class Test {
+  // CHECK: nonisolated(nonsending) final public func test() async
   public nonisolated func test() async {}
+
+  // CHECK: @_Concurrency.MainActor final public func compute(callback: nonisolated(nonsending) @escaping @Sendable () async -> Swift.Void)
+  public func compute(callback: @escaping @Sendable () async -> Void) {}
+}
+
+public struct InferenceTest {
+  // CHECK: nonisolated(nonsending) public func infersAttr() async
+  public func infersAttr() async {}
+
+  // CHECK: public func testNested(callback: @escaping (nonisolated(nonsending) @Sendable () async -> Swift.Void) -> Swift.Void)
+  public func testNested(callback: @escaping (@Sendable () async -> Void) -> Void) {}
+  // CHECK: public func testNested(dict: [Swift.String : (nonisolated(nonsending) () async -> Swift.Void)?])
+  public func testNested(dict: [String: (() async -> Void)?]) {}
 }
 
 //--- Client.swift
@@ -41,4 +56,25 @@ import A
 @MainActor
 func test(t: Test) async {
   await t.test() // Ok
+}
+
+// CHECK-LABEL: sil hidden @$s6Client16testWithCallback1ty1A4TestC_tYaF : $@convention(thin) @async (@guaranteed Test) -> ()
+// CHECK: function_ref @$s1A4TestC7compute8callbackyyyYaYbYCc_tF : $@convention(method) (@guaranteed @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> (), @guaranteed Test) -> ()
+// CHECK: } // end sil function '$s6Client16testWithCallback1ty1A4TestC_tYaF'
+@MainActor
+func testWithCallback(t: Test) async {
+  t.compute(callback: {})
+}
+
+// CHECK-LABEL: sil hidden @$s6Client13testInference1ty1A0C4TestV_tYaF : $@convention(thin) @async (@in_guaranteed InferenceTest) -> ()
+// CHECK: function_ref @$s1A13InferenceTestV10infersAttryyYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed InferenceTest) -> ()
+// CHECK: function_ref @$s1A13InferenceTestV10testNested8callbackyyyyYaYbYCXEc_tF : $@convention(method) (@guaranteed @callee_guaranteed (@guaranteed @noescape @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> (), @in_guaranteed InferenceTest) -> ()
+// CHECK: function_ref @$s1A13InferenceTestV10testNested4dictySDySSyyYaYCcSgG_tF : $@convention(method) (@guaranteed Dictionary<String, Optional<nonisolated(nonsending) () async -> ()>>, @in_guaranteed InferenceTest) -> ()
+// CHECK: } // end sil function '$s6Client13testInference1ty1A0C4TestV_tYaF'
+@MainActor
+func testInference(t: InferenceTest) async {
+    await t.infersAttr()
+
+    t.testNested { _ in }
+    t.testNested(dict: [:])
 }


### PR DESCRIPTION
- Fix printing of `nonisolated(nonsending)` in parameter type positions

    Printing shouldn't rely on parameter declaration bit because it only
    works in cases when there is an explicit `nonisolated(nonsending)`
    modifier on the type.

    Always print `nonisolated(nonsending)` before `sending`, `@escaping`
    and other declaration attributes/modifiers to avoid parsing issues.

- Make sure that `nonisolated(nonsending)` works together with `@autoclosure`

- Remove `isCallerIsolated` bit from `ParamDecl` as obsolete.

Resolves: rdar://164267736

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
