### PR TITLE
[Clang mangling] Don't mangle when Clang says not to

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4759,8 +4759,10 @@ void ClangImporter::Implementation::getMangledName(
     auto ctorGlobalDecl =
         clang::GlobalDecl(ctor, clang::CXXCtorType::Ctor_Complete);
     mangler->mangleCXXName(ctorGlobalDecl, os);
-  } else {
+  } else if (mangler->shouldMangleDeclName(clangDecl)) {
     mangler->mangleName(clangDecl, os);
+  } else {
+    os << clangDecl->getName();
   }
 }
 

--- a/test/Inputs/clang-importer-sdk/usr/include/string.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/string.h
@@ -7,6 +7,12 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+
+typedef __SIZE_TYPE__ size_t;
+#endif
+
 void* memcpy(void* s1, const void* s2, size_t n);
 void* memmove(void* s1, const void* s2, size_t n);
 char* strcpy (char* s1, const char* s2);
@@ -29,5 +35,9 @@ char* strtok(char* s1, const char* s2);
 void* memset(void* s, int c, size_t n);
 char* strerror(int errnum);
 size_t strlen(const char* s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SDK_STRING_H

--- a/test/Interop/Cxx/extern-c/Inputs/my-memory.h
+++ b/test/Interop/Cxx/extern-c/Inputs/my-memory.h
@@ -1,0 +1,11 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef __SIZE_TYPE__ size_t;
+
+void* memset(void* s, int c, size_t n);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/Interop/Cxx/extern-c/decls.swift
+++ b/test/Interop/Cxx/extern-c/decls.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -I %S/Inputs -import-bridging-header %S/../../../Inputs/clang-importer-sdk/usr/include/string.h -enable-experimental-cxx-interop | %FileCheck %s
+
+
+func zerome(ptr: UnsafeMutablePointer<Int>) {
+  memset(ptr, 0, MemoryLayout<Int>.size)
+}
+
+// Verify that the asmname is "memset", not a C++-mangled version
+// CHECK: sil [serialized] [asmname "memset"] [clang memset] @$sSo6memsetySvSgAB_s5Int32VSitFTo : $@convention(c) (Optional<UnsafeMutableRawPointer>, Int32, Int) -> Optional<UnsafeMutableRawPointer>

--- a/test/Interop/Cxx/extern-c/decls.swift
+++ b/test/Interop/Cxx/extern-c/decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -I %S/Inputs -import-bridging-header %S/../../../Inputs/clang-importer-sdk/usr/include/string.h -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -I %S/Inputs -import-bridging-header %S/Inputs/my-memory.h -enable-experimental-cxx-interop | %FileCheck %s
 
 
 func zerome(ptr: UnsafeMutablePointer<Int>) {


### PR DESCRIPTION
We have been mangling extern "C" symbols when building with C++ interoperability, leading to incorrectly-mangled names such as _Z6memset that should have been unmangled "memset". Fix this so we get consistent mangling between C and C++ interoperability modes.

Fixes rdar://164495210.
