### PR TITLE
bumped minor version number swift argument parser

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3625,7 +3625,7 @@ function Build-ArgumentParser([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ArgumentParser) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -UseBuiltCompilers Swift C`
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3625,7 +3625,8 @@ function Build-ArgumentParser([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ArgumentParser) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers Swift C`
+    -UseBuiltCompilers Swift `
+    -UseMSVCCompilers C `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -148,7 +148,7 @@
                 "swift-tools-protocols": "0.0.9",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
-                "swift-argument-parser": "1.5.1",
+                "swift-argument-parser": "1.6.1",
                 "swift-atomics": "1.2.0",
                 "swift-collections": "1.1.6",
                 "swift-crypto": "3.12.5",


### PR DESCRIPTION
Working on the [swift templates](https://github.com/swiftlang/swift-package-manager/pull/9211) proposal. In order to pass SwiftPM CI smoke tests, need to bump the swift-argument-parser version to 1.6.1 to support argument parsing features that come with templates.