### PR TITLE
Synchronization: Add errno to some linux lock fatalErrors

### DIFF
--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -137,7 +137,8 @@ extension _MutexHandle {
       // Block until an equivalent '_futexUnlock' has been called by the owner.
       // This returns '0' on success which means the kernel has acquired the
       // lock for us.
-      switch storage._futexLock() {
+      let lockResult = storage._futexLock()
+      switch lockResult {
       case 0:
         // Locked!
         return
@@ -191,7 +192,7 @@ extension _MutexHandle {
       // ESRCH  - "The thread ID in the futex word at uaddr does not exist."
       default:
         // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occurred while attempting to acquire a Mutex")
+        fatalError("Unknown error occurred while attempting to acquire a Mutex: \(lockResult)")
       }
     }
   }
@@ -308,7 +309,8 @@ extension _MutexHandle {
   @usableFromInline
   internal borrowing func _unlockSlow() {
     while true {
-      switch storage._futexUnlock() {
+      let unlockResult = storage._futexUnlock()
+      switch unlockResult {
       case 0:
         // Unlocked!
         return
@@ -360,7 +362,7 @@ extension _MutexHandle {
       //           space.)"
       default:
         // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occurred while attempting to release a Mutex")
+        fatalError("Unknown error occurred while attempting to release a Mutex: \(unlockResult)")
       }
     }
   }


### PR DESCRIPTION
In the comments it's stated that these errnos can't really occur for the implementation, but unfortunately they have been seen in some scenarios. To aide in debugging, it'd be nice to at least have the errno in the error message. I've omitted errno additions to the other two fatalErrors as the error message is quite clear on what went wrong to me (especially for recursive locking).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
