### PR TITLE
IRGen: Detect nested generic types during generation of the vwt of specialized metadata

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1387,7 +1387,8 @@ static void addValueWitnessesForAbstractType(IRGenModule &IGM,
   // reasons to continue using "generic" value witness table functions i.e the
   // same once used for runtime instantiated generic metadata.
   if (!IGM.Context.LangOpts.hasFeature(Feature::EmbeddedExistentials)) {
-    if (auto boundGenericType = dyn_cast<BoundGenericType>(abstractType)) {
+    auto *nomDecl = abstractType->getNominalOrBoundGenericNominal();
+    if (abstractType->isSpecialized() && nomDecl) {
       CanType concreteFormalType = getFormalTypeInPrimaryContext(abstractType);
 
       auto concreteLoweredType = IGM.getLoweredType(concreteFormalType);
@@ -1395,8 +1396,7 @@ static void addValueWitnessesForAbstractType(IRGenModule &IGM,
       auto packing = boundConcreteTI->getFixedPacking(IGM);
       boundGenericCharacteristics = {concreteLoweredType, boundConcreteTI,
                                      packing};
-      abstractType =
-          boundGenericType->getDecl()->getDeclaredType()->getCanonicalType();
+      abstractType = nomDecl->getDeclaredType()->getCanonicalType();
     }
   }
   CanType concreteFormalType = getFormalTypeInPrimaryContext(abstractType);

--- a/test/IRGen/prespecialized-metadata/nestedtype.swift
+++ b/test/IRGen/prespecialized-metadata/nestedtype.swift
@@ -1,0 +1,39 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future  -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: VENDOR=apple || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+struct Container<T> {
+  struct NonFixed {
+
+    init( _ t: T) {
+        w = t
+    }
+
+    var w: T? = nil
+    var x = 1
+    var y = 1
+    var z = 1
+  }
+}
+
+
+func doit2() {
+  consume(Container.NonFixed(5))
+}
+
+doit2()
+
+// Make sure we use the generic witness table functions rather than specialized
+// ones. We do this for code size.
+
+// CHECK: @"$s10nestedtype9ContainerV8NonFixedVySi_GWV" =
+// CHECK-SAME: s10nestedtype9ContainerV8NonFixedVwtk


### PR DESCRIPTION
The previous code would not detect Container<T>.NonFixed but only NonFixed<T>.
For code size reasons we want to use the generic value witness functions rather than specialized ones in specialized metadata.
