### PR TITLE
[LLDB] Replace more instances of the DEBUG_LOG macro with setError

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -405,7 +405,9 @@ public:
   void enableErrorCache() {
     ErrorCache = std::make_unique<llvm::DenseMap<KeyT, TCError>>();
   }
-  void setError(const char *msg, const TypeRef *TR) { LastError = {msg, TR}; }
+
+  /// Set the LastError variable.
+  void setError(const char *msg, const TypeRef *TR = nullptr);
 
   /// Retreive the error and reset it.
   std::string takeLastError();


### PR DESCRIPTION
Explanation: Better diagnostics in LLDB
Scope: LLDB
Issues: -
Original PRs: https://github.com/swiftlang/swift/pull/85809/commits
Risk: N/A
Testing: N/A
Reviewers: @augusto2112 @mikeash 