### PR TITLE
[LLDB] Replace more instances of the DEBUG_LOG macro with setError

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -405,7 +405,9 @@ public:
   void enableErrorCache() {
     ErrorCache = std::make_unique<llvm::DenseMap<KeyT, TCError>>();
   }
-  void setError(const char *msg, const TypeRef *TR) { LastError = {msg, TR}; }
+
+  /// Set the LastError variable.
+  void setError(const char *msg, const TypeRef *TR = nullptr);
 
   /// Retreive the error and reset it.
   std::string takeLastError();


### PR DESCRIPTION
This allows LLDB to query the last error and produce more helpful diagnostics. This is NFC for the runtime.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
