### PR TITLE
[Concurrency] Allow conditionally conforming to `Sendable` when confo…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7180,14 +7180,6 @@ static bool checkSendableInstanceStorage(
     }
   }
 
-  if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
-    auto *conformanceDecl = dc->getAsDecl() ? dc->getAsDecl() : nominal;
-    if (!isImplicitSendableCheck(check)) {
-      conformanceDecl->diagnose(diag::non_sendable_type_suppressed);
-    }
-    return true;
-  }
-
   // Stored properties of structs and classes must have
   // Sendable-conforming types.
   class Visitor: public StorageVisitor {
@@ -7462,6 +7454,25 @@ bool swift::checkSendableConformance(
   // and not some (possibly constrained) extension.
   if (wasImplied)
     conformanceDC = nominal;
+
+  // Sendable supression allows conditional conformances only.
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
+    bool hasUnconditionalConformance = false;
+    if (auto *normalConf = dyn_cast<NormalProtocolConformance>(conformance)) {
+      hasUnconditionalConformance =
+          normalConf->getConditionalRequirements().empty();
+    }
+
+    if (hasUnconditionalConformance) {
+      if (!isImplicitSendableCheck(check)) {
+        auto *conformanceDecl =
+            conformanceDC->getAsDecl() ? conformanceDC->getAsDecl() : nominal;
+        conformanceDecl->diagnose(diag::non_sendable_type_suppressed);
+      }
+      return true;
+    }
+  }
+
   return checkSendableInstanceStorage(nominal, conformanceDC, check);
 }
 

--- a/test/ModuleInterface/tilde_sendable.swift
+++ b/test/ModuleInterface/tilde_sendable.swift
@@ -33,3 +33,18 @@ protocol P {
 public struct S: P, ~Sendable {
   public let x: Int
 }
+
+// CHECK: #if compiler(>=5.3) && $TildeSendable
+// CHECK: public struct B<T> : ~Swift.Sendable {
+// CHECK: }
+// CHECK: #else
+// CHECK: public struct B<T> {
+// CHECK: }
+// CHECK: #endif
+public struct B<T>: ~Sendable {
+}
+
+// CHECK: extension Library.B : Swift.Sendable where T : Swift.Sendable {
+// CHECK: }
+extension B: Sendable where T: Sendable {
+}

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -52,3 +52,42 @@ do {
   check(NonSendable()) // expected-warning {{type 'NonSendable' does not conform to the 'Sendable' protocol}}
   check(NoInference()) // Ok
 }
+
+func takesSendable<T: Sendable>(_: T) {}
+
+class MyValue {} // expected-note 2 {{class 'MyValue' does not conform to the 'Sendable' protocol}}
+
+public struct D: ~Sendable {
+}
+
+extension D: Sendable {} // expected-error {{cannot both conform to and suppress conformance to 'Sendable'}}
+
+takesSendable(D())
+
+public struct F<T>: ~Sendable {
+  let x: T
+}
+
+extension F: Sendable where T: Sendable { }
+
+takesSendable(F(x: 42))
+
+public struct G<T, U>: ~Sendable { // expected-note {{making generic parameter 'U' conform to the 'Sendable' protocol}}
+  let t: T
+  let u: U // expected-warning {{stored property 'u' of 'Sendable'-conforming generic struct 'G' has non-Sendable type 'U'}}
+}
+
+extension G: Sendable where T: Sendable { }
+
+takesSendable(G(t: "", u: 42))
+takesSendable(G(t: MyValue(), u: 0)) // expected-warning {{type 'MyValue' does not conform to the 'Sendable' protocol}}
+
+public struct H<T, U>: ~Sendable {
+  let t: T
+  let u: U
+}
+
+extension H: Sendable where T: Sendable, U: Sendable { }
+
+takesSendable(H(t: "", u: 42))
+takesSendable(H(t: "", u: MyValue())) // expected-warning {{type 'MyValue' does not conform to the 'Sendable' protocol}}


### PR DESCRIPTION
…rmance is suppressed

For consistency with invertible protocols using `~Sendable` should only prohibit use of unconditional extensions.

For example:

```swift
struct G<T>: ~Sendable {}
```

The following (unconditional) extension is rejected:

```
extension G: Sendable {} // error: cannot both conform to and suppress conformance to 'Sendable'
```

But conditional on `T` is accepted:

```
extension G: Sendable where T: Sendable {} // Ok!
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
