### PR TITLE
Properly initialize buffer when called via legacy ABI

### DIFF
--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -157,6 +157,9 @@ public func _float16ToStringImpl(
   var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
     _unchecked: textBuffer,
     count: Int(bufferLength))
+  for i in 0..<Int(bufferLength) {
+      buffer[unchecked: i] = 0x30
+  }
   let textRange = _Float16ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
 
@@ -446,6 +449,9 @@ internal func _float32ToStringImpl(
   var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
     _unchecked: textBuffer,
     count: Int(bufferLength))
+  for i in 0..<Int(bufferLength) {
+      buffer[unchecked: i] = 0x30
+  }
   let textRange = _Float32ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
 
@@ -694,6 +700,9 @@ internal func _float64ToStringImpl(
   var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
     _unchecked: textBuffer,
     count: Int(bufferLength))
+  for i in 0..<Int(bufferLength) {
+      buffer[unchecked: i] = 0x30
+  }
   let textRange = _Float64ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
 
@@ -1197,6 +1206,9 @@ internal func _float80ToStringImpl(
   var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
     _unchecked: textBuffer,
     count: Int(bufferLength))
+  for i in 0..<Int(bufferLength) {
+      buffer[unchecked: i] = 0x30
+  }
   let textRange = _Float80ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
 


### PR DESCRIPTION
The new implementation strongly assumes the buffer is pre-filled with `"0"` characters (0x30).  This breaks folks trying to integrate this with the old stdlib code that did not do the pre-filling and called the legacy ABI.

Resolves #85539
