### PR TITLE
[Sema]: add fixit for `no_async_in_await` warning

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4672,7 +4672,8 @@ private:
         .highlight(E->getAwaitLoc());
       return;
     }
-    Ctx.Diags.diagnose(E->getAwaitLoc(), diag::no_async_in_await);
+    Ctx.Diags.diagnose(E->getAwaitLoc(), diag::no_async_in_await)
+        .fixItRemove(E->getAwaitLoc());
   }
 
   void diagnoseRedundantUnsafe(UnsafeExpr *E) const {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4666,10 +4666,11 @@ private:
   void diagnoseRedundantAwait(AwaitExpr *E) const {
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
       // For an if/switch expression, produce a tailored warning.
-      Ctx.Diags.diagnose(E->getAwaitLoc(),
-                         diag::effect_marker_on_single_value_stmt,
-                         "await", SVE->getStmt()->getKind())
-        .highlight(E->getAwaitLoc());
+      Ctx.Diags
+          .diagnose(E->getAwaitLoc(), diag::effect_marker_on_single_value_stmt,
+                    "await", SVE->getStmt()->getKind())
+          .highlight(E->getAwaitLoc())
+          .fixItRemove(E->getAwaitLoc());
       return;
     }
     Ctx.Diags.diagnose(E->getAwaitLoc(), diag::no_async_in_await)

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -50,7 +50,7 @@ actor BankAccount {
   }
 
   func testSelfBalance() async {
-    _ = await balance() // expected-warning {{no 'async' operations occur within 'await' expression}}
+    _ = await balance() // expected-warning {{no 'async' operations occur within 'await' expression}}{{9-15=}}
   }
 
   // returns the amount actually withdrawn
@@ -357,12 +357,12 @@ actor Calculator {
   // We will error on the next line when we get past type checking. But since we
   // error in the type checker, we do not make further progress.
   let _ = (await bananaAdd(1))(2)
-  let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
+  let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}{{11-17=}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
-  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
+  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}{{11-17=}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))
   let _ = plusOne(2)

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -54,7 +54,7 @@ actor Act {
 nonisolated let act = Act()
 
 func bad() async {
-    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}{{5-11=}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     // expected-note@+1 {{consider declaring an isolated method on 'Act' to perform the mutation}}
     await act.i = 666
@@ -66,13 +66,13 @@ protocol Proto: Actor {
 extension Act: Proto {}
 
 func good() async {
-    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}{{5-11=}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     // expected-note@+1 {{consider declaring an isolated method on 'Proto' to perform the mutation}}
     await (act as any Proto).i = 42
     let aIndirect: any Proto = act
 
-    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}{{5-11=}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     // expected-note@+1 {{consider declaring an isolated method on 'Proto' to perform the mutation}}
     await aIndirect.i = 777

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -275,7 +275,7 @@ extension MyActor {
     // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
     acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can not be used 'inout' on a nonisolated actor instance}}
     // expected-error@+3{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
-    // expected-warning@+2{{no 'async' operations occur within 'await' expression}}
+    // expected-warning@+2{{no 'async' operations occur within 'await' expression}}{{5-11=}}
     // expected-note@+1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
     await otherActor.mutable = 0
 
@@ -616,7 +616,7 @@ func testGlobalRestrictions(actor: MyActor) async {
 
   // stored and computed properties can be accessed. Only immutable stored properties can be accessed without 'await'
   _ = actor.immutable
-  _ = await actor.immutable // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await actor.immutable // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
   _ = actor.mutable  // expected-error{{actor-isolated property 'mutable' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = await actor.mutable
   _ = actor.text[0] // expected-error{{actor-isolated property 'text' cannot be accessed from outside of the actor}}{{7-7=await }}
@@ -1205,7 +1205,7 @@ extension MyActor {
     }
 
     acceptAsyncSendableClosureInheriting {
-      _ = await synchronous() // expected-warning{{no 'async' operations occur within 'await' expression}}
+      _ = await synchronous() // expected-warning{{no 'async' operations occur within 'await' expression}}{{11-17=}}
       counter += 1 // okay
     }
 

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -53,15 +53,15 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
   _ = anno.counter
 
   // make sure it's just a warning if someone was awaiting on it previously
-  _ = await ext.point // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = await formance.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = await anno.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await ext.point // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
+  _ = await formance.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
+  _ = await anno.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
   
   // this does not need an await, since the property is 'Sendable' and of a
   // value type
   _ = anno.point
   _ = await anno.point
-  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}{{7-13=}}
 
   // these do need await, regardless of reference or value type
   _ = await (formance as any MainCounter).counter

--- a/test/Concurrency/effectful_properties_async_if_optional_unwrap.swift
+++ b/test/Concurrency/effectful_properties_async_if_optional_unwrap.swift
@@ -48,7 +48,7 @@ struct Kappa {
     // though we could try to could give a better message
     if let await maybeData { // expected-error{{unwrap condition requires a valid identifier}}
       // expected-error@-1{{pattern variable binding cannot appear in an expression}}
-      // expected-warning@-2{{no 'async' operations occur within 'await' expression}}
+      // expected-warning@-2{{no 'async' operations occur within 'await' expression}}{{12-18=}}
       return maybeData // expected-error{{expression is 'async' but is not marked with 'await'}}
       // expected-note@-1{{property access is 'async'}}
     }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -653,7 +653,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
   }
 
   acceptAsyncSendableClosureInheriting {
-    await onlyOnMainActor() // expected-warning{{no 'async' operations occur within 'await' expression}}
+    await onlyOnMainActor() // expected-warning{{no 'async' operations occur within 'await' expression}}{{5-11=}}
   }
 }
 

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -42,7 +42,7 @@ func asyncFunction() async {}
 
 func callReasyncFunction() async {
   reasyncFunction { }
-  await reasyncFunction { } // expected-warning {{no 'async' operations occur within 'await' expression}}
+  await reasyncFunction { } // expected-warning {{no 'async' operations occur within 'await' expression}}{{3-9=}}
 
   reasyncFunction { await asyncFunction() }
   // expected-error@-1:3 {{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
@@ -58,11 +58,11 @@ enum HorseError : Error {
 func callReasyncRethrowsFunction() async throws {
   reasyncRethrowsFunction { }
   await reasyncRethrowsFunction { }
-  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}{{3-9=}}
   try reasyncRethrowsFunction { }
   // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
   try await reasyncRethrowsFunction { }
-  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}{{7-13=}}
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
 
   reasyncRethrowsFunction { await asyncFunction() }
@@ -84,10 +84,10 @@ func callReasyncRethrowsFunction() async throws {
   await reasyncRethrowsFunction { throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}
   // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
-  // expected-warning@-3 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-3 {{no 'async' operations occur within 'await' expression}}{{3-9=}}
   try reasyncRethrowsFunction { throw HorseError.colic }
   try await reasyncRethrowsFunction { throw HorseError.colic }
-  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}{{7-13=}}
 
   reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}

--- a/test/Concurrency/toplevel/no-async-5-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-5-top-level.swift
@@ -19,7 +19,7 @@ func isolatedSync() { // expected-note 2 {{calls to global function 'isolatedSyn
 }
 
 func nonIsolatedAsync() async {
-    await print(a) // expected-warning {{no 'async' operations occur within 'await' expression}}
+    await print(a) // expected-warning {{no 'async' operations occur within 'await' expression}}{{5-11=}}
     a = a + 10
 }
 

--- a/test/Concurrency/transfernonsendable_rbi_result.swift
+++ b/test/Concurrency/transfernonsendable_rbi_result.swift
@@ -72,14 +72,14 @@ func testActorCrossingBoundary() async {
   let _ = await (await mainActorResult(1))(2)
   // expected-error @-1 {{non-Sendable '(Int) -> Int'-typed result can not be returned from main actor-isolated global function 'mainActorResult' to global actor 'CustomActor'-isolated context}}
   // expected-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-warning @-3 {{no 'async' operations occur within 'await' expression}}
+  // expected-warning @-3 {{no 'async' operations occur within 'await' expression}}{{11-17=}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
   // expected-error @-1 {{non-Sendable '(Int) -> Int'-typed result can not be returned from actor-isolated instance method 'addCurried' to global actor 'CustomActor'-isolated context}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
+  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}{{11-17=}}
   // expected-error @-1 {{non-Sendable '(Int) -> Int'-typed result can not be returned from actor-isolated instance method 'addCurried' to global actor 'CustomActor'-isolated context}}
   // expected-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -69,7 +69,7 @@ func outside_good_generic<DP: DistProtocol>(dp: DP) async throws {
   _ = dp.local() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   _ = await dp.local() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   // the below warning is expected because we don't apply the "implicitly async" to the not-callable func
-  // expected-warning@-2{{no 'async' operations occur within 'await' expression}}
+  // expected-warning@-2{{no 'async' operations occur within 'await' expression}}{{7-13=}}
 
   _ = try dp.local() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   // the below warning is expected because we don't apply the "implicitly throwing" to the not-callable func

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -301,7 +301,7 @@ do {
   // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
 } // expected-error {{expected expression after operator}}
 
-_ = await /x/ // expected-warning {{no 'async' operations occur within 'await' expression}}
+_ = await /x/ // expected-warning {{no 'async' operations occur within 'await' expression}}{{5-11=}}
 
 /x/ = 0 // expected-error {{cannot assign to value: literals are not mutable}}
 /x/() // expected-error {{cannot call value of non-function type 'Regex<Substring>'}}

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -223,7 +223,7 @@ func composed2<U : None & A >(u : U) async {
   _ = u.someProp
   // FIXME: this ^ should raise "property access is 'async' but is not marked with 'await'""
 
-  _ = await u.someProp // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await u.someProp // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
 }
 
 func composed3<U : T & None >(u : U) throws {

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -6,7 +6,7 @@ func test1(asyncfp : () async -> Int, fp : () -> Int) async {
   _ = await asyncfp()
   _ = await asyncfp() + asyncfp()
   _ = await asyncfp() + fp()
-  _ = await fp() + 42  // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await fp() + 42  // expected-warning {{no 'async' operations occur within 'await' expression}}{{7-13=}}
   _ = 32 + asyncfp() + asyncfp() // expected-error {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   // expected-note@-1:12{{call is 'async'}}
   // expected-note@-2:24{{call is 'async'}}

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -423,12 +423,12 @@ func tryDo30(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitDo1() async -> Int {
   await do { 0 }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{3-9=}}
 }
 
 func awaitDo2() async -> Int {
   let x = await do { 0 }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{11-17=}}
   return x
 }
 
@@ -439,26 +439,26 @@ func awaitDo3() -> Int { // expected-note {{add 'async' to function 'awaitDo3()'
 
 func awaitDo4() async -> Int {
   return await do { 0 }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{10-16=}}
 }
 
 func awaitDo5() async -> Int {
   return await do { awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{10-16=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo6() async -> Int {
   await do { awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{3-9=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo7() async -> Int {
   let x = await do { awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -466,23 +466,23 @@ func awaitDo7() async -> Int {
 
 func awaitDo8() async -> Int {
   return await do { await awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{10-16=}}
 }
 
 func awaitDo9() async -> Int {
   await do { await awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{3-9=}}
 }
 
 func awaitDo10() async -> Int {
   let x = await do { await awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}{{11-17=}}
   return x
 }
 
 func awaitDo11() async -> Int {
   let x = await do { try await tryAwaitDo1() } catch { awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -490,14 +490,14 @@ func awaitDo11() async -> Int {
 
 func awaitDo12() async -> Int {
   let x = await do { try tryAwaitDo1() } catch { awaitDo4() }
-  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}{{11-17=}}
   // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitDo13() async throws -> Int {
-  let x = await do { // expected-warning {{'await' has no effect on 'do-catch' expression}}
+  let x = await do { // expected-warning {{'await' has no effect on 'do-catch' expression}}{{11-17=}}
     awaitDo4() // expected-warning {{result of call to 'awaitDo4()' is unused}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
@@ -527,13 +527,13 @@ func asyncBool() async -> Bool { true }
 
 func awaitDo14() async -> Int {
   await do { try tryDo4() } catch _ where asyncBool() { 0 } catch { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}{{3-9=}}
   // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
 }
 
 func awaitDo15() async -> Int {
   await do { try tryDo4() } catch _ where await asyncBool() { 0 } catch { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}{{3-9=}}
   // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
 }
 
@@ -566,19 +566,19 @@ func awaitDo20() async -> Int {
 func tryAwaitDo1() async throws -> Int {
   try await do { 0 }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
 }
 
 func tryAwaitDo2() async throws -> Int {
   try await do { 0 } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
 }
 
 func tryAwaitDo3() async throws -> Int {
   try await do { tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -590,7 +590,7 @@ func tryAwaitDo3() async throws -> Int {
 func tryAwaitDo4() async throws -> Int {
   try await do { try tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -598,7 +598,7 @@ func tryAwaitDo4() async throws -> Int {
 func tryAwaitDo5() async throws -> Int {
   try await do { await tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -608,13 +608,13 @@ func tryAwaitDo5() async throws -> Int {
 func tryAwaitDo6() async throws -> Int {
   try await do { try await tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
 }
 
 func tryAwaitDo7() async throws -> Int {
   try await do { tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -626,7 +626,7 @@ func tryAwaitDo7() async throws -> Int {
 func tryAwaitDo8() async throws -> Int {
   try await do { try tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -634,7 +634,7 @@ func tryAwaitDo8() async throws -> Int {
 func tryAwaitDo9() async throws -> Int {
   try await do { await tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -644,7 +644,7 @@ func tryAwaitDo9() async throws -> Int {
 func tryAwaitDo10() async throws -> Int {
   try await do { try await tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}{{7-13=}}
 }
 
 func tryAwaitDo11(_ fn: () async throws -> Int) async rethrows -> Int {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1305,42 +1305,42 @@ func tryIf29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitIf1() async -> Int {
   await if .random() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{3-9=}}
 }
 
 func awaitIf2() async -> Int {
   let x = await if .random() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{11-17=}}
   return x
 }
 
 func awaitIf3() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{10-16=}}
 }
 
 func awaitIf4() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{10-16=}}
 }
 
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{10-16=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{3-9=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1348,23 +1348,23 @@ func awaitIf7() async -> Int {
 
 func awaitIf8() async -> Int {
   return await if .random() { await awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{10-16=}}
 }
 
 func awaitIf9() async -> Int {
   await if .random() { await awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{3-9=}}
 }
 
 func awaitIf10() async -> Int {
   let x = await if .random() { await awaitIf4() } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{11-17=}}
   return x
 }
 
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1372,14 +1372,14 @@ func awaitIf11() async -> Int {
 
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{11-17=}}
   // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitIf13() async throws -> Int {
-  let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
+  let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}{{11-17=}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
@@ -1407,14 +1407,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{3-9=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf15() async -> Int {
   await if await asyncBool() { 0 } else { 1 }
-  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}{{3-9=}}
 }
 
 func awaitIf16() async -> Int {
@@ -1447,19 +1447,19 @@ func awaitIf20() async -> Int {
 func tryAwaitIf1() async throws -> Int {
   try await if .random() { 0 } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
 }
 
 func tryAwaitIf2() async throws -> Int {
   try await if .random() { 0 } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
 }
 
 func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1471,7 +1471,7 @@ func tryAwaitIf3() async throws -> Int {
 func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -1479,7 +1479,7 @@ func tryAwaitIf4() async throws -> Int {
 func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1489,13 +1489,13 @@ func tryAwaitIf5() async throws -> Int {
 func tryAwaitIf6() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
 }
 
 func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1507,7 +1507,7 @@ func tryAwaitIf7() async throws -> Int {
 func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -1515,7 +1515,7 @@ func tryAwaitIf8() async throws -> Int {
 func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1525,7 +1525,7 @@ func tryAwaitIf9() async throws -> Int {
 func tryAwaitIf10() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}{{7-13=}}
 }
 
 func tryAwaitIf11(_ fn: () async throws -> Int) async rethrows -> Int {

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1552,42 +1552,42 @@ func trySwitch29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitSwitch1() async -> Int {
   await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{3-9=}}
 }
 
 func awaitSwitch2() async -> Int {
   let x = await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{11-17=}}
   return x
 }
 
 func awaitSwitch3() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{10-16=}}
 }
 
 func awaitSwitch4() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{10-16=}}
 }
 
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{10-16=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{3-9=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1595,23 +1595,23 @@ func awaitSwitch7() async -> Int {
 
 func awaitSwitch8() async -> Int {
   return await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{10-16=}}
 }
 
 func awaitSwitch9() async -> Int {
   await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{3-9=}}
 }
 
 func awaitSwitch10() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{11-17=}}
   return x
 }
 
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{11-17=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1619,14 +1619,14 @@ func awaitSwitch11() async -> Int {
 
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{11-17=}}
   // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitSwitch13() async throws -> Int {
-  let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
+  let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}{{11-17=}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
@@ -1655,14 +1655,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{3-9=}}
   // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch15() async -> Int {
   await switch await asyncBool() { case true: 0 case false: 1 }
-  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}{{3-9=}}
 }
 
 func awaitSwitch16() async -> Int {
@@ -1695,19 +1695,19 @@ func awaitSwitch20() async -> Int {
 func tryAwaitSwitch1() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
 }
 
 func tryAwaitSwitch2() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
 }
 
 func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1719,7 +1719,7 @@ func tryAwaitSwitch3() async throws -> Int {
 func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -1727,7 +1727,7 @@ func tryAwaitSwitch4() async throws -> Int {
 func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1737,13 +1737,13 @@ func tryAwaitSwitch5() async throws -> Int {
 func tryAwaitSwitch6() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
 }
 
 func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1755,7 +1755,7 @@ func tryAwaitSwitch7() async throws -> Int {
 func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
@@ -1763,7 +1763,7 @@ func tryAwaitSwitch8() async throws -> Int {
 func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
   // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1773,7 +1773,7 @@ func tryAwaitSwitch9() async throws -> Int {
 func tryAwaitSwitch10() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}{{7-13=}}
 }
 
 func tryAwaitSwitch11(_ fn: () async throws -> Int) async rethrows -> Int {


### PR DESCRIPTION
adds a fixit to remove a superfluous `await` when that is diagnosed.

resolves: https://github.com/swiftlang/swift/issues/85818