### PR TITLE
[6.3] Optimizer: register explicit-copy instruction simplifications for SILCombine

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -115,6 +115,8 @@ private func registerSwiftPasses() {
   registerForSILCombine(BeginBorrowInst.self,      { run(BeginBorrowInst.self, $0) })
   registerForSILCombine(BeginCOWMutationInst.self, { run(BeginCOWMutationInst.self, $0) })
   registerForSILCombine(BuiltinInst.self,          { run(BuiltinInst.self, $0) })
+  registerForSILCombine(ExplicitCopyAddrInst.self, { run(ExplicitCopyAddrInst.self, $0) })
+  registerForSILCombine(ExplicitCopyValueInst.self,{ run(ExplicitCopyValueInst.self, $0) })
   registerForSILCombine(FixLifetimeInst.self,      { run(FixLifetimeInst.self, $0) })
   registerForSILCombine(GlobalValueInst.self,      { run(GlobalValueInst.self, $0) })
   registerForSILCombine(StructInst.self,           { run(StructInst.self, $0) })

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5544,3 +5544,37 @@ entry(%e_addr : $*NoncopyableEnum):
   end_borrow %i : $CopyableStruct
   return undef : $()
 }
+
+// CHECK-LABEL:      sil [ossa] @simplify_copy_take_init :
+// CHECK:              {{ }}copy_addr [take] %1 to [init] %0
+// CHECK-NEXT:         %3 = tuple ()
+// CHECK:            } // end sil function 'simplify_copy_take_init'
+sil [ossa] @simplify_copy_take_init : $@convention(thin) (@in String) -> @out String {
+bb0(%0 : $*String, %1 : $*String):
+  explicit_copy_addr [take] %1 to [init] %0
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL:      sil [ossa] @simplify_copy_assign :
+// CHECK:              {{ }}copy_addr %1 to %0
+// CHECK-NEXT:         %3 = tuple ()
+// CHECK:            } // end sil function 'simplify_copy_assign'
+sil [ossa] @simplify_copy_assign : $@convention(thin) (@inout String, @inout String) -> () {
+bb0(%0 : $*String, %1 : $*String):
+  explicit_copy_addr %1 to %0
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @simplify_explicit_copy_value :
+// CHECK:         %1 = copy_value %0
+// CHECK-NEXT:    return %1
+// CHECK:       } // end sil function 'simplify_explicit_copy_value'
+sil [ossa] @simplify_explicit_copy_value : $@convention(thin) (@guaranteed String) -> @owned String {
+bb0(%0 : @guaranteed $String):
+  %1 = explicit_copy_value %0
+  return %1
+}
+
+


### PR DESCRIPTION
* **Explanation**:  Fixes a compiler crash. Usually `explicit_copy_addr` and `explicit_copy_value` don't survive until the first SILCombine pass run anyway. But if they do, the simplifications need to be registered, otherwise SILCombine will complain.
* **Risk**: Zero. It's a trivial change which only affects the case where the compiler would otherwise crash.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://165617225
* **Reviewer**:  @aidan-hall
* **Main branch PR**: https://github.com/swiftlang/swift/pull/85722
