### PR TITLE
Rework emission of EditorPlaceholderExprs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2370,8 +2370,6 @@ NOTE(note_no_in_class_init_3plus,none,
      (Identifier, Identifier, Identifier, bool))
 ERROR(missing_unimplemented_init_runtime,none,
       "standard library error: missing _unimplementedInitializer", ())
-ERROR(missing_undefined_runtime,none,
-      "standard library error: missing _undefined", ())
 
 ERROR(inherited_default_value_not_in_designated_constructor,none,
       "default value inheritance via 'super' is only valid on the parameters of "

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5764,14 +5764,13 @@ class EditorPlaceholderExpr : public Expr {
   SourceLoc Loc;
   TypeRepr *PlaceholderTy;
   TypeRepr *ExpansionTyR;
-  Expr *SemanticExpr;
 
 public:
   EditorPlaceholderExpr(Identifier Placeholder, SourceLoc Loc,
                         TypeRepr *PlaceholderTy, TypeRepr *ExpansionTyR)
       : Expr(ExprKind::EditorPlaceholder, /*Implicit=*/false),
         Placeholder(Placeholder), Loc(Loc), PlaceholderTy(PlaceholderTy),
-        ExpansionTyR(ExpansionTyR), SemanticExpr(nullptr) {}
+        ExpansionTyR(ExpansionTyR) {}
 
   Identifier getPlaceholder() const { return Placeholder; }
   SourceRange getSourceRange() const { return Loc; }
@@ -5783,9 +5782,6 @@ public:
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::EditorPlaceholder;
   }
-
-  Expr *getSemanticExpr() const { return SemanticExpr; }
-  void setSemanticExpr(Expr *SE) { SemanticExpr = SE; }
 };
 
 /// A LazyInitializerExpr is used to embed an existing typechecked

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -91,6 +91,6 @@ FUNC_DECL(ModifyAtReferenceWritableKeyPath, "_modifyAtReferenceWritableKeyPath")
 FUNC_DECL(Swap, "swap")
 
 FUNC_DECL(UnimplementedInitializer, "_unimplementedInitializer")
-FUNC_DECL(Undefined, "_undefined")
+FUNC_DECL(UndefinedEditorPlaceholder, "_undefinedEditorPlaceholder")
 
 #undef FUNC_DECL

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -83,8 +83,6 @@ enum ContextualTypePurpose : uint8_t {
 
   CTP_ExprPattern,      ///< `~=` operator application associated with expression
                         /// pattern.
-
-  CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
 };
 
 namespace constraints {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4413,9 +4413,6 @@ public:
     if (ExpTyR && ExpTyR != TyR) {
       printRec(ExpTyR, Label::optional("type_repr_for_expansion"));
     }
-    if (auto *SE = E->getSemanticExpr()) {
-      printRec(SE, Label::always("semantic_expr"));
-    }
     printFoot();
   }
   void visitLazyInitializerExpr(LazyInitializerExpr *E, Label label) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -599,23 +599,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   //                                  Exprs
   //===--------------------------------------------------------------------===//
 
-  // A macro for handling the "semantic expressions" that are common
-  // on sugared expression nodes like string interpolation.  The
-  // semantic expression is set up by type-checking to include all the
-  // other children as sub-expressions, so if it exists, we should
-  // just bypass the rest of the visitation.
-#define HANDLE_SEMANTIC_EXPR(NODE)                         \
-  do {                                                     \
-    if (Expr *_semanticExpr = NODE->getSemanticExpr()) {   \
-      if ((_semanticExpr = doIt(_semanticExpr))) {         \
-        NODE->setSemanticExpr(_semanticExpr);              \
-      } else {                                             \
-        return nullptr;                                    \
-      }                                                    \
-      return NODE;                                         \
-    }                                                      \
-  } while (false)
-
   Expr *visitErrorExpr(ErrorExpr *E) {
     if (auto *origExpr = E->getOriginalExpr()) {
       auto *newOrigExpr = doIt(origExpr);
@@ -1267,7 +1250,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
   
   Expr *visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {
-    HANDLE_SEMANTIC_EXPR(E);
     return E;
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -499,6 +499,9 @@ namespace {
     emitFunctionCvtFromExecutionCallerToGlobalActor(FunctionConversionExpr *E,
                                                     SGFContext C);
 
+    /// Helper to emit a value of arbitrary type in an unreachable codepath.
+    RValue emitUnreachableValue(SILLocation loc, CanType ty);
+
     RValue visitActorIsolationErasureExpr(ActorIsolationErasureExpr *E,
                                           SGFContext C);
     RValue visitExtractFunctionIsolationExpr(ExtractFunctionIsolationExpr *E,
@@ -2136,6 +2139,32 @@ RValue RValueEmitter::emitFunctionCvtFromExecutionCallerToGlobalActor(
   return RValue(SGF, e, destType, result);
 }
 
+RValue RValueEmitter::emitUnreachableValue(SILLocation loc, CanType ty) {
+  ASSERT(!SGF.B.hasValidInsertionPoint() && "Must be unreachable");
+
+  // Continue code generation in a block with no predecessors.
+  // Whatever code is emitted here is guaranteed to be removed by SIL passes.
+  SGF.B.emitBlock(SGF.createBasicBlock());
+
+  // Since the type is uninhabited, use a SILUndef of so that we can return
+  // some sort of RValue from this API.
+  auto &lowering = SGF.getTypeLowering(ty);
+  auto loweredTy = lowering.getLoweredType();
+  auto undef = SILUndef::get(SGF.F, loweredTy);
+
+  // Create an alloc initialized with contents from the undefined addr type.
+  // It seems pack addresses do not satisfy isPlusOneOrTrivial, so we need an
+  // actual allocation.
+  if (loweredTy.isAddress()) {
+    auto resultAddr = SGF.emitTemporaryAllocation(loc, loweredTy);
+    SGF.emitSemanticStore(loc, undef, resultAddr, lowering, IsInitialization);
+    return RValue(SGF, loc, ty, SGF.emitManagedRValueWithCleanup(resultAddr));
+  }
+
+  // Otherwise, if it's not an address, just emit the undef value itself.
+  return RValue(SGF, loc, ty, ManagedValue::forRValueWithoutOwnership(undef));
+}
+
 RValue RValueEmitter::visitFunctionConversionExpr(FunctionConversionExpr *e,
                                                   SGFContext C) {
   CanAnyFunctionType srcType =
@@ -2660,28 +2689,7 @@ RValue RValueEmitter::visitUnreachableExpr(UnreachableExpr *E, SGFContext C) {
   // Emit the expression, followed by an unreachable.
   SGF.emitIgnoredExpr(E->getSubExpr());
   SGF.B.createUnreachable(E);
-
-  // Continue code generation in a block with no predecessors.
-  // Whatever code is emitted here is guaranteed to be removed by SIL passes.
-  SGF.B.emitBlock(SGF.createBasicBlock());
-
-  // Since the type is uninhabited, use a SILUndef of so that we can return
-  // some sort of RValue from this API.
-  auto &lowering = SGF.getTypeLowering(E->getType());
-  auto loweredTy = lowering.getLoweredType();
-  auto undef = SILUndef::get(SGF.F, loweredTy);
-
-  // Create an alloc initialized with contents from the undefined addr type.
-  // It seems pack addresses do not satisfy isPlusOneOrTrivial, so we need an
-  // actual allocation.
-  if (loweredTy.isAddress()) {
-    auto resultAddr = SGF.emitTemporaryAllocation(E, loweredTy);
-    SGF.emitSemanticStore(E, undef, resultAddr, lowering, IsInitialization);
-    return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(resultAddr));
-  }
-
-  // Otherwise, if it's not an address, just emit the undef value itself.
-  return RValue(SGF, E, ManagedValue::forRValueWithoutOwnership(undef));
+  return emitUnreachableValue(E, E->getType()->getCanonicalType());
 }
 
 static SILValue getArrayBuffer(SILValue array, SILGenFunction &SGF, SILLocation loc) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4782,34 +4782,7 @@ namespace {
     }
     
     Expr *visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {
-      simplifyExprType(E);
-      auto valueType = cs.getType(E);
-
-      // Synthesize a call to _undefined() of appropriate type.
-      FuncDecl *undefinedDecl = ctx.getUndefined();
-      if (!undefinedDecl) {
-        ctx.Diags.diagnose(E->getLoc(), diag::missing_undefined_runtime);
-        return nullptr;
-      }
-      DeclRefExpr *fnRef = new (ctx) DeclRefExpr(undefinedDecl, DeclNameLoc(),
-                                                 /*Implicit=*/true);
-      fnRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
-
-      StringRef msg = "attempt to evaluate editor placeholder";
-      Expr *argExpr = new (ctx) StringLiteralExpr(msg, E->getLoc(),
-                                                  /*implicit*/true);
-
-      auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {argExpr});
-      Expr *callExpr = CallExpr::createImplicit(ctx, fnRef, argList);
-
-      auto resultTy = TypeChecker::typeCheckExpression(
-          callExpr, dc, /*contextualInfo=*/{valueType, CTP_CannotFail});
-      assert(resultTy && "Conversion cannot fail!");
-      (void)resultTy;
-
-      cs.cacheExprTypes(callExpr);
-      E->setSemanticExpr(callExpr);
-      return E;
+      return simplifyExprType(E);
     }
 
     Expr *visitObjCSelectorExpr(ObjCSelectorExpr *E) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9589,7 +9589,6 @@ ExprWalker::rewriteTarget(SyntacticElementTarget target) {
     case CTP_SubscriptAssignSource:
     case CTP_Condition:
     case CTP_WrappedProperty:
-    case CTP_CannotFail:
     case CTP_SingleValueStmtBranch:
       result.setExpr(rewrittenExpr);
       break;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -864,7 +864,6 @@ GenericArgumentsMismatchFailure::getDiagnosticFor(
   case CTP_ThrowStmt:
   case CTP_ForEachSequence:
   case CTP_Unused:
-  case CTP_CannotFail:
   case CTP_YieldByReference:
   case CTP_EnumCaseRawValue:
   case CTP_ExprPattern:
@@ -973,7 +972,7 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
 
     case ConstraintLocator::ContextualType: {
       auto purpose = getContextualTypePurpose();
-      assert(!(purpose == CTP_Unused || purpose == CTP_CannotFail));
+      assert(purpose != CTP_Unused);
 
       // If this is call to a closure e.g. `let _: A = { B() }()`
       // let's point diagnostic to its result.
@@ -2949,9 +2948,7 @@ static std::optional<Diag<Type>>
 getContextualNilDiagnostic(ContextualTypePurpose CTP) {
   switch (CTP) {
   case CTP_Unused:
-  case CTP_CannotFail:
-    llvm_unreachable("These contextual type purposes cannot fail with a "
-                     "conversion type specified!");
+    llvm_unreachable("Expected a contextual purpose");
   case CTP_Initialization:
     return diag::cannot_convert_initializer_value_nil;
 
@@ -3749,7 +3746,6 @@ ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
   case CTP_ThrowStmt:
   case CTP_ForEachSequence:
   case CTP_Unused:
-  case CTP_CannotFail:
   case CTP_YieldByReference:
   case CTP_ExprPattern:
     break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16680,7 +16680,6 @@ void ConstraintSystem::addContextualConversionConstraint(
 
   case CTP_ArrayElement:
   case CTP_AssignSource:
-  case CTP_CannotFail:
   case CTP_Condition:
   case CTP_Unused:
   case CTP_YieldByValue:

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -273,7 +273,6 @@ bool SyntacticElementTarget::contextualTypeIsOnlyAHint() const {
   case CTP_SubscriptAssignSource:
   case CTP_Condition:
   case CTP_WrappedProperty:
-  case CTP_CannotFail:
   case CTP_ExprPattern:
   case CTP_SingleValueStmtBranch:
     return false;

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -293,8 +293,8 @@ func _unimplementedInitializer(className: StaticString,
 #if !$Embedded
 
 /// Previously used to evaluate editor placeholders.
-public // COMPILER_INTRINSIC
-func _undefined<T>(
+@usableFromInline // COMPILER_INTRINSIC
+internal func _undefined<T>(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) -> T {
@@ -304,8 +304,8 @@ func _undefined<T>(
 #else
 
 /// Previously used to evaluate editor placeholders.
-public // COMPILER_INTRINSIC
-func _undefined<T>(
+@usableFromInline // COMPILER_INTRINSIC
+internal func _undefined<T>(
   _ message: @autoclosure () -> StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
 ) -> T {

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -292,7 +292,7 @@ func _unimplementedInitializer(className: StaticString,
 
 #if !$Embedded
 
-/// Used to evaluate editor placeholders.
+/// Previously used to evaluate editor placeholders.
 public // COMPILER_INTRINSIC
 func _undefined<T>(
   _ message: @autoclosure () -> String = String(),
@@ -303,7 +303,7 @@ func _undefined<T>(
 
 #else
 
-/// Used to evaluate editor placeholders.
+/// Previously used to evaluate editor placeholders.
 public // COMPILER_INTRINSIC
 func _undefined<T>(
   _ message: @autoclosure () -> StaticString = StaticString(),
@@ -313,6 +313,38 @@ func _undefined<T>(
 }
 
 #endif
+
+/// Called when evaluating an editor placeholder in a playground.
+///
+/// We always export this into the client since it should never be used in an
+/// actual shipping binary and keeps it a pure compiler implementation detail.
+///
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
+#if !$Embedded
+@inline(never)
+#else
+@inline(__always)
+#endif
+@_alwaysEmitIntoClient // COMPILER_INTRINSIC
+internal func _undefinedEditorPlaceholder(
+  _filenameStart: Builtin.RawPointer,
+  _filenameLength: Builtin.Word,
+  _filenameIsASCII: Builtin.Int1,
+  _line: Builtin.Word
+) -> Never {
+  _assertionFailure(
+    "Fatal error",
+    "attempt to evaluate editor placeholder",
+    file: StaticString(
+            _start: _filenameStart,
+            utf8CodeUnitCount: _filenameLength,
+            isASCII: _filenameIsASCII),
+    line: UInt(_line),
+    flags: 0
+  )
+}
 
 /// Called when falling off the end of a switch and the type can be represented
 /// as a raw value.

--- a/test/IDE/editor_placeholder_exec.swift
+++ b/test/IDE/editor_placeholder_exec.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-run-simple-swift(-Xfrontend -warn-on-editor-placeholder) 2> %t/output || true
+// RUN: %FileCheck %s < %t/output
+// REQUIRES: executable_test
+
+print(<#placeholder#>)
+// CHECK: editor_placeholder_exec.swift:[[@LINE-1]]: Fatal error: attempt to evaluate editor placeholder


### PR DESCRIPTION
Rather than synthesizing a semantic expression to emit, add a compiler intrinsic to the stdlib that is simple enough to just SILGen the emission.