### PR TITLE
[cxx-interop] Fix crash when virtual methods take move-only types

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2266,12 +2266,21 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
     clang::Expr *argExpr = new (clangCtx) clang::DeclRefExpr(
         clangCtx, param, false, type.getNonReferenceType(),
         clang::ExprValueKind::VK_LValue, clang::SourceLocation());
-    if (type->isRValueReferenceType()) {
+    bool isMoveOnly = false;
+    if (!type->isReferenceType())
+      if (evaluateOrDefault(
+              ImporterImpl.SwiftContext.evaluator,
+              CxxValueSemantics({type.getTypePtr(), &ImporterImpl}),
+              {}) == CxxValueSemanticsKind::MoveOnly)
+        isMoveOnly = true;
+    if (type->isRValueReferenceType() || isMoveOnly) {
       argExpr = clangSema
                     .BuildCXXNamedCast(
                         clang::SourceLocation(), clang::tok::kw_static_cast,
-                        clangCtx.getTrivialTypeSourceInfo(type), argExpr,
-                        clang::SourceRange(), clang::SourceRange())
+                        clangCtx.getTrivialTypeSourceInfo(
+                            isMoveOnly ? clangCtx.getRValueReferenceType(type)
+                                       : type),
+                        argExpr, clang::SourceRange(), clang::SourceRange())
                     .get();
     }
     args.push_back(argExpr);

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -83,6 +83,11 @@ module VirtMethodWithRvalRef {
   requires cplusplus
 }
 
+module VirtMethodWitMoveOnly {
+  header "virtual-methods-move-only-type.h"
+  requires cplusplus
+}
+
 module LoggingFrts {
     header "logging-frts.h"
     requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-move-only-type.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/virtual-methods-move-only-type.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "swift/bridging"
+
+struct MoveOnly {
+  MoveOnly() {}
+  MoveOnly(MoveOnly&&) {}
+  MoveOnly(const MoveOnly&) = delete;
+  ~MoveOnly() {}
+};
+
+class CxxForeignRef;
+
+void retain(CxxForeignRef * obj);
+void release(CxxForeignRef * obj);
+
+class CxxForeignRef {
+public:
+  CxxForeignRef(const CxxForeignRef &) = delete;
+  CxxForeignRef() = default;
+
+  virtual void takesMoveOnly(MoveOnly);
+} SWIFT_SHARED_REFERENCE(retain, release);

--- a/test/Interop/Cxx/foreign-reference/move-only-in-virtual-methods.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-in-virtual-methods.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging %s -cxx-interoperability-mode=default -disable-availability-checking
+
+import VirtMethodWitMoveOnly
+
+func f(_ x: CxxForeignRef, _ y: consuming MoveOnly) {
+    x.takesMoveOnly(y)
+}


### PR DESCRIPTION
We build forwarding methods to call the virtual methods. The forwarding methods tried to copy move-only types which resulted in a compiler crash. Now we try to detect this scenario and insert the required cast to make sure we get a move instead.

rdar://162195228
