### PR TITLE
[Backtracing] Add missing availability annotations.

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -93,7 +93,8 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -experimental-spi-only-imports>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"Backtracing 6.2: macOS 26.0\">")
 
 if(${PROJECT_NAME}_ENABLE_DIRECT_RETAIN_RELEASE)
   find_package(SwiftSwiftDirectRuntime REQUIRED)

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -93,8 +93,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -experimental-spi-only-imports>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"Backtracing 6.2: macOS 26.0\">")
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 
 if(${PROJECT_NAME}_ENABLE_DIRECT_RETAIN_RELEASE)
   find_package(SwiftSwiftDirectRuntime REQUIRED)

--- a/stdlib/public/RuntimeModule/Address.swift
+++ b/stdlib/public/RuntimeModule/Address.swift
@@ -20,6 +20,7 @@ import Swift
 
 // .. Comparable .............................................................
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address {
   fileprivate var widestRepresentation: UInt64 {
     switch representation {
@@ -35,6 +36,7 @@ extension Backtrace.Address {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address: Comparable {
   /// Return true if `lhs` is lower than `rhs`
   public static func < (lhs: Backtrace.Address, rhs: Backtrace.Address) -> Bool {
@@ -48,6 +50,7 @@ extension Backtrace.Address: Comparable {
 
 // .. LosslessStringConvertible ..............................................
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address: LosslessStringConvertible {
   /// Create an Backtrace.Address from its string representation
   public init?(_ s: String) {
@@ -120,6 +123,7 @@ extension Backtrace.Address: LosslessStringConvertible {
 
 // .. ExpressibleByIntegerLiteral ............................................
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address: ExpressibleByIntegerLiteral {
   public typealias IntegerLiteralType = UInt64
 
@@ -139,6 +143,7 @@ extension Backtrace.Address: ExpressibleByIntegerLiteral {
 
 // .. FixedWidthInteger conversions ..........................................
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address {
   fileprivate func toFixedWidth<T: FixedWidthInteger>(
     type: T.Type = T.self
@@ -173,6 +178,7 @@ extension FixedWidthInteger {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address {
   /// Convert from a UInt16.
   public init(_ value: UInt16) {
@@ -218,6 +224,7 @@ extension Backtrace.Address {
 
 // -- Arithmetic -------------------------------------------------------------
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address {
   static func - (lhs: Backtrace.Address, rhs: Backtrace.Address) -> Int64 {
     let ulhs = UInt64(lhs)!

--- a/stdlib/public/RuntimeModule/Address.swift
+++ b/stdlib/public/RuntimeModule/Address.swift
@@ -164,6 +164,7 @@ extension FixedWidthInteger {
   ///
   /// This initializer will return nil if the address width is larger than the
   /// type you are attempting to convert into.
+  @available(Backtracing 6.2, *)
   public init?(_ address: Backtrace.Address) {
     guard let result = address.toFixedWidth(type: Self.self) else {
       return nil

--- a/stdlib/public/RuntimeModule/Backtrace+Codable.swift
+++ b/stdlib/public/RuntimeModule/Backtrace+Codable.swift
@@ -25,7 +25,7 @@ func stringFrom(sequence: some Sequence<UTF8.CodeUnit>) -> String? {
   }
 }
 
-@available(macOS 15.0, *)
+@available(Backtracing 6.2, *)
 extension Backtrace: Codable {
 
   enum CodingKeys: CodingKey {

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -27,6 +27,7 @@ import Swift
 // #endif
 
 /// Holds a backtrace.
+@available(Backtracing 6.2, *)
 public struct Backtrace: CustomStringConvertible, Sendable {
   /// The type of an address.
   ///
@@ -259,7 +260,6 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   var representation: [UInt8]
 
   /// A list of captured frame information.
-  @available(macOS 10.15, *)
   public var frames: some Sequence<Frame> {
     return CompactBacktraceFormat.Decoder(representation)
   }

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -407,6 +407,7 @@ public struct Backtrace: CustomStringConvertible, Sendable {
 
 // -- Capture Implementation -------------------------------------------------
 
+@available(Backtracing 6.2, *)
 extension Backtrace {
 
   // ###FIXME: There is a problem with @_specialize here that results in the

--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -30,6 +30,7 @@ internal import Musl
 
 /// A backtrace formatting theme.
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public protocol BacktraceFormattingTheme {
   func frameIndex(_ s: String) -> String
   func programCounter(_ s: String) -> String
@@ -48,6 +49,7 @@ public protocol BacktraceFormattingTheme {
   func imagePath(_ s: String) -> String
 }
 
+@available(Backtracing 6.2, *)
 extension BacktraceFormattingTheme {
   public func frameIndex(_ s: String) -> String { return s }
   public func programCounter(_ s: String) -> String { return s }
@@ -70,6 +72,7 @@ extension BacktraceFormattingTheme {
 ///
 /// This is used by chaining modifiers, e.g. .theme(.color).showSourceCode().
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public struct BacktraceFormattingOptions {
   var _theme: BacktraceFormattingTheme = BacktraceFormatter.Themes.plain
   var _showSourceCode: Bool = false
@@ -442,6 +445,7 @@ private func rtrim<S: StringProtocol>(_ s: S) -> S.SubSequence {
 
 /// Responsible for formatting backtraces.
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public struct BacktraceFormatter {
 
   /// The formatting options to apply when formatting data.

--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -363,6 +363,7 @@ private func measure<S: StringProtocol>(_ s: S) -> Int {
 }
 
 /// Pad the given string to the given width using spaces.
+@available(Backtracing 6.2, *)
 private func pad(_ s: String, to width: Int,
                  aligned alignment: BacktraceFormatter.Alignment = .left)
   -> String {

--- a/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
@@ -50,6 +50,7 @@ public protocol BacktraceJSONWriter {
 }
 
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public struct BacktraceJSONFormatter<
 Address: FixedWidthInteger,
 Writer: BacktraceJSONWriter> {
@@ -77,6 +78,7 @@ Writer: BacktraceJSONWriter> {
   }
 }
 
+@available(Backtracing 6.2, *)
 internal extension BacktraceJSONFormatter {
   func write(_ string: String, flush: Bool) {
     writer.write(string, flush: flush)
@@ -103,6 +105,7 @@ internal extension BacktraceJSONFormatter {
 }
 
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public extension BacktraceJSONFormatter {
   mutating func writeCrashLog(now: String) {
     writePreamble(now: now)
@@ -114,6 +117,7 @@ public extension BacktraceJSONFormatter {
 }
 
 @_spi(Formatting)
+@available(Backtracing 6.2, *)
 public extension BacktraceJSONFormatter {
   func writePreamble(now: String) {
     guard let description = getDescription(),
@@ -222,6 +226,7 @@ public extension BacktraceJSONFormatter {
   }
 }
 
+@available(Backtracing 6.2, *)
 internal extension BacktraceJSONFormatter {
   func writeThreadRegisters(thread: Log.Thread) {
     guard let registers = thread.registers else { return }

--- a/stdlib/public/RuntimeModule/Base64.swift
+++ b/stdlib/public/RuntimeModule/Base64.swift
@@ -119,6 +119,7 @@ fileprivate func reverse(at char: UTF8.CodeUnit) -> UInt8? {
 }
 
 @_spi(Base64)
+@available(Backtracing 6.2, *)
 public struct Base64Encoder<S: Sequence>: Sequence
   where S.Element == UInt8
 {
@@ -214,6 +215,7 @@ public struct Base64Encoder<S: Sequence>: Sequence
 }
 
 @_spi(Base64)
+@available(Backtracing 6.2, *)
 public struct Base64Decoder<S: Sequence>: Sequence
   where S.Element == UTF8.CodeUnit
 {

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -108,6 +108,16 @@ else()
   set(osx_deployment_target "${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
 endif()
 
+# Set the availability macro correctly; do NOT update this for newer
+# versions; instead, please use SwiftStdlib or StdlibDeploymentTarget for
+# future releases.  We don't do that here, because we don't yet support
+# iOS/watchOS/tvOS/visionOS.
+if(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX VERSION_LESS "26.0")
+  set(backtracing_availability "macOS ${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
+else()
+  set(backtracing_availability "macOS 26.0")
+endif()
+
 add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ${RUNTIME_SOURCES}
 
@@ -130,6 +140,8 @@ add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STD
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     ${RUNTIME_COMPILE_FLAGS}
     -parse-stdlib
+    -Xfrontend -define-availability
+    -Xfrontend "Backtracing 6.2: ${backtracing_availability}"
 
   LINK_FLAGS
     ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -108,16 +108,6 @@ else()
   set(osx_deployment_target "${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
 endif()
 
-# Set the availability macro correctly; do NOT update this for newer
-# versions; instead, please use SwiftStdlib or StdlibDeploymentTarget for
-# future releases.  We don't do that here, because we don't yet support
-# iOS/watchOS/tvOS/visionOS.
-if(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX VERSION_LESS "26.0")
-  set(backtracing_availability "macOS ${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
-else()
-  set(backtracing_availability "macOS 26.0")
-endif()
-
 add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ${RUNTIME_SOURCES}
 
@@ -140,8 +130,6 @@ add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STD
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     ${RUNTIME_COMPILE_FLAGS}
     -parse-stdlib
-    -Xfrontend -define-availability
-    -Xfrontend "Backtracing 6.2: ${backtracing_availability}"
 
   LINK_FLAGS
     ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}

--- a/stdlib/public/RuntimeModule/CachingMemoryReader.swift
+++ b/stdlib/public/RuntimeModule/CachingMemoryReader.swift
@@ -24,6 +24,7 @@ fileprivate let pageMask = pageSize - 1
 fileprivate let maxCachedSize = pageSize * 8
 
 @_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
 public class CachingMemoryReader<Reader: MemoryReader>: MemoryReader {
   private var reader: Reader
   private var cache: [Address:UnsafeRawBufferPointer]
@@ -98,8 +99,10 @@ extension CachingMemoryReader where Reader == UncachedMemserverMemoryReader {
 
 #if os(Linux) || os(macOS)
 @_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
 public typealias RemoteMemoryReader = CachingMemoryReader<UncachedRemoteMemoryReader>
 
+@available(Backtracing 6.2, *)
 extension CachingMemoryReader where Reader == UncachedRemoteMemoryReader {
   #if os(macOS)
   convenience public init(task: Any) {
@@ -113,8 +116,10 @@ extension CachingMemoryReader where Reader == UncachedRemoteMemoryReader {
 }
 
 @_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
 public typealias LocalMemoryReader = CachingMemoryReader<UncachedLocalMemoryReader>
 
+@available(Backtracing 6.2, *)
 extension CachingMemoryReader where Reader == UncachedLocalMemoryReader {
   convenience public init() {
     self.init(for: UncachedLocalMemoryReader())

--- a/stdlib/public/RuntimeModule/CompactBacktrace.swift
+++ b/stdlib/public/RuntimeModule/CompactBacktrace.swift
@@ -16,6 +16,7 @@
 
 import Swift
 
+@available(Backtracing 6.2, *)
 enum CompactBacktraceFormat {
   /// Tells us what size of machine words were used when generating the
   /// backtrace.
@@ -617,6 +618,7 @@ enum CompactBacktraceFormat {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension CompactBacktraceFormat.Instruction: Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     return lhs.rawValue < rhs.rawValue
@@ -626,6 +628,7 @@ extension CompactBacktraceFormat.Instruction: Comparable {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension CompactBacktraceFormat.Instruction {
   func decoded() -> CompactBacktraceFormat.DecodedInstruction? {
     switch self {

--- a/stdlib/public/RuntimeModule/CompactImageMap.swift
+++ b/stdlib/public/RuntimeModule/CompactImageMap.swift
@@ -20,6 +20,7 @@ private let slash = UInt8(ascii: "/")
 private let backslash = UInt8(ascii: "\\")
 
 @_spi(Internal)
+@available(Backtracing 6.2, *)
 public enum CompactImageMapFormat {
 
   /// The list of fixed prefixes used to encode paths.

--- a/stdlib/public/RuntimeModule/Compression.swift
+++ b/stdlib/public/RuntimeModule/Compression.swift
@@ -318,6 +318,7 @@ struct LZMAStream: CompressedStream {
 
 // .. Image Sources ............................................................
 
+@available(Backtracing 6.2, *)
 fileprivate func decompress<S: CompressedStream>(
   stream: S,
   source: ImageSource,
@@ -343,6 +344,7 @@ fileprivate func decompress<S: CompressedStream>(
   output.used(bytes: Int(totalBytes))
 }
 
+@available(Backtracing 6.2, *)
 fileprivate func decompressChunked<S: CompressedStream>(
   stream: S,
   source: ImageSource,
@@ -377,6 +379,7 @@ fileprivate func decompressChunked<S: CompressedStream>(
   )
 }
 
+@available(Backtracing 6.2, *)
 extension ImageSource {
   @_specialize(kind: full, where Traits == Elf32Traits)
   @_specialize(kind: full, where Traits == Elf64Traits)

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -17,6 +17,7 @@
 import Swift
 
 @_spi(CrashLog)
+@available(Backtracing 6.2, *)
 public struct CrashLog<Address: FixedWidthInteger>: Codable {
     public struct Frame: Codable {
         enum CodingKeys: String, CodingKey {
@@ -216,12 +217,14 @@ public struct CrashLog<Address: FixedWidthInteger>: Codable {
     }
 }
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Address {
     func hexRepresentation<Address:FixedWidthInteger>(nullAs: Address.Type) -> String {
         return hex(Address(self) ?? 0)
     }
 }
 
+@available(Backtracing 6.2, *)
 extension CrashLog.Frame.SourceLocation {
     init?(_ symbol: SymbolicatedBacktrace.SourceLocation?) {
         guard let symbol else { return nil }
@@ -236,6 +239,7 @@ extension CrashLog.Frame.SourceLocation {
     }
 }
 
+@available(Backtracing 6.2, *)
 extension CrashLog.Frame {
     func richFrame() -> RichFrame<Address>? {
         switch (kind, CrashLog.addressFromString(address), count) {
@@ -356,6 +360,7 @@ extension CrashLog.Frame {
     }
 }
 
+@available(Backtracing 6.2, *)
 extension CrashLog.Image {
     func imageMapImage() -> ImageMap.Image {
         return .init(
@@ -379,6 +384,7 @@ extension CrashLog.Image {
     }
 }
 
+@available(Backtracing 6.2, *)
 public extension CrashLog.Thread {
     func backtrace(architecture: String, images: ImageMap?) -> Backtrace {
         let frames = self.frames.compactMap { $0.richFrame() }
@@ -403,10 +409,12 @@ public extension CrashLog.Thread {
     }
 }
 
+@available(Backtracing 6.2, *)
 extension Context {
   static var addressType: any FixedWidthInteger.Type { Address.self }
 }
 
+@available(Backtracing 6.2, *)
 extension CrashLog {
     private static func context(forArchitecture arch: String) -> (any Context.Type)? {
         switch arch {

--- a/stdlib/public/RuntimeModule/CrashLogCapture.swift
+++ b/stdlib/public/RuntimeModule/CrashLogCapture.swift
@@ -17,6 +17,7 @@
 import Swift
 
 @_spi(CrashLog)
+@available(Backtracing 6.2, *)
 public class CrashLogCapture<Address: FixedWidthInteger> {
   public typealias Thread = CrashLog<Address>.Thread
 

--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -2006,6 +2006,7 @@ struct DwarfLineNumberInfo {
 // .. Testing ..................................................................
 
 @_spi(DwarfTest)
+@available(Backtracing 6.2, *)
 public func testDwarfReaderFor(path: String) -> Bool {
   guard let source = try? ImageSource(path: path) else {
     print("\(path) was not accessible")

--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -302,6 +302,7 @@ private enum DwarfError: Error {
 
 // .. Dwarf utilities for ImageSource ..........................................
 
+@available(Backtracing 6.2, *)
 extension ImageSource {
 
   func fetchULEB128(from a: Address) throws -> (Address, UInt64) {
@@ -428,6 +429,7 @@ extension ImageSource {
 
 // .. Dwarf utilities for ImageSourceCursor .....................................
 
+@available(Backtracing 6.2, *)
 extension ImageSourceCursor {
 
   mutating func readULEB128() throws -> UInt64 {
@@ -496,12 +498,14 @@ enum DwarfSection {
   case debugTuIndex
 }
 
+@available(Backtracing 6.2, *)
 protocol DwarfSource {
 
   func getDwarfSection(_ section: DwarfSection) -> ImageSource?
 
 }
 
+@available(Backtracing 6.2, *)
 struct DwarfReader<S: DwarfSource & AnyObject> {
 
   typealias Source = S
@@ -1798,6 +1802,7 @@ struct DwarfLineNumberState: CustomStringConvertible {
   }
 }
 
+@available(Backtracing 6.2, *)
 struct DwarfLineNumberInfo {
   typealias Address = UInt64
 

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -2047,6 +2047,7 @@ func getElfImageInfo<R: MemoryReader, Traits: ElfTraits>(
 // .. Testing ..................................................................
 
 @_spi(ElfTest)
+@available(Backtracing 6.2, *)
 public func testElfImageAt(path: String) -> Bool {
   guard let source = try? ImageSource(path: path) else {
     print("\(path) was not accessible")

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -971,6 +971,7 @@ struct Elf64Traits: ElfTraits {
 
 // .. ElfStringSection .........................................................
 
+@available(Backtracing 6.2, *)
 struct ElfStringSection {
   let source: ImageSource
 
@@ -1016,6 +1017,7 @@ protocol ElfSymbolTableProtocol {
   func lookupSymbol(address: Traits.Address) -> Symbol?
 }
 
+@available(Backtracing 6.2, *)
 protocol ElfSymbolLookupProtocol {
   associatedtype Traits: ElfTraits
   typealias CallSiteInfo = DwarfReader<ElfImage<Traits>>.CallSiteInfo
@@ -1026,6 +1028,7 @@ protocol ElfSymbolLookupProtocol {
   func sourceLocation(for address: Traits.Address) throws -> SourceLocation?
 }
 
+@available(Backtracing 6.2, *)
 struct ElfSymbolTable<SomeElfTraits: ElfTraits>: ElfSymbolTableProtocol {
   typealias Traits = SomeElfTraits
 
@@ -1173,6 +1176,7 @@ struct ElfSymbolTable<SomeElfTraits: ElfTraits>: ElfSymbolTableProtocol {
   }
 }
 
+@available(Backtracing 6.2, *)
 final class ElfImage<SomeElfTraits: ElfTraits>
   : DwarfSource, ElfSymbolLookupProtocol {
   typealias Traits = SomeElfTraits
@@ -1894,7 +1898,10 @@ final class ElfImage<SomeElfTraits: ElfTraits>
   }
 }
 
+@available(Backtracing 6.2, *)
 typealias Elf32Image = ElfImage<Elf32Traits>
+
+@available(Backtracing 6.2, *)
 typealias Elf64Image = ElfImage<Elf64Traits>
 
 // .. Checking for ELF images ..................................................
@@ -1908,6 +1915,7 @@ typealias Elf64Image = ElfImage<Elf64Traits>
 #if os(Linux)
 @_specialize(kind: full, where R == MemserverMemoryReader)
 #endif
+@available(Backtracing 6.2, *)
 func getElfImageInfo<R: MemoryReader>(at address: R.Address,
                                       using reader: R)
   -> (endOfText: R.Address, uuid: [UInt8]?)?
@@ -1948,6 +1956,7 @@ func getElfImageInfo<R: MemoryReader>(at address: R.Address,
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf32Traits)
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf64Traits)
 #endif
+@available(Backtracing 6.2, *)
 func getElfImageInfo<R: MemoryReader, Traits: ElfTraits>(
   at address: R.Address,
   using reader: R,

--- a/stdlib/public/RuntimeModule/ElfImageCache.swift
+++ b/stdlib/public/RuntimeModule/ElfImageCache.swift
@@ -30,6 +30,7 @@ internal import Musl
 /// Provides a per-thread image cache for ELF image processing.  This means
 /// if you take multiple backtraces from a thread, you won't load the same
 /// image multiple times.
+@available(Backtracing 6.2, *)
 final class ElfImageCache {
   var elf32: [String: Elf32Image] = [:]
   var elf64: [String: Elf64Image] = [:]

--- a/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
+++ b/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
@@ -17,6 +17,7 @@
 import Swift
 
 @_spi(Unwinders)
+@available(Backtracing 6.2, *)
 public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, IteratorProtocol {
   public typealias Context = C
   public typealias MemoryReader = M

--- a/stdlib/public/RuntimeModule/Image.swift
+++ b/stdlib/public/RuntimeModule/Image.swift
@@ -22,7 +22,8 @@ struct ImageSymbol {
   var offset: Int
 }
 
-internal protocol Image {
+@available(Backtracing 6.2, *)
+protocol Image {
   typealias UUID = [UInt8]
   typealias Address = ImageSource.Address
 
@@ -67,6 +68,7 @@ internal protocol Image {
   func lookupSymbol(address: Address) -> ImageSymbol?
 }
 
+@available(Backtracing 6.2, *)
 extension Image {
   public func swapIfRequired<T: FixedWidthInteger>(_ x: T) -> T {
     if shouldByteSwap {

--- a/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
@@ -38,6 +38,7 @@ fileprivate func getSysCtlString(_ name: String) -> String? {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension ImageMap {
 
   private static let platform = {

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -23,6 +23,7 @@ internal import BacktracingImpl.OS.Darwin
 #endif
 
 /// Holds a map of the process's address space.
+@available(Backtracing 6.2, *)
 public struct ImageMap: Collection, Sendable, Hashable {
 
   /// A type representing the sequence's elements.

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -137,6 +137,7 @@ public struct ImageMap: Collection, Sendable, Hashable {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension ImageMap: CustomStringConvertible {
   /// Generate a description of an ImageMap
   public var description: String {
@@ -167,6 +168,7 @@ extension ImageMap: CustomStringConvertible {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Image {
   /// Convert an ImageMap.Image to a Backtrace.Image.
   ///
@@ -204,6 +206,7 @@ extension Backtrace.Image {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension ImageMap: Codable {
 
   public func encode(to encoder: any Encoder) throws {

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -31,6 +31,7 @@ enum ImageSourceError: Error {
   case posixError(Int32)
 }
 
+@available(Backtracing 6.2, *)
 struct ImageSource {
 
   private class Storage {
@@ -343,6 +344,7 @@ struct ImageSource {
 }
 
 // MemoryReader support
+@available(Backtracing 6.2, *)
 extension ImageSource: MemoryReader {
   public func fetch(from address: Address,
                     into buffer: UnsafeMutableRawBufferPointer) throws {
@@ -379,6 +381,7 @@ extension ImageSource: MemoryReader {
 }
 
 /// Used as a cursor by the DWARF code
+@available(Backtracing 6.2, *)
 struct ImageSourceCursor {
   typealias Address = ImageSource.Address
   typealias Size = ImageSource.Size

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -31,7 +31,9 @@ internal import Musl
 internal import BacktracingImpl.OS.Darwin
 #endif
 
-@_spi(MemoryReaders) public protocol MemoryReader {
+@_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
+public protocol MemoryReader {
   typealias Address = UInt64
   typealias Size = UInt64
 
@@ -62,6 +64,7 @@ internal import BacktracingImpl.OS.Darwin
   func fetchString(from addr: Address, length: Int) throws -> String?
 }
 
+@available(Backtracing 6.2, *)
 extension MemoryReader {
 
   public func fetch<T>(from address: Address,
@@ -115,7 +118,9 @@ extension MemoryReader {
   }
 }
 
-@_spi(MemoryReaders) public struct UnsafeLocalMemoryReader: MemoryReader {
+@_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
+public struct UnsafeLocalMemoryReader: MemoryReader {
   public init() {}
 
   public func fetch(from address: Address,
@@ -138,11 +143,14 @@ extension MemoryReader {
 }
 
 #if os(macOS)
-@_spi(MemoryReaders) public struct MachError: Error {
+@_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
+public struct MachError: Error {
   var result: kern_return_t
 }
 
 @_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
 public struct UncachedRemoteMemoryReader: MemoryReader {
   private var task: task_t
 
@@ -170,6 +178,7 @@ public struct UncachedRemoteMemoryReader: MemoryReader {
 }
 
 @_spi(MemoryReaders)
+@available(Backtracing 6.2, *)
 public struct UncachedLocalMemoryReader: MemoryReader {
   public typealias Address = UInt64
   public typealias Size = UInt64

--- a/stdlib/public/RuntimeModule/RichFrame.swift
+++ b/stdlib/public/RuntimeModule/RichFrame.swift
@@ -17,6 +17,7 @@
 import Swift
 
 @_spi(Internal)
+@available(Backtracing 6.2, *)
 public enum RichFrame<T: FixedWidthInteger>: CustomStringConvertible, Equatable {
   public typealias Address = T
 

--- a/stdlib/public/RuntimeModule/RichFrame.swift
+++ b/stdlib/public/RuntimeModule/RichFrame.swift
@@ -122,6 +122,7 @@ public enum RichFrame<T: FixedWidthInteger>: CustomStringConvertible, Equatable 
   }
 }
 
+@available(Backtracing 6.2, *)
 extension RichFrame: LimitableElement {
   // LimitableElement wants to call this "omitted"
   public static func omitted(_ count: Int) -> Self {
@@ -129,6 +130,7 @@ extension RichFrame: LimitableElement {
   }
 }
 
+@available(Backtracing 6.2, *)
 extension Backtrace.Frame {
   init<T>(_ frame: RichFrame<T>) {
     switch frame {

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -33,6 +33,7 @@ internal import Musl
 internal import BacktracingImpl.Runtime
 
 /// A symbolicated backtrace
+@available(Backtracing 6.2, *)
 public struct SymbolicatedBacktrace: CustomStringConvertible {
   /// The `Backtrace` from which this was constructed
   public var backtrace: Backtrace

--- a/stdlib/public/RuntimeModule/Utils.swift
+++ b/stdlib/public/RuntimeModule/Utils.swift
@@ -62,6 +62,7 @@ func pad<T>(_ value: T, _ width: Int, align: PadAlignment = .left) -> String {
 }
 
 @_spi(Utils)
+@available(Backtracing 6.2, *)
 public func readString(from file: String) -> String? {
   let fd = open(file, O_RDONLY, 0)
   if fd < 0 {
@@ -88,6 +89,7 @@ public func readString(from file: String) -> String? {
 }
 
 @_spi(Utils)
+@available(Backtracing 6.2, *)
 public func stripWhitespace<S: StringProtocol>(_ s: S)
     -> S.SubSequence {
   guard let firstNonWhitespace = s.firstIndex(where: { !$0.isWhitespace })

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -31,12 +31,23 @@ if(NOT SWIFT_BUILD_STDLIB)
   set(BUILD_STANDALONE TRUE)
 endif()
 
+# Note: we disable availability checking because we need to use code from
+# the RuntimeModule, but we also need to build with an availability version
+# below that defined by Backtracing 6.2 (for now).
+#
+# We can't use the same trick that we use in the RuntimeModule or stdlib,
+# because we're importing those modules, but because we build *with* them,
+# we want to be able to use new things that are in them.  We don't have a
+# great solution to this, other than just turning off availability checking
+# for this code.
+
 set(BACKTRACING_COMPILE_FLAGS
   "-cxx-interoperability-mode=default"
   "-I${SWIFT_STDLIB_SOURCE_DIR}/public/RuntimeModule/modules"
   "-Xcc;-I${SWIFT_SOURCE_DIR}/include"
   "-Xcc;-I${CMAKE_BINARY_DIR}/include"
-  "-disable-upcoming-feature;MemberImportVisibility")
+  "-disable-upcoming-feature;MemberImportVisibility"
+  "-Xfrontend;-disable-availability-checking")
 
 set(BACKTRACING_SOURCES
   main.swift

--- a/test/Backtracing/BacktraceWithLimit.swift
+++ b/test/Backtracing/BacktraceWithLimit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -disable-availability-checking -Onone -o %t/BacktraceWithLimit
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/BacktraceWithLimit
 // RUN: %target-codesign %t/BacktraceWithLimit
 // RUN: %target-run %t/BacktraceWithLimit | %FileCheck %s
 

--- a/test/Backtracing/BacktraceWithLimit.swift
+++ b/test/Backtracing/BacktraceWithLimit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/BacktraceWithLimit
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -disable-availability-checking -Onone -o %t/BacktraceWithLimit
 // RUN: %target-codesign %t/BacktraceWithLimit
 // RUN: %target-run %t/BacktraceWithLimit | %FileCheck %s
 

--- a/test/Backtracing/BacktraceWithLimitAndTop.swift
+++ b/test/Backtracing/BacktraceWithLimitAndTop.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/BacktraceWithLimitAndTop
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/BacktraceWithLimitAndTop
 // RUN: %target-codesign %t/BacktraceWithLimitAndTop
 // RUN: %target-run %t/BacktraceWithLimitAndTop | %FileCheck %s
 

--- a/test/Backtracing/BacktraceWithLimitAndTop.swift
+++ b/test/Backtracing/BacktraceWithLimitAndTop.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/BacktraceWithLimitAndTop
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/BacktraceWithLimitAndTop
 // RUN: %target-codesign %t/BacktraceWithLimitAndTop
 // RUN: %target-run %t/BacktraceWithLimitAndTop | %FileCheck %s
 

--- a/test/Backtracing/CodableBacktrace.swift
+++ b/test/Backtracing/CodableBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-cpu-macos15.0 -disable-availability-checking -Xfrontend -parse-as-library -Onone -o %t/CodableBacktrace
+// RUN: %target-build-swift %s -target %target-cpu-macos15.0 -Xfrontend -disable-availability-checking -Xfrontend -parse-as-library -Onone -o %t/CodableBacktrace
 // RUN: %target-codesign %t/CodableBacktrace
 // RUN: %target-run %t/CodableBacktrace | %FileCheck %s
 

--- a/test/Backtracing/CodableBacktrace.swift
+++ b/test/Backtracing/CodableBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-cpu-macos15.0 -Xfrontend -parse-as-library -Onone -o %t/CodableBacktrace
+// RUN: %target-build-swift %s -target %target-cpu-macos15.0 -disable-availability-checking -Xfrontend -parse-as-library -Onone -o %t/CodableBacktrace
 // RUN: %target-codesign %t/CodableBacktrace
 // RUN: %target-run %t/CodableBacktrace | %FileCheck %s
 

--- a/test/Backtracing/CompactImageMap.swift
+++ b/test/Backtracing/CompactImageMap.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/ImageMap
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/ImageMap
 // RUN: %target-codesign %t/ImageMap
 // RUN: %target-run %t/ImageMap | tee %t/ImageMap.out
 // RUN: cat %t/ImageMap.out | %FileCheck %s

--- a/test/Backtracing/CompactImageMap.swift
+++ b/test/Backtracing/CompactImageMap.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/ImageMap
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/ImageMap
 // RUN: %target-codesign %t/ImageMap
 // RUN: %target-run %t/ImageMap | tee %t/ImageMap.out
 // RUN: cat %t/ImageMap.out | %FileCheck %s

--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/Inlining.swift -disable-availability-checking -parse-as-library -g -o %t/Inlining
+// RUN: %target-build-swift %S/Inputs/Inlining.swift -Xfrontend -disable-availability-checking -parse-as-library -g -o %t/Inlining
 // RUN: %target-build-swift %s -parse-as-library -g -o %t/DwarfReader
 // RUN: %target-run %t/DwarfReader %t/Inlining | %FileCheck %s
 

--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/Inlining.swift -parse-as-library -g -o %t/Inlining
+// RUN: %target-build-swift %S/Inputs/Inlining.swift -disable-availability-checking -parse-as-library -g -o %t/Inlining
 // RUN: %target-build-swift %s -parse-as-library -g -o %t/DwarfReader
 // RUN: %target-run %t/DwarfReader %t/Inlining | %FileCheck %s
 

--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -3,7 +3,7 @@
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -g %S/Inputs/fib.c -o %t/fib-no-uuid
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib-gnu -g %S/Inputs/fib.c -o %t/fib-compress-gnu
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib -g %S/Inputs/fib.c -o %t/fib-compress-zlib
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -o %t/ElfReader
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -g -o %t/ElfReader
 // RUN: %target-run %t/ElfReader %t/fib | %FileCheck %s
 // RUN: %target-run %t/ElfReader %t/fib-no-uuid | %FileCheck %s --check-prefix NOUUID
 // RUN: %target-run %t/ElfReader %t/fib-compress-gnu | %FileCheck %s --check-prefix CMPGNU

--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -3,7 +3,7 @@
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -g %S/Inputs/fib.c -o %t/fib-no-uuid
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib-gnu -g %S/Inputs/fib.c -o %t/fib-compress-gnu
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib -g %S/Inputs/fib.c -o %t/fib-compress-zlib
-// RUN: %target-build-swift %s -parse-as-library -g -o %t/ElfReader
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -o %t/ElfReader
 // RUN: %target-run %t/ElfReader %t/fib | %FileCheck %s
 // RUN: %target-run %t/ElfReader %t/fib-no-uuid | %FileCheck %s --check-prefix NOUUID
 // RUN: %target-run %t/ElfReader %t/fib-compress-gnu | %FileCheck %s --check-prefix CMPGNU

--- a/test/Backtracing/ImageMap.swift
+++ b/test/Backtracing/ImageMap.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/ImageMap
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/ImageMap
 // RUN: %target-codesign %t/ImageMap
 // RUN: %target-run %t/ImageMap | %FileCheck %s
 

--- a/test/Backtracing/ImageMap.swift
+++ b/test/Backtracing/ImageMap.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/ImageMap
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -Onone -o %t/ImageMap
 // RUN: %target-codesign %t/ImageMap
 // RUN: %target-run %t/ImageMap | %FileCheck %s
 

--- a/test/Backtracing/SimpleAsyncBacktrace.swift
+++ b/test/Backtracing/SimpleAsyncBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -g -parse-as-library -disable-availability-checking -Onone -o %t/SimpleAsyncBacktrace
+// RUN: %target-build-swift %s -g -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/SimpleAsyncBacktrace
 // RUN: %target-codesign %t/SimpleAsyncBacktrace
 // RUN: %target-run %t/SimpleAsyncBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SimpleAsyncBacktrace.swift
+++ b/test/Backtracing/SimpleAsyncBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -g -parse-as-library -Onone -o %t/SimpleAsyncBacktrace
+// RUN: %target-build-swift %s -g -parse-as-library -disable-availability-checking -Onone -o %t/SimpleAsyncBacktrace
 // RUN: %target-codesign %t/SimpleAsyncBacktrace
 // RUN: %target-run %t/SimpleAsyncBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SimpleBacktrace.swift
+++ b/test/Backtracing/SimpleBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -Xfrontend -parse-as-library -disable-availability-checking -Onone -o %t/SimpleBacktrace
+// RUN: %target-build-swift %s -Xfrontend -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/SimpleBacktrace
 // RUN: %target-codesign %t/SimpleBacktrace
 // RUN: %target-run %t/SimpleBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SimpleBacktrace.swift
+++ b/test/Backtracing/SimpleBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -Xfrontend -parse-as-library -Onone -o %t/SimpleBacktrace
+// RUN: %target-build-swift %s -Xfrontend -parse-as-library -disable-availability-checking -Onone -o %t/SimpleBacktrace
 // RUN: %target-codesign %t/SimpleBacktrace
 // RUN: %target-run %t/SimpleBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SymbolicatedBacktrace.swift
+++ b/test/Backtracing/SymbolicatedBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -Onone -o %t/SymbolicatedBacktrace
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -g -Onone -o %t/SymbolicatedBacktrace
 // RUN: %target-codesign %t/SymbolicatedBacktrace
 // RUN: %target-run %t/SymbolicatedBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SymbolicatedBacktrace.swift
+++ b/test/Backtracing/SymbolicatedBacktrace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -g -Onone -o %t/SymbolicatedBacktrace
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -Onone -o %t/SymbolicatedBacktrace
 // RUN: %target-codesign %t/SymbolicatedBacktrace
 // RUN: %target-run %t/SymbolicatedBacktrace | %FileCheck %s
 

--- a/test/Backtracing/SymbolicatedBacktraceInline.swift
+++ b/test/Backtracing/SymbolicatedBacktraceInline.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -g -O -o %t/SymbolicatedBacktraceInline
+// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -O -o %t/SymbolicatedBacktraceInline
 // RUN: %target-codesign %t/SymbolicatedBacktraceInline
 // RUN: %target-run %t/SymbolicatedBacktraceInline | %FileCheck %s
 

--- a/test/Backtracing/SymbolicatedBacktraceInline.swift
+++ b/test/Backtracing/SymbolicatedBacktraceInline.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -disable-availability-checking -g -O -o %t/SymbolicatedBacktraceInline
+// RUN: %target-build-swift %s -parse-as-library -Xfrontend -disable-availability-checking -g -O -o %t/SymbolicatedBacktraceInline
 // RUN: %target-codesign %t/SymbolicatedBacktraceInline
 // RUN: %target-run %t/SymbolicatedBacktraceInline | %FileCheck %s
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -507,6 +507,9 @@ def availability_macro_to_swift_abi_target_triple(macro):
     # that is formatted like this:
     #    SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
     matches = re.search(r'^[\s]*Swift(?:Stdlib|CompatibilitySpan)[\s]+([0-9\.]+)[\s]*:[\s]*(.+)', macro)
+    if not matches:
+      return None
+
     stdlib_vers = matches.group(1)
     vers_by_platform = {}
     for platform_vers in matches.group(2).split(', '):
@@ -585,8 +588,10 @@ for macro in load_availability_macros():
       config.swift_frontend_test_options += " -define-availability '{0}'".format(current_macro)
       config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(current_macro)
 
-    (stdlib_vers, triple) = availability_macro_to_swift_abi_target_triple(macro)
-    config.substitutions.append(('%target-swift-{}-abi-triple'.format(stdlib_vers), triple))
+    vers_info = availability_macro_to_swift_abi_target_triple(macro)
+    if vers_info:
+      (stdlib_vers, triple) = vers_info
+      config.substitutions.append(('%target-swift-{}-abi-triple'.format(stdlib_vers), triple))
 
 
 differentiable_programming = lit_config.params.get('differentiable_programming', None)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -55,6 +55,9 @@ SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visi
 # Identical to SwiftStdlib 6.2.
 SwiftCompatibilitySpan 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0
 
+# Backtracing is only available for macOS in 6.2
+Backtracing 6.2: macOS 26.0
+
 # TODO: When you add a new version, remember to tell the compiler about it
 # by also adding it to include/swift/AST/RuntimeVersions.def.
 


### PR DESCRIPTION
This is slightly complicated by us currently not supporting this code on iOS/tvOS/watchOS/visionOS.  We should fix that, at which point we can use the `SwiftStdlib`/`StdlibDeploymentTarget` macros instead.

rdar://164850733
