### PR TITLE
Revert "[Runtime] Don't use write back in EIC retain/release"

### DIFF
--- a/stdlib/public/SwiftDirectRuntime/RetainRelease.s
+++ b/stdlib/public/SwiftDirectRuntime/RetainRelease.s
@@ -192,8 +192,7 @@ Lslowpath_release:
 // Save/restore the preservemost registers and call swift_retain.
 Lcall_swift_release:
   maybe_pacibsp
-  sub   sp, sp, #0x50
-  str   x9, [sp]
+  str   x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -208,14 +207,12 @@ Lcall_swift_release:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldr   x9, [sp]
-  add   sp, sp, #0x50
+  ldr   x9, [sp], #0x50
   ret_maybe_ab
 
 LbridgeObjectReleaseDirectObjC:
   maybe_pacibsp
-  sub   sp, sp, #0x50
-  stp   x0, x9, [sp]
+  stp   x0, x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -230,8 +227,7 @@ LbridgeObjectReleaseDirectObjC:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp]
-  add   sp, sp, #0x50
+  ldp   x0, x9, [sp], #0x50
 LbridgeObjectReleaseObjCRet:
   ret_maybe_ab
 
@@ -334,8 +330,7 @@ Lslowpath_retain:
 // Save/restore the preservemost registers and call swift_retain.
 Lcall_swift_retain:
   maybe_pacibsp
-  sub   sp, sp, #0x50
-  stp   x0, x9, [sp]
+  stp   x0, x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -350,14 +345,12 @@ Lcall_swift_retain:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp]
-  add   sp, sp, #0x50
+  ldp   x0, x9, [sp], #0x50
   ret_maybe_ab
 
 Lswift_bridgeObjectRetainDirectObjC:
   maybe_pacibsp
-  sub   sp, sp, #0x50
-  stp   x0, x9, [sp]
+  stp   x0, x9, [sp, #-0x50]!
   stp   x10, x11, [sp, #0x10]
   stp   x12, x13, [sp, #0x20]
   stp   x14, x15, [sp, #0x30]
@@ -372,8 +365,7 @@ Lswift_bridgeObjectRetainDirectObjC:
   ldp   x14, x15, [sp, #0x30]
   ldp   x12, x13, [sp, #0x20]
   ldp   x10, x11, [sp, #0x10]
-  ldp   x0, x9, [sp]
-  add   sp, sp, #0x50
+  ldp   x0, x9, [sp], #0x50
   ret_maybe_ab
 
 #else


### PR DESCRIPTION
Reverts swiftlang/swift#85403

Turns out these changes don't actually improve anything.