### PR TITLE
CMake: Add GlibC Clang Overlay to export set

### DIFF
--- a/Runtimes/Overlay/Linux/glibc/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Linux/glibc/clang/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(SwiftGlibcClangOverlay INTERFACE
 target_compile_options(SwiftGlibcClangOverlay INTERFACE
   "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/glibc-overlay.yml>>")
 
+install(TARGETS SwiftGlibcClangOverlay EXPORT SwiftOverlayTargets)
+
 install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/glibc.modulemap"


### PR DESCRIPTION
Adding the Glibc Clang Overlay interface target to the installed export set. The interface library exists to plumb the appropriate flags through the build graph and ensure that the modulemap and header file are generated when depended on.

Interface libraries need to be in the export set when depended on by a public library to ensure that the appropriate install interface flags are exposed to targets importing the library from outside of the build system, regardless of whether the interface library actually installs any files.

This fixes the configuration-time error:

```
Export called with target "swiftGlibc" which requires "SwiftGlibcClangOverlay" that is not in any export set.
```