### PR TITLE
Revert "[CMake] Explicitly disable LTO if no LTO option is provided"

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -58,8 +58,6 @@ function(_compute_lto_flag option out_var)
     set(${out_var} "-flto=full" PARENT_SCOPE)
   elseif (lowercase_option STREQUAL "thin")
     set(${out_var} "-flto=thin" PARENT_SCOPE)
-  else()
-    set(${out_var} "-fno-lto" PARENT_SCOPE)
   endif()
 endfunction()
 


### PR DESCRIPTION
Reverts swiftlang/swift#85621. The PR ends up passing `-gline-tables-only` down to debug builds of the compiler, which breaks debuggability of the compiler itself. 