### PR TITLE
utils: Add option to build LLVM as shared library

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -27,8 +27,6 @@ set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
 
 # Disable certain targets to reduce the configure time or to avoid configuration
 # differences (and in some cases weird build errors on a complete build).
-set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
-set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
 set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
 set(LLVM_ENABLE_LIBXML2 YES CACHE BOOL "")
 set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
@@ -40,7 +38,6 @@ set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
 set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
 set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
 set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
-set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 
 set(CLANG_ENABLE_LIBXML2 NO CACHE BOOL "")
 

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -27,8 +27,6 @@ set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
 
 # Disable certain targets to reduce the configure time or to avoid configuration
 # differences (and in some cases weird build errors on a complete build).
-set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
-set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
 set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
 set(LLVM_ENABLE_LIBXML2 YES CACHE BOOL "")
 set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
@@ -40,7 +38,6 @@ set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
 set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
 set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
 set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
-set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 
 set(CLANG_ENABLE_LIBXML2 NO CACHE BOOL "")
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -220,6 +220,7 @@ param
   [switch] $IncludeNoAsserts = $false,
   [ValidateSet("debug", "release")]
   [string] $FoundationTestConfiguration = "debug",
+  [switch] $BuildLlvmDylib = $false,
 
   [switch] $Summary,
   [switch] $ToBatch
@@ -2263,7 +2264,29 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
     $SwiftFlags += @("-use-ld=lld");
   }
 
-  return $TestDefines + $DebugDefines + @{
+  $DylibDefines = if ($BuildLlvmDylib) {
+    @{
+      LLVM_BUILD_LLVM_DYLIB = "YES";
+      LLVM_BUILD_LLVM_DYLIB_VIS = "YES";
+      LLVM_BUILD_LLVM_C_DYLIB = "YES";
+      LLVM_DYLIB_EXPORT_INLINES = "YES";
+      LLVM_LINK_LLVM_DYLIB = "YES";
+      LLVM_TOOL_LLVM_SHLIB_BUILD = "YES";
+      CLANG_LINK_CLANG_DYLIB = "NO";
+    }
+  } else {
+    @{
+      LLVM_BUILD_LLVM_DYLIB = "NO";
+      LLVM_BUILD_LLVM_DYLIB_VIS = "NO";
+      LLVM_BUILD_LLVM_C_DYLIB = "NO";
+      LLVM_DYLIB_EXPORT_INLINES = "NO";
+      LLVM_LINK_LLVM_DYLIB = "NO";
+      LLVM_TOOL_LLVM_SHLIB_BUILD = "NO";
+      CLANG_LINK_CLANG_DYLIB = "NO";
+    }
+  }
+
+  return $TestDefines + $DebugDefines + $DylibDefines + @{
     CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
     CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
     CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";


### PR DESCRIPTION
This moves some of the CMake compiler defines related to building LLVM as a dynamic library from the CMake cache file to build.ps1. This is currently experimental.

This effort is tracked in #85241.