### PR TITLE
🍒 [windows] add Embeddable Python 3.10.1 to build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1013,16 +1013,6 @@ function Get-Dependencies {
       Expand-ZipFile "$FileName.zip" "$BinaryCache" "$FileName"
       Write-Output "$ArchName Python $PythonVersion installed."
     }
-    if (-not $EmbeddedPython) {
-      return
-    }
-    $PythonPTHPath = "$BinaryCache/$FileName/$(Get-PythonLibName)._pth"
-    $PythonPTHContent = [System.IO.File]::ReadAllText($PythonPTHPath).Replace("#import site","import site")
-    [System.IO.File]::WriteAllText($PythonPTHPath, $PythonPTHContent)
-    $GetPipURL = "https://bootstrap.pypa.io/get-pip.py"
-    $GetPipPath = "$BinaryCache/$FileName/get-pip.py"
-    $WebClient.DownloadFile($GetPipURL, $GetPipPath)
-    & "$BinaryCache/$FileName/python.exe" $GetPipPath
   }
 
   function Install-PIPIfNeeded() {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1789,7 +1789,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     LLDB_PYTHON_EXE_RELATIVE_PATH = "python.exe";
     LLDB_PYTHON_EXT_SUFFIX = ".pyd";
     LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";
-    LLDB_PYTHON_DLL_RELATIVE_PATH = "../../../../Python-$PythonVersion";
+    LLDB_PYTHON_DLL_RELATIVE_PATH = "../../../../Python-$PythonVersion/usr/bin";
     LLDB_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "lldb-tblgen.exe");
     LLDB_TEST_MAKE = "$BinaryCache\GnuWin32Make-4.4.1\bin\make.exe";
     LLVM_CONFIG_PATH = (Join-Path -Path $BuildTools -ChildPath "llvm-config.exe");

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -139,7 +139,7 @@ param
   [ValidateSet("Asserts", "NoAsserts")]
   [string] $PinnedToolchainVariant = "Asserts",
   [ValidatePattern('^\d+(\.\d+)*$')]
-  [string] $PythonVersion = "3.9.10",
+  [string] $PythonVersion = "3.10.1",
   [ValidatePattern("^r(?:[1-9]|[1-9][0-9])(?:[a-z])?$")]
   [string] $AndroidNDKVersion = "r27c",
   [ValidatePattern("^\d+\.\d+\.\d+(?:-\w+)?")]

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -348,7 +348,25 @@ $KnownPythons = @{
       URL = "https://www.nuget.org/api/v2/package/pythonarm64/3.9.10";
       SHA256 = "429ada77e7f30e4bd8ff22953a1f35f98b2728e84c9b1d006712561785641f69";
     };
-  }
+  };
+  "3.10.1" = @{
+    AMD64 = @{
+      URL = "https://www.nuget.org/api/v2/package/python/3.10.1";
+      SHA256 = "987a0e446d68900f58297bc47dc7a235ee4640a49dace58bc9f573797d3a8b33";
+    };
+    AMD64_Embedded = @{
+      URL = "https://www.python.org/ftp/python/3.10.1/python-3.10.1-embed-amd64.zip";
+      SHA256 = "502670dcdff0083847abf6a33f30be666594e7e5201cd6fccd4a523b577403de";
+    };
+    ARM64 = @{
+      URL = "https://www.nuget.org/api/v2/package/pythonarm64/3.10.1";
+      SHA256 = "16becfccedf1269ff0b8695a13c64fac2102a524d66cecf69a8f9229a43b10d3";
+    };
+    ARM64_Embedded = @{
+      URL = "https://www.python.org/ftp/python/3.10.1/python-3.10.1-embed-arm64.zip";
+      SHA256 = "1f9e215fe4e8f22a8e8fba1859efb1426437044fb3103ce85794630e3b511bc2";
+    };
+  };
 }
 
 $PythonWheels = @{
@@ -527,12 +545,20 @@ function Get-PythonPath([Hashtable] $Platform) {
   return [IO.Path]::Combine("$BinaryCache\", "Python$($Platform.Architecture.CMakeName)-$PythonVersion")
 }
 
+function Get-EmbeddedPythonPath([Hashtable] $Platform) {
+  return [IO.Path]::Combine("$BinaryCache\", "EmbeddedPython$($Platform.Architecture.CMakeName)-$PythonVersion")
+}
+
 function Get-PythonExecutable {
   return [IO.Path]::Combine((Get-PythonPath $BuildPlatform), "tools", "python.exe")
 }
 
 function Get-PythonScriptsPath {
   return [IO.Path]::Combine((Get-PythonPath $BuildPlatform), "tools", "Scripts")
+}
+
+function Get-EmbeddedPythonInstallDir() {
+  return [IO.Path]::Combine("$ImageRoot\", "Program Files", "Swift", "Python-$PythonVersion")
 }
 
 function Get-InstallDir([Hashtable] $Platform) {
@@ -852,6 +878,10 @@ function Invoke-VsDevShell([Hashtable] $Platform) {
   }
 }
 
+function Get-PythonLibName() {
+  return "python{0}{1}" -f ([System.Version]$PythonVersion).Major, ([System.Version]$PythonVersion).Minor
+}
+
 function Get-Dependencies {
   Write-Host "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Fetch-Dependencies ..." -ForegroundColor Cyan
   $ProgressPreference = "SilentlyContinue"
@@ -967,19 +997,32 @@ function Get-Dependencies {
   New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
   Export-Toolchain "$PinnedToolchain.exe" $BinaryCache $PinnedToolchain
 
-  function Get-KnownPython([string] $ArchName) {
+  function Get-KnownPython([string] $ArchName, [bool] $EmbeddedPython = $false) {
     if (-not $KnownPythons.ContainsKey($PythonVersion)) {
       throw "Unknown python version: $PythonVersion"
     }
-    return $KnownPythons[$PythonVersion].$ArchName
+    $Key = $(if ($EmbeddedPython) { "${ArchName}_Embedded" } else { $ArchName })
+    return $KnownPythons[$PythonVersion][$Key]
   }
 
-  function Install-Python([string] $ArchName) {
-    $Python = Get-KnownPython $ArchName
-    DownloadAndVerify $Python.URL "$BinaryCache\Python$ArchName-$PythonVersion.zip" $Python.SHA256
+  function Install-Python([string] $ArchName, [bool] $EmbeddedPython = $false) {
+    $Python = Get-KnownPython $ArchName $EmbeddedPython
+    $FileName = $(if ($EmbeddedPython) { "EmbeddedPython$ArchName-$PythonVersion" } else { "Python$ArchName-$PythonVersion" })
+    DownloadAndVerify $Python.URL "$BinaryCache\$FileName.zip" $Python.SHA256
     if (-not $ToBatch) {
-      Expand-ZipFile Python$ArchName-$PythonVersion.zip "$BinaryCache" Python$ArchName-$PythonVersion
+      Expand-ZipFile "$FileName.zip" "$BinaryCache" "$FileName"
+      Write-Output "$ArchName Python $PythonVersion installed."
     }
+    if (-not $EmbeddedPython) {
+      return
+    }
+    $PythonPTHPath = "$BinaryCache/$FileName/$(Get-PythonLibName)._pth"
+    $PythonPTHContent = [System.IO.File]::ReadAllText($PythonPTHPath).Replace("#import site","import site")
+    [System.IO.File]::WriteAllText($PythonPTHPath, $PythonPTHContent)
+    $GetPipURL = "https://bootstrap.pypa.io/get-pip.py"
+    $GetPipPath = "$BinaryCache/$FileName/get-pip.py"
+    $WebClient.DownloadFile($GetPipURL, $GetPipPath)
+    & "$BinaryCache/$FileName/python.exe" $GetPipPath
   }
 
   function Install-PIPIfNeeded() {
@@ -1017,12 +1060,13 @@ function Get-Dependencies {
     }
   }
 
+  # Ensure Python modules that are required as host build tools
   Install-Python $HostArchName
+  Install-Python $HostArchName $true
   if ($IsCrossCompiling) {
     Install-Python $BuildArchName
+    Install-Python $BuildArchName $true
   }
-
-  # Ensure Python modules that are required as host build tools
   Install-PythonModules
 
   if ($Android) {
@@ -1706,7 +1750,7 @@ function Load-LitTestOverrides($Filename) {
 function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
   $BuildTools = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform BuildTools), "bin")
   $PythonRoot = [IO.Path]::Combine((Get-PythonPath $Platform), "tools")
-  $PythonLibName = "python{0}{1}" -f ([System.Version]$PythonVersion).Major, ([System.Version]$PythonVersion).Minor
+  $PythonLibName = Get-PythonLibName
 
   $TestDefines = if ($Test) {
     @{
@@ -1745,6 +1789,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     LLDB_PYTHON_EXE_RELATIVE_PATH = "python.exe";
     LLDB_PYTHON_EXT_SUFFIX = ".pyd";
     LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";
+    LLDB_PYTHON_DLL_RELATIVE_PATH = "../../../../Python-$PythonVersion";
     LLDB_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "lldb-tblgen.exe");
     LLDB_TEST_MAKE = "$BinaryCache\GnuWin32Make-4.4.1\bin\make.exe";
     LLVM_CONFIG_PATH = (Join-Path -Path $BuildTools -ChildPath "llvm-config.exe");
@@ -1758,6 +1803,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     Python3_INCLUDE_DIR = "$PythonRoot\include";
     Python3_LIBRARY = "$PythonRoot\libs\$PythonLibName.lib";
     Python3_ROOT_DIR = $PythonRoot;
+    Python3_VERSION = $PythonVersion;
     SWIFT_TOOLCHAIN_VERSION = "${ToolchainIdentifier}";
     SWIFT_BUILD_SWIFT_SYNTAX = "YES";
     SWIFT_CLANG_LOCATION = (Get-PinnedToolchainToolsDir);
@@ -3072,8 +3118,18 @@ function Install-HostToolchain() {
 
   # Switch to swift-driver
   $SwiftDriver = ([IO.Path]::Combine((Get-ProjectBinaryCache $HostPlatform Driver), "bin", "swift-driver.exe"))
-  Copy-Item -Force $SwiftDriver "$($HostPlatform.ToolchainInstallRoot)\usr\bin\swift.exe"
-  Copy-Item -Force $SwiftDriver "$($HostPlatform.ToolchainInstallRoot)\usr\bin\swiftc.exe"
+  Copy-Item -Force `
+    -Path $SwiftDriver `
+    -Destination "$($HostPlatform.ToolchainInstallRoot)\usr\bin\swift.exe"
+  Copy-Item -Force `
+    -Path $SwiftDriver `
+    -Destination "$($HostPlatform.ToolchainInstallRoot)\usr\bin\swiftc.exe"
+
+  # Copy embeddable Python
+  New-Item -Type Directory -Path "$(Get-EmbeddedPythonInstallDir)" -ErrorAction Ignore | Out-Null
+  Copy-Item -Force -Recurse `
+    -Path "$(Get-EmbeddedPythonPath $HostPlatform)\*" `
+    -Destination "$(Get-EmbeddedPythonInstallDir)"
 }
 
 function Build-Inspect([Hashtable] $Platform) {
@@ -3146,6 +3202,7 @@ function Build-Installer([Hashtable] $Platform) {
     INCLUDE_SWIFT_DOCC = $INCLUDE_SWIFT_DOCC;
     SWIFT_DOCC_BUILD = "$(Get-ProjectBinaryCache $HostPlatform DocC)\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";
+    PythonVersion = $PythonVersion
   }
 
   Invoke-IsolatingEnvVars {


### PR DESCRIPTION
- **Explanation**:
This patch adds Embeddable Python 3.10.1 to `build.ps1` and passes it down to Wix when building the Windows toolchain installer.
- **Scope**:
This change impacts the swift toolchain installer on Windows.
- **Issues**:

- **Original PRs**:
	- https://github.com/swiftlang/swift/pull/83615
	- https://github.com/swiftlang/swift/pull/83488
	- https://github.com/swiftlang/swift/pull/85575
	- https://github.com/swiftlang/swift/pull/85629
- **Risk**:
Low, this adds a feature without dependencies.
- **Testing**:
Built and tested at desk.
- **Reviewers**:
  - @compnerd 