### PR TITLE
embedded: initial support for general existentials in the SIL optimizer

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -132,6 +132,7 @@ final public class ClassDecl: NominalTypeDecl {
 
 final public class ProtocolDecl: NominalTypeDecl {
   public var requiresClass: Bool { bridged.ProtocolDecl_requiresClass() }
+  public var isMarkerProtocol: Bool { bridged.ProtocolDecl_isMarkerProtocol() }
 }
 
 final public class BuiltinTupleDecl: NominalTypeDecl {}

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -143,6 +143,14 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
           }
         }
 
+      case let initExAddr as InitExistentialAddrInst:
+        if context.options.enableEmbeddedSwift {
+          for c in initExAddr.conformances where c.isConcrete && !c.protocol.isMarkerProtocol {
+            specializeWitnessTable(for: c, moduleContext)
+            worklist.addWitnessMethods(of: c, moduleContext)
+          }
+        }
+
       case let bi as BuiltinInst:
         switch bi.id {
         case .BuildOrdinaryTaskExecutorRef,

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -148,7 +148,7 @@ func specializeWitnessTable(for conformance: Conformance, _ context: ModulePassC
       guard !methodSubs.conformances.contains(where: {!$0.isValid}),
             context.loadFunction(function: origMethod, loadCalleesRecursively: true),
             let specializedMethod = context.specialize(function: origMethod, for: methodSubs,
-                                                       convertIndirectToDirect: true, isMandatory: true)
+                                                       convertIndirectToDirect: false, isMandatory: true)
       else {
         return origEntry
       }
@@ -215,7 +215,7 @@ private func specializeDefaultMethods(for conformance: Conformance,
       guard !methodSubs.conformances.contains(where: {!$0.isValid}),
             context.loadFunction(function: origMethod, loadCalleesRecursively: true),
             let specializedMethod = context.specialize(function: origMethod, for: methodSubs,
-                                                       convertIndirectToDirect: true, isMandatory: true)
+                                                       convertIndirectToDirect: false, isMandatory: true)
       else {
         return origEntry
       }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -879,7 +879,15 @@ final public
 class OpenExistentialValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
-class InitExistentialAddrInst : SingleValueInstruction, UnaryInstruction {}
+class InitExistentialAddrInst : SingleValueInstruction, UnaryInstruction {
+  public var conformances: ConformanceArray {
+    ConformanceArray(bridged: bridged.InitExistentialAddrInst_getConformances())
+  }
+
+  public var formalConcreteType: CanonicalType {
+    CanonicalType(bridged: bridged.InitExistentialAddrInst_getFormalConcreteType())
+  }
+}
 
 final public
 class DeinitExistentialAddrInst : Instruction, UnaryInstruction {}

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -347,6 +347,7 @@ struct BridgedDeclObj {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Class_getSuperclass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj Class_getDestructor() const;
   BRIDGED_INLINE bool ProtocolDecl_requiresClass() const;
+  BRIDGED_INLINE bool ProtocolDecl_isMarkerProtocol() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;
   BRIDGED_INLINE bool EnumElementDecl_hasAssociatedValues() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -260,6 +260,10 @@ bool BridgedDeclObj::ProtocolDecl_requiresClass() const {
   return getAs<swift::ProtocolDecl>()->requiresClass();
 }
 
+bool BridgedDeclObj::ProtocolDecl_isMarkerProtocol() const {
+  return getAs<swift::ProtocolDecl>()->isMarkerProtocol();
+}
+
 bool BridgedDeclObj::AbstractFunction_isOverridden() const {
   return getAs<swift::AbstractFunctionDecl>()->isOverridden();
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -808,6 +808,8 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool IndexAddrInst_needsStackProtection() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialRefInst_getConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType InitExistentialRefInst_getFormalConcreteType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialAddrInst_getConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType InitExistentialAddrInst_getFormalConcreteType() const;
   BRIDGED_INLINE bool OpenExistentialAddr_isImmutable() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar GlobalAccessInst_getGlobal() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar AllocGlobalInst_getGlobal() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1288,6 +1288,14 @@ BridgedCanType BridgedInstruction::InitExistentialRefInst_getFormalConcreteType(
   return getAs<swift::InitExistentialRefInst>()->getFormalConcreteType();
 }
 
+BridgedConformanceArray BridgedInstruction::InitExistentialAddrInst_getConformances() const {
+  return {getAs<swift::InitExistentialAddrInst>()->getConformances()};
+}
+
+BridgedCanType BridgedInstruction::InitExistentialAddrInst_getFormalConcreteType() const {
+  return getAs<swift::InitExistentialAddrInst>()->getFormalConcreteType();
+}
+
 bool BridgedInstruction::OpenExistentialAddr_isImmutable() const {
   switch (getAs<swift::OpenExistentialAddrInst>()->getAccessKind()) {
     case swift::OpenedExistentialAccess::Immutable: return true;

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -216,7 +216,9 @@ public:
 
   ReabstractionInfo(CanSILFunctionType substitutedType,
                     SILDeclRef methodDecl,
+                    bool convertIndirectToDirect,
                     SILModule &M) :
+    ConvertIndirectToDirect(convertIndirectToDirect),
     SubstitutedType(substitutedType),
     methodDecl(methodDecl),
     M(&M), isWholeModule(M.isWholeModule()) {}

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2413,7 +2413,8 @@ bool swift::specializeClassMethodInst(ClassMethodInst *cm) {
   SILType substitutedType =
       funcTy.substGenericArgs(m, subs, TypeExpansionContext::minimal());
 
-  ReabstractionInfo reInfo(substitutedType.getAs<SILFunctionType>(), cm->getMember(), m);
+  ReabstractionInfo reInfo(substitutedType.getAs<SILFunctionType>(), cm->getMember(),
+                           /*convertIndirectToDirect=*/ true, m);
   reInfo.createSubstitutedAndSpecializedTypes();
   CanSILFunctionType finalFuncTy = reInfo.getSpecializedType();
   SILType finalSILTy = SILType::getPrimitiveObjectType(finalFuncTy);
@@ -2465,7 +2466,8 @@ bool swift::specializeWitnessMethodInst(WitnessMethodInst *wm) {
   SILType substitutedType =
       funcTy.substGenericArgs(m, subs, TypeExpansionContext::minimal());
 
-  ReabstractionInfo reInfo(substitutedType.getAs<SILFunctionType>(), wm->getMember(), m);
+  ReabstractionInfo reInfo(substitutedType.getAs<SILFunctionType>(), wm->getMember(),
+                           /*convertIndirectToDirect=*/ false, m);
   reInfo.createSubstitutedAndSpecializedTypes();
   CanSILFunctionType finalFuncTy = reInfo.getSpecializedType();
   SILType finalSILTy = SILType::getPrimitiveObjectType(finalFuncTy);

--- a/test/embedded/general-existentials1.swift
+++ b/test/embedded/general-existentials1.swift
@@ -1,0 +1,300 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -O) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -Osize) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedExistentials
+
+protocol P {
+    func foo()
+    func bar()
+    func predicate() -> Bool
+}
+
+extension P {
+  public func predicate() -> Bool { true }
+}
+
+struct MyStruct : P {
+  var i: Int
+
+  func foo() { print("MyStruct.foo: \(i)") }
+  func bar() { print("MyStruct.bar: \(i)") }
+}
+
+struct LargeStruct : P {
+  var a: Int
+  var b: Int
+  var c: Int
+  var d: Int
+
+  func foo() { print("LargeStruct.foo: \(a), \(b), \(c), \(d)") }
+  func bar() { print("LargeStruct.bar: \(a), \(b), \(c), \(d)") }
+}
+
+struct GenericStruct<T: BinaryInteger> : P {
+  var t: T
+
+  func foo() { print("GenericStruct.foo: \(t)") }
+  func bar() { print("GenericStruct.bar: \(t)") }
+}
+
+func test(existential: any P) {
+  existential.foo()
+  existential.bar()
+}
+
+/*
+public protocol ProtoWithAssocType<T> {
+  associatedtype T
+  func foo(t: T)
+}
+
+final public class GenClass<T: BinaryInteger>: ProtoWithAssocType {
+  public func foo(t: T) {
+    print(t)
+  }
+}
+
+public func createExWithAssocType() -> any ProtoWithAssocType<Int> {
+  return GenClass<Int>()
+}
+
+public func callExWithAssocType(_ p: any ProtoWithAssocType<Int>) {
+  p.foo(t: 27)
+}
+
+public protocol Q {
+  func bar()
+}
+
+public protocol ProtoWithAssocConf {
+  associatedtype A: Q
+  func foo() -> A
+}
+
+public class GenClass2<T>: Q {
+  final var t: T
+
+  init(t : T) { self.t = t }
+
+  public func bar() {
+    print("bar")
+  }
+}
+
+public class DerivedFromGenClass2: GenClass2<Int> {
+  init() { super.init(t: 42) }
+
+  public override func bar() {
+    print("derived-bar")
+  }
+}
+
+final public class GenClass3<V>: ProtoWithAssocConf {
+  public func foo() -> GenClass2<Int> {
+    print("foo")
+    return GenClass2(t: 27)
+  }
+}
+
+final public class OtherClass: ProtoWithAssocConf {
+  public func foo() -> GenClass2<Int> {
+    print("other-foo")
+    return DerivedFromGenClass2()
+  }
+}
+
+
+public func createExWithAssocConf() -> any ProtoWithAssocConf {
+  return GenClass3<Int>()
+}
+
+public func callExWithAssocConf(_ p: any ProtoWithAssocConf) {
+  let x = p.foo()
+  x.bar()
+}
+
+public class Base<T>: P {
+  public func foo() { print("Base.foo()") }
+  public func bar() { print("Base.bar()") }
+}
+
+public class Derived1: Base<Int> {
+  public override func foo() { print("Derived1.foo()") }
+  public override func bar() { print("Derived1.bar()") }
+}
+
+public class Derived2<T>: Base<T> {
+  public override func foo() { print("Derived2.foo()") }
+  public override func bar() { print("Derived2.bar()") }
+}
+
+public func takes_p1(_ p: P1) {
+  p.normal()
+}
+
+public protocol P1 {
+  func normal()
+}
+
+public protocol P2 {
+  func foo()
+}
+
+public class ConditionalConformanceBase<A> {
+  final var a: A
+
+  init(a: A) { self.a = a }
+}
+
+extension ConditionalConformanceBase: P1 where A: P2 {
+  public func normal() {
+    a.foo()
+  }
+}
+
+public class ConditionalConformanceDerived<T>: ConditionalConformanceBase<T> {
+  init(t: T) { super.init(a: t) }
+}
+
+
+public func testConditionalConformance<T: P2>(t: T) {
+  takes_p1(ConditionalConformanceDerived(t: t))
+}
+
+
+struct S: P2 {
+  var i: Int
+
+  func foo() {
+    print(i)
+  }
+}
+
+protocol Q3 {
+  func bar()
+}
+
+protocol P3<T> {
+  associatedtype T: Q3
+
+  var t: T { get }
+
+  func foo()
+}
+
+extension P3 {
+  func foo() {
+    t.bar()
+  }
+}
+
+struct C3<T: Q3>: P3 {
+  var t: T
+
+
+  init(t: T) { self.t = t }
+}
+
+struct S3<I: BinaryInteger>: Q3 {
+  var x: I
+
+  func bar() {
+    print(x)
+  }
+}
+
+@inline(never)
+func testP3() -> any P3 {
+  return C3(t: S3(x: 102))
+}
+
+protocol P4<T> {
+  associatedtype T: Q
+
+  var t: T { get }
+
+  func foo()
+}
+
+extension P4 {
+  func foo() {
+    t.bar()
+  }
+}
+
+struct C4<T: Q>: P4 {
+  var t: T
+
+
+  init(t: T) { self.t = t }
+}
+
+struct K4<I: BinaryInteger>: Q {
+  var x: I
+
+  init(x: I) { self.x = x }
+
+  func bar() {
+    print(x)
+  }
+}
+
+@inline(never)
+func testP4() -> any P4 {
+  return C4(t: K4(x: 437))
+}
+*/
+
+@main
+struct Main {
+  static func main() {
+    test(existential: MyStruct(i: 27))
+    // CHECK: MyStruct.foo: 27 
+    // CHECK: MyStruct.bar: 27
+
+    test(existential: LargeStruct(a: 10, b: 11, c: 12, d: 13))
+    // CHECK: LargeStruct.foo: 10, 11, 12, 13
+    // CHECK: LargeStruct.bar: 10, 11, 12, 13
+
+    test(existential: GenericStruct(t: 28))
+    // CHECK: GenericStruct.foo: 28
+    // CHECK: GenericStruct.bar: 28
+
+    /*
+    callExWithAssocType(createExWithAssocType())
+    // xCHECK: 27
+
+    callExWithAssocConf(createExWithAssocConf())
+    // xCHECK: foo
+    // xCHECK: bar
+
+    callExWithAssocConf(OtherClass())
+    // xCHECK: other-foo
+    // xCHECK: derived-bar
+
+    test(existential: Derived1())
+    // xCHECK: Derived1.foo()
+    // xCHECK: Derived1.bar()
+
+    test(existential: Derived2<Bool>())
+    // xCHECK: Derived2.foo()
+    // xCHECK: Derived2.bar()
+
+    testConditionalConformance(t: S(i: 27))
+    // xCHECK: 27
+
+    testP3().foo()
+    // xCHECK: 102
+
+    testP4().foo()
+    // xCHECK: 437
+    */
+  }
+}
+
+


### PR DESCRIPTION
* don't re-abstract witness method calls for existentials
* specialize witness tables for general existentials in MandatoryPerformanceOptimizations
