### PR TITLE
[6.3][Sema]: suppress unexpected type warning on some async-let patterns

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1230,7 +1230,11 @@ Pattern *TypeChecker::coercePatternToType(
       // If the whole pattern is implicit, the user didn't write it.
       // Assume the compiler knows what it's doing.
     } else if (diagTy->isEqual(Context.TheEmptyTupleType)) {
-      shouldRequireType = true;
+      // Async-let bindings are commonly used to run a Void-returning
+      // synchronous function in an async context. As a policy choice, don't
+      // diagnose an inferred Void type (or optional thereof) on such bindings
+      // as potentially unexpected.
+      shouldRequireType = !var->isAsyncLet();
     } else if (auto MTT = diagTy->getAs<AnyMetatypeType>()) {
       if (MTT->getInstanceType()->isAnyObject())
         shouldRequireType = true;


### PR DESCRIPTION
- **Explanation**: Removes the warning emitted when creating `async let` bindings of `Void` type (or optional thereof)
- **Scope**: Affects diagnostics
- **Issues**: N/A (forum discussion: https://forums.swift.org/t/disable-constant-inferred-to-have-type-warning-when-using-async-let/83025)
- **Original PRs**: https://github.com/swiftlang/swift/pull/85615
- **Risk**: Very low; makes diagnostics more permissive
- **Testing**: Added unit tests
- **Reviewers**: @hamishknight
