### PR TITLE
[cxx-interop] Support rvalue-ref qualified methods

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5698,7 +5698,8 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
 // The base C++ method is either the original C++ method that corresponds
 // to the imported base member, or it's the synthesized C++ method thunk
 // used in another synthesized derived thunk that acts as a base member here.
-const clang::CXXMethodDecl *getCalledBaseCxxMethod(FuncDecl *baseMember) {
+static const clang::CXXMethodDecl *
+getCalledBaseCxxMethod(FuncDecl *baseMember) {
   if (baseMember->getClangDecl())
     return dyn_cast<clang::CXXMethodDecl>(baseMember->getClangDecl());
   // Another synthesized derived thunk is used as a base member here,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5732,6 +5732,10 @@ const clang::CXXMethodDecl *getCalledBaseCxxMethod(FuncDecl *baseMember) {
   if (!callExpr)
     return nullptr;
   auto *cv = callExpr->getCalledValue();
+  if (auto orig = baseMember->getASTContext()
+                      .getClangModuleLoader()
+                      ->getOriginalForClonedMember(cv))
+    cv = orig;
   if (!cv)
     return nullptr;
   if (!cv->getClangDecl())

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -60,10 +60,6 @@ STATISTIC(ImportNameNumCacheMisses, "# of times the import name cache was missed
 using namespace swift;
 using namespace importer;
 
-// Commonly-used Clang classes.
-using clang::CompilerInstance;
-using clang::CompilerInvocation;
-
 Identifier importer::getOperatorName(ASTContext &ctx,
                                      clang::OverloadedOperatorKind op) {
   switch (op) {

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -38,6 +38,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/OperatorKinds.h"
@@ -1955,6 +1956,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (!functionDecl)
       return ImportedName();
 
+    // We do not import && qualified operators yet.
+    if (const auto *method = dyn_cast<clang::CXXMethodDecl>(functionDecl)) {
+      if (method->getRefQualifier() == clang::RefQualifierKind::RQ_RValue)
+        return ImportedName();
+    }
+
     switch (op) {
     case clang::OverloadedOperatorKind::OO_Plus:
     case clang::OverloadedOperatorKind::OO_Minus:
@@ -2298,28 +2305,48 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   SmallString<16> newName;
   // Check if we need to rename the C++ method to disambiguate it.
   if (auto method = dyn_cast<clang::CXXMethodDecl>(D)) {
+    bool shouldAddMutable = false;
+    bool shouldAddConsuming = false;
     if (!method->isConst() && !method->isOverloadedOperator() && !method->isStatic()) {
       // See if any other methods within the same struct have the same name, but
       // differ in constness.
       auto otherDecls = dc->lookup(method->getDeclName());
-      bool shouldRename = false;
       for (auto otherDecl : otherDecls) {
         if (otherDecl == D)
           continue;
         if (auto otherMethod = dyn_cast<clang::CXXMethodDecl>(otherDecl)) {
           // TODO: what if the other method is also non-const?
           if (otherMethod->isConst()) {
-            shouldRename = true;
+            shouldAddMutable = true;
             break;
           }
         }
       }
-
-      if (shouldRename) {
-        newName = baseName;
-        newName += "Mutating";
-        baseName = newName;
+    }
+    if (method->getRefQualifier() == clang::RefQualifierKind::RQ_RValue &&
+        !method->isOverloadedOperator()) {
+      // See if any other methods within the same struct have the same name, but
+      // differ in ref qualifier.
+      auto otherDecls = dc->lookup(method->getDeclName());
+      for (auto otherDecl : otherDecls) {
+        if (otherDecl == D)
+          continue;
+        if (auto otherMethod = dyn_cast<clang::CXXMethodDecl>(otherDecl)) {
+          if (otherMethod->getRefQualifier() ==
+              clang::RefQualifierKind::RQ_LValue) {
+            shouldAddConsuming = true;
+            break;
+          }
+        }
       }
+    }
+    if (shouldAddMutable || shouldAddConsuming) {
+      newName = baseName;
+      if (shouldAddMutable)
+        newName += "Mutating";
+      if (shouldAddConsuming)
+        newName += "Consuming";
+      baseName = newName;
     }
     if (method->isImplicit() &&
         baseName.starts_with("__synthesizedVirtualCall_")) {

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -26,6 +26,10 @@ struct Base {
       __attribute__((swift_attr("import_unsafe"))) {
     return "Base::rvalueThisInBase";
   }
+  inline void refQualifierOverloads() & {}
+  inline void refQualifierOverloads() const & {}
+  inline void refQualifierOverloads() && {}
+  inline void refQualifierOverloads() const && {}
   // TODO: if these are unnamed we hit an (unrelated) SILGen bug. Same for
   // subscripts.
   inline const char *takesArgsInBase(int a, int b, int c) const

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -15,7 +15,11 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func rvalueThisInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public consuming func rvalueThisInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public mutating func refQualifierOverloadsMutating()
+// CHECK-NEXT:   public func refQualifierOverloads()
+// CHECK-NEXT:   public consuming func refQualifierOverloadsMutatingConsuming()
+// CHECK-NEXT:   public consuming func refQualifierOverloadsConsuming()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
@@ -54,6 +58,8 @@
 // CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public mutating func refQualifierOverloadsMutating()
+// CHECK-NEXT:   public func refQualifierOverloads()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
@@ -84,6 +90,8 @@
 // CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public mutating func refQualifierOverloadsMutating()
+// CHECK-NEXT:   public func refQualifierOverloads()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -268,8 +268,6 @@
 // CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
-// CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
-// CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -45,4 +45,14 @@ inline bool takesOptionalInt(std::optional<int> arg) { return (bool)arg; }
 inline bool takesOptionalString(std::optional<std::string> arg) { return (bool)arg; }
 inline bool takesOptionalHasDeletedCopyCtor(std::optional<HasDeletedCopyCtor> arg) { return (bool)arg; }
 
+struct DerivedFromOptional : std::optional<std::string> {
+  using std::optional<std::string>::optional;
+};
+
+struct ReturnsOptionalString {
+  ReturnsOptionalString() {}
+  std::optional<std::string> getStr() const { return "foo"; }
+  DerivedFromOptional getStrDerived() const { return "foo"; }
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H

--- a/test/Interop/Cxx/stdlib/lit.local.cfg
+++ b/test/Interop/Cxx/stdlib/lit.local.cfg
@@ -1,0 +1,6 @@
+# Make a local copy of the environment.
+config.environment = dict(config.environment)
+
+# FIXME: deserialization failure with the old driver in use-std-optional-lib.swift
+if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']

--- a/test/Interop/Cxx/stdlib/use-std-optional-lib.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-lib.swift
@@ -1,0 +1,14 @@
+// RUN: %target-build-swift %s -emit-module -emit-library -cxx-interoperability-mode=default -module-name OptionalLib -emit-module-path %t/artifacts/OptionalLib.swiftmodule -I %S/Inputs -O
+
+import StdOptional
+import CxxStdlib
+
+extension ReturnsOptionalString {
+    @inlinable
+    public var string: String? {
+        let _ = self.getStrDerived().pointee.map { $0 }
+        return self.getStr().value.map {
+            .init($0)
+        }
+    }
+}


### PR DESCRIPTION
We already imported methods that have && as qualifiers but did not support them properly. When in the C++ code there is overloading based on the reference qualifiers the imported Swift functions are ambiguous. This patch append "Consuming" to the && qualified methods' names to avoid the ambiguity. It also makes sure these methods are actually imported as consuming.

In case of operators, however, Swift does not have a way to distinguish between the consuming and non-consuming self. This patch prevents importing the consuming variants. This fixes some compiler crashes during deserialization that we hit due to the ambiguities.

Fixes #83801

rdar://158675235
