### PR TITLE
[ASTDumper] Fix some more JSON AST dump crashes.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1484,7 +1484,11 @@ namespace {
         printFlag(value.isLocalCapture(), "is_local_capture");
         printFlag(value.isDynamicSelfMetadata(), "is_dynamic_self_metadata");
         if (auto *D = value.getDecl()) {
-          printRec(D, Label::always("decl"));
+          // We print the decl ref, not the full decl, to avoid infinite
+          // recursion when a function captures itself (and also because
+          // those decls are already printed elsewhere, so we don't need to
+          // print what could be a very large amount of information twice).
+          printDeclRefField(D, Label::always("decl"));
         }
         if (auto *E = value.getExpr()) {
           printRec(E, Label::always("expr"));

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -260,6 +260,12 @@ std::string typeUSR(Type type) {
   if (!type)
     return "";
 
+  if (type->is<ModuleType>()) {
+    // ASTMangler does not support "module types". This can appear, for
+    // example, on the left-hand side of a `DotSyntaxBaseIgnoredExpr` for a
+    // module-qualified free function call: `Swift.print()`.
+    return "";
+  }
   if (type->hasArchetype()) {
     type = type->mapTypeOutOfEnvironment();
   }
@@ -279,6 +285,13 @@ std::string typeUSR(Type type) {
 std::string declTypeUSR(const ValueDecl *D) {
   if (!D)
     return "";
+
+  if (isa<ModuleDecl>(D)) {
+    // ASTMangler does not support "module types". This can appear, for
+    // example, on the left-hand side of a `DotSyntaxBaseIgnoredExpr` for a
+    // module-qualified free function call: `Swift.print()`.
+    return "";
+  }
 
   std::string usr;
   llvm::raw_string_ostream os(usr);

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -491,3 +491,15 @@ func toReplaceWith(arg: Int) {}
 func moduleTypeUSRRegressionTest() {
     Swift.print("")
 }
+
+// Regression test: When a function captures another function, don't print the
+// entire captured decl. This causes infinite recursion in the dumper when a
+// local (nested) function captures itself.
+func outerFn() {
+    func innerFun(shouldRecurse: Bool) {
+        if shouldRecurse {
+            innerFun(shouldRecurse: false)
+        }
+    }
+    innerFun(shouldRecurse: true)
+}

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -484,3 +484,10 @@ dynamic func toBeReplaced(arg: Int) {}
 
 @_dynamicReplacement(for: toBeReplaced(arg:))
 func toReplaceWith(arg: Int) {}
+
+// Regression test: Swift 6.2 and earlier crashed trying to form the type USR
+// of the "module type" of a `DotSyntaxBaseIgnoredExpr` when calling a
+// module-qualified free function.
+func moduleTypeUSRRegressionTest() {
+    Swift.print("")
+}


### PR DESCRIPTION
1. Don't attempt to compute type USR for `ModuleType`s.

    `ModuleType`s show up in some rare places, like the left-hand-side of a `DotSyntaxBaseIgnoredExpr` for a module-qualified function call. ASTMangler does not support these because they're not real types.

2. Print decl-refs, not full decls, for function captures.

    This avoids infinite recursion when a function captures itself; e.g.,

    ```swift
    func foo() {
      func bar() {
        bar()
      }
      bar()
    }
    ```

    It also just avoids printing unnecessarily verbose information, since those decls would have already been dumped elsewhere in the tree.