### PR TITLE
[6.3 🍒] [ASTDumper] Fix some crashers and malformed AST dumps

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1913,10 +1913,8 @@ namespace {
       printFoot();
     }
     void visitAnyPattern(AnyPattern *P, Label label) {
-      if (P->isAsyncLet()) {
-        printCommon(P, "async_let ", label);
-      }
       printCommon(P, "pattern_any", label);
+      printFlag(P->isAsyncLet(), "async_let", DeclModifierColor);
       printFoot();
     }
     void visitTypedPattern(TypedPattern *P, Label label) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1484,7 +1484,11 @@ namespace {
         printFlag(value.isLocalCapture(), "is_local_capture");
         printFlag(value.isDynamicSelfMetadata(), "is_dynamic_self_metadata");
         if (auto *D = value.getDecl()) {
-          printRec(D, Label::always("decl"));
+          // We print the decl ref, not the full decl, to avoid infinite
+          // recursion when a function captures itself (and also because
+          // those decls are already printed elsewhere, so we don't need to
+          // print what could be a very large amount of information twice).
+          printDeclRefField(D, Label::always("decl"));
         }
         if (auto *E = value.getExpr()) {
           printRec(E, Label::always("expr"));

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -260,6 +260,12 @@ std::string typeUSR(Type type) {
   if (!type)
     return "";
 
+  if (type->is<ModuleType>()) {
+    // ASTMangler does not support "module types". This can appear, for
+    // example, on the left-hand side of a `DotSyntaxBaseIgnoredExpr` for a
+    // module-qualified free function call: `Swift.print()`.
+    return "";
+  }
   if (type->hasArchetype()) {
     type = type->mapTypeOutOfEnvironment();
   }
@@ -279,6 +285,13 @@ std::string typeUSR(Type type) {
 std::string declTypeUSR(const ValueDecl *D) {
   if (!D)
     return "";
+
+  if (isa<ModuleDecl>(D)) {
+    // ASTMangler does not support "module types". This can appear, for
+    // example, on the left-hand side of a `DotSyntaxBaseIgnoredExpr` for a
+    // module-qualified free function call: `Swift.print()`.
+    return "";
+  }
 
   std::string usr;
   llvm::raw_string_ostream os(usr);

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -503,3 +503,11 @@ func outerFn() {
     }
     innerFun(shouldRecurse: true)
 }
+
+// Regression test: Discarded async lets were calling `printCommon` twice,
+// which resulted in invalid JSON (and not-so-great S-expression output)
+// either.
+func discardedAsyncLet() async {
+    func someTask() async {}
+    async let _ = someTask()
+}

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -491,3 +491,15 @@ func toReplaceWith(arg: Int) {}
 func moduleTypeUSRRegressionTest() {
     Swift.print("")
 }
+
+// Regression test: When a function captures another function, don't print the
+// entire captured decl. This causes infinite recursion in the dumper when a
+// local (nested) function captures itself.
+func outerFn() {
+    func innerFun(shouldRecurse: Bool) {
+        if shouldRecurse {
+            innerFun(shouldRecurse: false)
+        }
+    }
+    innerFun(shouldRecurse: true)
+}

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -484,3 +484,10 @@ dynamic func toBeReplaced(arg: Int) {}
 
 @_dynamicReplacement(for: toBeReplaced(arg:))
 func toReplaceWith(arg: Int) {}
+
+// Regression test: Swift 6.2 and earlier crashed trying to form the type USR
+// of the "module type" of a `DotSyntaxBaseIgnoredExpr` when calling a
+// module-qualified free function.
+func moduleTypeUSRRegressionTest() {
+    Swift.print("")
+}


### PR DESCRIPTION
- **Explanation**:
  - Fix crash when trying to print a module "type USR" for a module-qualified member reference.
  - Print decl-refs rather than full decls for function captures (to remove redundant data and avoid infinite recursion when a function captures itself).
  - Fix malformed JSON and S-expression output when dumping AST for `async let _ = ...`.
- **Scope**: This only effects the output of `-dump-ast`.
- **Issues**: N/A.
- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/85681
  - https://github.com/swiftlang/swift/pull/85807
- **Risk**: Low.
- **Testing**: Standard CI.
- **Reviewers**: @slavapestov for #85681