### PR TITLE
[Sanitizers] Add metadata to memsets created in zeroInit for LLDB

### DIFF
--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -23,7 +23,7 @@ public func f(_ i : Int?)
   // CHECK1: %[[alloca:.*]] = alloca %TSiSg
   // CHECK1: #dbg_declare(ptr %i.debug
   // CHECK1: call void @llvm.memset{{.*}}(ptr align {{(4|8)}} %[[alloca]],
-  // CHECK1-SAME:                         i8 0, i64 {{(5|9)}}, i1 false){{$}}
+  // CHECK1-SAME:                         i8 0, i64 {{(5|9)}}, i1 false), !Swift.isSwiftLLDBpreinit
   // CHECK1: #dbg_declare(ptr %val.debug, !{{.*}}, !DIExpression{{.*}},
   // CHECK1-SAME:              ![[DBG0:.*]])
   // CHECK1-LABEL: define {{.*}}@"$s4main1gyySSSgF"

--- a/test/DebugInfo/uninitialized.swift
+++ b/test/DebugInfo/uninitialized.swift
@@ -9,7 +9,7 @@ public func f() {
   // CHECK: %[[OBJ:.*]] = alloca ptr, align
   // CHECK: #dbg_declare(ptr %[[OBJ]],
   // CHECK: void @llvm.memset.{{.*}}(ptr align {{(4|8)}} %[[OBJ]], i8 0,
-  // CHECK-SAME:                    ){{$}}
+  // CHECK-SAME:                    ), !Swift.isSwiftLLDBpreinit
   // OPT-NOT: @llvm.memset
   // OPT: ret
 }
@@ -21,7 +21,7 @@ public func g() {
   // CHECK: %[[DICT:.*]] = alloca
   // CHECK: #dbg_declare(ptr %[[DICT]],
   // CHECK: void @llvm.memset.{{.*}}(ptr align {{(4|8)}} %[[DICT]], i8 0,
-  // CHECK-SAME:                    ){{$}}
+  // CHECK-SAME:                    ), !Swift.isSwiftLLDBpreinit
   // OPT-NOT: @llvm.memset
   // OPT: ret
 }


### PR DESCRIPTION
The swift compiler memsets new allocas to zero. It does this so that LLDB is able to display a friendly 'variable is uninitialized' message rather than garbage. Unfortunately this use of a variable before its lifetime.start disagrees with the memtag-stack tagging pass.

This patch attaches a piece of metadata to these memsets, so that the memtag-stack tagging pass can recognize them and work around them appropriately.

Paired with: https://github.com/swiftlang/llvm-project/pull/11846.

rdar://162206592