### PR TITLE
[Index] Mark declarations in libraries compiled with `-library-level spi` as SPI even if they don’t have `@_spi`

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1974,6 +1974,36 @@ bool shouldOutputEffectiveAccessOfValueSymbol(SymbolInfo Info) {
   }
 }
 
+static SymbolProperty getAccessLevel(const ValueDecl *D) {
+  AccessScope Scope = D->getFormalAccessScope();
+  if (Scope.isPublic()) {
+    if (D->isSPI()) {
+      return SymbolProperty::SwiftAccessControlSPI;
+    }
+    // If the entire library is marked as SPI, inherit that access level.
+    switch (D->getModuleContext()->getLibraryLevel()) {
+    case LibraryLevel::Other:
+      return SymbolProperty::SwiftAccessControlPublic;
+    case LibraryLevel::IPI:
+      return SymbolProperty::SwiftAccessControlSPI;
+    case LibraryLevel::SPI:
+      return SymbolProperty::SwiftAccessControlSPI;
+    case LibraryLevel::API:
+      return SymbolProperty::SwiftAccessControlPublic;
+    }
+  } else if (Scope.isPackage()) {
+    return SymbolProperty::SwiftAccessControlPackage;
+  } else if (Scope.isInternal()) {
+    return SymbolProperty::SwiftAccessControlInternal;
+  } else if (Scope.isFileScope()) {
+    return SymbolProperty::SwiftAccessControlFilePrivate;
+  } else if (Scope.isPrivate()) {
+    return SymbolProperty::SwiftAccessControlLessThanFilePrivate;
+  } else {
+    llvm_unreachable("Unsupported access scope");
+  }
+}
+
 bool IndexSwiftASTWalker::initIndexSymbol(
     ValueDecl *D, SourceLoc Loc, bool IsRef, IndexSymbol &Info,
     llvm::function_ref<bool(IndexSymbol &)> updateInfo) {
@@ -2023,25 +2053,7 @@ bool IndexSwiftASTWalker::initIndexSymbol(
   if (shouldOutputEffectiveAccessOfValueSymbol(Info.symInfo) &&
       (Info.roles & (SymbolRoleSet)SymbolRole::Reference) == 0 &&
       !isLocalSymbol(D)) {
-    AccessScope Scope = D->getFormalAccessScope();
-    if (Scope.isPublic()) {
-      if (D->isSPI()) {
-        Info.symInfo.Properties |= SymbolProperty::SwiftAccessControlSPI;
-      } else {
-        Info.symInfo.Properties |= SymbolProperty::SwiftAccessControlPublic;
-      }
-    } else if (Scope.isPackage()) {
-      Info.symInfo.Properties |= SymbolProperty::SwiftAccessControlPackage;
-    } else if (Scope.isInternal()) {
-      Info.symInfo.Properties |= SymbolProperty::SwiftAccessControlInternal;
-    } else if (Scope.isFileScope()) {
-      Info.symInfo.Properties |= SymbolProperty::SwiftAccessControlFilePrivate;
-    } else if (Scope.isPrivate()) {
-      Info.symInfo.Properties |=
-          SymbolProperty::SwiftAccessControlLessThanFilePrivate;
-    } else {
-      llvm_unreachable("Unsupported access scope");
-    }
+    Info.symInfo.Properties |= getAccessLevel(D);
   }
 
   return false;

--- a/test/Index/access_level_library_level.swift
+++ b/test/Index/access_level_library_level.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule | %FileCheck %s --check-prefix NO_LIBRARY_LEVEL
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule -library-level api | %FileCheck %s --check-prefix API_LIBRARY_LEVEL
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule -library-level spi | %FileCheck %s --check-prefix SPI_LIBRARY_LEVEL
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule -library-level ipi | %FileCheck %s --check-prefix IPI_LIBRARY_LEVEL
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -package-name MyModule -library-level other | %FileCheck %s --check-prefix OTHER_LIBRARY_LEVEL
+
+public func test() {}
+// NO_LIBRARY_LEVEL: [[@LINE-1]]:13 | function(public)/Swift | test() | {{.*}} | Def | rel: 0
+// API_LIBRARY_LEVEL: [[@LINE-2]]:13 | function(public)/Swift | test() | {{.*}} | Def | rel: 0
+// SPI_LIBRARY_LEVEL: [[@LINE-3]]:13 | function(SPI)/Swift | test() | {{.*}} | Def | rel: 0
+// IPI_LIBRARY_LEVEL: [[@LINE-4]]:13 | function(SPI)/Swift | test() | {{.*}} | Def | rel: 0
+// OTHER_LIBRARY_LEVEL: [[@LINE-5]]:13 | function(public)/Swift | test() | {{.*}} | Def | rel: 0

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -557,6 +557,11 @@ Typecheck("typecheck",
           llvm::cl::cat(Category),
           llvm::cl::init(false));
 
+static llvm::cl::opt<std::string>
+LibraryLevel("library-level",
+          llvm::cl::desc("Library distribution level 'api', 'spi' or 'other'"),
+          llvm::cl::cat(Category));
+
 static llvm::cl::opt<bool>
 Playground("playground",
            llvm::cl::desc("Whether coloring in playground"),
@@ -4789,7 +4794,19 @@ int main(int argc, char *argv[]) {
   }
 
   InitInvok.computeAArch64TBIOptions();
-
+  if (options::LibraryLevel == "api") {
+    InitInvok.getLangOptions().LibraryLevel = LibraryLevel::API;
+  } else if (options::LibraryLevel == "spi") {
+    InitInvok.getLangOptions().LibraryLevel = LibraryLevel::SPI;
+  } else if (options::LibraryLevel == "ipi") {
+    InitInvok.getLangOptions().LibraryLevel = LibraryLevel::IPI;
+  } else if (options::LibraryLevel == "other") {
+    InitInvok.getLangOptions().LibraryLevel = LibraryLevel::Other;
+  } else if (options::LibraryLevel != "") {
+    llvm::errs() << "invalid library-level: " << options::LibraryLevel << '\n';
+    return 1;
+  }
+  
   if (!options::InProcessPluginServerPath.empty()) {
     InitInvok.getSearchPathOptions().InProcessPluginServerPath =
         options::InProcessPluginServerPath;


### PR DESCRIPTION
To the best of my understanding `-library-level spi` can be thought of similar to wrapping the entire library with `@_spi(_)` and thus all public declarations get demoted to SPI, similar to public functions in an `@_spi` class. Respect that when indexing.

Noticed this while trying to align the definition of SPI in indexing with that of the [APIGenRecorder](https://github.com/swiftlang/swift/blob/c8178996c9ccae306983ccb9957631e603f19dcd/lib/IRGen/TBDGen.cpp#L702-L722)