### PR TITLE
Enable BPF target in LLVM backend by default

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1451,7 +1451,7 @@ def create_argument_parser():
            help='enable building llvm using modules')
 
     option('--llvm-targets-to-build', store,
-           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR',
+           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF',
            help='LLVM target generators to build')
 
     option('--llvm-ninja-targets', append,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -255,7 +255,7 @@ EXPECTED_DEFAULTS = {
     'llvm_max_parallel_lto_link_jobs':
         defaults.LLVM_MAX_PARALLEL_LTO_LINK_JOBS,
     'llvm_targets_to_build':
-        'X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR',
+        'X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF',
     'tsan_libdispatch_test': False,
     'long_test': False,
     'lto_type': None,


### PR DESCRIPTION
Adding the BPF target to the LLVM backend, allows eBPF programs to be built using the clang that ships with the OSS toolchains.

Should be a low-risk change, which I've tested locally by explicitly specifying the `--llvm-targets-to-build` flag:

```console
% build/Ninja-ReleaseAssert/llvm-linux-aarch64/bin/clang -print-targets | grep bpf
    bpf        - BPF (host endian)
    bpfeb      - BPF (big endian)
    bpfel      - BPF (little endian)

% touch empty.c

% build/Ninja-ReleaseAssert/llvm-linux-aarch64/bin/clang -target bpf -c empty.c -o empty.o

% file empty.o
empty.o: ELF 64-bit LSB relocatable, eBPF, version 1 (SYSV), not stripped
```



Looks like a negligible increase in build time vs previous PR toolchain builds:

| Job                  | Build script analyzer total | LLVM time (sec)   |
|----------------------|-----------------------------|-------------------|
| #1584 (this PR)[^0]  | 2hr 21m 53s                 | 1178.85           |
| #1583 (previous)[^1] | 2hr 22m 8s                  | 1171.51           |
| ...failed runs...    | ...failed runs...           | ...failed runs... |
| #1578 (previous)[^2] | 2hr 22m 40s                 | 1171.47           |
| #1577 (previous)[^3] | 2hr 21m 48s                 | 1168.54           |
| #1576 (previous)[^4] | 2hr 20m 39s                 | 1174.80           |


And an increased of size comparison of PR toolchain(s) vs last nightly main, it
looks like it's gone up a bit, but not by this PR:

| PR          | `stat -c %s` | Link                                                           |
|-------------|--------------|----------------------------------------------------------------|
| —           | 1187466342   | swift-DEVELOPMENT-SNAPSHOT-2025-08-27-a-ubuntu20.04.tar.gz[^5] |
| This PR     | 1212116532   | pull-request/85630/1584/ubuntu2204/PR-ubuntu2204.tar.gz[^6]    |
| Previous PR | 1213404191   | pull-request/85358/1583/ubuntu2204/PR-ubuntu2204.tar.gz[^7]    |
| Previous PR | 1213116282   | pull-request/79684/1578/ubuntu2204/PR-ubuntu2204.tar.gz[^8]    |

[^0]: https://ci.swift.org/job/swift-PR-toolchain-Linux/1584/consoleText
[^1]: https://ci.swift.org/job/swift-PR-toolchain-Linux/1583/consoleText 
[^2]: https://ci.swift.org/job/swift-PR-toolchain-Linux/1578/consoleText
[^3]: https://ci.swift.org/job/swift-PR-toolchain-Linux/1577/consoleText
[^4]: https://ci.swift.org/job/swift-PR-toolchain-Linux/1576/consoleText

[^5]: https://download.swift.org/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2025-08-27-a/swift-DEVELOPMENT-SNAPSHOT-2025-08-27-a-ubuntu20.04.tar.gz
[^6]: https://download.swift.org/tmp/pull-request/85630/1584/ubuntu2204/PR-ubuntu2204.tar.gz
[^7]: https://download.swift.org/tmp/pull-request/85358/1583/ubuntu2204/PR-ubuntu2204.tar.gz
[^8]: https://download.swift.org/tmp/pull-request/79684/1578/ubuntu2204/PR-ubuntu2204.tar.gz
