### PR TITLE
XFAIL availability_custom_domains_clang_build test on Android

### DIFF
--- a/test/Availability/availability_custom_domains_clang_build.swift
+++ b/test/Availability/availability_custom_domains_clang_build.swift
@@ -1,4 +1,6 @@
 // REQUIRES: swift_feature_CustomAvailability
+// XFAIL: OS=linux-android
+// XFAIL: OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -x c %S/Inputs/AvailabilityDomains.c -o %t/AvailabilityDomains.c.o -c


### PR DESCRIPTION
The test requires availability_domain.h which is clang builtin header that is not available in the Android NDK's bundled clang.
