### PR TITLE
[cxx-interop] Introduce SWIFT_REFCOUNTED_PTR

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -388,5 +388,32 @@ NOTE(nonescapable_field_of_escapable, none,
      "escapable record %0 cannot have non-escapable field '%1'",
      (const clang::NamedDecl *, StringRef))
 
+NOTE(refcounted_ptr_missing_torawpointer, none,
+     "SWIFT_REFCOUNTED_PTR on %0 is missing required "
+     "'_toRawPointer' parameter",
+     (const clang::NamedDecl *))
+
+NOTE(refcounted_ptr_torawpointer_lookup_failure, none,
+     "cannot find function '%0' specified in '_toRawPointer' "
+     "parameter of SWIFT_REFCOUNTED_PTR %1",
+     (StringRef, const clang::NamedDecl *))
+
+NOTE(refcounted_ptr_torawpointer_lookup_ambiguity, none,
+     "there are multiple candidates of function '%0' specified in "
+     "'_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR %1",
+     (StringRef, const clang::NamedDecl *))
+
+NOTE(refcounted_ptr_torawpointer_not_function, none,
+     "%0 specified in '_toRawPointer' parameter of "
+     "SWIFT_REFCOUNTED_PTR on %1 is not a function",
+     (const Decl *, const clang::NamedDecl *))
+
+NOTE(
+    refcounted_ptr_torawpointer_wrong_signature, none,
+    "function %0 specified in '_toRawPointer' parameter of "
+    "SWIFT_REFCOUNTED_PTR on %1 has incorrect signature; expected a function "
+    "that takes no arguments and returns a pointer to a foreign reference type",
+    (const Decl *, const clang::NamedDecl *))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2127,6 +2127,86 @@ namespace {
       return;
     }
 
+    bool
+    injectBridgingConversionsForRefCountedSmartPtrs(NominalTypeDecl *smartPtr) {
+      for (const auto *attr : smartPtr->getAttrs()) {
+        if (const auto *customAttr = dyn_cast<CustomAttr>(attr)) {
+          if (!customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
+                  "_refCountedPtr"))
+            continue;
+          auto clangDecl = cast<clang::TagDecl>(smartPtr->getClangDecl());
+          StringRef ToRawPtrFuncName;
+          for (auto arg : *customAttr->getArgs()) {
+            if (arg.getLabel().str() == "ToRawPointer") {
+              if (const auto *literal =
+                      dyn_cast<StringLiteralExpr>(arg.getExpr()))
+                ToRawPtrFuncName = literal->getValue();
+            }
+          }
+          if (ToRawPtrFuncName.empty()) {
+            Impl.addImportDiagnostic(
+                clangDecl,
+                Diagnostic(diag::refcounted_ptr_missing_torawpointer,
+                           clangDecl),
+                clangDecl->getLocation());
+            return false;
+          }
+
+          auto results = getValueDeclsForName(smartPtr, ToRawPtrFuncName);
+          if (results.empty()) {
+            Impl.addImportDiagnostic(
+                clangDecl,
+                Diagnostic(
+                    diag::refcounted_ptr_torawpointer_lookup_failure,
+                    Impl.SwiftContext.AllocateCopy(ToRawPtrFuncName.str()),
+                    clangDecl),
+                clangDecl->getLocation());
+            return false;
+          }
+          if (results.size() > 1) {
+            Impl.addImportDiagnostic(
+                clangDecl,
+                Diagnostic(
+                    diag::refcounted_ptr_torawpointer_lookup_ambiguity,
+                    Impl.SwiftContext.AllocateCopy(ToRawPtrFuncName.str()),
+                    clangDecl),
+                clangDecl->getLocation());
+            return false;
+          }
+
+          auto toRawPtrFunc = dyn_cast<FuncDecl>(results.front());
+          if (!toRawPtrFunc) {
+            Impl.addImportDiagnostic(
+                clangDecl,
+                Diagnostic(diag::refcounted_ptr_torawpointer_not_function,
+                           toRawPtrFunc, clangDecl),
+                clangDecl->getLocation());
+            return false;
+          }
+
+          auto pointeeType = toRawPtrFunc->getResultInterfaceType()
+                                 ->lookThroughSingleOptionalType();
+          ClassDecl *referenceDecl = pointeeType->getClassOrBoundGenericClass();
+
+          if (toRawPtrFunc->getParameters()->size() != 0 || !referenceDecl) {
+            Impl.addImportDiagnostic(
+                clangDecl,
+                Diagnostic(diag::refcounted_ptr_torawpointer_wrong_signature,
+                           toRawPtrFunc, clangDecl),
+                clangDecl->getLocation());
+            return false;
+          }
+
+          auto asReferenceDecl =
+              synthesizer.createSmartPtrBridgingProperty(toRawPtrFunc);
+          smartPtr->addMember(asReferenceDecl);
+          smartPtr->addMemberToLookupTable(asReferenceDecl);
+          break;
+        }
+      }
+      return true;
+    }
+
     Decl *VisitRecordDecl(const clang::RecordDecl *decl) {
       // Track whether this record contains fields we can't reference in Swift
       // as stored properties.
@@ -2735,6 +2815,9 @@ namespace {
 
       // If we need it, add an explicit "deinit" to this type.
       synthesizer.addExplicitDeinitIfRequired(result, decl);
+
+      if (!injectBridgingConversionsForRefCountedSmartPtrs(result))
+        return nullptr;
 
       result->setMemberLoader(&Impl, 0);
       return result;

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -111,6 +111,33 @@
   __attribute__((swift_attr("release:immortal")))    \
   __attribute__((swift_attr("unsafe")))
 
+/// The annotated `class` or `struct` is a smart pointer to an intrusively
+/// reference counted object. The pointee type is expected to be a Swift shared
+/// reference. The presence of this annotation will introduce conversion
+/// functions between the smart pointer type and Swift's native reference type.
+/// The conversion function is expected to return a +0 raw pointer to a Swift
+/// shared reference type.
+///
+///  ```c++
+///   template <class T>
+///   struct SWIFT_REFCOUNTED_PTR(.getPtr) Ptr {
+///     T *_Nullable getPtr() const { return ptr; }
+///   };
+///
+///   using PtrOfSharedRef = Ptr<SharedRef>;
+///  ```
+///
+/// In Swift, we can convert the smart pointer type to the corresponding native
+/// Swift reference:
+///  ```swift
+///  func f(_ x: PtrOfSharedRef) {
+///    let y = x.asReference
+///  }
+///  ```
+#define SWIFT_REFCOUNTED_PTR(_toRawPointer)                                            \
+  __attribute__((swift_attr(                                                           \
+      "@_refCountedPtr(ToRawPointer: \"" _CXX_INTEROP_STRINGIFY(_toRawPointer) "\")")))
+
 /// Specifies a name that will be used in Swift for this declaration instead of its original name.
 #define SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
 
@@ -280,6 +307,7 @@
 #define SWIFT_SHARED_REFERENCE(_retain, _release)
 #define SWIFT_IMMORTAL_REFERENCE
 #define SWIFT_UNSAFE_REFERENCE
+#define SWIFT_REFCOUNTED_PTR(_toRawPointer)
 #define SWIFT_NAME(_name)
 #define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName)
 #define SWIFT_COMPUTED_PROPERTY

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -14,6 +14,7 @@
 #define SWIFT_SWIFT_DECL_SYNTHESIZER_H
 
 #include "ImporterImpl.h"
+#include "swift/AST/Decl.h"
 #include "swift/ClangImporter/ClangImporter.h"
 
 namespace swift {
@@ -133,6 +134,9 @@ public:
                                                      VarDecl *storedRawValue,
                                                      bool wantLabel,
                                                      bool wantBody);
+
+  /// Create a constructor that initializes a class from a smart pointer.
+  VarDecl *createSmartPtrBridgingProperty(FuncDecl *bridgingFunction);
 
   /// Make a struct declaration into a raw-value-backed struct, with
   /// bridged computed rawValue property which differs from stored backing

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -97,3 +97,8 @@ module FRTReferenceReturns {
   header "frt-reference-returns.h"
   requires cplusplus
 }
+
+module RefCountedSmartPtrs {
+  header "refcounted-smartptrs.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <cstdio>
+#include <swift/bridging>
+
+class RefCountedBase {
+public:
+  RefCountedBase() : _refCount(1) { printf("created\n"); }
+
+protected:
+  virtual ~RefCountedBase() { printf("destroyed"); }
+
+private:
+
+  RefCountedBase(const RefCountedBase &) = delete;
+  RefCountedBase &operator=(const RefCountedBase &) = delete;
+  RefCountedBase(RefCountedBase &&) = delete;
+  RefCountedBase &operator=(RefCountedBase &&) = delete;
+
+  int _refCount;
+
+  int method() const { return 42; }
+
+  friend void retainSharedFRT(RefCountedBase *_Nonnull);
+  friend void releaseSharedFRT(RefCountedBase *_Nonnull);
+} SWIFT_SHARED_REFERENCE(retainSharedFRT, releaseSharedFRT);
+
+inline void retainSharedFRT(RefCountedBase *_Nonnull x) {
+  ++x->_refCount;
+}
+
+inline void releaseSharedFRT(RefCountedBase *_Nonnull x) {
+  --x->_refCount;
+  if (x->_refCount == 0)
+    delete x;
+}
+
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.getPtr) Ref {
+  Ref(T *_Nonnull ptr) : ptr(ptr) { retainSharedFRT(ptr); }
+  ~Ref() { releaseSharedFRT(ptr); }
+  Ref(const Ref &other) : ptr(other.ptr) { retainSharedFRT(ptr); }
+  Ref(Ref &&other) = delete;
+  Ref &operator=(const Ref &other) {
+    releaseSharedFRT(ptr);
+    ptr = other.ptr;
+    retainSharedFRT(ptr);
+    return *this;
+  }
+  Ref &operator=(Ref &&other) = delete;
+
+  T &operator*() const { return *ptr; }
+  T *_Nonnull getPtr() const { return ptr; }
+
+  T *_Nonnull ptr;
+};
+
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.get) Ptr {
+  Ptr(T *_Nullable ptr) : ptr(ptr) { retainSharedFRT(ptr); }
+  ~Ptr() { releaseSharedFRT(ptr); }
+  Ptr(const Ptr &other) : ptr(other.ptr) { retainSharedFRT(ptr); }
+  Ptr(Ptr &&other) : ptr(other.ptr) { other.ptr = nullptr; }
+  Ptr &operator=(const Ptr &other) {
+    releaseSharedFRT(ptr);
+    ptr = other.ptr;
+    retainSharedFRT(ptr);
+    return *this;
+  }
+  Ptr &operator=(Ptr &&other) {
+    releaseSharedFRT(ptr);
+    ptr = other.ptr;
+    other.ptr = nullptr;
+    return *this;
+  }
+  T &operator*() const { return *ptr; }
+  operator bool() const { return ptr; }
+  SWIFT_NAME(get())
+  T *_Nullable getPtr() const { return ptr; }
+
+  T *_Nullable ptr;
+};
+
+template <class T>
+struct DerivedRefBase {
+  DerivedRefBase(T *_Nonnull ptr) : ptr(ptr) { retainSharedFRT(ptr); }
+  ~DerivedRefBase() { releaseSharedFRT(ptr); }
+  DerivedRefBase(const DerivedRefBase &other) : ptr(other.ptr) { retainSharedFRT(ptr); }
+  DerivedRefBase(DerivedRefBase &&other) = delete;
+  DerivedRefBase &operator=(const DerivedRefBase &other) {
+    releaseSharedFRT(ptr);
+    ptr = other.ptr;
+    retainSharedFRT(ptr);
+    return *this;
+  }
+  DerivedRefBase &operator=(DerivedRefBase &&other) = delete;
+  T &operator*() const { return *ptr; }
+  T *_Nonnull getPtr() const { return ptr; }
+
+  T *_Nonnull ptr;
+};
+
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.getPtr) DerivedRef : DerivedRefBase<T> {
+  using DerivedRefBase<T>::DerivedRefBase;
+};
+
+using RefOfBase = Ref<RefCountedBase>;
+using PtrOfBase = Ptr<RefCountedBase>;
+using DerivedRefOfBase = DerivedRef<RefCountedBase>;
+
+namespace errors { // expected-note * {{'errors' declared here}}
+struct __attribute__((
+    swift_attr("@_refCountedPtr(Nullability: \"Nullable\")"))) MissingToRawPtr {};
+// expected-note@-1 * {{SWIFT_REFCOUNTED_PTR on 'MissingToRawPtr' is missing required '_toRawPointer' parameter}}
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) MissingConversionFunction {};
+// expected-note@-1 * {{cannot find function '.getPtr' specified in '_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR 'MissingConversionFunction'}}
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) MultipleConversionFunctions {
+// expected-note@-1 * {{there are multiple candidates of function '.getPtr' specified in '_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR 'MultipleConversionFunctions'}}
+  void getPtr();
+  void getPtr(int a);
+};
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) WrongConversionSignature {
+// expected-note@-1 * {{function 'getPtr()' specified in '_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR on 'WrongConversionSignature' has incorrect signature; expected a function that takes no arguments and returns a pointer to a foreign reference type}}
+  void getPtr();
+};
+
+class SWIFT_REFCOUNTED_PTR(.getPtr) PrivateConversionFunction {
+  // expected-note@-1 * {{cannot find function '.getPtr' specified in '_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR 'PrivateConversionFunction'}}
+  RefCountedBase *_Nonnull getPtr();
+};
+} // namespace errors

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-errors.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S%{fs-sep}Inputs -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}refcounted-smartptrs.h
+import RefCountedSmartPtrs
+
+func triggerWarnings(_ a: errors.MissingToRawPtr,               // @expected-error {{'MissingToRawPtr' is not a member type of enum '__ObjC.errors'}}
+                     _ b: errors.MissingConversionFunction,     // @expected-error {{'MissingConversionFunction' is not a member type of enum '__ObjC.errors'}}
+                     _ c: errors.MultipleConversionFunctions,   // @expected-error {{'MultipleConversionFunctions' is not a member type of enum '__ObjC.errors'}}
+                     _ d: errors.WrongConversionSignature,      // @expected-error {{'WrongConversionSignature' is not a member type of enum '__ObjC.errors'}}
+                     _ e: errors.PrivateConversionFunction) {   // @expected-error {{'PrivateConversionFunction' is not a member type of enum '__ObjC.errors'}}
+}

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
@@ -1,0 +1,19 @@
+// RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import RefCountedSmartPtrs
+
+func conversions(_ r: RefCountedBase) {
+    let ref = RefOfBase(r)
+    let ptr = PtrOfBase(r)
+    let _ = ref.asReference
+    let _ = ptr.asReference!
+    let derivedRef = DerivedRefOfBase(r)
+    let _ = derivedRef.asReference
+}
+
+conversions(RefCountedBase())
+
+// CHECK: created
+// CHECK: destroyed


### PR DESCRIPTION
This attribute introduces some conversions between the annotated smart pointer type and the native swift reference type. In the future we plan to introduce bridging so the smart pointer type can be hidden in the signature and we can automatically convert it to the native Swift reference type on the ABI boundaries.

This PR is using a new way to use swift_attr attributes. Instead of doing the parsing in the clang importer it falls back to Swift's attribute parsing and makes sure that the annotation has valid Swift attribute syntax.

rdar://156521316