### PR TITLE
build: explicitly error out if `-print-target-info` fails

### DIFF
--- a/Runtimes/Core/cmake/modules/PlatformInfo.cmake
+++ b/Runtimes/Core/cmake/modules/PlatformInfo.cmake
@@ -15,7 +15,14 @@ set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
 if(CMAKE_Swift_COMPILER_TARGET)
   list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
 endif()
-execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+execute_process(COMMAND ${module_triple_command}
+  OUTPUT_VARIABLE target_info_json
+  ERROR_VARIABLE stderr
+  RESULT_VARIABLE ec)
+if(ec)
+  message(FATAL_ERROR "'${module_triple_command}' returned non-zero exit code ${ec}")
+  message(CONFIGURE_LOG "Error Output: ${stderr}")
+endif()
 message(CONFIGURE_LOG "Swift target info: ${module_triple_command}\n"
 "${target_info_json}")
 


### PR DESCRIPTION
Rather than trying to silently continue, catch an execution error and report it to the user. There is no possible recovery at this point.