### PR TITLE
utils: avoid rebuilding swift-system

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3523,6 +3523,7 @@ function Build-Subprocess([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
+      SwiftSystem_DIR = (Get-ProjectCMakeModules $Platform System);
     }
 }
 


### PR DESCRIPTION
Ensure that we pass along swift-system to swift-subprocess when building to avoid the re-cloning and re-building of the dependency. This should reduce any potential bloat and build time costs.