### PR TITLE
[Test] Mark new test as executable_test

### DIFF
--- a/test/Interpreter/issue-78598.swift
+++ b/test/Interpreter/issue-78598.swift
@@ -2,6 +2,8 @@
 
 // https://github.com/swiftlang/swift/issues/78598
 
+// REQUIRES: executable_test
+
 var counter = 0
 
 final class Entry<Results> {


### PR DESCRIPTION
Otherwise, various [non-executable CI like Android fail](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/75/console).