### PR TITLE
SILGen: fix cast of Optional<any Sendable> -> Optional<Any>

### DIFF
--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -108,6 +108,13 @@ struct ExistentialLayout {
   /// Determine whether this refers to any non-marker protocols.
   bool containsNonMarkerProtocols() const;
 
+  /// Is the memory representation of this layout ABI-compatible with another?
+  ///
+  /// ABI compatability primarily has to do with which protocol's witness tables
+  /// will exist in the layout. Having any differences in terms of which witness
+  /// tables are present is an ABI difference.
+  bool isABICompatibleWith(ExistentialLayout const &other) const;
+
   ArrayRef<ParameterizedProtocolType *> getParameterizedProtocols() const & {
     return parameterized;
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1230,6 +1230,22 @@ bool ExistentialLayout::containsNonMarkerProtocols() const {
   return false;
 }
 
+bool ExistentialLayout::isABICompatibleWith(
+    ExistentialLayout const &other) const {
+  /// All non-marker protocols are expected to have witness tables.
+  auto hasWitnessTable = [](ProtocolDecl const *proto) {
+    return !proto->isMarkerProtocol();
+  };
+  auto selfProtos = make_filter_range(getProtocols(), hasWitnessTable);
+  auto otherProtos = make_filter_range(other.getProtocols(), hasWitnessTable);
+
+  // Ensure the number of non-marker protocols are the same and that they're
+  // the same ProtocolDecl* according to operator==.
+  //
+  // We rely on the relative order of protocols being canonical.
+  return llvm::equal(selfProtos, otherProtos);
+}
+
 LayoutConstraint ExistentialLayout::getLayoutConstraint() const {
   if (hasExplicitAnyObject) {
     return LayoutConstraint::getLayoutConstraint(

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -417,19 +417,15 @@ adjustForConditionalCheckedCastOperand(SILLocation loc, ManagedValue src,
   if (!hasAbstraction && (!requiresAddress || src.getType().isAddress()))
     return src;
   
-  TemporaryInitializationPtr init;
   if (requiresAddress) {
-    init = SGF.emitTemporary(loc, srcAbstractTL);
 
     if (hasAbstraction)
       src = SGF.emitSubstToOrigValue(loc, src, abstraction, sourceType);
 
-    // Okay, if all we need to do is drop the value in an address,
-    // this is easy.
-    SGF.B.emitStoreValueOperation(loc, src.forward(SGF), init->getAddress(),
-                                  StoreOwnershipQualifier::Init);
-    init->finishInitialization(SGF);
-    return init->getManagedAddress();
+    if (src.getType().isAddress())
+      return src;
+
+    return src.materialize(SGF, loc);
   }
   
   assert(hasAbstraction);

--- a/test/SILGen/Inputs/objc_bridging_sendable.h
+++ b/test/SILGen/Inputs/objc_bridging_sendable.h
@@ -4,4 +4,7 @@
 - (void) takeSendable: (id __attribute__((swift_attr("@Sendable")))) x;
 @property(readonly) id __attribute__((swift_attr("@Sendable"))) x;
 - (nullable __attribute__((swift_attr("@Sendable"))) id)test:(NSError *_Nullable __autoreleasing * _Nullable)error;
+- (nullable __attribute__((swift_attr("@Sendable"))) id)sendableNullableNSObject;
+- (nullable id)regularNullableNSObject;
+- (nonnull id)regularNSObject;
 @end

--- a/test/SILGen/objc_bridging_sendable.swift
+++ b/test/SILGen/objc_bridging_sendable.swift
@@ -34,3 +34,68 @@ func test_use_of_buffer_init() throws {
       try $0.test()
   }
 }
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s22objc_bridging_sendable5cast1yyXlSgSo6NSBlahCF : $@convention(thin) (@guaranteed NSBlah) -> @owned Optional<AnyObject> {
+// CHECK:       bb0(%0 : @guaranteed $NSBlah):
+// CHECK:         [[TEST_REF:%.*]] = objc_method %0 : $NSBlah, #NSBlah.sendableNullableNSObject!foreign : (NSBlah) -> () -> (any Sendable)?, $@convention(objc_method) (NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK:         [[RESULT:%.*]] = apply [[TEST_REF]](%0) : $@convention(objc_method) (NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK:         [[OPTIONAL_SENDABLE:%.*]] = alloc_stack $Optional<any Sendable>
+// CHECK:         switch_enum [[RESULT]] : $Optional<AnyObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+//
+//  AnyObject -> Optional<AnyObject> -> Any -> any Sendable -> Optional<any Sendable>
+//
+// CHECK:       bb1([[SUCCESS:%.*]] : @owned $AnyObject):
+// CHECK:         [[OPT_RESULT_VALUE:%.*]] = unchecked_ref_cast [[SUCCESS]] : $AnyObject to $Optional<AnyObject>
+// CHECK:         [[BRIDGE_INTRINSIC_REF:%.*]] = function_ref @$ss018_bridgeAnyObjectToB0yypyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK:         [[INTRINSIC_RET:%.*]] = alloc_stack $Any
+// CHECK:         apply [[BRIDGE_INTRINSIC_REF]]([[INTRINSIC_RET]], [[OPT_RESULT_VALUE]]) : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK:         [[ANY_EXT_ADDR:%.*]] = open_existential_addr immutable_access [[INTRINSIC_RET]] : $*Any to $*@opened({{.*}}, Any) Self
+// CHECK:         [[ANY_SENDABLE:%.*]] = alloc_stack $any Sendable
+// CHECK:         [[ANY_SENDABLE_EXT_ADDR:%.*]] = init_existential_addr [[ANY_SENDABLE]] : $*any Sendable, $@opened({{.*}}, Any) Self
+// CHECK:         copy_addr [[ANY_EXT_ADDR]] to [init] [[ANY_SENDABLE_EXT_ADDR]]
+// CHECK:         [[OPTIONAL_SENDABLE_DATA_ADDR:%.*]] = init_enum_data_addr [[OPTIONAL_SENDABLE]] : $*Optional<any Sendable>, #Optional.some!enumelt
+// CHECK:         copy_addr [take] [[ANY_SENDABLE]] to [init] [[OPTIONAL_SENDABLE_DATA_ADDR]]
+// CHECK:         inject_enum_addr [[OPTIONAL_SENDABLE]] : $*Optional<any Sendable>, #Optional.some!enumelt
+// CHECK:         br bb3
+//
+// The main thing we previously had trouble with is:
+//   Optional<any Sendable> -> Optional<Any> -> AnyObject
+//
+// CHECK:       bb3:
+// CHECK-NEXT:    [[ABI_COMPATABLE_IMPLICIT_CAST_RESULT:%.*]] = unchecked_addr_cast [[OPTIONAL_SENDABLE]] : $*Optional<any Sendable> to $*Optional<Any>
+// CHECK-NEXT:    [[EXPLICIT_CAST_RESULT:%.*]] = alloc_stack $AnyObject
+// CHECK:         checked_cast_addr_br take_always Optional<Any> in [[ABI_COMPATABLE_IMPLICIT_CAST_RESULT]] : $*Optional<Any> to AnyObject in [[EXPLICIT_CAST_RESULT]] : $*AnyObject
+func cast1(_ b: NSBlah) -> AnyObject? {
+  return b.sendableNullableNSObject() as? AnyObject
+}
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s22objc_bridging_sendable5cast2yyXlSgSo6NSBlahCF
+// CHECK:         [[OPTIONAL_ANY:%.*]] = alloc_stack $Optional<Any>
+// CHECK-NEXT:    switch_enum {{.*}} : $Optional<AnyObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+//
+// I've abbreviated the CHECK lines for bb1, since `cast1` already covers most of this:
+//   AnyObject -> Optional<AnyObject> -> Any -> Optional<Any>
+//
+// CHECK:         bb1({{.*}} : @owned $AnyObject):
+// CHECK:           function_ref @$ss018_bridgeAnyObjectToB0yypyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK:           [[OPTIONAL_ANY_DATA_ADDR:%.*]] = init_enum_data_addr [[OPTIONAL_ANY]] : $*Optional<Any>, #Optional.some!enumelt
+// CHECK:           copy_addr [take] {{.*}} to [init] [[OPTIONAL_ANY_DATA_ADDR]] : $*Any
+// CHECK:           inject_enum_addr [[OPTIONAL_ANY]] : $*Optional<Any>
+//
+//   Optional<Any> -> AnyObject
+//
+// CHECK:       bb3:                                              // Preds: bb2 bb1
+// CHECK-NEXT:    [[EXPLICIT_CAST_RESULT:%.*]] = alloc_stack $AnyObject
+// CHECK-NEXT:    checked_cast_addr_br take_always Optional<Any> in [[OPTIONAL_ANY]] : $*Optional<Any> to AnyObject in [[EXPLICIT_CAST_RESULT]] : $*AnyObject
+func cast2(_ b: NSBlah) -> AnyObject? {
+  return b.regularNullableNSObject() as? AnyObject
+}
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s22objc_bridging_sendable5cast3yyXlSgSo6NSBlahCF
+// CHECK:         [[BRIDGE_FN:%.*]] = function_ref @$ss018_bridgeAnyObjectToB0yypyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK:         apply [[BRIDGE_FN]]([[ANY:%.*]], {{.*}})
+// CHECK:         [[EXPLICIT_CAST_RESULT:%.*]] = alloc_stack $AnyObject
+// CHECK:         checked_cast_addr_br take_always Any in [[ANY]] : $*Any to AnyObject in [[EXPLICIT_CAST_RESULT]] : $*AnyObject
+func cast3(_ b: NSBlah) -> AnyObject? {
+  return b.regularNSObject() as? AnyObject
+}


### PR DESCRIPTION
In some cases, at least with ObjC bridging, we could end up throwing `SGF.emitSubstToOrigValue` into an infinite recursion through `Transform::transform`, in the case of the optional-to-optional conversion:

  Optional<any Sendable> -> Optional<Any>

There's special handling for such conversions in SILGen, and the problem is its old recognition of `any Sendable` being "equivalent" in terms of ABI to `Any` relied on type equality.

While the types are not equal at compile time, they are at runtime. Plus, they are ABI equivalent.

resolves rdar://163872193
