### PR TITLE
[SE-0513] Add a `CommandLine.executablePath` property.

### DIFF
--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -18,6 +18,21 @@ import SwiftShims
 internal func _swift_stdlib_getUnsafeArgvArgc(_: UnsafeMutablePointer<Int32>)
   -> UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+@_extern(c, "_NSGetExecutablePath")
+@usableFromInline
+func _NSGetExecutablePath(
+  _ buf: UnsafeMutablePointer<CChar>?,
+  _ bufsize: UnsafeMutablePointer<UInt32>
+) -> CInt
+#elseif os(Windows)
+@_silgen_name("_swift_stdlib_withExecutablePath")
+private func _withExecutablePath(_ body: (UnsafePointer<CWideChar>) -> Void)
+#else
+@_silgen_name("_swift_stdlib_withExecutablePath")
+private func _withExecutablePath(_ body: (UnsafePointer<CChar>) -> Void)
+#endif
+
 /// Command-line arguments for the current process.
 @frozen // namespace
 public enum CommandLine: ~BitwiseCopyable {}
@@ -117,8 +132,8 @@ extension CommandLine {
       _arguments = newValue
     }
   }
-}
 
+<<<<<<< HEAD
 // MARK: - Executable path
 
 extension CommandLine {
@@ -158,6 +173,80 @@ extension CommandLine {
     }
 
     return result
+=======
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+  /// The path to the current executable.
+  ///
+  /// The value of this property may not be canonical. If you need the canonical
+  /// path to the current executable, you can pass the value of this property to
+  /// [`realpath()`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html)
+  /// or use [`URL`](https://developer.apple.com/documentation/foundation/url)
+  /// to standardize the path.
+  ///
+  /// If the path to the current executable could not be determined, the value
+  /// of this property is `nil`.
+  ///
+  /// - Important: On some systems, it is possible to move an executable file on
+  ///   disk while it is running. If the current executable file is moved, the
+  ///   value of this property is not updated to its new path.
+  @_alwaysEmitIntoClient
+  public static var executablePath: FilePath? { // NOTE: can't be AEIC and stored!
+    // _NSGetExecutablePath() returns non-zero if the provided buffer is too
+    // small and updates its *bufsize argument to the required value. Call it
+    // once to get the buffer size before allocating.
+    var byteCount = UInt32(0)
+    _ = unsafe _NSGetExecutablePath(nil, &byteCount)
+    return unsafe withUnsafeTemporaryAllocation(
+      of: CChar.self,
+      capacity: Int(byteCount)
+    ) { buffer in
+      if (unsafe 0 == _NSGetExecutablePath(buffer.baseAddress!, &byteCount)) {
+        return unsafe FilePath(codeUnits: buffer.dropLast().span)
+      }
+      return nil
+    }
+  }
+#else
+  /// The path to the current executable.
+  ///
+  /// The value of this property may not be canonical. If you need the canonical
+  /// path to the current executable, you can pass the value of this property to
+  /// [`realpath()`](https://www.kernel.org/doc/man-pages/online/pages/man3/realpath.3.html)
+  /// ([`_wfullpath()`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fullpath-wfullpath?view=msvc-170)
+  /// on Windows) or use [`URL`](https://developer.apple.com/documentation/foundation/url)
+  /// to standardize the path.
+  ///
+  /// If the path to the current executable could not be determined, the value
+  /// of this property is `nil`.
+  ///
+  /// - Important: On some systems, it is possible to move an executable file on
+  ///   disk while it is running. If the current executable file is moved, the
+  ///   value of this property is not updated to its new path.
+  public static let executablePath: FilePath? = {
+#if os(WASI) || hasFeature(Embedded)
+    // Not supported on WASI because the platform does not provide this
+    // information within the WebAssembly VM. Not supported on Embedded Swift
+    // because there may not even be an operating system or file system present.
+    return nil
+#else
+    var result: String?
+
+    unsafe _withExecutablePath { path in
+      if unsafe path.pointee == 0 {
+        return
+      }
+#if os(Windows)
+      let buffer = unsafe UnsafeBufferPointer(start: path, count: wcslen(path))
+      result = unsafe FilePath(codeUnits: buffer.span)
+#else
+      let buffer = unsafe UnsafeBufferPointer(start: path, count: strlen(path))
+      result = unsafe FilePath(codeUnits: buffer.span)
+#endif
+    }
+
+    return result
+#endif
+>>>>>>> 686962e8ccc (Add an experimental `CommandLine.executablePath` property.)
   }()
 #endif
 }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1343,3 +1343,5 @@ Added: _swift_retainReturningCount
 Added: _$sSS9UTF16ViewV13_copyContents12initializingAB8IteratorV_SitSrys6UInt16VG_tF
 Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_SitSrys6UInt16VG_tF
 
+// SE-0513: CommandLine.executablePath
+Added: _$ss11CommandLineO14executablePathSSSgvpZMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1338,3 +1338,5 @@ Added: _swift_retainReturningCount
 Added: _$sSS9UTF16ViewV13_copyContents12initializingAB8IteratorV_SitSrys6UInt16VG_tF
 Added: _$sSs9UTF16ViewV13_copyContents12initializings16IndexingIteratorVyABG_SitSrys6UInt16VG_tF
 
+// SE-0513: CommandLine.executablePath
+Added: _$ss11CommandLineO14executablePathSSSgvpZMV

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -789,4 +789,7 @@ Func _hashValue(for:) has generic signature change from <H where H : Swift.Hasha
 Func _hashValue(for:) has parameter 0 changing from Default to Shared
 Func _hashValue(for:) is now with @_preInverseGenerics
 
+// SE-NNNN: CommandLine.executablePath
+Func _NSGetExecutablePath(_:_:) is a new API without '@available'
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
This PR adds `CommandLine.executablePath`. We have use cases for this property in Swift Testing, Swift Argument Parser, Foundation, and other places; three use cases a stdlib API makes.

Implements [SE-0513](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0513-commandline-executablepath.md).