### PR TITLE
[windows] refactor pip installation's Python invocation in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1307,7 +1307,7 @@ function Get-Dependencies {
       $GetPipURL = "https://bootstrap.pypa.io/get-pip.py"
       $GetPipPath = "$BinaryCache/$FileName/get-pip.py"
       $WebClient.DownloadFile($GetPipURL, $GetPipPath)
-      & "$BinaryCache/$FileName/python.exe" $GetPipPath
+      Invoke-Program -Silent "$(Get-PythonExecutable)" $GetPipPath
     }
 
     function Install-PIPIfNeeded {


### PR DESCRIPTION
This patch refactors the way we invoke Python in build.ps1 when we install pip for packaging.

This change fixes a build error when cross compiling (invoking the wrong Python for the build platform).

rdar://164654579