### PR TITLE
Platform: add `DirectX.Direct2D` module to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -195,6 +195,17 @@ module WinSDK [system] {
       link "dxgi.lib"
     }
 
+    module Direct2D {
+      header "d2d1.h"
+      header "d2d1_1.h"
+      header "d2d1_2.h"
+      header "d2d1_3.h"
+      export *
+
+      link "d2d1.lib"
+      link "dxgi.lib"
+    }
+
     // FIXME(compnerd) DXGI is part of the Direct3D interfaces currently; we
     // should split it out, but because it is part of the D3D11 interfaces, this
     // separate module is meant to augment the uncovered portions only.


### PR DESCRIPTION
Adding Direct2D to WinSDK. I tested the change locally and was able to use Direct2D types.

cc: @compnerd 

Fixes https://github.com/swiftlang/swift/issues/57723. 

For more context, I was trying to create a shim to expose Direct2D to my Swift package but ran into this assertion (same thing that referenced issue):
```
  Assertion failed: !D->isUnconditionallyVisible() && "expected a hidden declaration", file C:\Users\swift-ci\jenkins\workspace\swift-6.2-windows-toolchain-arm64\llvm-project\clang\lib\Serialization\ASTWriter.cpp, line 7184
  Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
  Stack dump:
  0.      C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\shared\dxgitype.h:91:3: current parser token 'DXGI_MODE_DESC'
  ```
I tried with a variety of toolchains (all with assertions enabled) and they all presented the same issue. I figured that the issue could be related with that type already present in WinSDK, so I decided to try to add the Direct2D module to WinSDK and I got things working. 
