### PR TITLE
[6.3][ASTPrinter] Print a fully resolved type for an outermost property wr…

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4870,7 +4870,9 @@ void PrintAST::visitMacroExpansionDecl(MacroExpansionDecl *decl) {
 void CustomAttr::printCustomAttr(ASTPrinter &Printer, const PrintOptions &Options) const {
   Printer.callPrintNamePre(PrintNameContext::Attribute);
   Printer << "@";
-  if (auto type = getType())
+  if (auto *init = getSemanticInit(); init && Options.IsForSwiftInterface)
+    init->getType().print(Printer, Options);
+  else if (auto type = getType())
     type.print(Printer, Options);
   else
     getTypeRepr()->print(Printer, Options);

--- a/test/ModuleInterface/property_wrapper_availability.swift
+++ b/test/ModuleInterface/property_wrapper_availability.swift
@@ -29,7 +29,7 @@ public struct UnavailableWrapper<T> {
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
   // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
-  // CHECK-NEXT: @Library.ConditionallyAvailableWrapper public var x: Swift.Int {
+  // CHECK-NEXT: @Library.ConditionallyAvailableWrapper<Swift.Int> public var x: Swift.Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
   // CHECK-NEXT:   set
@@ -50,7 +50,7 @@ public struct HasWrappers {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct UnavailableHasWrappers {
-  // CHECK-LABEL:   @Library.UnavailableWrapper public var x: Swift.Int {
+  // CHECK-LABEL:   @Library.UnavailableWrapper<Swift.Int> public var x: Swift.Int {
   // CHECK-NEXT:      get
   // CHECK-NEXT:      @available(iOS, unavailable)
   // CHECK-NEXT:      @available(tvOS, unavailable)

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -52,16 +52,24 @@ public struct ProjectedValueWrapper<T> {
   }
 }
 
+@propertyWrapper public struct HasTwoTypeParameters<Value, Other> {
+  public var wrappedValue: Value
+
+  init(wrappedValue: Value, _ other: Other) {
+    fatalError()
+  }
+}
+
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
-  // CHECK: @TestResilient.Wrapper public var x: {{(Swift.)?}}Int {
+  // CHECK: @TestResilient.Wrapper<Swift.Int> public var x: {{(Swift.)?}}Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
   // CHECK-NEXT: _modify  
   // CHECK-NEXT: }  
   @Wrapper public var x: Int
 
-  // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($y) public var y: Swift.Int {
+  // CHECK: @TestResilient.WrapperWithInitialValue<Swift.Int> @_projectedValueProperty($y) public var y: Swift.Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: }  
   @WrapperWithInitialValue public private(set) var y = 17
@@ -70,13 +78,41 @@ public struct HasWrappers {
   // CHECK-NEXT: get
   // CHECK-NEXT: }  
 
-  // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($z) public var z: Swift.Bool {
+  // CHECK: @TestResilient.HasTwoTypeParameters<Swift.Int, Swift.String> public var w1: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  @HasTwoTypeParameters(wrappedValue: 0, "other") public var w1: Int
+
+  // CHECK: @TestResilient.HasTwoTypeParameters<Swift.Int, Swift.String> public var w2: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  @HasTwoTypeParameters("other") public var w2: Int = 0
+
+  // CHECK: @TestResilient.HasTwoTypeParameters<TestResilient.HasTwoTypeParameters<Swift.Int, Swift.Double>, Swift.String> @TestResilient.HasTwoTypeParameters public var w3: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  @HasTwoTypeParameters("a")  @HasTwoTypeParameters(1.0) public var w3: Int = 0
+
+  // CHECK: @TestResilient.WrapperWithInitialValue<Swift.Bool> @_projectedValueProperty($z) public var z: Swift.Bool {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
   // CHECK-NEXT: _modify
   // CHECK-NEXT: }  
   @WrapperWithInitialValue(alternate: false) public var z
 
+  // CHECK: @TestResilient.HasTwoTypeParameters<TestResilient.Wrapper<Swift.Int>, Swift.String> @TestResilient.Wrapper public var composed: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  @HasTwoTypeParameters("other") @Wrapper public var composed: Int = 42
+  
   // CHECK: public func hasParameterWithImplementationWrapper(x: Swift.Int)
   public func hasParameterWithImplementationWrapper(@Wrapper x: Int) { }
 
@@ -89,9 +125,9 @@ public struct HasWrappers {
   // CHECK: @_alwaysEmitIntoClient public func hasParameterWithImplementationWrapperAEIC(@TestResilient.Wrapper x: Swift.Int)
   @_alwaysEmitIntoClient public func hasParameterWithImplementationWrapperAEIC(@Wrapper x: Int) { }
 
-  // CHECK: public func hasParameterWithAPIWrapper(@TestResilient.ProjectedValueWrapper x: Swift.Int)
+  // CHECK: public func hasParameterWithAPIWrapper(@TestResilient.ProjectedValueWrapper<Swift.Int> x: Swift.Int)
   public func hasParameterWithAPIWrapper(@ProjectedValueWrapper x: Int) { }
 
-  // CHECK: public func hasParameterWithAPIWrapperComposed(@TestResilient.ProjectedValueWrapper @TestResilient.Wrapper x: Swift.Int)
+  // CHECK: public func hasParameterWithAPIWrapperComposed(@TestResilient.ProjectedValueWrapper<TestResilient.Wrapper<Swift.Int>> @TestResilient.Wrapper x: Swift.Int)
   public func hasParameterWithAPIWrapperComposed(@ProjectedValueWrapper @Wrapper x: Int) { }
 }


### PR DESCRIPTION
…apper in swift interfaces

- Explanation:

  The type of an outermost property wrapper should be printed together with (inferred) generic arguments because otherwise if a any wrapper in the chain has generic parameters that are not involved in `wrappedValue:` argument it won't be impossible to infer them while type-checking the interface file where it appears.

- Resolves: rdar://122963120

- Main Branch PR: https://github.com/swiftlang/swift/pull/85736

- Risk: Very Low. This is a very targeted change that only affects swift interfaces and outermost property wrapper printing.

- Reviewed By: @hamishknight 

- Testing: Added new test-cases to the suite.

(cherry picked from commit 5b665a8426f7d3d10c222e6d5992e64841391049)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
