### PR TITLE
[Multi-threaded IRGen] Ensure that autolink info gets into each object file

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1740,9 +1740,7 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
 
     (void)layoutStringsEnabled(*IGM, /*diagnose*/ true);
 
-    // Only need to do this once.
-    if (!IGMcreated)
-      IGM->addLinkLibraries();
+    IGM->addLinkLibraries();
     IGMcreated = true;
   }
 

--- a/test/IRGen/autolink_multithread.swift
+++ b/test/IRGen/autolink_multithread.swift
@@ -1,0 +1,35 @@
+// This test checks that we produce autolink entries into the expected places
+// when performing multi-threaded IR generation.
+
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+
+// RUN: %target-swift-frontend -emit-ir %t/src/A.swift %t/src/B.swift -I %t -Fsystem %S/Inputs/Frameworks -o %t/A.ll -o %t/B.ll -num-threads 2 -O -g -module-name test
+// RUN: %FileCheck --check-prefix=CHECK-A %s <%t/A.ll
+// RUN: %FileCheck --check-prefix=CHECK-B %s <%t/B.ll
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: autolink-extract
+// REQUIRES: OS=macosx
+
+
+//--- A.swift
+import empty
+
+public func f() -> String { "hello" }
+
+// CHECK-A: !llvm.linker.options = !{
+// CHECK-A: !{{[0-9]+}} = !{!{{"-lempty"|"/DEFAULTLIB:empty.lib"}}}
+
+//--- B.swift
+import LinkFramework
+
+public func useLibrarySym() {
+  let _ = LinkFramework.IComeFromLinkFramework
+}
+
+// CHECK-B: !llvm.linker.options = !{
+// CHECK-B: !{{[0-9]+}} = !{!"-framework", !"LinkFramework"}


### PR DESCRIPTION
When performing multi-threaded IRGen, all of the link libraries used for autolinking went (only) into the first object file. If the object files were then placed in a static archive, the autolinking would only kick in if clients that link the static library reference something in the first object file. This causes link failures.

Make sure that we put the autolink information into each of the object files we create when doing multi-threaded IRGen.

Fixes the rest of rdar://162400654.