### PR TITLE
[NFC][update-checkout] remove usage of the multiprocessing module

### DIFF
--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -1,5 +1,5 @@
 import sys
-from multiprocessing import cpu_count
+import os
 import time
 from typing import Callable, List, Any, Optional, Tuple, Union
 from threading import Lock, Thread, Event
@@ -91,7 +91,7 @@ class ParallelRunner:
         if n_threads == 0:
             # Limit the number of threads as the performance regresses if the
             # number is too high.
-            n_threads = min(cpu_count() * 2, 16)
+            n_threads = min(os.cpu_count() * 2, 16)
         self._n_threads = n_threads
         self._monitor_polling_period = 0.1
         self._terminal_width = shutil.get_terminal_size().columns

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -15,7 +15,6 @@ import platform
 import re
 import sys
 import traceback
-from multiprocessing import freeze_support
 from typing import Any, Dict, Hashable, Optional, Set, List, Tuple, Union
 
 from .cli_arguments import CliArguments
@@ -768,7 +767,6 @@ def skip_list_for_platform(config: Dict[str, Any], all_repos: bool) -> List[str]
 
 
 def main() -> int:
-    freeze_support()
     args = CliArguments.parse_args()
 
     if not args.scheme:


### PR DESCRIPTION
This NFC patch removes the use of the `multiprocessing` module.

`update-checkout` no longer uses `multiprocessing` as of 9d3d43c9207b72e7cd698958f0af5bc180bb1d73. It's safe to remove the call to `multiprocessing.freeze_support` and `multiprocessing.cpu_count` [which is just a wrapper around `os.cpu_count`](https://github.com/python/cpython/blob/96bc021d7c93587a98b13a8bd191e5c9e31a6baf/Lib/multiprocessing/context.py#L41-L47).