### PR TITLE
[ClangImporter] Fix NS_CLOSED_ENUM to validate raw values

### DIFF
--- a/test/ClangImporter/Inputs/enum-closed-raw-value.h
+++ b/test/ClangImporter/Inputs/enum-closed-raw-value.h
@@ -1,0 +1,35 @@
+#ifndef ENUM_CLOSED_RAWVALUE_H
+#define ENUM_CLOSED_RAWVALUE_H
+
+// Test NS_CLOSED_ENUM with explicit enum_extensibility(closed) attribute
+typedef enum __attribute__((enum_extensibility(closed))) IntEnum : long {
+  IntEnumZero = 0,
+  IntEnumOne = 1
+} IntEnum;
+
+// Test NS_CLOSED_ENUM with non-contiguous values
+typedef enum __attribute__((enum_extensibility(closed))) NonContiguousEnum : long {
+  NonContiguousEnumFirst = 10,
+  NonContiguousEnumSecond = 20,
+  NonContiguousEnumThird = 30
+} NonContiguousEnum;
+
+// Test NS_CLOSED_ENUM with negative values
+typedef enum __attribute__((enum_extensibility(closed))) NegativeEnum : long {
+  NegativeEnumNegative = -1,
+  NegativeEnumZero = 0,
+  NegativeEnumPositive = 1
+} NegativeEnum;
+
+// Test regular NS_ENUM (non-frozen) for comparison - should accept any value
+typedef enum __attribute__((enum_extensibility(open))) OpenEnum : long {
+  OpenEnumZero = 0,
+  OpenEnumOne = 1
+} OpenEnum;
+
+// Test NS_CLOSED_ENUM with single case
+typedef enum __attribute__((enum_extensibility(closed))) SingleCaseEnum : long {
+  SingleCaseEnumOnly = 42
+} SingleCaseEnum;
+
+#endif // ENUM_CLOSED_RAWVALUE_H

--- a/test/ClangImporter/enum-closed-raw-value.swift
+++ b/test/ClangImporter/enum-closed-raw-value.swift
@@ -1,0 +1,117 @@
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/enum-closed-raw-value.h)
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -import-objc-header %S/Inputs/enum-closed-raw-value.h)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var EnumClosedRawValueTestSuite = TestSuite("NS_CLOSED_ENUM raw value validation")
+
+EnumClosedRawValueTestSuite.test("IntEnum: valid raw values") {
+  let zero = IntEnum(rawValue: 0)
+  expectNotNil(zero)
+  expectEqual(zero!, .zero)
+
+  let one = IntEnum(rawValue: 1)
+  expectNotNil(one)
+  expectEqual(one!, .one)
+}
+
+EnumClosedRawValueTestSuite.test("IntEnum: invalid raw values return nil") {
+  // This should pass with the fix - invalid values return nil
+  expectNil(IntEnum(rawValue: 100))
+  expectNil(IntEnum(rawValue: -1))
+  expectNil(IntEnum(rawValue: 2))
+}
+
+EnumClosedRawValueTestSuite.test("NonContiguousEnum: valid raw values") {
+  let first = NonContiguousEnum(rawValue: 10)
+  expectNotNil(first)
+  expectEqual(first!, .first)
+
+  let second = NonContiguousEnum(rawValue: 20)
+  expectNotNil(second)
+  expectEqual(second!, .second)
+
+  let third = NonContiguousEnum(rawValue: 30)
+  expectNotNil(third)
+  expectEqual(third!, .third)
+}
+
+EnumClosedRawValueTestSuite.test("NonContiguousEnum: invalid raw values between valid ones") {
+  expectNil(NonContiguousEnum(rawValue: 0))
+  expectNil(NonContiguousEnum(rawValue: 15))
+  expectNil(NonContiguousEnum(rawValue: 25))
+  expectNil(NonContiguousEnum(rawValue: 100))
+}
+
+EnumClosedRawValueTestSuite.test("NegativeEnum: valid raw values including negatives") {
+  let negative = NegativeEnum(rawValue: -1)
+  expectNotNil(negative)
+  expectEqual(negative!, .negative)
+
+  let zero = NegativeEnum(rawValue: 0)
+  expectNotNil(zero)
+  expectEqual(zero!, .zero)
+
+  let positive = NegativeEnum(rawValue: 1)
+  expectNotNil(positive)
+  expectEqual(positive!, .positive)
+}
+
+EnumClosedRawValueTestSuite.test("NegativeEnum: invalid raw values") {
+  expectNil(NegativeEnum(rawValue: -2))
+  expectNil(NegativeEnum(rawValue: 2))
+  expectNil(NegativeEnum(rawValue: 100))
+}
+
+EnumClosedRawValueTestSuite.test("OpenEnum: accepts ANY raw value for C compatibility") {
+  // Open (non-frozen) enums should accept arbitrary values
+  expectNotNil(OpenEnum(rawValue: 0))
+  expectNotNil(OpenEnum(rawValue: 1))
+
+  // Invalid values should still succeed for open enums
+  expectNotNil(OpenEnum(rawValue: 100))
+  expectNotNil(OpenEnum(rawValue: -1))
+}
+
+EnumClosedRawValueTestSuite.test("SingleCaseEnum: only valid value") {
+  let only = SingleCaseEnum(rawValue: 42)
+  expectNotNil(only)
+  expectEqual(only!, .only)
+}
+
+EnumClosedRawValueTestSuite.test("SingleCaseEnum: invalid raw values") {
+  expectNil(SingleCaseEnum(rawValue: 0))
+  expectNil(SingleCaseEnum(rawValue: 41))
+  expectNil(SingleCaseEnum(rawValue: 43))
+}
+
+EnumClosedRawValueTestSuite.test("Switch exhaustivity: frozen enums don't need default") {
+  // Frozen enums should be exhaustive - no default needed
+  let value = IntEnum.zero
+  switch value {
+  case .zero:
+    expectTrue(true) // Expected path
+  case .one:
+    expectTrue(false, "Wrong case")
+  }
+}
+
+EnumClosedRawValueTestSuite.test("Switch with invalid raw value scenario from bug report") {
+  // This was the crash scenario from issue #85701
+  // With the fix, init should return nil, so this branch never executes
+  if let ie = IntEnum(rawValue: 100) {
+    switch ie {
+    case .zero:
+      expectTrue(false, "Should not reach here - rawValue 100 is invalid")
+    case .one:
+      expectTrue(false, "Should not reach here - rawValue 100 is invalid")
+    }
+  } else {
+    // This is the expected path with the fix
+    expectTrue(true, "Correctly returned nil for invalid raw value")
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
## Summary

Fixes #85701 - `NS_CLOSED_ENUM` now properly validates raw values in `init?(rawValue:)`, returning `nil` for invalid values instead of creating invalid enum instances that crash later.

## Problem

When importing C enums marked with `NS_CLOSED_ENUM` (which map to `@frozen` Swift enums), the synthesized `init?(rawValue:)` used `Builtin.reinterpretCast` without validation. This allowed creating enum instances with invalid raw values that would crash with "Fatal error: unexpected enum case" when used in switch statements.

## Solution

- **For `@frozen` enums (`NS_CLOSED_ENUM`):** Generate a switch statement that validates the raw value against all declared cases, returning `nil` for invalid values
- **For non-frozen enums (`NS_ENUM`):** Preserve existing `reinterpretCast` behavior for C compatibility

## Implementation

Modified `synthesizeEnumRawValueConstructorBody()` in `lib/ClangImporter/SwiftDeclSynthesizer.cpp` to detect frozen enums and generate switch-based validation, following the same pattern used for native Swift enums in `DerivedConformanceRawRepresentable.cpp`.

## Testing

Added comprehensive execution tests that verify:
- Valid raw values correctly initialize enum instances
- Invalid raw values return `nil` (not crash)
- Non-contiguous and negative raw values handled correctly
- Open enums still accept arbitrary values for C compatibility

## Performance

Matches native Swift enums.