### PR TITLE
IRGen: Remove unsafe usage of static variable

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -450,6 +450,10 @@ class LinkEntity {
     // These are both type kinds and protocol-conformance kinds.
     // TYPE KINDS: BEGIN {{
 
+    /// A SIL differentiability witness. The pointer is a
+    /// SILDifferentiabilityWitness*.
+    DifferentiabilityWitness,
+
     /// A lazy protocol witness accessor function. The pointer is a
     /// canonical TypeBase*, and the secondary pointer is a
     /// ProtocolConformance*.
@@ -459,10 +463,6 @@ class LinkEntity {
     /// canonical TypeBase*, and the secondary pointer is a
     /// ProtocolConformance*.
     ProtocolWitnessTableLazyCacheVariable,
-
-    /// A SIL differentiability witness. The pointer is a
-    /// SILDifferentiabilityWitness*.
-    DifferentiabilityWitness,
 
     // Everything following this is a type kind.
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4023,38 +4023,41 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
   auto var = createVariable(*this, link, definitionType,
                             entity.getAlignment(*this), DbgTy);
 
-  // @escaping () -> ()
-  // NOTE: we explicitly desugar the `Void` type for the return as the test
-  // suite makes assumptions that it can emit the value witness table without a
-  // standard library for the target. `Context.getVoidType()` will attempt to
-  // lookup the `Decl` before returning the canonical type. To workaround this
-  // dependency, we simply desugar the `Void` return type to `()`.
-  static CanType kAnyFunctionType =
-      FunctionType::get({}, Context.TheEmptyTupleType,
-                        ASTExtInfo{})->getCanonicalType();
+  auto isZeroParamFunctionType = [this](Type t) -> bool {
+    if (auto *funcTy = t->getAs<FunctionType>()) {
+      return (funcTy->getParams().size() == 0 &&
+              funcTy->getResult()->isEqual(Context.TheEmptyTupleType));
+    }
+
+    return false;
+  };
 
   // Adjust the linkage for the well-known VWTs that are strongly defined
   // in the runtime.
   //
-  // We special case the "AnyFunctionType" here as this type is referened
+  // We special case the "AnyFunctionType" here as this type is referenced
   // inside the standard library with the definition being in the runtime
   // preventing the normal detection from identifying that this is module
   // local.
   //
   // If we are statically linking the standard library, we need to internalise
   // the symbols.
-  if (getSwiftModule()->isStdlibModule() ||
-      (Context.getStdlibModule() &&
-       Context.getStdlibModule()->isStaticLibrary()))
-    if (entity.isTypeKind() &&
-        (IsWellKnownBuiltinOrStructralType(entity.getType()) ||
-         entity.getType() == kAnyFunctionType))
-      if (auto *GV = dyn_cast<llvm::GlobalValue>(var))
-        if (GV->hasDLLImportStorageClass())
-          ApplyIRLinkage({llvm::GlobalValue::ExternalLinkage,
-                          llvm::GlobalValue::DefaultVisibility,
-                          llvm::GlobalValue::DefaultStorageClass})
-              .to(GV);
+  if (auto *GV = dyn_cast<llvm::GlobalValue>(var)) {
+    if (GV->hasDLLImportStorageClass()) {
+      if (getSwiftModule()->isStdlibModule() ||
+          (Context.getStdlibModule() &&
+           Context.getStdlibModule()->isStaticLibrary())) {
+        if (entity.isTypeKind() &&
+            (isWellKnownBuiltinOrStructuralType(entity.getType()) ||
+             isZeroParamFunctionType(entity.getType()))) {
+              ApplyIRLinkage({llvm::GlobalValue::ExternalLinkage,
+                              llvm::GlobalValue::DefaultVisibility,
+                              llvm::GlobalValue::DefaultStorageClass})
+                  .to(GV);
+        }
+      }
+    }
+  }
 
   // Install the concrete definition if we have one.
   if (definition && definition.hasInit()) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1411,13 +1411,13 @@ llvm::Module *IRGenModule::getModule() const {
   return ClangCodeGen->GetModule();
 }
 
-bool IRGenModule::IsWellKnownBuiltinOrStructralType(CanType T) const {
+bool IRGenModule::isWellKnownBuiltinOrStructuralType(CanType T) const {
   if (T == Context.TheEmptyTupleType || T == Context.TheNativeObjectType ||
       T == Context.TheBridgeObjectType || T == Context.TheRawPointerType ||
       T == Context.getAnyObjectType())
     return true;
 
-  if (auto IntTy = dyn_cast_or_null<BuiltinIntegerType>(T)) {
+  if (auto IntTy = dyn_cast<BuiltinIntegerType>(T)) {
     auto Width = IntTy->getWidth();
     if (Width.isPointerWidth())
       return true;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1196,7 +1196,7 @@ public:
 
   ClassMetadataStrategy getClassMetadataStrategy(const ClassDecl *theClass);
 
-  bool IsWellKnownBuiltinOrStructralType(CanType type) const;
+  bool isWellKnownBuiltinOrStructuralType(CanType type) const;
 
 private:
   TypeConverter &Types;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3664,7 +3664,7 @@ namespace {
       //
       // TODO: If a nominal type is in the same source file as we're currently
       // emitting, we would be able to see its value witness table.
-      if (IGF.IGM.IsWellKnownBuiltinOrStructralType(t))
+      if (IGF.IGM.isWellKnownBuiltinOrStructuralType(t))
         return emitFromValueWitnessTable(t);
 
       // If the type is a singleton aggregate, the field's layout is equivalent


### PR DESCRIPTION
We cannot use 'static' linkage for something that points into the ASTContext, because there might be more than one ASTContext in a single process.

Also, fix the spelling mistake in a related function name.

Finally, LinkEntity::Kind::DifferentiabilityWitness was in the wrong place. It's not a type kind. Move it to avoid UB when calling `isTypeKind()`.