### PR TITLE
[6.3] XFAIL availability_custom_domains_clang_build test on Android

### DIFF
--- a/test/Availability/availability_custom_domains_clang_build.swift
+++ b/test/Availability/availability_custom_domains_clang_build.swift
@@ -1,4 +1,6 @@
 // REQUIRES: swift_feature_CustomAvailability
+// XFAIL: OS=linux-android
+// XFAIL: OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -x c %S/Inputs/AvailabilityDomains.c -o %t/AvailabilityDomains.c.o -c


### PR DESCRIPTION
Explanation

XFAILs availability_custom_domains_clang_build on Android 

Scope

availability_domain.h is not available in the Android NDK 


Original PR

https://github.com/swiftlang/swift/pull/85599

Risk

Low, impacts test only