### PR TITLE
[6.3] Disable pack specialization

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -527,7 +527,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // of embedded Swift.
   if (!P.getOptions().EmbeddedSwift) {
     P.addGenericSpecializer();
-    P.addPackSpecialization();
+    // P.addPackSpecialization();
     // Run devirtualizer after the specializer, because many
     // class_method/witness_method instructions may use concrete types now.
     P.addDevirtualizer();

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %target-swift-frontend %s -emit-ir -O | %FileCheck %s
 
 // REQUIRES: swift_in_compiler


### PR DESCRIPTION
- **Explanation**: Disable the PackSpecialization pass in the FunctionPass pipeline, and mark the pack_specialization.swift test file, which relies on the pass, as XFAIL
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This change has minimal impact, since it is just a 2-line change to temporarily disable an optimization and an associated test. It is highly important, since the current PackSpecialization pass causes compiler crashes when building certain projects (see issue).
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://164515160
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/85491
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Lost potential performance gains from the pass.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit tests (see below). 
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @eeckstein
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
