### PR TITLE
[SILGen] Add assert to `emitApplyAllocatingInitializer`

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6920,6 +6920,7 @@ RValue SILGenFunction::emitApplyAllocatingInitializer(SILLocation loc,
                                                       PreparedArguments &&args,
                                                       Type overriddenSelfType,
                                                       SGFContext C) {
+  ASSERT(init);
   ConstructorDecl *ctor = cast<ConstructorDecl>(init.getDecl());
 
   // Form the reference to the allocating initializer.


### PR DESCRIPTION
Make sure we reliably assert in release builds if `getBuiltinInitDecl` passes a null value here. We really ought to change `cast` to always assert, but I'm leaving that for another day.