### PR TITLE
[update-checkout] add the 'status' subcommand

### DIFF
--- a/utils/update_checkout/tests/test_locked_repository.py
+++ b/utils/update_checkout/tests/test_locked_repository.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import unittest
 from unittest.mock import patch
 
-from update_checkout.update_checkout import UpdateArguments, _is_any_repository_locked
+from update_checkout.update_checkout import UpdateArguments
+from update_checkout.git_command import is_any_repository_locked
 
 FAKE_PATH = Path("/fake_path")
 
@@ -46,7 +47,7 @@ class TestIsAnyRepositoryLocked(unittest.TestCase):
         mock_is_dir.return_value = True
         mock_iterdir.side_effect = iterdir_side_effect
 
-        result = _is_any_repository_locked(pool_args)
+        result = is_any_repository_locked(pool_args)
         self.assertEqual(result, {"repo1"})
 
     @patch("pathlib.Path.exists")
@@ -61,7 +62,7 @@ class TestIsAnyRepositoryLocked(unittest.TestCase):
         mock_is_dir.return_value = False
         mock_iterdir.return_value = []
 
-        result = _is_any_repository_locked(pool_args)
+        result = is_any_repository_locked(pool_args)
         self.assertEqual(result, set())
 
     @patch("pathlib.Path.exists")
@@ -76,7 +77,7 @@ class TestIsAnyRepositoryLocked(unittest.TestCase):
         mock_is_dir.return_value = False
         mock_iterdir.return_value = []
 
-        result = _is_any_repository_locked(pool_args)
+        result = is_any_repository_locked(pool_args)
         self.assertEqual(result, set())
 
     @patch("pathlib.Path.exists")
@@ -95,7 +96,7 @@ class TestIsAnyRepositoryLocked(unittest.TestCase):
             FAKE_PATH.joinpath(x) for x in ("index.lock", "merge.lock", "HEAD")
         ]
 
-        result = _is_any_repository_locked(pool_args)
+        result = is_any_repository_locked(pool_args)
         self.assertEqual(result, {"repo1"})
 
     @patch("pathlib.Path.exists")
@@ -114,5 +115,5 @@ class TestIsAnyRepositoryLocked(unittest.TestCase):
             FAKE_PATH.joinpath(x) for x in ("HEAD", "config", "logs")
         ]
 
-        result = _is_any_repository_locked(pool_args)
+        result = is_any_repository_locked(pool_args)
         self.assertEqual(result, set())

--- a/utils/update_checkout/tests/test_status_command.py
+++ b/utils/update_checkout/tests/test_status_command.py
@@ -1,0 +1,78 @@
+import subprocess
+import tempfile
+from typing import List
+import unittest
+from pathlib import Path
+
+from .scheme_mock import UPDATE_CHECKOUT_PATH
+
+
+class TestStatusCommand(unittest.TestCase):
+    def call(self, args: List[str], cwd: Path):
+        subprocess.check_call(
+            args, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+
+    def init_repo(self, path: Path, with_changes: bool):
+        self.call(args=["git", "init"], cwd=path)
+        self.call(
+            args=["git", "config", "--local", "user.name", "swift_test"], cwd=path
+        )
+        self.call(
+            args=["git", "config", "--local", "user.email", "no-reply@swift.org"],
+            cwd=path,
+        )
+        self.call(args=["git", "config", "commit.gpgsign", "false"], cwd=path)
+
+        (path / "file.txt").write_text("initial\n")
+        self.call(args=["git", "add", "file.txt"], cwd=path)
+        self.call(args=["git", "commit", "-m", "initial commit"], cwd=path)
+
+        if with_changes:
+            (path / "file.txt").write_text("modified\n")
+
+    def test_repositories_with_active_changes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            repo_1 = root / "repo_1"
+            repo_2 = root / "repo_2"
+            repo_1.mkdir()
+            repo_2.mkdir()
+
+            self.init_repo(repo_1, True)
+            self.init_repo(repo_2, True)
+
+            output = subprocess.run(
+                [UPDATE_CHECKOUT_PATH, "--source-root", str(root), "status"],
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            self.assertIn("The following repositories have active changes:", output)
+            self.assertIn("  - [repo_1] 1 active change", output)
+            self.assertIn("  - [repo_2] 1 active change", output)
+
+    def test_repositories_without_active_changes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            repo_1 = root / "repo_1"
+            repo_2 = root / "repo_2"
+            repo_1.mkdir()
+            repo_2.mkdir()
+
+            self.init_repo(repo_1, False)
+            self.init_repo(repo_2, False)
+
+            output = subprocess.run(
+                [UPDATE_CHECKOUT_PATH, "--source-root", str(root), "status"],
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            self.assertIn("No repositories have active changes.", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/update_checkout/update_checkout/cli_arguments.py
+++ b/utils/update_checkout/update_checkout/cli_arguments.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
 
@@ -26,6 +26,7 @@ class CliArguments(argparse.Namespace):
     source_root: Path
     use_submodules: bool
     verbose: bool
+    command: Optional[Any]
 
     @staticmethod
     def parse_args() -> "CliArguments":
@@ -153,4 +154,8 @@ repositories.
             help="Increases the script's verbosity.",
             action="store_true",
         )
+
+        subparsers = parser.add_subparsers(dest='command')
+        subparsers.add_parser('status', help='Print the status of all the repositories')
+
         return parser.parse_args()

--- a/utils/update_checkout/update_checkout/commands/__init__.py
+++ b/utils/update_checkout/update_checkout/commands/__init__.py
@@ -1,0 +1,3 @@
+from .status import StatusCommand
+
+__all__ = ["StatusCommand"]

--- a/utils/update_checkout/update_checkout/commands/status.py
+++ b/utils/update_checkout/update_checkout/commands/status.py
@@ -1,0 +1,87 @@
+from typing import List, Tuple
+
+from ..parallel_runner import (
+    ParallelRunner,
+    RunnerArguments,
+)
+from ..runner_arguments import UpdateArguments
+from ..cli_arguments import CliArguments
+from ..git_command import (
+    Git,
+    is_any_repository_locked,
+    is_git_repository,
+)
+
+
+class StatusCommand:
+    """
+    The status command prints the list of repositories with active changes
+    (uncommitted, untracked and/or staged).
+
+    Its goal is to help users determine if it's safe to run the script with
+    --reset-to-remote.
+    """
+    _args: CliArguments
+    _pool_args: List[UpdateArguments]
+
+    def __init__(self, args: CliArguments):
+        self._args = args
+        self._pool_args = []
+        for repo_path in args.source_root.iterdir():
+            if not is_git_repository(repo_path):
+                continue
+            repo_name = repo_path.name
+
+            my_args = RunnerArguments(
+                repo_name=repo_name,
+                output_prefix="Checking the status of",
+                source_root=args.source_root,
+                verbose=args.verbose,
+            )
+            self._pool_args.append(my_args)
+
+    def run(self):
+        # TODO: If we add more commands, make error handling more generic
+        locked_repositories = is_any_repository_locked(self._pool_args)
+        if len(locked_repositories) > 0:
+            results = [
+                Exception(f"'{repo_name}' is locked by git. Cannot update it.")
+                for repo_name in locked_repositories
+            ]
+        else:
+            results = ParallelRunner(
+                self._get_uncommitted_changes_of_repository,
+                self._pool_args,
+                self._args.n_processes,
+            ).run()
+
+        return self._handle_results(results)
+
+    def _handle_results(self, results) -> int:
+        ret = ParallelRunner.check_results(results, "STATUS")
+        if ret > 0:
+            return ret
+
+        repos_with_active_changes: List[Tuple[str, int]] = []
+        for result, pool_arg in zip(results, self._pool_args):
+            if result is None or result[0] == "":
+                continue
+            status_output: str = result[0]
+            repos_with_active_changes.append((pool_arg.repo_name, len(status_output.splitlines())))
+
+        if len(repos_with_active_changes) == 0:
+            print("No repositories have active changes.")
+        else:
+            print("The following repositories have active changes:")
+            for repo_name, file_count in repos_with_active_changes:
+                msg = f"  - [{repo_name}] {file_count} active change"
+                if file_count > 1:
+                    msg += "s"
+                print(msg)
+
+        return 0
+
+    @staticmethod
+    def _get_uncommitted_changes_of_repository(pool_args: RunnerArguments):
+        repo_path = pool_args.source_root.joinpath(pool_args.repo_name)
+        return Git.run(repo_path, ["status", "--short"], fatal=True)

--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -7,7 +7,6 @@ from concurrent.futures import ThreadPoolExecutor
 import shutil
 
 from .git_command import GitException
-
 from .runner_arguments import (
     RunnerArguments,
     AdditionalSwiftSourcesArguments,
@@ -84,7 +83,7 @@ class ParallelRunner:
     ):
         def run_safely(*args, **kwargs):
             try:
-                fn(*args, **kwargs)
+                return fn(*args, **kwargs)
             except GitException as e:
                 return e
 
@@ -158,6 +157,9 @@ class ParallelRunner:
         for r in results:
             if r is None:
                 continue
+            if isinstance(r, tuple) and len(r) == 3:
+                if r[1] == 0:
+                    continue
             if fail_count == 0:
                 print(f"======{operation} FAILURES======")
             fail_count += 1

--- a/utils/update_checkout/update_checkout/runner_arguments.py
+++ b/utils/update_checkout/update_checkout/runner_arguments.py
@@ -8,14 +8,14 @@ from .cli_arguments import CliArguments
 @dataclass
 class RunnerArguments:
     repo_name: str
-    scheme_name: str
     output_prefix: str
+    source_root: Path
     verbose: bool
 
 
 @dataclass
 class UpdateArguments(RunnerArguments):
-    source_root: Path
+    scheme_name: str
     config: Dict[str, Any]
     scheme_map: Any
     tag: Optional[str]
@@ -28,6 +28,7 @@ class UpdateArguments(RunnerArguments):
 
 @dataclass
 class AdditionalSwiftSourcesArguments(RunnerArguments):
+    scheme_name: str
     args: CliArguments
     repo_info: str
     repo_branch: str


### PR DESCRIPTION
This patch adds the `status` command to `update-checkout` to quickly check the status of all the git repositories.

The status command prints the list of repositories with active changes (uncommitted, untracked and/or staged). This subcommand should help users determine if it's safe to run `update-checkout --clone --reset-to-remote`.

## Examples

### When some repositories have active changes:

```bash
> ./swift/utils/update-checkout status
The following repositories have active changes:
  - [swift] 1 active change
  - [llvm-project] 2 active changes
```

### When no repository has active changes:

```bash
> ./swift/utils/update-checkout status
No repositories have active changes.
```

rdar://165437920