### PR TITLE
Change reduce to take initial value consuming

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -778,10 +778,10 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @_alwaysEmitIntoClient
-  public func reduce<Result, E: Error>( // AsyncSequence now has an untyped throws duplicate of this method to resolve ambiguity
-    _ initialResult: Result,
+  public func reduce<Result: ~Copyable, E: Error>(
+    _ initialResult: consuming Result,
     _ nextPartialResult:
-      (_ partialResult: Result, Element) throws(E) -> Result
+      (_ partialResult: consuming Result, Element) throws(E) -> Result
   ) throws(E) -> Result {
     var accumulator = initialResult
     for element in self {

--- a/test/Constraints/issue-55410.swift
+++ b/test/Constraints/issue-55410.swift
@@ -6,5 +6,5 @@ protocol P {}
 typealias T = (P) -> Void
 let x: T! = [1, 2, 3].reversed().reduce()
 // expected-error@-1 {{no exact matches in call to instance method 'reduce'}}
-// expected-note@-2 {{found candidate with type '(T?, (T?, Int) throws(E) -> T?) throws(E) -> T?' (aka '(Optional<(any P) -> ()>, (Optional<(any P) -> ()>, Int) throws(E) -> Optional<(any P) -> ()>) throws(E) -> Optional<(any P) -> ()>')}}
+// expected-note@-2 {{found candidate with type '(consuming T?, (consuming T?, Int) throws(E) -> T?) throws(E) -> T?' (aka '(consuming Optional<(any P) -> ()>, (consuming Optional<(any P) -> ()>, Int) throws(E) -> Optional<(any P) -> ()>) throws(E) -> Optional<(any P) -> ()>')}}
 // expected-note@-3 {{found candidate with type '(__owned T?, (inout T?, Int) throws(E) -> ()) throws(E) -> T?' (aka '(__owned Optional<(any P) -> ()>, (inout Optional<(any P) -> ()>, Int) throws(E) -> ()) throws(E) -> Optional<(any P) -> ()>')}}

--- a/test/Constraints/tuple-arguments-unsupported.swift
+++ b/test/Constraints/tuple-arguments-unsupported.swift
@@ -11,9 +11,9 @@ test3(.success()) // expected-error {{missing argument for parameter #1 in call}
 
 func toString(indexes: Int?...) -> String {
   let _ = indexes.reduce(0) { print($0); return $0.0 + ($0.1 ?? 0)}
-  // expected-error@-1 {{contextual closure type '(Int, Int?) -> Int' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
   let _ = indexes.reduce(0) { (true ? $0 : (1, 2)).0 + ($0.1 ?? 0) }
-  // expected-error@-1 {{contextual closure type '(Int, Int?) -> Int' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
   _ = ["Hello", "Foo"].sorted { print($0); return $0.0.count > ($0).1.count }
   // expected-error@-1 {{contextual closure type '(String, String) throws -> Bool' expects 2 arguments, but 1 was used in closure body}}
 }

--- a/test/Constraints/tuple-arguments-unsupported.swift
+++ b/test/Constraints/tuple-arguments-unsupported.swift
@@ -11,9 +11,9 @@ test3(.success()) // expected-error {{missing argument for parameter #1 in call}
 
 func toString(indexes: Int?...) -> String {
   let _ = indexes.reduce(0) { print($0); return $0.0 + ($0.1 ?? 0)}
-  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) -> Int' expects 2 arguments, but 1 was used in closure body}}
   let _ = indexes.reduce(0) { (true ? $0 : (1, 2)).0 + ($0.1 ?? 0) }
-  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) throws -> Int' expects 2 arguments, but 1 was used in closure body}}
+  // expected-error@-1 {{contextual closure type '(consuming Int, Int?) -> Int' expects 2 arguments, but 1 was used in closure body}}
   _ = ["Hello", "Foo"].sorted { print($0); return $0.0.count > ($0).1.count }
   // expected-error@-1 {{contextual closure type '(String, String) throws -> Bool' expects 2 arguments, but 1 was used in closure body}}
 }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -74,7 +74,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         min({#by: (Equatable, Equatable) throws(Error) -> Bool##(Equatable, Equatable) throws(Error) -> Bool#})[' throws'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         max({#by: (Equatable, Equatable) throws(Error) -> Bool##(Equatable, Equatable) throws(Error) -> Bool#})[' throws'][#Equatable?#]{{; name=.+}}
 // FIXME: The following should include 'partialResult' as local parameter name: "(nextPartialResult): (_ partialResult: Result, Equatable)"
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         reduce({#(initialResult): Result#}, {#(nextPartialResult): (Result, Equatable) throws(Error) -> Result##(_ partialResult: Result, Equatable) throws(Error) -> Result#})[' throws'][#Result#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         reduce({#(initialResult): ~Copyable#}, {#(nextPartialResult): (consuming ~Copyable, Equatable) throws(Error) -> ~Copyable##(_ partialResult: consuming ~Copyable, Equatable) throws(Error) -> ~Copyable#})[' throws'][#~Copyable#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         dropFirst({#(k): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // FIXME: restore Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[IteratorProtocol.Element]#]{{; name=.+}}
 

--- a/test/SIL/manual_ownership.swift
+++ b/test/SIL/manual_ownership.swift
@@ -401,7 +401,7 @@ func benchCaptureProp<S : Sequence>(
   let initial = it.next()!
   return
     IteratorSequence(it) // expected-warning {{accessing 'it' may produce a copy}}
-           .reduce(initial, f)
+      .reduce(initial, f) // expected-warning {{accessing 'initial' may produce a copy; write 'copy' to acknowledge or 'consume' to elide}}
 }
 func benchCaptureProp_fixed<S : Sequence>(
   _ s: S, _ f: (S.Element, S.Element) -> S.Element) -> S.Element {
@@ -410,7 +410,7 @@ func benchCaptureProp_fixed<S : Sequence>(
   let initial = it.next()!
   return
     IteratorSequence(copy it)
-           .reduce(initial, f)
+           .reduce(initial, f) // expected-warning {{accessing 'initial' may produce a copy; write 'copy' to acknowledge or 'consume' to elide}}
 }
 
 extension FixedWidthInteger {

--- a/test/SILOptimizer/prespecialize_public.swift
+++ b/test/SILOptimizer/prespecialize_public.swift
@@ -18,8 +18,8 @@ extension Sequence where Element: BinaryInteger {
 // CHECK:   cond_br [[T5]], bb3, bb1
 
 // CHECK: bb1:
-// CHECK:   [[T6:%.*]] = function_ref @$sSTsE6reduceyqd__qd__n_qd__qd__n_7ElementQztKXEtKRi_d__lF
-// CHECK:   apply {{.*}} [[T6]]<Self, Double>(
+// CHECK:   [[T6:%.*]] = function_ref @$sSTsE6reduceyqd__qd__n_qd__qd__n_7ElementQztqd_0_YKXEtqd_0_YKs5ErrorRd_0_Ri_d__r0_lF
+// CHECK:   apply {{.*}} [[T6]]<Self, Double, Never>(
 // CHECK:   br bb2(
 
 // CHECK: bb2({{.*}} : $Double):

--- a/test/SILOptimizer/prespecialize_public.swift
+++ b/test/SILOptimizer/prespecialize_public.swift
@@ -18,8 +18,8 @@ extension Sequence where Element: BinaryInteger {
 // CHECK:   cond_br [[T5]], bb3, bb1
 
 // CHECK: bb1:
-// CHECK:   [[T6:%.*]] = function_ref @$sSTsE6reduceyqd__qd___qd__qd___7ElementQztqd_0_YKXEtqd_0_YKs5ErrorRd_0_r0_lF
-// CHECK:   apply {{.*}} [[T6]]<Self, Double, Never>(
+// CHECK:   [[T6:%.*]] = function_ref @$sSTsE6reduceyqd__qd__n_qd__qd__n_7ElementQztKXEtKRi_d__lF
+// CHECK:   apply {{.*}} [[T6]]<Self, Double>(
 // CHECK:   br bb2(
 
 // CHECK: bb2({{.*}} : $Double):

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -80,7 +80,6 @@ Func Sequence.min(by:) is now without rethrows
 Func Sequence.reduce(into:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result, E where Self : Swift.Sequence, E : Swift.Error>
 Func Sequence.reduce(into:_:) has parameter 1 type change from (inout Result, Self.Element) throws -> () to (inout Result, Self.Element) throws(E) -> ()
 Func Sequence.reduce(into:_:) is now without rethrows
-Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result, E where Self : Swift.Sequence, E : Swift.Error>
 Func Sequence.reduce(_:_:) is now without rethrows
 Func Sequence.starts(with:by:) has generic signature change from <Self, PossiblePrefix where Self : Swift.Sequence, PossiblePrefix : Swift.Sequence> to <Self, PossiblePrefix, E where Self : Swift.Sequence, PossiblePrefix : Swift.Sequence, E : Swift.Error>
 Func Sequence.starts(with:by:) is now without rethrows
@@ -466,6 +465,6 @@ Func Hashable.hash(into:) has generic signature change from <Self where Self : S
 Func Hasher.combine(_:) has generic signature change from <H where H : Swift.Hashable> to <H where H : Swift.Hashable, H : ~Copyable>
 Func Hasher.combine(_:) has parameter 0 changing from Default to Shared
 
-Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result where Self : Swift.Sequence, Result : ~Copyable>
+Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result, E where Self : Swift.Sequence, E : Swift.Error, Result : ~Copyable>
 Func Sequence.reduce(_:_:) has parameter 0 changing from Default to Owned
 

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -465,3 +465,7 @@ Accessor Hashable.hashValue.Get() has generic signature change from <Self where 
 Func Hashable.hash(into:) has generic signature change from <Self where Self : Swift.Hashable> to <Self where Self : Swift.Hashable, Self : ~Copyable>
 Func Hasher.combine(_:) has generic signature change from <H where H : Swift.Hashable> to <H where H : Swift.Hashable, H : ~Copyable>
 Func Hasher.combine(_:) has parameter 0 changing from Default to Shared
+
+Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result where Self : Swift.Sequence, Result : ~Copyable>
+Func Sequence.reduce(_:_:) has parameter 0 changing from Default to Owned
+

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -975,7 +975,4 @@ Func _hashValue(for:) has mangled name changing from 'Swift._hashValue<A where A
 Func _hashValue(for:) has parameter 0 changing from Default to Shared
 Func _hashValue(for:) is now with @_preInverseGenerics
 
-// Make Reduce consume initial value. Old one is still there @usableFromInline and confuses the ABI checker
-Func Sequence.reduce(_:_:) is a new API without '@available'
-
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -975,4 +975,7 @@ Func _hashValue(for:) has mangled name changing from 'Swift._hashValue<A where A
 Func _hashValue(for:) has parameter 0 changing from Default to Shared
 Func _hashValue(for:) is now with @_preInverseGenerics
 
+// Make Reduce consume initial value. Old one is still there @usableFromInline and confuses the ABI checker
+Func Sequence.reduce(_:_:) is a new API without '@available'
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/ConsumingReduce.swift
+++ b/test/stdlib/ConsumingReduce.swift
@@ -1,0 +1,54 @@
+//===--- ConsumingReduce.swift - tests reduce consuming initial value -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let ConsumingReduceTests = TestSuite("ConsumingReduce")
+
+struct Noncopyable<Wrapped: ~Copyable>: ~Copyable {
+  var wrapped: Wrapped
+}
+
+extension Noncopyable where Wrapped: BinaryInteger {
+  static func +(lhs: consuming Self, rhs: borrowing Wrapped) -> Self {
+    lhs.wrapped += rhs
+    return lhs
+  }
+}
+
+extension Sequence where Element: BinaryInteger {
+  func noncopyableSum() -> Noncopyable<Element> {
+    self.reduce(.init(wrapped: 0)) { $0 + $1 }
+  }
+}
+
+class Klass {
+  var i: Int
+  init(_ i: Int) { self.i = i }
+}
+
+ConsumingReduceTests.test("consuming reduce") {
+  expectEqual((0..<10).noncopyableSum().wrapped, 45)
+  
+  // TODO: this doesn't really test much, may want to
+  // use isTriviallyIdentical(to:) with an array
+  // once it's available
+  var d = (0..<10).reduce(Klass(0)) {
+    $0.i += $1
+    return $0
+  }
+  expectTrue(isKnownUniquelyReferenced(&d))
+}
+
+runAllTests()


### PR DESCRIPTION
This would potentially mitigate some foot guns from e.g. `reduce([], +)`

**Explanation:** This is the implementation for https://github.com/swiftlang/swift-evolution/blob/main/proposals/0515-noncopyable-reduce.md which allows the result of reduce to return a non copyable value.
**Scope:** Only the always emit into copy version of reduce on sequence.
**Issues:** https://github.com/swiftlang/swift-evolution/blob/main/proposals/0515-noncopyable-reduce.md
**Risk:** Low. This is a straightforward parameter convention change for an already always emit into client function.
**Testing:** New tests have been add to exercise the change.