### PR TITLE
[SE-0489] Better `debugDescription` for `EncodingError` and  `Decodin…

### DIFF
--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -37,7 +37,7 @@ func test() {
   // FIXME: -module-abi-name ABI name is leaking.
 
   let _: String = #fooMacro(1)
-  // expected-error @-1 {{typeMismatch(_CompilerSwiftCompilerPluginMessageHandling.PluginToHostMessage}}
+  // expected-error @-1 {{typeMismatch}}
   let _: String = #fooMacro(2)
   // expected-error @-1 {{failed to receive result from plugin (from macro 'fooMacro')}}
   let _: String = #fooMacro(3)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1151,3 +1151,13 @@ Added: _swift_retain_preservemost
 
 // New debug environment variable for the concurrency runtime.
 Added: _concurrencyEnableTaskSlabAllocator
+
+// SE-0489 Better debugDescription for EncodingError and DecodingError
+Added: _$ss13DecodingErrorO16debugDescriptionSSvg
+Added: _$ss13DecodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesWP
+Added: _$ss13EncodingErrorO16debugDescriptionSSvg
+Added: _$ss13EncodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesWP

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1146,3 +1146,13 @@ Added: __swift_debug_metadataAllocatorPageSize
 
 // New debug environment variable for the concurrency runtime.
 Added: _concurrencyEnableTaskSlabAllocator
+
+// SE-0489 Better debugDescription for EncodingError and DecodingError
+Added: _$ss13DecodingErrorO16debugDescriptionSSvg
+Added: _$ss13DecodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesWP
+Added: _$ss13EncodingErrorO16debugDescriptionSSvg
+Added: _$ss13EncodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesWP

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -879,4 +879,8 @@ Func _float64ToStringImpl(_:_:_:_:) is a new API without '@available'
 Func _int64ToStringImpl(_:_:_:_:_:) is a new API without '@available'
 Func _uint64ToStringImpl(_:_:_:_:_:) is a new API without '@available'
 
+// New conformances from SE-0489: Better debugDescription for EncodingError and DecodingError
+Enum DecodingError has added a conformance to an existing protocol CustomDebugStringConvertible
+Enum EncodingError has added a conformance to an existing protocol CustomDebugStringConvertible
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
- **Explanation**:

Cherry-pick changes from #80941 - Approved API changes targeted at swift-6.3

- **Scope**:

These changes were merged to `main`, but annotated as available in 6.3, so the availability must match existence of the implementation.

- **Issues**:

None

- **Original PRs**:

https://github.com/swiftlang/swift/pull/80941

- **Risk**:

Changes the output of `debugDescription` of Codable errors. Tests that depend on this output have been updated. Production code not expected to rely on specific output.

- **Testing**:

See original PR. Full CI testing with additional tests added to validate new functionality.

- **Reviewers**:

@stephentyrone
