### PR TITLE
[cxx-interop] Suppress warning in non-arc Obj-C++

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -567,6 +567,8 @@ static void writePostImportPrologue(raw_ostream &os, ModuleDecl &M) {
         "#pragma clang diagnostic ignored \"-Wunknown-pragmas\"\n"
         "#pragma clang diagnostic ignored \"-Wnullability\"\n"
         "#pragma clang diagnostic ignored "
+        "\"-Warc-bridge-casts-disallowed-in-nonarc\"\n"
+        "#pragma clang diagnostic ignored "
         "\"-Wdollar-in-identifier-extension\"\n"
         "#pragma clang diagnostic ignored "
         "\"-Wunsafe-buffer-usage\"\n"

--- a/test/Interop/SwiftToObjCxx/optional-objc-class-in-obj-cxx.swift
+++ b/test/Interop/SwiftToObjCxx/optional-objc-class-in-obj-cxx.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-swift-frontend %s -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseCoreFoundation.h
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/UseCoreFoundation.h -o %t/o.o
+// RUN: %target-interop-build-clangxx -Werror=arc-bridge-casts-disallowed-in-nonarc -std=gnu++20 -fno-objc-arc -c -x objective-c++-header %t/UseCoreFoundation.h -o %t/o.o
 
 // REQUIRES: objc_interop
 
@@ -13,4 +14,8 @@ public class TestFoundationType {
     public init(resourcesBundle bundle: Bundle? = nil) {
         _bundle = bundle
     }
+}
+
+public func getArray() -> [String] {
+    []
 }


### PR DESCRIPTION
We have some arc specific casts in our generated headers that can trigger some warnings in non-arc Obj-C++ code. These casts are noop in that case so it is fine to have them there. And we do want them as we want the code to be compatible both with arc and non-arc code.

rdar://163281971
