### PR TITLE
[6.2] Cherry-pick [Distributed] add availability annotations in test

### DIFF
--- a/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
+++ b/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
@@ -9,11 +9,10 @@
 
 import Distributed
 
-// NOTE: None of the ad-hoc protocol requirement implementations
-
 public protocol Transferable: Sendable {}
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class TheSpecificResultHandlerWhichIsANonFinalClass: DistributedTargetInvocationResultHandler {
   public typealias SerializationRequirement = Transferable
 
@@ -30,6 +29,7 @@ public class TheSpecificResultHandlerWhichIsANonFinalClass: DistributedTargetInv
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Transferable
 
@@ -51,6 +51,7 @@ public class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class FakeInvocationEncoder : DistributedTargetInvocationEncoder {
   public typealias SerializationRequirement = Transferable
 
@@ -72,6 +73,7 @@ public class FakeInvocationEncoder : DistributedTargetInvocationEncoder {
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class NotFinalActorSystemForAdHocRequirementTest: DistributedActorSystem, @unchecked Sendable {
   public typealias ActorID = String
   public typealias InvocationEncoder = FakeInvocationEncoder


### PR DESCRIPTION
Explanation

Test is failing on 6.2 with error: 'RemoteCallArgument' is only available in iOS 16.0 or newer etc

Scope

Adds missing availability annotations to test

Original PRs

https://github.com/swiftlang/swift/pull/84414

Risk

Low, impacts test only