### PR TITLE
[CS] Remove `getImplicitValueConversionLocator` & `ImplicitConversion`

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1013,26 +1013,6 @@ public:
   }
 };
 
-class LocatorPathElt::ImplicitConversion final
-    : public StoredIntegerElement<1> {
-public:
-  ImplicitConversion(ConversionRestrictionKind kind)
-      : StoredIntegerElement(ConstraintLocator::ImplicitConversion,
-                             static_cast<unsigned>(kind)) {}
-
-  ConversionRestrictionKind getConversionKind() const {
-    return static_cast<ConversionRestrictionKind>(getValue());
-  }
-
-  bool is(ConversionRestrictionKind kind) const {
-    return getConversionKind() == kind;
-  }
-
-  static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == ConstraintLocator::ImplicitConversion;
-  }
-};
-
 class LocatorPathElt::ContextualType final : public StoredIntegerElement<1> {
 public:
   ContextualType(ContextualTypePurpose purpose)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -252,9 +252,6 @@ CUSTOM_LOCATOR_PATH_ELT(ConformanceRequirement)
 /// A source-specified placeholder.
 CUSTOM_LOCATOR_PATH_ELT(PlaceholderType)
 
-/// The implicit conversion applied at a given location.
-CUSTOM_LOCATOR_PATH_ELT(ImplicitConversion)
-
 /// An implicit call to a 'dynamicMember' subscript for a dynamic member lookup.
 SIMPLE_LOCATOR_PATH_ELT(ImplicitDynamicMemberSubscript)
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3393,12 +3393,6 @@ public:
   ConstraintLocator *
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
-  /// Compute a constraint locator for an implicit value-to-value
-  /// conversion rooted at the given location.
-  ConstraintLocator *
-  getImplicitValueConversionLocator(ConstraintLocatorBuilder root,
-                                    ConversionRestrictionKind restriction);
-
   /// Lookup and return parent associated with given expression.
   Expr *getParentExpr(Expr *expr) {
     if (auto result = getExprDepthAndParent(expr))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7739,16 +7739,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                  isExpr<ForcedCheckedCastExpr>(anchor);
         };
 
-        if (!isCGFloatInit(anchor) && !isCoercionOrCast(anchor, path) &&
-            llvm::none_of(path, [&](const LocatorPathElt &rawElt) {
-              if (auto elt =
-                      rawElt.getAs<LocatorPathElt::ImplicitConversion>()) {
-                auto convKind = elt->getConversionKind();
-                return convKind == ConversionRestrictionKind::DoubleToCGFloat ||
-                       convKind == ConversionRestrictionKind::CGFloatToDouble;
-              }
-              return false;
-            })) {
+        if (!isCGFloatInit(anchor) && !isCoercionOrCast(anchor, path)) {
           conversionsOrFixes.push_back(
               desugar1->isCGFloat()
                   ? ConversionRestrictionKind::CGFloatToDouble
@@ -11029,10 +11020,6 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
                                              ConstraintLocator *locator) {
   auto anchor = locator->getAnchor();
   if (!anchor)
-    return nullptr;
-
-  // Avoid checking implicit conversions injected by the compiler.
-  if (locator->findFirst<LocatorPathElt::ImplicitConversion>())
     return nullptr;
 
   auto getType = [&cs](Expr *expr) -> Type {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -95,7 +95,6 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ArgumentAttribute:
   case ConstraintLocator::UnresolvedMemberChainResult:
   case ConstraintLocator::PlaceholderType:
-  case ConstraintLocator::ImplicitConversion:
   case ConstraintLocator::ImplicitDynamicMemberSubscript:
   case ConstraintLocator::SyntacticElement:
   case ConstraintLocator::PackType:
@@ -460,12 +459,6 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   case ConstraintLocator::ConstraintLocator::ImplicitDynamicMemberSubscript:
     out << "implicit dynamic member subscript";
     break;
-
-  case ConstraintLocator::ConstraintLocator::ImplicitConversion: {
-    auto convElt = elt.castTo<LocatorPathElt::ImplicitConversion>();
-    out << "implicit conversion " << getName(convElt.getConversionKind());
-    break;
-  }
 
   case ConstraintLocator::ConstraintLocator::PackType: {
     auto packElt = elt.castTo<LocatorPathElt::PackType>();

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2580,13 +2580,6 @@ static std::pair<bool, unsigned>
 isInvalidPartialApplication(ConstraintSystem &cs,
                             const AbstractFunctionDecl *member,
                             ConstraintLocator *locator) {
-  // If this is a compiler synthesized implicit conversion, let's skip
-  // the check because the base of `UDE` is not the base of the injected
-  // initializer.
-  if (locator->isLastElement<LocatorPathElt::ConstructorMember>() &&
-      locator->findFirst<LocatorPathElt::ImplicitConversion>())
-    return {false, 0};
-
   auto *UDE = getAsExpr<UnresolvedDotExpr>(locator->getAnchor());
   if (UDE == nullptr)
     return {false,0};


### PR DESCRIPTION
These are now unused since #78957
