### PR TITLE
[CMake] Explicitly disable LTO if no LTO option is provided

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -58,6 +58,8 @@ function(_compute_lto_flag option out_var)
     set(${out_var} "-flto=full" PARENT_SCOPE)
   elseif (lowercase_option STREQUAL "thin")
     set(${out_var} "-flto=thin" PARENT_SCOPE)
+  else()
+    set(${out_var} "-fno-lto" PARENT_SCOPE)
   endif()
 endfunction()
 


### PR DESCRIPTION
When compiling Swift as an LLVM external project (not the non-unified workflow from the build-script), if one tries to enable LTO for LLVM projects it will end up affecting Swift and the Swift standard library, even if the options `SWIFT_TOOLS_ENABLE_LTO` and
`SWIFT_STDLIB_ENABLE_LTO` are disabled or using their default values, because [HandleLLVMOptions] modifies the `CMAKE_C/CXX_FLAGS` globally.

By setting `-fno-lto` explicitly when those options are disabled or using their default values, the options from `CMAKE_C/CXX_FLAGS` are overriden, and the `SWIFT_*_ENABLE_LTO` controls the usage or not of LTO optimizations and the presence of bitcode in the object files.

[HandleLLVMOptions]: https://github.com/swiftlang/llvm-project/blob/b58b2a34d5094928c4ee1b94a7d5412b14540c01/llvm/cmake/modules/HandleLLVMOptions.cmake#L1278-L1310
