### PR TITLE
[update-checkout] fix white space padding when printing the repo hashes

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -650,8 +650,9 @@ def repo_hashes(args: CliArguments, config: Dict[str, Any]) -> Dict[str, str]:
 
 def print_repo_hashes(args: CliArguments, config: Dict[str, Any]):
     repos = repo_hashes(args, config)
+    max_length = max(len(name) for name in repos.keys())
     for repo_name, repo_hash in sorted(repos.items(), key=lambda x: x[0]):
-        print("{:<35}: {:<35}".format(repo_name, repo_hash))
+        print(f"{repo_name:<{max_length + 1}}: {repo_hash}")
 
 
 def merge_no_duplicates(


### PR DESCRIPTION
This patch switches to using a variable white space padding depending on the max length of the repositories names.

## Before

```
...
swift-docc-symbolkit               : 89e737aca30bd42a9f7e114e609884267ea6aabe
swift-driver                       : 22807ff2e2d20e7595b914c87b055681d41d245c
swift-experimental-string-processing : efe8986824694c53fd5e94a4c634f20b3682baeb
swift-format                       : 83d46d640dc60e2f201daa28c35e191da96fe941
swift-foundation                   : 907a38e6f92277e4aac7ad089b88ff188be4711e
swift-foundation-icu               : 2e2854eee567589ed44c5f3c85c7343e6d91978d
...
```

## After

```
...
swift-docc-symbolkit                 : 89e737aca30bd42a9f7e114e609884267ea6aabe
swift-driver                         : 22807ff2e2d20e7595b914c87b055681d41d245c
swift-experimental-string-processing : efe8986824694c53fd5e94a4c634f20b3682baeb
swift-format                         : 83d46d640dc60e2f201daa28c35e191da96fe941
swift-foundation                     : 907a38e6f92277e4aac7ad089b88ff188be4711e
swift-foundation-icu                 : 2e2854eee567589ed44c5f3c85c7343e6d91978d
...
```