### PR TITLE
[Frontend] Enforce an error was emitted for invalid conformance

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1120,6 +1120,13 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
 
   // Emit extracted constant values for every file in the batch
   emitConstValuesForAllPrimaryInputsIfNeeded(Instance);
+
+  // Make sure we emitted an error if we encountered an invalid conformance.
+  // This is important since `ASTContext::hadError` accounts for delayed
+  // conformance diags, so we need to ensure we don't exit with a non-zero exit
+  // code without emitting any error.
+  ASSERT(ctx.Diags.hadAnyError() || !ctx.hasDelayedConformanceErrors() &&
+         "Encountered invalid conformance without emitting error?");
 }
 
 static bool printSwiftVersion(const CompilerInvocation &Invocation) {

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1496,8 +1496,15 @@ void ConstraintSystem::openGenericRequirement(
   switch (kind) {
   case RequirementKind::Conformance: {
     auto protoDecl = req.getProtocolDecl();
-    // Determine whether this is the protocol 'Self' constraint we should
-    // skip.
+    // Determine whether this is the protocol 'Self' constraint we should skip.
+    //
+    // NOTE: At first glance it seems like this is just an optimization to avoid
+    // adding a redundant constraint, but it is in fact load bearing for
+    // DistributedActor since we can form a conformance to Actor in
+    // GetDistributedActorAsActorConformanceRequest despite the fact that
+    // DistributedActor does not require Actor conformance (although conforming
+    // types are guaranteed to have the witnesses). So a conformance check in
+    // that case would fail.
     if (skipProtocolSelfConstraint && protoDecl == outerDC &&
         protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
       return;


### PR DESCRIPTION
Make sure we emitted an error if we encountered an invalid conformance error. This is important since `ASTContext::hadError` accounts for such delayed errors, so we need to make sure we don't ever exit with a non-zero exit code without emitting any error.