### PR TITLE
embedded: change the function representation of directly called witness methods

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -227,6 +227,25 @@ extension TypeProperties {
     GenericSignature(bridged: rawType.bridged.getInvocationGenericSignatureOfFunctionType())
   }
 
+  public var functionTypeRepresentation: FunctionTypeRepresentation {
+    switch rawType.bridged.getFunctionTypeRepresentation() {
+      case .Thick:                 return .thick
+      case .Block:                 return .block
+      case .Thin:                  return .thin
+      case .CFunctionPointer:      return .cFunctionPointer
+      case .Method:                return .method
+      case .ObjCMethod:            return .objCMethod
+      case .WitnessMethod:         return .witnessMethod
+      case .Closure:               return .closure
+      case .CXXMethod:             return .cxxMethod
+      case .KeyPathAccessorGetter: return .keyPathAccessorGetter
+      case .KeyPathAccessorSetter: return .keyPathAccessorSetter
+      case .KeyPathAccessorEquals: return .keyPathAccessorEquals
+      case .KeyPathAccessorHash:   return .keyPathAccessorHash
+      default: fatalError()
+    }
+  }
+
   //===--------------------------------------------------------------------===//
   //                             Type properties
   //===--------------------------------------------------------------------===//
@@ -304,6 +323,59 @@ extension TypeProperties {
 
   public var isSILPackElementAddress: Bool {
     return rawType.bridged.isSILPackElementAddress()
+  }
+}
+
+public enum FunctionTypeRepresentation {
+  /// A freestanding thick function.
+  case thick
+
+  /// A thick function that is represented as an Objective-C block.
+  case block
+
+  /// A freestanding thin function that needs no context.
+  case thin
+
+  /// A C function pointer, which is thin and also uses the C calling convention.
+  case cFunctionPointer
+
+  /// A Swift instance method.
+  case method
+
+  /// An Objective-C method.
+  case objCMethod
+
+  /// A Swift protocol witness.
+  case witnessMethod
+
+  /// A closure invocation function that has not been bound to a context.
+  case closure
+
+  /// A C++ method that takes a "this" argument (not a static C++ method or constructor).
+  /// Except for handling the "this" argument, has the same behavior as "CFunctionPointer".
+  case cxxMethod
+
+  /// A KeyPath accessor function, which is thin and also uses the variadic length generic
+  /// components serialization in trailing buffer. Each representation has a different convention
+  /// for which parameters have serialized generic type info.
+  case keyPathAccessorGetter, keyPathAccessorSetter, keyPathAccessorEquals, keyPathAccessorHash
+
+  public var bridged: BridgedASTType.FunctionTypeRepresentation {
+    switch self {
+      case .thick:                 return .Thick
+      case .block:                 return .Block
+      case .thin:                  return .Thin
+      case .cFunctionPointer:      return .CFunctionPointer
+      case .method:                return .Method
+      case .objCMethod:            return .ObjCMethod
+      case .witnessMethod:         return .WitnessMethod
+      case .closure:               return .Closure
+      case .cxxMethod:             return .CXXMethod
+      case .keyPathAccessorGetter: return .KeyPathAccessorGetter
+      case .keyPathAccessorSetter: return .KeyPathAccessorSetter
+      case .keyPathAccessorEquals: return .KeyPathAccessorEquals
+      case .keyPathAccessorHash:   return .KeyPathAccessorHash
+    }
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -21,6 +21,7 @@ swift_compiler_sources(Optimizer
   DeinitDevirtualizer.swift
   DestroyHoisting.swift
   DiagnoseInfiniteRecursion.swift
+  EmbeddedWitnessCallSpecialization.swift
   InitializeStaticGlobals.swift
   LetPropertyLowering.swift
   LifetimeDependenceDiagnostics.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -538,38 +538,7 @@ private struct SpecializationInfo {
 
     let newApplyArgs = getNewApplyArguments(context)
 
-    let builder = Builder(before: apply, context)
-    let funcRef = builder.createFunctionRef(specializedFunction)
-
-    switch apply {
-    case let oldPartialApply as PartialApplyInst:
-      let newPartialApply = builder.createPartialApply(
-        function: funcRef, substitutionMap: SubstitutionMap(),
-        capturedArguments: newApplyArgs, calleeConvention: oldPartialApply.calleeConvention,
-        hasUnknownResultIsolation: oldPartialApply.hasUnknownResultIsolation,
-        isOnStack: oldPartialApply.isOnStack)
-      oldPartialApply.replace(with: newPartialApply, context)
-
-    case let oldApply as ApplyInst:
-      let newApply = builder.createApply(function: funcRef, SubstitutionMap(), arguments: newApplyArgs,
-                                         isNonThrowing: oldApply.isNonThrowing,
-                                         isNonAsync: oldApply.isNonAsync)
-      oldApply.replace(with: newApply, context)
-
-    case let oldTryApply as TryApplyInst:
-      builder.createTryApply(function: funcRef, SubstitutionMap(), arguments: newApplyArgs,
-                             normalBlock: oldTryApply.normalBlock, errorBlock: oldTryApply.errorBlock,
-                             isNonAsync: oldTryApply.isNonAsync)
-      context.erase(instruction: oldTryApply)
-
-    case let oldBeginApply as BeginApplyInst:
-      let newApply = builder.createBeginApply(function: funcRef, SubstitutionMap(), arguments: newApplyArgs,
-                                              isNonThrowing: oldBeginApply.isNonThrowing,
-                                              isNonAsync: oldBeginApply.isNonAsync)
-      oldBeginApply.replace(with: newApply, context)
-    default:
-      fatalError("unknown apply")
-    }
+    apply.replace(withCallTo: specializedFunction, arguments: newApplyArgs, context)
   }
 
   private func insertCompensatingDestroysForOwnedClosureArguments(_ context: FunctionPassContext) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -410,7 +410,7 @@ private struct SpecializationInfo {
         // The specialized function is always a thin function. This is important because we add additional
         // parameters after the Self parameter of witness methods. In this case the new function is not a
         // method anymore.
-        makeThin: true, makeBare: true)
+        withRepresentation: .thin, makeBare: true)
 
     context.buildSpecializedFunction(
       specializedFunction: specializedFunction,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EmbeddedWitnessCallSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EmbeddedWitnessCallSpecialization.swift
@@ -1,0 +1,95 @@
+//===--- EmbeddedWitnessCallSpecialization.swift ---------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Changes the function representation of directly called witness methods in Embedded Swift.
+///
+/// If a function with `witness_method` convention is directly called, the function is specialized
+/// by changing the convention to `method` and the call is replaced by a call to the specialized
+/// function:
+///
+/// ```
+///   %1 = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+///   %2 = apply %1(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+/// ...
+/// sil [ossa] @callee : $@convention(witness_method: P) (@guaranteed C) -> () {
+///   ...
+/// }
+/// ```
+/// ->
+/// ```
+///   %1 = function_ref @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> ()
+///   %2 = apply %1(%0) : $@convention(method) (@guaranteed C) -> ()
+/// ...
+/// // specialized callee
+/// sil shared [ossa] @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> () {
+///   ...
+/// }
+/// ```
+///
+/// This is needed in Embedded Swift because the `witness_method` convention requires passing the
+/// witness table to the callee. However, the witness table is not necessarily available.
+/// A witness table is only generated if an existential value of a protocol is created.
+///
+/// This is a rare situation because only witness thunks have `witness_method` convention and those
+/// thunks are created as "transparent" functions, which means they are always inlined (after de-
+/// virtualization of a witness method call). However, inlining - even of transparent functions -
+/// can fail for some reasons.
+///
+let embeddedWitnessCallSpecialization = FunctionPass(name: "embedded-witness-call-specialization") {
+  (function: Function, context: FunctionPassContext) in
+
+  guard context.options.enableEmbeddedSwift,
+        !function.isGeneric
+  else {
+    return
+  }
+  for inst in function.instructions {
+    if let apply = inst as? FullApplySite {
+      specializeDirectWitnessMethodCall(apply: apply, context)
+    }
+  }
+}
+
+private func specializeDirectWitnessMethodCall(apply: FullApplySite, _ context: FunctionPassContext) {
+  guard apply.callee.type.functionTypeRepresentation == .witnessMethod,
+        let callee = apply.referencedFunction,
+        callee.isDefinition
+  else {
+    return
+  }
+
+  let specializedFunctionName = context.mangle(withChangedRepresentation: callee)
+
+  let specializedFunction: Function
+
+  if let existingSpecializedFunction = context.lookupFunction(name: specializedFunctionName) {
+    specializedFunction = existingSpecializedFunction
+
+  } else {
+    specializedFunction = context.createSpecializedFunctionDeclaration(
+      from: callee, withName: specializedFunctionName,
+      withParams: Array(callee.convention.parameters),
+      withRepresentation: .method)
+
+    context.buildSpecializedFunction(
+      specializedFunction: specializedFunction,
+      buildFn: { (specializedFunction, specializedContext) in
+        cloneFunction(from: callee, toEmpty: specializedFunction, specializedContext)
+      })
+
+    context.notifyNewFunction(function: specializedFunction, derivedFrom: callee)
+  }
+
+  apply.replace(withCallTo: specializedFunction, arguments: Array(apply.arguments), context)
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
@@ -553,7 +553,7 @@ private struct PackExplodedFunction {
         withParams: newParameters,
         withResults: newResults,
         // If a method has a dynamic self parameter, it cannot be converted into a thin function (non-method).
-        makeThin: !original.mayBindDynamicSelf)
+        withRepresentation: original.mayBindDynamicSelf ? nil : .thin)
 
       self.buildSpecializedFunction(context)
     }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
@@ -164,6 +164,10 @@ struct FunctionPassContext : MutatingContext {
     }
   }
 
+  func mangle(withChangedRepresentation original: Function) -> String {
+    String(taking: bridgedPassContext.mangleWithChangedRepresentation(original.bridged))
+  }
+
   func createSpecializedFunctionDeclaration(
     from original: Function, withName specializedFunctionName: String,
     withParams specializedParameters: [ParameterInfo],

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/FunctionPassContext.swift
@@ -168,12 +168,13 @@ struct FunctionPassContext : MutatingContext {
     from original: Function, withName specializedFunctionName: String,
     withParams specializedParameters: [ParameterInfo],
     withResults specializedResults: [ResultInfo]? = nil,
-    makeThin: Bool = false,
+    withRepresentation: FunctionTypeRepresentation? = nil,
     makeBare: Bool = false,
     preserveGenericSignature: Bool = true
   ) -> Function {
     return specializedFunctionName._withBridgedStringRef { nameRef in
       let bridgedParamInfos = specializedParameters.map { $0._bridged }
+      let repr = withRepresentation ?? original.loweredFunctionType.functionTypeRepresentation
 
       return bridgedParamInfos.withUnsafeBufferPointer { paramBuf in
 
@@ -183,7 +184,7 @@ struct FunctionPassContext : MutatingContext {
             return bridgedPassContext.createSpecializedFunctionDeclaration(
               nameRef, paramBuf.baseAddress, paramBuf.count,
               resultBuf.baseAddress, resultBuf.count,
-              original.bridged, makeThin, makeBare,
+              original.bridged, repr.bridged, makeBare,
               preserveGenericSignature
             ).function
           }
@@ -191,7 +192,7 @@ struct FunctionPassContext : MutatingContext {
           return bridgedPassContext.createSpecializedFunctionDeclaration(
             nameRef, paramBuf.baseAddress, paramBuf.count,
             nil, 0,
-            original.bridged, makeThin, makeBare,
+            original.bridged, repr.bridged, makeBare,
             preserveGenericSignature
           ).function
         }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -73,6 +73,7 @@ private func registerSwiftPasses() {
   registerPass(allocBoxToStack, { allocBoxToStack.run($0) })
   registerPass(asyncDemotion, { asyncDemotion.run($0) })
   registerPass(booleanLiteralFolding, { booleanLiteralFolding.run($0) })
+  registerPass(embeddedWitnessCallSpecialization, { embeddedWitnessCallSpecialization.run($0) })
   registerPass(letPropertyLowering, { letPropertyLowering.run($0) })
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
   registerPass(constantCapturePropagation, { constantCapturePropagation.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -241,6 +241,47 @@ extension FullApplySite {
   }
 }
 
+extension ApplySite {
+  func replace(withCallTo callee: Function, arguments newArguments: [Value], _ context: some MutatingContext) {
+    let builder = Builder(before: self, context)
+    let calleeRef = builder.createFunctionRef(callee)
+
+    switch self {
+    case let applyInst as ApplyInst:
+      let newApply = builder.createApply(function: calleeRef,
+                                         applyInst.substitutionMap,
+                                         arguments: newArguments,
+                                         isNonThrowing: applyInst.isNonThrowing)
+      applyInst.replace(with: newApply, context)
+
+    case let partialAp as PartialApplyInst:
+      let newApply = builder.createPartialApply(function: calleeRef,
+                                                substitutionMap: partialAp.substitutionMap,
+                                                capturedArguments: newArguments,
+                                                calleeConvention: partialAp.calleeConvention,
+                                                hasUnknownResultIsolation: partialAp.hasUnknownResultIsolation,
+                                                isOnStack: partialAp.isOnStack)
+      partialAp.replace(with: newApply, context)
+
+    case let tryApply as TryApplyInst:
+      builder.createTryApply(function: calleeRef,
+                             tryApply.substitutionMap,
+                             arguments: newArguments,
+                             normalBlock: tryApply.normalBlock, errorBlock: tryApply.errorBlock)
+      context.erase(instruction: tryApply)
+
+    case let beginApply as BeginApplyInst:
+      let newApply = builder.createBeginApply(function: calleeRef,
+                                              beginApply.substitutionMap,
+                                              arguments: newArguments)
+      beginApply.replace(with: newApply, context)
+
+    default:
+      fatalError("unknown apply")
+    }
+  }
+}
+
 extension Builder {
   static func insert(after inst: Instruction, _ context: some MutatingContext, insertFunc: (Builder) -> ()) {
     Builder.insert(after: inst, location: inst.location, context, insertFunc: insertFunc)

--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -1350,7 +1350,7 @@ Some kinds need arguments, which precede ``Tf``.
   spec-arg ::= identifier
   spec-arg ::= type
 
-  SPEC-INFO ::= FRAGILE? ASYNC-REMOVED? PASSID
+  SPEC-INFO ::= FRAGILE? (ASYNC-REMOVED|REPR-CHANGED)? PASSID
 
   PASSID ::= '0'                             // AllocBoxToStack,
   PASSID ::= '1'                             // ClosureSpecializer,
@@ -1361,10 +1361,12 @@ Some kinds need arguments, which precede ``Tf``.
   PASSID ::= '6'                             // MoveDiagnosticInOutToOut,
   PASSID ::= '7'                             // AsyncDemotion,
   PASSID ::= '8'                             // PackSpecialization,
+  PASSID ::= '9'                             // EmbeddedWitnessCallSpecialization
 
   FRAGILE ::= 'q'
 
   ASYNC-REMOVED ::= 'a'                      // async effect removed
+  REPR-CHANGED ::= 'r'                       // function type representation changed
 
   ARG-SPEC-KIND ::= 'n'                      // Unmodified argument
   ARG-SPEC-KIND ::= 'c'                      // Consumes n 'type' arguments which are closed over types in argument order

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2985,6 +2985,22 @@ struct BridgedASTType {
     ObjC
   };
 
+  enum class FunctionTypeRepresentation {
+    Thick = 0,
+    Block,
+    Thin,
+    CFunctionPointer,
+    Method = 8,
+    ObjCMethod,
+    WitnessMethod,
+    Closure,
+    CXXMethod,
+    KeyPathAccessorGetter,
+    KeyPathAccessorSetter,
+    KeyPathAccessorEquals,
+    KeyPathAccessorHash
+  };
+
   swift::TypeBase * _Nullable type;
 
   BRIDGED_INLINE swift::Type unbridged() const;
@@ -3047,6 +3063,7 @@ struct BridgedASTType {
   BRIDGED_INLINE BridgedOptionalInt getValueOfIntegerType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getInvocationGenericSignatureOfFunctionType() const;
+  BRIDGED_INLINE FunctionTypeRepresentation getFunctionTypeRepresentation() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedSubstitutionMap substMap) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType mapOutOfEnvironment() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -713,6 +713,25 @@ BridgedGenericSignature BridgedASTType::getInvocationGenericSignatureOfFunctionT
   return {unbridged()->castTo<swift::SILFunctionType>()->getInvocationGenericSignature().getPointer()};
 }
 
+BridgedASTType::FunctionTypeRepresentation BridgedASTType::getFunctionTypeRepresentation() const {
+  static_assert((int)FunctionTypeRepresentation::Thick == (int)swift::SILFunctionTypeRepresentation::Thick);
+  static_assert((int)FunctionTypeRepresentation::Block == (int)swift::SILFunctionTypeRepresentation::Block);
+  static_assert((int)FunctionTypeRepresentation::Thin == (int)swift::SILFunctionTypeRepresentation::Thin);
+  static_assert((int)FunctionTypeRepresentation::CFunctionPointer == (int)swift::SILFunctionTypeRepresentation::CFunctionPointer);
+  static_assert((int)FunctionTypeRepresentation::Method == (int)swift::SILFunctionTypeRepresentation::Method);
+  static_assert((int)FunctionTypeRepresentation::ObjCMethod == (int)swift::SILFunctionTypeRepresentation::ObjCMethod);
+  static_assert((int)FunctionTypeRepresentation::WitnessMethod == (int)swift::SILFunctionTypeRepresentation::WitnessMethod);
+  static_assert((int)FunctionTypeRepresentation::Closure == (int)swift::SILFunctionTypeRepresentation::Closure);
+  static_assert((int)FunctionTypeRepresentation::CXXMethod == (int)swift::SILFunctionTypeRepresentation::CXXMethod);
+  static_assert((int)FunctionTypeRepresentation::KeyPathAccessorGetter == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorGetter);
+  static_assert((int)FunctionTypeRepresentation::KeyPathAccessorSetter == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorSetter);
+  static_assert((int)FunctionTypeRepresentation::KeyPathAccessorEquals == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorEquals);
+  static_assert((int)FunctionTypeRepresentation::KeyPathAccessorHash == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorHash);
+
+  auto fnType = unbridged()->castTo<swift::SILFunctionType>();
+  return (FunctionTypeRepresentation)(fnType->getRepresentation());
+}
+
 BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
   return {unbridged().subst(substMap.unbridged()).getPointer()};
 }

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -165,7 +165,8 @@ enum class SpecializationPass : uint8_t {
   MoveDiagnosticInOutToOut,
   AsyncDemotion,
   PackSpecialization,
-  LAST = PackSpecialization
+  EmbeddedWitnessCallSpecialization,
+  LAST = EmbeddedWitnessCallSpecialization
 };
 
 constexpr uint8_t MAX_SPECIALIZATION_PASS = 10;

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -399,6 +399,8 @@ NODE(OutlinedEnumProjectDataForLoad)
 NODE(OutlinedEnumGetTag)
 // Added in Swift 5.9 + 1
 NODE(AsyncRemoved)
+// Added in Swift 6.3 + 1
+NODE(RepresentationChanged)
 
 // Added in Swift 5.TBD
 NODE(ObjectiveCProtocolSymbolicReference)

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -274,7 +274,7 @@ struct BridgedPassContext {
                                                         const BridgedResultInfo *_Nullable specializedBridgedResults,
                                                         SwiftInt resultCount,
                                                         BridgedFunction bridgedOriginal,
-                                                        bool makeThin,
+                                                        BridgedASTType::FunctionTypeRepresentation representation,
                                                         bool makeBare,
                                                         bool preserveGenericSignature) const;
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -202,6 +202,7 @@ struct BridgedPassContext {
                                                       BridgedFunction bridgedOriginalFunction) const;
   BridgedOwnedString mangleWithExplodedPackArgs(BridgedArrayRef bridgedPackArgs,
                                                 BridgedFunction applySiteCallee) const;
+  BridgedOwnedString mangleWithChangedRepresentation(BridgedFunction applySiteCallee) const;
 
   void inlineFunction(BridgedInstruction apply, bool mandatoryInline) const;
   BRIDGED_INLINE bool eliminateDeadAllocations(BridgedFunction f) const;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -75,6 +75,8 @@ PASS(MandatoryDestroyHoisting, "mandatory-destroy-hoisting",
      "Hoist destroy_value instructions for non-lexical values")
 PASS(DeadEndBlockDumper, "dump-deadendblocks",
      "Tests the DeadEndBlocks utility")
+PASS(EmbeddedWitnessCallSpecialization, "embedded-witness-call-specialization",
+     "Mandatory witness method call specialization")
 PASS(EscapeInfoDumper, "dump-escape-info",
      "Dumps escape information")
 PASS(AddressEscapeInfoDumper, "dump-addr-escape-info",

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -104,6 +104,8 @@ class FunctionSignatureSpecializationMangler : public SpecializationMangler {
 
   ReturnValueModifierIntBase ReturnValue;
 
+  bool changedRepresentation = false;
+
 public:
   FunctionSignatureSpecializationMangler(ASTContext &Ctx, SpecializationPass Pass,
                                          swift::SerializedKind_t Serialized,
@@ -123,6 +125,7 @@ public:
   void setArgumentBoxToStack(unsigned OrigArgIdx);
   void setArgumentInOutToOut(unsigned OrigArgIdx);
   void setReturnValueOwnedToUnowned();
+  void setChangedRepresentation() { changedRepresentation = true; }
 
   // For effects
   void setRemovedEffect(EffectKind effect);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3377,6 +3377,8 @@ NodePointer Demangler::demangleGenericSpecializationWithDroppedArguments() {
 NodePointer Demangler::demangleFunctionSpecialization() {
   NodePointer Spec = demangleSpecAttributes(
         Node::Kind::FunctionSignatureSpecialization);
+  if (Spec && Spec->getFirstChild()->getKind() == Node::Kind::RepresentationChanged)
+    return Spec;
   while (Spec && !nextIf('_')) {
     Spec = addChild(Spec, demangleFuncSpecParam(Node::Kind::FunctionSignatureSpecializationParam));
   }
@@ -3619,6 +3621,7 @@ NodePointer Demangler::addFuncSpecParamNumber(NodePointer Param,
 NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
   bool isSerialized = nextIf('q');
   bool asyncRemoved = nextIf('a');
+  bool representationChanged = nextIf('r');
 
   int PassID = (int)nextChar() - '0';
   if (PassID < 0 || PassID >= MAX_SPECIALIZATION_PASS) {
@@ -3633,6 +3636,10 @@ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
 
   if (asyncRemoved)
     SpecNd->addChild(createNode(Node::Kind::AsyncRemoved),
+                     *this);
+
+  if (representationChanged)
+    SpecNd->addChild(createNode(Node::Kind::RepresentationChanged),
                      *this);
 
   SpecNd->addChild(createNode(Node::Kind::SpecializationPassID, PassID),

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -487,6 +487,7 @@ bool NodePrinter::isSimpleType(NodePointer Node) {
   case Node::Kind::ReadAccessor:
   case Node::Kind::Read2Accessor:
   case Node::Kind::RelatedEntityDeclName:
+  case Node::Kind::RepresentationChanged:
   case Node::Kind::RetroactiveConformance:
   case Node::Kind::Setter:
   case Node::Kind::Shared:
@@ -1331,6 +1332,10 @@ void NodePrinter::printSpecializationPrefix(NodePointer node,
     }
     return;
   }
+  if (node->getFirstChild()->getKind() == Node::Kind::RepresentationChanged) {
+    Printer << "representation changed of ";
+    return;
+  }
   Printer << Description << " <";
   const char *Separator = "";
   int argNum = 0;
@@ -1427,6 +1432,10 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::AsyncRemoved:
     Printer << "async demotion of ";
+    print(Node->getChild(0), depth + 1);
+    return nullptr;
+  case Node::Kind::RepresentationChanged:
+    Printer << "representation changed of ";
     print(Node->getChild(0), depth + 1);
     return nullptr;
   case Node::Kind::CurryThunk:

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -451,6 +451,11 @@ ManglingError Remangler::mangleAsyncRemoved(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleRepresentationChanged(Node *node, unsigned depth) {
+  Buffer << "r";
+  return ManglingError::Success;
+}
+
 ManglingError Remangler::mangleDroppedArgument(Node *node, unsigned depth) {
   Buffer << "t" << node->getIndex();
   return ManglingError::Success;

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1518,6 +1518,9 @@ ManglingError Remangler::mangleFunctionSignatureSpecialization(Node *node,
   Buffer << "Tf";
   bool returnValMangled = false;
   for (NodePointer Child : *node) {
+    if (Child->getKind() == Node::Kind::RepresentationChanged) {
+      returnValMangled = true;
+    }
     if (Child->getKind() == Node::Kind::FunctionSignatureSpecializationReturn) {
       Buffer << '_';
       returnValMangled = true;
@@ -3190,6 +3193,11 @@ ManglingError Remangler::mangleIsSerialized(Node *node, unsigned depth) {
 
 ManglingError Remangler::mangleAsyncRemoved(Node *node, unsigned depth) {
   Buffer << 'a';
+  return ManglingError::Success;
+}
+
+ManglingError Remangler::mangleRepresentationChanged(Node *node, unsigned depth) {
+  Buffer << 'r';
   return ManglingError::Success;
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -265,6 +265,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addMandatoryPerformanceOptimizations();
   P.addOnoneSimplification();
   P.addInitializeStaticGlobals();
+  P.addEmbeddedWitnessCallSpecialization();
 
   P.addMandatoryDestroyHoisting();
 
@@ -892,6 +893,10 @@ static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
   if (P.getOptions().AssumeSingleThreaded) {
     P.addAssumeSingleThreaded();
   }
+
+  // Needs to run again at the end of the pipeline (after all de-virtualizations
+  // are done) in case an optimization pass de-virtualizes a witness method call.
+  P.addEmbeddedWitnessCallSpecialization();
 
   // Emits remarks on all functions with @_assemblyVision attribute.
   P.addAssemblyVisionRemarkGenerator();

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -351,6 +351,17 @@ BridgedOwnedString BridgedPassContext::mangleWithExplodedPackArgs(
   return BridgedOwnedString(mangler.mangle());
 }
 
+BridgedOwnedString BridgedPassContext::mangleWithChangedRepresentation(BridgedFunction applySiteCallee) const {
+  auto pass = Demangle::SpecializationPass::EmbeddedWitnessCallSpecialization;
+
+  Mangle::FunctionSignatureSpecializationMangler mangler(
+      applySiteCallee.getFunction()->getASTContext(),
+      pass, IsNotSerialized, applySiteCallee.getFunction());
+
+  mangler.setChangedRepresentation();
+  return BridgedOwnedString(mangler.mangle());
+}
+
 void BridgedPassContext::fixStackNesting(BridgedFunction function) const {
   switch (StackNesting::fixNesting(function.getFunction())) {
     case StackNesting::Changes::None:

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -393,7 +393,7 @@ createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
                                      const BridgedResultInfo * _Nullable specializedBridgedResults,
                                      SwiftInt resultCount,
                                      BridgedFunction bridgedOriginal,
-                                     bool makeThin,
+                                     BridgedASTType::FunctionTypeRepresentation representation,
                                      bool makeBare,
                                      bool preserveGenericSignature) const {
   auto *original = bridgedOriginal.getFunction();
@@ -415,9 +415,7 @@ createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
   // The specialized function is always a thin function. This is important
   // because we may add additional parameters after the Self parameter of
   // witness methods. In this case the new function is not a method anymore.
-  auto extInfo = originalType->getExtInfo();
-  if (makeThin)
-    extInfo = extInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
+  auto extInfo = originalType->getExtInfo().withRepresentation((SILFunctionTypeRepresentation)representation);
 
   auto ClonedTy = SILFunctionType::get(
       preserveGenericSignature ? originalType->getInvocationGenericSignature() : GenericSignature(),

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -352,6 +352,11 @@ std::string FunctionSignatureSpecializationMangler::mangle() {
   ArgOpStorage.clear();
   beginMangling();
 
+  if (changedRepresentation) {
+    appendSpecializationOperator("Tfr");
+    return finalize();
+  }
+
   for (unsigned i : indices(OrigArgs)) {
     mangleArgument(OrigArgs[i]);
   }

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -442,6 +442,7 @@ $s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible fun
 $s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()
 $s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> ()
 $s3foo4main1SVs5Int32VSbTf3npSSi3Si0_n ---> function signature specialization <Arg[1] = [Constant Propagated Struct : main.S][Constant Propagated Struct : Swift.Int32][Constant Propagated Integer : 3][Constant Propagated Struct : Swift.Bool][Constant Propagated Integer : 0]> of foo
+$e4test4BaseCyxGAA1PA2aEP3fooyyFTWTfr9 ---> representation changed of protocol witness for test.P.foo() -> () in conformance test.Base<A> : test.P in test
 $s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> ()
 $s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> ()
 $s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any test.P<Self.T == A>) -> ()

--- a/test/SILOptimizer/witness-call-specialization.sil
+++ b/test/SILOptimizer/witness-call-specialization.sil
@@ -1,0 +1,98 @@
+// RUN: %target-sil-opt -enable-experimental-feature Embedded %s -embedded-witness-call-specialization | %FileCheck %s
+// RUN: %target-sil-opt %s -embedded-witness-call-specialization | %FileCheck --check-prefix=CHECKNE %s
+
+// REQUIRES: swift_feature_Embedded
+
+sil_stage canonical
+
+import Builtin
+
+protocol P {}
+
+class C: P {}
+
+// CHECK-LABEL: sil [ossa] @test_simple :
+// CHECK:         [[F:%.*]] = function_ref @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> ()
+// CHECK:         apply [[F]](%0) : $@convention(method) (@guaranteed C) -> ()
+// CHECK:       } // end sil function 'test_simple'
+// CHECKNE-LABEL: sil [ossa] @test_simple :
+// CHECKNE:         [[F:%.*]] = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECKNE:         apply [[F]](%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECKNE:       } // end sil function 'test_simple'
+sil [ossa] @test_simple : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %1 = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %2 = apply %1(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @second_use :
+// CHECK:         [[F:%.*]] = function_ref @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> ()
+// CHECK:         apply [[F]](%0) : $@convention(method) (@guaranteed C) -> ()
+// CHECK:       } // end sil function 'second_use'
+sil [ossa] @second_use : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %1 = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %2 = apply %1(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @dont_handle_generic_functions :
+// CHECK:         [[F:%.*]] = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECK:         apply [[F]](%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECK:       } // end sil function 'dont_handle_generic_functions'
+sil [ossa] @dont_handle_generic_functions : $@convention(thin) <T> (@guaranteed C, @in_guaranteed T) -> () {
+bb0(%0 : @guaranteed $C, %1 : $*T):
+  %2 = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %3 = apply %2(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %4 = tuple ()
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @only_specialize_witness_methods :
+// CHECK:         [[F:%.*]] = function_ref @thin_function : $@convention(thin) (@guaranteed C) -> ()
+// CHECK:         apply [[F]](%0) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK:       } // end sil function 'only_specialize_witness_methods'
+sil [ossa] @only_specialize_witness_methods : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %1 = function_ref @thin_function : $@convention(thin) (@guaranteed C) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed C) -> ()
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @callee_must_have_body :
+// CHECK:         [[F:%.*]] = function_ref @no_body : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECK:         apply [[F]](%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+// CHECK:       } // end sil function 'callee_must_have_body'
+sil [ossa] @callee_must_have_body : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %1 = function_ref @no_body : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %2 = apply %1(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
+  %3 = tuple ()
+  return %3
+}
+
+
+// CHECK-LABEL: sil shared [ossa] @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> () {
+// CHECK:         fix_lifetime %0
+// CHECK-NEXT:    %2 = tuple ()
+// CHECK-NEXT:    return %2
+// CHECK:       } // end sil function '$e6calleeTfr9'
+sil [ossa] @callee : $@convention(witness_method: P) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  fix_lifetime %0
+  %2 = tuple ()
+  return %2
+}
+
+sil [ossa] @thin_function : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  fix_lifetime %0
+  %2 = tuple ()
+  return %2
+}
+
+sil [ossa] @no_body : $@convention(witness_method: P) (@guaranteed C) -> ()

--- a/test/embedded/accessors.swift
+++ b/test/embedded/accessors.swift
@@ -8,6 +8,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 
+// For some reason integer hashing results in an undefined symbol "arc4random_buf" linker error on linux
+// REQUIRES: OS=macosx
+
 public class C {
   public var x: Int {
     _read {
@@ -19,6 +22,25 @@ public class C {
   }
 
   var y: Int = 27
+}
+
+public protocol P {
+  var d: [Int : WrappedBool] { get set }
+}
+
+extension P {
+  mutating func set(key: Int) {
+    d[key]?.b = true
+  }
+}
+
+public struct WrappedBool {
+  public var b: Bool = true
+}
+
+public class S: P {
+  public var d: [Int : WrappedBool] = [:]
+  public func foo() {}
 }
 
 @main
@@ -33,5 +55,11 @@ struct Main {
 
     print("2") // CHECK: 2
     print("")
+
+    var handler = S()
+    handler.d[27] = WrappedBool(b: false)
+    handler.set(key: 27)
+    // CHECK: true
+    print(handler.d[27]!.b ? "true" : "false") 
   }
 }


### PR DESCRIPTION
This is needed in Embedded Swift because the `witness_method` convention requires passing the witness table to the callee.
However, the witness table is not necessarily available.
A witness table is only generated if an existential value of a protocol is created.

This is a rare situation because only witness thunks have `witness_method` convention and those thunks are created as "transparent" functions, which means they are always inlined (after de-virtualization of a witness method call).
However, inlining - even of transparent functions - can fail for some reasons.

This change adds a new EmbeddedWitnessCallSpecialization pass:
If a function with `witness_method` convention is directly called, the function is specialized by changing the convention to `method` and the call is replaced by a call to the specialized function:

```
  %1 = function_ref @callee : $@convention(witness_method: P) (@guaranteed C) -> ()
  %2 = apply %1(%0) : $@convention(witness_method: P) (@guaranteed C) -> ()
...
sil [ossa] @callee : $@convention(witness_method: P) (@guaranteed C) -> () {
  ...
}
```
->
```
  %1 = function_ref @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> ()
  %2 = apply %1(%0) : $@convention(method) (@guaranteed C) -> ()
...
// specialized callee
sil shared [ossa] @$e6calleeTfr9 : $@convention(method) (@guaranteed C) -> () {
  ...
}
```

Fixes a compiler crash
rdar://165184147