### PR TITLE
Address some overload deprecations in `llvm::support::endian`

### DIFF
--- a/lib/Tooling/libSwiftScan/SwiftCaching.cpp
+++ b/lib/Tooling/libSwiftScan/SwiftCaching.cpp
@@ -397,9 +397,8 @@ createCachedCompilation(SwiftScanCAS &CAS, const llvm::cas::CASID &ID,
     return KeyProxy.takeError();
   auto Input = KeyProxy->getData();
 
-  unsigned Index =
-      llvm::support::endian::read<uint32_t, llvm::endianness::little,
-                                  llvm::support::unaligned>(Input.data());
+  unsigned Index = llvm::support::endian::read<uint32_t>(
+      Input.data(), llvm::endianness::little);
   {
     swift::cas::CompileJobResultSchema Schema(CAS.getCAS());
     if (Schema.isRootNode(*Proxy)) {

--- a/tools/libMockPlugin/MockPlugin.cpp
+++ b/tools/libMockPlugin/MockPlugin.cpp
@@ -240,9 +240,8 @@ int TestRunner::run() {
     llvm::SmallVector<char, 0> response_data;
     llvm::raw_svector_ostream(response_data) << response;
     auto response_size = response_data.size();
-    auto response_header =
-        llvm::support::endian::byte_swap<uint64_t, llvm::endianness::little>(
-            response_size);
+    auto response_header = llvm::support::endian::byte_swap<uint64_t>(
+        response_size, llvm::endianness::little);
     ioSize = fwrite(&response_header, sizeof(response_header), 1, stdout);
     if (!ioSize) {
       llvm::errs() << "failed to write response header\n";


### PR DESCRIPTION
See:
* https://github.com/llvm/llvm-project/pull/161045
* https://github.com/llvm/llvm-project/pull/160979
