### PR TITLE
[stdlib] Fix assertionFailure() not respecting -assert-config Release at -Onone

### DIFF
--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -163,8 +163,7 @@ public func precondition(
 ///     where `assertionFailure(_:file:line:)` is called.
 ///   - line: The line number to print along with `message`. The default is the
 ///     line number where `assertionFailure(_:file:line:)` is called.
-@inlinable
-@inline(__always)
+@_transparent
 #if $Embedded
 @_disfavoredOverload
 #endif
@@ -182,8 +181,7 @@ public func assertionFailure(
 }
 
 #if $Embedded
-@inlinable
-@inline(__always)
+@_transparent
 public func assertionFailure(
   _ message: @autoclosure () -> StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line

--- a/validation-test/stdlib/AssertDiagnosticsSIL.swift
+++ b/validation-test/stdlib/AssertDiagnosticsSIL.swift
@@ -1,7 +1,10 @@
 // RUN: %target-swift-frontend %s -emit-sil -verify
 
-func assertionFailure_isNotNoreturn() -> Int {
-  _ = 0 // Don't implicitly return the assertionFailure call.
+// assertionFailure() is now @_transparent (previously @inlinable), so the
+// compiler can see that it never returns, eliminating the "missing return" error.
+func assertionFailure_isNoreturn() -> Int {
+  _ = 0
   assertionFailure("")
-} // expected-error {{missing return in global function expected to return 'Int'}}
+  // No error expected - assertionFailure() is recognized as Never-returning
+}
 


### PR DESCRIPTION
Fixes #85382.

Currently, `assertionFailure()` crashes at `-Onone -assert-config Release` because it used `@inlinable @inline(__always)` instead of `@_transparent`. At `-Onone`, this caused a call to the pre-compiled stdlib (built in Debug mode) instead of inlining.

To address this, we change it to `@_transparent` for mandatory inlining at all optimization levels, consistent with `assert()`, `precondition()`, and `preconditionFailure()`.