### PR TITLE
AST: Rename `GenericContext::isGeneric` to `hasGenericParamList`

### DIFF
--- a/docs/Generics/chapters/declarations.tex
+++ b/docs/Generics/chapters/declarations.tex
@@ -1051,7 +1051,7 @@ Subclass of \texttt{DeclContext}. Base class for declaration kinds which can hav
 \begin{itemize}
 \item \texttt{getParsedGenericParams()} returns the declaration's parsed generic parameter list, or \texttt{nullptr}.
 \item \texttt{getGenericParams()} returns the declaration's full generic parameter list, which includes any implicit generic parameters. Evaluates a \texttt{GenericParamListRequest}.
-\item \texttt{isGeneric()} answers if this declaration has a generic parameter list. This is equivalent to calling \texttt{DeclContext::isInnermostContextGeneric()}. Compare with \texttt{DeclContext::isGenericContext()}.
+\item \texttt{hasGenericParamList()} answers if this declaration has a generic parameter list. This is equivalent to calling \texttt{isInnermostContextGeneric()} on \texttt{DeclContext}. Compare with \texttt{DeclContext::isGenericContext()}.
 \item \texttt{getGenericContextDepth()} returns the \IndexSource{depth}depth of the declaration's generic parameter list, or \texttt{(unsigned)-1} if neither this declaration nor any outer declaration is generic.
 \item \texttt{getTrailingWhereClause()} returns the declaration's trailing \texttt{where} clause, or \texttt{nullptr}.
 \end{itemize}

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1696,15 +1696,15 @@ public:
   ///
   /// \code
   /// class C<T> {
-  ///   func f1() {}    // isGeneric == false
-  ///   func f2<T>() {} // isGeneric == true
+  ///   func f1() {}    // hasGenericParamList == false
+  ///   func f2<T>() {} // hasGenericParamList == true
   /// }
   ///
-  /// protocol P { // isGeneric == true due to implicit Self param
-  ///   func p()   // isGeneric == false
+  /// protocol P { // hasGenericParamList == true due to implicit Self param
+  ///   func p()   // hasGenericParamList == false
   /// }
   /// \endcode
-  bool isGeneric() const { return getGenericParams() != nullptr; }
+  bool hasGenericParamList() const { return getGenericParams() != nullptr; }
   bool hasComputedGenericSignature() const;
   bool isComputingGenericSignature() const;
   

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6892,10 +6892,10 @@ bool ASTContext::overrideGenericSignatureReqsSatisfied(
   auto *baseCtx = base->getAsGenericContext();
   auto *derivedCtx = derived->getAsGenericContext();
 
-  if (baseCtx->isGeneric() != derivedCtx->isGeneric())
+  if (baseCtx->hasGenericParamList() != derivedCtx->hasGenericParamList())
     return false;
 
-  if (baseCtx->isGeneric() &&
+  if (baseCtx->hasGenericParamList() &&
       (baseCtx->getGenericParams()->size() !=
        derivedCtx->getGenericParams()->size()))
     return false;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -281,7 +281,7 @@ Type ASTBuilder::createNominalType(GenericTypeDecl *decl, Type parent) {
     return Type();
 
   // If the declaration is generic, fail.
-  if (nominalDecl->isGeneric())
+  if (nominalDecl->hasGenericParamList())
     return Type();
 
   // Imported types can be renamed to be members of other (non-generic)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2008,9 +2008,10 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
       // type declaration are not part of the mangling, so check whether the
       // naming declaration has generic parameters.
       auto namedGenericContext = opaque->getNamingDecl()->getAsGenericContext();
-      treatAsGeneric = namedGenericContext && namedGenericContext->isGeneric();
+      treatAsGeneric =
+          namedGenericContext && namedGenericContext->hasGenericParamList();
     } else {
-      treatAsGeneric = genericContext->isGeneric();
+      treatAsGeneric = genericContext->hasGenericParamList();
     }
     if (treatAsGeneric) {
       auto genericParams = subs.getGenericSignature().getGenericParams();
@@ -5430,7 +5431,7 @@ static std::optional<unsigned> getEnclosingTypeGenericDepth(const Decl *decl) {
   if (!typeDecl)
     return std::nullopt;
 
-  if (!typeDecl->isGeneric())
+  if (!typeDecl->hasGenericParamList())
     return std::nullopt;
 
   return typeDecl->getGenericSignature()->getMaxDepth();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2961,7 +2961,7 @@ void PrintAST::printMembers(ArrayRef<Decl *> members, bool needComma,
 }
 
 void PrintAST::printGenericDeclGenericParams(GenericContext *decl) {
-  if (decl->isGeneric())
+  if (decl->hasGenericParamList())
     if (auto GenericSig = decl->getGenericSignature()) {
       Printer.printStructurePre(PrintStructureKind::DeclGenericParameterClause);
       printGenericSignature(GenericSig, PrintParams | InnermostOnly);
@@ -6364,7 +6364,7 @@ public:
     printQualifiedType(T);
 
     auto *typeAliasDecl = T->getDecl();
-    if (typeAliasDecl->isGeneric()) {
+    if (typeAliasDecl->hasGenericParamList()) {
       if (Options.PrintTypesForDebugging)
         printGenericArgs(T->getDirectGenericArgs());
       else

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3239,7 +3239,7 @@ public:
     void verifyParsed(DestructorDecl *DD) {
       PrettyStackTraceDecl debugStack("verifying DestructorDecl", DD);
 
-      if (DD->isGeneric()) {
+      if (DD->hasGenericParamList()) {
         Out << "DestructorDecl cannot be generic";
         abort();
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4250,7 +4250,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   }
 
   if (auto *extension = dyn_cast<ExtensionDecl>(getDeclContext()))
-    if (extension->isGeneric())
+    if (extension->hasGenericParamList())
       signature.InExtensionOfGenericType = true;
 
   return signature;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -629,7 +629,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
 bool DeclContext::isInnermostContextGeneric() const {
   if (auto Decl = getAsDecl())
     if (auto GC = Decl->getAsGenericContext())
-      return GC->isGeneric();
+      return GC->hasGenericParamList();
   return false;
 }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -467,7 +467,7 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   auto &C = getASTContext();
   auto *DC = getDeclContext();
 
-  if (!DC->isTypeContext() || !isGeneric())
+  if (!DC->isTypeContext() || !hasGenericParamList())
     return false;
 
   // === Check the name
@@ -512,7 +512,7 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   }
 
   // === Check generics
-  if (!isGeneric()) {
+  if (!hasGenericParamList()) {
     return false;
   }
 
@@ -809,7 +809,7 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordArgument() const
     }
 
     // === Check generics
-    if (!isGeneric()) {
+    if (!hasGenericParamList()) {
       return false;
     }
 
@@ -949,7 +949,7 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordReturnType() con
   }
 
   // === Check generics
-  if (!isGeneric()) {
+  if (!hasGenericParamList()) {
     return false;
   }
 
@@ -1078,7 +1078,7 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordErrorType() cons
     }
 
     // === Check generics
-    if (!isGeneric()) {
+    if (!hasGenericParamList()) {
       return false;
     }
 
@@ -1188,7 +1188,7 @@ AbstractFunctionDecl::isDistributedTargetInvocationDecoderDecodeNextArgument() c
 
 
     // === Check generics
-    if (!isGeneric()) {
+    if (!hasGenericParamList()) {
       return false;
     }
 
@@ -1282,7 +1282,7 @@ AbstractFunctionDecl::isDistributedTargetInvocationResultHandlerOnReturn() const
     }
 
     // === Check generics
-    if (!isGeneric()) {
+    if (!hasGenericParamList()) {
       return false;
     }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3768,7 +3768,7 @@ createTupleExtensionGenericParams(ASTContext &ctx,
     return nullptr;
 
   auto *typeAlias = cast<TypeAliasDecl>(referenced.first[0]);
-  if (!typeAlias->isGeneric())
+  if (!typeAlias->hasGenericParamList())
     return nullptr;
 
   return createExtensionGenericParams(ctx, ext, typeAlias);

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -113,7 +113,7 @@ struct PackReferenceCollector: TypeWalker {
     }
 
     if (auto *typeAliasType = dyn_cast<TypeAliasType>(t.getPointer())) {
-      if (typeAliasType->getDecl()->isGeneric()) {
+      if (typeAliasType->getDecl()->hasGenericParamList()) {
         if (auto parentType = typeAliasType->getParent())
           parentType.walk(*this);
 
@@ -403,7 +403,7 @@ SmallVector<Type, 2> BoundGenericType::getExpandedGenericArgs() {
 
 /// <T...> Foo<T, Pack{Int, String}> => Pack{T..., Int, String}
 SmallVector<Type, 2> TypeAliasType::getExpandedGenericArgs() {
-  if (!getDecl()->isGeneric())
+  if (!getDecl()->hasGenericParamList())
     return SmallVector<Type, 2>();
 
   auto genericSig = getGenericSignature();

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -962,7 +962,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     // DependentMemberType X, and the right hand side is the
     // underlying type of the typealias.
     if (auto *typeAliasDecl = dyn_cast<TypeAliasDecl>(decl)) {
-      if (typeAliasDecl->isGeneric())
+      if (typeAliasDecl->hasGenericParamList())
         continue;
 
       // Ignore the typealias if we have an associated type with the same name
@@ -1046,7 +1046,7 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
   auto isSuitableType = [&](TypeDecl *req) -> bool {
     // Ignore generic types.
     if (auto genReq = dyn_cast<GenericTypeDecl>(req))
-      if (genReq->isGeneric())
+      if (genReq->hasGenericParamList())
         return false;
 
     // Ignore typealiases with UnboundGenericType, since they

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -311,7 +311,7 @@ swift::cxx_translation::getDeclRepresentation(
         !AFD->getASTContext().LangOpts.hasFeature(
             Feature::GenerateBindingsForThrowingFunctionsInCXX))
       return {Unsupported, UnrepresentableThrows};
-    if (AFD->isGeneric())
+    if (AFD->hasGenericParamList())
       genericSignature = AFD->getGenericSignature();
   }
   if (const auto *typeDecl = dyn_cast<NominalTypeDecl>(VD)) {
@@ -325,7 +325,7 @@ swift::cxx_translation::getDeclRepresentation(
       return {Unsupported, UnrepresentableMoveOnly};
     if (isa<ClassDecl>(VD) && VD->isObjC())
       return {Unsupported, UnrepresentableObjC};
-    if (typeDecl->isGeneric()) {
+    if (typeDecl->hasGenericParamList()) {
       if (isa<ClassDecl>(VD))
         return {Unsupported, UnrepresentableGeneric};
       genericSignature = typeDecl->getGenericSignature();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6341,7 +6341,7 @@ namespace {
 
       if (auto *GTD = dyn_cast<GenericTypeDecl>(typeDecl)) {
         typealias->setGenericSignature(GTD->getGenericSignature());
-        if (GTD->isGeneric()) {
+        if (GTD->hasGenericParamList()) {
           typealias->getASTContext().evaluator.cacheOutput(
                 GenericParamListRequest{typealias},
                 std::move(GTD->getGenericParams()->clone(typealias)));
@@ -6564,7 +6564,7 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   auto *GTD = dyn_cast<GenericTypeDecl>(typeDecl);
   if (GTD && !isa<ProtocolDecl>(GTD)) {
     alias->setGenericSignature(GTD->getGenericSignature());
-    if (GTD->isGeneric()) {
+    if (GTD->hasGenericParamList()) {
       alias->getASTContext().evaluator.cacheOutput(
             GenericParamListRequest{alias},
             std::move(GTD->getGenericParams()->clone(alias)));

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -266,7 +266,7 @@ void CompletionLookup::foundFunction(const AnyFunctionType *AFT) {
 
 bool CompletionLookup::canBeUsedAsRequirementFirstType(Type selfTy,
                                                        TypeAliasDecl *TAD) {
-  if (TAD->isGeneric())
+  if (TAD->hasGenericParamList())
     return false;
 
   auto T = TAD->getDeclaredInterfaceType();

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -768,7 +768,7 @@ void EmitPolymorphicParameters::injectAdHocDistributedRequirements() {
   auto loc = Fn.getLocation();
 
   auto *funcDecl = dyn_cast_or_null<FuncDecl>(loc.getAsDeclContext());
-  if (!(funcDecl && funcDecl->isGeneric()))
+  if (!(funcDecl && funcDecl->hasGenericParamList()))
     return;
 
   if (!funcDecl->isDistributedWitnessWithAdHocSerializationRequirement())

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -84,7 +84,7 @@ void ClangSyntaxPrinter::printModuleNamespaceQualifiersIfNeeded(
 
 bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclTemplateSpecifiers(
     const NominalTypeDecl *typeDecl) {
-  if (!typeDecl->isGeneric())
+  if (!typeDecl->hasGenericParamList())
     return true;
   printGenericSignature(
       typeDecl->getGenericSignature().getCanonicalSignature());
@@ -93,7 +93,7 @@ bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclTemplateSpecifiers(
 
 bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclInnerStaticAssert(
     const NominalTypeDecl *typeDecl) {
-  if (!typeDecl->isGeneric())
+  if (!typeDecl->hasGenericParamList())
     return true;
   printGenericSignatureInnerStaticAsserts(
       typeDecl->getGenericSignature().getCanonicalSignature());
@@ -173,7 +173,7 @@ void ClangSyntaxPrinter::printNominalTypeReference(
   if (!printNestedTypeNamespaceQualifiers(typeDecl))
     os << "::";
   ClangSyntaxPrinter(typeDecl->getASTContext(), os).printBaseName(typeDecl);
-  if (typeDecl->isGeneric())
+  if (typeDecl->hasGenericParamList())
     printGenericSignatureParams(
         typeDecl->getGenericSignature().getCanonicalSignature());
 }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2381,7 +2381,7 @@ private:
 
     if (auto *clangTypeDecl =
           dyn_cast<clang::TypeDecl>(alias->getClangDecl())) {
-      assert(!alias->isGeneric()
+      assert(!alias->hasGenericParamList()
              && "generic typealias backed by clang typedecl?");
 
       maybePrintTagKeyword(alias);
@@ -2391,7 +2391,7 @@ private:
         printNullability(optionalKind);
     } else if (auto *clangObjCClass
                = dyn_cast<clang::ObjCInterfaceDecl>(alias->getClangDecl())){
-      assert(!alias->isGeneric()
+      assert(!alias->hasGenericParamList()
              && "generic typealias backed by clang interface?");
 
       os << clangObjCClass->getName() << " *";
@@ -2713,7 +2713,7 @@ private:
 
     if (auto *extension = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
       const ClassDecl *extendedClass = extension->getSelfClassDecl();
-      assert(extendedClass->isGeneric());
+      assert(extendedClass->hasGenericParamList());
       assert(extension->getGenericParams()->size() ==
              extendedClass->getGenericParams()->size() &&
              "extensions with custom generic parameters?");

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -610,7 +610,7 @@ public:
       bool imported = false;
       if (TAD->hasClangNode())
         imported = addImport(TD);
-      assert((imported || !TAD->isGeneric()) &&
+      assert((imported || !TAD->hasGenericParamList()) &&
              "referencing non-imported generic typealias?");
     } else if (addImport(TD)) {
       return;
@@ -1109,7 +1109,7 @@ public:
             vd, [this](const NominalTypeDecl *decl) {
               return printer.isZeroSized(decl);
             });
-        if (nmtd->isGeneric()) {
+        if (nmtd->hasGenericParamList()) {
           auto genericSignature =
               nmtd->getGenericSignature().getCanonicalSignature();
           ClangSyntaxPrinter(nmtd->getASTContext(), os).printGenericSignature(genericSignature);

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -794,7 +794,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     ClangSyntaxPrinter(FD->getASTContext(), functionSignatureOS)
         .printNominalTypeOutsideMemberDeclTemplateSpecifiers(typeDecl);
   }
-  if (FD->isGeneric()) {
+  if (FD->hasGenericParamList()) {
     auto Signature = FD->getGenericSignature().getCanonicalSignature();
     if (!cxx_translation::isExposableToCxx(Signature))
       return ClangRepresentation::unsupported;
@@ -1257,7 +1257,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   if (typeDeclContext)
     ClangSyntaxPrinter(FD->getASTContext(), os).printNominalTypeOutsideMemberDeclInnerStaticAssert(
         typeDeclContext);
-  if (FD->isGeneric()) {
+  if (FD->hasGenericParamList()) {
     auto Signature = FD->getGenericSignature().getCanonicalSignature();
     ClangSyntaxPrinter(FD->getASTContext(), os).printGenericSignatureInnerStaticAsserts(Signature);
   }

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -91,9 +91,9 @@ printCValueTypeStorageStruct(raw_ostream &os, const NominalTypeDecl *typeDecl,
 void ClangValueTypePrinter::forwardDeclType(
     raw_ostream &os, const NominalTypeDecl *typeDecl,
     DeclAndTypePrinter &declAndTypePrinter) {
-  ClangSyntaxPrinter(typeDecl->getASTContext(), os).printParentNamespaceForNestedTypes(
-      typeDecl, [&](raw_ostream &) {
-        if (typeDecl->isGeneric()) {
+  ClangSyntaxPrinter(typeDecl->getASTContext(), os)
+      .printParentNamespaceForNestedTypes(typeDecl, [&](raw_ostream &) {
+        if (typeDecl->hasGenericParamList()) {
           auto genericSignature =
               typeDecl->getGenericSignature().getCanonicalSignature();
           ClangSyntaxPrinter(typeDecl->getASTContext(), os).printGenericSignature(genericSignature);
@@ -201,7 +201,7 @@ void ClangValueTypePrinter::printValueTypeDecl(
       return;
     ClangSyntaxPrinter(Context, os).printGenericSignatureParams(genericSignature);
   };
-  if (typeDecl->isGeneric()) {
+  if (typeDecl->hasGenericParamList()) {
     genericSignature = typeDecl->getGenericSignature();
     assert(cxx_translation::isExposableToCxx(genericSignature));
 
@@ -580,7 +580,7 @@ void ClangValueTypePrinter::printTypePrecedingGenericTraits(
   printer.printNominalTypeReference(typeDecl,
                                     /*moduleContext=*/nullptr);
   os << "> = ";
-  if (typeDecl->isGeneric()) {
+  if (typeDecl->hasGenericParamList()) {
     auto signature = typeDecl->getGenericSignature().getCanonicalSignature();
     llvm::interleave(
         signature.getInnermostGenericParams(), os,
@@ -729,7 +729,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
       os << "::";
     os << cxx_synthesis::getCxxImplNamespaceName() << "::";
     printCxxImplClassName(os, NTD);
-    if (NTD->isGeneric())
+    if (NTD->hasGenericParamList())
       printer.printGenericSignatureParams(
           NTD->getGenericSignature().getCanonicalSignature());
     os << "; };\n";

--- a/lib/Refactoring/Async/AsyncConverter.cpp
+++ b/lib/Refactoring/Async/AsyncConverter.cpp
@@ -1880,7 +1880,7 @@ void AsyncConverter::addAsyncFuncReturnType(
 
 void AsyncConverter::addResultTypeAnnotationIfNecessary(
     const FuncDecl *FD, const AsyncHandlerDesc &HandlerDesc) {
-  if (FD->isGeneric()) {
+  if (FD->hasGenericParamList()) {
     OS << tok::colon << " ";
     addAsyncFuncReturnType(HandlerDesc);
   }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3809,7 +3809,7 @@ public:
           if (!classDecl->isForeignReferenceType()) {
             assert(!classDecl->hasClangNode() &&
                    "unexpected imported class type in C function");
-            assert(!classDecl->isGeneric());
+            assert(!classDecl->hasGenericParamList());
             return ParameterConvention::Indirect_In_Guaranteed;
           }
         }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2080,7 +2080,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
     // See the call to getClassFieldOffsetOffset() inside
     // emitKeyPathComponent().
     if (auto *parentClass = dyn_cast<ClassDecl>(decl->getDeclContext())) {
-      if (parentClass->isGeneric()) {
+      if (parentClass->hasGenericParamList()) {
         auto ancestry = parentClass->checkAncestry();
         if (ancestry.contains(AncestryFlags::ResilientOther))
           return false;

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -123,7 +123,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF, SILLocation loc,
 
   // FIXME: Figure out the right SubstitutionMap stuff if the witness
   // has generic parameters of its own.
-  assert(!cast<FuncDecl>(witness)->isGeneric() &&
+  assert(!cast<FuncDecl>(witness)->hasGenericParamList() &&
          "Generic witnesses not supported");
 
   auto *dc = cast<FuncDecl>(witness)->getDeclContext();

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -544,7 +544,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
 
     // If the declaration has generic parameters, it cannot witness an
     // associated type.
-    if (genericDecl->isGeneric())
+    if (genericDecl->hasGenericParamList())
       continue;
 
     // Skip typealiases with an unbound generic type as their underlying type.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -349,7 +349,7 @@ static bool isDeclMoreConstrainedThan(ValueDecl *decl1, ValueDecl *decl2) {
   auto func1 = dyn_cast<FuncDecl>(decl1);
   auto func2 = dyn_cast<FuncDecl>(decl2);
   if (func1 && func2) {
-    bothGeneric = func1->isGeneric() && func2->isGeneric();
+    bothGeneric = func1->hasGenericParamList() && func2->hasGenericParamList();
 
     sig1 = func1->getGenericSignature();
     sig2 = func2->getGenericSignature();
@@ -358,7 +358,8 @@ static bool isDeclMoreConstrainedThan(ValueDecl *decl1, ValueDecl *decl2) {
   auto subscript1 = dyn_cast<SubscriptDecl>(decl1);
   auto subscript2 = dyn_cast<SubscriptDecl>(decl2);
   if (subscript1 && subscript2) {
-    bothGeneric = subscript1->isGeneric() && subscript2->isGeneric();
+    bothGeneric =
+        subscript1->hasGenericParamList() && subscript2->hasGenericParamList();
 
     sig1 = subscript1->getGenericSignature();
     sig2 = subscript2->getGenericSignature();
@@ -518,14 +519,14 @@ bool CompareDeclSpecializationRequest::evaluate(
   // A non-generic declaration is more specialized than a generic declaration.
   if (auto func1 = dyn_cast<AbstractFunctionDecl>(decl1)) {
     auto func2 = cast<AbstractFunctionDecl>(decl2);
-    if (func1->isGeneric() != func2->isGeneric())
-      return completeResult(func2->isGeneric());
+    if (func1->hasGenericParamList() != func2->hasGenericParamList())
+      return completeResult(func2->hasGenericParamList());
   }
 
   if (auto subscript1 = dyn_cast<SubscriptDecl>(decl1)) {
     auto subscript2 = cast<SubscriptDecl>(decl2);
-    if (subscript1->isGeneric() != subscript2->isGeneric())
-      return completeResult(subscript2->isGeneric());
+    if (subscript1->hasGenericParamList() != subscript2->hasGenericParamList())
+      return completeResult(subscript2->hasGenericParamList());
   }
 
   // Members of protocol extensions have special overloading rules.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9032,7 +9032,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Solved;
         };
 
-        if (witness->isGeneric()) {
+        if (witness->hasGenericParamList()) {
           // `DistributedActorSystem.remoteCall`
           if (witness->isDistributedActorSystemRemoteCall(/*isVoidReturn=*/false)) {
             if (GP->isEqual(cast<FuncDecl>(witness)->getResultInterfaceType()))

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2043,7 +2043,7 @@ tryOptimizeGenericDisjunction(ConstraintSystem &cs, Constraint *disjunction,
     assert(decl);
 
     auto *AFD = dyn_cast<AbstractFunctionDecl>(decl);
-    if (!AFD || !AFD->isGeneric())
+    if (!AFD || !AFD->hasGenericParamList())
       return false;
 
     if (AFD->getAttrs().hasAttribute<DisfavoredOverloadAttr>())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5093,7 +5093,7 @@ bool ConstraintSystem::isArgumentGenericFunction(Type argType, Expr *argExpr) {
       auto choice = selectedOverload->choice;
       if (auto func =
               dyn_cast_or_null<AbstractFunctionDecl>(choice.getDeclOrNull())) {
-        if (func->isGeneric())
+        if (func->hasGenericParamList())
           return true;
       }
 
@@ -5116,7 +5116,7 @@ bool ConstraintSystem::isArgumentGenericFunction(Type argType, Expr *argExpr) {
       continue;
 
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
-      if (func->isGeneric())
+      if (func->hasGenericParamList())
         return true;
   }
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -209,7 +209,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
 
   // The innermost generic parameters are mapped to error types.
   unsigned innerDepth = genericSig->getMaxDepth();
-  if (!genericDecl->isGeneric())
+  if (!genericDecl->hasGenericParamList())
     ++innerDepth;
 
   // We treat substitution failure as success, to ignore requirements

--- a/lib/Sema/LegalConstExprVerifier.cpp
+++ b/lib/Sema/LegalConstExprVerifier.cpp
@@ -245,7 +245,7 @@ checkSupportedWithSectionAttribute(const Expr *expr,
 
       // Function references are allowed if they are non-generic
       if (auto *funcDecl = dyn_cast<FuncDecl>(decl)) {
-        if (!funcDecl->isGeneric() &&
+        if (!funcDecl->hasGenericParamList() &&
             !funcDecl->getDeclContext()->isGenericContext()) {
           continue;
         }
@@ -265,7 +265,7 @@ checkSupportedWithSectionAttribute(const Expr *expr,
           auto instanceType = baseType->getMetatypeInstanceType();
           if (auto nominal = instanceType->getNominalOrBoundGenericNominal()) {
             // Allow non-generic, non-resilient types
-            if (!nominal->isGeneric() && !nominal->isResilient()) {
+            if (!nominal->hasGenericParamList() && !nominal->isResilient()) {
               continue;
             }
           }

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -698,7 +698,7 @@ bool swift::canOpenExistentialAt(ValueDecl *callee, unsigned paramIdx,
 
   // Only allow opening the innermost generic parameters.
   auto genericContext = callee->getAsGenericContext();
-  if (!genericContext || !genericContext->isGeneric())
+  if (!genericContext || !genericContext->hasGenericParamList())
     return false;
 
   auto genericSig = callee->getInnermostDeclContext()

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4386,7 +4386,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
 
   bool foundMatch = llvm::any_of(lookupResult, [&](const LookupResultEntry &entry) {
     auto *init = cast<ConstructorDecl>(entry.getValueDecl());
-    if (!init->isGeneric() || init->getGenericParams()->size() != 1)
+    if (!init->hasGenericParamList() || init->getGenericParams()->size() != 1)
       return false;
 
     auto genericSignature = init->getGenericSignature();

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -812,7 +812,7 @@ CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
 
   bool isNoEscape = type->castTo<AnyFunctionType>()->isNoEscape();
   FindCapturedVars finder(AFD->getLoc(), AFD, isNoEscape,
-                          AFD->isObjC(), AFD->isGeneric());
+                          AFD->isObjC(), AFD->hasGenericParamList());
 
   if (auto *body = AFD->getTypecheckedBody())
     body->walk(finder);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2989,7 +2989,7 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
 
   // Check that the nominal type and the typealias are either both generic
   // at this level or neither are.
-  if (nominal->isGeneric() != typealias->isGeneric())
+  if (nominal->hasGenericParamList() != typealias->hasGenericParamList())
     return false;
 
   // Make sure either both have generic signatures or neither do.
@@ -3014,7 +3014,8 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
     return false;
 
   // If neither is generic at this level, we have a pass-through typealias.
-  if (!typealias->isGeneric()) return true;
+  if (!typealias->hasGenericParamList())
+    return true;
 
   if (typealias->getUnderlyingType()->isEqual(
         nominal->getSelfInterfaceType())) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -638,9 +638,10 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
           return false;
         if (!classDecl->isTypeErasedGenericClass()) {
           softenIfAccessNote(value, reason.getAttr(),
-            value->diagnose(diag::objc_in_generic_extension,
-                            classDecl->isGeneric())
-                .limitBehavior(behavior));
+                             value
+                                 ->diagnose(diag::objc_in_generic_extension,
+                                            classDecl->hasGenericParamList())
+                                 .limitBehavior(behavior));
           reason.describe(value);
           return true;
         }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -177,15 +177,15 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
     // behavior by not considering generic declarations in protocols as
     // overrides at all.
     if (decl->getDeclContext()->getSelfProtocolDecl() &&
-        declCtx->isGeneric())
+        declCtx->hasGenericParamList())
       return false;
 
     auto *parentCtx = parentDecl->getAsGenericContext();
 
-    if (declCtx->isGeneric() != parentCtx->isGeneric())
+    if (declCtx->hasGenericParamList() != parentCtx->hasGenericParamList())
       return false;
 
-    if (declCtx->isGeneric() &&
+    if (declCtx->hasGenericParamList() &&
         (declCtx->getGenericParams()->size() !=
          parentCtx->getGenericParams()->size()))
       return false;
@@ -318,10 +318,10 @@ static bool areOverrideCompatibleSimple(ValueDecl *decl,
   // If their genericity is different, they aren't compatible.
   if (auto genDecl = decl->getAsGenericContext()) {
     auto genParentDecl = parentDecl->getAsGenericContext();
-    if (genDecl->isGeneric() != genParentDecl->isGeneric())
+    if (genDecl->hasGenericParamList() != genParentDecl->hasGenericParamList())
       return false;
 
-    if (genDecl->isGeneric() &&
+    if (genDecl->hasGenericParamList() &&
         (genDecl->getGenericParams()->size() !=
          genParentDecl->getGenericParams()->size()))
       return false;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -436,7 +436,7 @@ TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl,
     // Non-generic type aliases can only be accessed if the
     // underlying type is not dependent.
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
-      if (!aliasDecl->isGeneric() &&
+      if (!aliasDecl->hasGenericParamList() &&
           aliasDecl->getUnderlyingType()->hasTypeParameter() &&
           !doesTypeAliasFullyConstrainAllOuterGenericParams(aliasDecl)) {
         return UnsupportedMemberTypeAccessKind::TypeAliasOfUnboundGeneric;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -148,7 +148,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
   for (const auto &decl : decls) {
     auto init = dyn_cast<ConstructorDecl>(decl);
-    if (!init || init->getDeclContext() != nominal || init->isGeneric())
+    if (!init || init->getDeclContext() != nominal ||
+        init->hasGenericParamList())
       continue;
 
     ParamDecl *argumentParam = nullptr;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1094,10 +1094,10 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
   GenericSignature reqSig = proto->getGenericSignature();
   if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(req)) {
-    if (funcDecl->isGeneric())
+    if (funcDecl->hasGenericParamList())
       reqSig = funcDecl->getGenericSignature();
   } else if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(req)) {
-    if (subscriptDecl->isGeneric())
+    if (subscriptDecl->hasGenericParamList())
       reqSig = subscriptDecl->getGenericSignature();
   }
 
@@ -2472,9 +2472,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       if (auto classDecl = ext->getSelfClassDecl()) {
         if (classDecl->isGenericContext()) {
           if (!classDecl->isTypeErasedGenericClass()) {
-            Context.Diags.diagnose(ComplainLoc,
-                                   diag::objc_protocol_in_generic_extension,
-                                   classDecl->isGeneric(), T, ProtoType);
+            Context.Diags.diagnose(
+                ComplainLoc, diag::objc_protocol_in_generic_extension,
+                classDecl->hasGenericParamList(), T, ProtoType);
             conformance->setInvalid();
             return;
           }
@@ -6234,11 +6234,11 @@ static unsigned getNameLength(DeclName name) {
 }
 
 /// Determine whether a particular declaration is generic.
-static bool isGeneric(ValueDecl *decl) {
+static bool hasGenericParamList(ValueDecl *decl) {
   if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
-    return func->isGeneric();
+    return func->hasGenericParamList();
   if (auto subscript = dyn_cast<SubscriptDecl>(decl))
-    return subscript->isGeneric();
+    return subscript->hasGenericParamList();
   return false;
 }
 
@@ -6285,7 +6285,7 @@ static bool shouldWarnAboutPotentialWitness(
 
   // If the witness is generic and requirement is not, or vice-versa,
   // don't warn.
-  if (isGeneric(req) != isGeneric(witness))
+  if (hasGenericParamList(req) != hasGenericParamList(witness))
     return false;
 
   // Don't warn if the potential witness has been explicitly given less
@@ -7338,7 +7338,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
         auto asdTy = asd->getInterfaceType();
         GenericSignature reqSig = proto->getGenericSignature();
         if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(asd)) {
-          if (subscriptDecl->isGeneric())
+          if (subscriptDecl->hasGenericParamList())
             reqSig = subscriptDecl->getGenericSignature();
         }
         RequirementEnvironment reqEnv(proto, reqSig, proto, nullptr, nullptr);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -593,7 +593,7 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
       } else if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
         if (isa<ProtocolDecl>(typeDecl->getDeclContext()) &&
             getStage() == TypeResolutionStage::Structural) {
-          if (aliasDecl && !aliasDecl->isGeneric()) {
+          if (aliasDecl && !aliasDecl->hasGenericParamList()) {
             return adjustAliasType(aliasDecl->getStructuralType());
           }
         }
@@ -1791,7 +1791,7 @@ static void diagnoseGenericArgumentsOnSelf(const TypeResolution &resolution,
 
   diags.diagnose(repr->getNameLoc(), diag::cannot_specialize_self);
 
-  if (selfNominal->isGeneric() && !isa<ProtocolDecl>(selfNominal)) {
+  if (selfNominal->hasGenericParamList() && !isa<ProtocolDecl>(selfNominal)) {
     diags
         .diagnose(repr->getNameLoc(), diag::specialize_explicit_type_instead,
                   declaredType)
@@ -6481,7 +6481,7 @@ Type TypeChecker::substMemberTypeWithBase(TypeDecl *member,
 
   auto *aliasDecl = dyn_cast<TypeAliasDecl>(member);
   if (aliasDecl) {
-    if (aliasDecl->isGeneric()) {
+    if (aliasDecl->hasGenericParamList()) {
       return UnboundGenericType::get(
           aliasDecl, baseTy,
           aliasDecl->getASTContext());

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -148,7 +148,7 @@ static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
   // If this decl is generic, the constraints are handled when the generic
   // parameters are applied, so we don't have to handle them here (which makes
   // getting the right substitution maps easier).
-  if (!decl || decl->isGeneric())
+  if (!decl || decl->hasGenericParamList())
     return;
 
   // struct A<T> {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -273,8 +273,8 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
     return;
 
   // The declaration may not be generic itself, but instead carry additional
-  // generic requirements in a contextual where clause, so checking !isGeneric()
-  // is insufficient.
+  // generic requirements in a contextual where clause, so checking
+  // !hasGenericParamList() is insufficient.
   const auto ParentSig = GC->getParent()->getGenericSignatureOfContext();
   if (ParentSig && ParentSig->isEqual(GenericSig))
     return;
@@ -316,7 +316,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
   };
 
   // FIXME: Not right for extensions of nested generic types
-  if (GC->isGeneric()) {
+  if (GC->hasGenericParamList()) {
     for (auto *GP : GenericSig.getInnermostGenericParams()) {
       if (GP->getDecl()->isImplicit())
         continue;


### PR DESCRIPTION
`isGeneric` is a misleading name because this method checks for the existence of a `GenericParamList`, which is not implied by genericity.
