### PR TITLE
[CSOptimizer] Skip `??` if it's involved in optional chain with unres…

### DIFF
--- a/test/Constraints/nil-coalescing-favoring.swift
+++ b/test/Constraints/nil-coalescing-favoring.swift
@@ -62,3 +62,12 @@ func test_no_incorrect_favoring(v: Int?, o: Int) {
   sameType(s1, as: Int?.self)
   sameType(s2, as: Int?.self)
 }
+
+extension Int {
+  func test() -> Int { 42 }
+}
+
+func test_optional_chaining(v: Int?, defaultV: Int) {
+  // CHECK: declref_expr type="(consuming Int?, @autoclosure () throws -> Int?) throws -> Int?" {{.*}} decl="Swift.(file).??
+  _ = (v ?? defaultV)?.test() // Ok (no warnings)
+}


### PR DESCRIPTION
…olved result type

`??` operator is overloaded on optionality of its result. When the first argument matches exactly, the ranking is going to be skewed towards selecting an overload choice that returns a non-optional type. This is not always correct i.e. when operator is involved in optional chaining. To avoid producing an incorrect favoring, let's skip the this disjunction when constraints associated with result type indicate that it should be optional.

Simply adding it as a binding won't work because if the second argument is non-optional the overload that returns `T?` would still have a lower score.

Resolves: rdar://164201746

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
