### PR TITLE
[Custom availability] Suppress custom @available when printing Swift interfaces

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -904,6 +904,7 @@ private:
   const SourceRange DeprecatedRange;
   const llvm::VersionTuple Obsoleted;
   const SourceRange ObsoletedRange;
+  Decl *Owner = nullptr;
 
 public:
   /// Returns true if the `AvailabilityDomain` associated with the attribute
@@ -1001,6 +1002,9 @@ public:
   /// Returns the kind of availability the attribute specifies.
   Kind getKind() const { return static_cast<Kind>(Bits.AvailableAttr.Kind); }
 
+  /// Returns the declaration that owns this attribute.
+  Decl *getOwner() const { return Owner; }
+
   /// Create an `AvailableAttr` that specifies universal unavailability, e.g.
   /// `@available(*, unavailable)`.
   static AvailableAttr *createUniversallyUnavailable(ASTContext &C,
@@ -1070,6 +1074,9 @@ private:
   void setComputedSemanticAttr() {
     Bits.AvailableAttr.HasComputedSemanticAttr = true;
   }
+
+  friend class DeclAttribute;
+  void attachToDeclImpl(Decl *D);
 };
 
 /// Indicates that the given declaration is visible to Objective-C.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -405,6 +405,9 @@ public:
   /// Suppress @_lifetime attribute and emit @lifetime instead.
   bool SuppressLifetimes = false;
 
+  /// Suppress custom availability domains.
+  bool SuppressCustomAvailability = false;
+
   /// Suppress @inline(always) attribute and emit @inline(__always) instead.
   bool SuppressInlineAlways = false;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -505,7 +505,7 @@ EXPERIMENTAL_FEATURE(AddressableParameters, true)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
 
 /// Allow custom availability domains to be defined and referenced.
-EXPERIMENTAL_FEATURE(CustomAvailability, true)
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 
 /// Syntax sugar features for concurrency.
 EXPERIMENTAL_FEATURE(ConcurrencySyntaxSugar, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -243,6 +243,15 @@ bool PrintOptions::excludeAttr(const DeclAttribute *DA) const {
                     [CA](CustomAttr *other) { return other == CA; }))
       return true;
   }
+  if (SuppressCustomAvailability) {
+    if (auto availableAttr = dyn_cast<AvailableAttr>(DA)) {
+      if (auto owner = availableAttr->getOwner()) {
+        if (auto semanticAttr = owner->getSemanticAvailableAttr(availableAttr)) {
+          return semanticAttr->getDomain().isCustom();
+        }
+      }
+    }
+  }
   return false;
 }
 
@@ -3309,6 +3318,13 @@ static void
 suppressingFeatureLifetimes(PrintOptions &options,
                                      llvm::function_ref<void()> action) {
   llvm::SaveAndRestore<bool> scope(options.SuppressLifetimes, true);
+  action();
+}
+
+static void
+suppressingFeatureCustomAvailability(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<bool> scope(options.SuppressCustomAvailability, true);
   action();
 }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2323,6 +2323,16 @@ AvailableAttr::AvailableAttr(
   Bits.AvailableAttr.IsGroupedWithWildcard = false;
 }
 
+void AvailableAttr::attachToDeclImpl(Decl *D) {
+  // Prefer to set the parent PatternBindingDecl as the owner for a VarDecl,
+  // this ensures we can handle PBDs with multiple vars.
+  if (auto *VD = dyn_cast<VarDecl>(D)) {
+    if (auto *PBD = VD->getParentPatternBinding())
+      D = PBD;
+  }
+  Owner = D;
+}
+
 AvailableAttr *AvailableAttr::createUniversallyUnavailable(ASTContext &C,
                                                            StringRef Message,
                                                            StringRef Rename) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -352,7 +352,15 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(GeneralizedIsSameMetaTypeBuiltin)
-UNINTERESTING_FEATURE(CustomAvailability)
+
+static bool usesFeatureCustomAvailability(Decl *decl) {
+  for (auto attr : decl->getSemanticAvailableAttrs()) {
+    if (attr.getDomain().isCustom())
+      return true;
+  }
+
+  return false;
+}
 
 static bool usesFeatureAsyncExecutionBehaviorAttributes(Decl *decl) {
   // Explicit `@concurrent` attribute on the declaration.

--- a/test/ModuleInterface/availability_custom_domains.swift
+++ b/test/ModuleInterface/availability_custom_domains.swift
@@ -15,14 +15,17 @@
 
 import Oceans // re-exports Rivers
 
-// CHECK-NOT:  $CustomAvailability
-
-// CHECK:      @available(Colorado)
+// CHECK:      #if compiler(>=5.3) && $CustomAvailability
+// CHECK-NEXT: @available(Colorado)
 // CHECK-NEXT: public func availableInColorado()
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func availableInColorado()
+// CHECK-NEXT: #endif
 @available(Colorado)
 public func availableInColorado() { }
 
-// CHECK:      @available(Arctic, unavailable)
+// CHECK:      #if compiler(>=5.3) && $CustomAvailability
+// CHECK-NEXT:      @available(Arctic, unavailable)
 // CHECK-NEXT: @available(Pacific)
 // CHECK-NEXT: public func unavailableInArcticButAvailableInPacific()
 @available(Arctic, unavailable)


### PR DESCRIPTION
Because custom availability domains are only parsed behind a flag, conditionally suppress @available attributes that refer to custom domains. This allows the Swift interface to be consumed by compilers without this support enabled.