### PR TITLE
Don't abort on Linux if `withLockIfAvailable()` is called recursively.

### DIFF
--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -235,8 +235,7 @@ extension _MutexHandle {
 
     // EDEADLK - "The futex word at uaddr is already locked by the caller."
     case 35:
-      // TODO: Replace with a colder function / one that takes a StaticString
-      fatalError("Attempt to try to lock Mutex in already acquired thread")
+      return false
 
     // This handles all of the following errors which generally aren't
     // applicable to this implementation:

--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -114,12 +114,6 @@ extension Mutex where Value: ~Copyable {
   ///     }
   ///     return try body(&value)
   ///
-  /// - Warning: Recursive calls to `withLockIfAvailable` within the
-  ///   closure parameter has behavior that is platform dependent.
-  ///   Some platforms may choose to panic the process, deadlock,
-  ///   or leave this behavior unspecified. This will never
-  ///   reacquire the lock however.
-  ///
   /// - Parameter body: A closure with a parameter of `Value`
   ///   that has exclusive access to the value being stored within
   ///   this mutex. This closure is considered the critical section


### PR DESCRIPTION
On all platforms except Linux, calling `withLockIfAvailable()` recursively just returns `nil`. However, our Linux implementation chooses to abort the process instead. We don't need this inconsistent/destructive behaviour and can just return `nil` as we do elsewhere.