### PR TITLE
[CSOptimizer] Use `conformsToKnownProtocol` to check whether paramete…

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1316,27 +1316,20 @@ static void determineBestChoicesInContext(
               return 0.3;
           }
 
-          auto &ctx = cs.getASTContext();
-
           // Check if the other side conforms to `ExpressibleByArrayLiteral`
           // protocol (in some way). We want an overly optimistic result
           // here to avoid under-favoring.
           if (candidateType->isArray() &&
-              checkConformanceWithoutContext(
-                  paramType,
-                  ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral),
-                  /*allowMissing=*/true))
+              TypeChecker::conformsToKnownProtocol(
+                  paramType, KnownProtocolKind::ExpressibleByArrayLiteral))
             return 0.3;
 
           // Check if the other side conforms to
           // `ExpressibleByDictionaryLiteral` protocol (in some way).
           // We want an overly optimistic result here to avoid under-favoring.
           if (candidateType->isDictionary() &&
-              checkConformanceWithoutContext(
-                  paramType,
-                  ctx.getProtocol(
-                      KnownProtocolKind::ExpressibleByDictionaryLiteral),
-                  /*allowMissing=*/true))
+              TypeChecker::conformsToKnownProtocol(
+                  paramType, KnownProtocolKind::ExpressibleByDictionaryLiteral))
             return 0.3;
         }
 

--- a/validation-test/Sema/type_checker_perf/fast/array_literals_with_custom_types.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_literals_with_custom_types.swift.gyb
@@ -1,0 +1,16 @@
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+struct MyIntValue: ExpressibleByArrayLiteral {
+    init(arrayLiteral: Int...) {}
+}
+
+func +(x: MyIntValue, y: MyIntValue) -> MyIntValue { [] }
+func +(x: MyIntValue, y: Int) -> MyIntValue { [] }
+
+func test(y: Int) {
+%for i in range(0, N):
+  [1] + y +
+%end
+  [1] + y
+}


### PR DESCRIPTION
…r conforms to `ExpressibleBy{Array, Dictionary}Literal`

The existing check is no-op because it would never produce a null for `paramType` under the conditions in `else` branch. A better API it use here is `conformsToKnownProtocol` just like in other cases.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
