### PR TITLE
[6.3] Add pretty stack trace entry for all index operations

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -830,6 +830,7 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
 
 /// Emits index data for all primary inputs, or the main module.
 static void emitIndexData(const CompilerInstance &Instance) {
+  llvm::PrettyStackTraceFormat trace("While emitting index data");
   if (Instance.getPrimarySourceFiles().empty()) {
     emitIndexDataForSourceFile(nullptr, Instance);
   } else {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -2330,6 +2330,7 @@ void IndexSwiftASTWalker::collectRecursiveModuleImports(
 //===----------------------------------------------------------------------===//
 
 void index::indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer) {
+  PrettyStackTraceDeclContext trace("indexing decl context", DC);
   assert(DC);
   SourceFile *SF = DC->getParentSourceFile();
   IndexSwiftASTWalker walker(consumer, DC->getASTContext(), SF);
@@ -2338,6 +2339,7 @@ void index::indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer) {
 }
 
 void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
+  PrettyStackTraceDeclContext trace("indexing source file", SF);
   assert(SF);
   IndexSwiftASTWalker walker(consumer, SF->getASTContext(), SF);
   walker.visitModule(*SF->getParentModule());


### PR DESCRIPTION
In case we hit a crash during indexing, this will make it easier to identify the crash as coming from indexing vs from compilation.
