### PR TITLE
[LLDB] Add an API for unregistering MemoryBuffer modules (NFC)

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -373,11 +373,14 @@ public:
   /// FIXME: make this an actual import *path* once submodules are designed.
   bool registerMemoryBuffer(StringRef importPath,
                             std::unique_ptr<llvm::MemoryBuffer> input,
-                            llvm::VersionTuple version) {
-    return MemoryBuffers
-        .insert({importPath, MemoryBufferInfo(std::move(input), version)})
-        .second;
-  }
+                            llvm::VersionTuple version);
+
+  /// During the transtion to explicitly tracked module dependencies LLDB may
+  /// instruct this loader to forget one of the (now redundant) MemoryBuffers
+  /// because it found an explicit module file on disk.
+  ///
+  /// \return true if the importPath existed.
+  bool unregisterMemoryBuffer(StringRef importPath);
 
   void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override {}

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1708,6 +1708,19 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
   return M;
 }
 
+bool MemoryBufferSerializedModuleLoader::registerMemoryBuffer(
+    StringRef importPath, std::unique_ptr<llvm::MemoryBuffer> input,
+    llvm::VersionTuple version) {
+  return MemoryBuffers
+      .insert({importPath, MemoryBufferInfo(std::move(input), version)})
+      .second;
+}
+
+bool MemoryBufferSerializedModuleLoader::unregisterMemoryBuffer(
+    StringRef importPath) {
+  return MemoryBuffers.erase(importPath);
+}
+
 void SerializedModuleLoaderBase::loadExtensions(NominalTypeDecl *nominal,
                                                 unsigned previousGeneration) {
   for (auto &modulePair : LoadedModuleFiles) {


### PR DESCRIPTION
(cherry picked from commit addff767a61e813c3327e5456e9ec42d0c5bc793)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
