### PR TITLE
Don’t repeat lookup work that may not round-trip

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3238,6 +3238,11 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
 static DirectlyReferencedTypeDecls directReferencesForDeclRefTypeRepr(
     Evaluator &evaluator, ASTContext &ctx, DeclRefTypeRepr *repr,
     DeclContext *dc, DirectlyReferencedTypeLookupOptions options) {
+  // If we've already bound this TypeRepr, don't repeat the work.
+  if (repr->isBound()) {
+    return DirectlyReferencedTypeDecls({ repr->getBoundDecl() }, {});
+  }
+
   if (auto *qualIdentTR = dyn_cast<QualifiedIdentTypeRepr>(repr)) {
     auto result = directReferencesForTypeRepr(
         evaluator, ctx, qualIdentTR->getBase(), dc, options);

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -440,3 +440,11 @@ func dependentTypeLookup<T, U, V, W, X>(_: T, _: U, _: V, _: W, _: X) where
   X: Identifiable, X: ComparableIdentifiable, X.NonexistentModule::ID == Int
   // expected-error@-1 {{module selector is not allowed on generic member type; associated types with the same name are merged instead of shadowing one another}} {{49-68=}}
 {}
+
+// rdar://164647850 -- conforming to `Swift::Error` doesn't work when there's an `Error` type around
+
+enum Error {}
+enum E: Swift::Error { case err }
+
+func testErrorConformance() -> Result<Void, E> { .success(()) }
+// no-error@-1

--- a/validation-test/compiler_crashers_fixed/RequirementMachine-areReducedTypeParametersEqual-1801de.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementMachine-areReducedTypeParametersEqual-1801de.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::rewriting::RequirementMachine::areReducedTypeParametersEqual(swift::Type, swift::Type) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   typealias Index extension Collection where Self : a{b : Index} protocol a


### PR DESCRIPTION
When a DeclRefTypeRepr is bound to a known declaration, the exact DeclNameRef used to create it is erased. This means that we no longer know exactly which module selector was used in the source code, so repeating the lookup with the same instance might produce different results.

Avoid this problem by reusing the bound decl instead of trying to look up the same declaration again.

Fixes rdar://164647850.