### PR TITLE
SIL: add an option `-sil-print-ownership` to print ownership

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2012,6 +2012,23 @@ public:
     }
   }
 
+  template <typename Inst>
+  void printForwardingOwnershipKind(Inst *inst) {
+    if (inst->getNumRealOperands() == 0) {
+      return;
+    }
+    bool matching = false;
+    for (Operand *op : inst->getRealOperands()) {
+      if (inst->getForwardingOwnershipKind() == op->get()->getOwnershipKind()) {
+        matching = true;
+        break;
+      }
+    }
+    if (!matching) {
+      *this << ", forwarding: @" << inst->getForwardingOwnershipKind();
+    }
+  }
+
   void visitStoreInst(StoreInst *SI) {
     *this << Ctx.getID(SI->getSrc()) << " to ";
     printStoreOwnershipQualifier(SI->getOwnershipQualifier());
@@ -2456,6 +2473,7 @@ public:
         SI->getElements(), [&](const SILValue &V) { *this << getIDAndType(V); },
         [&] { *this << ", "; });
     *this << ')';
+    printForwardingOwnershipKind(SI);
   }
 
   void visitObjectInst(ObjectInst *OI) {
@@ -2511,6 +2529,7 @@ public:
           [&] { *this << ", "; });
       *this << ')';
     }
+    printForwardingOwnershipKind(TI);
   }
 
   void visitTupleAddrConstructorInst(TupleAddrConstructorInst *TI) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -87,6 +87,10 @@ SILPrintTypes("sil-print-types", llvm::cl::init(false),
                    llvm::cl::desc("always print type annotations for instruction operands in SIL output"));
 
 llvm::cl::opt<bool>
+SILPrintOwnership("sil-print-ownership", llvm::cl::init(false),
+                   llvm::cl::desc("print ownership of instruction results in SIL output"));
+
+llvm::cl::opt<bool>
 SILPrintNoUses("sil-print-no-uses", llvm::cl::init(false),
                    llvm::cl::desc("omit use comments in SIL output"));
 
@@ -693,6 +697,35 @@ protected:
   }
 };
 
+static bool hasNonAddressResults(const SILInstruction *inst) {
+  for (SILValue result : inst->getResults()) {
+    if (result->getType().isObject())
+      return true;
+  }
+  return false;
+}
+
+/// Returns true if the ownership of a result of `inst` mismatches with its type.
+/// That can happen e.g. for non-trivial enums which are constructed with a trivial case:
+/// ```
+/// enum E {
+///   case A
+///   case B(AnyObject)
+/// }
+///
+///   %1 = enum $E, #E.A!enumelt  // type of %1 is non trivial, but ownership is "none"
+/// ```
+static bool hasUnusualResultOwnership(const SILInstruction *inst) {
+  for (SILValue result : inst->getResults()) {
+    if (result->getType().isObject() &&
+        result->getOwnershipKind() == OwnershipKind::None &&
+        !result->getType().isTrivial(*inst->getFunction())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace
 
 namespace swift {
@@ -1092,6 +1125,28 @@ public:
     printBranchTargets(inst);
   }
 
+  void printOwnershipOfInstruction(const SILInstruction *inst) {
+
+    if (!inst->isStaticInitializerInst() &&
+        inst->getFunction()->hasOwnership() &&
+        hasNonAddressResults(inst) &&
+        (SILPrintOwnership || hasUnusualResultOwnership(inst)))
+    {
+      lineComments.delim();
+
+      *this << "ownership: ";
+      llvm::interleave(inst->getResults(),
+        [&](SILValue result) {
+          if (result->getType().isAddress()) {
+            *this << '-';
+          } else {
+            *this << result->getOwnershipKind();
+          }
+        },
+        [&] { *this << ", "; });
+    }
+  }
+
   void printUserList(ArrayRef<SILValue> values, SILNodePointer node) {
     if (SILPrintNoUses)
       return;
@@ -1363,6 +1418,8 @@ public:
 
     // Print users, or id for valueless instructions.
     printUsersOfInstruction(I);
+
+    printOwnershipOfInstruction(I);
 
     // Print SIL location.
     if (Ctx.printVerbose()) {

--- a/test/SIL/Parser/forwarding_ownership.sil
+++ b/test/SIL/Parser/forwarding_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin
@@ -9,15 +9,26 @@ class Klass {
 class SubKlass : Klass {
 }
 
+enum E {
+  case A
+  case B(AnyObject)
+}
+
+
 struct NonTrivialStruct {
   var id:Klass
+}
+
+struct S {
+  var i: Int
+  var e: E
 }
 
 // CHECK-LABEL: sil [ossa] @unchecked_ref_cast_test :
 sil [ossa] @unchecked_ref_cast_test : $@convention(thin) <T> (@in T, @owned Klass) -> () {
 bb0(%0 : $*T, %1 : @owned $Klass):
   destroy_addr %0 : $*T
-// CHECK: unchecked_ref_cast %1 : $Klass to $Optional<Klass>, forwarding: @unowned
+// CHECK: unchecked_ref_cast %1 to $Optional<Klass>, forwarding: @unowned
   %3 = unchecked_ref_cast %1 : $Klass to $Optional<Klass>, forwarding: @unowned
   %4 = copy_value %3 : $Optional<Klass>
   destroy_value %1 : $Klass
@@ -37,6 +48,26 @@ bb0(%0 : @owned $Klass):
   return %8 : $()
 }
 // CHECK-LABEL: } // end sil function 'struct_test'
+
+// CHECK-LABEL: sil [ossa] @none_to_owned_struct :
+// CHECK:         %2 = struct $S (%0, %1), forwarding: @owned
+// CHECK-LABEL: } // end sil function 'none_to_owned_struct'
+sil [ossa] @none_to_owned_struct : $@convention(thin) (Int) -> @owned S {
+bb0(%0 : $Int):
+  %1 = enum $E, #E.A!enumelt
+  %2 = struct $S (%0, %1), forwarding: @owned
+  return %2
+}
+
+// CHECK-LABEL: sil [ossa] @none_to_owned_tuple :
+// CHECK:         %2 = tuple (%0, %1), forwarding: @owned
+// CHECK-LABEL: } // end sil function 'none_to_owned_tuple'
+sil [ossa] @none_to_owned_tuple : $@convention(thin) (Int) -> @owned (Int, E) {
+bb0(%0 : $Int):
+  %1 = enum $E, #E.A!enumelt
+  %2 = tuple (%0, %1), forwarding: @owned
+  return %2
+}
 
 // CHECK-LABEL: sil [ossa] @switch_test : $@convention(thin) () -> () {
 // CHECK: switch_enum {{.*}}, forwarding: @guaranteed

--- a/test/SIL/print_ownership.sil
+++ b/test/SIL/print_ownership.sil
@@ -1,0 +1,56 @@
+// RUN: %target-sil-opt -sil-print-ownership %s | %FileCheck %s --check-prefix=CHECK --check-prefix=ENABLE
+// RUN: %target-sil-opt %s | %FileCheck %s --check-prefix=CHECK --check-prefix=DISABLE
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+enum E {
+  case A
+  case B(AnyObject)
+}
+
+struct S {
+  var e: E
+  var o: AnyObject
+}
+
+struct T {
+  var s: S
+}
+
+// CHECK-LABEL: sil [ossa] @ossa_function :
+// CHECK:         enum $E{{.*}} ownership: none
+// ENABLE:        struct $S{{.*}} ownership: owned
+// ENABLE:        begin_apply {{.*}} ownership: -, guaranteed
+// DISABLE-NOT:   ownership
+// CHECK:       } // end sil function 'ossa_function'
+sil [ossa] @ossa_function : $@convention(thin) (@inout T, @owned AnyObject) -> () {
+bb0(%0 : $*T, %1 : @owned $AnyObject):
+  %2 = enum $E, #E.A!enumelt
+  %3 = struct $S (%2, %1)
+  %4 = struct_element_addr %0, #T.s
+  store %3 to [assign] %4
+  (%6, %7) = begin_apply undef() : $@yield_once () -> (@yields @in_guaranteed AnyObject)
+  end_apply %7 as $()
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil @non_ossa_function :
+// CHECK-NOT:     ownership
+// CHECK:       } // end sil function 'non_ossa_function'
+sil @non_ossa_function : $@convention(thin) (@inout T, @owned AnyObject) -> () {
+bb0(%0 : $*T, %1 : $AnyObject):
+  %2 = enum $E, #E.A!enumelt
+  %3 = struct $S (%2, %1)
+  %4 = struct_element_addr %0, #T.s
+  store %3 to %4
+  (%6, %7) = begin_apply undef() : $@yield_once () -> (@yields @in_guaranteed AnyObject)
+  end_apply %7 as $()
+  %9 = tuple ()
+  return %9
+}
+


### PR DESCRIPTION
With this option the ownership of instruction results is printed in the comments at the end of the line, e.g.

```
  %3 = struct $S (%2, %1)                         // ownership: owned
```

And even without enabling this option, ownership comments are printed if the ownership of a result mismatches with its type.
That can happen e.g. for non-trivial enums which are constructed with a trivial case:

```
enum E {
  case A
  case B(AnyObject)
}

  %1 = enum $E, #E.A!enumelt  // type of %1 is non trivial, but ownership is "none"
```

This PR also adds printing of forwarding ownership for `struct` and `tuple` instructions: print `forwarding: <ownership>` if the ownership of the result mismatches the operand ownership(s).
We already do this for all other forwarding instructions, but `struct` and `tuple` were missing.