### PR TITLE
Remove unused ASTSectionImporter entry point (NFC)

### DIFF
--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -64,11 +64,5 @@ namespace swift {
   parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
                   StringRef Data, const llvm::Triple &filter);
 
-  // An old version temporarily left for remaining call site.
-  // TODO: remove this once the other version is committed and used.
-  bool parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
-                       StringRef Data, const llvm::Triple &filter,
-                       SmallVectorImpl<std::string> &foundModules);
-
 }
 #endif

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -104,17 +104,3 @@ swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
 
   return foundModules;
 }
-
-bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
-                            StringRef buf,
-                            const llvm::Triple &filter,
-                            SmallVectorImpl<std::string> &foundModules) {
-  auto Result = parseASTSection(Loader, buf, filter);
-  if (auto E = Result.takeError()) {
-    llvm::dbgs() << toString(std::move(E));
-    return false;
-  }
-  for (auto m : *Result)
-    foundModules.push_back(m);
-  return true;
-}


### PR DESCRIPTION
This was introduced as a temporary measure in https://github.com/swiftlang/swift/pull/67833

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
