### PR TITLE
[AST] NFC: Rename `LookupConformanceInModuleRequest` -> `LookupConformanceRequest`

### DIFF
--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -776,10 +776,11 @@ void simple_display(llvm::raw_ostream &out,
 
 SourceLoc extractNearestSourceLoc(const LookupConformanceDescriptor &desc);
 
-class LookupConformanceInModuleRequest
-    : public SimpleRequest<LookupConformanceInModuleRequest,
+class LookupConformanceRequest
+    : public SimpleRequest<LookupConformanceRequest,
                            ProtocolConformanceRef(LookupConformanceDescriptor),
-                           RequestFlags::Uncached|RequestFlags::DependencySink> {
+                           RequestFlags::Uncached |
+                               RequestFlags::DependencySink> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -52,7 +52,7 @@ SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
-SWIFT_REQUEST(NameLookup, LookupConformanceInModuleRequest,
+SWIFT_REQUEST(NameLookup, LookupConformanceRequest,
               ProtocolConformanceRef(LookupConformanceDescriptor),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, LookupInModuleRequest,

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -202,7 +202,7 @@ ProtocolConformanceRef swift::lookupConformance(Type type,
   // If we are recursively checking for implicit conformance of a nominal
   // type to a KnownProtocol, fail without evaluating this request. This
   // squashes cycles.
-  LookupConformanceInModuleRequest request{{type, protocol}};
+  LookupConformanceRequest request{{type, protocol}};
   if (auto kp = protocol->getKnownProtocolKind()) {
     if (auto nominal = type->getAnyNominal()) {
       ImplicitKnownProtocolConformanceRequest icvRequest{nominal, *kp};
@@ -543,8 +543,8 @@ static ProtocolConformanceRef getPackTypeConformance(
 }
 
 ProtocolConformanceRef
-LookupConformanceInModuleRequest::evaluate(
-    Evaluator &evaluator, LookupConformanceDescriptor desc) const {
+LookupConformanceRequest::evaluate(Evaluator &evaluator,
+                                   LookupConformanceDescriptor desc) const {
   auto type = desc.Ty;
   auto *protocol = desc.PD;
   ASTContext &ctx = protocol->getASTContext();

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -427,10 +427,10 @@ void ModuleQualifiedLookupRequest::writeDependencySink(
 }
 
 //----------------------------------------------------------------------------//
-// LookupConformanceInModuleRequest computation.
+// LookupConformanceRequest computation.
 //----------------------------------------------------------------------------//
 
-void LookupConformanceInModuleRequest::writeDependencySink(
+void LookupConformanceRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker,
     ProtocolConformanceRef lookupResult) const {
   if (lookupResult.isInvalid() || !lookupResult.isConcrete())


### PR DESCRIPTION
This request no longer takes a module argument.
