### PR TITLE
embedded: don't try to specialize vtables of C++ imported reference-counted classes

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -128,6 +128,8 @@ final public class ClassDecl: NominalTypeDecl {
   final public var destructor: DestructorDecl {
     bridged.Class_getDestructor().getAs(DestructorDecl.self)
   }
+
+  public var isForeign: Bool { bridged.Class_isForeign() }
 }
 
 final public class ProtocolDecl: NominalTypeDecl {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -48,6 +48,9 @@ private struct VTableSpecializer {
     }
 
     let classDecl = classType.nominal! as! ClassDecl
+    if classDecl.isForeign {
+      return
+    }
     guard let origVTable = context.lookupVTable(for: classDecl) else {
       if context.enableWMORequiredDiagnostics {
         context.diagnosticEngine.diagnose(.cannot_specialize_class, classType, at: errorLocation)

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -346,6 +346,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool Struct_hasUnreferenceableStorage() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Class_getSuperclass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj Class_getDestructor() const;
+  BRIDGED_INLINE bool Class_isForeign() const;
   BRIDGED_INLINE bool ProtocolDecl_requiresClass() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -256,6 +256,10 @@ BridgedDeclObj BridgedDeclObj::Class_getDestructor() const {
   return {getAs<swift::ClassDecl>()->getDestructor()};
 }
 
+bool BridgedDeclObj::Class_isForeign() const {
+  return getAs<swift::ClassDecl>()->isForeign();
+}
+
 bool BridgedDeclObj::ProtocolDecl_requiresClass() const {
   return getAs<swift::ProtocolDecl>()->requiresClass();
 }

--- a/test/embedded/cxx-import-reference.swift
+++ b/test/embedded/cxx-import-reference.swift
@@ -40,3 +40,12 @@ public func test()
   let c =  C.create()
   c.foo()
 }
+
+public func cast<S,D>(_ s:S, to type:D.Type) -> D {
+  return unsafeBitCast(s, to: type.self)
+}
+
+public func testcast(_ provider: AnyObject) -> C {
+  return cast (provider, to: C.self)
+}
+


### PR DESCRIPTION
Fixes a false compiler error

rdar://165209061