### PR TITLE
Follow up: Availability of Set thread base priority when running escalated Tasks

### DIFF
--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -51,9 +51,9 @@ swift_dispatch_thread_override_self(qos_class_t override_qos) {
 static inline uint32_t
 swift_dispatch_thread_override_self_with_base(qos_class_t override_qos, qos_class_t base_qos) {
 
-  if (__builtin_available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, *)) {
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
     return dispatch_thread_override_self_with_base(override_qos, base_qos);
-  } else if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+  } else if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
     // If we don't have the ability to set our base qos correctly, at least set the override
     // We want to return 0 here because we have nothing to reset in this case
     (void) dispatch_thread_override_self(override_qos);
@@ -64,7 +64,7 @@ swift_dispatch_thread_override_self_with_base(qos_class_t override_qos, qos_clas
 
 static inline void
 swift_dispatch_thread_reset_override_self(uint32_t opaque) {
-  if (__builtin_available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, *)) {
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
     dispatch_thread_reset_override_self(opaque);
   }
 }

--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -322,15 +322,15 @@ actor Test {
           await task2.value // Escalate task2 which should be queued behind task1 on the actor
         }
 
-        // This test will only work properly on 27.0+
-        if #available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+        // This test will only work properly if Dispatch supports lowering the base priority of a thread
+        if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *) {
           tests.test("Task escalation doesn't impact qos_class_self") {
             let task = Task(priority: .utility) {
               let initialQos = DispatchQoS(
                 qosClass: DispatchQoS.QoSClass(rawValue: qos_class_self())!,
                 relativePriority: 0)
               expectEqual(initialQos, DispatchQoS.utility)
-              let childTask = Task {
+              let innerTask = Task {
                 let qosBeforeEscalate = DispatchQoS(
                   qosClass: DispatchQoS.QoSClass(rawValue: qos_class_self())!,
                   relativePriority: 0)
@@ -353,7 +353,7 @@ actor Test {
                 expectEqual(qosAfterYield, DispatchQoS.utility)
               }
 
-              await childTask.value
+              await innerTask.value
             }
 
             await task.value


### PR DESCRIPTION
Follow up to adjust availability of APIs


Marking those 9998, following an established pattern: 
```
// These are deliberately not the standard 9999, as we don't want to hit the
// special case where it's always available, and we don't want this check to be
// rewritten in any find/replace operations.
if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *) {
```