### PR TITLE
[Sema]: suppress unexpected type warning on some async-let patterns

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1234,7 +1234,7 @@ Pattern *TypeChecker::coercePatternToType(
       // synchronous function in an async context. As a policy choice, don't
       // diagnose an inferred Void type (or optional thereof) on such bindings
       // as potentially unexpected.
-      shouldRequireType = var->isAsyncLet() ? false : true;
+      shouldRequireType = !var->isAsyncLet();
     } else if (auto MTT = diagTy->getAs<AnyMetatypeType>()) {
       if (MTT->getInstanceType()->isAnyObject())
         shouldRequireType = true;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1232,12 +1232,9 @@ Pattern *TypeChecker::coercePatternToType(
     } else if (diagTy->isEqual(Context.TheEmptyTupleType)) {
       // Async-let bindings are commonly used to run a Void-returning
       // synchronous function in an async context. As a policy choice, don't
-      // diagnose a Void result on these bindings as potentially unexpected.
-      if (!isOptional && var->isAsyncLet()) {
-        shouldRequireType = false;
-      } else {
-        shouldRequireType = true;
-      }
+      // diagnose an inferred Void type (or optional thereof) on such bindings
+      // as potentially unexpected.
+      shouldRequireType = var->isAsyncLet() ? false : true;
     } else if (auto MTT = diagTy->getAs<AnyMetatypeType>()) {
       if (MTT->getInstanceType()->isAnyObject())
         shouldRequireType = true;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1230,7 +1230,14 @@ Pattern *TypeChecker::coercePatternToType(
       // If the whole pattern is implicit, the user didn't write it.
       // Assume the compiler knows what it's doing.
     } else if (diagTy->isEqual(Context.TheEmptyTupleType)) {
-      shouldRequireType = true;
+      // Async-let bindings are commonly used to run a Void-returning
+      // synchronous function in an async context. As a policy choice, don't
+      // diagnose a Void result on these bindings as potentially unexpected.
+      if (!isOptional && var->isAsyncLet()) {
+        shouldRequireType = false;
+      } else {
+        shouldRequireType = true;
+      }
     } else if (auto MTT = diagTy->getAs<AnyMetatypeType>()) {
       if (MTT->getInstanceType()->isAnyObject())
         shouldRequireType = true;

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -63,10 +63,15 @@ func testVoidResultTypeDiagnostics() async {
   async let void6 = asyncVoid()
   await void6
 
-  // expected-warning @+2 {{constant 'maybeVoid' inferred to have type '()?', which may be unexpected}}
-  // expected-note @+1 {{add an explicit type annotation to silence this warning}}
   async let maybeVoid = { Bool.random() ? () : nil }()
   await maybeVoid
+
+  do {
+    final class C: Sendable { func doit() {} }
+    let c: C? = nil
+    async let maybeVoid2 = c?.doit()
+    let _: ()? = await maybeVoid2
+  }
 
   // expected-warning @+2 {{constant 'boxOVoid' inferred to have type '[()]', which may be unexpected}}
   // expected-note @+1 {{add an explicit type annotation to silence this warning}}

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -42,3 +42,34 @@ func testInterpolation() async {
   async let y = "\(12345)"
   _ = await y
 }
+
+// https://forums.swift.org/t/disable-constant-inferred-to-have-type-warning-when-using-async-let/83025
+
+func testVoidResultTypeDiagnostics() async {
+  async let void = print("hello")
+  await void
+  async let void2 = ()
+  await void2
+  async let void3 = Void()
+  await void3
+  async let void4 = { _ = 42 }()
+  await void4
+
+  @Sendable func syncVoid() {}
+  async let void5 = syncVoid()
+  await void5
+
+  @Sendable func asyncVoid() async {}
+  async let void6 = asyncVoid()
+  await void6
+
+  // expected-warning @+2 {{constant 'maybeVoid' inferred to have type '()?', which may be unexpected}}
+  // expected-note @+1 {{add an explicit type annotation to silence this warning}}
+  async let maybeVoid = { Bool.random() ? () : nil }()
+  await maybeVoid
+
+  // expected-warning @+2 {{constant 'boxOVoid' inferred to have type '[()]', which may be unexpected}}
+  // expected-note @+1 {{add an explicit type annotation to silence this warning}}
+  async let boxOVoid = { [(), (), ()] }()
+  await boxOVoid // expected-warning {{expression of type '[()]' is unused}}
+}


### PR DESCRIPTION
It is somewhat common to use an async-let binding to run a synchronous, void-returning function in an async context. In such cases, the binding's type being inferred as Void is expected, and requiring programmers to explicitly write this to suppress a warning seems like unnecessary boilerplate. This patch changes the diagnostic logic to exempt async-let bindings from the existing diagnostic when the inferred type is Void, or an optional thereof.

see: https://forums.swift.org/t/disable-constant-inferred-to-have-type-warning-when-using-async-let/83025
