### PR TITLE
[Sema] Improve error for unqualified use of static variable in method

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -136,6 +136,10 @@ ERROR(expected_result_in_contextual_member,none,
 ERROR(unexpected_arguments_in_enum_case,none,
       "enum case %base0 has no associated values", (const ValueDecl *))
 
+ERROR(static_can_only_be_used_on_type_not_instance,none,
+      "static member %0 can only be used on the type %1, not on the instance %2",
+      (DeclNameRef, Type, StringRef))
+
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
       (Type, DeclNameRef))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1554,11 +1554,14 @@ public:
 class AllowTypeOrInstanceMember final : public AllowInvalidMemberRef {
   AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType,
                             ValueDecl *member, DeclNameRef name,
+                            Expr *baseExpr,
                             ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowTypeOrInstanceMember, baseType,
-                              member, name, locator) {
+                              member, name, locator),
+        BaseExpr(baseExpr) {
     assert(member);
   }
+  Expr *BaseExpr;
 
 public:
   std::string getName() const override {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1553,8 +1553,7 @@ public:
 
 class AllowTypeOrInstanceMember final : public AllowInvalidMemberRef {
   AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType,
-                            ValueDecl *member, DeclNameRef name,
-                            Expr *baseExpr,
+                            ValueDecl *member, DeclNameRef name, Expr *baseExpr,
                             ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowTypeOrInstanceMember, baseType,
                               member, name, locator),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4854,7 +4854,8 @@ bool InvalidMemberRefOnExistential::diagnoseAsError() {
   return true;
 }
 
-StringRef AllowTypeOrInstanceMemberFailure::getInstanceNameFromBaseExpr() const {
+StringRef
+AllowTypeOrInstanceMemberFailure::getInstanceNameFromBaseExpr() const {
 
   if (!BaseExpr)
     return "instance";
@@ -5120,8 +5121,9 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       Diag.emplace(
           emitDiagnostic(diag::could_not_use_enum_element_on_instance, Name));
     } else {
-      Diag.emplace(emitDiagnostic(diag::static_can_only_be_used_on_type_not_instance,
-                                  Name, baseTy, getInstanceNameFromBaseExpr()));
+      Diag.emplace(
+          emitDiagnostic(diag::static_can_only_be_used_on_type_not_instance,
+                         Name, baseTy, getInstanceNameFromBaseExpr()));
     }
 
     Diag->highlight(getSourceRange());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5099,8 +5099,33 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       Diag.emplace(
           emitDiagnostic(diag::could_not_use_enum_element_on_instance, Name));
     } else {
-      Diag.emplace(emitDiagnostic(diag::could_not_use_type_member_on_instance,
-                                  baseTy, Name));
+      StringRef instanceName = "instance";
+      Expr *baseExpr = nullptr;
+      Expr *anchor = getRawAnchor().dyn_cast<Expr*>();
+
+      if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+          baseExpr = UDE->getBase();
+      }
+      else if (auto *MRE = dyn_cast<MemberRefExpr>(anchor)) {
+          baseExpr = MRE->getBase();
+      }
+
+      if (baseExpr) {
+        Expr *semantic = baseExpr->getSemanticsProvidingExpr();
+        if (auto *DRE = dyn_cast<DeclRefExpr>(semantic)) {
+          instanceName = DRE->getDecl()->getBaseName().userFacingName();
+        }
+        else {
+          auto &SM = getASTContext().SourceMgr;
+          auto SR = semantic->getSourceRange();
+          if (SR.isValid()) {
+            auto CSR = Lexer::getCharSourceRangeFromSourceRange(SM,SR);
+            instanceName = SM.extractText(CSR);
+          }
+        }
+      }
+      Diag.emplace(emitDiagnostic(diag::static_can_only_be_used_on_type_not_instance,
+                                  Name, baseTy, instanceName));
     }
 
     Diag->highlight(getSourceRange());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4854,6 +4854,27 @@ bool InvalidMemberRefOnExistential::diagnoseAsError() {
   return true;
 }
 
+StringRef AllowTypeOrInstanceMemberFailure::getInstanceNameFromBaseExpr() const {
+
+  if (!BaseExpr)
+    return "instance";
+
+  Expr *semantic = BaseExpr->getSemanticsProvidingExpr();
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(semantic)) {
+    return DRE->getDecl()->getBaseName().userFacingName();
+  }
+
+  auto &SM = getASTContext().SourceMgr;
+  auto SR = semantic->getSourceRange();
+
+  if (SR.isValid()) {
+    auto CSR = Lexer::getCharSourceRangeFromSourceRange(SM, SR);
+    return SM.extractText(CSR);
+  }
+  return "instance";
+}
+
 bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   auto loc = getLoc();
   auto *DC = getDC();
@@ -5099,33 +5120,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       Diag.emplace(
           emitDiagnostic(diag::could_not_use_enum_element_on_instance, Name));
     } else {
-      StringRef instanceName = "instance";
-      Expr *baseExpr = nullptr;
-      Expr *anchor = getRawAnchor().dyn_cast<Expr*>();
-
-      if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
-          baseExpr = UDE->getBase();
-      }
-      else if (auto *MRE = dyn_cast<MemberRefExpr>(anchor)) {
-          baseExpr = MRE->getBase();
-      }
-
-      if (baseExpr) {
-        Expr *semantic = baseExpr->getSemanticsProvidingExpr();
-        if (auto *DRE = dyn_cast<DeclRefExpr>(semantic)) {
-          instanceName = DRE->getDecl()->getBaseName().userFacingName();
-        }
-        else {
-          auto &SM = getASTContext().SourceMgr;
-          auto SR = semantic->getSourceRange();
-          if (SR.isValid()) {
-            auto CSR = Lexer::getCharSourceRangeFromSourceRange(SM,SR);
-            instanceName = SM.extractText(CSR);
-          }
-        }
-      }
       Diag.emplace(emitDiagnostic(diag::static_can_only_be_used_on_type_not_instance,
-                                  Name, baseTy, instanceName));
+                                  Name, baseTy, getInstanceNameFromBaseExpr()));
     }
 
     Diag->highlight(getSourceRange());

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1380,16 +1380,19 @@ class AllowTypeOrInstanceMemberFailure final : public MemberReferenceFailure {
   Type BaseType;
   ValueDecl *Member;
   DeclNameRef Name;
+  Expr *BaseExpr;
 
 public:
   AllowTypeOrInstanceMemberFailure(const Solution &solution, Type baseType,
                                    ValueDecl *member, DeclNameRef name,
+                                   Expr *baseExpr,
                                    ConstraintLocator *locator)
       : MemberReferenceFailure(solution, locator),
-        BaseType(baseType->getRValueType()), Member(member), Name(name) {
+        BaseType(baseType->getRValueType()), Member(member), Name(name), BaseExpr(baseExpr) {
     assert(member);
   }
 
+  StringRef getInstanceNameFromBaseExpr() const;
   bool diagnoseAsError() override;
 };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1385,10 +1385,10 @@ class AllowTypeOrInstanceMemberFailure final : public MemberReferenceFailure {
 public:
   AllowTypeOrInstanceMemberFailure(const Solution &solution, Type baseType,
                                    ValueDecl *member, DeclNameRef name,
-                                   Expr *baseExpr,
-                                   ConstraintLocator *locator)
+                                   Expr *baseExpr, ConstraintLocator *locator)
       : MemberReferenceFailure(solution, locator),
-        BaseType(baseType->getRValueType()), Member(member), Name(name), BaseExpr(baseExpr) {
+        BaseType(baseType->getRValueType()), Member(member), Name(name),
+        BaseExpr(baseExpr) {
     assert(member);
   }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1034,7 +1034,8 @@ bool AllowInvalidMemberRef::diagnoseForAmbiguity(
 bool AllowTypeOrInstanceMember::diagnose(const Solution &solution,
                                          bool asNote) const {
   AllowTypeOrInstanceMemberFailure failure(solution, getBaseType(), getMember(),
-                                           getMemberName(), BaseExpr, getLocator());
+                                           getMemberName(), BaseExpr,
+                                           getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1053,8 +1054,8 @@ AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
     else if (auto *DME = dyn_cast<DynamicMemberRefExpr>(anchor))
       baseExpr = DME->getBase();
   }
-  return new (cs.getAllocator())
-      AllowTypeOrInstanceMember(cs, baseType, member, usedName, baseExpr, locator);
+  return new (cs.getAllocator()) AllowTypeOrInstanceMember(
+      cs, baseType, member, usedName, baseExpr, locator);
 }
 
 bool AllowInvalidPartialApplication::diagnose(const Solution &solution,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1034,7 +1034,7 @@ bool AllowInvalidMemberRef::diagnoseForAmbiguity(
 bool AllowTypeOrInstanceMember::diagnose(const Solution &solution,
                                          bool asNote) const {
   AllowTypeOrInstanceMemberFailure failure(solution, getBaseType(), getMember(),
-                                           getMemberName(), getLocator());
+                                           getMemberName(), BaseExpr, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1042,8 +1042,19 @@ AllowTypeOrInstanceMember *
 AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
                                   ValueDecl *member, DeclNameRef usedName,
                                   ConstraintLocator *locator) {
+
+  Expr *baseExpr = nullptr;
+
+  if (auto *anchor = locator->getAnchor().dyn_cast<Expr *>()) {
+    if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor))
+      baseExpr = UDE->getBase();
+    else if (auto *MRE = dyn_cast<MemberRefExpr>(anchor))
+      baseExpr = MRE->getBase();
+    else if (auto *DME = dyn_cast<DynamicMemberRefExpr>(anchor))
+      baseExpr = DME->getBase();
+  }
   return new (cs.getAllocator())
-      AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
+      AllowTypeOrInstanceMember(cs, baseType, member, usedName, baseExpr, locator);
 }
 
 bool AllowInvalidPartialApplication::diagnose(const Solution &solution,

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -45,7 +45,7 @@ struct S1 {
 func testStatic() {
   // static.
   S1.staticMethod()
-  S1().staticMethod() // expected-error {{static member 'staticMethod' cannot be used on instance of type 'S1'}}
+  S1().staticMethod() // expected-error {{static member 'staticMethod' can only be used on the type 'S1', not on the instance S1()}}
 }
 
 struct S2 {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -69,7 +69,7 @@ func classMethods(_ b: B, other: NSObject) {
   i += B.classMethod(1)
   i += B.classMethod(1, with: 2)
 
-  i += b.classMethod() // expected-error{{static member 'classMethod' cannot be used on instance of type 'B'}}
+  i += b.classMethod() // expected-error{{static member 'classMethod' can only be used on the type 'B', not on the instance b}}
 
   // Both class and instance methods exist.
   B.description()

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -294,7 +294,7 @@ class r15117741S {
   static func g() {}
 }
 func test15117741(_ s: r15117741S) {
-  s.g() // expected-error {{static member 'g' cannot be used on instance of type 'r15117741S'}}
+  s.g() // expected-error {{static member 'g' can only be used on the type 'r15117741S', not on the instance }}
 }
 
 
@@ -366,7 +366,7 @@ class C_25341015 {
   static func baz(_ x: Int, _ y: Int) {}
   func baz() {}
   func qux() {
-    baz(1, 2) // expected-error {{static member 'baz' cannot be used on instance of type 'C_25341015'}} {{5-5=C_25341015.}}
+    baz(1, 2) // expected-error {{static member 'baz' can only be used on the type 'C_25341015', not on the instance self}} {{5-5=C_25341015.}}
   }
 }
 
@@ -375,7 +375,7 @@ struct S_25341015 {
 
   func foo(z: Int) {}
   func bar() {
-    foo(1, y: 2) // expected-error {{static member 'foo' cannot be used on instance of type 'S_25341015'}} {{5-5=S_25341015.}}
+    foo(1, y: 2) // expected-error {{static member 'foo' can only be used on the type 'S_25341015', not on the instance self}} {{5-5=S_25341015.}}
   }
 }
 
@@ -545,7 +545,7 @@ class D {
   static func foo() {}
 
   func bar() {
-    foo() // expected-error {{static member 'foo' cannot be used on instance of type 'D'}}
+    foo() // expected-error {{static member 'foo' can only be used on the type 'D', not on the instance self}}
   }
 }
 
@@ -645,7 +645,7 @@ func rdar_50467583_and_50909555() {
   }
 
   func test(_ s: S) {
-    s[1] // expected-error {{static member 'subscript' cannot be used on instance of type 'S'}} {{5-6=S}}
+    s[1] // expected-error {{static member 'subscript' can only be used on the type 'S', not on the instance instance}}
     // expected-error@-1 {{missing argument for parameter #2 in subscript}} {{8-8=, <#Int#>}}
   }
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -137,7 +137,7 @@ func generic<T: P>(_ t: T) {
   let _: (Int) -> () = id(T.bar(t))
 
   _ = t.mut // expected-error{{cannot reference 'mutating' method as function value}}
-  _ = t.tum // expected-error{{static member 'tum' cannot be used on instance of type 'T'}}
+  _ = t.tum // expected-error{{static member 'tum' can only be used on the type 'T', not on the instance t}}
 }
 
 func genericClassP<T: ClassP>(_ t: T) {

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -170,7 +170,7 @@ func test_outside(
   _ = distributed.actorSystem
 
   // ==== static functions
-  _ = distributed.staticFunc() // expected-error{{static member 'staticFunc' cannot be used on instance of type 'DistributedActor_1'}}
+  _ = distributed.staticFunc() // expected-error{{static member 'staticFunc' can only be used on the type 'DistributedActor_1', not on the instance distribute}}
   _ = DistributedActor_1.staticFunc()
 
   // ==== non-distributed functions

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -182,7 +182,7 @@ func testStatic(_ sf: StaticFuncs, sfi: StaticFuncsGeneric<Int>) {
   x = StaticFuncs.chameleon()
   x = sf.chameleon2()
 
-  x = sfi.chameleon() // expected-error {{static member 'chameleon' cannot be used on instance of type 'StaticFuncsGeneric<Int>'}}
+  x = sfi.chameleon() // expected-error {{static member 'chameleon' can only be used on the type 'StaticFuncsGeneric<Int>', not on the instance sfi}}
   typealias SFI = StaticFuncsGeneric<Int>
   x = SFI.chameleon()
   _ = x

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -157,7 +157,7 @@ protocol StaticEq {
 }
 
 func staticEqCheck<T : StaticEq, U : StaticEq>(_ t: T, u: U) {
-  if t.isEqual(t, t) { return } // expected-error{{static member 'isEqual' cannot be used on instance of type 'T'}} // expected-error {{missing argument label 'y:' in call}}
+  if t.isEqual(t, t) { return } // expected-error{{static member 'isEqual' can only be used on the type 'T', not on the instance t}} // expected-error {{missing argument label 'y:' in call}}
 
   if T.isEqual(t, y: t) { return }
   if U.isEqual(u, y: u) { return }

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -122,7 +122,7 @@ var zi = ZI(x: 1, f: 3.0)
 var i : Int = XI.f()
 i = XI.f()
 i = xi.g()
-i = yi.f() // expected-error{{static member 'f' cannot be used on instance of type 'YI' (aka 'YT<Int>')}}
+i = yi.f() // expected-error{{static member 'f' can only be used on the type 'YI' (aka 'YT<Int>'), not on the instance yi}}
 i = yi.g()
 
 var xif : (XI) -> () -> Int = XI.g

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -105,7 +105,7 @@ extension X {
     shadowedByMemberOnXinB() // expected-member-visibility-warning{{'shadowedByMemberOnXinB()' is deprecated}}
     shadowedByMemberOnXinC()
 
-    _ = max(0, 1) // expected-ambiguity-error{{static member 'max' cannot be used on instance of type 'X'}}
+    _ = max(0, 1) // expected-ambiguity-error{{static member 'max' can only be used on the type 'X', not on the instance self}}
     // expected-ambiguity-error@-1{{cannot call value of non-function type 'Int'}}
   }
 

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -97,25 +97,25 @@ class ThisDerived1 : ThisBase1 {
     self.baseFunc0()
     self.baseFunc1(42)
     self[0] = 42.0
-    self.baseStaticVar = 42 // expected-error {{static member 'baseStaticVar' cannot be used on instance of type 'ThisDerived1'}}
-    self.baseStaticProp = 42 // expected-error {{static member 'baseStaticProp' cannot be used on instance of type 'ThisDerived1'}}
-    self.baseStaticFunc0() // expected-error {{static member 'baseStaticFunc0' cannot be used on instance of type 'ThisDerived1'}}
+    self.baseStaticVar = 42 // expected-error {{static member 'baseStaticVar' can only be used on the type 'ThisDerived1', not on the instance self}}
+    self.baseStaticProp = 42 // expected-error {{static member 'baseStaticProp' can only be used on the type 'ThisDerived1', not on the instance self}}
+    self.baseStaticFunc0() // expected-error {{static member 'baseStaticFunc0' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     self.baseExtProp = 42
     self.baseExtFunc0()
     self.baseExtStaticVar = 42
     self.baseExtStaticProp = 42
-    self.baseExtStaticFunc0() // expected-error {{static member 'baseExtStaticFunc0' cannot be used on instance of type 'ThisDerived1'}}
+    self.baseExtStaticFunc0() // expected-error {{static member 'baseExtStaticFunc0' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     var bs1 : BaseNestedStruct
     var bc1 : BaseNestedClass
     var bo1 : BaseNestedUnion = .BaseUnionX(42)
     var bt1 : BaseNestedTypealias
-    var bs2 = self.BaseNestedStruct() // expected-error{{static member 'BaseNestedStruct' cannot be used on instance of type 'ThisDerived1'}}
-    var bc2 = self.BaseNestedClass() // expected-error{{static member 'BaseNestedClass' cannot be used on instance of type 'ThisDerived1'}}
+    var bs2 = self.BaseNestedStruct() // expected-error{{static member 'BaseNestedStruct' can only be used on the type 'ThisDerived1', not on the instance sel}}
+    var bc2 = self.BaseNestedClass() // expected-error{{static member 'BaseNestedClass' can only be used on the type 'ThisDerived1', not on the instance self}}
     var bo2 = self.BaseUnionX(24) // expected-error {{value of type 'ThisDerived1' has no member 'BaseUnionX'}}
-    var bo3 = self.BaseNestedUnion.BaseUnionX(24) // expected-error{{static member 'BaseNestedUnion' cannot be used on instance of type 'ThisDerived1'}}
-    var bt2 = self.BaseNestedTypealias(42) // expected-error{{static member 'BaseNestedTypealias' cannot be used on instance of type 'ThisDerived1'}}
+    var bo3 = self.BaseNestedUnion.BaseUnionX(24) // expected-error{{static member 'BaseNestedUnion' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var bt2 = self.BaseNestedTypealias(42) // expected-error{{static member 'BaseNestedTypealias' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     var bes1 : BaseExtNestedStruct
     var bec1 : BaseExtNestedClass
@@ -132,33 +132,33 @@ class ThisDerived1 : ThisBase1 {
     self.derivedFunc0()
     self.derivedStaticVar = 42 // expected-error {{static member 'derivedStaticVar' cannot be used on instance of type 'ThisDerived1'}}
     self.derivedStaticProp = 42 // expected-error {{static member 'derivedStaticProp' cannot be used on instance of type 'ThisDerived1'}}
-    self.derivedStaticFunc0() // expected-error {{static member 'derivedStaticFunc0' cannot be used on instance of type 'ThisDerived1'}}
+    self.derivedStaticFunc0() // expected-error {{static member 'derivedStaticFunc0' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     self.derivedExtProp = 42
     self.derivedExtFunc0()
     self.derivedExtStaticVar = 42
     self.derivedExtStaticProp = 42
-    self.derivedExtStaticFunc0() // expected-error {{static member 'derivedExtStaticFunc0' cannot be used on instance of type 'ThisDerived1'}}
+    self.derivedExtStaticFunc0() // expected-error {{static member 'derivedExtStaticFunc0' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     var ds1 : DerivedNestedStruct
     var dc1 : DerivedNestedClass
     var do1 : DerivedNestedUnion = .DerivedUnionX(42)
     var dt1 : DerivedNestedTypealias
-    var ds2 = self.DerivedNestedStruct() // expected-error{{static member 'DerivedNestedStruct' cannot be used on instance of type 'ThisDerived1'}}
-    var dc2 = self.DerivedNestedClass() // expected-error{{static member 'DerivedNestedClass' cannot be used on instance of type 'ThisDerived1'}}
+    var ds2 = self.DerivedNestedStruct() // expected-error{{static member 'DerivedNestedStruct' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var dc2 = self.DerivedNestedClass() // expected-error{{static member 'DerivedNestedClass' can only be used on the type 'ThisDerived1', not on the instance self}}
     var do2 = self.DerivedUnionX(24) // expected-error {{value of type 'ThisDerived1' has no member 'DerivedUnionX'}}
-    var do3 = self.DerivedNestedUnion.DerivedUnionX(24) // expected-error{{static member 'DerivedNestedUnion' cannot be used on instance of type 'ThisDerived1'}}
-    var dt2 = self.DerivedNestedTypealias(42) // expected-error{{static member 'DerivedNestedTypealias' cannot be used on instance of type 'ThisDerived1'}}
+    var do3 = self.DerivedNestedUnion.DerivedUnionX(24) // expected-error{{static member 'DerivedNestedUnion' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var dt2 = self.DerivedNestedTypealias(42) // expected-error{{static member 'DerivedNestedTypealias' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     var des1 : DerivedExtNestedStruct
     var dec1 : DerivedExtNestedClass
     var deo1 : DerivedExtNestedUnion = .DerivedExtUnionX(42)
     var det1 : DerivedExtNestedTypealias
-    var des2 = self.DerivedExtNestedStruct() // expected-error{{static member 'DerivedExtNestedStruct' cannot be used on instance of type 'ThisDerived1'}}
-    var dec2 = self.DerivedExtNestedClass() // expected-error{{static member 'DerivedExtNestedClass' cannot be used on instance of type 'ThisDerived1'}}
+    var des2 = self.DerivedExtNestedStruct() // expected-error{{static member 'DerivedExtNestedStruct' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var dec2 = self.DerivedExtNestedClass() // expected-error{{static member 'DerivedExtNestedClass' can only be used on the type 'ThisDerived1', not on the instance self}}
     var deo2 = self.DerivedExtUnionX(24) // expected-error {{value of type 'ThisDerived1' has no member 'DerivedExtUnionX'}}
-    var deo3 = self.DerivedExtNestedUnion.DerivedExtUnionX(24) // expected-error{{static member 'DerivedExtNestedUnion' cannot be used on instance of type 'ThisDerived1'}}
-    var det2 = self.DerivedExtNestedTypealias(42) // expected-error{{static member 'DerivedExtNestedTypealias' cannot be used on instance of type 'ThisDerived1'}}
+    var deo3 = self.DerivedExtNestedUnion.DerivedExtUnionX(24) // expected-error{{static member 'DerivedExtNestedUnion' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var det2 = self.DerivedExtNestedTypealias(42) // expected-error{{static member 'DerivedExtNestedTypealias' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     self.Type // expected-error {{value of type 'ThisDerived1' has no member 'Type'}}
   }
@@ -169,27 +169,27 @@ class ThisDerived1 : ThisBase1 {
     super.baseFunc0()
     super.baseFunc1(42)
     super[0] = 42.0
-    super.baseStaticVar = 42 // expected-error {{static member 'baseStaticVar' cannot be used on instance of type 'ThisBase1'}}
-    super.baseStaticProp = 42 // expected-error {{static member 'baseStaticProp' cannot be used on instance of type 'ThisBase1'}}
-    super.baseStaticFunc0() // expected-error {{static member 'baseStaticFunc0' cannot be used on instance of type 'ThisBase1'}}
+    super.baseStaticVar = 42 // expected-error {{static member 'baseStaticVar' can only be used on the type 'ThisBase1', not on the instance super}}
+    super.baseStaticProp = 42 // expected-error {{static member 'baseStaticProp' can only be used on the type 'ThisBase1', not on the instance super}}
+    super.baseStaticFunc0() // expected-error {{static member 'baseStaticFunc0' can only be used on the type 'ThisBase1', not on the instance super}}
 
     super.baseExtProp = 42
     super.baseExtFunc0()
     super.baseExtStaticVar = 42
     super.baseExtStaticProp = 42
-    super.baseExtStaticFunc0() // expected-error {{static member 'baseExtStaticFunc0' cannot be used on instance of type 'ThisBase1'}}
+    super.baseExtStaticFunc0() // expected-error {{static member 'baseExtStaticFunc0' can only be used on the type 'ThisBase1', not on the instance super}}
 
-    var bs2 = super.BaseNestedStruct() // expected-error{{static member 'BaseNestedStruct' cannot be used on instance of type 'ThisBase1'}}
-    var bc2 = super.BaseNestedClass() // expected-error{{static member 'BaseNestedClass' cannot be used on instance of type 'ThisBase1'}}
+    var bs2 = super.BaseNestedStruct() // expected-error{{static member 'BaseNestedStruct' can only be used on the type 'ThisBase1', not on the instance super}}
+    var bc2 = super.BaseNestedClass() // expected-error{{static member 'BaseNestedClass' can only be used on the type 'ThisBase1', not on the instance super}}
     var bo2 = super.BaseUnionX(24) // expected-error {{value of type 'ThisBase1' has no member 'BaseUnionX'}}
-    var bo3 = super.BaseNestedUnion.BaseUnionX(24) // expected-error{{static member 'BaseNestedUnion' cannot be used on instance of type 'ThisBase1'}}
-    var bt2 = super.BaseNestedTypealias(42) // expected-error{{static member 'BaseNestedTypealias' cannot be used on instance of type 'ThisBase1'}}
+    var bo3 = super.BaseNestedUnion.BaseUnionX(24) // expected-error{{static member 'BaseNestedUnion' can only be used on the type 'ThisBase1', not on the instance super}}
+    var bt2 = super.BaseNestedTypealias(42) // expected-error{{static member 'BaseNestedTypealias' can only be used on the type 'ThisBase1', not on the instance super}}
 
-    var bes2 = super.BaseExtNestedStruct() // expected-error{{static member 'BaseExtNestedStruct' cannot be used on instance of type 'ThisBase1'}}
-    var bec2 = super.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' cannot be used on instance of type 'ThisBase1'}}
+    var bes2 = super.BaseExtNestedStruct() // expected-error{{static member 'BaseExtNestedStruct' can only be used on the type 'ThisBase1', not on the instance super}}
+    var bec2 = super.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' can only be used on the type 'ThisBase1', not on the instancesuper}}
     var beo2 = super.BaseExtUnionX(24) // expected-error {{value of type 'ThisBase1' has no member 'BaseExtUnionX'}}
-    var beo3 = super.BaseExtNestedUnion.BaseExtUnionX(24) // expected-error{{static member 'BaseExtNestedUnion' cannot be used on instance of type 'ThisBase1'}}
-    var bet2 = super.BaseExtNestedTypealias(42) // expected-error{{static member 'BaseExtNestedTypealias' cannot be used on instance of type 'ThisBase1'}}
+    var beo3 = super.BaseExtNestedUnion.BaseExtUnionX(24) // expected-error{{static member 'BaseExtNestedUnion' can only be used on the type 'ThisBase1', not on the instance super}}
+    var bet2 = super.BaseExtNestedTypealias(42) // expected-error{{static member 'BaseExtNestedTypealias' can only be used on the type 'ThisBase1', not on the instance super}}
 
     super.derivedInstanceVar = 42 // expected-error {{value of type 'ThisBase1' has no member 'derivedInstanceVar'}}
     super.derivedProp = 42 // expected-error {{value of type 'ThisBase1' has no member 'derivedProp'}}
@@ -354,8 +354,8 @@ struct GenericChameleon<U>: Crawlable {
   static func chameleon() {}
 
   func testStaticOnInstance(arg: GenericChameleon<Never>) {
-    arg.chameleon() // expected-error {{static member 'chameleon' cannot be used on instance of type 'GenericChameleon<Never>'}} {{5-8=GenericChameleon<Never>}}
-    arg.crawl() // expected-error {{static member 'crawl' cannot be used on instance of type 'GenericChameleon<Never>'}} {{5-8=GenericChameleon<Never>}}
+    arg.chameleon() // expected-error {{static member 'chameleon' can only be used on the type 'GenericChameleon<Never>', not on the instance arg}} {{5-8=GenericChameleon<Never>}}
+    arg.crawl() // expected-error {{static member 'crawl' can only be used on the type 'GenericChameleon<Never>', not on the instance arg}} {{5-8=GenericChameleon<Never>}}
   }
 }
 

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -121,17 +121,17 @@ class ThisDerived1 : ThisBase1 {
     var bec1 : BaseExtNestedClass
     var beo1 : BaseExtNestedUnion = .BaseExtUnionX(42)
     var bet1 : BaseExtNestedTypealias
-    var bes2 = self.BaseExtNestedStruct() // expected-error{{static member 'BaseExtNestedStruct' cannot be used on instance of type 'ThisDerived1'}}
-    var bec2 = self.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' cannot be used on instance of type 'ThisDerived1'}}
+    var bes2 = self.BaseExtNestedStruct() // expected-error{{static member 'BaseExtNestedStruct' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var bec2 = self.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' can only be used on the type 'ThisDerived1', not on the instance self}}
     var beo2 = self.BaseExtUnionX(24) // expected-error {{value of type 'ThisDerived1' has no member 'BaseExtUnionX'}}
-    var beo3 = self.BaseExtNestedUnion.BaseExtUnionX(24) // expected-error{{static member 'BaseExtNestedUnion' cannot be used on instance of type 'ThisDerived1'}}
-    var bet2 = self.BaseExtNestedTypealias(42) // expected-error{{static member 'BaseExtNestedTypealias' cannot be used on instance of type 'ThisDerived1'}}
+    var beo3 = self.BaseExtNestedUnion.BaseExtUnionX(24) // expected-error{{static member 'BaseExtNestedUnion' can only be used on the type 'ThisDerived1', not on the instance self}}
+    var bet2 = self.BaseExtNestedTypealias(42) // expected-error{{static member 'BaseExtNestedTypealias' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     self.derivedInstanceVar = 42
     self.derivedProp = 42
     self.derivedFunc0()
-    self.derivedStaticVar = 42 // expected-error {{static member 'derivedStaticVar' cannot be used on instance of type 'ThisDerived1'}}
-    self.derivedStaticProp = 42 // expected-error {{static member 'derivedStaticProp' cannot be used on instance of type 'ThisDerived1'}}
+    self.derivedStaticVar = 42 // expected-error {{static member 'derivedStaticVar' can only be used on the type 'ThisDerived1', not on the instance self}}
+    self.derivedStaticProp = 42 // expected-error {{static member 'derivedStaticProp' can only be used on the type 'ThisDerived1', not on the instance self}}
     self.derivedStaticFunc0() // expected-error {{static member 'derivedStaticFunc0' can only be used on the type 'ThisDerived1', not on the instance self}}
 
     self.derivedExtProp = 42
@@ -186,7 +186,7 @@ class ThisDerived1 : ThisBase1 {
     var bt2 = super.BaseNestedTypealias(42) // expected-error{{static member 'BaseNestedTypealias' can only be used on the type 'ThisBase1', not on the instance super}}
 
     var bes2 = super.BaseExtNestedStruct() // expected-error{{static member 'BaseExtNestedStruct' can only be used on the type 'ThisBase1', not on the instance super}}
-    var bec2 = super.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' can only be used on the type 'ThisBase1', not on the instancesuper}}
+    var bec2 = super.BaseExtNestedClass() // expected-error{{static member 'BaseExtNestedClass' can only be used on the type 'ThisBase1', not on the instance super}}
     var beo2 = super.BaseExtUnionX(24) // expected-error {{value of type 'ThisBase1' has no member 'BaseExtUnionX'}}
     var beo3 = super.BaseExtNestedUnion.BaseExtUnionX(24) // expected-error{{static member 'BaseExtNestedUnion' can only be used on the type 'ThisBase1', not on the instance super}}
     var bet2 = super.BaseExtNestedTypealias(42) // expected-error{{static member 'BaseExtNestedTypealias' can only be used on the type 'ThisBase1', not on the instance super}}

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -374,7 +374,7 @@ enum EnumWithStaticMember {
   static let staticVar = EmptyStruct()
 
   func foo() {
-    let _ = staticVar // expected-error {{static member 'staticVar' cannot be used on instance of type 'EnumWithStaticMember'}}
+    let _ = staticVar // expected-error {{static member 'staticVar' can only be used on the type 'EnumWithStaticMember', not on the instance self}}
   }
 }
 

--- a/test/Sema/static_member_on_instance.swift
+++ b/test/Sema/static_member_on_instance.swift
@@ -1,0 +1,146 @@
+//// RUN: %target-typecheck-verify-swift
+
+// =====================================================
+// Test 1: Basic instance access
+// =====================================================
+struct S1 {
+    static let v = 1
+}
+func t1(_ s: S1) {
+    _ = s.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S1', not on the instance s}}
+}
+
+// =====================================================
+// Test 2: Direct inside same type using self
+// =====================================================
+struct S2 {
+    static let v = 1
+    func f() {
+        _ = self.v
+        // expected-error@-1 {{static member 'v' can only be used on the type 'S2', not on the instance self}}
+    }
+}
+
+// =====================================================
+// Test 3: Array indexing
+// =====================================================
+struct S3 { static let v = 1 }
+func t3(arr: [S3], i: Int) {
+    _ = arr[i].v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S3', not on the instance arr[i]}}
+}
+
+// =====================================================
+// Test 4: Tuple extraction
+// =====================================================
+struct S4 { static let v = 1 }
+func t4(_ s1: S4, _ s2: S4) {
+    let tup = (s1, s2)
+    _ = tup.0.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S4', not on the instance tup.0}}
+}
+
+// =====================================================
+// Test 5: Parenthesized instance (((s)))
+// =====================================================
+struct S5 { static let v = 1 }
+func t5(_ s: S5) {
+    _ = (((s))).v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S5', not on the instance s}}
+}
+
+// =====================================================
+// Test 6: Enum case diagnostic (baseline, unchanged)
+// =====================================================
+enum E6 { case a }
+func t6(_ e: E6) {
+    _ = e.a
+    // expected-error@-1 {{enum case 'a' cannot be used as an instance member}}
+    // (This tests we did not break the unrelated enum case diagnostic.)
+}
+
+// =====================================================
+// Test 7: Constructor call as base (S()).v
+// =====================================================
+struct S7 { static let v = 1 }
+func t7() {
+    _ = (S7()).v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S7', not on the instance S7()}}
+}
+
+// =====================================================
+// Test 8: Ternary conditional base
+// =====================================================
+struct S8 { static let v = 1 }
+func t8(_ cond: Bool, s1: S8, s2: S8) {
+    _ = (cond ? s1 : s2).v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S8', not on the instance cond ? s1 : s2}}
+}
+
+// =====================================================
+// Test 9: Optional chaining s?.v
+// =====================================================
+struct S9 { static let v = 1 }
+struct C9 { var s: S9? }
+func t9(_ c: C9) {
+    _ = c.s?.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S9', not on the instance c.s?}}
+}
+
+// =====================================================
+// Test 10: Forced unwrap s!.v
+// =====================================================
+struct S10 { static let v = 1 }
+func t10(_ s: S10?) {
+    _ = s!.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S10', not on the instance s!}}
+}
+
+// =====================================================
+// Test 11: Valid static access
+// =====================================================
+struct S11 { static let v = 1 }
+func t11_ok() {
+    _ = S11.v   // OK
+}
+
+// =====================================================
+// Test 12: Shadowed type name (let S = S())
+// =====================================================
+struct S12 { static let v = 1 }
+func t12() {
+    let S = S12()
+    _ = S.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S12', not on the instance S}}
+}
+
+// =====================================================
+// Test 13: Nested struct access b.a.v
+// =====================================================
+struct A13 { static let v = 1 }
+struct B13 { let a: A13 }
+func t13(_ b: B13) {
+    _ = b.a.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'A13', not on the instance b.a}}
+}
+
+// =====================================================
+// Test 14: Optional member chain c.s?.v
+// =====================================================
+struct S14 { static let v = 1 }
+struct C14 { var s: S14? }
+func t14(_ c: C14) {
+    _ = c.s?.v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S14', not on the instance c.s?}}
+}
+
+// =====================================================
+// Test 15: S().v (again) — duplicate of constructor path
+// =====================================================
+struct S15 { static let v = 1 }
+func t15() {
+    _ = (S15()).v
+    // expected-error@-1 {{static member 'v' can only be used on the type 'S15', not on the instance S15()}}
+}
+

--- a/test/TypeCoercion/overload_member.swift
+++ b/test/TypeCoercion/overload_member.swift
@@ -69,7 +69,7 @@ func test_static_method_value_coerce(_ a: A) {
 func test_mixed_overload(_ a: A, x: X, y: Y) {
   var x1 = a.mixed(x: x)
   x1 = x
-  var y1 = a.mixed(y: y) // expected-error {{static member 'mixed' cannot be used on instance of type 'A'}} {{12-13=A}}
+  var y1 = a.mixed(y: y) // expected-error {{static member 'mixed' can only be used on the type 'A', not on the instance a}} {{12-13=A}}
   
   A.mixed(x) // expected-error{{cannot convert value of type 'X' to expected argument type 'A'}}
   var x2 = A.mixed(a)(x: x)
@@ -89,7 +89,7 @@ func test_mixed_overload_coerce(_ a: A, x: inout X, y: Y, z: Z) {
 func test_mixed_method_value_coerce(_ a: A) {
   var _ : (X) -> X = a.mixed
   var _ : (Y) -> Y = A.mixed
-  var _ : (Y) -> Y = a.mixed; // expected-error {{static member 'mixed' cannot be used on instance of type 'A'}} {{22-23=A}}
+  var _ : (Y) -> Y = a.mixed; // expected-error {{static member 'mixed' can only be used on the type 'A', not on the instance a}} {{22-23=A}}
   var _ : (A) -> (X) -> X = A.mixed
 }
 
@@ -130,8 +130,8 @@ extension A {
 
   func test_mixed_method_value_coerce() {
     var _ : (X) -> X = mixed
-    var _ : (Y) -> Y = mixed; // expected-error {{static member 'mixed' cannot be used on instance of type 'A'}} {{24-24=A.}}
-    var _ : (Y) -> Y = mixed; // expected-error {{static member 'mixed' cannot be used on instance of type 'A'}} {{24-24=A.}}
+    var _ : (Y) -> Y = mixed; // expected-error {{static member 'mixed' can only be used on the type 'A', not on the instance self}} {{24-24=A.}}
+    var _ : (Y) -> Y = mixed; // expected-error {{static member 'mixed' can only be used on the type 'A', not on the instance self}} {{24-24=A.}}
     var _ : (A) -> (X) -> X = A.mixed
   }
 

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -829,7 +829,7 @@ func invalid_refs_through_dynamic_lookup() {
     _ = lens.foo           // expected-error {{static member 'foo' cannot be used on instance of type 'S'}}
     _ = lens.bar()
     _ = lens.bar().faz + 1 
-    _ = lens.baz("hello")  // expected-error {{static member 'baz' cannot be used on instance of type 'S'}}
+    _ = lens.baz("hello")  // expected-error {{static member 'baz' can only be used on the type 'S', not on the instance lens}}
   }
   
   func testStatic(_ lens: AMetatype<S>) {

--- a/test/decl/protocol/existential_member_access/metatype.swift
+++ b/test/decl/protocol/existential_member_access/metatype.swift
@@ -45,9 +45,9 @@ do {
   existMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'TypeMemberOnInstanceAndViceVersa'}}
 
   // TypeMemberOnInstanceAndViceVersa
-  instance.static_invariantSelfMethod // expected-error {{static member 'static_invariantSelfMethod' cannot be used on instance of type 'any TypeMemberOnInstanceAndViceVersa'}}
-  instance.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on instance of type 'any TypeMemberOnInstanceAndViceVersa'}}
-  instance[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on instance of type 'any TypeMemberOnInstanceAndViceVersa'}}
+  instance.static_invariantSelfMethod // expected-error {{static member 'static_invariantSelfMethod' can only be used on the type 'any TypeMemberOnInstanceAndViceVersa', not on the instance instance}}
+  instance.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' can only be used on the type 'any TypeMemberOnInstanceAndViceVersa', not on the instance instance}}
+  instance[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' can only be used on the type 'any TypeMemberOnInstanceAndViceVersa', not on the instance instance}}
 }
 
 /// Used to verify the type of an expression. Use like this:

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -309,7 +309,7 @@ struct StaticAndInstanceS : InstanceP {
 }
 func StaticProtocolFunc() {
   let a: StaticP = StaticS1()
-  a.f() // expected-error{{static member 'f' cannot be used on instance of type 'any StaticP'}}
+  a.f() // expected-error{{static member 'f' can only be used on the type 'any StaticP', not on the instance a}}
 }
 func StaticProtocolGenericFunc<t : StaticP>(_: t) {
   t.f()

--- a/test/decl/subscript/static.swift
+++ b/test/decl/subscript/static.swift
@@ -14,8 +14,8 @@ func useMyStruct() {
   MyStruct.self[1] = "zyzyx"
   MyStruct[2] = "asdfg"
   
-  MyStruct()[0] // expected-error {{static member 'subscript' cannot be used on instance of type 'MyStruct'}}
-  MyStruct()[1] = "zyzyx" // expected-error {{static member 'subscript' cannot be used on instance of type 'MyStruct'}}
+  MyStruct()[0] // expected-error {{static member 'subscript' can only be used on the type 'MyStruct', not on the instance instance}}
+  MyStruct()[1] = "zyzyx" // expected-error {{static member 'subscript' can only be used on the type 'MyStruct', not on the instance instanc}}
 }
 
 struct BadStruct {
@@ -34,7 +34,7 @@ class Dyn {
 
 func useDyn() {
   _ = Dyn.foo
-  _ = Dyn().bar // expected-error{{static member 'bar' cannot be used on instance of type 'Dyn'}}
+  _ = Dyn().bar // expected-error{{static member 'bar' can only be used on the type 'Dyn', not on the instance Dyn()}}
 }
 
 class BadBase {

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -129,7 +129,7 @@ class Y5 {
   static var x = X()
   
   subscript(idx: Int) -> X {
-    get { return x } // expected-error {{static member 'x' cannot be used on instance of type 'Y5'}}
+    get { return x } // expected-error {{static member 'x' can only be used on the type 'Y5', not on the instance self}}
     set {}
   }
 }

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -232,7 +232,7 @@ func test_invalid_references() {
         }
 
         let x = c.lowercased()
-        // expected-error@-1 {{static member 'c' cannot be used on instance of type 'Test'}}
+        // expected-error@-1 {{static member 'c' can only be used on the type 'Test', not on the instance self}}
 
         print(Test.c.lowercased()) // Ok
 

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -177,15 +177,15 @@ class ReferenceSelfInLazyProperty : BaseClass {
 
 class ReferenceStaticInLazyProperty {
   lazy var refs1 = i
-  // expected-error@-1 {{static member 'i' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+  // expected-error@-1 {{static member 'i' can only be used on the type 'ReferenceStaticInLazyProperty', not on the instance self}}
   lazy var refs2 = f()
-  // expected-error@-1 {{static member 'f' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+  // expected-error@-1 {{static member 'f' can only be used on the type 'ReferenceStaticInLazyProperty', not on the instance self}}
 
   lazy var trefs1: Int = i
-  // expected-error@-1 {{static member 'i' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+  // expected-error@-1 {{static member 'i' can only be used on the type 'ReferenceStaticInLazyProperty', not on the instance self}}
 
   lazy var trefs2: Int = f()
-  // expected-error@-1 {{static member 'f' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+  // expected-error@-1 {{static member 'f' can only be used on the type 'ReferenceStaticInLazyProperty', not on the instance self}}
 
   static var i = 42
   static func f() -> Int { return 0 }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -630,7 +630,7 @@ func staticPropRefs() -> (Int, Int, String, UnicodeScalar, UInt8) {
 }
 
 func staticPropRefThroughInstance(_ foo: MonoStruct) -> Int {
-  return foo.foo //expected-error{{static member 'foo' cannot be used on instance of type 'MonoStruct'}}
+  return foo.foo //expected-error{{static member 'foo' can only be used on the type 'MonoStruct', not on the instance foo}}
 }
 
 func memberwiseInitOnlyTakesInstanceVars() -> MonoStruct {

--- a/test/expr/leading_dot/static_members_on_protocol_in_generic_context.swift
+++ b/test/expr/leading_dot/static_members_on_protocol_in_generic_context.swift
@@ -166,9 +166,9 @@ test_combo(.property) // Ok
 test_combo(.method()) // Ok
 test_combo(.otherProperty) // Ok
 test_combo(.otherProperty.other) // Ok
-test_combo(.otherProperty.property) // expected-error {{static member 'property' cannot be used on instance of type 'S'}}
+test_combo(.otherProperty.property) // expected-error {{static member 'property' can only be used on the type 'S', not on the instance .otherProperty}}
 test_combo(.otherMethod()) // Ok
-test_combo(.otherMethod().method()) // expected-error {{static member 'method' cannot be used on instance of type 'S'}}
+test_combo(.otherMethod().method()) // expected-error {{static member 'method' can only be used on the type 'S', not on the instance .otherMethod()}}
 test_combo(.otherGeneric(42)) // Ok
 
 test_combo(.genericFn(42)) // expected-error {{global function 'test_combo' requires that 'G<Int>' conform to 'Q'}}

--- a/test/expr/postfix/dot/dot_keywords.swift
+++ b/test/expr/postfix/dot/dot_keywords.swift
@@ -95,7 +95,7 @@ extension S.A.B {
   private static let x: Int = 5
     
   func f() -> Int {
-    return x  // expected-error {{static member 'x' cannot be used on instance of type 'S.A.B'}} {{12-12=S.A.B.}}
+    return x  // expected-error {{static member 'x' can only be used on the type 'S.A.B', not on the instance self}} {{12-12=S.A.B.}}
   }
 }
 
@@ -106,7 +106,7 @@ extension P {
   static func f() {}
 
   func g() {
-    f() // expected-error {{static member 'f' cannot be used on instance of type 'Self'}} {{5-5=Self.}}
+    f() // expected-error {{static member 'f' can only be used on the type 'Self', not on the instance self}} {{5-5=Self.}}
   }
 }
 

--- a/test/expr/primary/selector/property.swift
+++ b/test/expr/primary/selector/property.swift
@@ -37,7 +37,7 @@ class ObjCClass {
     let _ = #selector(setter: myConstant) // expected-error {{argument of '#selector(setter:)' refers to non-settable property 'myConstant'}}
     let _ = #selector(setter: myComputedReadOnlyProperty) // expected-error {{argument of '#selector(setter:)' refers to non-settable property 'myComputedReadOnlyProperty'}}
 
-    let _ = #selector(myClassFunc) // expected-error{{static member 'myClassFunc' cannot be used on instance of type 'ObjCClass'}}
+    let _ = #selector(myClassFunc) // expected-error{{static member 'myClassFunc' can only be used on the type 'ObjCClass', not on the instance self}}
   }
 
   class func classMethod() {
@@ -204,9 +204,9 @@ class InstanceStaticTestClass {
     let _ = #selector(getter: instanceProperty)
     let _ = #selector(instanceMethod)
 
-    let _ = #selector(getter: staticProperty) // expected-error{{static member 'staticProperty' cannot be used on instance of type 'InstanceStaticTestClass'}}
-    let _ = #selector(classMethod) // expected-error{{static member 'classMethod' cannot be used on instance of type 'InstanceStaticTestClass'}}
-    let _ = #selector(staticMethod) // expected-error{{static member 'staticMethod' cannot be used on instance of type 'InstanceStaticTestClass'}}
+    let _ = #selector(getter: staticProperty) // expected-error{{static member 'staticProperty' can only be used on the type 'InstanceStaticTestClass', not on the instance self}}
+    let _ = #selector(classMethod) // expected-error{{static member 'classMethod' can only be used on the type 'InstanceStaticTestClass', not on the instance self}}
+    let _ = #selector(staticMethod) // expected-error{{static member 'staticMethod' can only be used on the type 'InstanceStaticTestClass', not on the instance self}}
 
     let _ = #selector(instanceAndStaticMethod)
   }

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -34,7 +34,7 @@ struct S0 {
     _ = self.f2(_:`let`:) // expected-warning {{keyword 'let' does not need to be escaped in argument list}}{{19-20=}}{{23-24=}}
     _ = self.f3(_:`var`:) // expected-warning {{keyword 'var' does not need to be escaped in argument list}}{{19-20=}}{{23-24=}}
 
-    _ = f3(_:y:z:) // expected-error{{static member 'f3(_:y:z:)' cannot be used on instance of type 'S0'}}{{9-9=S0.}}
+    _ = f3(_:y:z:) // expected-error{{static member 'f3(_:y:z:)' can only be used on the type 'S0', not on the instance self}}{{9-9=S0.}}
   }
 
   static func testStaticS0() {


### PR DESCRIPTION
### Resolves 
https://github.com/swiftlang/swift/issues/48759

### Summary
This PR improves the diagnostic emitted when a static member is referenced through an instance.
The previous diagnostic was misleading because it stated that the static member “cannot be used on an instance,” without clarifying the correct usage.
This change updates the diagnostic to explicitly state that static members must be referenced on the type.

### Changes made

1. Added a new diagnostic to include/swift/AST/DiagnosticsSema.def
2. Updated lib/Sema/CSDiagnostics.cpp to extract the relevant tokens and emit the updated message
3. Added test coverage in test/Sema/static_member_on_instance.swift


### Original Example (from Issue)
````
struct HasStatic {
    func foo() {
        print(cvar)
    }
    static let cvar = 123
}
````

### Previous Output
````
$ swiftc 48759.swift 
48759.swift:3:15: error: static member 'cvar' cannot be used on instance of type 'HasStatic'
1 | struct HasStatic {
2 |     func foo() {
3 |         print(cvar)
  |               `- error: static member 'cvar' cannot be used on instance of type 'HasStatic'
4 |     }
5 |     static let cvar = 123
````

### Updated Output
````
$ swiftc 48759.swift 
48759.swift:3:15: error: static member 'cvar' can only be used on the type 'HasStatic', not on the instance self
1 | struct HasStatic {
2 |     func foo() {
3 |         print(cvar)
  |               `- error: static member 'cvar' can only be used on the type 'HasStatic', not on the instance self
4 |     }
5 |     static let cvar = 123
````


