### PR TITLE
[6.3] Add Embedded Swift Cxx exception personality

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -206,12 +206,13 @@ linkEmbeddedRuntimeFunctionByName(#NAME, EFFECT, StringRef(#CC) == "C_CC");    \
     }
 
     for (auto *F : Functions) {
-      auto declRef = SILDeclRef(F, SILDeclRef::Kind::Func);
+      auto declRef = SILDeclRef(F, SILDeclRef::Kind::Func,
+                                F->hasOnlyCEntryPoint());
       auto *Fn = linkUsedFunctionByName(declRef.mangle(), /*Linkage*/{},
                                         /*byAsmName=*/false);
 
       // If we have @_cdecl or @_silgen_name, also link the foreign thunk
-      if (Fn->hasCReferences()) {
+      if (Fn->hasCReferences() && !F->hasOnlyCEntryPoint()) {
         auto declRef = SILDeclRef(F, SILDeclRef::Kind::Func, /*isForeign*/true);
         linkUsedFunctionByName(declRef.mangle(), /*Linkage*/{},
                                /*byAsmName=*/false);

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -271,7 +271,7 @@ func isValidPointerForNativeRetain(object: Builtin.RawPointer) -> Bool {
   #if _pointerBitWidth(_64)
   if unsafe (objectBits & HeapObject.immortalObjectPointerBit) != 0 { return false }
   #endif
-  
+
   return true
 }
 
@@ -575,4 +575,20 @@ func _embeddedReportFatalErrorInFile(prefix: StaticString, message: UnsafeBuffer
   print(prefix, terminator: "")
   if message.count > 0 { print(": ", terminator: "") }
   unsafe print(message)
+}
+
+// CXX Exception Personality
+
+public typealias _Unwind_Action = CInt
+public typealias _Unwind_Reason_Code = CInt
+
+@c @used
+public func _swift_exceptionPersonality(
+  version: CInt,
+  actions: _Unwind_Action,
+  exceptionClass: UInt64,
+  exceptionObject: UnsafeMutableRawPointer,
+  context: UnsafeMutableRawPointer
+) -> _Unwind_Reason_Code {
+  fatalError("C++ exception handling detected but the Embedded Swift runtime does not support exceptions")
 }

--- a/test/embedded/linkage/cxx-exceptions.swift
+++ b/test/embedded/linkage/cxx-exceptions.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o -cxx-interoperability-mode=default
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+@_expose(Cxx)
+func f1() {
+  print("OK!")
+}
+
+f1()
+
+// CHECK: OK!


### PR DESCRIPTION
- **Explanation**: Adds a Swift personality function for C++ exceptions to the Embedded Swift runtime.
- **Scope**: Only affects Embedded Swift when both C++ interoperability and C++ exceptions are enabled.
- **Issues**: rdar://164423867, https://github.com/swiftlang/swift/issues/85490
- **Original PRs**: https://github.com/swiftlang/swift/pull/85492
- **Risk**: Low. Adds a new function to the Embedded Swift runtime and a narrow `@c`-related fix to the SIL linker.
- **Testing**: New tests + CI
- **Reviewers**: @rauhul and myself worked on this together
