### PR TITLE
Task Cancellation Shields

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -468,7 +468,10 @@ public:
 
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.
-  bool isCancelled() const;
+  ///
+  /// \param ignoreShield if cancellation shield should be ignored. 
+  ///        Cancellation shields prevent the observation of the isCancelled flag while active.
+  bool isCancelled(bool ignoreShield) const;
 
   // ==== INITIAL TASK RECORDS =================================================
   // A task may have a number of "initial" records set, they MUST be set in the
@@ -530,6 +533,15 @@ public:
 
   /// Returns true if storage has still more bindings.
   bool localValuePop();
+
+  // ==== Cancellation Shields -------------------------------------------------
+
+  /// Install a cancellation shield in this task.
+  /// Returns true if the shield was installed, and false if there was already 
+  /// one active and this action didn't change anything.
+  bool cancellationShieldPush();
+
+  void cancellationShieldPop();
 
   // ==== Child Fragment -------------------------------------------------------
 

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1236,6 +1236,16 @@ BUILTIN_MISC_OPERATION(TaskLocalValuePush, "taskLocalValuePush", "", Special)
 /// Signature: () -> ()
 BUILTIN_MISC_OPERATION(TaskLocalValuePop, "taskLocalValuePop", "", Special)
 
+/// Equivalent to calling swift_task_cancellationShieldPush.
+///
+/// Signature: () -> (Bool)
+BUILTIN_MISC_OPERATION(TaskCancellationShieldPush, "taskCancellationShieldPush", "", Special)
+
+/// Equivalent to calling swift_task_cancellationShieldPop.
+///
+/// Signature: () -> ()
+BUILTIN_MISC_OPERATION(TaskCancellationShieldPop, "taskCancellationShieldPop", "", Special)
+
 #undef BUILTIN_TYPE_TRAIT_OPERATION
 #undef BUILTIN_UNARY_OPERATION
 #undef BUILTIN_BINARY_PREDICATE

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -604,6 +604,31 @@ size_t swift_task_getJobFlags(AsyncTask* task);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_isCancelled(AsyncTask* task);
 
+/// This is an options enum that is used to pass flags to
+/// swift_task_isCancelledWithFlags. It is meant to be a flexible toggle.
+///
+/// Since this is an options enum, so all values should be powers of 2.
+///
+/// NOTE: We are purposely leaving this as a uint64_t so that on all platforms
+/// this could be a pointer to a different enum instance if we need it to be.
+enum swift_task_is_cancelled_flag : uint64_t {
+  /// We aren't passing any flags.
+  /// Effectively this is a backwards compatible mode.
+  swift_task_is_cancelled_flag_None = 0x0,
+
+  /// Ignore any active cancellation shield and return the actual cancellation
+  /// state of the task.
+  swift_task_is_cancelled_flag_IgnoreCancellationShield = 0x1,
+};
+
+/// Check if the task is cancelled.
+///
+/// \param task The task to check cancellation status for.
+/// \param flags Flags controlling the behavior of the check.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_isCancelledWithFlags(AsyncTask* task,
+                                     swift_task_is_cancelled_flag flags);
+
 /// Returns the current priority of the task which is >= base priority of the
 /// task. This function does not exist in the base ABI of this library and must
 /// be deployment limited

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -606,11 +606,6 @@ bool swift_task_isCancelled(AsyncTask* task);
 
 /// This is an options enum that is used to pass flags to
 /// swift_task_isCancelledWithFlags. It is meant to be a flexible toggle.
-///
-/// Since this is an options enum, so all values should be powers of 2.
-///
-/// NOTE: We are purposely leaving this as a uint64_t so that on all platforms
-/// this could be a pointer to a different enum instance if we need it to be.
 enum swift_task_is_cancelled_flag : uint64_t {
   /// We aren't passing any flags.
   /// Effectively this is a backwards compatible mode.

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -721,6 +721,16 @@ void swift_task_localValuePop();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localsCopyTo(AsyncTask* target);
 
+/// Install a task cancellation shield in the current task.
+///
+/// Returns `true` if the shield was installed and we need to pop it when leaving the shielded scope.
+/// Returns `false` if the shield was not installed, because there was one already active.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_cancellationShieldPush();
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_cancellationShieldPop();
+
 /// Switch the current task to a new executor if we aren't already
 /// running on a compatible executor.
 ///

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -731,6 +731,13 @@ bool swift_task_cancellationShieldPush();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_cancellationShieldPop();
 
+/// Check if the current task has an active cancellation shield.
+///
+/// Returns `true` if a cancellation shield is currently active for the given task.
+/// Returns `false` if no shield is active.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_hasActiveCancellationShield(AsyncTask *task);
+
 /// Switch the current task to a new executor if we aren't already
 /// running on a compatible executor.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2734,6 +2734,26 @@ FUNCTION(TaskLocalValuePop,
          EFFECT(RuntimeEffect::Concurrency),
          UNKNOWN_MEMEFFECTS)
 
+// void swift_task_cancellationShieldPush();
+FUNCTION(TaskCancellationShieldPush,
+         _Concurrency, swift_task_cancellationShieldPush, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(Int1Ty),
+         ARGS(),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_task_cancellationShieldPop();
+FUNCTION(TaskCancellationShieldPop,
+         _Concurrency, swift_task_cancellationShieldPop, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(),
+         ARGS(),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
 // AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContextWithType(const Metadata *);
 FUNCTION(AutoDiffCreateLinearMapContextWithType,
          Swift, swift_autoDiffCreateLinearMapContextWithType, SwiftCC,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2754,6 +2754,16 @@ FUNCTION(TaskCancellationShieldPop,
          EFFECT(RuntimeEffect::Concurrency),
          UNKNOWN_MEMEFFECTS)
 
+// bool swift_task_hasActiveCancellationShield(AsyncTask *task);
+FUNCTION(TaskHasActiveCancellationShield,
+         _Concurrency, swift_task_hasActiveCancellationShield, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(Int1Ty),
+         ARGS(SwiftTaskPtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Concurrency),
+         MEMEFFECTS(ReadOnly))
+
 // AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContextWithType(const Metadata *);
 FUNCTION(AutoDiffCreateLinearMapContextWithType,
          Swift, swift_autoDiffCreateLinearMapContextWithType, SwiftCC,

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -291,6 +291,8 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) {
         case BuiltinValueKind::FlowSensitiveSelfIsolation:
         case BuiltinValueKind::FlowSensitiveDistributedSelfIsolation:
         case BuiltinValueKind::TaskLocalValuePush:
+        case BuiltinValueKind::TaskCancellationShieldPush:
+        case BuiltinValueKind::TaskCancellationShieldPop:
           callVisitUse(op);
           continue;
         default:

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2460,6 +2460,14 @@ static ValueDecl *getDereferenceBorrow(ASTContext &ctx, Identifier id) {
   return builder.build(id);
 }
 
+static ValueDecl *getTaskCancellationShieldPush(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _parameters(), _int(1));
+}
+
+static ValueDecl *getTaskCancellationShieldPop(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _parameters(), _void);
+}
+
 /// An array of the overloaded builtin kinds.
 static const OverloadedBuiltinKind OverloadedBuiltinKinds[] = {
   OverloadedBuiltinKind::None,
@@ -3573,6 +3581,12 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::DereferenceBorrow:
     return getDereferenceBorrow(Context, Id);
+
+  case BuiltinValueKind::TaskCancellationShieldPush:
+    return getTaskCancellationShieldPush(Context, Id);
+
+  case BuiltinValueKind::TaskCancellationShieldPop:
+    return getTaskCancellationShieldPop(Context, Id);
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1591,6 +1591,11 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     auto *valueMetatype = IGF.emitTypeMetadataRef(argTypes[1].getASTType());
     return emitBuiltinTaskLocalValuePush(IGF, key, value, valueMetatype);
   }
+  case BuiltinValueKind::TaskCancellationShieldPush:
+    out.add(emitBuiltinTaskCancellationShieldPush(IGF));
+    return;
+  case BuiltinValueKind::TaskCancellationShieldPop:
+    return emitBuiltinTaskCancellationShieldPop(IGF);
 
   // Builtins without IRGen implementations.
   case BuiltinValueKind::None:

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -368,6 +368,21 @@ void irgen::emitBuiltinTaskLocalValuePop(IRGenFunction &IGF) {
   call->setCallingConv(IGF.IGM.SwiftCC);
 }
 
+llvm::Value *irgen::emitBuiltinTaskCancellationShieldPush(IRGenFunction &IGF) {
+  auto *call =
+      IGF.Builder.CreateCall(IGF.IGM.getTaskCancellationShieldPushFunctionPointer(), {});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGF.IGM.SwiftCC);
+  return call;
+}
+
+void irgen::emitBuiltinTaskCancellationShieldPop(IRGenFunction &IGF) {
+  auto *call =
+      IGF.Builder.CreateCall(IGF.IGM.getTaskCancellationShieldPopFunctionPointer(), {});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGF.IGM.SwiftCC);
+}
+
 void irgen::emitFinishAsyncLet(IRGenFunction &IGF,
                                llvm::Value *asyncLet,
                                llvm::Value *resultBuffer) {

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -138,6 +138,10 @@ void emitBuiltinTaskLocalValuePush(IRGenFunction &IGF, llvm::Value *key,
 
 void emitBuiltinTaskLocalValuePop(IRGenFunction &IGF);
 
+llvm::Value *emitBuiltinTaskCancellationShieldPush(IRGenFunction &IGF);
+
+void emitBuiltinTaskCancellationShieldPop(IRGenFunction &IGF);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1080,6 +1080,9 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemovePriorityEscalationHandler)
 // second is an address to our generic Value.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
 
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPush)
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPop)
+
 #undef BUILTIN_OPERAND_OWNERSHIP
 
 #define SHOULD_NEVER_VISIT_BUILTIN(ID)                                         \
@@ -1091,6 +1094,8 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentAsyncTask)
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentExecutor)
 SHOULD_NEVER_VISIT_BUILTIN(TaskLocalValuePop)
+// SHOULD_NEVER_VISIT_BUILTIN(TaskCancellationShieldPush)
+// SHOULD_NEVER_VISIT_BUILTIN(TaskCancellationShieldPop)
 #undef SHOULD_NEVER_VISIT_BUILTIN
 
 // Builtins that should be lowered to SIL instructions so we should never see

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1094,8 +1094,6 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPop)
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentAsyncTask)
 SHOULD_NEVER_VISIT_BUILTIN(GetCurrentExecutor)
 SHOULD_NEVER_VISIT_BUILTIN(TaskLocalValuePop)
-// SHOULD_NEVER_VISIT_BUILTIN(TaskCancellationShieldPush)
-// SHOULD_NEVER_VISIT_BUILTIN(TaskCancellationShieldPop)
 #undef SHOULD_NEVER_VISIT_BUILTIN
 
 // Builtins that should be lowered to SIL instructions so we should never see

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -674,6 +674,8 @@ CONSTANT_OWNERSHIP_BUILTIN(None, TaskAddPriorityEscalationHandler)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskRemovePriorityEscalationHandler)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePush)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePop)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskCancellationShieldPush)
+CONSTANT_OWNERSHIP_BUILTIN(None, TaskCancellationShieldPop)
 
 #undef CONSTANT_OWNERSHIP_BUILTIN
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -221,6 +221,8 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::TaskRemovePriorityEscalationHandler:
     case BuiltinValueKind::TaskLocalValuePush:
     case BuiltinValueKind::TaskLocalValuePop:
+    case BuiltinValueKind::TaskCancellationShieldPush:
+    case BuiltinValueKind::TaskCancellationShieldPop:
       return true;
     }
   }

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -381,6 +381,14 @@ OVERRIDE_TASK_LOCAL(task_localsCopyTo, void,
                     (AsyncTask *target),
                     (target))
 
+OVERRIDE_TASK(task_cancellationShieldPush, bool,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, , )
+
+OVERRIDE_TASK(task_cancellationShieldPop, void,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, , )
+
 OVERRIDE_TASK_STATUS(task_hasTaskGroupStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                      swift::, , )

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -389,6 +389,10 @@ OVERRIDE_TASK(task_cancellationShieldPop, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
               swift::, , )
 
+OVERRIDE_TASK(task_hasActiveCancellationShield, bool,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, (AsyncTask *task), (task))
+
 OVERRIDE_TASK_STATUS(task_hasTaskGroupStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                      swift::, , )

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -227,6 +227,14 @@ public struct DiscardingTaskGroup {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
+  ///
+  /// ### Interaction with task cancellation shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// to return `false` even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -519,6 +527,14 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
+  ///
+  /// ### Interaction with task cancellation shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// to return `false` even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1858,6 +1858,12 @@ static void swift_task_cancellationShieldPopImpl() {
 }
 
 SWIFT_CC(swift)
+static bool swift_task_hasActiveCancellationShieldImpl(AsyncTask *task) {
+  return task->_private()._status().load(std::memory_order_relaxed)
+      .hasCancellationShield();
+}
+
+SWIFT_CC(swift)
 static NullaryContinuationJob*
 swift_task_createNullaryContinuationJobImpl(
     size_t priority,

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1841,6 +1841,23 @@ static void swift_task_removePriorityEscalationHandlerImpl(
 }
 
 SWIFT_CC(swift)
+static bool swift_task_cancellationShieldPushImpl() {
+  if (AsyncTask *task = swift_task_getCurrent()) {
+    auto installed = task->cancellationShieldPush();
+    return installed;
+  }
+
+  return false; // did not install shield
+}
+
+SWIFT_CC(swift)
+static void swift_task_cancellationShieldPopImpl() {
+  if (AsyncTask *task = swift_task_getCurrent()) {
+    task->cancellationShieldPop();
+  }
+}
+
+SWIFT_CC(swift)
 static NullaryContinuationJob*
 swift_task_createNullaryContinuationJobImpl(
     size_t priority,

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1759,6 +1759,13 @@ bool swift::swift_task_isCancelled(AsyncTask *task) {
   return task->isCancelled();
 }
 
+bool swift::swift_task_isCancelledWithFlags(AsyncTask *task,
+                                            swift_task_is_cancelled_flag flags) {
+  bool ignoreCancellationShield =
+      flags & swift_task_is_cancelled_flag_IgnoreCancellationShield;
+  return task->isCancelled(ignoreCancellationShield);
+}
+
 SWIFT_CC(swift)
 static CancellationNotificationStatusRecord*
 swift_task_addCancellationHandlerImpl(

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -769,10 +769,12 @@ public struct UnsafeCurrentTask {
   /// After the value of this property becomes `true`, it remains `true` indefinitely.
   /// There is no way to uncancel a task.
   ///
-  /// ### Task cancellation shields effect on cancellation
-  /// A task may
-  /// - SeeAlso: `checkCancellation()`
-  /// - SeeAlso: `withTaskCancellationShield(operation:)`
+  /// This property returns the actual cancellation state of the task, regardless of whether
+  /// a cancellation shield is active. Use ``Task/isCancelled`` (the static property)
+  /// if you need cancellation checking that respects active shields.
+  ///
+  /// - SeeAlso: ``Task/checkCancellation()``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     unsafe _taskIsCancelled(_task)
   }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -779,6 +779,20 @@ public struct UnsafeCurrentTask {
     unsafe _taskIsCancelled(_task)
   }
 
+  /// Check if the task is cancelled, optionally ignoring active cancellation shields.
+  ///
+  /// - Parameter ignoreTaskCancellationShield: If `true`, returns the actual cancellation
+  ///   state regardless of any active cancellation shields. If `false`, respects
+  ///   cancellation shields and returns `false` when a shield is active.
+  /// - Returns: `true` if the task is cancelled (considering shield settings), `false` otherwise.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal func _isCancelled(ignoreTaskCancellationShield: Bool) -> Bool {
+    // swift_task_is_cancelled_flag_IgnoreCancellationShield = 0x1
+    let flags: UInt64 = ignoreTaskCancellationShield ? 0x1 : 0x0
+    return unsafe _taskIsCancelledWithFlags(_task, flags: flags)
+  }
+
   /// The current task's priority.
   ///
   /// - SeeAlso: `TaskPriority`
@@ -967,6 +981,11 @@ public func _taskCancel(_ task: Builtin.NativeObject)
 @_silgen_name("swift_task_isCancelled")
 @usableFromInline
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
+
+@available(SwiftStdlib 6.4, *)
+@_silgen_name("swift_task_isCancelledWithFlags")
+@usableFromInline
+func _taskIsCancelledWithFlags(_ task: Builtin.NativeObject, flags: UInt64) -> Bool
 
 @available(SwiftStdlib 6.4, *)
 @_silgen_name("swift_task_hasActiveCancellationShield")

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -792,6 +792,12 @@ public struct UnsafeCurrentTask {
   public func cancel() {
     unsafe _taskCancel(_task)
   }
+
+  /// Checks if this task has an active cancellation shield.
+  @available(SwiftStdlib 6.4, *)
+  public var hasActiveCancellationShield: Bool {
+    unsafe _taskHasActiveCancellationShield(_task)
+  }
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -933,6 +939,10 @@ public func _taskCancel(_ task: Builtin.NativeObject)
 @_silgen_name("swift_task_isCancelled")
 @usableFromInline
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
+
+@available(SwiftStdlib 6.4, *)
+@_silgen_name("swift_task_hasActiveCancellationShield")
+internal func _taskHasActiveCancellationShield(_ task: Builtin.NativeObject) -> Bool
 
 @_silgen_name("swift_task_currentPriority")
 internal func _taskCurrentPriority(_ task: Builtin.NativeObject) -> UInt8

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -142,6 +142,7 @@ import Swift
 @frozen
 public struct Task<Success: Sendable, Failure: Error>: Sendable {
   @usableFromInline
+  @available(SwiftStdlib 5.1, *)
   internal let _task: Builtin.NativeObject
 
   @_alwaysEmitIntoClient
@@ -754,6 +755,8 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) async throws -> 
 @available(SwiftStdlib 5.1, *)
 @unsafe
 public struct UnsafeCurrentTask {
+  @usableFromInline
+  @available(SwiftStdlib 5.1, *)
   internal let _task: Builtin.NativeObject
 
   // May only be created by the standard library.
@@ -814,8 +817,12 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public var hasActiveCancellationShield: Bool {
-    unsafe _taskHasActiveCancellationShield(_task)
+    @_alwaysEmitIntoClient
+    get {
+      unsafe _taskHasActiveCancellationShield(_task)
+    }
   }
 }
 
@@ -961,6 +968,7 @@ func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
 @available(SwiftStdlib 6.4, *)
 @_silgen_name("swift_task_hasActiveCancellationShield")
+@usableFromInline
 internal func _taskHasActiveCancellationShield(_ task: Builtin.NativeObject) -> Bool
 
 @_silgen_name("swift_task_currentPriority")

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -801,6 +801,9 @@ public struct UnsafeCurrentTask {
   /// Task.isCancelled
   /// ```
   ///
+  /// Prefer using `Task.isCancelled` (the static property) in most situations when checking
+  /// the cancellation status from inside the task.
+  ///
   /// - SeeAlso: ``Task/isCancelled``
   /// - SeeAlso: ``Task/checkCancellation()``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -807,7 +807,7 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     if #available(SwiftStdlib 6.4, *) {
-      _isCancelled(ignoreTaskCancellationShield: true)
+      unsafe _isCancelled(ignoreTaskCancellationShield: true)
     } else {
       unsafe _taskIsCancelled(_task)
     }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -766,7 +766,10 @@ public struct UnsafeCurrentTask {
   /// After the value of this property becomes `true`, it remains `true` indefinitely.
   /// There is no way to uncancel a task.
   ///
+  /// ### Task cancellation shields effect on cancellation
+  /// A task may
   /// - SeeAlso: `checkCancellation()`
+  /// - SeeAlso: `withTaskCancellationShield(operation:)`
   public var isCancelled: Bool {
     unsafe _taskIsCancelled(_task)
   }
@@ -793,7 +796,23 @@ public struct UnsafeCurrentTask {
     unsafe _taskCancel(_task)
   }
 
-  /// Checks if this task has an active cancellation shield.
+  /// Checks if this task is executing in a scope with a task cancellation shield activated by the
+  /// ``withTaskCancellationShield(operation:)`` function.
+  ///
+  /// An active task cancellation shield prevents a task's ability to observe if it was cancelled,
+  /// i.e. the ``Task/isCancelled`` property will always return `false` when the task is executing
+  /// with an active shield.
+  ///
+  /// This property is primarily aimed at debugging and understanding cancellation behavior
+  /// in complex call hierarchies, and should not be used in regular control flow.
+  ///
+  /// Returns `true` when executing within a task that has an active cancellation shield.
+  ///
+  /// Cancellation shields are not automatically inherited by child tasks; each child task must install
+  /// its own shield if needed if it, independently, wanted to ignore cancellation during a specific scope.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``Task/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
   public var hasActiveCancellationShield: Bool {
     unsafe _taskHasActiveCancellationShield(_task)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -258,6 +258,79 @@ func _taskRemoveCancellationHandler(
 
 // ==== Task Cancellation Shielding -------------------------------------------
 
+/// Enters a scope in which a task cancellation shield is active.
+///
+/// Cancellation shields are primarily used to ensure some cleanup code will
+/// definitely run, even if the context in which the cleanup functions are called from
+/// is a cancelled task, and the functions may otherwise return early (due to observing
+/// the cancellation of the current task).
+///
+/// For example, a resource cleanup function might internally check for cancellation,
+/// which could cause it to skip important cleanup work:
+///
+/// ```swift
+/// let resource = await makeResource()
+/// defer {
+///   await withTaskCancellationShield {
+///     await resource.finish() // runs to completion, even if task was cancelled earlier
+///   }
+/// }
+///
+/// struct Resource {
+///   func finish() {
+///     guard !Task.isCancelled() else { return } // returns early if task was cancelled!
+///     // real work happens here
+///   }
+/// ```
+///
+/// While inside a cancellation shield, `Task.isCancelled` returns `false` and
+/// `Task.checkCancellation()` does not throw, even if the surrounding task
+/// has been cancelled. Similarly task cancellation handlers do not trigger
+/// while executing in a shielded block of code.
+///
+/// Once the shield scope exits, the task's actual
+/// cancellation status becomes observable again. Cancellation shields to not
+/// prevent the task from becoming cancelled, but only prevent observing the
+/// cancellation while executing inside a shielded scope.
+///
+/// Cancellation shields also prevent cancellation from propagating to child tasks
+/// created within the shielded scope:
+///
+/// ```swift
+/// let task = Task {
+///   withUnsafeCurrentTask { $0?.cancel() } // cancel the task
+///
+///   await withTaskCancellationShield {
+///     // Child tasks created here do NOT observe the parent's cancellation
+///     // and therefore start as not cancelled. They can be individually cancelled though.
+///     await withTaskGroup(of: Void.self) { group in
+///       group.addTask {
+///         print(Task.isCancelled) // false
+///       }
+///       for await _ in group {}
+///
+///       group.cancelAll() // explicitly cancelling the group does cancel child tasks of the group
+///       group.addTask {
+///         print(Task.isCancelled) // true
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// Note that shielding the `addTask` call itself does not shield the child task:
+///
+/// ```swift
+/// await withTaskGroup(of: Void.self) { group in
+///   group.cancelAll()
+///   withTaskCancellationShield {
+///     group.addTask { print(Task.isCancelled) } // true - child IS cancelled
+///   }
+///   group.addTask {
+///     withTaskCancellationShield { print(Task.isCancelled) } // false - shielded inside child
+///   }
+/// }
+/// ```
 @available(SwiftStdlib 6.4, *)
 public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   operation: nonisolated(nonsending) () async throws(Failure) -> Value,
@@ -273,6 +346,80 @@ public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   return try await operation()
 }
 
+
+/// Enters a scope in which a task cancellation shield is active.
+///
+/// Cancellation shields are primarily used to ensure some cleanup code will
+/// definitely run, even if the context in which the cleanup functions are called from
+/// is a cancelled task, and the functions may otherwise return early (due to observing
+/// the cancellation of the current task).
+///
+/// For example, a resource cleanup function might internally check for cancellation,
+/// which could cause it to skip important cleanup work:
+///
+/// ```swift
+/// let resource = await makeResource()
+/// defer {
+///   await withTaskCancellationShield {
+///     await resource.finish() // runs to completion, even if task was cancelled earlier
+///   }
+/// }
+///
+/// struct Resource {
+///   func finish() {
+///     guard !Task.isCancelled() else { return } // returns early if task was cancelled!
+///     // real work happens here
+///   }
+/// ```
+///
+/// While inside a cancellation shield, `Task.isCancelled` returns `false` and
+/// `Task.checkCancellation()` does not throw, even if the surrounding task
+/// has been cancelled. Similarly task cancellation handlers do not trigger
+/// while executing in a shielded block of code.
+///
+/// Once the shield scope exits, the task's actual
+/// cancellation status becomes observable again. Cancellation shields to not
+/// prevent the task from becoming cancelled, but only prevent observing the
+/// cancellation while executing inside a shielded scope.
+///
+/// Cancellation shields also prevent cancellation from propagating to child tasks
+/// created within the shielded scope:
+///
+/// ```swift
+/// let task = Task {
+///   withUnsafeCurrentTask { $0?.cancel() } // cancel the task
+///
+///   await withTaskCancellationShield {
+///     // Child tasks created here do NOT observe the parent's cancellation
+///     // and therefore start as not cancelled. They can be individually cancelled though.
+///     await withTaskGroup(of: Void.self) { group in
+///       group.addTask {
+///         print(Task.isCancelled) // false
+///       }
+///       for await _ in group {}
+///
+///       group.cancelAll() // explicitly cancelling the group does cancel child tasks of the group
+///       group.addTask {
+///         print(Task.isCancelled) // true
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// Note that shielding the `addTask` call itself does not shield the child task:
+///
+/// ```swift
+/// await withTaskGroup(of: Void.self) { group in
+///   group.cancelAll()
+///   withTaskCancellationShield {
+///     group.addTask { print(Task.isCancelled) } // true - child IS cancelled
+///   }
+///   group.addTask {
+///     withTaskCancellationShield { print(Task.isCancelled) } // false - shielded inside child
+///   }
+/// }
+/// ```
 @available(SwiftStdlib 6.4, *)
 public func withTaskCancellationShield<Value, Failure>(
   operation: () throws(Failure) -> Value,
@@ -290,7 +437,23 @@ public func withTaskCancellationShield<Value, Failure>(
 
 @available(SwiftStdlib 6.4, *)
 extension Task where Success == Never, Failure == Never {
-  /// Checks if the current task has an active cancellation shield.
+  /// Checks if the current task is executing in a scope with a task cancellation shield activated by the
+  /// ``withTaskCancellationShield(operation:)`` function.
+  ///
+  /// An active task cancellation shield prevents a task's ability to observe if it was cancelled,
+  /// i.e. the ``Task/isCancelled`` property will always return `false` when the task is executing
+  /// with an active shield.
+  ///
+  /// This property is primarily aimed at  debugging and understanding cancellation behavior
+  /// in complex call hierarchies, and should not be used in regular control flow.
+  ///
+  /// Returns `true` when executing within a task that has an active cancellation shield.
+  ///
+  /// Cancellation shields are not automatically inherited by child tasks; each child task must install
+  /// its own shield if needed if it, independently, wanted to ignore cancellation during a specific scope.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``UnsafeCurrentTask/hasActiveCancellationShield``
   public static var hasActiveCancellationShield: Bool {
     unsafe withUnsafeCurrentTask { task in
       unsafe task?.hasActiveCancellationShield ?? false

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -255,3 +255,35 @@ func _taskRemoveCancellationHandler(
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 )
 
+
+// ==== Task Cancellation Shielding -------------------------------------------
+
+@available(SwiftStdlib 6.3, *)
+public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
+  operation: nonisolated(nonsending) () async throws(Failure) -> Value,
+) async throws(Failure) -> Value {
+  let didInstallShield = Builtin.taskCancellationShieldPush()
+
+  defer { 
+    if Bool(didInstallShield) {
+      Builtin.taskCancellationShieldPop()
+     }
+  }
+
+  return try await operation()
+}
+
+@available(SwiftStdlib 6.3, *)
+public func withTaskCancellationShield<Value, Failure>(
+  operation: () throws(Failure) -> Value,
+) throws(Failure) -> Value {
+  let didInstallShield = Builtin.taskCancellationShieldPush()
+
+  defer { 
+    if Bool(didInstallShield) {
+      Builtin.taskCancellationShieldPop()
+    }
+  }
+
+  return try operation()
+}

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -332,6 +332,7 @@ func _taskRemoveCancellationHandler(
 /// }
 /// ```
 @available(SwiftStdlib 6.4, *)
+@_alwaysEmitIntoClient
 public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   operation: nonisolated(nonsending) () async throws(Failure) -> Value,
 ) async throws(Failure) -> Value {
@@ -421,6 +422,7 @@ public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
 /// }
 /// ```
 @available(SwiftStdlib 6.4, *)
+@_alwaysEmitIntoClient
 public func withTaskCancellationShield<Value, Failure>(
   operation: () throws(Failure) -> Value,
 ) throws(Failure) -> Value {
@@ -454,9 +456,14 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   /// - SeeAlso: ``UnsafeCurrentTask/hasActiveCancellationShield``
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public static var hasActiveCancellationShield: Bool {
-    unsafe withUnsafeCurrentTask { task in
-      unsafe task?.hasActiveCancellationShield ?? false
+    @_alwaysEmitIntoClient
+    get {
+      unsafe withUnsafeCurrentTask { task in
+        unsafe task?.hasActiveCancellationShield ?? false
+      }
     }
   }
 }

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -258,13 +258,13 @@ func _taskRemoveCancellationHandler(
 
 // ==== Task Cancellation Shielding -------------------------------------------
 
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.4, *)
 public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   operation: nonisolated(nonsending) () async throws(Failure) -> Value,
 ) async throws(Failure) -> Value {
   let didInstallShield = Builtin.taskCancellationShieldPush()
 
-  defer { 
+  defer {
     if Bool(didInstallShield) {
       Builtin.taskCancellationShieldPop()
      }
@@ -273,17 +273,27 @@ public nonisolated(nonsending) func withTaskCancellationShield<Value, Failure>(
   return try await operation()
 }
 
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.4, *)
 public func withTaskCancellationShield<Value, Failure>(
   operation: () throws(Failure) -> Value,
 ) throws(Failure) -> Value {
   let didInstallShield = Builtin.taskCancellationShieldPush()
 
-  defer { 
+  defer {
     if Bool(didInstallShield) {
       Builtin.taskCancellationShieldPop()
     }
   }
 
   return try operation()
+}
+
+@available(SwiftStdlib 6.4, *)
+extension Task where Success == Never, Failure == Never {
+  /// Checks if the current task has an active cancellation shield.
+  public static var hasActiveCancellationShield: Bool {
+    unsafe withUnsafeCurrentTask { task in
+      unsafe task?.hasActiveCancellationShield ?? false
+    }
+  }
 }

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -197,7 +197,12 @@ extension Task {
   /// After the value of this property becomes `true`, it remains `true` indefinitely.
   /// There is no way to uncancel a task.
   ///
-  /// - SeeAlso: `checkCancellation()`
+  /// This property returns the actual cancellation state of the task, regardless of whether
+  /// a cancellation shield is active. Use ``Task/isCancelled`` (the static property)
+  /// if you need cancellation checking that respects active shields.
+  ///
+  /// - SeeAlso: ``checkCancellation()``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   @_transparent public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
@@ -210,7 +215,14 @@ extension Task where Success == Never, Failure == Never {
   /// After the value of this property becomes `true`, it remains `true` indefinitely.
   /// There is no way to uncancel a task.
   ///
-  /// - SeeAlso: `checkCancellation()`
+  /// ### Interaction with task cancellation shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// to return `false` even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``checkCancellation()``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public static var isCancelled: Bool {
      unsafe withUnsafeCurrentTask { task in
        unsafe task?.isCancelled ?? false

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -502,6 +502,14 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
+  ///
+  /// ### Interaction with task cancellation shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// to return `false` even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -828,6 +836,14 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
+  ///
+  /// ### Interaction with task cancellation shields
+  ///
+  /// Cancellation may be suppressed by an active task cancellation shield
+  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// to return `false` even though the task has been cancelled externally.
+  ///
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -799,7 +799,7 @@ void swift::_swift_taskGroup_detachChild(TaskGroup *group,
 /// The caller must guarantee that this is called while holding the owning
 /// task's status record lock.
 void swift::_swift_taskGroup_cancel(TaskGroup *group) {
-  (void) group->statusCancel();
+  (void) group->statusCancel(); // TODO: do prevent the task group from being cancelled? I think probably no, we cancel and "don't observe", same as Task
 
   // Because only the owning task of the task group can modify the
   // child list of a task group status record, and it can only do so
@@ -830,7 +830,7 @@ void swift::_swift_taskGroup_cancel_unlocked(TaskGroup *group,
 /**************************************************************************/
 
 /// Perform any cancellation actions required by the given record.
-static void performCancellationAction(TaskStatusRecord *record) {
+static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord *record) {
   switch (record->getKind()) {
   // Child tasks need to be recursively cancelled.
   case TaskStatusRecordKind::ChildTask: {
@@ -853,6 +853,10 @@ static void performCancellationAction(TaskStatusRecord *record) {
   case TaskStatusRecordKind::CancellationNotification: {
     auto notification =
       cast<CancellationNotificationStatusRecord>(record);
+    if (status.hasCancellationShield()) {
+      SWIFT_TASK_DEBUG_LOG("cancellation shielded: skip cancellation handler invocation in task = %p", swift_task_getCurrent());
+      return; 
+    }
     notification->run();
     return;
   }
@@ -889,7 +893,9 @@ static void swift_task_cancelImpl(AsyncTask *task) {
   auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
   auto newStatus = oldStatus;
   while (true) {
-    if (oldStatus.isCancelled()) {
+    // Are we already cancelled? 
+    // Even if we have a cancellation shield active, we do want to set the isCancelled flag.
+    if (oldStatus.isCancelled(/*ignoreShield=*/false)) {
       return;
     }
 
@@ -907,8 +913,8 @@ static void swift_task_cancelImpl(AsyncTask *task) {
 
   newStatus.traceStatusChanged(task, false, oldStatus.isRunning());
   if (newStatus.getInnermostRecord() == nullptr) {
-     // No records, nothing to propagate
-     return;
+    // No records, nothing to propagate
+    return;
   }
 
   withStatusRecordLock(task, newStatus, [&](ActiveTaskStatus status) {
@@ -917,7 +923,9 @@ static void swift_task_cancelImpl(AsyncTask *task) {
       // modify this list that is being iterated. However, cancellation is
       // happening from outside of the task so we know that no new records will
       // be added since that's only possible while on task.
-      performCancellationAction(cur);
+      //
+      // Each action must independently take care of how to deal with cancellation shields.
+      performCancellationAction(newStatus, cur);
     }
   });
 }

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -799,7 +799,7 @@ void swift::_swift_taskGroup_detachChild(TaskGroup *group,
 /// The caller must guarantee that this is called while holding the owning
 /// task's status record lock.
 void swift::_swift_taskGroup_cancel(TaskGroup *group) {
-  (void) group->statusCancel(); // TODO: do prevent the task group from being cancelled? I think probably no, we cancel and "don't observe", same as Task
+  (void) group->statusCancel();
 
   // Because only the owning task of the task group can modify the
   // child list of a task group status record, and it can only do so

--- a/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
+++ b/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
@@ -307,6 +307,14 @@ OVERRIDE_TASK_LOCAL(task_localsCopyTo, void,
                     (AsyncTask *target),
                     (target))
 
+OVERRIDE_TASK(task_cancellationShieldPush, bool,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, ,)
+
+OVERRIDE_TASK(task_cancellationShieldPop, void,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, ,)
+
 OVERRIDE_TASK_STATUS(task_addStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                      swift::, (TaskStatusRecord *newRecord), (newRecord))

--- a/test/Concurrency/Runtime/async_task_cancellation_shield.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_shield.swift
@@ -324,6 +324,10 @@ func test_task_isCancelled_instance_vs_static() async {
 
     await withTaskCancellationShield {
       print("3. Inside shield, Task.isCancelled (static): \(Task.isCancelled)")
+      withUnsafeCurrentTask { unsafeTask in
+        print("3.1. Inside shield, unsafeCurrentTask.hasActiveCancellationShield: \(unsafeTask!.hasActiveCancellationShield)")
+        print("3.2. Inside shield, unsafeCurrentTask.isCancelled: \(unsafeTask!.isCancelled)")
+      }
       insideShieldCheckNow.signal()
       insideShield.wait()
     }
@@ -338,9 +342,13 @@ func test_task_isCancelled_instance_vs_static() async {
   print("2. task.isCancelled (instance): \(task.isCancelled)")
   proceed.signal()
 
+  // CHECK: 3.1. Inside shield, unsafeCurrentTask.hasActiveCancellationShield: true
+  // CHECK: 3.2. Inside shield, unsafeCurrentTask.isCancelled: true
+
   insideShieldCheckNow.wait()
-  // CHECK: 3. task.isCancelled (instance) (suspended while shielded): true
-  print("3. task.isCancelled (instance) (suspended while shielded): \(task.isCancelled)")
+  // CHECK: 3.3. task.isCancelled (instance) (suspended while shielded): true
+  print("3.3. task.isCancelled (instance) (suspended while shielded): \(task.isCancelled)")
+
 
   insideShield.signal()
   // CHECK: 5. After shield, Task.isCancelled (static): true

--- a/test/Concurrency/Runtime/async_task_cancellation_shield.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_shield.swift
@@ -1,0 +1,295 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: synchronization
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import Synchronization
+
+@available(SwiftStdlib 6.3, *)
+func test_task_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_task_cancel_shield
+
+  let t = Task {
+    print("Inside task, before cancel: isCancelled:\(Task.isCancelled)")  
+    // CHECK: Inside task, before cancel: isCancelled:false
+
+    print("cancel self")
+    withUnsafeCurrentTask { $0?.cancel() }  // cancel myself!
+
+    print("Inside task, after cancel: isCancelled:\(Task.isCancelled)")  
+    // CHECK: Inside task, after cancel: isCancelled:true
+
+    withTaskCancellationShield {
+      print("Inside task, shielded: isCancelled:\(Task.isCancelled)") 
+       // CHECK: Inside task, shielded: isCancelled:false
+    }
+    print("Inside task, after shield: isCancelled:\(Task.isCancelled)") 
+     // CHECK: Inside task, after shield: isCancelled:true
+
+    await withTaskCancellationShield {
+      await withTaskCancellationHandler {
+        print("shielded, withTaskCancellationHandler - operation")  
+        // CHECK: shielded, withTaskCancellationHandler - operation
+
+      } onCancel: {
+        // MUST NOT execute because we're shielded
+        print("shielded, withTaskCancellationHandler - onCancel") 
+         // CHECK-NOT: shielded, withTaskCancellationHandler - onCancel
+      }
+    }
+
+    async let child = {
+      print("Inside child-task: isCancelled:\(Task.isCancelled)")  
+      // CHECK: Inside child-task: isCancelled:true
+      withTaskCancellationShield {
+        print("Inside child-task, shielded: isCancelled:\(Task.isCancelled)")  
+        // CHECK: Inside child-task, shielded: isCancelled:false
+      }
+    }()
+    _ = await child
+
+    let t2 = Task {
+      let unsafeT2 = withUnsafeCurrentTask { $0! }  // escape self reference unsafely
+
+      await withTaskCancellationShield {
+        await withTaskCancellationHandler {
+          print("cancel self")
+          unsafeT2.cancel()  // cancel self, but we're shielded, so the handler MUST NOT run anyway
+          // CHECK-NOT: Task{}.cancel, withTaskCancellationHandler - onCancel
+          print("Task{}.cancel, shielded, withTaskCancellationHandler - operation")
+          // CHECK: Task{}.cancel, shielded, withTaskCancellationHandler - operation
+        } onCancel: {
+          // MUST NOT execute because we're shielded
+          print("Task{}.cancel, withTaskCancellationHandler - onCancel")
+          // CHECK-NOT: Task{}.cancel, withTaskCancellationHandler - onCancel
+        }
+      }
+    }
+    await t2.value
+  }
+
+  await t.value
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_defer_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function) // CHECK: test_defer_cancel_shield
+
+  let task = Task {
+    withUnsafeCurrentTask { $0?.cancel() }
+
+    print("Inside task, before cancel: isCancelled:\(Task.isCancelled)")
+    // CHECK: Inside task, before cancel: isCancelled:true
+
+    defer {
+      defer {
+        print("Inside defer, after cancel: isCancelled:\(Task.isCancelled)")
+        // CHECK: Inside defer, after cancel: isCancelled:true
+
+        withTaskCancellationShield {
+          print("Inside defer, shielded, after cancel: isCancelled:\(Task.isCancelled)")
+          // CHECK: Inside defer, shielded, after cancel: isCancelled:false
+        }
+
+        print("Inside defer, after cancel: isCancelled:\(Task.isCancelled)")
+        // CHECK: Inside defer, after cancel: isCancelled:true
+      }
+    }
+  }
+
+  await task.value
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_nested_shields() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_nested_shields
+
+  let task = Task {
+    withUnsafeCurrentTask { $0?.cancel() }
+    print("Before shield, after cancel: isCancelled:\(Task.isCancelled)")
+    // CHECK: Before shield, after cancel: isCancelled:true
+
+    withTaskCancellationShield {
+      print("Inside shield, after cancel: isCancelled:\(Task.isCancelled)")
+      // CHECK: Inside shield, after cancel: isCancelled:false
+      
+      withTaskCancellationShield {
+        print("Inside shield shield, after cancel: isCancelled:\(Task.isCancelled)")
+        // CHECK: Inside shield shield, after cancel: isCancelled:false
+      }
+
+      // make sure we didn't remove the "outer" shield by accident
+      print("Popped shield, still shielded, after cancel: isCancelled:\(Task.isCancelled)")
+      // CHECK: Popped shield, still shielded, after cancel: isCancelled:false
+    }
+
+    print("Inside task, after cancel: isCancelled:\(Task.isCancelled)")
+    // CHECK: Inside task, after cancel: isCancelled:true
+  }
+
+  await task.value
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_sleep_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_sleep_cancel_shield
+
+  let task = Task {
+    await withTaskCancellationShield {
+      try! await Task.sleep(for: .seconds(1))
+    }
+  }
+
+  task.cancel()
+  await task.value
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_async_stream_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_async_stream_cancel_shield
+  
+  let (stream, continuation) = AsyncThrowingStream<Void, any Error>.makeStream()
+  let task = Task {
+    try await withTaskCancellationShield {
+      for try await value in stream {
+        print("Inside loop")
+        // CHECK: Inside loop
+      }
+    }
+  }
+
+  task.cancel()
+  continuation.yield(())
+  continuation.finish()
+  try! await task.value
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_child_task_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_child_task_cancel_shield
+
+  let cancellableContinuation = CancellableContinuation()
+  await withTaskGroup { group in
+    group.addTask {
+      await withTaskCancellationShield {
+        try! await cancellableContinuation.wait()
+      }
+    }
+
+    group.cancelAll()
+    cancellableContinuation.complete()
+    print("cancellableContinuation.complete()")
+  }
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_task_group_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_task_group_cancel_shield
+
+  await withTaskGroup(of: Void.self) { group in
+    group.cancelAll()
+    group.addTask {
+      print("Outside cancellation shield, isCancelled:\(Task.isCancelled)")
+      // CHECK: Outside cancellation shield, isCancelled:true
+
+      await withTaskCancellationShield {
+        print("Inside cancellation shield, isCancelled:\(Task.isCancelled)")
+        // CHECK: Inside cancellation shield, isCancelled:false
+
+        await withTaskGroup { group in
+          print("Inside task group, isCancelled:\(Task.isCancelled)")
+          // CHECK: Inside task group, isCancelled:false
+
+          group.addTask {
+            print("Inside child task, isCancelled:\(Task.isCancelled)")
+            // CHECK: Inside child task, isCancelled:false
+          }
+        }
+      }
+    }
+  }
+}
+
+@available(SwiftStdlib 6.3, *)
+func test_add_task_cancel_shield() async {
+  print("==== ------------------------------------------------")
+  print(#function)  // CHECK: test_add_task_cancel_shield
+
+  await withTaskGroup(of: Void.self) { group in
+    group.cancelAll()
+    // The cancellation shield is only protecting the addTask but not the child task
+    withTaskCancellationShield {
+      group.addTask {
+        print("Inside child task, isCancelled:\(Task.isCancelled)")
+        // CHECK: Inside child task, isCancelled:true
+      }
+    }
+    group.addTask {
+      print("Inside child task, isCancelled:\(Task.isCancelled)")
+      // CHECK: Inside child task, isCancelled:true
+    }
+  }
+}
+
+@available(SwiftStdlib 6.3, *)
+struct CancellableContinuation: ~Copyable {
+  let state = Mutex<(Bool, (CheckedContinuation<Void, any Error>?))>((false, nil))
+
+  func wait() async throws {
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        self.state.withLock { state -> CheckedContinuation<Void, any Error>? in
+          if state.0 {
+            return continuation
+          } else {
+            state.1 = continuation
+            return nil
+          }
+        }?.resume(throwing: CancellationError())
+      }
+    } onCancel: {
+      self.state.withLock { state in
+        state.0 = true
+        return state.1
+      }?.resume(throwing: CancellationError())
+    }
+  }
+
+  func complete() {
+    var cc = self.state.withLock { $0.1 }
+    while true {
+      if let cc {
+        cc.resume()
+        return
+      }
+      cc = self.state.withLock { $0.1 }
+    }
+  }
+}
+
+@available(SwiftStdlib 6.3, *)
+@main struct Main {
+  static func main() async {
+    await test_task_cancel_shield()
+    await test_defer_cancel_shield()
+    await test_nested_shields()
+    await test_sleep_cancel_shield()
+    await test_async_stream_cancel_shield()
+    await test_child_task_cancel_shield()
+    await test_task_group_cancel_shield()
+    await test_add_task_cancel_shield()
+    print("DONE")
+  }
+}

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -985,6 +985,20 @@ nonisolated(nonsending) func testTaskLocalValuePush<Value>(_ key: Builtin.RawPoi
 // CHECK: call swiftcc {} @swift_task_localValuePop()
 nonisolated(nonsending) func testTaskLocalValuePop() async {
   Builtin.taskLocalValuePop()
+} 
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins22testTaskLocalValuePushyyBp_xntYalF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3, ptr noalias %4, ptr %Value)
+// CHECK: [[TASK_VAR:%.*]] = call swiftcc ptr @swift_task_alloc({{.*}}
+// CHECK: call ptr %InitializeWithTake(ptr noalias [[TASK_VAR]], ptr noalias {{%.*}}, ptr %Value)
+// CHECK: call swiftcc {} @swift_task_localValuePush(ptr %3, ptr [[TASK_VAR]], ptr %Value)
+nonisolated(nonsending) func testTaskCancellationShieldPush<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
+  Builtin.taskCancellationShieldPush()
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins21testTaskLocalValuePopyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: call swiftcc {} @swift_task_localValuePop()
+nonisolated(nonsending) func taskCancellationShieldPop() async {
+  Builtin.taskCancellationShieldPop()
 }  
 
 // CHECK: ![[R]] = !{i64 0, i64 9223372036854775807}

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-builtin-module -module-name builtins -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -enable-builtin-module -module-name builtins -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime --dump-input=always
 
 // REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
 
@@ -987,17 +987,15 @@ nonisolated(nonsending) func testTaskLocalValuePop() async {
   Builtin.taskLocalValuePop()
 } 
 
-// CHECK-LABEL: define {{.*}}void @"$s8builtins22testTaskLocalValuePushyyBp_xntYalF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3, ptr noalias %4, ptr %Value)
-// CHECK: [[TASK_VAR:%.*]] = call swiftcc ptr @swift_task_alloc({{.*}}
-// CHECK: call ptr %InitializeWithTake(ptr noalias [[TASK_VAR]], ptr noalias {{%.*}}, ptr %Value)
-// CHECK: call swiftcc {} @swift_task_localValuePush(ptr %3, ptr [[TASK_VAR]], ptr %Value)
-nonisolated(nonsending) func testTaskCancellationShieldPush<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
+// CHECK-LABEL: define {{.*}}void @"$s8builtins30testTaskCancellationShieldPushyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: call swiftcc i1 @swift_task_cancellationShieldPush()
+nonisolated(nonsending) func testTaskCancellationShieldPush() async {
   Builtin.taskCancellationShieldPush()
 }
 
-// CHECK-LABEL: define {{.*}}void @"$s8builtins21testTaskLocalValuePopyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
-// CHECK: call swiftcc {} @swift_task_localValuePop()
-nonisolated(nonsending) func taskCancellationShieldPop() async {
+// CHECK-LABEL: define {{.*}}void @"$s8builtins29testTaskCancellationShieldPopyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: call swiftcc {} @swift_task_cancellationShieldPop()
+nonisolated(nonsending) func testTaskCancellationShieldPop() async {
   Builtin.taskCancellationShieldPop()
 }  
 

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -979,3 +979,17 @@ func testTaskLocalValuePush<Value>(_ key: Builtin.RawPointer, _ value: consuming
 func testTaskLocalValuePop() async {
   Builtin.taskLocalValuePop()
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins21taskCancellationShieldPushyyYaF : $@convention(thin) @async () -> () {
+// CHECK:   builtin "taskCancellationShieldPush"() : $()
+// CHECK: } // end sil function '$s8builtins21taskCancellationShieldPushyyYaF'
+func taskCancellationShieldPush() async {
+  Builtin.taskCancellationShieldPush()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins21taskCancellationShieldPopyyYaF : $@convention(thin) @async () -> () {
+// CHECK:   builtin "taskCancellationShieldPop"() : $()
+// CHECK: } // end sil function '$s8builtins21taskCancellationShieldPopyyYaF'
+func taskCancellationShieldPop() async {
+  Builtin.taskCancellationShieldPop()
+}

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -980,16 +980,16 @@ func testTaskLocalValuePop() async {
   Builtin.taskLocalValuePop()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins21taskCancellationShieldPushyyYaF : $@convention(thin) @async () -> () {
-// CHECK:   builtin "taskCancellationShieldPush"() : $()
-// CHECK: } // end sil function '$s8builtins21taskCancellationShieldPushyyYaF'
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins26taskCancellationShieldPushyyYaF : $@convention(thin) @async () -> () {
+// CHECK:   builtin "taskCancellationShieldPush"() : $Builtin.Int1
+// CHECK: } // end sil function '$s8builtins26taskCancellationShieldPushyyYaF'
 func taskCancellationShieldPush() async {
   Builtin.taskCancellationShieldPush()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins21taskCancellationShieldPopyyYaF : $@convention(thin) @async () -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins25taskCancellationShieldPopyyYaF : $@convention(thin) @async () -> () {
 // CHECK:   builtin "taskCancellationShieldPop"() : $()
-// CHECK: } // end sil function '$s8builtins21taskCancellationShieldPopyyYaF'
+// CHECK: } // end sil function '$s8builtins25taskCancellationShieldPopyyYaF'
 func taskCancellationShieldPop() async {
   Builtin.taskCancellationShieldPop()
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -403,6 +403,7 @@ Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 // Cancellation shields
 Added: _swift_task_cancellationShieldPush
 Added: _swift_task_cancellationShieldPop
+Added: _swift_task_hasActiveCancellationShield
 
 // CoroutineAccessors
 Added: _swift_task_dealloc_through

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -406,6 +406,7 @@ Added: _swift_task_cancellationShieldPop
 Added: _swift_task_hasActiveCancellationShield
 Added: _$sSct27hasActiveCancellationShieldSbvpMV
 Added: _$sScTss5NeverORszABRs_rlE27hasActiveCancellationShieldSbvpZMV
+Added: _swift_task_isCancelledWithFlags
 
 // UnsafeCurrentTask's _task became usable from inline
 Added: _$sSct5_taskBovg

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -400,6 +400,10 @@ Added: _$sScfsE25isIsolatingCurrentContextSbSgyF
 Added: _$sScf25isIsolatingCurrentContextSbSgyFTj
 Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 
+// Cancellation shields
+Added: _swift_task_cancellationShieldPush
+Added: _swift_task_cancellationShieldPop
+
 // CoroutineAccessors
 Added: _swift_task_dealloc_through
 

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -404,6 +404,12 @@ Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 Added: _swift_task_cancellationShieldPush
 Added: _swift_task_cancellationShieldPop
 Added: _swift_task_hasActiveCancellationShield
+Added: _$sSct27hasActiveCancellationShieldSbvpMV
+Added: _$sScTss5NeverORszABRs_rlE27hasActiveCancellationShieldSbvpZMV
+
+// UnsafeCurrentTask's _task became usable from inline
+Added: _$sSct5_taskBovg
+Added: _$sSct5_taskBovpMV
 
 // CoroutineAccessors
 Added: _swift_task_dealloc_through

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -403,6 +403,7 @@ Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 // Cancellation shields
 Added: _swift_task_cancellationShieldPush
 Added: _swift_task_cancellationShieldPop
+Added: _swift_task_hasActiveCancellationShield
 
 // CoroutineAccessors
 Added: _swift_task_dealloc_through

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -406,6 +406,7 @@ Added: _swift_task_cancellationShieldPop
 Added: _swift_task_hasActiveCancellationShield
 Added: _$sSct27hasActiveCancellationShieldSbvpMV
 Added: _$sScTss5NeverORszABRs_rlE27hasActiveCancellationShieldSbvpZMV
+Added: _swift_task_isCancelledWithFlags
 
 // UnsafeCurrentTask's _task became usable from inline
 Added: _$sSct5_taskBovg

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -400,6 +400,10 @@ Added: _$sScfsE25isIsolatingCurrentContextSbSgyF
 Added: _$sScf25isIsolatingCurrentContextSbSgyFTj
 Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 
+// Cancellation shields
+Added: _swift_task_cancellationShieldPush
+Added: _swift_task_cancellationShieldPop
+
 // CoroutineAccessors
 Added: _swift_task_dealloc_through
 

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -404,6 +404,12 @@ Added: _$sScf25isIsolatingCurrentContextSbSgyFTq
 Added: _swift_task_cancellationShieldPush
 Added: _swift_task_cancellationShieldPop
 Added: _swift_task_hasActiveCancellationShield
+Added: _$sSct27hasActiveCancellationShieldSbvpMV
+Added: _$sScTss5NeverORszABRs_rlE27hasActiveCancellationShieldSbvpZMV
+
+// UnsafeCurrentTask's _task became usable from inline
+Added: _$sSct5_taskBovg
+Added: _$sSct5_taskBovpMV
 
 // CoroutineAccessors
 Added: _swift_task_dealloc_through


### PR DESCRIPTION
This is a follow up from the "async" `deinit` work, which will allow us to guarantee cleanup code to run in deinitializers, even if they need to call asynchronous code, and even if they may be run in a task that was cancelled: by "shielding" it from cancellation.

This is incomplete, the child handling needs some more love.

SE proposal: https://github.com/swiftlang/swift-evolution/pull/3037/