### PR TITLE
Fill in missing `unsafe` markers

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -812,8 +812,8 @@ public struct UnownedSerialExecutor: Sendable {
     // any SerialExecutor needs a raw witness table pointer, so mask off the low
     // bits, knowing the witness table pointer is aligned to the pointer size.
     let rawExecutorData = unsafe unsafeBitCast(executor, to: (UInt, UInt).self)
-    let mask = ~(UInt(MemoryLayout<UnsafeRawPointer>.alignment) - 1)
-    let alignedExecutor = unsafe (rawExecutorData.0, rawExecutorData.1 & mask)
+    let mask = unsafe ~(UInt(MemoryLayout<UnsafeRawPointer>.alignment) - 1)
+    let alignedExecutor = (rawExecutorData.0, rawExecutorData.1 & mask)
     return unsafe unsafeBitCast(alignedExecutor, to: (any SerialExecutor)?.self)
   }
 }

--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -158,7 +158,7 @@ public func _float16ToStringImpl(
     _unchecked: textBuffer,
     count: Int(bufferLength))
   for i in 0..<Int(bufferLength) {
-      buffer[unchecked: i] = 0x30
+    unsafe buffer[unchecked: i] = 0x30
   }
   let textRange = _Float16ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
@@ -450,7 +450,7 @@ internal func _float32ToStringImpl(
     _unchecked: textBuffer,
     count: Int(bufferLength))
   for i in 0..<Int(bufferLength) {
-      buffer[unchecked: i] = 0x30
+    unsafe buffer[unchecked: i] = 0x30
   }
   let textRange = _Float32ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
@@ -701,7 +701,7 @@ internal func _float64ToStringImpl(
     _unchecked: textBuffer,
     count: Int(bufferLength))
   for i in 0..<Int(bufferLength) {
-      buffer[unchecked: i] = 0x30
+    unsafe buffer[unchecked: i] = 0x30
   }
   let textRange = _Float64ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound
@@ -1207,7 +1207,7 @@ internal func _float80ToStringImpl(
     _unchecked: textBuffer,
     count: Int(bufferLength))
   for i in 0..<Int(bufferLength) {
-      buffer[unchecked: i] = 0x30
+    unsafe buffer[unchecked: i] = 0x30
   }
   let textRange = _Float80ToASCII(value: value, buffer: &buffer)
   let textLength = textRange.upperBound - textRange.lowerBound


### PR DESCRIPTION
Apparently, I missed marking some code in FP printing `unsafe`.
While I'm doing this, also fix a couple of `unsafe` mismatches in the Executor code that I noticed while building.