### PR TITLE
[wasm] Enable `-internalize-at-link` for stdlib build by default

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -216,6 +216,8 @@ class WasmStdlib(cmake_product.CMakeProduct):
 
     def add_extra_cmake_options(self):
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        self.cmake_options.define('SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS:STRING',
+                                  '-Xfrontend;-internalize-at-link;')
 
     def test(self, host_target):
         self._test(host_target, 'wasm32-wasip1')
@@ -299,6 +301,7 @@ class WasmThreadsStdlib(WasmStdlib):
                                   '-mthread-model;posix;-pthread;'
                                   '-ftls-model=local-exec')
         self.cmake_options.define('SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS:STRING',
+                                  '-Xfrontend;-internalize-at-link;'
                                   '-Xcc;-matomics;-Xcc;-mbulk-memory;'
                                   '-Xcc;-mthread-model;-Xcc;posix;'
                                   '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')


### PR DESCRIPTION
We can assume that all consumers of the WebAssembly stdlib will be using static linking, so we can safely enable `-internalize-at-link` to allow wasm-ld linker to omit some dead code during [its GC process]( https://github.com/llvm/llvm-project/blob/main/lld/wasm/MarkLive.cpp).

This change resulted 2.2mb binary size reduction in a simple hello world program.
```console
$ ls -l $(find . -name Hello.wasm)
-rwxrwxr-x 1 katei katei 7102099 Dec  1 20:07 ./.build.baseline/wasm32-unknown-wasip1-threads/release/Hello.wasm
-rwxrwxr-x 1 katei katei 4785486 Dec  1 20:06 ./.build.new/wasm32-unknown-wasip1-threads/release/Hello.wasm
```
