### PR TITLE
Add options to the build-stdlib-docs target to transform docs for static hosting.

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1252,6 +1252,12 @@ def create_argument_parser():
            default=False,
            help='Build and preview standard library documentation with Swift-DocC.'
                 'Note: this builds Swift-DocC to perform the docs build.')
+    option('--stdlib-docs-static-hosting', toggle_true,
+           default=False,
+           help='Build the standard library documentation for static hosting.')
+    option('--stdlib-docs-hosting-base-path', store,
+           default='/',
+           help='The base path for hosting the standard library documentation.')
 
     option('--build-swift-clang-overlays', toggle_true,
            default=True,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -293,6 +293,8 @@ EXPECTED_DEFAULTS = {
     'swift_user_visible_version': defaults.SWIFT_USER_VISIBLE_VERSION,
     'build_stdlib_docs': False,
     'preview_stdlib_docs': False,
+    'stdlib_docs_static_hosting': False,
+    'stdlib_docs_hosting_base_path': '/',
     'symbols_package': None,
     'clean_libdispatch': True,
     'clean_foundation': True,
@@ -609,6 +611,7 @@ EXPECTED_OPTIONS = [
     SetTrueOption('--wasmkit', dest='build_wasmkit'),
     SetTrueOption('--build-stdlib-docs'),
     SetTrueOption('--preview-stdlib-docs'),
+    SetTrueOption('--stdlib-docs-static-hosting'),
     SetTrueOption('-B', dest='benchmark'),
     SetTrueOption('-S', dest='skip_build'),
     SetTrueOption('-b', dest='build_llbuild'),
@@ -838,6 +841,8 @@ EXPECTED_OPTIONS = [
     StrOption('--swift-darwin-supported-archs'),
     SetTrueOption('--swift-freestanding-is-darwin'),
     AppendOption('--extra-swift-cmake-options'),
+
+    StrOption('--stdlib-docs-hosting-base-path'),
 
     StrOption('--linux-archs'),
     StrOption('--linux-static-archs'),

--- a/utils/swift_build_support/swift_build_support/products/stdlib_docs.py
+++ b/utils/swift_build_support/swift_build_support/products/stdlib_docs.py
@@ -17,7 +17,6 @@ from . import swiftdocc
 from . import swiftdoccrender
 from .. import shell
 
-
 class StdlibDocs(product.Product):
     @classmethod
     def is_build_script_impl_product(cls):
@@ -42,10 +41,13 @@ class StdlibDocs(product.Product):
             os.path.dirname(self.build_dir),
             f'swift-{host_target}'
         )
+
         symbol_graph_dir = os.path.join(swift_build_dir, "lib", "symbol-graph")
         output_path = os.path.join(swift_build_dir, "Swift.doccarchive")
 
         docc_action = 'preview' if self.args.preview_stdlib_docs else 'convert'
+        static_hosting_option = '--transform-for-static-hosting' if self.args.stdlib_docs_static_hosting else ''
+        hosting_base_path = self.args.stdlib_docs_hosting_base_path
 
         docc_cmd = [
             docc_path,
@@ -60,6 +62,9 @@ class StdlibDocs(product.Product):
             "Swift",
             "--fallback-bundle-identifier",
             "org.swift.swift",
+            static_hosting_option,
+            "--hosting-base-path",
+            hosting_base_path
         ]
 
         shell.call(docc_cmd)


### PR DESCRIPTION
The build script already lets us build the documentation for the Swift standard library, but without any configuration so we have to host it at `/documentation/swift` and it isn't suitable for static hosting. This change exposes swift-docc's options to alter the base path, and to produce a DocC archive that's transformed for static hosting.