### PR TITLE
[Reflection] Improve size computation for remote type metadata reading.

### DIFF
--- a/include/swift/ABI/TrailingObjects.h
+++ b/include/swift/ABI/TrailingObjects.h
@@ -421,6 +421,15 @@ public:
   }
 };
 
+// Helper function to determine at build time if a type has TrailingObjects.
+// This is useful for determining if trailingTypeCount and
+// sizeWithTrailingTypeCount are available for code that reads TrailingObjects
+// values in a generalized fashion.
+template <typename T>
+static constexpr bool typeHasTrailingObjects() {
+  return std::is_base_of_v<trailing_objects_internal::TrailingObjectsBase, T>;
+}
+
 } // end namespace ABI
 } // end namespace swift
 

--- a/validation-test/Reflection/function_types.swift
+++ b/validation-test/Reflection/function_types.swift
@@ -1,0 +1,59 @@
+// Target Swift 5.5 so functions with global actors are encoded as a proper
+// mangled name, not a function accessor. Remote Mirror can't call function
+// accessors and will fail to read the type.
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-swift-5.5-abi-triple -lswiftSwiftReflectionTest %s -o %t/function_types
+// RUN: %target-codesign %t/function_types
+
+// RUN: %target-run %target-swift-reflection-test %t/function_types | %FileCheck %s --check-prefix=CHECK
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+struct S {
+  var f = { @MainActor in }
+}
+
+// This Task is necessary to ensure that the concurrency runtime is brought in.
+// Without that, the type lookup for @MainActor may fail.
+Task {}
+
+// CHECK: Type reference:
+// CHECK: (struct function_types.S)
+
+// CHECK: Type info:
+// CHECK: (struct size=
+// CHECK:   (field name=f offset=0
+// CHECK:     (thick_function size=
+// CHECK:       (field name=function offset=0
+// CHECK:         (builtin size=
+// CHECK:       (field name=context
+// CHECK:         (reference kind=strong refcounting=native)))))
+// CHECK: Mangled name: $s14function_types1SV
+// CHECK: Demangled name: function_types.S
+reflect(any: S())
+
+// CHECK: Type reference:
+// CHECK: (function
+// CHECK:   (global-actor
+// CHECK:       (class Swift.MainActor))
+// CHECK:       (parameters)
+// CHECK:       (result
+// CHECK:         (tuple))
+
+// CHECK: Type info:
+// CHECK: (thick_function size=
+// CHECK:   (field name=function offset=0
+// CHECK:     (builtin size=
+// CHECK:   (field name=context offset=
+// CHECK:     (reference kind=strong refcounting=native)))
+// CHECK: Mangled name: $syyScMYcc
+// CHECK: Demangled name: @Swift.MainActor () -> ()
+reflect(any: S().f)
+
+doneReflecting()
+


### PR DESCRIPTION
Take advantage of the ability to iterate over TrailingObjects when computing the size of certain kinds of type metadata. This avoids the occasional issue where a new trailing object is added to a type, the remote metadata reader isn't fully updated for it, and doesn't read enough data. This change fixes an issue with function type metadata where we didn't read the global actor field.

Not all type metadata is amenable to this, as some don't use TrailingObjects for their trailing data (e.g. various nominal types) and extended existentials need to dereference their Shape pointer to determine the number of TrailingObjects, which needs some additional code when done remotely. We are able to automatically calculate the sizes of Existential and Function.

rdar://162855053