### PR TITLE
[DependencyScanning] Disable TestModuleCycle Unit Test

### DIFF
--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -367,7 +367,8 @@ public func funcA() { }\n"));
   ASSERT_TRUE(DiagnosticsReader.warningMessages.front() == "This is a warning");
 }
 
-TEST_F(ScanTest, TestModuleCycle) {
+// Disabled due to rdar://165014838
+TEST_F(ScanTest, DISABLED_TestModuleCycle) {
   SmallString<256> tempDir;
   ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory("ScanTest.TestModuleCycle", tempDir));
   SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };


### PR DESCRIPTION
This unit test is behaving unexpectedly and it is blocking PR testing. This PR disables it to allow PR testing and investigation. 

Workaround for rdar://165014838 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
