### PR TITLE
AST: Properly disallow isa/cast/dyn_cast on `Type`

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4397,8 +4397,8 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 
       if (decl->hasSendingResult()) {
         Printer << "sending ";
-      } else if (auto *ft = llvm::dyn_cast_if_present<AnyFunctionType>(
-                     decl->getInterfaceType())) {
+      } else if (auto *ft =
+                     decl->getInterfaceType()->getAs<AnyFunctionType>()) {
         if (ft->hasExtInfo() && ft->hasSendingResult()) {
           Printer << "sending ";
         }

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1123,7 +1123,7 @@ ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
 ProtocolConformanceRef ReplaceOpaqueTypesWithUnderlyingTypes::
 operator()(InFlightSubstitution &IFS, Type maybeOpaqueType,
            ProtocolDecl *protocol) const {
-  auto archetype = dyn_cast<OpaqueTypeArchetypeType>(maybeOpaqueType);
+  auto *archetype = maybeOpaqueType->getAs<OpaqueTypeArchetypeType>();
   if (!archetype)
     return ProtocolConformanceRef::forAbstract(maybeOpaqueType, protocol);
 
@@ -1194,7 +1194,7 @@ Type ReplaceExistentialArchetypesWithConcreteTypes::operator()(
 
 ProtocolConformanceRef ReplaceExistentialArchetypesWithConcreteTypes::operator()(
     InFlightSubstitution &IFS, Type origType, ProtocolDecl *proto) const {
-  auto existentialArchetype = dyn_cast<ExistentialArchetypeType>(origType);
+  auto *existentialArchetype = origType->getAs<ExistentialArchetypeType>();
   if (!existentialArchetype ||
       existentialArchetype->getGenericEnvironment() != env)
     return ProtocolConformanceRef::forAbstract(origType.subst(IFS), proto);

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1392,7 +1392,7 @@ void writeAssociatedTypeAliases(llvm::json::OStream &JSON,
                              toFullyQualifiedTypeNameString(type));
               JSON.attribute("substitutedMangledTypeName",
                              toMangledTypeNameString(type));
-              if (auto OpaqueTy = dyn_cast<OpaqueTypeArchetypeType>(type)) {
+              if (auto *OpaqueTy = type->getAs<OpaqueTypeArchetypeType>()) {
                 writeSubstitutedOpaqueTypeAliasDetails(JSON, *OpaqueTy);
               }
             });

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3601,7 +3601,7 @@ bool swift::irgen::hasValidSignatureForEmbedded(SILFunction *f) {
   auto s = f->getLoweredFunctionType()->getInvocationGenericSignature();
   for (auto genParam : s.getGenericParams()) {
     auto mappedParam = f->getGenericEnvironment()->mapTypeIntoEnvironment(genParam);
-    if (auto archeTy = dyn_cast<ArchetypeType>(mappedParam)) {
+    if (auto *archeTy = mappedParam->getAs<ArchetypeType>()) {
       if (archeTy->requiresClass())
         continue;
     }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1599,7 +1599,7 @@ private:
     std::vector<Type> GenericArgs;
     Type CurrentType = BGT;
     while (CurrentType && CurrentType->getAnyNominal()) {
-      if (auto *BGT = llvm::dyn_cast<BoundGenericType>(CurrentType))
+      if (auto *BGT = CurrentType->getAs<BoundGenericType>())
         GenericArgs.insert(GenericArgs.end(), BGT->getGenericArgs().begin(),
                            BGT->getGenericArgs().end());
       CurrentType = CurrentType->getNominalParent();
@@ -2460,9 +2460,10 @@ private:
         return TypeWalker::Action::Stop;
 
       DeclContext *D = nullptr;
-      if (auto *TAT = llvm::dyn_cast<TypeAliasType>(T))
+      if (auto *TAT = llvm::dyn_cast<TypeAliasType>(T.getPointer()))
         D = TAT->getDecl()->getDeclContext();
-      else if (auto *NT = llvm::dyn_cast<NominalOrBoundGenericNominalType>(T))
+      else if (auto *NT = llvm::dyn_cast<NominalOrBoundGenericNominalType>(
+                   T.getPointer()))
         D = NT->getDecl()->getDeclContext();
 
       // A type inside a function uses that function's signature as part of

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9977,7 +9977,7 @@ ConstraintSystem::matchPackElementType(Type elementType, Type patternType,
       return tryFix([&]() {
         auto envShape = genericEnv->mapTypeIntoEnvironment(
             genericEnv->getOpenedElementShapeClass());
-        if (auto *pack = dyn_cast<PackType>(envShape))
+        if (auto *pack = dyn_cast<PackType>(envShape.getPointer()))
           envShape = pack->unwrapSingletonPackExpansion()->getPatternType();
 
         return SkipSameShapeRequirement::create(

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -151,7 +151,7 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
     return true;
 
   ProtocolDecl *BaseTypeProtocolDecl = nullptr;
-  if (auto opaqueType = dyn_cast<OpaqueTypeArchetypeType>(BaseTy)) {
+  if (auto *opaqueType = BaseTy->getAs<OpaqueTypeArchetypeType>()) {
     if (opaqueType->getConformsTo().size() == 1) {
       BaseTypeProtocolDecl = opaqueType->getConformsTo().front();
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2627,7 +2627,7 @@ private:
           if (ty->isKnownImmutableKeyPathType())
             return StorageAccessKind::Get;
 
-          if (auto existential = dyn_cast<ExistentialType>(ty)) {
+          if (auto *existential = ty->getAs<ExistentialType>()) {
             if (auto superclass =
                     existential->getExistentialLayout().getSuperclass()) {
               if (superclass->isKnownImmutableKeyPathType())

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5412,7 +5412,7 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
     unwrappedType = wrappedOptionalType;
   }
 
-  if (auto dynamicSelfType = dyn_cast<DynamicSelfType>(unwrappedType)) {
+  if (auto *dynamicSelfType = unwrappedType->getAs<DynamicSelfType>()) {
     unwrappedType = dynamicSelfType->getSelfType();
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5626,7 +5626,7 @@ struct ImplementationOnlyWalker : TypeWalker {
   const ModuleDecl *currentModule;
   ImplementationOnlyWalker(const ModuleDecl *M) : currentModule(M) {}
   Action walkToTypePre(Type ty) override {
-    if (auto *typeAlias = dyn_cast<TypeAliasType>(ty)) {
+    if (auto *typeAlias = dyn_cast<TypeAliasType>(ty.getPointer())) {
       if (importedImplementationOnly(typeAlias->getDecl()))
         return Action::Stop;
     } else if (auto *nominal = ty->getAs<NominalType>()) {


### PR DESCRIPTION
We currently disallow these by deleting them in the `swift` namespace. This approach has several loopholes, all of which ultimately work because we happen to define specializations of `simplify_type` for `swift::Type`:
* `llvm::isa/cast/dyn_cast`. The deleted partial specializations will not be selected because they are not defined in the `llvm` namespace.
* The argument is a non-const `Type`. The deleted function templates will not be selected because they all accept a `const Type &`, and there is a better `Y &Val` partial specialization in LLVM.
* Other casting function templates such as `isa_and_nonull` and `cast_if_present` are not deleted.

Eliminate these loopholes by instead triggering a static assertion failure with a helpful message upon instantiation of `CastInfo` for `swift::Type`.