### PR TITLE
[6.3] [Embedded] Only strip "external" from global variables that have definitions

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -522,7 +522,8 @@ void SILLinkerVisitor::visitGlobalAddrInst(GlobalAddrInst *GAI) {
   // In Embedded Swift, we want to actually link globals from other modules too,
   // so strip "external" from the linkage.
   SILGlobalVariable *G = GAI->getReferencedGlobal();
-  G->setLinkage(stripExternalFromLinkage(G->getLinkage()));
+  if (G->isDefinition())
+    G->setLinkage(stripExternalFromLinkage(G->getLinkage()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/embedded/modules-extern.swift
+++ b/test/embedded/modules-extern.swift
@@ -21,7 +21,11 @@ public func publicFuncInAModule() {
 @usableFromInline
 internal func internalFuncInAModule() {
   some_c_api()
+  _ = globalVariable
 }
+
+@_extern(c)
+var globalVariable: Int
 
 // BEGIN Main.swift
 


### PR DESCRIPTION
- **Explanation**: Embedded Swift ends up rewriting the linkage of global variables as part of linking together all of the Swift modules. Doing so for extern global variables (e.g., ones meant to be implemented in C) breaks the LLVM module, because they will never have definitions. Only make this change when the global variable is a definition.
- **Scope**: Limited to Embedded Swift when using `@_extern` on variables, a feature that is new in 6.3
- **Original PRs**: https://github.com/swiftlang/swift/pull/85776
- **Risk**: Very low due to extremely narrow scope.
- **Testing**: New regression test.