### PR TITLE
[test] enable use-std-span.swift on Darwin x86_64

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -4,9 +4,6 @@
 // TODO: test failed in Windows PR testing: rdar://144384453
 // UNSUPPORTED: OS=windows-msvc
 
-// TODO: test failed in macOS PR testing but passes locally: rdar://163049442
-// UNSUPPORTED: OS_FAMILY=darwin && !CPU=arm64
-
 // REQUIRES: executable_test
 // REQUIRES: std_span
 


### PR DESCRIPTION
Checking if this test case still crashes in CI since I haven't been able to reproduce it locally.

rdar://163049442