### PR TITLE
[RemoteInspection] Use the address returned by resolveRemoteAddress

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2923,7 +2923,7 @@ private:
       RemoteAddress address(descriptor.getRemoteAddress());
       address = Reader->resolveRemoteAddress(address).value_or(address);
       snprintf(addressBuf, sizeof(addressBuf), "$%" PRIx64,
-               (uint64_t)descriptor.getRemoteAddress().getRawAddress());
+               (uint64_t)address.getRawAddress());
       auto anonNode = dem.createNode(Node::Kind::AnonymousContext);
       CharVector addressStr;
       addressStr.append(addressBuf, dem);


### PR DESCRIPTION
A previous change introduced the "resolveRemoteAddress" API in the MemoryReader interface, along with one use of it. However, the resolved memory address is created, but left accidentally unused.

rdar://161919584
