### PR TITLE
[6.3] Revert "[Caching][NFC] Using llvm::cas::CASConfiguration"

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -32,7 +32,6 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringSet.h"
-#include "llvm/CAS/CASConfiguration.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Mutex.h"
 #include <optional>
@@ -1037,8 +1036,8 @@ using BridgeClangDependencyCallback = llvm::function_ref<ModuleDependencyInfo(
 /// A carrier of state shared among possibly multiple invocations of the
 /// dependency scanner.
 class SwiftDependencyScanningService {
-  /// The CAS configuration created the Scanning Service if used.
-  std::optional<llvm::cas::CASConfiguration> CASConfig;
+  /// The CASOption created the Scanning Service if used.
+  std::optional<clang::CASOptions> CASOpts;
 
   /// The persistent Clang dependency scanner service
   std::optional<clang::tooling::dependencies::DependencyScanningService>

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -20,7 +20,6 @@
 
 #include "clang/CAS/CASOptions.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/CAS/CASConfiguration.h"
 
 namespace swift {
 
@@ -38,8 +37,8 @@ public:
   /// Import modules from CAS.
   bool ImportModuleFromCAS = false;
 
-  /// CAS Configuration.
-  llvm::cas::CASConfiguration Config;
+  /// CASOptions
+  clang::CASOptions CASOpts;
 
   /// Clang Include Trees.
   std::string ClangIncludeTree;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -637,9 +637,9 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   if (!Instance.getInvocation().getCASOptions().EnableCaching)
     return false;
 
-  if (CASConfig) {
+  if (CASOpts) {
     // If CASOption matches, the service is initialized already.
-    if (*CASConfig == Instance.getInvocation().getCASOptions().Config)
+    if (*CASOpts == Instance.getInvocation().getCASOptions().CASOpts)
       return false;
 
     // CASOption mismatch, return error.
@@ -648,18 +648,13 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   }
 
   // Setup CAS.
-  CASConfig = Instance.getInvocation().getCASOptions().Config;
-
-  clang::CASOptions CASOpts;
-  CASOpts.CASPath = CASConfig->CASPath;
-  CASOpts.PluginPath = CASConfig->PluginPath;
-  CASOpts.PluginOptions = CASConfig->PluginOptions;
+  CASOpts = Instance.getInvocation().getCASOptions().CASOpts;
 
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       clang::tooling::dependencies::ScanningOutputFormat::FullIncludeTree,
-      CASOpts, Instance.getSharedCASInstance(),
-      Instance.getSharedCacheInstance(),
+      Instance.getInvocation().getCASOptions().CASOpts,
+      Instance.getSharedCASInstance(), Instance.getSharedCacheInstance(),
       /*CachingOnDiskFileSystem=*/nullptr,
       // The current working directory optimization (off by default)
       // should not impact CAS. We set the optization to all to be

--- a/lib/Basic/CASOptions.cpp
+++ b/lib/Basic/CASOptions.cpp
@@ -23,14 +23,14 @@ void CASOptions::enumerateCASConfigurationFlags(
       llvm::function_ref<void(llvm::StringRef)> Callback) const {
   if (EnableCaching) {
     Callback("-cache-compile-job");
-    if (!Config.CASPath.empty()) {
+    if (!CASOpts.CASPath.empty()) {
       Callback("-cas-path");
-      Callback(Config.CASPath);
+      Callback(CASOpts.CASPath);
     }
-    if (!Config.PluginPath.empty()) {
+    if (!CASOpts.PluginPath.empty()) {
       Callback("-cas-plugin-path");
-      Callback(Config.PluginPath);
-      for (auto Opt : Config.PluginOptions) {
+      Callback(CASOpts.PluginPath);
+      for (auto Opt : CASOpts.PluginOptions) {
         Callback("-cas-plugin-option");
         Callback((llvm::Twine(Opt.first) + "=" + Opt.second).str());
       }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1198,9 +1198,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     // compiler can be more efficient to compute swift cache key without having
     // the knowledge about clang command-line options.
     if (ctx.CASOpts.EnableCaching || ctx.CASOpts.ImportModuleFromCAS) {
-      CI->getCASOpts().CASPath = ctx.CASOpts.Config.CASPath;
-      CI->getCASOpts().PluginPath = ctx.CASOpts.Config.PluginPath;
-      CI->getCASOpts().PluginOptions = ctx.CASOpts.Config.PluginOptions;
+      CI->getCASOpts() = ctx.CASOpts.CASOpts;
       // When clangImporter is used to compile (generate .pcm or .pch), need to
       // inherit the include tree from swift args (last one wins) and clear the
       // input file.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -804,15 +804,15 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks);
   Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
   if (const Arg *A = Args.getLastArg(OPT_cas_path))
-    Opts.Config.CASPath = A->getValue();
+    Opts.CASOpts.CASPath = A->getValue();
 
   if (const Arg *A = Args.getLastArg(OPT_cas_plugin_path))
-    Opts.Config.PluginPath = A->getValue();
+    Opts.CASOpts.PluginPath = A->getValue();
 
   for (StringRef Opt : Args.getAllArgValues(OPT_cas_plugin_option)) {
     StringRef Name, Value;
     std::tie(Name, Value) = Opt.split('=');
-    Opts.Config.PluginOptions.emplace_back(std::string(Name),
+    Opts.CASOpts.PluginOptions.emplace_back(std::string(Name),
                                             std::string(Value));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -477,12 +477,12 @@ bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
     return false;
 
   const auto &Opts = getInvocation().getCASOptions();
-  if (Opts.Config.CASPath.empty() && Opts.Config.PluginPath.empty()) {
+  if (Opts.CASOpts.CASPath.empty() && Opts.CASOpts.PluginPath.empty()) {
     Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
                          "no CAS options provided");
     return true;
   }
-  auto MaybeDB = Opts.Config.createDatabases();
+  auto MaybeDB = Opts.CASOpts.getOrCreateDatabases();
   if (!MaybeDB) {
     Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
                          toString(MaybeDB.takeError()));

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1805,7 +1805,7 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
 
   if (casOpts.EnableCaching) {
     genericSubInvocation.getCASOptions().EnableCaching = casOpts.EnableCaching;
-    genericSubInvocation.getCASOptions().Config = casOpts.Config;
+    genericSubInvocation.getCASOptions().CASOpts = casOpts.CASOpts;
     genericSubInvocation.getCASOptions().HasImmutableFileSystem =
         casOpts.HasImmutableFileSystem;
     casOpts.enumerateCASConfigurationFlags(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1431,8 +1431,8 @@ static bool generateReproducer(CompilerInstance &Instance,
   llvm::sys::path::append(casPath, "cas");
   clang::CASOptions newCAS;
   newCAS.CASPath = casPath.str();
-  newCAS.PluginPath = casOpts.Config.PluginPath;
-  newCAS.PluginOptions = casOpts.Config.PluginOptions;
+  newCAS.PluginPath = casOpts.CASOpts.PluginPath;
+  newCAS.PluginOptions = casOpts.CASOpts.PluginOptions;
   auto db = newCAS.getOrCreateDatabases();
   if (!db) {
     diags.diagnose(SourceLoc(), diag::error_cas_initialization,


### PR DESCRIPTION
- **Explanation**: This reverts commit 4f059033bb2cbbb684fb782f36a8351052ca8742. The change is actually not NFC since previously, there is a cache in the CompilerInvocation that prevents the same CAS from the same CASOptions from being initialized multiple times, which was relied upon when running inside sub invocation. When switching to a non-caching simple CASOption types, it causes every single sub instance will create its own CAS, and it can consume too many file descriptors and causing errors during dependency scanning.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Fixes `too many open file` error when running dependency scanning.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://164903080
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/85547
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. This is a revert.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Test failure projects after revert.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @benlangmuir 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->



