### PR TITLE
[cxx-interop] Emit `#endif // defined(__OBJC__)` with the comment consistently

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1574,7 +1574,7 @@ private:
     }
     os << "\n";
     if (representation.isObjCxxOnly())
-      os << "#endif\n";
+      os << "#endif // defined(__OBJC__)\n";
     return representation;
   }
 
@@ -1684,7 +1684,7 @@ private:
         FD->getParameters(), funcTy->isThrowing(), funcTy);
     os << "}\n";
     if (result.isObjCxxOnly())
-      os << "#endif\n";
+      os << "#endif // defined(__OBJC__)\n";
   }
 
   enum class PrintLeadingSpace : bool {

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -55,7 +55,7 @@ static void emitObjCConditional(raw_ostream &out,
     out << "#else\n";
     nonObjCCase();
   }
-  out << "#endif\n";
+  out << "#endif // defined(__OBJC__)\n";
 }
 
 static void emitExternC(raw_ostream &out,

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1686,7 +1686,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   if (!isDefinition) {
     os << ";\n";
     if (result.isObjCxxOnly())
-      os << "#endif\n";
+      os << "#endif // defined(__OBJC__)\n";
     return;
   }
 
@@ -1699,7 +1699,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
                     dispatchInfo);
   os << "  }\n";
   if (result.isObjCxxOnly())
-    os << "#endif\n";
+    os << "#endif // defined(__OBJC__)\n";
 }
 
 /// Returns true if the given property name like `isEmpty` can be remapped

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -737,7 +737,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   os << "} // namespace\n";
   os << "#pragma clang diagnostic pop\n";
   if (objCxxOnly)
-    os << "#endif // #if defined(__OBJC__)\n";
+    os << "#endif // defined(__OBJC__)\n";
   os << "} // namespace swift\n";
   os << "\n";
   printer.printModuleNamespaceStart(*moduleContext);

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -412,7 +412,7 @@ SWIFT_CLASS("_TtC8comments13UnorderedList")
 - (void)f0;
 @end
 
-#endif
+#endif // defined(__OBJC__)
 #if __has_attribute(external_source_symbol)
 # pragma clang attribute pop
 #endif


### PR DESCRIPTION
This makes sure that whenever we emit `#if defined(__OBJC__)`, the matching `#endif` has a comment `// defined(__OBJC__)`.

This makes both testing and reading the header file easier.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
