### PR TITLE
[Test] Fix Interpreter/issue-78598.swift to work with back deployment

### DIFF
--- a/test/Interpreter/issue-78598.swift
+++ b/test/Interpreter/issue-78598.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple %no-fixup-chains) | %FileCheck %s
 
 // https://github.com/swiftlang/swift/issues/78598
 


### PR DESCRIPTION
The test uses -target %target-swift-5.9-abi-triple which expands to macOS 14.0, causing the linker to emit chained fixups. Add %no-fixup-chains to allow the test to run on older OS versions like 10.14.4 that don't support chained fixups.

rdar://165227305