### PR TITLE
[SILGen] Fix load ownership for trivial tuple elements in consuming switch

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2672,7 +2672,9 @@ void PatternMatchEmission::emitDestructiveCaseBlocks() {
         for (unsigned i = 0, e = p->getNumElements(); i < e; ++i) {
           SILValue element = SGF.B.createTupleElementAddr(p, baseAddr, i);
           if (element->getType().isLoadable(SGF.F)) {
-            element = SGF.B.createLoad(p, element, LoadOwnershipQualifier::Take);
+            element =
+                SGF.getTypeLowering(element->getType())
+                    .emitLoad(SGF.B, p, element, LoadOwnershipQualifier::Take);
           }
           visit(p->getElement(i).getPattern(),
                 SGF.emitManagedRValueWithCleanup(element));

--- a/test/SILGen/address_only_enum_trivial_payload.swift
+++ b/test/SILGen/address_only_enum_trivial_payload.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -sil-verify-all
+
+// Test that consuming switch on address only enum with trivial payload case correctly use load [trivial]
+// instead of load [take].
+
+protocol AProtocol {}
+
+enum AddressOnly: ~Copyable {
+  case unloadableAndInt(any AProtocol, Int)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s33address_only_enum_trivial_payload14consumeTheEnum
+func consumeTheEnum(_ value: consuming AddressOnly) -> Int {
+  // CHECK: switch_enum_addr {{.*}}AddressOnly.unloadableAndInt
+  switch consume value {
+  case .unloadableAndInt(_, let count):
+    // CHECK: [[ADDR:%[0-9]+]] = unchecked_take_enum_data_addr
+    // CHECK: [[TRIVIAL_ADDR:%[0-9]+]] = tuple_element_addr [[ADDR]], 1
+    // CHECK: load [trivial] [[TRIVIAL_ADDR]]
+    return count
+  }
+}


### PR DESCRIPTION
In consuming switch when emitting case block that destructures a tuple payload, it was unconditionally issuing load [take] even if the element was a trivial type. Later code assumes loads for trivial types have trivial ownership. With asserts enabled, the test added in this change would previously crash at:

(value->getOwnershipKind() == OwnershipKind::None), function forObjectRValueWithoutOwnership, file ManagedValue.h, line 210.
The fix uses TypeLowering::emitLoad() instead of directly creating the load, which handles setting ownership to trivial if the type is trivial.

Resolves https://github.com/swiftlang/swift/issues/85743