### PR TITLE
<rdar://165142180> fix immediate Task docs

### DIFF
--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -56,9 +56,9 @@ import Swift
 extension Task where Failure == ${FAILURE_TYPE} {
 
   % if IS_DETACHED:
-  /// Create and immediately start running a new task in the context of the calling thread/task.
-  % else:
   /// Create and immediately start running a new detached task in the context of the calling thread/task.
+  % else:
+  /// Create and immediately start running a new task in the context of the calling thread/task.
   % end # IS_DETACHED
   ///
   /// This function _starts_ the created task on the calling context.


### PR DESCRIPTION
Currently, the docs for `Task.immediate` indicate that a detached `Task` will be made, and the docs for `Task.immediateDetached` indicate that a non-detached `Task` will be made. Is this reversed?

This PR changes the docs so `Task.immediate` will indicate a non-detached `Task` will be made, and `Task.immediateDetached` will indicate a detached `Task` will be made.

Fixes rdar://165142180 (Task immediate and immediateDetached docs reversed)