### PR TITLE
[6.3 🍒][CSOptimizer] Also favor existential metatype candidates in paramType isAny fast path

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1434,11 +1434,22 @@ static void determineBestChoicesInContext(
         }
       }
 
-      // If the parameter is `Any` we assume that all candidates are
-      // convertible to it, which makes it a perfect match. The solver
-      // would then decide whether erasing to an existential is preferable.
-      if (paramType->isAny())
-        return 1;
+      if (paramType->isAnyExistentialType()) {
+        // If the parameter is `Any` we assume that all candidates are
+        // convertible to it, which makes it a perfect match. The solver
+        // would then decide whether erasing to an existential is preferable.
+        if (paramType->isAny())
+          return 1;
+
+        // If the parameter is `Any.Type` we assume that all metatype
+        // candidates are convertible to it.
+        if (auto *EMT = paramType->getAs<ExistentialMetatypeType>()) {
+          if (EMT->getExistentialInstanceType()->isAny() &&
+              (candidateType->is<ExistentialMetatypeType>() ||
+               candidateType->is<MetatypeType>()))
+            return 1;
+        }
+      }
 
       // Check if a candidate could be matched to a parameter by
       // an existential opening.

--- a/test/Interpreter/issue-85020.swift
+++ b/test/Interpreter/issue-85020.swift
@@ -2,6 +2,8 @@
 
 // https://github.com/swiftlang/swift/issues/85020
 
+// REQUIRES: executable_test
+
 struct Store {
   let theType: Any.Type
 

--- a/test/Interpreter/issue-85020.swift
+++ b/test/Interpreter/issue-85020.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/85020
+
+struct Store {
+  let theType: Any.Type
+
+  init(of theType: Any.Type) {
+    print("init from TYPE: \(theType)")
+    self.theType = theType
+  }
+
+  init(of instance: Any) {
+    print("init from VALUE: \(instance)")
+    self.init(of: type(of: instance))
+  }
+}
+
+let a: (any Numeric)? = 42
+print("a: \(type(of: a))")
+// CHECK: a: Optional<Numeric>
+
+let storeA = Store(of: a!)
+// CHECK-NEXT: init from VALUE: 42
+// CHECK-NEXT: init from TYPE: Int
+
+let b: (any Numeric.Type)? = type(of: 42)
+print("b: \(type(of: b))")
+// CHECK-NEXT: b: Optional<Numeric.Type>
+
+let storeB = Store(of: b!)
+// CHECK-NEXT: init from TYPE: Int
+


### PR DESCRIPTION
- **Explanation**:
Resolves a regression in overload resolution with metatype candidates.

- **Scope**:
Besides resolving the regression, the fix adds an additional fast path for metatypes, so it is not expected to negatively impact performance.
- **Issues**:
Resolves: https://github.com/swiftlang/swift/issues/85020
Resolves: rdar://163074598
- **Original PRs**:
https://github.com/swiftlang/swift/pull/85652
- **Risk**:
Low. The change only tweaks overload scoring when the parameter is Any/Any.Type, returning to the same behavior as is in current/previous releases.
- **Testing**:
Adds a test case to catch this specific behavior. I also built a custom toolchain with this fix and verified that the issue is resolved in the original project in which it was discovered.
- **Reviewers**:
@xedin