### PR TITLE
[6.3] embedded: don't try to specialize vtables of C++ imported reference-counted classes

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -72,6 +72,8 @@ final public class ClassDecl: NominalTypeDecl {
   final public var destructor: DestructorDecl {
     bridged.Class_getDestructor().getAs(DestructorDecl.self)
   }
+
+  public var isForeign: Bool { bridged.Class_isForeign() }
 }
 
 final public class ProtocolDecl: NominalTypeDecl {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -48,6 +48,9 @@ private struct VTableSpecializer {
     }
 
     let classDecl = classType.nominal! as! ClassDecl
+    if classDecl.isForeign {
+      return
+    }
     guard let origVTable = context.lookupVTable(for: classDecl) else {
       if context.enableWMORequiredDiagnostics {
         context.diagnosticEngine.diagnose(.cannot_specialize_class, classType, at: errorLocation)

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -334,6 +334,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool Struct_hasUnreferenceableStorage() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Class_getSuperclass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj Class_getDestructor() const;
+  BRIDGED_INLINE bool Class_isForeign() const;
   BRIDGED_INLINE bool ProtocolDecl_requiresClass() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -218,6 +218,10 @@ BridgedDeclObj BridgedDeclObj::Class_getDestructor() const {
   return {getAs<swift::ClassDecl>()->getDestructor()};
 }
 
+bool BridgedDeclObj::Class_isForeign() const {
+  return getAs<swift::ClassDecl>()->isForeign();
+}
+
 bool BridgedDeclObj::ProtocolDecl_requiresClass() const {
   return getAs<swift::ProtocolDecl>()->requiresClass();
 }

--- a/test/embedded/cxx-import-reference.swift
+++ b/test/embedded/cxx-import-reference.swift
@@ -40,3 +40,12 @@ public func test()
   let c =  C.create()
   c.foo()
 }
+
+public func cast<S,D>(_ s:S, to type:D.Type) -> D {
+  return unsafeBitCast(s, to: type.self)
+}
+
+public func testcast(_ provider: AnyObject) -> C {
+  return cast (provider, to: C.self)
+}
+


### PR DESCRIPTION
* **Explanation**:  Fixes a false compiler error which using reference-counted C++ classes in embedded swift.
* **Risk**: Low. The change only affects embedded swift. It's a simple bail-out condition for vtable specialization.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://165209061
* **Reviewer**:  @DougGregor
* **Main branch PR**: https://github.com/swiftlang/swift/pull/85647
