### PR TITLE
CMake: Synchronization Source Lists

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -138,9 +138,18 @@ if(${PROJECT_NAME}_SINGLE_THREADED_MODE)
 else()
   target_sources(swiftSynchronization PRIVATE
     Mutex/Mutex.swift
+    # Apple Sources
     $<$<PLATFORM_ID:Darwin>:Mutex/DarwinImpl.swift>
+    # Android and Linux Sources
     $<$<PLATFORM_ID:Android,Linux>:Mutex/LinuxImpl.swift>
-    $<$<PLATFORM_ID:Android,WASI>:Mutex/SpinLoopHint.swift>
+    $<$<PLATFORM_ID:Android,Linux>:Mutex/SpinLoopHint.swift>
+    # FreeBSD Sources
+    $<$<PLATFORM_ID:FreeBSD>:Mutex/FreeBSDImpl.swift>
+    # OpenBSD Sources
+    $<$<PLATFORM_ID:OpenBSD>:Mutex/OpenBSDImpl.swift>
+    # Wasm Sources
+    $<$<PLATFORM_ID:WASI>:Mutex/WasmImpl.swift>
+    # Windows Sources
     $<$<PLATFORM_ID:Windows>:Mutex/WindowsImpl.swift>)
 endif()
 


### PR DESCRIPTION
Fixing sources used to build synchronization library. This aligns the synchronization source list with what is posted in the old build system.

```
set(SWIFT_SYNCHRONIZATION_DARWIN_SOURCES
  Mutex/DarwinImpl.swift
  Mutex/Mutex.swift
)
set(SWIFT_SYNCHRONIZATION_LINUX_SOURCES
  Mutex/LinuxImpl.swift
  Mutex/Mutex.swift
  Mutex/SpinLoopHint.swift
)
set(SWIFT_SYNCHRONIZATION_FREEBSD_SOURCES
  Mutex/FreeBSDImpl.swift
  Mutex/Mutex.swift
)
set(SWIFT_SYNCHRONIZATION_WASM_SOURCES
  Mutex/Mutex.swift
  Mutex/WasmImpl.swift
)
set(SWIFT_SYNCHRONIZATION_WINDOWS_SOURCES
  Mutex/Mutex.swift
  Mutex/WindowsImpl.swift
)
set(SWIFT_SYNCHRONIZATION_OPENBSD_SOURCES
  Mutex/Mutex.swift
  Mutex/OpenBSDImpl.swift
)
```

This is specifically to fix this error when building for Linux:

```
/build/swift/Runtimes/Supplemental/Synchronization/Mutex/LinuxImpl.swift:99:19: error: cannot find '_tries' in scope
 97 |       // This value is controlled on a per architecture bases defined in
 98 |       // 'SpinLoopHint.swift'.
 99 |       var tries = _tries
    |                   `- error: cannot find '_tries' in scope
100 |
101 |       repeat {

/build/swift/Runtimes/Supplemental/Synchronization/Mutex/LinuxImpl.swift:126:9: error: cannot find '_spinLoopHint' in scope
124 |         // effect of slowing down this loop if only by a little to preserve
125 |         // energy.
126 |         _spinLoopHint()
    |         `- error: cannot find '_spinLoopHint' in scope
127 |       } while tries != 0
128 |     }
ninja: build stopped: subcommand failed.
```