### PR TITLE
[Concurrency] TildeSendable: Fix handling of isolated types and inherited conformances

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7375,6 +7375,24 @@ bool swift::checkSendableConformance(
       return false;
   }
 
+  // Sendable supression allows conditional conformances only.
+  if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
+    bool hasUnconditionalConformance = false;
+    if (auto *normalConf = dyn_cast<NormalProtocolConformance>(conformance)) {
+      hasUnconditionalConformance =
+          normalConf->getConditionalRequirements().empty();
+    }
+
+    if (hasUnconditionalConformance) {
+      if (!isImplicitSendableCheck(check)) {
+        auto *conformanceDecl =
+            conformanceDC->getAsDecl() ? conformanceDC->getAsDecl() : nominal;
+        conformanceDecl->diagnose(diag::non_sendable_type_suppressed);
+      }
+      return true;
+    }
+  }
+
   // Global-actor-isolated types can be Sendable. We do not check the
   // instance data because it's all isolated to the global actor.
   switch (getActorIsolation(nominal)) {
@@ -7457,24 +7475,6 @@ bool swift::checkSendableConformance(
   // and not some (possibly constrained) extension.
   if (wasImplied)
     conformanceDC = nominal;
-
-  // Sendable supression allows conditional conformances only.
-  if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
-    bool hasUnconditionalConformance = false;
-    if (auto *normalConf = dyn_cast<NormalProtocolConformance>(conformance)) {
-      hasUnconditionalConformance =
-          normalConf->getConditionalRequirements().empty();
-    }
-
-    if (hasUnconditionalConformance) {
-      if (!isImplicitSendableCheck(check)) {
-        auto *conformanceDecl =
-            conformanceDC->getAsDecl() ? conformanceDC->getAsDecl() : nominal;
-        conformanceDecl->diagnose(diag::non_sendable_type_suppressed);
-      }
-      return true;
-    }
-  }
 
   return checkSendableInstanceStorage(nominal, conformanceDC, check);
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7378,6 +7378,12 @@ bool swift::checkSendableConformance(
   // Sendable supression allows conditional conformances only.
   if (nominal->suppressesConformance(KnownProtocolKind::Sendable)) {
     bool hasUnconditionalConformance = false;
+
+    if (auto *inherited = dyn_cast<InheritedProtocolConformance>(conformance)) {
+      hasUnconditionalConformance =
+          inherited->getConditionalRequirements().empty();
+    }
+
     if (auto *normalConf = dyn_cast<NormalProtocolConformance>(conformance)) {
       hasUnconditionalConformance =
           normalConf->getConditionalRequirements().empty();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -133,6 +133,17 @@ public:
     }
 
     if (auto *TD = dyn_cast<const TypeDecl *>(decl)) {
+      if (rpk == RepressibleProtocolKind::Sendable) {
+        auto *C = dyn_cast<ClassDecl>(TD);
+        if (C && C->isActor()) {
+          diagnoseInvalid(
+              repr, repr.getLoc(),
+              diag::conformance_repression_only_on_struct_class_enum,
+              ctx.getProtocol(*kp));
+          return Type();
+        }
+      }
+
       if (!(isa<StructDecl>(TD) || isa<ClassDecl>(TD) || isa<EnumDecl>(TD))) {
         diagnoseInvalid(repr, repr.getLoc(),
                         diag::conformance_repression_only_on_struct_class_enum,

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -131,4 +131,8 @@ do {
 
   class Child2: Base, ~Sendable {}
   // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
+
+  actor A: ~Sendable {
+    // expected-error@-1 {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+  }
 }

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -27,6 +27,9 @@ extension InExt: ~Sendable { // expected-error {{conformance to inferrable proto
 func test<T: ~Sendable>(_: T) {} // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
 func test<Q>(other: Q) where Q: ~Sendable {} // expected-error {{type 'Sendable' cannot be suppressed}}
 
+func testSendable<T: Sendable>(_: T) {}
+
+
 struct Generic<T: ~Sendable> { // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
   var x: T
 }
@@ -47,10 +50,8 @@ do {
     // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
   }
 
-  func check<T: Sendable>(_: T) {}
-
-  check(NonSendable()) // expected-warning {{type 'NonSendable' does not conform to the 'Sendable' protocol}}
-  check(NoInference()) // Ok
+  testSendable(NonSendable()) // expected-warning {{type 'NonSendable' does not conform to the 'Sendable' protocol}}
+  testSendable(NoInference()) // Ok
 }
 
 func takesSendable<T: Sendable>(_: T) {}
@@ -91,3 +92,31 @@ extension H: Sendable where T: Sendable, U: Sendable { }
 
 takesSendable(H(t: "", u: 42))
 takesSendable(H(t: "", u: MyValue())) // expected-warning {{type 'MyValue' does not conform to the 'Sendable' protocol}}
+
+@MainActor
+protocol IsolatedP {
+}
+
+@MainActor
+protocol IsolatedSendableP: Sendable {
+}
+
+do {
+  struct S1: ~Sendable, W {
+    // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
+  }
+
+  struct S2: IsolatedP, ~Sendable { // Ok (because isolated protocol is not Sendable unless explicitly stated)
+  }
+
+  struct S3: IsolatedSendableP, ~Sendable {
+    // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
+  }
+
+  @MainActor
+  class IsolatedC: ~Sendable {}
+  // expected-note@-1 {{class 'IsolatedC' explicitly suppresses conformance to 'Sendable' protocol}}
+
+  testSendable(IsolatedC())
+  // expected-warning@-1 {{type 'IsolatedC' does not conform to the 'Sendable' protocol}}
+}

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -119,4 +119,16 @@ do {
 
   testSendable(IsolatedC())
   // expected-warning@-1 {{type 'IsolatedC' does not conform to the 'Sendable' protocol}}
+
+  @MainActor
+  class IsolatedBase {} // derived as Sendable
+
+  class Child1: IsolatedBase, ~Sendable {}
+  // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
+
+  class Base: Sendable {}
+  // expected-warning@-1 {{non-final class 'Base' cannot conform to the 'Sendable' protocol}}
+
+  class Child2: Base, ~Sendable {}
+  // expected-error@-1 {{cannot both conform to and suppress conformance to 'Sendable'}}
 }


### PR DESCRIPTION
-  If a type is suppressing `~Sendable` global-actor isolation shouldn't
    make it `Sendable` and the compiler should diagnose cases were 
   `Sendable` comes from an isolated protocol.

- Account for inherited conformances. This helps to properly detect and account for derived conformances to `Sendable` protocol that come from parent classes.

- Disallow `Sendable` suppression on actor declarations

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
