### PR TITLE
[windows] remove pip installation

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1298,16 +1298,6 @@ function Get-Dependencies {
         Expand-ZipFile "$FileName.zip" "$BinaryCache" "$FileName"
         Write-Success "$ArchName Python $PythonVersion"
       }
-      if (-not $EmbeddedPython) {
-        return
-      }
-      $PythonPTHPath = "$BinaryCache/$FileName/$(Get-PythonLibName)._pth"
-      $PythonPTHContent = [System.IO.File]::ReadAllText($PythonPTHPath).Replace("#import site","import site")
-      [System.IO.File]::WriteAllText($PythonPTHPath, $PythonPTHContent)
-      $GetPipURL = "https://bootstrap.pypa.io/get-pip.py"
-      $GetPipPath = "$BinaryCache/$FileName/get-pip.py"
-      $WebClient.DownloadFile($GetPipURL, $GetPipPath)
-      Invoke-Program -Silent "$(Get-PythonExecutable)" $GetPipPath
     }
 
     function Install-PIPIfNeeded {


### PR DESCRIPTION
This patch removes the `pip` installation commands from `build.ps1`.

These commands were used to install `pip` alongside embeddable Python to be packaged in the installer.

Using `get-pip.py` does not work when crosscompiling because the scripts expects to be called by an interpreter of the same architecture as the one `pip` will run on.

rdar://164751668