### PR TITLE
Move JSON formatting code to Runtime Module

### DIFF
--- a/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
@@ -1,0 +1,322 @@
+//===--- BacktraceJSONFormatter.swift -------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Provides functionality to format JSON backtraces.
+//
+//===----------------------------------------------------------------------===//
+import Swift
+
+@_spi(Formatting)
+public enum BacktraceJSONFormatterBacktrace {
+  case raw(Backtrace)
+  case symbolicated(SymbolicatedBacktrace)
+}
+
+@_spi(Formatting)
+public protocol BacktraceJSONFormatterThread {
+  associatedtype ThreadID: Equatable
+
+  var id: ThreadID { get }
+  var name: String { get }
+  func getBacktrace() -> BacktraceJSONFormatterBacktrace
+}
+
+@_spi(Formatting)
+public protocol BacktraceJSONFormatter {
+  associatedtype ThreadType: BacktraceJSONFormatterThread
+
+  static func write(_ string: String, flush: Bool) 
+  static func writeln(_ string: String, flush: Bool)
+
+  static func getDescription() -> String?
+  static func getArchitecture() -> String?
+  static func getPlatform() -> String?
+  static func getFaultAddress() -> String?
+  static func allThreads() -> [ThreadType]
+  static func crashingThreadIndex() -> Int?
+  static func writeThreadRegisters(thread: ThreadType, capturedBytes: inout [UInt64:Array<UInt8>])
+  static func getImages() -> ImageMap?
+
+  // settings for the output format
+  static func getShouldShowAllThreads() -> Bool
+  static func getShouldShowAllRegisters() -> Bool
+  static func getShouldDemangle() -> Bool
+  static func getShouldSanitize() -> Bool
+  static func getShowMentionedImages() -> Bool
+}
+
+@_spi(Formatting)
+public extension BacktraceJSONFormatter {
+    static func writeRegister<T: FixedWidthInteger>(
+      name: String, value: T, first: Bool = false,
+      captureMemory: ((T) -> Void)
+    ) {
+      if !first {
+        write(", ", flush: false)
+      }
+      write("\"\(name)\": \"\(hex(value))\"", flush: false)
+
+      captureMemory(value)
+    }
+
+    static func writeRegister<C: Context>(
+      name: String, context: C, register: C.Register, first: Bool = false,
+      captureMemory: ((C.GPRValue) -> Void)
+    ) {
+      let value = context.getRegister(register)!
+      writeRegister(name: name, value: value, first: first, captureMemory: captureMemory)
+    }
+
+    static func writeGPRs<C: Context, Rs: Sequence>(_ context: C, range: Rs,
+      captureMemory: ((C.GPRValue) -> Void))
+      where Rs.Element == C.Register
+    {
+      var first = true
+      for reg in range {
+        writeRegister(name: "\(reg)", context: context, register: reg,
+                           first: first, captureMemory: captureMemory)
+        if first {
+          first = false
+        }
+      }
+    }
+
+    static func writeRegisterDump(_ context: X86_64Context, captureMemory: ((X86_64Context.GPRValue) -> Void)) {
+      writeGPRs(context, range: .rax ... .r15, captureMemory: captureMemory)
+      writeRegister(name: "rip", value: context.programCounter, captureMemory: captureMemory)
+      writeRegister(name: "rflags", context: context, register: .rflags, captureMemory: captureMemory)
+      writeRegister(name: "cs", context: context, register: .cs, captureMemory: captureMemory)
+      writeRegister(name: "fs", context: context, register: .fs, captureMemory: captureMemory)
+      writeRegister(name: "gs", context: context, register: .gs, captureMemory: captureMemory)
+    }
+
+    static func writeRegisterDump(_ context: I386Context, captureMemory: ((I386Context.GPRValue) -> Void)) {
+      writeGPRs(context, range: .eax ... .edi, captureMemory: captureMemory)
+      writeRegister(name: "eip", value: context.programCounter, captureMemory: captureMemory)
+      writeRegister(name: "eflags", context: context, register: .eflags, captureMemory: captureMemory)
+      writeRegister(name: "es", context: context, register: .es, captureMemory: captureMemory)
+      writeRegister(name: "cs", context: context, register: .cs, captureMemory: captureMemory)
+      writeRegister(name: "ss", context: context, register: .ss, captureMemory: captureMemory)
+      writeRegister(name: "ds", context: context, register: .ds, captureMemory: captureMemory)
+      writeRegister(name: "fs", context: context, register: .fs, captureMemory: captureMemory)
+      writeRegister(name: "gs", context: context, register: .gs, captureMemory: captureMemory)
+    }
+
+    static func writeRegisterDump(_ context: ARM64Context, captureMemory: ((ARM64Context.GPRValue) -> Void)) {
+      writeGPRs(context, range: .x0 ..< .x29, captureMemory: captureMemory)
+      writeRegister(name: "fp", context: context, register: .x29, captureMemory: captureMemory)
+      writeRegister(name: "lr", context: context, register: .x30, captureMemory: captureMemory)
+      writeRegister(name: "sp", context: context, register: .sp, captureMemory: captureMemory)
+      writeRegister(name: "pc", context: context, register: .pc, captureMemory: captureMemory)
+    }
+
+    static func writeRegisterDump(_ context: ARMContext, captureMemory: ((ARMContext.GPRValue) -> Void)) {
+      writeGPRs(context, range: .r0 ... .r10, captureMemory: captureMemory)
+      writeRegister(name: "fp", context: context, register: .r11, captureMemory: captureMemory)
+      writeRegister(name: "ip", context: context, register: .r12, captureMemory: captureMemory)
+      writeRegister(name: "sp", context: context, register: .r13, captureMemory: captureMemory)
+      writeRegister(name: "lr", context: context, register: .r14, captureMemory: captureMemory)
+      writeRegister(name: "pc", context: context, register: .r15, captureMemory: captureMemory)
+    }
+}
+
+@_spi(Formatting)
+public extension BacktraceJSONFormatter {
+  static func crashingThreadID() -> ThreadType.ThreadID? {
+    guard let crashingThreadIndex = crashingThreadIndex() else { return nil }
+    let crashingThread = allThreads()[crashingThreadIndex]
+    return crashingThread.id
+  }
+
+  static func writePreamble(now: String) {
+    guard let description = getDescription(), let faultAddress = getFaultAddress(),
+    let platform = getPlatform(), let architecture = getArchitecture() else { return }
+
+    write("""
+        { \
+        "timestamp": "\(now)", \
+        "kind": "crashReport", \
+        "description": "\(escapeJSON(description))", \
+        "faultAddress": "\(faultAddress)", \
+        "platform": "\(escapeJSON(platform))", \
+        "architecture": "\(escapeJSON(architecture))"
+        """,
+    flush: false)
+  }
+
+  static func writeThreads(
+    mentionedImages: inout Set<Int>,
+    capturedBytes: inout [UInt64:Array<UInt8>]) {
+
+    write(#", "threads": [ "#, flush: false)
+    if getShouldShowAllThreads() {
+      let crashingThreadId = crashingThreadID()
+      var first = true
+      for (ndx, thread) in allThreads().enumerated() {
+        if first {
+          first = false
+        } else {
+          write(", ", flush: false)
+        }
+
+        writeThread(index: ndx,
+          thread: thread,
+          isCrashingThread: thread.id == crashingThreadId,
+          mentionedImages: &mentionedImages,
+          capturedBytes: &capturedBytes)
+      }
+    } else {
+      if let crashingThreadIndex = crashingThreadIndex() {
+        let crashingThread = allThreads()[crashingThreadIndex]
+        writeThread(index: crashingThreadIndex,
+                    thread: crashingThread,
+                    isCrashingThread: true,
+                    mentionedImages: &mentionedImages,
+                    capturedBytes: &capturedBytes)
+      }
+    }
+
+    write(" ]", flush: false)
+
+    if !getShouldShowAllThreads() && allThreads().count > 1 {
+      write(", \"omittedThreads\": \(allThreads().count - 1)", flush: false)
+    }
+  }
+
+  static func writeThread(
+    index: Int,
+    thread: ThreadType,
+    isCrashingThread: Bool,
+    mentionedImages: inout Set<Int>,
+    capturedBytes: inout [UInt64:Array<UInt8>]) {
+
+      write("{ ", flush: false)
+
+      if !thread.name.isEmpty {
+        write("\"name\": \"\(escapeJSON(thread.name))\", ", flush: false)
+      }
+      if isCrashingThread {
+        write(#""crashed": true, "#, flush: false)
+      }
+      if getShouldShowAllRegisters() || isCrashingThread {
+        write(#""registers": {"#, flush: false)
+        writeThreadRegisters(thread: thread, capturedBytes: &capturedBytes)
+        write(" }, ", flush: false)
+      }
+
+      write(#""frames": ["#, flush: false)
+      var first = true
+      switch thread.getBacktrace() {
+        case let .raw(backtrace):
+          for frame in backtrace.frames {
+            if first {
+              first = false
+            } else {
+              write(",", flush: false)
+            }
+
+            write(" { \(frame.jsonBody) }", flush: false)
+          }
+        case let .symbolicated(backtrace):
+          for frame in backtrace.frames {
+            if first {
+              first = false
+            } else {
+              write(",", flush: false)
+            }
+
+            write(" { ", flush: false)
+
+            write(frame.captured.jsonBody, flush: false)
+
+            if frame.inlined {
+              write(#", "inlined": true"#, flush: false)
+            }
+            if frame.isSwiftRuntimeFailure {
+              write(#", "runtimeFailure": true"#, flush: false)
+            }
+            if frame.isSwiftThunk {
+              write(#", "thunk": true"#, flush: false)
+            }
+            if frame.isSystem {
+              write(#", "system": true"#, flush: false)
+            }
+
+            if let symbol = frame.symbol {
+              write("""
+                      , "symbol": "\(escapeJSON(symbol.rawName))"\
+                      , "offset": \(symbol.offset)
+                      """, flush: false)
+
+              if getShouldDemangle() {
+                let formattedOffset: String
+                if symbol.offset > 0 {
+                  formattedOffset = " + \(symbol.offset)"
+                } else if symbol.offset < 0 {
+                  formattedOffset = " - \(symbol.offset)"
+                } else {
+                  formattedOffset = ""
+                }
+
+                write("""
+                        , "description": \"\(escapeJSON(symbol.name))\(formattedOffset)\"
+                        """, flush: false)
+              }
+
+              if symbol.imageIndex >= 0 {
+                write(", \"image\": \"\(symbol.imageName)\"", flush: false)
+              }
+
+              if var sourceLocation = symbol.sourceLocation {
+                if getShouldSanitize() {
+                  sourceLocation.path = sanitizePath(sourceLocation.path)
+                }
+                write(#", "sourceLocation": { "#, flush: false)
+
+                write("""
+                        "file": "\(escapeJSON(sourceLocation.path))", \
+                        "line": \(sourceLocation.line), \
+                        "column": \(sourceLocation.column)
+                        """, flush: false)
+
+                write(" }", flush: false)
+              }
+            }
+            write(" }", flush: false)
+          }
+      }
+      write(" ] ", flush: false)
+
+      write("}", flush: false)
+
+      if getShowMentionedImages() {
+        switch thread.getBacktrace() {
+          case let .raw(backtrace):
+            for frame in backtrace.frames {
+              let address = frame.adjustedProgramCounter
+              if let images = getImages(), let imageNdx = images.firstIndex(
+                   where: { address >= $0.baseAddress
+                              && address < $0.endOfText }
+                 ) {
+                mentionedImages.insert(imageNdx)
+              }
+            }
+          case let .symbolicated(backtrace):
+            for frame in backtrace.frames {
+              if let symbol = frame.symbol, symbol.imageIndex >= 0 {
+                mentionedImages.insert(symbol.imageIndex)
+              }
+            }
+        }
+      }    
+  }  
+}

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -35,6 +35,7 @@ set(RUNTIME_SOURCES
   Backtrace.swift
   Backtrace+Codable.swift
   BacktraceFormatter.swift
+  BacktraceJSONFormatter.swift
   Base64.swift
   ByteSwapping.swift
   CachingMemoryReader.swift

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -44,6 +44,8 @@ set(RUNTIME_SOURCES
   Compression.swift
   Context.swift
   CoreSymbolication.swift
+  CrashLog.swift
+  CrashLogCapture.swift
   Dwarf.swift
   EightByteBuffer.swift
   Elf.swift

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -985,6 +985,42 @@ extension arm_gprs {
   #endif
 }
 
+extension ARM64Context {
+    public static var registerDumpOrder: [String] {
+        get {
+            let r = (Register.x0 ..< Register.x29).map { "\($0)" }
+            return r + ["fp","lr","sp","pc"]
+        }
+    }
+}
+
+extension ARMContext {
+    public static var registerDumpOrder: [String] {
+        get {
+            let r = (Register.r0 ... Register.r10).map { "\($0)" }
+            return r + ["fp","ip","sp","lr","pc"]
+        }
+    }
+}
+
+extension I386Context {
+    public static var registerDumpOrder: [String] {
+        get {
+            let r = (Register.eax ... Register.edi).map { "\($0)" }
+            return r + ["eip","eflags","es","cs","ss","ds","fs","gs"]
+        }
+    }
+}
+
+extension X86_64Context {
+    public static var registerDumpOrder: [String] {
+        get {
+            let r = (Register.rax ... Register.r15).map { "\($0)" }
+            return r + ["rip","rflags","cs","fs","gs"]
+        }
+    }
+}
+
 // .. Darwin specifics .........................................................
 
 #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -985,7 +985,7 @@ extension arm_gprs {
   #endif
 }
 
-extension ARM64Context {
+@_spi(Contexts) extension ARM64Context {
     public static var registerDumpOrder: [String] {
         get {
             let r = (Register.x0 ..< Register.x29).map { "\($0)" }
@@ -994,7 +994,7 @@ extension ARM64Context {
     }
 }
 
-extension ARMContext {
+@_spi(Contexts) extension ARMContext {
     public static var registerDumpOrder: [String] {
         get {
             let r = (Register.r0 ... Register.r10).map { "\($0)" }
@@ -1003,7 +1003,7 @@ extension ARMContext {
     }
 }
 
-extension I386Context {
+@_spi(Contexts) extension I386Context {
     public static var registerDumpOrder: [String] {
         get {
             let r = (Register.eax ... Register.edi).map { "\($0)" }
@@ -1012,7 +1012,7 @@ extension I386Context {
     }
 }
 
-extension X86_64Context {
+@_spi(Contexts) extension X86_64Context {
     public static var registerDumpOrder: [String] {
         get {
             let r = (Register.rax ... Register.r15).map { "\($0)" }

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -1,0 +1,376 @@
+//===--- CrashLog.swift ---------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This can ingest and egest crash logs that were sent as text or JSON.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+public struct CrashLog<Address: FixedWidthInteger>: Codable {
+    public struct Frame: Codable {
+        enum CodingKeys: String, CodingKey {
+            case kind
+            case address
+            case count
+            case symbol
+            case offset
+            case description
+            case image
+            case sourceLocation
+            case inlined
+            case isSwiftRuntimeFailure = "runtimeFailure"
+            case isSwiftThunk = "thunk"
+            case isSystem = "system"
+        }
+
+        public enum Kind: String, Codable {
+            case programCounter
+            case returnAddress
+            case asyncResumePoint
+            case omittedFrames
+            case truncated
+        }
+
+        public struct SourceLocation: Codable {
+            public var file: String
+            public var line: Int
+            public var column: Int
+        }
+
+        // looking at swift-backtrace, SwiftBacktrace.outputJSONCrashLog.outputJSONThread
+        // it looks like most of these fields are only populated if the backtrace is (at least partially) symbolicated.
+        // the only one always populated in non-symbolicated backtraces is kind and usually address is too
+        // (or count for omittedFrames)
+        // even for (partially) symbolicated backtraces, some frames may not have a symbol
+        public var kind: Kind
+        public var address: String?
+        /// count of ommitted frames, for kind == "omittedFrames"
+        public var count: Int?
+        public var symbol: String?
+        public var offset: Int?
+        public var description: String?
+        public var image: String?
+        public var sourceLocation: SourceLocation?
+
+        public var inlined: Bool = false
+        public var isSwiftRuntimeFailure: Bool = false
+        public var isSwiftThunk: Bool = false
+        public var isSystem: Bool = false
+
+        public var jsonBody: String {
+            switch kind {
+              case .programCounter:
+                "\"kind\": \"programCounter\", \"address\": \"\(address ?? "")\""
+              case .returnAddress:
+                "\"kind\": \"returnAddress\", \"address\": \"\(address ?? "")\""
+              case .asyncResumePoint:
+                "\"kind\": \"asyncResumePoint\", \"address\": \"\(address ?? "")\""
+              case .omittedFrames:
+                "\"kind\": \"omittedFrames\", \"count\": \(count ?? 0)"
+              case .truncated:
+                "\"kind\": \"truncated\""
+            }
+        }
+    }
+
+    public struct Thread: Codable {
+        public var name: String?
+        public var crashed: Bool
+        public var registers: [String:String]?
+        public var frames: [Frame]
+
+        @_spi(Formatting)
+        public init(name: String?, crashed: Bool, registers: [String:String]?, frames: [Frame]) {
+            self.name = name
+            self.crashed = crashed
+            self.registers = registers
+            self.frames = frames
+        }
+    }
+
+    public struct Image: Codable {
+        // looking at swift-backtrace, SwiftBacktrace.outputJSONCrashLog.outputJSONCrashLog
+        // the only mandatory fields for an image are baseAddress and endOfText
+        public var name: String?
+        public var buildId: String?
+        public var path: String?
+        public var baseAddress: String
+        public var endOfText: String
+    }
+
+    // all of these fields are present in all crash logs from swift-backtrace
+    // (at least, from all JSON crash logs)
+    public var timestamp: String
+    public var kind: String
+    public var description: String
+    public var faultAddress: String
+    public var platform: String
+    public var architecture: String
+    public var threads: [Thread]
+
+    public var capturedMemory: [String:String]?
+    public var omittedImages: Int?
+    public var images: [Image]?
+
+    public var backtraceTime: Double
+
+    public init(timestamp: String,
+        kind: String,
+        description: String,
+        faultAddress: String,
+        platform: String,
+        architecture: String,
+        threads: [Thread],
+        capturedMemory: [String:String]?,
+        omittedImages: Int?,
+        images: [Image]?,
+        backtraceTime: Double)
+    {
+        self.timestamp = timestamp
+        self.kind = kind
+        self.description = description
+        self.faultAddress = faultAddress
+        self.platform = platform
+        self.architecture = architecture
+        self.threads = threads
+        self.capturedMemory = capturedMemory
+        self.omittedImages = omittedImages
+        self.images = images
+        self.backtraceTime = backtraceTime
+    }
+}
+
+extension Backtrace.Address {
+    func hexRepresentation<Address:FixedWidthInteger>(nullAs: Address.Type) -> String {
+        return hex(Address(self) ?? 0)
+    }
+}
+
+extension CrashLog.Frame.SourceLocation {
+    init?(_ symbol: SymbolicatedBacktrace.SourceLocation?) {
+        guard let symbol else { return nil }
+
+        file = symbol.path
+        line = symbol.line
+        column = symbol.column
+    }
+}
+
+extension CrashLog.Frame {
+    func richFrame() -> RichFrame<Address>? {
+        switch (kind, CrashLog.addressFromString(address), count) {
+            case (.programCounter, let addr?, _): return .programCounter(addr)
+            case (.returnAddress, let addr?, _): return .returnAddress(addr)
+            case (.asyncResumePoint, let addr?, _): return .asyncResumePoint(addr)
+            case (.omittedFrames, _, let ommittedFrames?): return .omittedFrames(ommittedFrames)
+            case (.truncated, _, _): return .truncated
+            default: return nil
+        }
+    }
+
+    @_spi(Formatting)
+    public init?(fromFrame frame: SymbolicatedBacktrace.Frame) {
+        switch (frame.captured, frame.symbol) {
+            case
+            (.programCounter(let addr), let sbtSymbol?),
+            (.returnAddress(let addr), let sbtSymbol?),
+            (.asyncResumePoint(let addr), let sbtSymbol?):
+
+            kind = switch frame.captured {
+                case .programCounter: .programCounter
+                case .returnAddress: .returnAddress
+                case .asyncResumePoint: .asyncResumePoint
+                default: fatalError("inconsistent state")
+            }
+
+            address = addr.hexRepresentation(nullAs: Address.self)
+            symbol = sbtSymbol.name
+            offset = sbtSymbol.offset
+            description = sbtSymbol.description
+            image = sbtSymbol.imageName
+            sourceLocation = .init(sbtSymbol.sourceLocation)
+            inlined = frame.inlined
+            isSwiftRuntimeFailure = frame.isSwiftRuntimeFailure
+            isSwiftThunk = frame.isSwiftThunk
+            isSystem = frame.isSystem
+
+            case (.omittedFrames(let count), _):
+            self.count = count
+            kind = .omittedFrames
+
+            case (.truncated, _):
+            kind = .truncated
+
+            default: return nil
+        }
+    }
+
+    @_spi(Formatting)
+    public init?(fromFrame frame: Backtrace.Frame) {
+        switch frame {
+            case
+            .programCounter(let addr),
+            .returnAddress(let addr),
+            .asyncResumePoint(let addr):
+
+            kind = switch frame {
+                case .programCounter: .programCounter
+                case .returnAddress: .returnAddress
+                case .asyncResumePoint: .asyncResumePoint
+                default: fatalError("inconsistent state")
+            }
+
+            address = addr.hexRepresentation(nullAs: Address.self)
+
+            case .omittedFrames(let count):
+            self.count = count
+            kind = .omittedFrames
+
+            case .truncated:
+            kind = .truncated
+        }
+    }
+}
+
+extension CrashLog.Image {
+    func imageMapImage() -> ImageMap.Image {
+        return .init(
+            name: name,
+            path: path,
+            uniqueID: CrashLog.bytesFromHexString(buildId ?? ""),
+            baseAddress: ImageMap.Address(CrashLog.addressFromString(baseAddress) ?? 0),
+            endOfText: ImageMap.Address(CrashLog.addressFromString(endOfText) ?? 0)
+            )
+    }
+
+    @_spi(Formatting)
+    public init(fromImageMapImage image: ImageMap.Image) {
+        self.name = image.name
+        if let uniqueID = image.uniqueID {
+            self.buildId = hex(uniqueID)
+        }
+        self.path = image.path
+        self.baseAddress = hex(image.baseAddress)
+        self.endOfText = hex(image.endOfText)
+    }
+}
+
+public extension CrashLog.Thread {
+    func backtrace(architecture: String, images: ImageMap?) -> Backtrace {
+        let frames = self.frames.compactMap { $0.richFrame() }
+        return Backtrace(architecture: architecture, frames: frames, images: images)
+    }
+
+    mutating func updateWithBacktrace(symbolicatedBacktrace: SymbolicatedBacktrace) {
+        frames = symbolicatedBacktrace.frames.compactMap { CrashLog.Frame(fromFrame: $0) }
+    }
+}
+
+extension Context {
+  static var addressType: any FixedWidthInteger.Type { Address.self }
+}
+
+extension CrashLog {
+    private static func context(forArchitecture arch: String) -> (any Context.Type)? {
+        switch arch {
+            case "arm": return ARMContext.self
+            case "arm64": return ARM64Context.self
+            case "i386": return I386Context.self
+            case "x86_64": return X86_64Context.self
+            default: return nil
+        }
+    }
+
+    private static func wordSize(forAddressType addr: any FixedWidthInteger.Type) -> ImageMap.WordSize? {
+        switch addr.bitWidth {
+            case 16: return .sixteenBit
+            case 32: return .thirtyTwoBit
+            case 64: return .sixtyFourBit
+            default: return nil
+        }
+    }
+
+    public mutating func symbolicate(allThreads: Bool = false) {
+        let images = imageMap()
+
+        func symbolicateThread(_ thread: CrashLog.Thread) -> CrashLog.Thread {
+            var thread = thread
+            let backtrace: Backtrace = thread.backtrace(architecture: architecture, images: images)
+            if let symbolicatedBacktrace = backtrace.symbolicated(with: images) {
+                thread.updateWithBacktrace(symbolicatedBacktrace: symbolicatedBacktrace)
+            }
+            return thread
+        }
+
+        let symbolicatedThreads = threads.map {
+            if allThreads || $0.crashed {
+                symbolicateThread($0)
+            } else {
+                $0
+            }
+        }
+
+        self.threads = symbolicatedThreads
+    }
+
+    @_spi(Testing)
+    @_spi(Formatting)
+    public static func wordSize(forArchitecture arch: String) -> ImageMap.WordSize? {
+        guard let context = context(forArchitecture: arch) else { return nil }
+        return wordSize(forAddressType: context.addressType)
+    }
+
+    @_spi(Testing)
+    @_spi(Formatting)
+    public static func addressFromString(_ address: String?) -> Address? {
+        func trimOx(_ hex: String) -> String {
+            if hex.hasPrefix("0x") { String(hex.dropFirst(2)) } else { hex }
+        }
+
+        guard let address,
+         let addressValue = Int(trimOx(address), radix: 16) else {
+            return nil
+        }
+        
+        return Address(addressValue)
+    }
+
+    @_spi(Testing)
+    @_spi(Formatting)
+    public static func bytesFromHexString(_ hexString: any StringProtocol) -> [UInt8] {
+        guard hexString.count >= 2 else {
+            return []
+        }
+
+        let i = hexString.startIndex
+        let j = hexString.index(after: i)
+        let byteString = hexString[i...j]
+
+        if let byte = UInt8(byteString, radix: 16) {
+            return [byte] + bytesFromHexString(hexString.dropFirst(2))
+        } else {
+            return []
+        }
+    }
+
+    public func imageMap() -> ImageMap? {
+        guard let images,
+        let wordSize = Self.wordSize(forArchitecture: architecture) else { return nil }
+
+        var imageMapImages = images.map { $0.imageMapImage() }
+        // sort the images in case they somehow ended up out of order in the crash log
+        imageMapImages.sort(by: { $0.baseAddress < $1.baseAddress })
+
+        return ImageMap(platform: platform, images: imageMapImages, wordSize: wordSize)
+    }
+}

--- a/stdlib/public/RuntimeModule/CrashLogCapture.swift
+++ b/stdlib/public/RuntimeModule/CrashLogCapture.swift
@@ -1,0 +1,133 @@
+//===--- CrashLogCapture.swift --------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Captures registers for a CrashLog from a Context.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@_spi(Formatting)
+public class CrashLogCapture<Address: FixedWidthInteger> {
+  public typealias Thread = CrashLog<Address>.Thread
+
+  public let captureMemory: ((Address) -> Void)
+
+  public init(captureMemory: @escaping (Address) -> Void) {
+    self.captureMemory = captureMemory
+  }
+
+  func captureRegister(name: String,
+  value: Address,
+  into thread: inout Thread) {
+    thread.registers?[name] = hex(value)
+    captureMemory(value)
+  }
+
+  func captureRegister<C: Context>(
+    name: String,
+    context: C,
+    register: C.Register,
+    into thread: inout Thread)
+    where Address == C.GPRValue
+  {
+    captureRegister(name: name,
+    value: context.getRegister(register)!, into: &thread)
+  }
+
+  func captureGPRs<C: Context, Rs: Sequence>(
+    _ context: C, range: Rs, into thread: inout Thread)
+    where Rs.Element == C.Register, Address == C.GPRValue
+  {
+    for reg in range {
+      captureRegister(name: "\(reg)",
+      context: context,
+      register: reg,
+      into: &thread)
+    }
+  }
+
+  public func captureRegisterDump(_ context: X86_64Context,
+  into thread: inout Thread)
+  where Address == X86_64Context.GPRValue
+  {
+    captureGPRs(context, range: .rax ... .r15, into: &thread)
+
+    captureRegister(name: "rip",
+    value: context.programCounter,
+    into: &thread)
+
+    captureRegister(name: "rflags",
+    context: context,
+    register: .rflags,
+    into: &thread)
+
+    captureRegister(name: "cs",
+    context: context,
+    register: .cs,
+    into: &thread)
+
+    captureRegister(name: "fs",
+    context: context,
+    register: .fs,
+    into: &thread)
+
+    captureRegister(name: "gs",
+    context: context,
+    register: .gs,
+    into: &thread)
+  }
+
+  public func captureRegisterDump(_ context: I386Context,
+  into thread: inout Thread)
+  where Address == I386Context.GPRValue 
+  {
+    captureGPRs(context, range: .eax ... .edi, into: &thread)
+
+    captureRegister(name: "eip", value: context.programCounter, into: &thread)
+
+    captureRegister(name: "eflags",
+    context: context,
+    register: .eflags,
+    into: &thread)
+
+    captureRegister(name: "es", context: context, register: .es, into: &thread)
+    captureRegister(name: "cs", context: context, register: .cs, into: &thread)
+    captureRegister(name: "ss", context: context, register: .ss, into: &thread)
+    captureRegister(name: "ds", context: context, register: .ds, into: &thread)
+    captureRegister(name: "fs", context: context, register: .fs, into: &thread)
+    captureRegister(name: "gs", context: context, register: .gs, into: &thread)
+  }
+
+  public func captureRegisterDump(_ context: ARM64Context,
+  into thread: inout Thread)
+  where Address == ARM64Context.GPRValue 
+  {
+    captureGPRs(context, range: .x0 ..< .x29, into: &thread)
+    captureRegister(name: "fp", context: context, register: .x29, into: &thread)
+    captureRegister(name: "lr", context: context, register: .x30, into: &thread)
+    captureRegister(name: "sp", context: context, register: .sp, into: &thread)
+    captureRegister(name: "pc", context: context, register: .pc, into: &thread)
+  }
+
+  public func captureRegisterDump(_ context: ARMContext,
+  into thread: inout Thread)
+  where Address == ARMContext.GPRValue 
+  {
+    captureGPRs(context, range: .r0 ... .r10, into: &thread)
+    captureRegister(name: "fp", context: context, register: .r11, into: &thread)
+    captureRegister(name: "ip", context: context, register: .r12, into: &thread)
+    captureRegister(name: "sp", context: context, register: .r13, into: &thread)
+    captureRegister(name: "lr", context: context, register: .r14, into: &thread)
+    captureRegister(name: "pc", context: context, register: .r15, into: &thread)
+  }  
+}

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -33,7 +33,8 @@ public struct ImageMap: Collection, Sendable, Hashable {
 
   /// Tells us what size of machine words were used when capturing the
   /// image map.
-  enum WordSize: Sendable {
+  @_spi(Testing)
+  public enum WordSize: Sendable {
     case sixteenBit
     case thirtyTwoBit
     case sixtyFourBit
@@ -43,7 +44,8 @@ public struct ImageMap: Collection, Sendable, Hashable {
   typealias Address = UInt64
 
   /// The internal representation of an image.
-  struct Image: Sendable, Hashable {
+  @_spi(Formatting)
+  public struct Image: Sendable, Hashable {
     var name: String?
     var path: String?
     var uniqueID: [UInt8]?
@@ -55,7 +57,8 @@ public struct ImageMap: Collection, Sendable, Hashable {
   public private(set) var platform: String
 
   /// The actual image storage.
-  var images: [Image]
+  @_spi(Formatting)
+  public var images: [Image]
 
   /// The size of words used when capturing.
   var wordSize: WordSize

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -41,16 +41,22 @@ public struct ImageMap: Collection, Sendable, Hashable {
   }
 
   /// We use UInt64s for addresses here.
-  typealias Address = UInt64
+  @_spi(Testing)
+  public typealias Address = UInt64
 
   /// The internal representation of an image.
   @_spi(Formatting)
   public struct Image: Sendable, Hashable {
-    var name: String?
-    var path: String?
-    var uniqueID: [UInt8]?
-    var baseAddress: Address
-    var endOfText: Address
+    @_spi(Testing)
+    public var name: String?
+    @_spi(Testing)
+    public var path: String?
+    @_spi(Testing)
+    public var uniqueID: [UInt8]?
+    @_spi(Testing)
+    public var baseAddress: Address
+    @_spi(Testing)
+    public var endOfText: Address
   }
 
   /// The name of the platform that captured this image map.
@@ -61,7 +67,8 @@ public struct ImageMap: Collection, Sendable, Hashable {
   public var images: [Image]
 
   /// The size of words used when capturing.
-  var wordSize: WordSize
+  @_spi(Testing)
+  public var wordSize: WordSize
 
   /// Construct an ImageMap.
   init(platform: String, images: [Image], wordSize: WordSize) {

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -273,7 +273,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
   }
 
   /// Construct a SymbolicatedBacktrace from a backtrace and a list of images.
-  private init(backtrace: Backtrace, images: ImageMap, frames: [Frame]) {
+  init(backtrace: Backtrace, images: ImageMap, frames: [Frame]) {
     self.backtrace = backtrace
     self.images = images
     self.frames = frames

--- a/stdlib/public/RuntimeModule/Utils.swift
+++ b/stdlib/public/RuntimeModule/Utils.swift
@@ -26,7 +26,8 @@ internal import Glibc
 internal import Musl
 #endif
 
-internal func hex<T: FixedWidthInteger>(_ value: T,
+@_spi(Utils)
+public func hex<T: FixedWidthInteger>(_ value: T,
                                         prefix shouldPrefix: Bool = true,
                                         width: Int = MemoryLayout<T>.size * 2)
   -> String {
@@ -38,7 +39,8 @@ internal func hex<T: FixedWidthInteger>(_ value: T,
   return "\(prefix)\(padding)\(digits)"
 }
 
-internal func hex(_ bytes: some Sequence<UInt8>) -> String {
+@_spi(Utils)
+public func hex(_ bytes: some Sequence<UInt8>) -> String {
   return bytes.map{ hex($0, prefix: false) }.joined(separator: "")
 }
 

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -25,22 +25,10 @@ import CRT
 @_spi(Formatting) import Runtime
 @_spi(Internal) import Runtime
 @_spi(MemoryReaders) import Runtime
+@_spi(Utils) import Runtime
 
-public enum JSONOutputThreadBacktrace {
-  case raw(Backtrace)
-  case symbolicated(SymbolicatedBacktrace)
-}
-
-public protocol JSONOutputThread {
-  associatedtype ThreadID: Equatable
-
-  var id: ThreadID { get }
-  var name: String { get }
-  func getBacktrace() -> JSONOutputThreadBacktrace
-}
-
-extension TargetThread: JSONOutputThread {
-  func getBacktrace() -> JSONOutputThreadBacktrace {
+extension TargetThread: BacktraceJSONFormatterThread {
+  func getBacktrace() -> BacktraceJSONFormatterBacktrace {
     switch backtrace {
       case .raw(let bt):
         return .raw(bt)
@@ -50,29 +38,7 @@ extension TargetThread: JSONOutputThread {
   }
 }
 
-public protocol JSONOutput {
-  associatedtype ThreadType: JSONOutputThread
-
-  static func write(_ string: String, flush: Bool) 
-  static func writeln(_ string: String, flush: Bool)
-
-  static func getDescription() -> String?
-  static func getArchitecture() -> String?
-  static func getPlatform() -> String?
-  static func getFaultAddress() -> String?
-  static func getShouldShowAllThreads() -> Bool
-  static func getShouldShowAllRegisters() -> Bool
-  static func getShouldDemangle() -> Bool
-  static func getShouldSanitize() -> Bool
-  static func getShowMentionedImages() -> Bool
-
-  static func allThreads() -> [ThreadType]
-  static func crashingThreadIndex() -> Int?
-  static func writeThreadRegisters(thread: ThreadType, capturedBytes: inout [UInt64:Array<UInt8>])
-  static func getImages() -> ImageMap?
-}
-
-extension SwiftBacktrace: JSONOutput {
+extension SwiftBacktrace: BacktraceJSONFormatter {
   static func getDescription() -> String? {
     guard let target = target else {
       print("swift-backtrace: unable to get target",
@@ -152,7 +118,7 @@ extension SwiftBacktrace: JSONOutput {
 
   static func writeThreadRegisters(thread: TargetThread, capturedBytes: inout [UInt64:Array<UInt8>]) {
     if let context = thread.context {
-      outputJSONRegisterDump(context) { addressValue in
+      writeRegisterDump(context) { addressValue in
         if let bytes = try? target?.reader.fetch(
             from: RemoteMemoryReader.Address(addressValue),
             count: 16,
@@ -168,273 +134,7 @@ extension SwiftBacktrace: JSONOutput {
   }
 }
 
-extension JSONOutput {
-    static func outputJSONRegister<T: FixedWidthInteger>(
-      name: String, value: T, first: Bool = false,
-      captureMemory: ((T) -> Void)
-    ) {
-      if !first {
-        write(", ", flush: false)
-      }
-      write("\"\(name)\": \"\(hex(value))\"", flush: false)
-
-      captureMemory(value)
-    }
-
-    static func outputJSONRegister<C: Context>(
-      name: String, context: C, register: C.Register, first: Bool = false,
-      captureMemory: ((C.GPRValue) -> Void)
-    ) {
-      let value = context.getRegister(register)!
-      outputJSONRegister(name: name, value: value, first: first, captureMemory: captureMemory)
-    }
-
-    static func outputJSONGPRs<C: Context, Rs: Sequence>(_ context: C, range: Rs,
-      captureMemory: ((C.GPRValue) -> Void))
-      where Rs.Element == C.Register
-    {
-      var first = true
-      for reg in range {
-        outputJSONRegister(name: "\(reg)", context: context, register: reg,
-                           first: first, captureMemory: captureMemory)
-        if first {
-          first = false
-        }
-      }
-    }
-
-    static func outputJSONRegisterDump(_ context: X86_64Context, captureMemory: ((X86_64Context.GPRValue) -> Void)) {
-      outputJSONGPRs(context, range: .rax ... .r15, captureMemory: captureMemory)
-      outputJSONRegister(name: "rip", value: context.programCounter, captureMemory: captureMemory)
-      outputJSONRegister(name: "rflags", context: context, register: .rflags, captureMemory: captureMemory)
-      outputJSONRegister(name: "cs", context: context, register: .cs, captureMemory: captureMemory)
-      outputJSONRegister(name: "fs", context: context, register: .fs, captureMemory: captureMemory)
-      outputJSONRegister(name: "gs", context: context, register: .gs, captureMemory: captureMemory)
-    }
-
-    static func outputJSONRegisterDump(_ context: I386Context, captureMemory: ((I386Context.GPRValue) -> Void)) {
-      outputJSONGPRs(context, range: .eax ... .edi, captureMemory: captureMemory)
-      outputJSONRegister(name: "eip", value: context.programCounter, captureMemory: captureMemory)
-      outputJSONRegister(name: "eflags", context: context, register: .eflags, captureMemory: captureMemory)
-      outputJSONRegister(name: "es", context: context, register: .es, captureMemory: captureMemory)
-      outputJSONRegister(name: "cs", context: context, register: .cs, captureMemory: captureMemory)
-      outputJSONRegister(name: "ss", context: context, register: .ss, captureMemory: captureMemory)
-      outputJSONRegister(name: "ds", context: context, register: .ds, captureMemory: captureMemory)
-      outputJSONRegister(name: "fs", context: context, register: .fs, captureMemory: captureMemory)
-      outputJSONRegister(name: "gs", context: context, register: .gs, captureMemory: captureMemory)
-    }
-
-    static func outputJSONRegisterDump(_ context: ARM64Context, captureMemory: ((ARM64Context.GPRValue) -> Void)) {
-      outputJSONGPRs(context, range: .x0 ..< .x29, captureMemory: captureMemory)
-      outputJSONRegister(name: "fp", context: context, register: .x29, captureMemory: captureMemory)
-      outputJSONRegister(name: "lr", context: context, register: .x30, captureMemory: captureMemory)
-      outputJSONRegister(name: "sp", context: context, register: .sp, captureMemory: captureMemory)
-      outputJSONRegister(name: "pc", context: context, register: .pc, captureMemory: captureMemory)
-    }
-
-    static func outputJSONRegisterDump(_ context: ARMContext, captureMemory: ((ARMContext.GPRValue) -> Void)) {
-      outputJSONGPRs(context, range: .r0 ... .r10, captureMemory: captureMemory)
-      outputJSONRegister(name: "fp", context: context, register: .r11, captureMemory: captureMemory)
-      outputJSONRegister(name: "ip", context: context, register: .r12, captureMemory: captureMemory)
-      outputJSONRegister(name: "sp", context: context, register: .r13, captureMemory: captureMemory)
-      outputJSONRegister(name: "lr", context: context, register: .r14, captureMemory: captureMemory)
-      outputJSONRegister(name: "pc", context: context, register: .r15, captureMemory: captureMemory)
-    }
-}
-
-public extension JSONOutput {
-  static func crashingThreadID() -> ThreadType.ThreadID? {
-    guard let crashingThreadIndex = crashingThreadIndex() else { return nil }
-    let crashingThread = allThreads()[crashingThreadIndex]
-    return crashingThread.id
-  }
-
-  static func writePreamble(now: timespec) {
-    guard let description = getDescription(), let faultAddress = getFaultAddress(),
-    let platform = getPlatform(), let architecture = getArchitecture() else { return }
-
-    write("""
-        { \
-        "timestamp": "\(formatISO8601(now))", \
-        "kind": "crashReport", \
-        "description": "\(escapeJSON(description))", \
-        "faultAddress": "\(faultAddress)", \
-        "platform": "\(escapeJSON(platform))", \
-        "architecture": "\(escapeJSON(architecture))"
-        """,
-    flush: false)
-  }
-
-  static func writeThreads(
-    mentionedImages: inout Set<Int>,
-    capturedBytes: inout [UInt64:Array<UInt8>]) {
-
-    write(#", "threads": [ "#, flush: false)
-    if getShouldShowAllThreads() {
-      let crashingThreadId = crashingThreadID()
-      var first = true
-      for (ndx, thread) in allThreads().enumerated() {
-        if first {
-          first = false
-        } else {
-          write(", ", flush: false)
-        }
-
-        writeThread(index: ndx,
-          thread: thread,
-          isCrashingThread: thread.id == crashingThreadId,
-          mentionedImages: &mentionedImages,
-          capturedBytes: &capturedBytes)
-      }
-    } else {
-      if let crashingThreadIndex = crashingThreadIndex() {
-        let crashingThread = allThreads()[crashingThreadIndex]
-        writeThread(index: crashingThreadIndex,
-                    thread: crashingThread,
-                    isCrashingThread: true,
-                    mentionedImages: &mentionedImages,
-                    capturedBytes: &capturedBytes)
-      }
-    }
-
-    write(" ]", flush: false)
-
-    if !getShouldShowAllThreads() && allThreads().count > 1 {
-      write(", \"omittedThreads\": \(allThreads().count - 1)", flush: false)
-    }
-  }
-
-  static func writeThread(
-    index: Int,
-    thread: ThreadType,
-    isCrashingThread: Bool,
-    mentionedImages: inout Set<Int>,
-    capturedBytes: inout [UInt64:Array<UInt8>]) {
-
-      write("{ ", flush: false)
-
-      if !thread.name.isEmpty {
-        write("\"name\": \"\(escapeJSON(thread.name))\", ", flush: false)
-      }
-      if isCrashingThread {
-        write(#""crashed": true, "#, flush: false)
-      }
-      if getShouldShowAllRegisters() || isCrashingThread {
-        write(#""registers": {"#, flush: false)
-        writeThreadRegisters(thread: thread, capturedBytes: &capturedBytes)
-        write(" }, ", flush: false)
-      }
-
-      write(#""frames": ["#, flush: false)
-      var first = true
-      switch thread.getBacktrace() {
-        case let .raw(backtrace):
-          for frame in backtrace.frames {
-            if first {
-              first = false
-            } else {
-              write(",", flush: false)
-            }
-
-            write(" { \(frame.jsonBody) }", flush: false)
-          }
-        case let .symbolicated(backtrace):
-          for frame in backtrace.frames {
-            if first {
-              first = false
-            } else {
-              write(",", flush: false)
-            }
-
-            write(" { ", flush: false)
-
-            write(frame.captured.jsonBody, flush: false)
-
-            if frame.inlined {
-              write(#", "inlined": true"#, flush: false)
-            }
-            if frame.isSwiftRuntimeFailure {
-              write(#", "runtimeFailure": true"#, flush: false)
-            }
-            if frame.isSwiftThunk {
-              write(#", "thunk": true"#, flush: false)
-            }
-            if frame.isSystem {
-              write(#", "system": true"#, flush: false)
-            }
-
-            if let symbol = frame.symbol {
-              write("""
-                      , "symbol": "\(escapeJSON(symbol.rawName))"\
-                      , "offset": \(symbol.offset)
-                      """, flush: false)
-
-              if getShouldDemangle() {
-                let formattedOffset: String
-                if symbol.offset > 0 {
-                  formattedOffset = " + \(symbol.offset)"
-                } else if symbol.offset < 0 {
-                  formattedOffset = " - \(symbol.offset)"
-                } else {
-                  formattedOffset = ""
-                }
-
-                write("""
-                        , "description": \"\(escapeJSON(symbol.name))\(formattedOffset)\"
-                        """, flush: false)
-              }
-
-              if symbol.imageIndex >= 0 {
-                write(", \"image\": \"\(symbol.imageName)\"", flush: false)
-              }
-
-              if var sourceLocation = symbol.sourceLocation {
-                if getShouldSanitize() {
-                  sourceLocation.path = sanitizePath(sourceLocation.path)
-                }
-                write(#", "sourceLocation": { "#, flush: false)
-
-                write("""
-                        "file": "\(escapeJSON(sourceLocation.path))", \
-                        "line": \(sourceLocation.line), \
-                        "column": \(sourceLocation.column)
-                        """, flush: false)
-
-                write(" }", flush: false)
-              }
-            }
-            write(" }", flush: false)
-          }
-      }
-      write(" ] ", flush: false)
-
-      write("}", flush: false)
-
-      if getShowMentionedImages() {
-        switch thread.getBacktrace() {
-          case let .raw(backtrace):
-            for frame in backtrace.frames {
-              let address = frame.adjustedProgramCounter
-              if let images = getImages(), let imageNdx = images.firstIndex(
-                   where: { address >= $0.baseAddress
-                              && address < $0.endOfText }
-                 ) {
-                mentionedImages.insert(imageNdx)
-              }
-            }
-          case let .symbolicated(backtrace):
-            for frame in backtrace.frames {
-              if let symbol = frame.symbol, symbol.imageIndex >= 0 {
-                mentionedImages.insert(symbol.imageIndex)
-              }
-            }
-        }
-      }    
-  }  
-}
-
 extension SwiftBacktrace {
-
   static func outputJSONCrashLog() {
     guard let target = target else {
       print("swift-backtrace: unable to get target",
@@ -442,20 +142,14 @@ extension SwiftBacktrace {
       return
     }
 
-    // let crashingThread = target.threads[target.crashingThreadNdx]
-    // var mentionedImages = Set<Int>()
-    // var capturedBytes: [UInt64:Array<UInt8>] = [:]
-
-
-
     var mentionedImages = Set<Int>()
     var capturedBytes: [UInt64:Array<UInt8>] = [:]
 
-    writePreamble(now: now)
+    writePreamble(now: formatISO8601(now))
 
     writeThreads(mentionedImages: &mentionedImages, capturedBytes: &capturedBytes)
 
-    if !capturedBytes.isEmpty && !(args.sanitize ?? false) {
+    if !capturedBytes.isEmpty && !getShouldSanitize() {
       write(#", "capturedMemory": {"#)
       var first = true
       for (address, bytes) in capturedBytes {

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -255,34 +255,3 @@ func formatISO8601(_ time: timespec) -> String {
 
   return isoTime
 }
-
-/// Escape a JSON string
-func escapeJSON(_ s: String) -> String {
-  var result = ""
-  let utf8View = s.utf8
-  var chunk = utf8View.startIndex
-  var pos = chunk
-  let end = utf8View.endIndex
-
-  result.reserveCapacity(utf8View.count)
-
-  while pos != end {
-    let scalar = utf8View[pos]
-    switch scalar {
-      case 0x22, 0x5c, 0x00...0x1f:
-        result += s[chunk..<pos]
-        result += "\\"
-        result += String(Unicode.Scalar(scalar))
-        pos = utf8View.index(after: pos)
-        chunk = pos
-      default:
-        pos = utf8View.index(after: pos)
-    }
-  }
-
-  if chunk != end {
-    result += s[chunk..<pos]
-  }
-
-  return result
-}

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -26,6 +26,7 @@ import CRT
 @_spi(Contexts) import Runtime
 @_spi(Registers) import Runtime
 @_spi(MemoryReaders) import Runtime
+@_spi(CrashLog) import Runtime
 
 @main
 internal struct SwiftBacktrace {
@@ -497,6 +498,7 @@ Generate a backtrace for the parent process.
     if (args.demangle) { options.formUnion(.demangle) }
     if (args.sanitize == true) { options.formUnion(.sanitize) }
     if (args.showImages == .mentioned) { options.formUnion(.mentionedImages) }
+    if (args.showImages != ImagesToShow.none) { options.formUnion(.images) }
     if (args.threads == true) { options.formUnion(.allThreads) }
     return options
   }
@@ -695,7 +697,15 @@ Generate a backtrace for the parent process.
           return
         }
 
-        outputJSONCrashLog(crashLog: crashLog, options: getJsonBacktraceFormatterOptions())
+        let writer = SwiftBacktraceWriter()
+        let options = getJsonBacktraceFormatterOptions()
+
+        var backtraceFormatter = BacktraceJSONFormatter(
+          crashLog: crashLog,
+          writer: writer,
+          options: options)
+
+        backtraceFormatter.writeCrashLog(now: formatISO8601(now))
     }
 
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Crash
 // RUN: %target-codesign %t/Crash
 // RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/Crash 2>&1 || true
-// RUN: %validate-json %t/crash.json | %FileCheck %s
+// RUN: %validate-json %t/crash.json | %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 
 
 // Also check that we generate valid JSON with various different options set.
@@ -14,13 +14,13 @@
 // RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/Crash 2>&1 || true
 // RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/Crash 2>&1 || true
 // RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/Crash 2>&1 || true
-// RUN: %validate-json %t/crash2.json
-// RUN: %validate-json %t/crash3.json
-// RUN: %validate-json %t/crash4.json
-// RUN: %validate-json %t/crash5.json
-// RUN: %validate-json %t/crash6.json
-// RUN: %validate-json %t/crash7.json
-// RUN: %validate-json %t/crash8.json
+// RUN: %validate-json %t/crash2.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
+// RUN: %validate-json %t/crash3.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
+// RUN: %validate-json %t/crash4.json| %FileCheck %s --check-prefixes CHECK,SANITIZED,DEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED
+// RUN: %validate-json %t/crash5.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,SYMBOLICATED,CAPTUREDMEM
+// RUN: %validate-json %t/crash6.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,DEMANGLED,IMAGES,SYMBOLICATED,CAPTUREDMEM
+// RUN: %validate-json %t/crash7.json| %FileCheck %s --check-prefixes CHECK,IMAGES,OMITTEDIMAGES,CAPTUREDMEM
+// RUN: %validate-json %t/crash8.json| %FileCheck %s --check-prefixes CHECK,UNSANITIZED,UNDEMANGLED,IMAGES,OMITTEDIMAGES,SYMBOLICATED,CAPTUREDMEM
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
@@ -98,109 +98,116 @@ struct Crash {
 // CHECK-NEXT:     "frames": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "programCounter",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level5yyF",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "level5() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 51,
-// CHECK-NEXT:           "column": 15
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5Crash6level5yyF",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "level5() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 51,
+// SYMBOLICATED-NEXT:    "column": 15
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level4yyF",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "level4() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 45,
-// CHECK-NEXT:           "column": 3
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5Crash6level4yyF",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "level4() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 45,
+// SYMBOLICATED-NEXT:    "column": 3
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level3yyF",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "level3() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 41,
-// CHECK-NEXT:           "column": 3
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5Crash6level3yyF",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "level3() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 41,
+// SYMBOLICATED-NEXT:    "column": 3
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level2yyF",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "level2() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 37,
-// CHECK-NEXT:           "column": 3
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5Crash6level2yyF",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "level2() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 37,
+// SYMBOLICATED-NEXT:    "column": 3
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level1yyF",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "level1() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 33,
-// CHECK-NEXT:           "column": 3
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5Crash6level1yyF",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "level1() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 33,
+// SYMBOLICATED-NEXT:    "column": 3
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "symbol": "{{_?}}$s5CrashAAV4mainyyFZ",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "static Crash.main() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 57,
-// CHECK-NEXT:           "column": 5
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5CrashAAV4mainyyFZ",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "static Crash.main() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 57,
+// SYMBOLICATED-NEXT:    "column": 5
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "system": true,
-// CHECK-NEXT:         "symbol": "{{_?}}$s5CrashAAV5$mainyyFZ",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "static Crash.$main() + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{/*}}<compiler-generated>",
-// CHECK-NEXT:           "line": 0,
-// CHECK-NEXT:           "column": 0
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "system": true,
+// SYMBOLICATED-NEXT:  "symbol": "{{_?}}$s5CrashAAV5$mainyyFZ",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "static Crash.$main() + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// SYMBOLICATED-NEXT:    "file": "{{/*}}<compiler-generated>",
+// SYMBOLICATED-NEXT:    "line": 0,
+// SYMBOLICATED-NEXT:    "column": 0
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "returnAddress",
-// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:         "system": true,
-// CHECK-NEXT:         "symbol": "{{_?main}}",
-// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
-// CHECK-NEXT:         "description": "main + [[OFFSET]]",
-// CHECK-NEXT:         "image": "Crash",
-// CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 0,
-// CHECK-NEXT:           "column": 0
-// CHECK-NEXT:         }
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}"
+// SYMBOLICATED-NEXT:  "system": true,
+// SYMBOLICATED-NEXT:  "symbol": "{{_?main}}",
+// SYMBOLICATED-NEXT:  "offset": [[OFFSET:[0-9]+]],
+// DEMANGLED-NEXT:     "description": "main + [[OFFSET]]",
+// SYMBOLICATED-NEXT:  "image": "Crash",
+// SYMBOLICATED-NEXT:  "sourceLocation": {
+// UNSANITIZED-NEXT:     "file": "{{.*}}/test/Backtracing/JSON.swift",
+// SANITIZED-NEXT:       "file": "{{.*}}/JSON.swift",
+// SYMBOLICATED-NEXT:    "line": 0,
+// SYMBOLICATED-NEXT:    "column": 0
+// SYMBOLICATED-NEXT:  }
 // CHECK-NEXT:       },
 
 // More frames here, but they're system specific
@@ -208,28 +215,28 @@ struct Crash {
 // CHECK:          ]
 // CHECK:        }
 // CHECK-NEXT: ],
-// CHECK-NEXT: "capturedMemory": {
-// CHECK-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
+// CAPTUREDMEM-NEXT: "capturedMemory": {
+// CAPTUREDMEM-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
 
 // More captures here, but system specific
 
-// CHECK:      },
-// CHECK-NEXT: "omittedImages": {{[0-9]+}},
-// CHECK-NEXT: "images": [
-// CHECK-NEXT:   {
+// CAPTUREDMEM:      },
+// OMITTEDIMAGES-NEXT: "omittedImages": {{[0-9]+}},
+// IMAGES-NEXT: "images": [
+// IMAGES-NEXT:   {
 
 // Maybe multiple images before this one
 
-// CHECK:          "name": "Crash",
+// IMAGES:          "name": "Crash",
 //                 "buildId": ... is optional
-// CHECK:          "path": "{{.*}}/Crash",
-// CHECK-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
-// CHECK-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
-// CHECK-NEXT:   }
+// IMAGES:          "path": "{{.*}}/Crash",
+// IMAGES-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
+// IMAGES-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
+// IMAGES-NEXT:   }
 
 // Maybe multiple images after this one
 
-// CHECK:      ],
+// IMAGES:      ],
 // CHECK-NEXT: "backtraceTime": {{[0-9]+(\.[0-9]+)?}}
 
 // CHECK-NEXT: }


### PR DESCRIPTION
Refactoring the JSON writer in `swift-backtrace` to allow its reuse. This will be used by the new swift-symbolicate tool.

Currently this is in draft for feedback and is not yet complete. The shared JSON formatting code has been moved into the Runtime module.

This now also simplifies the flow a bit, at least for JSON. The crash log is all captured in the CrashLog instance and output to JSON from there, meaning the exact same code will be shared between swift-backtrace and swift-symbolicate for JSON output, rather than workarounds.