### PR TITLE
[cxx-interop] Temporarily replace `XFAIL` with `UNSUPPORTED`

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,7 +1,7 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 // TODO <expected> not yet supported with libstdc++
-// XFAIL: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu
 
 // https://github.com/apple/swift/issues/70226
 // UNSUPPORTED: OS=windows-msvc


### PR DESCRIPTION
This test is actually passing on new Linux versions, e.g. Ubuntu 24.04.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
