### PR TITLE
[6.3] IRGen/ABI: fix count of requirements in getAddrOfGenericEnvironment

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -4622,9 +4622,13 @@ llvm::Constant *IRGenModule::getAddrOfGenericEnvironment(
         }
         genericParamCounts.push_back(genericParamCount);
 
+        SmallVector<Requirement, 2> reqs;
+        SmallVector<InverseRequirement, 2> inverses;
+        signature->getRequirementsWithInverses(reqs, inverses);
+
         auto flags = GenericEnvironmentFlags()
           .withNumGenericParameterLevels(genericParamCounts.size())
-          .withNumGenericRequirements(signature.getRequirements().size());
+          .withNumGenericRequirements(reqs.size());
 
         ConstantStructBuilder fields = builder.beginStruct();
         fields.setPacked(true);
@@ -4651,7 +4655,7 @@ llvm::Constant *IRGenModule::getAddrOfGenericEnvironment(
         fields.addAlignmentPadding(Alignment(4));
 
         // Generic requirements
-        irgen::addGenericRequirements(*this, fields, signature);
+        irgen::addGenericRequirements(*this, fields, signature, reqs, inverses);
         return fields.finishAndCreateFuture();
       });
 }

--- a/test/IRGen/keypaths_inverses.swift
+++ b/test/IRGen/keypaths_inverses.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -module-name keypaths -emit-ir %s | %FileCheck %s
+
+// The purpose of this test is to validate that a keypath formed via a protocol
+// that has an inverse requirement on Self produces the same generic environment
+// metadata as one without the inverse. So Mashable and Dashable should have the
+// same metadata fundamentally.
+
+// CHECK-LABEL: @"generic environment 8keypaths8MashableRzl" = linkonce_odr hidden constant
+// CHECK-SAME:    i32 4097, i16 1, i8 -128, [1 x i8] zeroinitializer, i32 128
+
+// CHECK-LABEL: @"generic environment 8keypaths8DashableRzl" = linkonce_odr hidden constant
+// CHECK-SAME:    i32 4097, i16 1, i8 -128, [1 x i8] zeroinitializer, i32 128
+
+
+protocol Mashable: ~Copyable {
+  var masher: String { get set }
+}
+
+protocol Dashable {
+  var dasher: String { get set }
+}
+
+func formKeypath1<T: Mashable>(_ t: T) -> WritableKeyPath<T, String> {
+  return \T.masher
+}
+
+func formKeypath2<T: Dashable>(_ t: T) -> WritableKeyPath<T, String> {
+  return \T.dasher
+}


### PR DESCRIPTION
- Summary: keypath metadata was emitting the wrong count of requirements in its generic signature, as it emits a separate count from the actual generic signature itself.
- Original PR: https://github.com/swiftlang/swift/pull/85450
- Risk: This is an ABI change, as any keypath formed using a generic type that conforms to a noncopyable or nonescapable protocol will have its count of conformance requirements change to a corrected, smaller number. It's not expected to be a breaking change, as it's correcting an inaccurate count to be a smaller number than it was before.