### PR TITLE
[Concurrency] A few improvements for `nonisolated(nonsending)`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8910,6 +8910,10 @@ ERROR(nonisolated_nonsending_incompatible_with_isolated_any,none,
       "cannot use %0 together with '@isolated(any)'",
       (TypeRepr *))
 
+ERROR(nonisolated_nonsending_incompatible_with_sending,none,
+      "cannot use 'nonisolated(nonsending)' together with 'sending'",
+      ())
+
 ERROR(invalid_function_conversion_with_non_sendable,none,
       "cannot convert %0 to %1 because crossing of an isolation boundary "
       "requires parameter and result types to conform to 'Sendable' protocol",

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5013,6 +5013,10 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     auto normalIsolation = computeClosureIsolationFromParent(
         closure, parentIsolation, checkIsolatedCapture);
 
+    bool isIsolationBoundary =
+        isIsolationInferenceBoundaryClosure(closure,
+                                            /*canInheritActorContext=*/true);
+
     // The solver has to be conservative and produce a conversion to
     // `nonisolated(nonsending)` because at solution application time
     // we don't yet know whether there are any captures which would
@@ -5023,7 +5027,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     // isolated parameters. If our closure is nonisolated and we have a
     // conversion to nonisolated(nonsending), then we should respect that.
     if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
-        !normalIsolation.isGlobalActor()) {
+        isIsolationBoundary || !normalIsolation.isGlobalActor()) {
       if (auto *fce =
               dyn_cast_or_null<FunctionConversionExpr>(Parent.getAsExpr())) {
         auto expectedIsolation =
@@ -5042,8 +5046,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     // NOTE: Since we already checked for global actor isolated things, we
     // know that all Sendable closures must be nonisolated. That is why it is
     // safe to rely on this path to handle Sendable closures.
-    if (isIsolationInferenceBoundaryClosure(closure,
-                                            /*canInheritActorContext=*/true))
+    if (isIsolationBoundary)
       return ActorIsolation::forNonisolated(/*unsafe=*/false);
 
     return normalIsolation;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5472,6 +5472,12 @@ TypeResolver::resolveCallerIsolatedTypeRepr(CallerIsolatedTypeRepr *repr,
     type = resolveAttributedType(baseRepr, options, attrs);
 
     attrs.diagnoseUnclaimed(resolution, options, type);
+
+    if (isa<SendingTypeRepr>(baseRepr)) {
+      diagnoseInvalid(repr, repr->getStartLoc(),
+                      diag::nonisolated_nonsending_incompatible_with_sending);
+      return ErrorType::get(getASTContext());
+    }
   }
 
   if (type->hasError())

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -87,6 +87,9 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Whether the immediate context has an @escaping attribute.
   DirectEscaping = 1 << 14,
+
+  /// Whether the immediate context is a `sending` parameter or result.
+  DirectSending = 1 << 15,
 };
 
 /// Type resolution contexts that require special handling.
@@ -265,7 +268,8 @@ public:
   void setContext(Context newContext) {
     context = newContext;
     flags &= ~(unsigned(TypeResolutionFlags::Direct) |
-               unsigned(TypeResolutionFlags::DirectEscaping));
+               unsigned(TypeResolutionFlags::DirectEscaping) |
+               unsigned(TypeResolutionFlags::DirectSending));
   }
   void setContext(std::nullopt_t) { setContext(Context::None); }
 

--- a/test/Concurrency/attr_execution/migration_mode.swift
+++ b/test/Concurrency/attr_execution/migration_mode.swift
@@ -54,6 +54,12 @@ do {
     // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     func asyncF() async
   }
+
+  func sending1(_: sending () async -> Void) {}
+  func sending2(_: sending (() async -> Void) async -> Void) {}
+  // expected-warning@-1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}
+  func sending3(_: () async -> sending () async -> Void) {}
+  // expected-warning@-1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}
 }
 protocol Functions {}
 extension Functions {

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -147,7 +147,7 @@ func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
     normalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     normalAcceptsSendableAsyncClosure { }
 }
 
@@ -181,7 +181,7 @@ func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
     await normalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await normalGlobalActorAcceptsSendableAsyncClosure { }
 }
 
@@ -258,7 +258,7 @@ func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
     await asyncNormalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalAcceptsSendableAsyncClosure { }
 }
 
@@ -300,7 +300,7 @@ func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
     await asyncNormalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalGlobalActorAcceptsSendableAsyncClosure { }
 }
 

--- a/test/Parse/execution_behavior_attrs.swift
+++ b/test/Parse/execution_behavior_attrs.swift
@@ -84,3 +84,14 @@ do {
   nonisolated(0) // expected-warning {{result of call to 'nonisolated' is unused}}
   print("hello")
 }
+
+do {
+  func testSending1(_: nonisolated(nonsending) sending @escaping () async -> Void) {}
+  // expected-error@-1 {{cannot use 'nonisolated(nonsending)' together with 'sending'}}
+  func testSending2(_: sending nonisolated(nonsending) @escaping () async -> Void) {}
+  // expected-error@-1 {{cannot use 'nonisolated(nonsending)' together with 'sending'}}
+  func testSending3(_: () -> nonisolated(nonsending) sending () async -> Void) {}
+  // expected-error@-1 {{cannot use 'nonisolated(nonsending)' together with 'sending'}}
+  func testSending4(_: (() -> sending nonisolated(nonsending) @Sendable () async -> Void) -> Void) {}
+  // expected-error@-1 {{cannot use 'nonisolated(nonsending)' together with 'sending'}}
+}


### PR DESCRIPTION
- Don't attempt to infer `nonisolated(nonsending) on a `sending` parameter or result

- Ban use of `nonisolated(nonsending)` together with `sending`

- Allow transferring `nonisolated(nonsending)` to isolation boundary closures
  
   This means that i.e. `@Sendable` closures in global actor isolated context would still get `nonisolated(nonsending)` if they are passed to a parameter with `nonisolated(nonsending)` async function type.

Resolves: rdar://163792371
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
