### PR TITLE
[update-checkout] remove unused test and finalize `utf-8` encoding refactor

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -94,6 +94,7 @@ class CallQuietlyException(Exception):
 
 def call_quietly(*args, **kwargs):
     kwargs["stderr"] = subprocess.STDOUT
+    kwargs["encoding"] = "utf-8"
     try:
         return subprocess.check_output(*args, **kwargs)
     except subprocess.CalledProcessError as e:

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -54,7 +54,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
         )
 
         # Test that we're actually checking out the 'extra' scheme based on the output
-        self.assertIn("git checkout refs/heads/main", output.decode("utf-8"))
+        self.assertIn("git checkout refs/heads/main", output)
 
 
 class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -13,7 +13,6 @@
 import os
 
 from . import scheme_mock
-from unittest import mock
 
 
 class CloneTestCase(scheme_mock.SchemeMockTestCase):
@@ -56,27 +55,6 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
 
         # Test that we're actually checking out the 'extra' scheme based on the output
         self.assertIn("git checkout refs/heads/main", output.decode("utf-8"))
-
-    def test_manager_not_called_on_long_socket(self):
-        fake_tmpdir = "/tmp/very/" + "/long" * 20 + "/tmp"
-
-        with mock.patch("tempfile.gettempdir", return_value=fake_tmpdir), mock.patch(
-            "multiprocessing.Manager"
-        ) as mock_manager:
-
-            self.call(
-                [
-                    self.update_checkout_path,
-                    "--config",
-                    self.config_path,
-                    "--source-root",
-                    self.source_root,
-                    "--clone",
-                ]
-            )
-            # Ensure that we do not try to create a Manager when the tempdir
-            # is too long.
-            mock_manager.assert_not_called()
 
 
 class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):


### PR DESCRIPTION
This patch removes an unused test and finalizes refactoring the use of the `utf-8` encoding. Using `utf-8` at the invocation rather than when consuming the output avoids runtime errors.