### PR TITLE
[RemoteInspection] Use the address returned by resolveRemoteAddress

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2923,7 +2923,7 @@ private:
       RemoteAddress address(descriptor.getRemoteAddress());
       address = Reader->resolveRemoteAddress(address).value_or(address);
       snprintf(addressBuf, sizeof(addressBuf), "$%" PRIx64,
-               (uint64_t)descriptor.getRemoteAddress().getRawAddress());
+               (uint64_t)address.getRawAddress());
       auto anonNode = dem.createNode(Node::Kind::AnonymousContext);
       CharVector addressStr;
       addressStr.append(addressBuf, dem);


### PR DESCRIPTION
• **Explanation**: A previous change introduced the "resolveRemoteAddress" API in the MemoryReader interface, along with one use of it. However, the resolved memory address is created, but left accidentally unused. This patch actually uses the value returned by `resolveRemoteAddress`.
• **Scope**: This affects RemoteInspection clients that override resolveRemoteAddress, which effectively is just LLDB.
• **Risk**: Low, this simply changes the private discriminator string of types parsed from metadata for LLDB.
• **Problem**: rdar://161919584
• **Original PR**: https://github.com/swiftlang/swift/pull/85823
* **Reviewed by:** @adrian-prantl  