### PR TITLE
[Sema] Catch use-before-declarations in nested closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@
 
 ## Swift (next)
 
+* The checking for illegal forward references to local variables is now consistent regardless of
+  whether the reference appears in a closure. Previously the type-checker could incorrectly permit
+  forward references within a closure that it would reject outside of the closure, however this
+  is not something that can be supported in general in the type-checker. In most cases this should
+  have no impact since such invalid references would have already been rejected by later diagnostic
+  passes in the compiler. However there are a couple of cases that were previously legal that are
+  now illegal.
+
+  These include:
+
+  - `lazy` local variables with initializers that forward reference a local variable in a closure,
+    or local variables with attached macros that relocate the initializer into an accessor, e.g:
+
+    ```swift
+    func foo() {
+      lazy var x = { y } // error: use of local variable 'y' before its declaration
+      let y = 0
+    }
+    ```
+
+    ```swift
+    func foo() {
+      @LazyLikeMacro var x = { y } // error: use of local variable 'y' before its declaration
+      let y = 0
+    }
+    ```
+
+  - Forward references to local computed variables from a closure, e.g:
+
+    ```swift
+    func foo() {
+      var x = { y } // error: use of local variable 'y' before its declaration
+      var y: Int { 0 }
+    }
+    ```
+
+  Both cases were already invalid if there was no closure involved. These are now consistently
+  rejected.
+
+  This then allows for consistent shadowing behavior inside and outside of closures, allowing the
+  following previously illegal case to become legal:
+
+  ```swift
+  struct S {
+    var x: Int
+    func foo() {
+      // Already legal, both refer to `self.x`
+      let y = x
+      let x = x
+
+      let z = x // Refers to the local var.
+    }
+    func bar() {
+      // Both previously illegal, now both refer to `self.x`.
+      let y = { x }()
+      let x: Int = { x }()
+
+      let z = x // Still refers to the local var.
+    }
+  }
+  ```
+
 * To simplify writing cross-platform code for Apple platforms while adopting
   new APIs, availability on macOS, iOS, tvOS, watchOS, and visionOS can now be
   specified implicitly using `anyAppleOS` for operating system versions starting
@@ -78,6 +140,8 @@
   applies when the memory is to later be used again as `Element`. In that case,
   the non-padding bytes of `Element` must allow every bit pattern to be
   permissible in a valid value of `Element`.
+
+## Swift 6.3
 
 * [SE-0491][]:
   You can now use a module selector to specify which module Swift should look inside to find a named declaration. A

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -393,29 +393,34 @@ static bool isMemberChainTail(Expr *expr, Expr *parent, MemberChainKind kind) {
 }
 
 static bool isValidForwardReference(ValueDecl *D, DeclContext *DC,
-                                    ValueDecl **localDeclAfterUse) {
-  *localDeclAfterUse = nullptr;
-
-  // References to variables injected by lldb are always valid.
-  if (isa<VarDecl>(D) && cast<VarDecl>(D)->isDebuggerVar())
+                                    ValueDecl *&localDeclAfterUse,
+                                    bool &shouldUseOuterResults) {
+  // Only VarDecls require declaration before use.
+  auto *VD = dyn_cast<VarDecl>(D);
+  if (!VD)
     return true;
 
-  // If we find something in the current context, it must be a forward
-  // reference, because otherwise if it was in scope, it would have
-  // been returned by the call to ASTScope::lookupLocalDecls() above.
-  if (D->getDeclContext()->isLocalContext()) {
-    do {
-      if (D->getDeclContext() == DC) {
-        *localDeclAfterUse = D;
-        return false;
-      }
+  // Non-local and variables injected by lldb are always valid.
+  auto *varDC = VD->getDeclContext();
+  if (!varDC->isLocalContext() || VD->isDebuggerVar())
+    return true;
 
-      // If we're inside of a 'defer' context, walk up to the parent
-      // and check again. We don't want 'defer' bodies to forward
-      // reference bindings in the immediate outer scope.
-    } while (isa<FuncDecl>(DC) &&
-             cast<FuncDecl>(DC)->isDeferBody() &&
-             (DC = DC->getParent()));
+  while (true) {
+    if (varDC == DC) {
+      localDeclAfterUse = VD;
+      return false;
+    }
+    if (isa<AbstractClosureExpr>(DC) ||
+        (isa<FuncDecl>(DC) && cast<FuncDecl>(DC)->isDeferBody())) {
+      // If we cross a closure, don't allow falling back to an outer result if
+      // we have a forward reference. This preserves the behavior prior to
+      // diagnosing this in Sema.
+      if (isa<AbstractClosureExpr>(DC))
+        shouldUseOuterResults = false;
+      DC = DC->getParent();
+      continue;
+    }
+    break;
   }
   return true;
 }
@@ -587,19 +592,20 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
     Lookup = TypeChecker::lookupUnqualified(DC, LookupName, Loc, lookupOptions);
 
     ValueDecl *localDeclAfterUse = nullptr;
-    AllDeclRefs =
-        findNonMembers(Lookup.innerResults(), UDRE->getRefKind(),
-                       /*breakOnMember=*/true, ResultValues,
-                       [&](ValueDecl *D) {
-                         return isValidForwardReference(D, DC, &localDeclAfterUse);
-                       });
+    bool shouldUseOuterResults = true;
+    AllDeclRefs = findNonMembers(
+        Lookup.innerResults(), UDRE->getRefKind(),
+        /*breakOnMember=*/true, ResultValues, [&](ValueDecl *D) {
+          return isValidForwardReference(D, DC, localDeclAfterUse,
+                                         shouldUseOuterResults);
+        });
 
     // If local declaration after use is found, check outer results for
     // better matching candidates.
     if (ResultValues.empty() && localDeclAfterUse) {
       auto innerDecl = localDeclAfterUse;
       while (localDeclAfterUse) {
-        if (Lookup.outerResults().empty()) {
+        if (!shouldUseOuterResults || Lookup.outerResults().empty()) {
           Context.Diags.diagnose(Loc, diag::use_local_before_declaration, Name);
           Context.Diags.diagnose(innerDecl, diag::decl_declared_here,
                                  localDeclAfterUse);
@@ -609,12 +615,12 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
         Lookup.shiftDownResults();
         ResultValues.clear();
         localDeclAfterUse = nullptr;
-        AllDeclRefs =
-            findNonMembers(Lookup.innerResults(), UDRE->getRefKind(),
-                           /*breakOnMember=*/true, ResultValues,
-                           [&](ValueDecl *D) {
-                             return isValidForwardReference(D, DC, &localDeclAfterUse);
-                           });
+        AllDeclRefs = findNonMembers(
+            Lookup.innerResults(), UDRE->getRefKind(),
+            /*breakOnMember=*/true, ResultValues, [&](ValueDecl *D) {
+              return isValidForwardReference(D, DC, localDeclAfterUse,
+                                             shouldUseOuterResults);
+            });
       }
     }
   }

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -643,8 +643,8 @@ struct PatternBindingWithTwoVars3 { var x = y, y = x }
 
 // https://github.com/apple/swift/issues/51518
 do {
-  let closure1 = { closure2() } // expected-error {{circular reference}} expected-note {{through reference here}}
-  let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}}
+  let closure1 = { closure2() } // expected-error {{use of local variable 'closure2' before its declaration}}
+  let closure2 = { closure1() } // expected-note {{'closure2' declared here}}
 }
 
 func color(with value: Int) -> Int {

--- a/test/NameLookup/use_before_declaration_shadowing.swift
+++ b/test/NameLookup/use_before_declaration_shadowing.swift
@@ -54,20 +54,41 @@ func testTopLevel() {
   }
   do {
     _ = {
-      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+      let _: String = topLevelString
     }
-    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+    let topLevelString = 0
+    _ = topLevelString
   }
   _ = {
     _ = {
-      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+      let _: String = topLevelString
     }
-    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+    let topLevelString = 0
+    _ = topLevelString
   }
   func bar() {
     _ = {
-      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+      let _: String = topLevelString
     }
-    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+    let topLevelString = 0
+    _ = topLevelString
+  }
+}
+
+struct TestLocalPropertyShadowing {
+  var str: String
+
+  func foo() {
+    { _ = str }()
+    let str = str
+    _ = str
+  }
+  func bar() {
+    let str = { str }
+    _ = str
+  }
+  func baz() {
+    let str = str
+    _ = str
   }
 }

--- a/test/NameLookup/use_before_declaration_shadowing.swift
+++ b/test/NameLookup/use_before_declaration_shadowing.swift
@@ -1,0 +1,73 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -parse-as-library
+
+func testLocal() {
+  // The first `y` here is considered the inner result.
+  do {
+    let y = ""
+    do {
+      let _: String = y
+      let y = 0
+      _ = y
+    }
+  }
+  do {
+    let y = ""
+    do {
+      _ = {
+        let _: String = y
+      }
+      let y = 0
+      _ = y
+    }
+  }
+  do {
+    let y = ""
+    _ = {
+      _ = {
+        let _: String = y
+      }
+      let y = 0
+      _ = y
+    }
+  }
+  do {
+    let y = ""
+    func bar() {
+      _ = {
+        let _: String = y
+      }
+      let y = 0
+      _ = y
+    }
+  }
+}
+
+let topLevelString = ""
+
+func testTopLevel() {
+  // Here 'topLevelString' is now an outer result.
+  do {
+    let _: String = topLevelString
+    let topLevelString = 0
+    _ = topLevelString
+  }
+  do {
+    _ = {
+      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+    }
+    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+  }
+  _ = {
+    _ = {
+      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+    }
+    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+  }
+  func bar() {
+    _ = {
+      let _: String = topLevelString // expected-error {{use of local variable 'topLevelString' before its declaration}}
+    }
+    let topLevelString = 0 // expected-note {{'topLevelString' declared here}}
+  }
+}

--- a/test/SILOptimizer/closure_lifetime_fixup_undef.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_undef.swift
@@ -1,14 +1,12 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend %s -sil-verify-all -c
 
-// Report the error but don't crash.
+// Make sure we don't crash.
 
 class TestUndefined {
   private var stringList: [String]!
 
   func dontCrash(strings: [String]) {
     assert(stringList.allSatisfy({ $0 == stringList.first!}))
-    // expected-error@-1 {{use of local variable 'stringList' before its declaration}}
     let stringList = strings.filter({ $0 == "a" })
-    // expected-note@-1 {{'stringList' declared here}}
   }
 }

--- a/test/SILOptimizer/closure_lifetime_fixup_undef.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_undef.swift
@@ -1,13 +1,14 @@
-// RUN: not %target-swift-frontend %s -sil-verify-all -c 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
 
 // Report the error but don't crash.
-// CHECK: error: closure captures 'stringList' before it is declared
 
 class TestUndefined {
   private var stringList: [String]!
 
   func dontCrash(strings: [String]) {
     assert(stringList.allSatisfy({ $0 == stringList.first!}))
+    // expected-error@-1 {{use of local variable 'stringList' before its declaration}}
     let stringList = strings.filter({ $0 == "a" })
+    // expected-note@-1 {{'stringList' declared here}}
   }
 }

--- a/test/SILOptimizer/definite_init_closures_fail.swift
+++ b/test/SILOptimizer/definite_init_closures_fail.swift
@@ -65,3 +65,7 @@ struct Generic<T : P> {
   } // expected-error {{return from initializer without initializing all stored properties}}
 }
 
+func captureUninitialized() {
+  let fn: () -> Void // expected-note {{constant defined here}}
+  fn = { fn() } // expected-error {{constant 'fn' captured by a closure before being initialized}}
+}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -1852,6 +1852,18 @@ class TestLazyLocal {
   }
 }
 
+class TestLocalPropertyShadowing {
+  var str: String = ""
+
+  func foo() {
+    let str = { str }
+    // expected-error@-1 {{reference to property 'str' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-note@-2 {{reference 'self.' explicitly}}
+    // expected-note@-3 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+    _ = str
+  }
+}
+
 class TestExtensionOnOptionalSelf {
   init() {}
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -358,7 +358,8 @@ func test_no_crash_with_circular_ref_due_to_error() {
       // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
       // expected-error@-2 {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
       // expected-error@-3 {{cannot call value of non-function type 'Int?'}}
-      print(next)
+      // expected-note@-4 {{'next' declared here}}
+      print(next) // expected-error {{use of local variable 'next' before its declaration}}
       return x
     }
     return 0
@@ -676,20 +677,26 @@ func test_recursive_var_reference_in_multistatement_closure() {
 
   func test(optionalInt: Int?, themes: MyStruct?) {
     takeClosure {
-      let int = optionalInt { // expected-error {{cannot call value of non-function type 'Int?'}}
-        print(int)
+      let int = optionalInt {
+        // expected-error@-1 {{cannot call value of non-function type 'Int?'}}
+        // expected-note@-2 {{'int' declared here}}
+        print(int) // expected-error {{use of local variable 'int' before its declaration}}
       }
     }
 
     takeClosure {
-      let theme = themes?.someMethod() { // expected-error {{extra trailing closure passed in call}}
-        _ = theme
+      let theme = themes?.someMethod() {
+        // expected-error@-1 {{extra trailing closure passed in call}}
+        // expected-note@-2 {{'theme' declared here}}
+        _ = theme // expected-error {{use of local variable 'theme' before its declaration}}
       }
     }
 
     takeClosure {
-      let theme = themes?.filter({ $0 }) { // expected-error {{value of type 'MyStruct' has no member 'filter'}}
-        _ = theme
+      let theme = themes?.filter({ $0 }) {
+        // expected-error@-1 {{value of type 'MyStruct' has no member 'filter'}}
+        // expected-note@-2 {{'theme' declared here}}
+        _ = theme // expected-error {{use of local variable 'theme' before its declaration}}
       }
     }
   }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -244,23 +244,24 @@ func test_as_2() {
   x as [] // expected-error {{expected element type}} {{9-9= <#type#>}}
 }
 
-func test_lambda() {
+func test_lambda1() {
   // A simple closure.
   var a = { (value: Int) -> () in markUsed(value+1) }
   // expected-warning@-1 {{initialization of variable 'a' was never used; consider replacing with assignment to '_' or removing it}}
+}
 
+func test_lambda2() {
   // A recursive lambda.
-  var fib = { (n: Int) -> Int in
-    // expected-warning@-1 {{variable 'fib' was never mutated; consider changing to 'let' constant}}
+  var fib = { (n: Int) -> Int in // expected-note 2{{'fib' declared here}}
     if (n < 2) {
       return n
     }
     
-    return fib(n-1)+fib(n-2)
+    return fib(n-1)+fib(n-2) // expected-error 2{{use of local variable 'fib' before its declaration}}
   }
 }
 
-func test_lambda2() {
+func test_lambda3() {
   { () -> protocol<Int> in
     // expected-error @-1 {{'protocol<...>' composition syntax has been removed and is not needed here}} {{11-24=Int}}
     // expected-error @-2 {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -252,12 +252,21 @@ func test_lambda1() {
 
 func test_lambda2() {
   // A recursive lambda.
-  var fib = { (n: Int) -> Int in // expected-note 2{{'fib' declared here}}
+  var fibLocal = { (n: Int) -> Int in // expected-note 2{{'fibLocal' declared here}}
     if (n < 2) {
       return n
     }
     
-    return fib(n-1)+fib(n-2) // expected-error 2{{use of local variable 'fib' before its declaration}}
+    return fibLocal(n-1)+fibLocal(n-2) // expected-error 2{{use of local variable 'fibLocal' before its declaration}}
+  }
+
+  var fib = { (n: Int) -> Int in
+    if (n < 2) {
+      return n
+    }
+
+    // These resolve to the top-level function.
+    return fib(n-1)+fib(n-2)
   }
 }
 

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1647,3 +1647,14 @@ func testCaptureList() {
   let _ = { [x = (if .random() { 0 } else { 1 })] in x }
   // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 }
+
+func testUseBeforeDecl() throws {
+  let x = if .random() { // expected-note {{'x' declared here}}
+    print(y) // expected-error {{use of local variable 'y' before its declaration}}
+    let y = 0 // expected-note {{'y' declared here}}
+    print(x) // expected-error {{use of local variable 'x' before its declaration}}
+    throw Err()
+  } else {
+    0
+  }
+}

--- a/validation-test/IDE/crashers_fixed/TypeChecker-typeCheckCondition-5dcea3.swift
+++ b/validation-test/IDE/crashers_fixed/TypeChecker-typeCheckCondition-5dcea3.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"19e34c4f","signature":"swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*)","signatureAssert":"Assertion failed: (!expr->getType() || isa<OpaqueValueExpr>(expr) && \"the bool condition is already type checked\"), function typeCheckCondition"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 {
   let a = {
     switch a {

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar100753270.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar100753270.swift
@@ -20,7 +20,7 @@ struct Test { // expected-note {{to match this opening '{'}}
     var infos = [Info]()
 
     for (index, info) in infos.enumerated() {
-      let dataPerHost = Dictionary(grouping: info.data) { data in
+      let dataPerHost = Dictionary(grouping: info.data) { data in // expected-note {{'dataPerHost' declared here}}
         let location = data.location()
         guard let host = location.host else {
           return 0
@@ -30,7 +30,7 @@ struct Test { // expected-note {{to match this opening '{'}}
         // Missing paren!
       }
 
-      for _ in dataPerHost { // `dataPerHost` is inside of the closure!
+      for _ in dataPerHost { // expected-error {{use of local variable 'dataPerHost' before its declaration}}
       }
     }
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar141012049.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar141012049.swift
@@ -1,12 +1,12 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
 
 func test(_ v: [Int]) {
-  let result = v.filter { }.flatMap(\.wrong) {
+  let result = v.filter { }.flatMap(\.wrong) { // expected-note {{'result' declared here}}
     // expected-error@-1 {{type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
     // expected-error@-2 {{cannot convert value of type '()' to closure result type 'Bool'}}
     // expected-error@-3 {{value of type 'Int' has no member 'wrong'}}
     // expected-error@-4 {{extra trailing closure passed in call}}
-    print(result)
+    print(result) // expected-error {{use of local variable 'result' before its declaration}}
   }
 
   let otherResult = v.filter { _ in false }.flatMap(\.wrong, { $0 }, 42)

--- a/validation-test/compiler_crashers_fixed/KeyPathExpr-getKeyPathType-c80788.swift
+++ b/validation-test/compiler_crashers_fixed/KeyPathExpr-getKeyPathType-c80788.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"6bb0b020","signature":"swift::KeyPathExpr::getKeyPathType() const","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 { let a = \ .b { c} (let c = a

--- a/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckStmtConditionElement-08b850.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckStmtConditionElement-08b850.swift
@@ -1,0 +1,11 @@
+// {"kind":"typecheck","signature":"swift::TypeChecker::typeCheckStmtConditionElement(swift::StmtConditionElement&, bool&, swift::DeclContext*)","signatureAssert":"Assertion failed: (!elt.getPattern()->hasType() && \"the pattern binding condition is already type checked\"), function typeCheckPatternBindingStmtConditionElement"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a {
+  func b() {}
+}
+func foo() {
+  _ = { c }
+  var d: a?
+  guard let d else {}
+  let c = d.b()
+}


### PR DESCRIPTION
Previously we would allow these in Sema and diagnose them in SILGen, but allowing them in Sema is unsound because it means the constraint system ends up kicking interface type requests for declarations that should be type-checked as part of the closure itself. Adjust the name lookup logic to look through parent closures when detecting invalid forward references. This then allows us to have consistent shadowing behavior inside and outside of closures.

Forum post: https://forums.swift.org/t/ensuring-forward-references-to-local-variables-are-consistently-rejected/83265

rdar://74430478
rdar://163656720
Resolves #83628