### PR TITLE
Fix TypeLowering: BitwiseCopyable archetypes are trivial

### DIFF
--- a/include/swift/SIL/SILTypeProperties.h
+++ b/include/swift/SIL/SILTypeProperties.h
@@ -262,6 +262,7 @@ public:
     return MayHaveCustomDeinit_t((Flags & CustomDeinitFlag) != 0);
   }
 
+  void setTrivial() { Flags &= ~NonTrivialFlag; }
   void setNonTrivial() { Flags |= NonTrivialFlag; }
   void setIsOrContainsRawPointer() { Flags |= HasRawPointerFlag; }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -775,8 +775,14 @@ namespace {
               type, getReferenceSILTypeProperties(isSensitive));
         }
       }
-      return asImpl().handleAddressOnly(
-          type, getOpaqueSILTypeProperties(isSensitive));
+      auto props = getOpaqueSILTypeProperties(isSensitive);
+      if (ProtocolDecl *bitwiseCopyable =
+          TC.Context.getProtocol(KnownProtocolKind::BitwiseCopyable)) {
+        // Archetypes only have unconditional conformance.
+        if (lookupConformance(type, bitwiseCopyable))
+          props.setTrivial();
+      }
+      return asImpl().handleAddressOnly(type, props);
     }
 
     RetTy visitExistentialType(CanType type,


### PR DESCRIPTION
This PR is blocked on a SILGen issue with keypath setter thunks. When Scalar is considered trivial, SILGen omits the temporary allocation for the `@in` argument. In general, we should assume that `@in` may modify the contents of its address even if it is trivial. The callee might not be able to see that it is a trivial type and attempt to
destroy it. We might want it to be legal for that destroy to zero the memory.

A similar bug was fixed here:
https://github.com/swiftlang/swift/pull/65579/commits/dc95b112cd382d5befd744474609a1b9f900c8c1

The current blocker is:
```
SIL verification failed: Found mutating or consuming use of an in_guaranteed parameter?!: !ImmutableAddressUseVerifier().isMutatingOrConsuming(fArg)

Verifying argument:
-> %0 = argument of bb0 : $*Scalar                // user: %5
     %5 = apply %4<Scalar>(%0, %3, %1) : $@convention(method) <τ_0_0 where τ_0_0 : SIMDScalar> (@in τ_0_0, Int, @inout SIMD2<τ_0_0>) -> ()

In function:

// key path setter for SIMD2.subscript(_:) : <A>SIMD2<A>A
sil shared [thunk] [ossa] @$ss5SIMD2VyxSicips10SIMDScalarRzlAByxGxTk : $@convention(keypath_accessor_setter) <Scalar where Scalar : SIMDScalar> (@in_guaranteed Scalar, @inout SIMD2<Scalar>, @in_guaranteed Int) -> () {
// %0                                             // user: %5
// %1                                             // user: %5
// %2                                             // user: %3
bb0(%0 : $*Scalar, %1 : $*SIMD2<Scalar>, %2 : $*Int):
  %3 = load [trivial] %2                          // user: %5
  // function_ref SIMD2.subscript.setter
  %4 = function_ref @$ss5SIMD2VyxSicis : $@convention(method) <τ_0_0 where τ_0_0 : SIMDScalar> (@in τ_0_0, Int, @inout SIMD2<τ_0_0>) -> () // user: %5
  %5 = apply %4<Scalar>(%0, %3, %1) : $@convention(method) <τ_0_0 where τ_0_0 : SIMDScalar> (@in τ_0_0, Int, @inout SIMD2<τ_0_0>) -> ()
  %6 = tuple ()                                   // user: %7
  return %6                                       // id: %7
} // end sil function '$ss5SIMD2VyxSicips10SIMDScalarRzlAByxGxTk'
```
