### PR TITLE
[Test] Fix unstable Backtracing unit test

### DIFF
--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -69,9 +69,11 @@ while (true) {
 
 // make sure there are no threads before the crashing thread (rdar://164566321)
 
-// CHECK-NOT: Thread {{[0-9]+}}:
+// we expect the first thread not to be thread 0, it should be the crashing thread instead
+// CHECK-NOT: Thread 0{{( ".*")?}}:
 
-// CHECK: Thread {{[1-9]+}} {{(".*" )?}}crashed:
+// we expect a crash on a thread other than 0
+// CHECK: Thread {{[1-9][0-9]*}} {{(".*" )?}}crashed:
 
 // CHECK: 0                    0x{{[0-9a-f]+}} reallyCrashMe() + {{[0-9]+}} in CrashWithThreads at {{.*}}/CrashWithThreads
 // CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} crashMe() + {{[0-9]+}} in CrashWithThreads at {{.*}}/CrashWithThreads

--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -57,7 +57,7 @@ func spawnThread(_ shouldCrash: Bool) {
 
 let crashingThreadIndex = (1..<10).randomElement()
 
-for threadIndex in 0..<10 {
+for threadIndex in 1..<10 {
   spawnThread(threadIndex == crashingThreadIndex)
 }
 


### PR DESCRIPTION
There was a problem in CrashWithThreads where it failed about 10% of the time.

This fixes it.

rdar://165728982
