### PR TITLE
[IDE] Avoid printing some Swift extensions twice in mixed source fram…

### DIFF
--- a/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Headers/MyType.h
+++ b/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Headers/MyType.h
@@ -1,0 +1,2 @@
+@interface MyType
+@end

--- a/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Modules/TestExt.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Modules/TestExt.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,16 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 6.2
+// swift-module-flags: -target arm64-apple-macos10.13 -enable-library-evolution -swift-version 5 -module-name TestExt
+
+@_exported import TestExt
+
+extension MyType {
+  public struct MyInnerType {
+    public func test() {}
+  }
+}
+
+extension Int {
+    public struct OtherInnerType {
+    }
+}

--- a/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Modules/module.modulemap
+++ b/test/SynthesizeInterfaceTool/Inputs/Frameworks/TestExt.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module TestExt {
+  header "MyType.h"
+  export *
+}

--- a/test/SynthesizeInterfaceTool/test-swift-extension-printing.swift
+++ b/test/SynthesizeInterfaceTool/test-swift-extension-printing.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-synthesize-interface -module-name TestExt -F %S/Inputs/Frameworks -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx && CPU=arm64
+
+// CHECK: open class MyType
+
+// CHECK: extension MyType {
+// CHECK:     public struct MyInnerType {
+// CHECK:         public func test()
+// CHECK:     }
+// CHECK: }
+
+// CHECK-NOT: public struct MyInnerType
+
+// CHECK: extension Int {
+// CHECK:     public struct OtherInnerType {
+// CHECK:     }
+// CHECK: }
+
+// CHECK-NOT: public struct MyInnerType


### PR DESCRIPTION
…eworks

`printModuleInterfaceDecl` printes extensions right after the type they are associated with is printed. Extensions associated with a type that appears in the "target" module shouldn't be added to `SwiftDecls` because that would lead to double printing them.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
