### PR TITLE
build.ps1: fix toolchain name trimming for arm64

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1366,7 +1366,7 @@ function Get-Dependencies {
 
     # TODO(compnerd) stamp/validate that we need to re-extract
     New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
-    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $PinnedToolchain.TrimStart("swift-").TrimEnd("-a-windows10")
+    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $PinnedToolchain.TrimStart("swift-").TrimEnd("-arm64").TrimEnd("-a-windows10")
     Write-Success "Swift Toolchain $PinnedVersion"
 
     if ($Android) {


### PR DESCRIPTION
Currently, this expects a string like "swift-DEVELOPMENT-SNAPSHOT-2025-11-03-a-windows10" but arm64 builds also have a "-arm64" tacked on.

`.TrimEnd("-arm64")` is a no-op on the x64 version, so I figured better to do it this way than a messy regex or conditions.