### PR TITLE
[cxx-interop] Remove annotationOnly flag from Escapability request

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -531,10 +531,6 @@ enum class CxxEscapability { Escapable, NonEscapable, Unknown };
 struct EscapabilityLookupDescriptor final {
   const clang::Type *type;
   ClangImporter::Implementation *impl;
-  // Only explicitly ~Escapable annotated types are considered ~Escapable.
-  // This is for backward compatibility, so we continue to import aggregates
-  // containing pointers as Escapable types.
-  bool annotationOnly = true;
 
   friend llvm::hash_code hash_value(const EscapabilityLookupDescriptor &desc) {
     return llvm::hash_combine(desc.type);
@@ -542,7 +538,7 @@ struct EscapabilityLookupDescriptor final {
 
   friend bool operator==(const EscapabilityLookupDescriptor &lhs,
                          const EscapabilityLookupDescriptor &rhs) {
-    return lhs.type == rhs.type && lhs.annotationOnly == rhs.annotationOnly;
+    return lhs.type == rhs.type;
   }
 
   friend bool operator!=(const EscapabilityLookupDescriptor &lhs,

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -101,8 +101,10 @@ struct HoldsShared {
                                SWIFT_RETURNS_UNRETAINED;
 };
 
-template <typename, typename> struct TTake2 {};
-template <typename T> struct PassThru {};
+template <typename F, typename S> struct SWIFT_ESCAPABLE_IF(F, S) TTake2 {};
+template <typename T> struct PassThru {
+  T field;
+};
 struct IsUnsafe { int *p; };
 struct HasUnsafe : TTake2<PassThru<HasUnsafe>, IsUnsafe> {};
 using AlsoUnsafe = PassThru<HasUnsafe>;
@@ -207,8 +209,7 @@ func useTTakeInt(x: TTakeInt) {
 }
 
 func useTTakePtr(x: TTakePtr) {
-  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+  _ = x
 }
 
 func useTTakeSafeTuple(x: TTakeSafeTuple) {
@@ -216,8 +217,7 @@ func useTTakeSafeTuple(x: TTakeSafeTuple) {
 }
 
 func useTTakeUnsafeTuple(x: TTakeUnsafeTuple) {
-  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-  _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+  _ = x
 }
 
 func useTTakeUnsafeTuple(x: HasUnsafe) {


### PR DESCRIPTION
The `annotationOnly` flag was originally introduced to control for which types we would infer escapability, and for which we would rely solely on annotations. However, due to backward compatibility issues, this flag is currently always set to `true`. Therefore, this patch removes the `annotationOnly` flag and makes the compiler infer escapability from bases and fields only for simple records, such as aggregates.

rdar://165046977
