### PR TITLE
Basic: Use getrusage() to read memory usage

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -39,9 +39,6 @@
 #ifdef HAVE_PROC_PID_RUSAGE
 #include <libproc.h>
 #endif
-#ifdef HAVE_MALLOC_MALLOC_H
-#include <malloc/malloc.h>
-#endif
 #if defined(_WIN32)
 #define NOMINMAX
 #include "Windows.h"
@@ -536,25 +533,16 @@ FrontendStatsTracer::~FrontendStatsTracer()
 // associated fields in the provided AlwaysOnFrontendCounters.
 void updateProcessWideFrontendCounters(
     UnifiedStatsReporter::AlwaysOnFrontendCounters &C) {
-  if (auto instrExecuted = getInstructionsExecuted()) {
-    C.NumInstructionsExecuted = instrExecuted;
+#if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
+  struct rusage_info_v4 ru;
+  if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru) == 0) {
+    C.NumInstructionsExecuted = ru.ri_instructions;
+    C.MaxMallocUsage = ru.ri_lifetime_max_phys_footprint;
+    return;
   }
-
-#if defined(HAVE_MALLOC_ZONE_STATISTICS) && defined(HAVE_MALLOC_MALLOC_H)
-  // On Darwin we have a lifetime max that's maintained by malloc we can
-  // just directly query, even if we only make one query on shutdown.
-  malloc_statistics_t Stats;
-  // Query all zones.
-  malloc_zone_statistics(/*zone=*/NULL, &Stats);
-  C.MaxMallocUsage = (int64_t)Stats.max_size_in_use;
-#else
-  // If we don't have a malloc-tracked max-usage counter, we have to rely
-  // on taking the max over current-usage samples while running and hoping
-  // we get called often enough. This will happen when profiling/tracing,
-  // but not while doing single-query-on-shutdown collection.
-  C.MaxMallocUsage = std::max(C.MaxMallocUsage,
-                              (int64_t)llvm::sys::Process::GetMallocUsage());
 #endif
+
+  // FIXME: Do something useful when the above API is not available.
 }
 
 static inline void


### PR DESCRIPTION
On macOS 26, malloc_zone_statistics() always returns a malloc_statistics_t with the max_size_in_use field set to zero. This was an intentional change, so let's remove calls to this API.

Instead, use the proc_pid_rusage() API and return the ri_lifetime_max_phys_footprint field of rusage_info_v4.

Finally, remove the llvm::sys::Process::GetMallocUsage() call on other platforms altogether. It returns the current value and not the max value, so its misleading.