### PR TITLE
Sema: Fix infinite loop in OrderDeclarations::operator() [6.3]

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2542,6 +2542,9 @@ namespace {
         auto opposite = (*this)(rightDecl, leftDecl);
         if (normal != opposite)
           return normal;
+
+        leftContext = leftContext->getParent();
+        rightContext = rightContext->getParent();
       }
 
       // Final tiebreaker: Kind

--- a/test/multifile/Inputs/objc_selector_conflict_multifile_other.swift
+++ b/test/multifile/Inputs/objc_selector_conflict_multifile_other.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension EmitTest {
+  @objc static func emit(_ number : Int) -> Int {
+  // expected-note@-1 {{'emit' previously declared here}}
+    return 0
+  }
+}

--- a/test/multifile/objc_selector_conflict_multifile.swift
+++ b/test/multifile/objc_selector_conflict_multifile.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift %S/Inputs/objc_selector_conflict_multifile_other.swift
+// REQUIRES: objc_interop
+
+import Foundation
+
+class EmitTest {}
+
+extension EmitTest {
+  @objc static func emit(_ string : String) -> String {
+    // expected-error@-1 {{method 'emit' with Objective-C selector 'emit:' conflicts with previous declaration with the same Objective-C selector}}
+    return ""
+  }
+}


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/85656.

* **Description:** If the two declarations were in different source files, we would get stuck in the while loop at the end.

* **Scope of the issue:** Compiler would hang when attempting to diagnose `@objc` selector conflict in WMO build with multiple source files.

* **Origination:** Looks like this was introduced in 6.1 with 07b9fe9ce6692da25f386fb933deffb71c21b8a2.

* **Radar:** rdar://164519548.

* **Risk:** Very low.

* **Reviewed by:** @DougGregor 
