### PR TITLE
Sema: don't require `RangeReplaceableCollection` in `for` exprs

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1496,12 +1496,8 @@ bool ConstraintSystem::generateConstraints(SingleValueStmtExpr *E) {
   setType(E, resultType);
 
   if (E->getStmtKind() == SingleValueStmtExpr::Kind::For) {
-    auto *rrcProtocol =
-        ctx.getProtocol(KnownProtocolKind::RangeReplaceableCollection);
     auto *sequenceProtocol = ctx.getProtocol(KnownProtocolKind::Sequence);
 
-    addConstraint(ConstraintKind::ConformsTo, resultType,
-                  rrcProtocol->getDeclaredInterfaceType(), loc);
     Type elementTypeVar = createTypeVariable(loc, /*options*/ 0);
     Type elementType = DependentMemberType::get(
         resultType, sequenceProtocol->getAssociatedType(ctx.Id_Element));

--- a/test/stmt/for-expr.swift
+++ b/test/stmt/for-expr.swift
@@ -8,8 +8,16 @@ func f() -> String {
       x.uppercased()
     } else  {
       "*skip*"
-
     }
   }
 }
+
 print(f()) // CHECK: H*skip*L*skip*O
+
+// Not fully exercising this one, as it will fail at run time due to `OutputSpan` not having backing storage.
+// But at least we need this to type check successfully.
+func g() -> OutputSpan<Int> {
+  for (i, x) in "hello".enumerated() {
+    42
+  }
+}


### PR DESCRIPTION
Removed unused `RangeReplaceableCollection` protocol constraint.

It restricted the feature only to `RangeReplaceableCollection`, which isn't `~Copyable` or `~Escapable`, and we ideally would like to support both of those constraints. As there's no suitable protocol inheriting from both, it should "just work" in the current implementation with removed `RangeReplaceableCollection` constraint on any type that has `init()` and `func append(_:)` defined on it.
