### PR TITLE
[ClangImporter] Do not import function decl if already imported via type signature

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3828,8 +3828,8 @@ namespace {
       if (!dc)
         return nullptr;
 
-      // We may have already imported this function decl before we imported the
-      // parent record. In such a case it's important we don't re-import.
+      // We may have already imported this function decl while importing its
+      // decl context. Check decl cache to make sure we don't import twice.
       auto known = Impl.ImportedDecls.find({decl, getVersion()});
       if (known != Impl.ImportedDecls.end()) {
         return known->second;
@@ -4004,6 +4004,13 @@ namespace {
             decl, Diagnostic(diag::invoked_func_not_imported, decl),
             decl->getSourceRange().getBegin());
         return nullptr;
+      }
+
+      // We may have already imported this function decl while importing its
+      // type signature. Check decl cache to make sure we don't import twice.
+      auto known2 = Impl.ImportedDecls.find({decl, getVersion()});
+      if (known2 != Impl.ImportedDecls.end()) {
+        return known2->second;
       }
 
       if (name && name.isSimpleName()) {


### PR DESCRIPTION
This is a small incremental patch that is designed to address the issue discovered by 9aa3c5d17c4bf7379bb7798a44fb350a95436250, which is that we are importing various Decls multiple times.

rdar://164616956