### PR TITLE
Address `llvm::StringSwitch` deprecations in advance

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -539,8 +539,8 @@ void decodeRequirement(
               .Case("D", LayoutConstraintKind::NativeClass)
               .Case("T", LayoutConstraintKind::Trivial)
               .Case("B", LayoutConstraintKind::BridgeObject)
-              .Cases("E", "e", LayoutConstraintKind::TrivialOfExactSize)
-              .Cases("M", "m", LayoutConstraintKind::TrivialOfAtMostSize)
+              .Cases({"E", "e"}, LayoutConstraintKind::TrivialOfExactSize)
+              .Cases({"M", "m"}, LayoutConstraintKind::TrivialOfAtMostSize)
               .Case("S", LayoutConstraintKind::TrivialStride)
               .Default(std::nullopt);
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -367,18 +367,18 @@ getArchForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
   auto tripleArchName = triple.getArchName();
 
   return llvm::StringSwitch<StringRef>(tripleArchName)
-              .Cases("arm64", "aarch64", "arm64")
-              .Cases("arm64_32", "aarch64_32", "arm64_32")
-              .Cases("x86_64", "amd64", "x86_64")
-              .Cases("i386", "i486", "i586", "i686", "i786", "i886", "i986",
-                     "i386")
-              .Cases("unknown", "", "unknown")
-  // These values are also supported, but are handled by the default case below:
-  //          .Case ("armv7s", "armv7s")
-  //          .Case ("armv7k", "armv7k")
-  //          .Case ("armv7", "armv7")
-  //          .Case ("arm64e", "arm64e")
-              .Default(tripleArchName);
+      .Cases({"arm64", "aarch64"}, "arm64")
+      .Cases({"arm64_32", "aarch64_32"}, "arm64_32")
+      .Cases({"x86_64", "amd64"}, "x86_64")
+      .Cases({"i386", "i486", "i586", "i686", "i786", "i886", "i986"}, "i386")
+      .Cases({"unknown", ""}, "unknown")
+      // These values are also supported, but are handled by the default case
+      // below:
+      //          .Case ("armv7s", "armv7s")
+      //          .Case ("armv7k", "armv7k")
+      //          .Case ("armv7", "armv7")
+      //          .Case ("arm64e", "arm64e")
+      .Default(tripleArchName);
 }
 
 static StringRef
@@ -405,20 +405,21 @@ getOSForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
   auto tripleOSNameNoVersion = tripleOSName.take_until(llvm::isDigit);
 
   return llvm::StringSwitch<StringRef>(tripleOSNameNoVersion)
-              .Cases("macos", "macosx", "darwin", "macos")
-              .Cases("unknown", "", "unknown")
-  // These values are also supported, but are handled by the default case below:
-  //          .Case ("ios", "ios")
-  //          .Case ("tvos", "tvos")
-  //          .Case ("watchos", "watchos")
-              .Default(tripleOSNameNoVersion);
+      .Cases({"macos", "macosx", "darwin"}, "macos")
+      .Cases({"unknown", ""}, "unknown")
+      // These values are also supported, but are handled by the default case
+      // below:
+      //          .Case ("ios", "ios")
+      //          .Case ("tvos", "tvos")
+      //          .Case ("watchos", "watchos")
+      .Default(tripleOSNameNoVersion);
 }
 
 static std::optional<StringRef>
 getEnvironmentForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
   auto tripleEnvironment = triple.getEnvironmentName();
   return llvm::StringSwitch<std::optional<StringRef>>(tripleEnvironment)
-      .Cases("unknown", "", std::nullopt)
+      .Cases({"unknown", ""}, std::nullopt)
       // These values are also supported, but are handled by the default case
       // below:
       //          .Case ("simulator", StringRef("simulator"))

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3452,11 +3452,11 @@ class DarwinLegacyFilterDeclConsumer : public swift::VisibleDeclConsumer {
       if (!VD->hasName() || VD->getBaseName().isSpecial())
         return true;
       return llvm::StringSwitch<bool>(VD->getBaseName().userFacingName())
-          .Cases("OSErr", "OSStatus", "OptionBits", false)
-          .Cases("FourCharCode", "OSType", false)
+          .Cases({"OSErr", "OSStatus", "OptionBits"}, false)
+          .Cases({"FourCharCode", "OSType"}, false)
           .Case("Boolean", false)
           .Case("kUnknownType", false)
-          .Cases("UTF32Char", "UniChar", "UTF16Char", "UTF8Char", false)
+          .Cases({"UTF32Char", "UniChar", "UTF16Char", "UTF8Char"}, false)
           .Case("ProcessSerialNumber", false)
           .Default(true);
     }
@@ -3464,7 +3464,7 @@ class DarwinLegacyFilterDeclConsumer : public swift::VisibleDeclConsumer {
     if (clangModule->Parent &&
         clangModule->Parent->Name == "CarbonCore") {
       return llvm::StringSwitch<bool>(clangModule->Name)
-          .Cases("BackupCore", "DiskSpaceRecovery", "MacErrors", false)
+          .Cases({"BackupCore", "DiskSpaceRecovery", "MacErrors"}, false)
           .Case("UnicodeUtilities", false)
           .Default(true);
     }
@@ -3474,9 +3474,9 @@ class DarwinLegacyFilterDeclConsumer : public swift::VisibleDeclConsumer {
       // Note that this is a list of things to /drop/ rather than to /keep/.
       // We're more likely to see new, modern headers added to OSServices.
       return llvm::StringSwitch<bool>(clangModule->Name)
-          .Cases("IconStorage", "KeychainCore", "Power", true)
-          .Cases("SecurityCore", "SystemSound", true)
-          .Cases("WSMethodInvocation", "WSProtocolHandler", "WSTypes", true)
+          .Cases({"IconStorage", "KeychainCore", "Power"}, true)
+          .Cases({"SecurityCore", "SystemSound"}, true)
+          .Cases({"WSMethodInvocation", "WSProtocolHandler", "WSTypes"}, true)
           .Default(false);
     }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1487,13 +1487,13 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.RuntimeVariant =
           llvm::StringSwitch<std::optional<OutputInfo::MSVCRuntime>>(
               A->getValue())
-              .Cases("MD", "MultiThreadedDLL", "shared-ucrt",
+              .Cases({"MD", "MultiThreadedDLL", "shared-ucrt"},
                      OutputInfo::MSVCRuntime::MultiThreadedDLL)
-              .Cases("MDd", "MultiThreadedDebugDLL", "shared-debug-ucrt",
+              .Cases({"MDd", "MultiThreadedDebugDLL", "shared-debug-ucrt"},
                      OutputInfo::MSVCRuntime::MultiThreadedDebugDLL)
-              .Cases("MT", "MultiThreaded", "static-ucrt",
+              .Cases({"MT", "MultiThreaded", "static-ucrt"},
                      OutputInfo::MSVCRuntime::MultiThreaded)
-              .Cases("MTd", "MultiThreadedDebug", "static-debug-ucrt",
+              .Cases({"MTd", "MultiThreadedDebug", "static-debug-ucrt"},
                      OutputInfo::MSVCRuntime::MultiThreadedDebug)
               .Default(std::nullopt);
       if (!OI.RuntimeVariant)

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -76,8 +76,8 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   auto requiresLLD = [&]{
     if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
       return llvm::StringSwitch<bool>(A->getValue())
-        .Cases("lld", "lld.exe", "lld-link", "lld-link.exe", true)
-        .Default(false);
+          .Cases({"lld", "lld.exe", "lld-link", "lld-link.exe"}, true)
+          .Default(false);
     }
     // Force to use lld for LTO on Windows because we don't support link LTO or
     // something else except for lld LTO at this time.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -568,9 +568,10 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
                    OPT_disable_module_selectors_in_module_interface,
                    false);
   } else if (auto envValue = ::getenv("SWIFT_MODULE_SELECTORS_IN_INTERFACES")) {
-    Opts.UseModuleSelectors = llvm::StringSwitch<bool>(envValue)
-        .CasesLower("false", "no", "off", "0", false)
-        .Default(true);
+    Opts.UseModuleSelectors =
+        llvm::StringSwitch<bool>(envValue)
+            .CasesLower({"false", "no", "off", "0"}, false)
+            .Default(true);
   } else {
     // Any heuristics we might add would go here.
     Opts.UseModuleSelectors = false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1444,12 +1444,13 @@ bool Parser::parseDifferentiableAttributeArguments(
   // Parse optional differentiability parameters.
   // Parse differentiability kind (optional).
   if (Tok.is(tok::identifier)) {
-    diffKind = llvm::StringSwitch<DifferentiabilityKind>(Tok.getText())
-        .Case("reverse", DifferentiabilityKind::Reverse)
-        .Cases("wrt", "withRespectTo", DifferentiabilityKind::Normal)
-        .Case("_linear", DifferentiabilityKind::Linear)
-        .Case("_forward", DifferentiabilityKind::Forward)
-        .Default(DifferentiabilityKind::NonDifferentiable);
+    diffKind =
+        llvm::StringSwitch<DifferentiabilityKind>(Tok.getText())
+            .Case("reverse", DifferentiabilityKind::Reverse)
+            .Cases({"wrt", "withRespectTo"}, DifferentiabilityKind::Normal)
+            .Case("_linear", DifferentiabilityKind::Linear)
+            .Case("_forward", DifferentiabilityKind::Forward)
+            .Default(DifferentiabilityKind::NonDifferentiable);
 
     switch (diffKind) {
     // Reject unsupported differentiability kinds.

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -358,7 +358,7 @@ static void collectClangModuleHeaderIncludes(
          dir != end && !errorCode; dir.increment(errorCode)) {
 
       if (llvm::StringSwitch<bool>(llvm::sys::path::extension(dir->path()))
-              .Cases(".h", ".H", ".hh", ".hpp", true)
+              .Cases({".h", ".H", ".hh", ".hpp"}, true)
               .Default(false)) {
 
         // Compute path to the header relative to the root of the module


### PR DESCRIPTION
There's a whole bunch of these, e.g.
- https://github.com/llvm/llvm-project/pull/163405
- https://github.com/llvm/llvm-project/pull/164276
- https://github.com/llvm/llvm-project/pull/165119
- https://github.com/llvm/llvm-project/pull/166016
- https://github.com/llvm/llvm-project/pull/166066

Paired with https://github.com/swiftlang/llvm-project/pull/11910.