### PR TITLE
OpaqueValues: provide stdlib build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,10 @@ option(SWIFT_STDLIB_ENABLE_STRICT_CONCURRENCY_COMPLETE
   "Build the stdlib with -strict-concurrency=complete"
   FALSE)
 
+option(SWIFT_STDLIB_ENABLE_SIL_OPAQUE_VALUES
+  "Build the stdlib with -enable-sil-opaque-values"
+  FALSE)
+
 option(SWIFT_ENABLE_SYNCHRONIZATION
   "Enable build of the Swift Synchronization module"
   FALSE)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -647,6 +647,10 @@ function(_compile_swift_files
     list(APPEND swift_flags "-strict-concurrency=complete")
   endif()
 
+  if (SWIFT_STDLIB_ENABLE_SIL_OPAQUE_VALUES)
+    list(APPEND swift_flags "-Xfrontend" "-enable-sil-opaque-values")
+  endif()
+
   if (SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES)
     list(APPEND swift_flags "-Xfrontend" "-enable-relative-protocol-witness-tables")
     list(APPEND swift_flags "-Xfrontend" "-swift-async-frame-pointer=never")


### PR DESCRIPTION
Should allow testing with preset:
```
extra-cmake-options=-DSWIFT_STDLIB_ENABLE_SIL_OPAQUE_VALUES=TRUE
```
