### PR TITLE
[ABIChecker] Remove -iframework from swift-api-digester

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2099,10 +2099,6 @@ def BI : JoinedOrSeparate<["-"], "BI">,
 def BI_EQ : Joined<["-"], "BI=">, Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   Alias<BI>;
 
-def iframework : JoinedOrSeparate<["-"], "iframework">,
-  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
-  HelpText<"add a directory to the clang importer system framework search path">;
-
 def baseline_path : JoinedOrSeparate<["-"], "baseline-path">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
   HelpText<"The path to the Json file that we should use as the baseline">;

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -38,7 +38,6 @@
 #include "swift/Option/Options.h"
 #include "swift/Parse/ParseVersion.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
@@ -2365,7 +2364,6 @@ public:
     Triple = ParsedArgs.getLastArgValue(OPT_target).str();
     SwiftVersion = ParsedArgs.getLastArgValue(OPT_swift_version).str();
     SystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_Fsystem);
-    llvm::append_range(SystemFrameworkPaths, ParsedArgs.getAllArgValues(OPT_iframework));
     BaselineFrameworkPaths = ParsedArgs.getAllArgValues(OPT_BF);
     FrameworkPaths = ParsedArgs.getAllArgValues(OPT_F);
     SystemModuleImportPaths = ParsedArgs.getAllArgValues(OPT_Isystem);


### PR DESCRIPTION
-iframework is a holdover from when swift-api-digester was an LLVM tool. Now that everything has switched over to -Fsystem, -iframework can be removed.

rdar://153665579