### PR TITLE
Retain the Swift calling convention when it's on an imported C declaration

### DIFF
--- a/test/IRGen/c_calling_conventions.swift
+++ b/test/IRGen/c_calling_conventions.swift
@@ -21,6 +21,6 @@ func test() {
   // CHECK: call swiftcc void @with_swiftcc()
   with_swiftcc()
 }
-// CHECK: declare swiftcc void @with_swiftcc()
+// CHECK: declare {{.*}}swiftcc void @with_swiftcc()
 
 test()

--- a/test/IRGen/c_calling_conventions.swift
+++ b/test/IRGen/c_calling_conventions.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -I%t %t/caller.swift -emit-ir | %FileCheck %s
+
+//--- c_funcs.h
+
+__attribute__((swiftcall))
+extern void with_swiftcc(void);
+
+//--- module.modulemap
+
+module c_funcs {
+  header "c_funcs.h"
+}
+
+//--- caller.swift
+
+import c_funcs
+
+func test() {
+  // CHECK: call swiftcc void @with_swiftcc()
+  with_swiftcc()
+}
+// CHECK: declare swiftcc void @with_swiftcc()
+
+test()


### PR DESCRIPTION
Fixes issue #69264.
