### PR TITLE
[test] Propagate CMake shared linker flags for tests to use

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -31,3 +31,4 @@ else:
     )
     config.substitutions.append(('%c-flags', config.c_flags))
     config.substitutions.append(('%exe-linker-flags', config.exe_linker_flags))
+    config.substitutions.append(('%shared-linker-flags', config.shared_linker_flags))

--- a/test/Macros/macro_plugin_server_mod.swift
+++ b/test/Macros/macro_plugin_server_mod.swift
@@ -24,6 +24,7 @@
 
 // RUN: %cmake-c-compiler \
 // RUN:   %c-flags -target %host_triple -isysroot %host_sdk \
+// RUN:   %shared-linker-flags \
 // RUN:   -shared -o %t/plugins/libCrashOnLoad.dylib \
 // RUN:   %t/CrashOnLoad.c
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -52,6 +52,7 @@ config.cmake_c_compiler = r'''@CMAKE_C_COMPILER@'''
 config.cmake_cxx_compiler = r'''@CMAKE_CXX_COMPILER@'''
 config.c_flags = r'''@CMAKE_C_FLAGS@'''
 config.exe_linker_flags = r'''@CMAKE_EXE_LINKER_FLAGS@'''
+config.shared_linker_flags = r'''@CMAKE_SHARED_LINKER_FLAGS@'''
 
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"


### PR DESCRIPTION
The same that some setups needs the `CMAKE_EXE_LINKER_FLAGS` propagated for the test to compile plugins in the same configuration as the compiler was using, the `CMAKE_SHARED_LINKER_FLAGS` needs to be propagated if one wants to match the configuration used by CMake to create libraries during the tests.

Add a new `config` value derived from `CMAKE_EXE_LINKER_FLAGS`, turn that value into a substitution for the `Macros` tests, and use the substibution in one test that creates a shared object. This allows the shared object to be linked in the same way that it has been configured in CMake.