### PR TITLE
[CSOptimizer] Also favor existential metatype candidates in paramType isAny fast path

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1429,11 +1429,22 @@ static void determineBestChoicesInContext(
         }
       }
 
-      // If the parameter is `Any` we assume that all candidates are
-      // convertible to it, which makes it a perfect match. The solver
-      // would then decide whether erasing to an existential is preferable.
-      if (paramType->isAny())
-        return 1;
+      if (paramType->isAnyExistentialType()) {
+        // If the parameter is `Any` we assume that all candidates are
+        // convertible to it, which makes it a perfect match. The solver
+        // would then decide whether erasing to an existential is preferable.
+        if (paramType->isAny())
+          return 1;
+
+        // If the parameter is `Any.Type` we assume that all metatype
+        // candidates are convertible to it.
+        if (auto *EMT = paramType->getAs<ExistentialMetatypeType>()) {
+          if (EMT->getExistentialInstanceType()->isAny() &&
+              (candidateType->is<ExistentialMetatypeType>() ||
+               candidateType->is<MetatypeType>()))
+            return 1;
+        }
+      }
 
       // Check if a candidate could be matched to a parameter by
       // an existential opening.

--- a/test/Interpreter/issue-85020.swift
+++ b/test/Interpreter/issue-85020.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/85020
+
+struct Store {
+  let theType: Any.Type
+
+  init(of theType: Any.Type) {
+    print("init from TYPE: \(theType)")
+    self.theType = theType
+  }
+
+  init(of instance: Any) {
+    print("init from VALUE: \(instance)")
+    self.init(of: type(of: instance))
+  }
+}
+
+let a: (any Numeric)? = 42
+print("a: \(type(of: a))")
+// CHECK: a: Optional<Numeric>
+
+let storeA = Store(of: a!)
+// CHECK-NEXT: init from VALUE: 42
+// CHECK-NEXT: init from TYPE: Int
+
+let b: (any Numeric.Type)? = type(of: 42)
+print("b: \(type(of: b))")
+// CHECK-NEXT: b: Optional<Numeric.Type>
+
+let storeB = Store(of: b!)
+// CHECK-NEXT: init from TYPE: Int
+


### PR DESCRIPTION
Adds a test case and a fix to CSOptimizer, regarding a fast path with `Any` parameters that recently landed (https://github.com/swiftlang/swift/commit/c46f9e4f45d5a7195129bdf72d039a4c3d1dc99b). This change introduced a regression where it would cause `(T.Type) -> (Any)` disjunctions to outrank `(T.Type) -> (Any.Type)`.

Refines the check to also favor existential metatype candidates.

Resolves: https://github.com/swiftlang/swift/issues/85020
Resolves: rdar://163074598