### PR TITLE
test: remove stdlib unittest dependency for tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -474,9 +474,11 @@ foreach(SDK ${SWIFT_SDKS})
         list(APPEND test_dependencies "touch-covering-tests")
       endif()
 
-      list(APPEND test_dependencies
-        "swiftStdlibCollectionUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-        "swiftStdlibUnicodeUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+      if(SWIFT_BUILD_STDLIB)
+        list(APPEND test_dependencies
+          "swiftStdlibCollectionUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
+          "swiftStdlibUnicodeUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+      endif()
 
       set(validation_test_dependencies)
 


### PR DESCRIPTION
When building without the standard library, we exclude the standard library from the test dependencies. The unittest framework is dependency on the standard library and cannot be built without it. Remove this dependency in that case as well.