### PR TITLE
SILOptimizer: don't remove empty conflicting access scopes

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -17,6 +17,7 @@ swift_compiler_sources(Optimizer
   ComputeEscapeEffects.swift
   ComputeSideEffects.swift
   CopyToBorrowOptimization.swift
+  DeadAccessScopeElimination.swift
   DeadStoreElimination.swift
   DeinitDevirtualizer.swift
   DestroyHoisting.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadAccessScopeElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadAccessScopeElimination.swift
@@ -1,0 +1,247 @@
+//===--- DeadAccessScopeElimination.swift ----------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Eliminates dead access scopes if they are not conflicting with other scopes.
+///
+/// Removes:
+/// ```
+///   %2 = begin_access [modify] [dynamic] %1
+///   ...                                       // no uses of %2
+///   end_access %2
+/// ```
+///
+/// However, dead _conflicting_ access scopes are not removed.
+/// If a conflicting scope becomes dead because an optimization e.g. removed a load, it is still
+/// important to get an access violation at runtime.
+/// Even a propagated value of a redundant load from a conflicting scope is undefined.
+///
+/// ```
+///   %2 = begin_access [modify] [dynamic] %1
+///   store %x to %2
+///   %3 = begin_access [read] [dynamic] %1    // conflicting with %2!
+///   %y = load %3
+///   end_access %3
+///   end_access %2
+///   use(%y)
+/// ```
+/// After redundant-load-elimination:
+/// ```
+///   %2 = begin_access [modify] [dynamic] %1
+///   store %x to %2
+///   %3 = begin_access [read] [dynamic] %1    // now dead, but still conflicting with %2
+///   end_access %3
+///   end_access %2
+///   use(%x)                                  // propagated from the store, but undefined here!
+/// ```
+/// In this case the scope `%3` is not removed because it's important to get an access violation
+/// error at runtime before the undefined value `%x` is used.
+///
+/// This pass considers potential conflicting access scopes in called functions.
+/// But it does not consider potential conflicting access in callers (because it can't!).
+/// However, optimizations, like redundant-load-elimination, can only do such transformations if
+/// the outer access scope is within the function, e.g.
+///
+/// ```
+/// bb0(%0 : $*T):     // an inout from a conflicting scope in the caller
+///   store %x to %0
+///   %3 = begin_access [read] [dynamic] %1
+///   %y = load %3     // cannot be propagated because it cannot be proved that %1 is the same address as %0
+///   end_access %3
+/// ```
+///
+/// All those checks are only done for dynamic access scopes, because they matter for runtime
+/// exclusivity checking. Dead static scopes are removed unconditionally.
+///
+let deadAccessScopeElimination = FunctionPass(name: "dead-access-scope-elimination") {
+  (function: Function, context: FunctionPassContext) in
+
+  // Add all dead scopes here and then remove the ones which turn out to be conflicting.
+  var removableScopes = SpecificIterableInstructionSet<BeginAccessInst>(context)
+  defer { removableScopes.deinitialize() }
+
+  var scopeTree = ScopeTree(context)
+
+  // The payload is the recent access instruction at the block begin, e.g.
+  // ```
+  //   %1 = begin_acces %0
+  //   br bb2
+  // bb2:                  // recent access instruction at begin of bb2 is: `%1 = begin_acces %0`
+  // ```
+  // It's nil if the block is not within an access scope.
+  //
+  var blockWorklist = BasicBlockWorklistWithPayload<Instruction?>(context)
+  defer { blockWorklist.deinitialize() }
+
+  blockWorklist.pushIfNotVisited(function.entryBlock, with: nil)
+
+  // Walk through the control flow in depth-first order. Note that we don't need to do any kind
+  // of state merging at merge-points, because access scopes must be consistent on all paths.
+  while let (block, recentAccessInstAtBlockBegin) = blockWorklist.pop() {
+
+    // The last seen `begin_access` (or `end_access` in case of not perfectly nested scopes; see ScopeTree.backlinks)
+    var recentAccessInst = recentAccessInstAtBlockBegin
+
+    for inst in block.instructions {
+      process(instruction: inst, updating: &recentAccessInst, &scopeTree, &removableScopes)
+    }
+
+    blockWorklist.pushIfNotVisited(contentsOf: block.successors, with: recentAccessInst)
+  }
+
+  for deadBeginAccess in removableScopes {
+    context.erase(instructionIncludingAllUsers: deadBeginAccess)
+  }
+}
+
+private func process(instruction: Instruction,
+                     updating recentAccessInst: inout Instruction?,
+                     _ scopeTree: inout ScopeTree,
+                     _ removableScopes: inout SpecificIterableInstructionSet<BeginAccessInst>)
+{
+  switch instruction {
+
+  case let beginAccess as BeginAccessInst:
+    if beginAccess.isDead {
+      // Might be removed again later if it turns out to be in a conflicting scope.
+      removableScopes.insert(beginAccess)
+    }
+    if beginAccess.enforcement != .dynamic {
+      // We unconditionally remove dead _static_ scopes, because they don't have any impact at runtime.
+      // Usually static scopes are already removed in the optimization pipeline. However optimizations
+      // might turn dynamic into static scopes. So let's handle them.
+      break
+    }
+    scopeTree.visitEnclosingScopes(of: recentAccessInst) { enclosingBeginAccess in
+      if beginAccess.accessKind.conflicts(with: enclosingBeginAccess.accessKind),
+         // Avoid computing alias info if both scopes are not removable anyway.
+         removableScopes.contains(beginAccess) || removableScopes.contains(enclosingBeginAccess),
+         scopeTree.context.aliasAnalysis.mayAlias(beginAccess.address, enclosingBeginAccess.address)
+      {
+        // Conflicting enclosing scopes are not removable.
+        removableScopes.erase(enclosingBeginAccess)
+        // ... as well as the inner scope (which conflicts with the enclosing scope).
+        removableScopes.erase(beginAccess)
+      }
+    }
+    scopeTree.update(recent: &recentAccessInst, with: beginAccess)
+
+  case let endAccess as EndAccessInst where endAccess.beginAccess.enforcement == .dynamic:
+    scopeTree.update(recent: &recentAccessInst, with: endAccess)
+
+  default:
+    if instruction.mayCallFunction {
+      // Check for potential conflicting scopes in called functions.
+      scopeTree.visitEnclosingScopes(of: recentAccessInst) { enclosingBeginAccess in
+        if removableScopes.contains(enclosingBeginAccess),
+           instruction.mayHaveAccessScopeWhichConflicts(with: enclosingBeginAccess, scopeTree.context)
+        {
+          removableScopes.erase(enclosingBeginAccess)
+        }
+      }
+    }
+  }
+}
+
+/// Represents the tree of access scopes in a function.
+/// Note that if the scopes are not nested perfectly, it's strictly speaking not a tree.
+private struct ScopeTree {
+
+  // Links `begin_access` and `end_access` instructions in backward control flow direction.
+  // This is used to visit all enclosing scopes of a `begin_access`.
+  // As an optimization, `end_access`es are ignored for scopes which are perfectly nested - which is
+  // by far the most common case. In this case the backlinks simply are the parent links in the scope tree.
+  //
+  // Example of not perfectly nested scopes:
+  // ```
+  //   %1 = begin_access    <------------------+
+  //   ...                                     |
+  //   %2 = begin_access    <--------------+  -+
+  //   ...                                 |
+  //   end_access %1        <---------+   -+
+  //   ...                            |
+  //   %3 = begin_access    <-----+  -+
+  //   ...                        |
+  //   end_access %2        <-+  -+
+  //   ...                    |
+  //   end_access %3         -+
+  // ```
+  //
+  // Perfectly nested scopes:
+  // ```
+  //   %1 = begin_access    <-+   <-+
+  //   ...                    |     |
+  //   %2 = begin_access     -+     |
+  //   end_access %2                |    <- ignored
+  //   ...                          |
+  //   %3 = begin_access     -------+
+  //   end_access %3                     <- ignored
+  //   ...
+  //   end_access %1                     <- ignored
+  // ```
+  private var backlinks = Dictionary<Instruction, Instruction>()
+
+  let context: FunctionPassContext
+
+  init(_ context: FunctionPassContext) { self.context = context }
+
+  mutating func update(recent: inout Instruction?, with beginAccess: BeginAccessInst) {
+    backlinks[beginAccess] = recent
+    recent = beginAccess
+  }
+
+  mutating func update(recent: inout Instruction?, with endAccess: EndAccessInst) {
+    if endAccess.beginAccess == recent {
+      // The scope is perfectly nested. Ignore it and directly backlink to the parent of the `begin_access`
+      recent = backlinks[endAccess.beginAccess]
+    } else {
+      backlinks[endAccess] = recent
+      recent = endAccess
+    }
+  }
+
+  func visitEnclosingScopes(of accessInstruction: Instruction?, closure: (BeginAccessInst) -> ()) {
+    // Ignore scopes which are already closed
+    var ignore = SpecificInstructionSet<BeginAccessInst>(context)
+    defer { ignore.deinitialize() }
+
+    var enclosingScope = accessInstruction
+
+    while let parent = enclosingScope {
+      switch parent {
+      case let parentBeginAccess as BeginAccessInst where !ignore.contains(parentBeginAccess):
+        closure(parentBeginAccess)
+      case let parentEndAccess as EndAccessInst:
+        // Seeing an `end_access` in the backlink chain means that this scope is already closed.
+        ignore.insert(parentEndAccess.beginAccess)
+      default:
+        break
+      }
+      enclosingScope = backlinks[parent]
+    }
+  }
+}
+
+private extension Instruction {
+  func mayHaveAccessScopeWhichConflicts(with beginAccess: BeginAccessInst, _ context: FunctionPassContext) -> Bool {
+    if beginAccess.accessKind == .read {
+      return mayWrite(toAddress: beginAccess.address, context.aliasAnalysis)
+    } else {
+      return mayReadOrWrite(address: beginAccess.address, context.aliasAnalysis)
+    }
+  }
+}
+
+private extension BeginAccessInst {
+  var isDead: Bool { users.allSatisfy({ $0.isIncidentalUse }) }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -94,6 +94,7 @@ private func registerSwiftPasses() {
   registerPass(cleanupDebugStepsPass, { cleanupDebugStepsPass.run($0) })
   registerPass(namedReturnValueOptimization, { namedReturnValueOptimization.run($0) })
   registerPass(stripObjectHeadersPass, { stripObjectHeadersPass.run($0) })
+  registerPass(deadAccessScopeElimination, { deadAccessScopeElimination.run($0) })
   registerPass(deadStoreElimination, { deadStoreElimination.run($0) })
   registerPass(redundantLoadElimination, { redundantLoadElimination.run($0) })
   registerPass(mandatoryRedundantLoadElimination, { mandatoryRedundantLoadElimination.run($0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -101,6 +101,8 @@ PASS(EarlyRedundantLoadElimination, "early-redundant-load-elimination",
      "Early Redundant Load Elimination")
 PASS(RedundantLoadElimination, "redundant-load-elimination",
      "Redundant Load Elimination")
+PASS(DeadAccessScopeElimination, "dead-access-scope-elimination",
+     "Removes dead, non-conflicting access scopes")
 PASS(DeadStoreElimination, "dead-store-elimination",
      "Dead Store Elimination")
 PASS(LifetimeDependenceDiagnostics,

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -64,7 +64,6 @@ namespace {
     SILValue
     visitUncheckedTrivialBitCastInst(UncheckedTrivialBitCastInst *UTBCI);
     SILValue visitEndCOWMutationInst(EndCOWMutationInst *ECM);
-    SILValue visitBeginAccessInst(BeginAccessInst *BAI);
     SILValue visitMetatypeInst(MetatypeInst *MTI);
     SILValue visitConvertFunctionInst(ConvertFunctionInst *cfi);
 
@@ -416,16 +415,6 @@ visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *UBCI) {
     if (Op->getOperand()->getType() == UBCI->getType())
       return Op->getOperand();
 
-  return SILValue();
-}
-
-SILValue InstSimplifier::visitBeginAccessInst(BeginAccessInst *BAI) {
-  // Remove "dead" begin_access.
-  if (llvm::all_of(BAI->getUses(), [](Operand *operand) -> bool {
-        return isIncidentalUse(operand->getUser());
-      })) {
-    return BAI->getOperand();
-  }
   return SILValue();
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -599,6 +599,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addRedundantPhiElimination();
   P.addCSE();
   P.addDCE();
+  P.addDeadAccessScopeElimination();
 
   // Perform retain/release code motion and run the first ARC optimizer.
   P.addEarlyCodeMotion();

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -54,7 +54,7 @@ static bool seemsUseful(SILInstruction *I) {
   // Even though begin_access/destroy_value/copy_value/end_lifetime have
   // side-effects, they can be DCE'ed if they do not have useful
   // dependencies/reverse dependencies
-  if (isa<BeginAccessInst>(I) || isa<CopyValueInst>(I) ||
+  if (isa<CopyValueInst>(I) ||
       isa<DestroyValueInst>(I) || isa<EndLifetimeInst>(I) ||
       isa<EndBorrowInst>(I))
     return false;
@@ -359,12 +359,6 @@ void DCE::markLive() {
         } else {
           markInstructionLive(&I);
         }
-        break;
-      }
-      case SILInstructionKind::EndAccessInst: {
-        // An end_access is live only if it's begin_access is also live.
-        auto *beginAccess = cast<EndAccessInst>(&I)->getBeginAccess();
-        addReverseDependency(beginAccess, &I);
         break;
       }
       case SILInstructionKind::DestroyValueInst: {

--- a/test/SILOptimizer/dead-access-scope-elimination.sil
+++ b/test/SILOptimizer/dead-access-scope-elimination.sil
@@ -1,0 +1,309 @@
+// RUN: %target-sil-opt %s -dead-access-scope-elimination | %FileCheck %s
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+sil_global @g1: $Int
+sil_global @g2: $Int
+
+sil @unknown : $@convention(thin) () -> ()
+sil @readonly : $@convention(thin) () -> () {
+[global: read]
+}
+sil @pure : $@convention(thin) () -> () {
+[global: ]
+}
+
+// CHECK-LABEL: sil [ossa] @simple_dead :
+// CHECK-NOT:     begin_access
+// CHECK-NOT:     end_access
+// CHECK:       } // end sil function 'simple_dead'
+sil [ossa] @simple_dead : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %2 = begin_access [modify] [dynamic] %0
+  fix_lifetime %2
+  debug_value %2 : $*Int, name "g1"
+  end_access %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @simple_alive :
+// CHECK:         [[A:%.*]] = begin_access
+// CHECK:         [[L:%.*]] = load [trivial] [[A]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'simple_alive'
+sil [ossa] @simple_alive : $@convention(thin) () -> Int {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %2 = begin_access [modify] [dynamic] %0
+  %3 = load [trivial] %2
+  end_access %2
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @conflicting :
+// CHECK:         %1 = begin_access [modify]
+// CHECK:         %2 = begin_access [read]
+// CHECK:         end_access %2
+// CHECK:         end_access %1
+// CHECK:       } // end sil function 'conflicting'
+sil [ossa] @conflicting : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [modify] [dynamic] %0
+  %2 = begin_access [read] [dynamic] %0
+  end_access %2
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @not_conflicting :
+// CHECK-NOT:     begin_access
+// CHECK-NOT:     end_access
+// CHECK:       } // end sil function 'not_conflicting'
+sil [ossa] @not_conflicting : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [read] [dynamic] %0
+  %2 = begin_access [read] [dynamic] %0
+  end_access %2
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @not_aliasing :
+// CHECK-NOT:     begin_access
+// CHECK-NOT:     end_access
+// CHECK:       } // end sil function 'not_aliasing'
+sil [ossa] @not_aliasing : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = global_addr @g2 : $*Int
+  %2 = begin_access [modify] [dynamic] %0
+  %3 = begin_access [read] [dynamic] %1
+  end_access %3
+  end_access %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @call_with_potential_access :
+// CHECK:         %2 = begin_access [read]
+// CHECK:         %3 = begin_access [read]
+// CHECK:         end_access %3
+// CHECK:         end_access %2
+// CHECK:       } // end sil function 'call_with_potential_access'
+sil [ossa] @call_with_potential_access : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = global_addr @g2 : $*Int
+  %2 = begin_access [read] [dynamic] %0
+  %3 = begin_access [read] [dynamic] %1
+  %4 = function_ref @unknown : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  end_access %3
+  end_access %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @call_pure :
+// CHECK-NOT:     begin_access
+// CHECK-NOT:     end_access
+// CHECK:       } // end sil function 'call_pure'
+sil [ossa] @call_pure : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = global_addr @g2 : $*Int
+  %2 = begin_access [read] [dynamic] %0
+  %3 = begin_access [read] [dynamic] %1
+  %4 = function_ref @pure : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  end_access %3
+  end_access %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @call_readonly :
+// CHECK:         %3 = begin_access
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_access %3
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'call_readonly'
+sil [ossa] @call_readonly : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = global_addr @g2 : $*Int
+  %2 = function_ref @readonly : $@convention(thin) () -> ()
+  %3 = begin_access [modify] [dynamic] %0
+  %4 = apply %2() : $@convention(thin) () -> ()
+  end_access %3
+  %6 = begin_access [read] [dynamic] %0
+  %7 = apply %2() : $@convention(thin) () -> ()
+  end_access %6
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @unknown_call_via_destructor :
+// CHECK:         %2 = begin_access [read]
+// CHECK:         end_access %2
+// CHECK:       } // end sil function 'unknown_call_via_destructor'
+sil [ossa] @unknown_call_via_destructor : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0: @owned $AnyObject):
+  %1 = global_addr @g1 : $*Int
+  %2 = begin_access [read] [dynamic] %1
+  destroy_value %0
+  end_access %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @two_inner_accesses :
+// CHECK:         %1 = begin_access [read]
+// CHECK-NEXT:    %2 = begin_access [modify]
+// CHECK-NEXT:    end_access %2
+// CHECK-NEXT:    end_access %1
+// CHECK:       } // end sil function 'two_inner_accesses'
+sil [ossa] @two_inner_accesses : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [read] [dynamic] %0
+  %2 = begin_access [modify] [dynamic] %0
+  end_access %2
+  %4 = begin_access [read] [dynamic] %0
+  end_access %4
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @partially_overlapping_accesses :
+// CHECK:         %2 = begin_access [read] [dynamic] %1
+// CHECK:         apply
+// CHECK-NEXT:    end_access %2
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'partially_overlapping_accesses'
+sil [ossa] @partially_overlapping_accesses : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = global_addr @g2 : $*Int
+  %2 = begin_access [read] [dynamic] %0
+  %3 = begin_access [read] [dynamic] %1
+  end_access %2
+  %4 = function_ref @unknown : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  %6 = begin_access [read] [dynamic] %0
+  end_access %3
+  end_access %6
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @multi_block1 :
+// CHECK:       bb0:
+// CHECK:         %1 = begin_access
+// CHECK:       bb1:
+// CHECK:         %3 = begin_access
+// CHECK:       bb2:
+// CHECK:         %6 = begin_access
+// CHECK:       bb3:
+// CHECK:         %9 = begin_access
+// CHECK:       } // end sil function 'multi_block1'
+sil [ossa] @multi_block1 : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [modify] [dynamic] %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = begin_access [read] [dynamic] %0
+  end_access %3
+  br bb3
+
+bb2:
+  %6 = begin_access [read] [dynamic] %0
+  end_access %6
+  br bb3
+
+bb3:
+  %9 = begin_access [read] [dynamic] %0
+  end_access %9
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @multi_block2 :
+// CHECK:       bb0:
+// CHECK:         %1 = begin_access
+// CHECK:       bb1:
+// CHECK:         %3 = begin_access
+// CHECK:       bb2:
+// CHECK:         end_access %1
+// CHECK-NEXT:    br bb3
+// CHECK:       bb3:
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'multi_block2'
+sil [ossa] @multi_block2 : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [modify] [dynamic] %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = begin_access [read] [dynamic] %0
+  end_access %3
+  end_access %1
+  br bb3
+
+bb2:
+  end_access %1
+  %8 = begin_access [read] [dynamic] %0
+  end_access %8
+  br bb3
+
+bb3:
+  %11 = begin_access [read] [dynamic] %0
+  end_access %11
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @nested_static :
+// CHECK-NOT:     begin_access [modify] [static]
+// CHECK:       } // end sil function 'nested_static'
+sil [ossa] @nested_static : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [modify] [dynamic] %0
+  %2 = begin_access [modify] [static] %1
+  end_access %2
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @non_dead_inside_dead :
+// CHECK:         begin_access [modify]
+// CHECK:         begin_access [read]
+// CHECK:       } // end sil function 'non_dead_inside_dead'
+sil [ossa] @non_dead_inside_dead : $@convention(thin) () -> Int {
+bb0:
+  %0 = global_addr @g1 : $*Int
+  %1 = begin_access [modify] [dynamic] %0
+  %2 = begin_access [read] [dynamic] %0
+  %3 = load [trivial] %2
+  end_access %2
+  end_access %1
+  return %3
+}
+

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -253,11 +253,10 @@ bb3:
   br bb1
 }
 
-// Check that DCE eliminates dead access instructions.
+// Dead accesses must not be removed
 // CHECK-LABEL: sil @dead_access
-// CHECK: bb0
-// CHECK-NEXT: tuple
-// CHECK-NEXT: return
+// CHECK:         begin_access
+// CHECK:         begin_access
 // CHECK-LABEL: end sil function 'dead_access'
 sil @dead_access : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -290,11 +290,10 @@ bb3:
   br bb1
 }
 
-// Check that DCE eliminates dead access instructions.
+// Dead accesses must not be removed
 // CHECK-LABEL: sil [ossa] @dead_access :
-// CHECK: bb0
-// CHECK-NEXT: tuple
-// CHECK-NEXT: return
+// CHECK:         begin_access
+// CHECK:         begin_access
 // CHECK-LABEL: } // end sil function 'dead_access'
 sil [ossa] @dead_access : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):

--- a/test/SILOptimizer/exclusivity_violation.swift
+++ b/test/SILOptimizer/exclusivity_violation.swift
@@ -1,0 +1,67 @@
+// RUN: %target-run-simple-swift(-Onone)
+// RUN: %target-run-simple-swift(-O)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+
+var tests = TestSuite("exclusivity checking")
+
+struct NC: ~Copyable {
+  var i: Int = 1
+
+  mutating func add(_ other: borrowing Self) {
+    i += other.i
+    i += other.i
+    print(self.i, other.i)
+  }
+}
+
+class C1 {
+  var nc = NC()
+
+  func foo() {
+    nc.add(nc)
+  }
+}
+
+struct S {
+  var i: Int = 1
+
+  mutating func add(_ c: C2) {
+    let other = c.getS()
+    i += other.i
+    i += other.i
+    print(self.i, other.i)
+  }
+}
+
+final class C2 {
+  var s = S()
+
+  @inline(never)
+  func getS() -> S { s }
+
+  func foo() {
+    s.add(self)
+  }
+}
+
+tests.test("non-copyable type")
+  .crashOutputMatches("Simultaneous accesses")
+  .code {
+    expectCrashLater()
+
+    C1().foo()
+  }
+
+tests.test("copyable type")
+  .crashOutputMatches("Simultaneous accesses")
+  .code {
+    expectCrashLater()
+
+    C2().foo()
+  }
+
+runAllTests()

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -325,33 +325,17 @@ public class B {
   deinit
 }
 
-// simplify access markers
-sil @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
+// CHECK-LABEL: sil @dont_remove_empty_access_scopes : $@convention(method) (@guaranteed A) -> () {
+// CHECK:         begin_access
+// CHECK-LABEL: } // end sil function 'dont_remove_empty_access_scopes'
+sil @dont_remove_empty_access_scopes : $@convention(method) (@guaranteed A) -> () {
 bb0(%0 : $A):
   %badr = ref_element_addr %0 : $A, #A.b
   %ba1 = begin_access [read] [dynamic] %badr : $*B
   end_access %ba1 : $*B
-  %ba2 = begin_access [read] [dynamic] %badr : $*B
-  fix_lifetime %ba2 : $*B
-  end_access %ba2 : $*B
-  %ba3 = begin_access [read] [dynamic] %badr : $*B
-  %b = load %ba3 : $*B
-  end_access %ba3 : $*B
-  %xadr = ref_element_addr %b : $B, #B.x
-  %xaccess = begin_access [read] [dynamic] %xadr : $*Int
-  end_access %xaccess : $*Int
-
   %r = tuple ()
   return %r : $()
 }
-
-// CHECK-LABEL: sil @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-// CHECK: bb0(%0 : $A):
-// CHECK-NEXT: [[ADR:%.*]] = ref_element_addr %0 : $A, #A.b
-// CHECK-NEXT: fix_lifetime [[ADR]] : $*B
-// CHECK-NEXT: %{{.*}} = tuple ()
-// CHECK-NEXT: return %{{.*}} : $()
-// CHECK-LABEL: } // end sil function 'simplify_accesssil'
 
 // Test replacement of metatype instructions with metatype arguments.
 protocol SomeP {}

--- a/test/SILOptimizer/sil_simplify_instrs_ossa.sil
+++ b/test/SILOptimizer/sil_simplify_instrs_ossa.sil
@@ -370,31 +370,14 @@ public class B {
 
 // simplify access markers
 
-// CHECK-LABEL: sil [ossa] @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-// CHECK: bb0(%0 : @guaranteed $A):
-// CHECK-NEXT: [[ADR:%.*]] = ref_element_addr %0 : $A, #A.b
-// CHECK-NEXT: fix_lifetime [[ADR]] : $*B
-// CHECK-NEXT: %{{.*}} = tuple ()
-// CHECK-NEXT: return %{{.*}} : $()
-// CHECK: } // end sil function 'simplify_accesssil'
-sil [ossa] @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
+// CHECK-LABEL: sil [ossa] @dont_remove_empty_access_scopes : $@convention(method) (@guaranteed A) -> () {
+// CHECK:         begin_access
+// CHECK:       } // end sil function 'dont_remove_empty_access_scopes'
+sil [ossa] @dont_remove_empty_access_scopes : $@convention(method) (@guaranteed A) -> () {
 bb0(%0 : @guaranteed $A):
   %badr = ref_element_addr %0 : $A, #A.b
   %ba1 = begin_access [read] [dynamic] %badr : $*B
   end_access %ba1 : $*B
-  %ba2 = begin_access [read] [dynamic] %badr : $*B
-  fix_lifetime %ba2 : $*B
-  end_access %ba2 : $*B
-  %ba3 = begin_access [read] [dynamic] %badr : $*B
-  %b = load [copy] %ba3 : $*B
-  end_access %ba3 : $*B
-  %bb = begin_borrow %b : $B
-  %xadr = ref_element_addr %bb : $B, #B.x
-  %xaccess = begin_access [read] [dynamic] %xadr : $*Int
-  end_access %xaccess : $*Int
-  end_borrow %bb : $B
-  destroy_value %b : $B
-
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
Empty access scopes can be a result of e.g. redundant-load-elimination. It is important to keep such access scopes (if they might be conflicting) to detect access violations at runtime.
This PR removes the simple unconditional dead access scope elimination optimizations from instruction simplification and dead-code elimination.

To compensate for that, I added new DeadAccessScopeElimination pass. For example, it removes:

```
  %2 = begin_access [modify] [dynamic] %1
  ...                                       // no uses of %2
  end_access %2
```

However, dead _conflicting_ access scopes are not removed.
If a conflicting scope becomes dead because an optimization e.g. removed a load, it is still important to get an access violation at runtime.
Even a propagated value of a redundant load from a conflicting scope is undefined.

```
  %2 = begin_access [modify] [dynamic] %1
  store %x to %2
  %3 = begin_access [read] [dynamic] %1    // conflicting with %2!
  %y = load %3
  end_access %3
  end_access %2
  use(%y)
```
After redundant-load-elimination:
```
  %2 = begin_access [modify] [dynamic] %1
  store %x to %2
  %3 = begin_access [read] [dynamic] %1    // now dead, but still conflicting with %2
  end_access %3
  end_access %2
  use(%x)                                  // propagated from the store, but undefined here!
```
In this case the scope `%3` is not removed because it's important to get an access violation error at runtime before the undefined value `%x` is used.

This pass considers potential conflicting access scopes in called functions.
But it does not consider potential conflicting access in callers (because it can't!).
However, optimizations, like redundant-load-elimination, can only do such transformations if the outer access scope is within the function, e.g.

```
bb0(%0 : $*T):     // an inout from a conflicting scope in the caller
  store %x to %0
  %3 = begin_access [read] [dynamic] %1
  %y = load %3     // cannot be propagated because it cannot be proved that %1 is the same address as %0
  end_access %3
```

All those checks are only done for dynamic access scopes, because they matter for runtime exclusivity checking.
Dead static scopes are removed unconditionally.

rdar://164571252