### PR TITLE
[6.3] [Sema] A couple of binding-related crasher fixes

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -959,11 +959,8 @@ AnnotatedInsertionPoint
 ConditionalClausePatternUseScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   auto *initializer = sec.getInitializer();
-  if (!isa<ErrorExpr>(initializer)) {
-    scopeCreator
-      .constructExpandAndInsert<ConditionalClauseInitializerScope>(
-        this, initializer);
-    }
+  scopeCreator.constructExpandAndInsert<ConditionalClauseInitializerScope>(
+      this, initializer);
 
   return {this,
           "Succeeding code must be in scope of conditional clause pattern bindings"};

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-getTypeOfReferencePre-60045c.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-getTypeOfReferencePre-60045c.swift
@@ -1,0 +1,9 @@
+// {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::getTypeOfReferencePre(swift::constraints::OverloadChoice, swift::DeclContext*, swift::constraints::ConstraintLocatorBuilder, swift::constraints::PreparedOverloadBuilder*)","signatureAssert":"Assertion failed: (func->isOperator() && \"Lookup should only find operators\"), function getTypeOfReferencePre"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  switch if .random()  else {
+  }
+  {
+  case let !a where a:
+  }
+}

--- a/validation-test/compiler_crashers_fixed/ConstraintWalker-walkToExprPost-c956e0.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintWalker-walkToExprPost-c956e0.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"1562769e","signature":"(anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum c
   func d()  e {
     if let

--- a/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-5c070f.swift
+++ b/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-5c070f.swift
@@ -1,0 +1,7 @@
+// {"kind":"typecheck","signature":"swift::constraints::TypeVarRefCollector::walkToStmtPre(swift::Stmt*)","signatureAssert":"Assertion failed: (result), function getClosureType"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  guard let a = (a  if{
+    return
+  }
+) "

--- a/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-e56ccf.swift
+++ b/validation-test/compiler_crashers_fixed/TypeVarRefCollector-walkToStmtPre-e56ccf.swift
@@ -1,0 +1,10 @@
+// {"kind":"typecheck","signature":"swift::constraints::TypeVarRefCollector::walkToStmtPre(swift::Stmt*)","signatureAssert":"Assertion failed: (result), function getClosureType"}
+// RUN: not %target-swift-frontend -typecheck %s
+{
+  switch if <#expression#> {
+    return
+  }
+  {
+  case let !a where a:
+  }
+}


### PR DESCRIPTION
*6.3 partial cherry-pick of #85538*

- Explanation: A couple of low risk crasher fixes, fixing ASTScope logic to ensure we still build a valid scope tree for erroneous condition initializers, and fixing expression pattern constraint generation to invalidate nested unresolved VarDecls early
- Scope: Affects ASTScope and ExprPattern type-checking logic for invalid code
- Issue: rdar://164990215
- Risk: Low, the fixes are straightforward and only affect invalid code
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich