### PR TITLE
[ASTDumper] Fix malformed JSON for `async let _ = ...`.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1913,10 +1913,8 @@ namespace {
       printFoot();
     }
     void visitAnyPattern(AnyPattern *P, Label label) {
-      if (P->isAsyncLet()) {
-        printCommon(P, "async_let ", label);
-      }
       printCommon(P, "pattern_any", label);
+      printFlag(P->isAsyncLet(), "async_let", DeclModifierColor);
       printFoot();
     }
     void visitTypedPattern(TypedPattern *P, Label label) {

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -503,3 +503,11 @@ func outerFn() {
     }
     innerFun(shouldRecurse: true)
 }
+
+// Regression test: Discarded async lets were calling `printCommon` twice,
+// which resulted in invalid JSON (and not-so-great S-expression output)
+// either.
+func discardedAsyncLet() async {
+    func someTask() async {}
+    async let _ = someTask()
+}


### PR DESCRIPTION
By calling `printCommon` twice, this inserts a JSON object into another JSON object without a key. This should assert inside LLVM's JSON helper, but only if the compiler is built with assertions enabled (which Xcode's compiler isn't).

This also fixes the S-expression version, which is similarly busted:

```
(pattern_entry
  (async_let  type="Int"              (pattern_any type="Int")
  (original_init=call_expr type="Int" ...
```
