### PR TITLE
[cxx-interop] Reapply implicitly defined copy and move constructors

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -737,6 +737,12 @@ ValueDecl *getImportedMemberOperator(const DeclBaseName &name,
 /// as permissive as the input C++ access.
 AccessLevel convertClangAccess(clang::AccessSpecifier access);
 
+/// Lookup and return the copy constructor of \a decl
+///
+/// Returns nullptr if \a decl doesn't have a valid copy constructor
+const clang::CXXConstructorDecl *
+findCopyConstructor(const clang::CXXRecordDecl *decl);
+
 /// Read file IDs from 'private_fileid' Swift attributes on a Clang decl.
 ///
 /// May return >1 fileID when a decl is annotated more than once, which should

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -575,15 +575,7 @@ SourceLoc extractNearestSourceLoc(EscapabilityLookupDescriptor desc);
 // When a reference type is copied, the pointer’s value is copied rather than
 // the object’s storage. This means reference types can be imported as
 // copyable to Swift, even when they are non-copyable in C++.
-enum class CxxValueSemanticsKind {
-  Unknown,
-  Copyable,
-  MoveOnly,
-  // A record that is either not copyable/movable or not destructible.
-  MissingLifetimeOperation,
-  // A record that has no copy and no move operations
-  UnavailableConstructors,
-};
+enum class CxxValueSemanticsKind { Unknown, Copyable, MoveOnly };
 
 struct CxxValueSemanticsDescriptor final {
   const clang::Type *type;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8477,10 +8477,11 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   llvm::SmallDenseSet<const clang::RecordDecl *, 4> seen;
 
   auto maybePushToStack = [&](const clang::Type *type) {
-    auto recordDecl = type->getAsRecordDecl();
-    if (!recordDecl)
+    const auto *recordType = type->getAs<clang::RecordType>();
+    if (!recordType)
       return;
 
+    auto recordDecl = recordType->getDecl();
     if (seen.insert(recordDecl).second) {
       // When a reference type is copied, the pointer’s value is copied rather
       // than the object’s storage. This means reference types can be imported
@@ -8503,7 +8504,6 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   while (!stack.empty()) {
     const clang::RecordDecl *recordDecl = stack.back();
     stack.pop_back();
-
     if (!hasNonCopyableAttr(recordDecl)) {
       auto injectedStlAnnotation =
           recordDecl->isInStdNamespace()

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8326,17 +8326,16 @@ bool importer::isViewType(const clang::CXXRecordDecl *decl) {
   return !hasOwnedValueAttr(decl) && hasPointerInSubobjects(decl);
 }
 
-static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
-  if (decl->hasSimpleCopyConstructor())
-    return true;
-
-  return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-    return ctor->isCopyConstructor() && !ctor->isDeleted() &&
-           !ctor->isIneligibleOrNotSelected() &&
-           // FIXME: Support default arguments (rdar://142414553)
-           ctor->getNumParams() == 1 &&
-           ctor->getAccess() == clang::AccessSpecifier::AS_public;
-  });
+const clang::CXXConstructorDecl *
+importer::findCopyConstructor(const clang::CXXRecordDecl *decl) {
+  for (auto ctor : decl->ctors()) {
+    if (ctor->isCopyConstructor() &&
+        // FIXME: Support default arguments (rdar://142414553)
+        ctor->getNumParams() == 1 && ctor->getAccess() == clang::AS_public &&
+        !ctor->isDeleted() && !ctor->isIneligibleOrNotSelected())
+      return ctor;
+  }
+  return nullptr;
 }
 
 static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {
@@ -8504,7 +8503,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   while (!stack.empty()) {
     const clang::RecordDecl *recordDecl = stack.back();
     stack.pop_back();
-    if (!hasNonCopyableAttr(recordDecl)) {
+    bool isExplicitlyNonCopyable = hasNonCopyableAttr(recordDecl);
+    if (!isExplicitlyNonCopyable) {
       auto injectedStlAnnotation =
           recordDecl->isInStdNamespace()
               ? STLConditionalParams.find(recordDecl->getName())
@@ -8531,13 +8531,28 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
 
     const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
     if (!cxxRecordDecl || !recordDecl->isCompleteDefinition()) {
-      if (hasNonCopyableAttr(recordDecl))
+      if (isExplicitlyNonCopyable)
         return CxxValueSemanticsKind::MoveOnly;
       continue;
     }
 
-    bool isCopyable = !hasNonCopyableAttr(cxxRecordDecl) &&
-                      hasCopyTypeOperations(cxxRecordDecl);
+    bool isCopyable = !isExplicitlyNonCopyable;
+    if (!isExplicitlyNonCopyable) {
+      auto copyCtor = findCopyConstructor(cxxRecordDecl);
+      isCopyable = copyCtor || cxxRecordDecl->needsImplicitCopyConstructor();
+      if ((copyCtor && copyCtor->isDefaulted()) ||
+          cxxRecordDecl->needsImplicitCopyConstructor()) {
+        // If the copy constructor is implicit/defaulted, we ask Clang to
+        // generate its definition. The implicitly-defined copy constructor
+        // performs full member-wise copy. Thus, if any member of this type is
+        // ~Copyable, the type should also be ~Copyable.
+        for (auto field : cxxRecordDecl->fields())
+          maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
+        for (auto base : cxxRecordDecl->bases())
+          maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
+      }
+    }
+
     bool isMovable = hasMoveTypeOperations(cxxRecordDecl);
 
     if (!hasDestroyTypeOperations(cxxRecordDecl) ||
@@ -8551,7 +8566,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       continue;
     }
 
-    if (hasNonCopyableAttr(cxxRecordDecl) && isMovable)
+    if (isExplicitlyNonCopyable && isMovable)
       return CxxValueSemanticsKind::MoveOnly;
 
     if (isCopyable)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5467,112 +5467,103 @@ getConditionalCopyableAttrParams(const clang::RecordDecl *decl) {
 CxxEscapability
 ClangTypeEscapability::evaluate(Evaluator &evaluator,
                                 EscapabilityLookupDescriptor desc) const {
-  bool hadUnknown = false;
-  auto evaluateEscapability = [&](const clang::Type *type) {
-    auto escapability = evaluateOrDefault(
-        evaluator,
-        ClangTypeEscapability({type, desc.impl, desc.annotationOnly}),
-        CxxEscapability::Unknown);
-    if (escapability == CxxEscapability::Unknown)
-      hadUnknown = true;
-    return escapability;
-  };
-
+  bool hasUnknown = false;
   auto desugared = desc.type->getUnqualifiedDesugaredType();
   if (const auto *recordType = desugared->getAs<clang::RecordType>()) {
     auto recordDecl = recordType->getDecl();
-    if (hasNonEscapableAttr(recordDecl))
-      return CxxEscapability::NonEscapable;
     if (hasEscapableAttr(recordDecl))
       return CxxEscapability::Escapable;
-    auto injectedStlAnnotation =
-        recordDecl->isInStdNamespace()
-            ? STLConditionalParams.find(recordDecl->getName())
-            : STLConditionalParams.end();
-    auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
-                         ? injectedStlAnnotation->second
-                         : std::vector<int>();
-    auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
+  }
 
-    if (!STLParams.empty() || !conditionalParams.empty()) {
-      HeaderLoc loc{recordDecl->getLocation()};
-      std::function checkArgEscapability =
-          [&](clang::TemplateArgument &arg,
-              StringRef argToCheck) -> std::optional<CxxEscapability> {
-        if (arg.getKind() != clang::TemplateArgument::Type && desc.impl) {
-          desc.impl->diagnose(loc, diag::type_template_parameter_expected,
-                              argToCheck);
-          return CxxEscapability::Unknown;
+  llvm::SmallVector<const clang::Type *, 4> stack;
+  // Keep track of Decls we've seen to avoid cycles
+  llvm::SmallDenseSet<const clang::Type *, 4> seen;
+
+  auto maybePushToStack = [&](const clang::Type *type) {
+    auto desugared = type->getUnqualifiedDesugaredType();
+    if (seen.insert(desugared).second)
+      stack.push_back(desugared);
+  };
+
+  maybePushToStack(desc.type);
+  while (!stack.empty()) {
+    auto type = stack.back();
+    stack.pop_back();
+    if (const auto *recordType = type->getAs<clang::RecordType>()) {
+      auto recordDecl = recordType->getDecl();
+      if (hasNonEscapableAttr(recordDecl))
+        return CxxEscapability::NonEscapable;
+      if (hasEscapableAttr(recordDecl))
+        continue;
+      auto injectedStlAnnotation =
+          recordDecl->isInStdNamespace()
+              ? STLConditionalParams.find(recordDecl->getName())
+              : STLConditionalParams.end();
+      auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
+                           ? injectedStlAnnotation->second
+                           : std::vector<int>();
+      auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
+
+      if (!STLParams.empty() || !conditionalParams.empty()) {
+        HeaderLoc loc{recordDecl->getLocation()};
+        std::function checkArgEscapability =
+            [&](clang::TemplateArgument &arg,
+                StringRef argToCheck) -> std::optional<CxxEscapability> {
+          if (arg.getKind() != clang::TemplateArgument::Type) {
+            if (desc.impl)
+              desc.impl->diagnose(loc, diag::type_template_parameter_expected,
+                                  argToCheck);
+            hasUnknown = true;
+            return std::nullopt;
+          }
+          maybePushToStack(arg.getAsType()->getUnqualifiedDesugaredType());
+          // FIXME don't return anything
+          return std::nullopt;
+        };
+
+        checkConditionalParams<CxxEscapability>(
+            recordDecl, STLParams, conditionalParams, checkArgEscapability);
+
+        if (desc.impl)
+          for (auto name : conditionalParams)
+            desc.impl->diagnose(loc, diag::unknown_template_parameter, name);
+
+        continue;
+      }
+      if (desc.annotationOnly) {
+        hasUnknown = true;
+        continue;
+      }
+      auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
+      if (recordDecl->getDefinition() &&
+          (!cxxRecordDecl || cxxRecordDecl->isAggregate())) {
+        if (cxxRecordDecl) {
+          // TODO llvm::foreach ?
+          for (auto base : cxxRecordDecl->bases())
+            maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
         }
 
-        auto argEscapability = evaluateEscapability(
-            arg.getAsType()->getUnqualifiedDesugaredType());
-        if (argEscapability == CxxEscapability::NonEscapable)
-          return CxxEscapability::NonEscapable;
-        return std::nullopt;
-      };
-
-      auto result = checkConditionalParams<CxxEscapability>(
-          recordDecl, STLParams, conditionalParams, checkArgEscapability);
-      if (result.has_value())
-        return result.value();
-
-      if (desc.impl)
-        for (auto name : conditionalParams)
-          desc.impl->diagnose(loc, diag::unknown_template_parameter, name);
-
-      return hadUnknown ? CxxEscapability::Unknown : CxxEscapability::Escapable;
+        for (auto field : recordDecl->fields())
+          maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
+        continue;
+      }
     }
-    if (desc.annotationOnly)
-      return CxxEscapability::Unknown;
-    auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
-    if (recordDecl->getDefinition() &&
-        (!cxxRecordDecl || cxxRecordDecl->isAggregate())) {
-      if (cxxRecordDecl) {
-        for (auto base : cxxRecordDecl->bases()) {
-          auto baseEscapability = evaluateEscapability(
-              base.getType()->getUnqualifiedDesugaredType());
-          if (baseEscapability == CxxEscapability::NonEscapable)
-            return CxxEscapability::NonEscapable;
-        }
-      }
-
-      for (auto field : recordDecl->fields()) {
-        auto fieldEscapability = evaluateEscapability(
-            field->getType()->getUnqualifiedDesugaredType());
-        if (fieldEscapability == CxxEscapability::NonEscapable)
-          return CxxEscapability::NonEscapable;
-      }
-
-      return hadUnknown ? CxxEscapability::Unknown : CxxEscapability::Escapable;
+    if (type->isArrayType()) {
+      auto elemTy = cast<clang::ArrayType>(type)
+                        ->getElementType()
+                        ->getUnqualifiedDesugaredType();
+      maybePushToStack(elemTy);
+    } else if (const auto *vecTy = type->getAs<clang::VectorType>()) {
+      maybePushToStack(vecTy->getElementType()->getUnqualifiedDesugaredType());
+    } else if (type->isAnyPointerType() || type->isBlockPointerType() ||
+               type->isMemberPointerType() || type->isReferenceType()) {
+      if (desc.annotationOnly)
+        hasUnknown = true;
+      else
+        return CxxEscapability::NonEscapable;
     }
   }
-  if (desugared->isArrayType()) {
-    auto elemTy = cast<clang::ArrayType>(desugared)
-                      ->getElementType()
-                      ->getUnqualifiedDesugaredType();
-    return evaluateOrDefault(
-        evaluator,
-        ClangTypeEscapability({elemTy, desc.impl, desc.annotationOnly}),
-        CxxEscapability::Unknown);
-  }
-  if (const auto *vecTy = desugared->getAs<clang::VectorType>()) {
-    return evaluateOrDefault(
-        evaluator,
-        ClangTypeEscapability(
-            {vecTy->getElementType()->getUnqualifiedDesugaredType(), desc.impl,
-             desc.annotationOnly}),
-        CxxEscapability::Unknown);
-  }
-
-  // Base cases
-  if (desugared->isAnyPointerType() || desugared->isBlockPointerType() ||
-      desugared->isMemberPointerType() || desugared->isReferenceType())
-    return desc.annotationOnly ? CxxEscapability::Unknown
-                               : CxxEscapability::NonEscapable;
-  if (desugared->isScalarType())
-    return CxxEscapability::Escapable;
-  return CxxEscapability::Unknown;
+  return hasUnknown ? CxxEscapability::Unknown : CxxEscapability::Escapable;
 }
 
 void swift::simple_display(llvm::raw_ostream &out,
@@ -8520,7 +8511,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
             if (importerImpl)
               importerImpl->diagnose(
                   loc, diag::type_template_parameter_expected, argToCheck);
-            return CxxValueSemanticsKind::Unknown;
+            return std::nullopt;
           }
           maybePushToStack(arg.getAsType()->getUnqualifiedDesugaredType());
           // FIXME: return std::nullopt for now, while we don't refactor ClangTypeEscapability request

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2103,11 +2103,11 @@ namespace {
       return importer::recordHasReferenceSemantics(decl, &Impl);
     }
 
-    bool recordHasMoveOnlySemantics(const clang::RecordDecl *decl) {
+    bool recordIsCopyable(const clang::RecordDecl *decl) {
       auto semanticsKind = evaluateOrDefault(
           Impl.SwiftContext.evaluator,
           CxxValueSemantics({decl->getTypeForDecl(), &Impl}), {});
-      return semanticsKind == CxxValueSemanticsKind::MoveOnly;
+      return semanticsKind == CxxValueSemanticsKind::Copyable;
     }
 
     void markReturnsUnsafeNonescapable(AbstractFunctionDecl *fd) {
@@ -2286,7 +2286,7 @@ namespace {
             loc, ArrayRef<InheritedEntry>(), nullptr, dc);
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
-      if (recordHasMoveOnlySemantics(decl)) {
+      if (!recordIsCopyable(decl)) {
         if (decl->isInStdNamespace() && decl->getName() == "promise") {
           // Do not import std::promise.
           return nullptr;
@@ -3170,8 +3170,7 @@ namespace {
       auto valueSemanticsKind = evaluateOrDefault(
           Impl.SwiftContext.evaluator,
           CxxValueSemantics({decl->getTypeForDecl(), &Impl}), {});
-      if (valueSemanticsKind == CxxValueSemanticsKind::MissingLifetimeOperation ||
-          valueSemanticsKind == CxxValueSemanticsKind::UnavailableConstructors) {
+      if (valueSemanticsKind == CxxValueSemanticsKind::Unknown) {
 
         HeaderLoc loc(decl->getLocation());
         if (hasUnsafeAPIAttr(decl))
@@ -3183,12 +3182,6 @@ namespace {
         if (hasIteratorAPIAttr(decl))
           Impl.diagnose(loc, diag::api_pattern_attr_ignored, "import_iterator",
                         decl->getNameAsString());
-
-        if (valueSemanticsKind == CxxValueSemanticsKind::UnavailableConstructors) {
-          Impl.addImportDiagnostic(
-              decl, Diagnostic(diag::record_unsupported_default_args),
-              decl->getLocation());
-        }
 
         Impl.addImportDiagnostic(
             decl,
@@ -3426,7 +3419,7 @@ namespace {
         auto semanticsKind = evaluateOrDefault(
             Impl.SwiftContext.evaluator,
             CxxValueSemantics({parent->getTypeForDecl(), &Impl}), {});
-        if (semanticsKind == CxxValueSemanticsKind::MissingLifetimeOperation)
+        if (semanticsKind == CxxValueSemanticsKind::Unknown)
           return nullptr;
       }
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3074,8 +3074,7 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
       ctx.evaluator, 
       CxxValueSemantics({clangType->getTypeForDecl(), &ImporterImpl}), {});
 
-  if (valueSemanticsKind != CxxValueSemanticsKind::Copyable &&
-      valueSemanticsKind != CxxValueSemanticsKind::MoveOnly)
+  if (valueSemanticsKind == CxxValueSemanticsKind::Unknown)
     return nullptr;
 
   auto cxxRecordSemanticsKind = evaluateOrDefault(

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-ignore-unrelated
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-ignore-unrelated
 
 //--- Inputs/module.modulemap
 module Test {
@@ -12,10 +12,11 @@ module Test {
 //--- Inputs/noncopyable.h
 #include "swift/bridging"
 #include <string>
+#include <vector>
 
 struct NonCopyable {
     NonCopyable() = default;
-    NonCopyable(const NonCopyable& other) = delete;
+    NonCopyable(const NonCopyable& other) = delete; // expected-note {{'NonCopyable' has been explicitly marked deleted here}}
     NonCopyable(NonCopyable&& other) = default;
 };
 
@@ -79,9 +80,62 @@ struct SWIFT_NONCOPYABLE NonCopyableNonMovable { // expected-note {{record 'NonC
     NonCopyableNonMovable(NonCopyableNonMovable&& other) = delete;
 };
 
+struct ImplicitCopyConstructor {
+  NonCopyable element;
+};
+
+template <typename T, typename P, typename R>
+struct TemplatedImplicitCopyConstructor {
+  T element;
+  P *pointer;
+  R &reference;
+};
+
+using NonCopyableT = TemplatedImplicitCopyConstructor<NonCopyable, int, int>;
+using NonCopyableP = TemplatedImplicitCopyConstructor<int, NonCopyable, int>;
+using NonCopyableR = TemplatedImplicitCopyConstructor<int, int, NonCopyable>;
+
+struct DefaultedCopyConstructor {
+  NonCopyable element; // expected-note {{copy constructor of 'DefaultedCopyConstructor' is implicitly deleted because field 'element' has a deleted copy constructor}}
+  DefaultedCopyConstructor(const DefaultedCopyConstructor&) = default; 
+  // expected-warning@-1 {{explicitly defaulted copy constructor is implicitly deleted}}
+  // expected-note@-2 {{replace 'default' with 'delete'}}
+  DefaultedCopyConstructor(DefaultedCopyConstructor&&) = default;
+};
+
+template<typename T>
+struct TemplatedDefaultedCopyConstructor {
+  T element;
+  TemplatedDefaultedCopyConstructor(const TemplatedDefaultedCopyConstructor&) = default;
+  TemplatedDefaultedCopyConstructor(TemplatedDefaultedCopyConstructor&&) = default;
+};
+
+template<typename T>
+struct DerivedTemplatedDefaultedCopyConstructor : TemplatedDefaultedCopyConstructor<T> {};
+
+using CopyableDefaultedCopyConstructor = TemplatedDefaultedCopyConstructor<NonCopyableP>;
+using NonCopyableDefaultedCopyConstructor = TemplatedDefaultedCopyConstructor<NonCopyable>;
+using CopyableDerived = DerivedTemplatedDefaultedCopyConstructor<NonCopyableR>;
+using NonCopyableDerived = DerivedTemplatedDefaultedCopyConstructor<NonCopyable>;
+
 template<typename T> struct SWIFT_COPYABLE_IF(T) DisposableContainer {};
 struct POD { int x; float y; }; // special members are implicit, but should be copyable
 using DisposablePOD = DisposableContainer<POD>; // should also be copyable
+
+struct DerivesFromMe : MyPair<DisposableContainer<DerivesFromMe>, std::vector<NonCopyable>> {};
+struct DerivesFromMeToo : MyPair<std::vector<NonCopyable>, DisposableContainer<DerivesFromMe>> {};
+
+template <typename T>
+struct OneField {
+    T field;
+};
+
+template <typename F, typename S>
+struct SWIFT_COPYABLE_IF(F, S) NoFields {};
+
+struct FieldDependsOnMe { // used to trigger a request cycle
+  OneField<NoFields<FieldDependsOnMe, NonCopyable>> field;
+};
 
 //--- test.swift
 import Test
@@ -133,6 +187,34 @@ func missingLifetimeOperation() {
     takeCopyable(s)
 }
 
+func implicitCopyConstructor(i: borrowing ImplicitCopyConstructor, t: borrowing NonCopyableT, p: borrowing NonCopyableP, r: borrowing NonCopyableR) {
+  takeCopyable(i) // expected-error {{global function 'takeCopyable' requires that 'ImplicitCopyConstructor' conform to 'Copyable'}}
+  takeCopyable(t) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableT' (aka 'TemplatedImplicitCopyConstructor<NonCopyable, CInt, CInt>') conform to 'Copyable'}}
+  
+  // References and pointers to non-copyable types are still copyable
+  takeCopyable(p)
+  takeCopyable(r)
+}
+
+func defaultCopyConstructor(d: borrowing DefaultedCopyConstructor, d1: borrowing CopyableDefaultedCopyConstructor, d2: borrowing NonCopyableDefaultedCopyConstructor, d3: borrowing CopyableDerived, d4: borrowing NonCopyableDerived) {
+  takeCopyable(d) // expected-error {{global function 'takeCopyable' requires that 'DefaultedCopyConstructor' conform to 'Copyable'}}
+  takeCopyable(d1)
+  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableDefaultedCopyConstructor' (aka 'TemplatedDefaultedCopyConstructor<NonCopyable>') conform to 'Copyable'}}
+  takeCopyable(d3)
+  takeCopyable(d4) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableDerived' (aka 'DerivedTemplatedDefaultedCopyConstructor<NonCopyable>') conform to 'Copyable'}}
+}
+
 func copyableDisposablePOD(p: DisposablePOD) {
   takeCopyable(p)
+}
+
+func couldCreateCycleOfCxxValueSemanticsRequests() {
+  let d1 = DerivesFromMe()
+  takeCopyable(d1) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
+
+  let d2 = DerivesFromMeToo()
+  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
+
+  let d3 = FieldDependsOnMe()
+  takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}
 }

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -193,10 +193,10 @@ public func noAnnotations() -> View {
     // CHECK-NO-LIFETIMES: nonescapable.h:56:39: error: template parameter 'Missing' does not exist
     i2()
     // CHECK: nonescapable.h:62:33: error: template parameter 'S' expected to be a type parameter
-    // CHECK: nonescapable.h:80:41: error: a function with a ~Escapable result needs a parameter to depend on
-    // CHECK: note: '@_lifetime(immortal)' can be used to indicate that values produced
     // CHECK-NO-LIFETIMES: nonescapable.h:62:33: error: template parameter 'S' expected to be a type parameter
     j1()
+    // CHECK: nonescapable.h:80:41: error: a function with a ~Escapable result needs a parameter to depend on
+    // CHECK: note: '@_lifetime(immortal)' can be used to indicate that values produced
     // CHECK-NO-LIFETIMES: nonescapable.h:80:41: error: a function cannot return a ~Escapable result
     j2()
     // CHECK: nonescapable.h:81:41: error: a function with a ~Escapable result needs a parameter to depend on

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -99,3 +99,9 @@ module CustomSmartPtr {
   requires cplusplus
   export *
 }
+
+module StdExpected {
+  header "std-expected.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-expected.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-expected.h
@@ -1,0 +1,23 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+
+#include <memory>
+#include <expected>
+
+using NonCopyableExpected = std::expected<std::unique_ptr<bool>, int>;
+
+template<typename T>
+class UniqueRef {
+public:
+  std::unique_ptr<T> _field;
+};
+
+struct Decoder {};
+enum Error {
+  DoomA,
+  DoomB
+};
+
+using DecoderOrError = std::expected<UniqueRef<Decoder>, Error>;
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -89,4 +89,9 @@ struct CountCopies {
 
 inline std::unique_ptr<CountCopies> getCopyCountedUniquePtr() { return std::make_unique<CountCopies>(); }
 
+struct HasUniqueIntVector {
+  HasUniqueIntVector() = default;
+  std::vector<std::unique_ptr<int>> x;
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -40,4 +40,10 @@ struct NonCopyable {
 using VectorOfNonCopyable = std::vector<NonCopyable>;
 using VectorOfPointer = std::vector<NonCopyable *>;
 
+struct HasVector {
+  std::vector<NonCopyable> field;
+};
+
+struct BaseHasVector : HasVector {};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H

--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+// TODO <expected> not yet supported with libstdc++
+// XFAIL: OS=linux-gnu
+
+// https://github.com/apple/swift/issues/70226
+// UNSUPPORTED: OS=windows-msvc
+
+import StdExpected
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let nonCopExpected = NonCopyableExpected()
+takeCopyable(nonCopExpected)
+// CHECK: error: global function 'takeCopyable' requires that 'NonCopyableExpected' (aka {{.*}}) conform to 'Copyable'
+
+let doe = DecoderOrError()
+takeCopyable(doe)
+// CHECK: error: global function 'takeCopyable' requires that 'DecoderOrError' (aka {{.*}}) conform to 'Copyable'
+
+// CHECK-NOT: error

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
@@ -10,3 +10,7 @@ func takeCopyable<T: Copyable>(_ x: T) {}
 let vecUniquePtr = getVectorNonCopyableUniquePtr()
 takeCopyable(vecUniquePtr)
 // CHECK: error: global function 'takeCopyable' requires that 'std{{.*}}vector{{.*}}unique_ptr{{.*}}NonCopyable{{.*}}' conform to 'Copyable'
+
+let uniqueIntVec = HasUniqueIntVector()
+takeCopyable(uniqueIntVec)
+// CHECK: error: global function 'takeCopyable' requires that 'HasUniqueIntVector' conform to 'Copyable'

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -29,3 +29,11 @@ let vecFloat = VectorOfFloat()
 takeCopyable(vecFloat)
 takeCxxVector(vecFloat)
 // CHECK-NOT: error
+
+let hasVector = HasVector()
+takeCopyable(hasVector)
+// CHECK: error: global function 'takeCopyable' requires that 'HasVector' conform to 'Copyable'
+
+let baseHasVector = BaseHasVector()
+takeCopyable(baseHasVector)
+// CHECK: error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'


### PR DESCRIPTION
This patch reapplies https://github.com/swiftlang/swift/pull/84646 and https://github.com/swiftlang/swift/pull/85236:

> If a C++ type doesn't have a user provided copy constructor, Clang will declare one implicitly, unless one of its fields is not copy-constructible. Clang assumes that any `std::vector `is always copy-constructible, including a `std::vector` of a non-copy constructible type. So, let's use the CxxValueSemantics implemented in https://github.com/swiftlang/swift/pull/84340 to figure out if we should ask Clang to define the copy constructor for such types.
>
> This also includes types that have a defaulted, user-provided copy constructor.

These patches were reverted (https://github.com/swiftlang/swift/pull/85331) because they triggered a cycle in the `CxxValueSemantics` requests. After https://github.com/swiftlang/swift/pull/85485, these cycles have been prevented and we can safely re-land those patches. 

rdar://151870709
rdar://152496447