### PR TITLE
[SE-0512] Adjust the docs for `Mutex.withLockIfAvailable()` re: spurious failures.

### DIFF
--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -120,8 +120,13 @@ extension Mutex where Value: ~Copyable {
   ///   as it will only be executed if the calling thread acquires
   ///   the lock.
   ///
-  /// - Returns: The return value, if any, of the `body` closure parameter
-  ///   or nil if the lock couldn't be acquired.
+  /// - Returns: The return value, if any, of the `body` closure parameter or
+  ///   `nil` if the lock couldn’t be acquired.
+  ///
+  /// - Note: This function cannot spuriously fail to acquire the lock. The
+  ///   behavior of similar functions in other languages (such as C's
+  ///   `mtx_trylock()`) is platform-dependent and may differ from Swift's
+  ///   behavior.
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent


### PR DESCRIPTION
This PR adjusts the documentation for `Mutex.withLockIfAvailable()` to clarify that it is not subject to spurious failures. The C11 and C++11 specs for their respective `tryLock()` APIs allow for spurious failures, but our implementations and those of every other similar API I've found don't use weak `cmpxchg`s and don't spuriously fail.

Implements [SE-0512](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0512-withlockifavailable-cannot-spuriously-fail.md).