### PR TITLE
[Do Not Merge] [SILGen] Allow opaque reads to noncopyable properties to use getter

### DIFF
--- a/test/SILGen/Inputs/resilient_access_noncopyable_getter.swift
+++ b/test/SILGen/Inputs/resilient_access_noncopyable_getter.swift
@@ -1,0 +1,10 @@
+public struct Source: ~Copyable {
+  public init() {}
+
+  public var mutableSpan: MutableSpan<Int> {
+    @_lifetime(&self)
+    mutating get {
+      MutableSpan()
+    }
+  }
+}

--- a/test/SILGen/resilient_access_noncopyable_getter.swift
+++ b/test/SILGen/resilient_access_noncopyable_getter.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/NCLib.swiftmodule -module-name=NCLib %S/Inputs/resilient_access_noncopyable_getter.swift -enable-experimental-feature Lifetimes
+// RUN: %target-swift-emit-silgen %s -I %t -enable-experimental-feature Lifetimes | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %t -enable-experimental-feature Lifetimes -verify
+
+import NCLib
+
+// Verify that when accessing a noncopyable member on a resilient struct which explicitly declared a getter,
+// we should be able to assign the result to a local variable as the getter returns an owned value.
+
+// CHECK-LABEL: sil hidden [ossa] @$s35resilient_access_noncopyable_getter4testyyF : $@convention(thin) () -> ()
+func test() {
+  var source = Source()
+  
+  // CHECK: [[MUTSPAN_BOX:%.*]] = alloc_box {{.*}} var, name "mutSpan"
+  // CHECK: [[MUTSPAN_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[MUTSPAN_BOX]]
+  // CHECK: [[MUTSPAN_ADDR:%.*]] = project_box [[MUTSPAN_BORROW]], 0
+  // CHECK: [[MUTABLE_SPAN_GETTER:%.*]] = function_ref @$s5NCLib6SourceV11mutableSpans07MutableD0VySiGvg : $@convention(method) (@inout Source) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  // CHECK: [[MUTSPAN:%.*]] = apply [[MUTABLE_SPAN_GETTER]]
+  // CHECK: store [[MUTSPAN]] to [init] [[MUTSPAN_ADDR]]
+  var mutSpan = source.mutableSpan
+  mutSpan[0] = 1
+}


### PR DESCRIPTION
**Note:** This is really more of a strawman change that shouldn't be merged. I'm very new to the swift compiler and assume this is too naive of a solution, but I figured maybe it'll at least be helpful as a reference for some digging into the issue that I did. I'd also love to learn about how more experienced swift maintainers think about an issue like this.

Also note I am seeing some new test failures from this change in the `CAS` tests, need to understand a bit more where that's coming from.

Here's a simple reproducer of the issue this is solving:
```
/// A resilient library:

public struct Source: ~Copyable {
  public init() {}

  public var mutableSpan: MutableSpan<Int> {
    @_lifetime(&self)
    mutating get {
      MutableSpan()
    }
  }
}
```

```
/// Client of the resilient library:
import NCLib

func test() {
  var source = Source()

  var mutSpan = source.mutableSpan // 'source.mutableSpan' is borrowed and cannot be consumed
  mutSpan[0] = 1
}
```

Currently OpaqueReadOwnershipRequest::evaluate always returns `Borrowed` for noncopyable types. This results in calling code outside of the resilience domain being required to go through Read accessor for accessing noncopyable properties, even if a getter was available.  This is through the code path `Decl.cpp:getOpaqueReadAccessStrategy` where `storage->requiresOpaqueReadCoroutine()` will return `true` if the storage says the read ownership is `Borrowed`.
 
This then prevents calling code from obtaining owned values from noncopyable acccessors, which is required for making meaningful use of nonescapable types since they represent a projection of the source.

This can be fixed by having the resilient library specify OpaqueReadOwnership::Owned for read access to noncopyable types if there was a getter specified. The result is that when compiling the calling code, AbstractStorageDecl::requiresOpaqueReadCoroutine will now return false, allowing the calling code to use the getter when querying  getOpaqueReadAccessStrategy)

For this change I tried to go with as _targeted_ of a fix as possible to avoid affecting existing code, so it specifically allows usage of the getter for the case of:
1. The storage type is noncopyable and nonescapable
2. It is a method on some type where that type is escapable (meaning that ~Escapable property could not be a stored property)
3. The author explicitly wrote a getter (so there is no explicit _read accessor being overlooked)

However I do have a followup question here: Why is it not preferred to always use the getter for a noncopyable type if there was one written as opposed to defaulting to the synthesized _read accessor? I'm not familiar with all the details, but I assume the synthesized _read would just call the getter and yield the element, so trying to understand when that would be preferable over the caller just using the getter directly. Is it intentionally this way to provide ABI stability in the case where the library author wants to remove the getter in favor of a Read accessor?

Resolves: rdar://165738432
