### PR TITLE
[Test] Add executable_test requirement to distributed actor test

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -1,3 +1,4 @@
+// REQUIRES: executable_test
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: concurrency


### PR DESCRIPTION
The test uses %target-run which means it needs REQUIRES: executable_test

rdar://163875444

