### PR TITLE
[APIGen] Mark symbols from non-API level library as private

### DIFF
--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -705,6 +705,11 @@ class APIGenRecorder final : public APIRecorder {
   bool isSPI(const Decl *decl) {
     assert(decl);
 
+    // If the module's library level is more restricted than API, all symbols
+    // should be SPIs.
+    if (module->getLibraryLevel() < swift::LibraryLevel::API)
+      return true;
+
     if (auto value = dyn_cast<ValueDecl>(decl)) {
       auto accessScope =
           value->getFormalAccessScope(/*useDC=*/nullptr,

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -1,8 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -package-name MyModule -swift-version 5
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -package-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -package-name MyModule -swift-version 5 -library-level api
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -package-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 import Foundation

--- a/test/APIJSON/availability.swift
+++ b/test/APIJSON/availability.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -target arm64-apple-macos12
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -target arm64-apple-macos12 -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 @available(iOS 13.0, *)

--- a/test/APIJSON/extension.swift
+++ b/test/APIJSON/extension.swift
@@ -1,8 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -library-level api
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 import Foundation

--- a/test/APIJSON/library-level.swift
+++ b/test/APIJSON/library-level.swift
@@ -2,9 +2,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -library-level api
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/none.json -target arm64-apple-macos26
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -target arm64-apple-macos26 -library-level api
-// RUN: %validate-json %t/api.json | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/spi.json -target arm64-apple-macos26 -library-level spi
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/ipi.json -target arm64-apple-macos26 -library-level ipi
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -parse-as-library  -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/other.json -target arm64-apple-macos26 -library-level other
+// RUN: %validate-json %t/api.json | %FileCheck %s --check-prefixes CHECK,API
+// RUN: %validate-json %t/none.json | %FileCheck %s --check-prefixes CHECK,NON-API
+// RUN: %validate-json %t/spi.json | %FileCheck %s --check-prefixes CHECK,NON-API
+// RUN: %validate-json %t/ipi.json | %FileCheck %s --check-prefixes CHECK,NON-API
+// RUN: %validate-json %t/other.json | %FileCheck %s --check-prefixes CHECK,NON-API
 
 import Foundation
 
@@ -25,79 +32,73 @@ public class MyClass2 : NSObject {
 @available(iOS 8.0, *)
 public func spiAvailableFunc() {}
 
-@_spi_available(macOS 11, *)
-@available(iOS 10, *)
-public class SPIClass {
-  public func noAvailabilityAttr() {}
-}
-
 // CHECK:      {
 // CHECK-NEXT:   "target": "arm64-apple-macos26",
 // CHECK-NEXT:   "globals": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassC9spiMethodyyFTj",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassC9spiMethodyyFTq",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCACycfC",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCACycfc",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMa",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMn",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMo",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMu",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCN",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCfD",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
 // CHECK-NEXT:       "SPIAvailable": true
@@ -105,7 +106,7 @@ public class SPIClass {
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
 // CHECK-NEXT:       "SPIAvailable": true
@@ -113,155 +114,83 @@ public class SPIClass {
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C9spiMethodyyFTj",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C9spiMethodyyFTq",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfC",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfc",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMa",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMn",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMo",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMu",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CN",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CfD",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule15newUnprovenFuncyyF",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule16spiAvailableFuncyyF",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassC18noAvailabilityAttryyFTj",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassC18noAvailabilityAttryyFTq",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMa",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMm",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMn",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMo",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMu",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCN",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCfD",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
-// CHECK-NEXT:       "SPIAvailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCfd",
-// CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
-// CHECK-NEXT:       "linkage": "exported",
-// CHECK-NEXT:       "introduced": "11",
 // CHECK-NEXT:       "SPIAvailable": true
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
@@ -269,51 +198,53 @@ public class SPIClass {
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_TtC8MyModule7MyClass",
 // CHECK-NEXT:       "access": "private",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "super": "NSObject",
 // CHECK-NEXT:       "instanceMethods": [
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "spiMethod",
 // CHECK-NEXT:           "access": "private",
-// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift"
+// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift"
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "init",
 // CHECK-NEXT:           "access": "private",
-// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift"
+// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift"
 // CHECK-NEXT:         }
 // CHECK-NEXT:       ],
 // CHECK-NEXT:       "classMethods": []
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_TtC8MyModule8MyClass2",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
+// CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "super": "NSObject",
 // CHECK-NEXT:       "instanceMethods": [
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "spiMethod",
 // CHECK-NEXT:           "access": "private",
-// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift"
+// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift"
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "spiAvailableMethod",
 // CHECK-NEXT:           "access": "private",
-// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift",
+// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:           "introduced": "10.10",
 // CHECK-NEXT:           "SPIAvailable": true
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "init",
-// CHECK-NEXT:           "access": "public",
-// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift"
+// API-NEXT:             "access": "public",
+// NON-API-NEXT:         "access": "private",
+// CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift"
 // CHECK-NEXT:         }
 // CHECK-NEXT:       ],
 // CHECK-NEXT:       "classMethods": []
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
- // CHECK-NEXT:  "categories": [],
+// CHECK-NEXT:   "categories": [],
 // CHECK-NEXT:   "version": "1.0"
 // CHECK-NEXT: }

--- a/test/APIJSON/non-objc-class.swift
+++ b/test/APIJSON/non-objc-class.swift
@@ -1,8 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -library-level api
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 import Foundation

--- a/test/APIJSON/objc-implement.swift
+++ b/test/APIJSON/objc-implement.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %t/objc-implement.swift -typecheck -parse-as-library -emit-module-interface-path %t/ObjcImplement.swiftinterface -enable-library-evolution -module-name ObjcImplement -import-underlying-module -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %t/objc-implement.swift -typecheck -parse-as-library -emit-module-interface-path %t/ObjcImplement.swiftinterface -enable-library-evolution -module-name ObjcImplement -import-underlying-module -swift-version 5 -emit-api-descriptor-path %t/api.json -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 //--- objc-implement.swift

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -1,8 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/ModuleCache)
-// RUN: %target-swift-frontend %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-frontend %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %target-swift-frontend %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -library-level api
+// RUN: %target-swift-frontend %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 -emit-api-descriptor-path %t/api.json -library-level api
 // RUN: %validate-json %t/api.json | %FileCheck %s
 
 // Struct has no objc data.


### PR DESCRIPTION
All symbols are private (as in the API descriptor) if the library level is more restricted than `LibraryLevel::API`.

Resolves rdar://164901718

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
