### PR TITLE
OpaqueValues: ensure no-implicit-copy captures are correct

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1341,31 +1341,14 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     arg = SILValue(fArg);
     
     if (isNoImplicitCopy && !arg->getType().isMoveOnly()) {
-      // FIXME: this incompatible with -enable-sil-opaque-values
-      switch (fnConv.getSILArgumentConvention(argIndex)) {
-      case SILArgumentConvention::Indirect_Inout:
-      case SILArgumentConvention::Indirect_InoutAliasable:
-      case SILArgumentConvention::Indirect_In:
-      case SILArgumentConvention::Indirect_In_Guaranteed:
-      case SILArgumentConvention::Indirect_In_CXX:
-      case SILArgumentConvention::Pack_Inout:
-      case SILArgumentConvention::Pack_Owned:
-      case SILArgumentConvention::Pack_Guaranteed:
+      if (fnConv.isSILIndirect(paramInfo)) {
         arg = SGF.B.createCopyableToMoveOnlyWrapperAddr(VD, arg);
-        break;
-        
-      case SILArgumentConvention::Direct_Owned:
-        arg = SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(VD, arg);
-        break;
-      
-      case SILArgumentConvention::Direct_Guaranteed:
+
+      } else if (paramInfo.isGuaranteedInCallee()) {
         arg = SGF.B.createGuaranteedCopyableToMoveOnlyWrapperValue(VD, arg);
-        break;
-      
-      case SILArgumentConvention::Direct_Unowned:
-      case SILArgumentConvention::Indirect_Out:
-      case SILArgumentConvention::Pack_Out:
-        llvm_unreachable("should be impossible");
+
+      } else {
+        arg = SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(VD, arg);
       }
     }
 

--- a/test/SILOptimizer/moveonly_copyable_wrapper_capture.swift
+++ b/test/SILOptimizer/moveonly_copyable_wrapper_capture.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-sil-opaque-values -sil-verify-all -emit-sil -verify %s
 
 class Class {}
 //struct Class : ~Copyable {}


### PR DESCRIPTION
This should be a NFC for non-sil-opaque-values mode.