### PR TITLE
Guard against self-swap in `*Span/swapAt(_:_:)`

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -344,6 +344,7 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
+    guard i != j else { return }
     _precondition(indices.contains(Index(i)))
     _precondition(indices.contains(Index(j)))
     unsafe swapAt(unchecked: i, unchecked: j)

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -256,6 +256,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
+    guard i != j else { return }
     _precondition(indices.contains(Index(i)))
     _precondition(indices.contains(Index(j)))
     unsafe swapAt(unchecked: i, unchecked: j)


### PR DESCRIPTION
Adds `guard i != j else { return }` to `*Span/swapAt(_:_:)`.

Comment: Other containers guard against it.

Context: https://forums.swift.org/t/is-self-move-well-defined/83433