### PR TITLE
[CS] Fix a couple of missing error paths

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2212,6 +2212,8 @@ private:
 
     if (auto newResultTarget = rewriter.rewriteTarget(target)) {
       resultExpr = newResultTarget->getAsExpr();
+    } else {
+      hadError = true;
     }
 
     switch (mode) {
@@ -2259,8 +2261,11 @@ private:
     }
 
     auto *resultExpr = thenStmt->getResult();
-    if (auto newResultTarget = rewriter.rewriteTarget(*target))
+    if (auto newResultTarget = rewriter.rewriteTarget(*target)) {
       resultExpr = newResultTarget->getAsExpr();
+    } else {
+      hadError = true;
+    }
 
     thenStmt->setResult(resultExpr);
 

--- a/validation-test/compiler_crashers_fixed/DiagnoseWalker-walkToExprPre-50b7d0.swift
+++ b/validation-test/compiler_crashers_fixed/DiagnoseWalker-walkToExprPre-50b7d0.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"7f0c85e8","signature":"diagSyntacticUseRestrictions(swift::Expr const*, swift::DeclContext const*, bool)::DiagnoseWalker::walkToExprPre(swift::Expr*)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 class a<b, c>: ExpressibleByDictionaryLiteral {
   typealias Key = b
   typealias Value = c

--- a/validation-test/compiler_crashers_fixed/ImplicitSelfUsageChecker-isClosureRequiringSelfQualification-ef6fa0.swift
+++ b/validation-test/compiler_crashers_fixed/ImplicitSelfUsageChecker-isClosureRequiringSelfQualification-ef6fa0.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ImplicitSelfUsageChecker::isClosureRequiringSelfQualification(swift::AbstractClosureExpr const*, bool)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a : ExpressibleByBooleanLiteral {
   c(d : Bool -> (
 }


### PR DESCRIPTION
Make sure we set `hadError` other we'll fail to invalidate the target.