### PR TITLE
[IRGenDebugInfo] Replace llvm.dbg.coroframe_entry with dbg.declare_value

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -53,7 +53,7 @@ enum ArtificialKind : bool { RealValue = false, ArtificialValue = true };
 enum class AddrDbgInstrKind : uint8_t {
   DbgDeclare,
   DbgValueDeref,
-  DbgCoroFrameEntry,
+  DbgDeclareValue,
 };
 
 /// Helper object that keeps track of the current CompileUnit, File,


### PR DESCRIPTION
We had introduced coroframe_entry downstream while the upstream proposal was discussed. It has since been merged upstream, so this commit changes the code to use the upstream intrisic, avoiding a binary incompatibility in the IR w.r.t. upstream.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
