### PR TITLE
Adjust availability checks in DispatchShims.h

### DIFF
--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -53,7 +53,7 @@ swift_dispatch_thread_override_self_with_base(qos_class_t override_qos, qos_clas
 
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
     return dispatch_thread_override_self_with_base(override_qos, base_qos);
-  } else if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+  } else if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
     // If we don't have the ability to set our base qos correctly, at least set the override
     // We want to return 0 here because we have nothing to reset in this case
     (void) dispatch_thread_override_self(override_qos);


### PR DESCRIPTION
The dispatch_thread_override_self is already available in earlier OSes so adjust the availability.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
