### PR TITLE
[Concurrency] Allow transferring `nonisolated(nonsending)` to isolati…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5013,6 +5013,10 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     auto normalIsolation = computeClosureIsolationFromParent(
         closure, parentIsolation, checkIsolatedCapture);
 
+    bool isIsolationBoundary =
+        isIsolationInferenceBoundaryClosure(closure,
+                                            /*canInheritActorContext=*/true);
+
     // The solver has to be conservative and produce a conversion to
     // `nonisolated(nonsending)` because at solution application time
     // we don't yet know whether there are any captures which would
@@ -5023,7 +5027,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     // isolated parameters. If our closure is nonisolated and we have a
     // conversion to nonisolated(nonsending), then we should respect that.
     if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
-        !normalIsolation.isGlobalActor()) {
+        isIsolationBoundary || !normalIsolation.isGlobalActor()) {
       if (auto *fce =
               dyn_cast_or_null<FunctionConversionExpr>(Parent.getAsExpr())) {
         auto expectedIsolation =
@@ -5042,8 +5046,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     // NOTE: Since we already checked for global actor isolated things, we
     // know that all Sendable closures must be nonisolated. That is why it is
     // safe to rely on this path to handle Sendable closures.
-    if (isIsolationInferenceBoundaryClosure(closure,
-                                            /*canInheritActorContext=*/true))
+    if (isIsolationBoundary)
       return ActorIsolation::forNonisolated(/*unsafe=*/false);
 
     return normalIsolation;

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -143,11 +143,11 @@ func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
     normalAcceptsAsyncClosure { }
 
     // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     normalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     normalAcceptsSendableAsyncClosure { }
 }
 
@@ -177,11 +177,11 @@ func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-ni-ns-note @-4 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '@concurrent () async -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await normalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await normalGlobalActorAcceptsSendableAsyncClosure { }
 }
 
@@ -254,11 +254,11 @@ func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
     // expected-ni-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalAcceptsSendableAsyncClosure { }
 }
 
@@ -296,11 +296,11 @@ func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-ni-ns-note @-4 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '@concurrent () async -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalGlobalActorAcceptsSendableAsyncClosure { }
 }
 


### PR DESCRIPTION
…on boundary closures

Isolation boundary closures don't assume parent isolation and should be able to get `nonisolated(nonsending)` transferred to them jus like regular nonisolated closures do.

Resolves: rdar://163792371

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
