### PR TITLE
[Sema] A couple of binding-related crasher fixes

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -959,11 +959,8 @@ AnnotatedInsertionPoint
 ConditionalClausePatternUseScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   auto *initializer = sec.getInitializer();
-  if (!isa<ErrorExpr>(initializer)) {
-    scopeCreator
-      .constructExpandAndInsert<ConditionalClauseInitializerScope>(
-        this, initializer);
-    }
+  scopeCreator.constructExpandAndInsert<ConditionalClauseInitializerScope>(
+      this, initializer);
 
   return {this,
           "Succeeding code must be in scope of conditional clause pattern bindings"};

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3167,6 +3167,16 @@ namespace {
       }
 
       case PatternKind::Expr: {
+        // Make sure we invalidate any nested VarDecls early since generating
+        // constraints for a `where` clause may happen before we've generated
+        // constraints for the ExprPattern. We'll record a fix when visiting
+        // the UnresolvedPatternExpr.
+        // FIXME: We ought to use a conjunction for switch cases, then we
+        // wouldn't need this logic.
+        auto *EP = cast<ExprPattern>(pattern);
+        EP->getSubExpr()->forEachUnresolvedVariable([&](VarDecl *VD) {
+          CS.setType(VD, ErrorType::get(CS.getASTContext()));
+        });
         // We generate constraints for ExprPatterns in a separate pass. For
         // now, just create a type variable.
         return setType(CS.createTypeVariable(CS.getConstraintLocator(locator),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5582,6 +5582,10 @@ bool ConstraintSystem::repairFailures(
     if (!anchor)
       return false;
 
+    // If we have an ErrorExpr anchor, we don't need to do any more fixes.
+    if (isExpr<ErrorExpr>(anchor))
+      return true;
+
     // This could be:
     // - `InOutExpr` used with r-value e.g. `foo(&x)` where `x` is a `let`.
     // - `ForceValueExpr` e.g. `foo.bar! = 42` where `bar` or `foo` are

--- a/test/IDE/complete_return.swift
+++ b/test/IDE/complete_return.swift
@@ -1,21 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_VOID_1 | %FileCheck %s -check-prefix=RETURN_VOID_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_INT_1 | %FileCheck %s -check-prefix=RETURN_INT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_INT_2 | %FileCheck %s -check-prefix=RETURN_INT_2
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TRY_RETURN_INT | %FileCheck %s -check-prefix=RETURN_INT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TRY_RETURN_VOID | %FileCheck %s -check-prefix=RETURN_VOID_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1 | %FileCheck %s -check-prefix=RETURN_TR1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2 | %FileCheck %s -check-prefix=RETURN_TR2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3 | %FileCheck %s -check-prefix=RETURN_TR3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_METHOD | %FileCheck %s -check-prefix=RETURN_TR1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_METHOD | %FileCheck %s -check-prefix=RETURN_TR2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_METHOD | %FileCheck %s -check-prefix=RETURN_TR3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR3
+// RUN: %batch-code-completion
 
 struct FooStruct {
   var instanceVar : Int
@@ -64,11 +47,11 @@ func testReturnInt2(_ fooObject: FooStruct) {
 }
 
 func testMisplacedTry() throws -> Int {
-  try return #^TRY_RETURN_INT^#
+  try return #^TRY_RETURN_INT?check=RETURN_INT_1^#
 }
 
 func testMisplacedTryVoid() throws {
-  try return #^TRY_RETURN_VOID^#
+  try return #^TRY_RETURN_VOID?check=RETURN_VOID_1^#
 }
 
 func testTR1() -> Int? {
@@ -111,26 +94,26 @@ struct TestStruct {
     var i : Int
     var oi : Int?
     var fs : FooStruct
-    return #^RETURN_TR1_METHOD^#
+    return #^RETURN_TR1_METHOD?check=RETURN_TR1^#
   }
   func testTR2_method(_ g : Gen) -> Int? {
-    return g.#^RETURN_TR2_METHOD^#
+    return g.#^RETURN_TR2_METHOD?check=RETURN_TR2^#
   }
   func testTR3_method(_ g : Gen) -> Int? {
-    return g.IG.#^RETURN_TR3_METHOD^#
+    return g.IG.#^RETURN_TR3_METHOD?check=RETURN_TR3^#
   }
 
   static func testTR1_static() -> Int? {
     var i : Int
     var oi : Int?
     var fs : FooStruct
-    return #^RETURN_TR1_STATICMETHOD^#
+    return #^RETURN_TR1_STATICMETHOD?check=RETURN_TR1^#
   }
   static func testTR2_static(_ g : Gen) -> Int? {
-    return g.#^RETURN_TR2_STATICMETHOD^#
+    return g.#^RETURN_TR2_STATICMETHOD?check=RETURN_TR2^#
   }
   static func testTR3_static(_ g : Gen) -> Int? {
-    return g.IG.#^RETURN_TR3_STATICMETHOD^#
+    return g.IG.#^RETURN_TR3_STATICMETHOD?check=RETURN_TR3^#
   }
 }
 
@@ -140,12 +123,12 @@ func testClosures(_ g: Gen) {
   var fs : FooStruct
 
   _ = { () -> Int? in
-    return #^RETURN_TR1_CLOSURE^#
+    return #^RETURN_TR1_CLOSURE?check=RETURN_TR1^#
   }
   _ = { () -> Int? in
-    return g.#^RETURN_TR2_CLOSURE^#
+    return g.#^RETURN_TR2_CLOSURE?check=RETURN_TR2^#
   }
   _ = { () -> Int? in
-    return g.IG.#^RETURN_TR3_CLOSURE^#
+    return g.IG.#^RETURN_TR3_CLOSURE?check=RETURN_TR3^#
   }
 }

--- a/test/IDE/complete_return.swift
+++ b/test/IDE/complete_return.swift
@@ -132,3 +132,17 @@ func testClosures(_ g: Gen) {
     return g.IG.#^RETURN_TR3_CLOSURE?check=RETURN_TR3^#
   }
 }
+
+// Make sure we can do a completion in an out-of-place return
+do {
+  return TestStruct.#^COMPLETE_IN_INVALID_RETURN^#
+  // COMPLETE_IN_INVALID_RETURN: Decl[StaticMethod]/CurrNominal: testTR1_static()[#Int?#]; name=testTR1_static()
+  // COMPLETE_IN_INVALID_RETURN: Decl[StaticMethod]/CurrNominal: testTR2_static({#(g): Gen#})[#Int?#]; name=testTR2_static(:)
+  // COMPLETE_IN_INVALID_RETURN: Decl[StaticMethod]/CurrNominal: testTR3_static({#(g): Gen#})[#Int?#]; name=testTR3_static(:)
+}
+
+struct TestReturnInInit {
+  init() {
+    return TestStruct.#^COMPLETE_IN_INVALID_INIT_RETURN?check=COMPLETE_IN_INVALID_RETURN^#
+  }
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -179,6 +179,8 @@ return 42 // expected-error {{return invalid outside of a func}}
 
 return // expected-error {{return invalid outside of a func}}
 
+return VoidReturn1() // expected-error {{return invalid outside of a func}}
+
 func NonVoidReturn1() -> Int {
   _ = 0
   return // expected-error {{non-void function should return a value}}

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getClosureType-aac79a.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getClosureType-aac79a.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::getClosureType(swift::ClosureExpr const*) const","signatureAssert":"Assertion failed: (result), function getClosureType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 return {
   lazy var a = if .random() { return }
 }

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getTypeOfReferencePre-60045c.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getTypeOfReferencePre-60045c.swift
@@ -1,0 +1,9 @@
+// {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::getTypeOfReferencePre(swift::constraints::OverloadChoice, swift::DeclContext*, swift::constraints::ConstraintLocatorBuilder, swift::constraints::PreparedOverloadBuilder*)","signatureAssert":"Assertion failed: (func->isOperator() && \"Lookup should only find operators\"), function getTypeOfReferencePre"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  switch if .random()  else {
+  }
+  {
+  case let !a where a:
+  }
+}

--- a/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-5c070f.swift
+++ b/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-5c070f.swift
@@ -1,0 +1,7 @@
+// {"kind":"typecheck","signature":"swift::constraints::TypeVarRefCollector::walkToStmtPre(swift::Stmt*)","signatureAssert":"Assertion failed: (result), function getClosureType"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  guard let a = (a  if{
+    return
+  }
+) "

--- a/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-e56ccf.swift
+++ b/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-e56ccf.swift
@@ -1,0 +1,10 @@
+// {"kind":"typecheck","signature":"swift::constraints::TypeVarRefCollector::walkToStmtPre(swift::Stmt*)","signatureAssert":"Assertion failed: (result), function getClosureType"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  switch if <#expression#> {
+    return
+  }
+  {
+  case let !a where a:
+  }
+}


### PR DESCRIPTION
I'm planning on adding an assert that ensures we don't type-check bindings independently of their closure context, the fuzzer found crashers for the following cases, which with some modification can also crash even without the assert. Fix up these cases such that we can land the assert without regressing anything.

- Better handle recovery for structurally invalid ReturnStmts such that we still type-check the result expression
- Invalidate unresolved variables in ExprPatterns early in CSGen to ensure we don't generate constraints for a `where` clause before we've assigned them a type
- Remove a redundant ErrorExpr check from ASTScopes