### PR TITLE
🍒 [6.3][cxx-interop] Refactor ClangTypeEscapability and CxxValueSemantics requests

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -575,15 +575,7 @@ SourceLoc extractNearestSourceLoc(EscapabilityLookupDescriptor desc);
 // When a reference type is copied, the pointer’s value is copied rather than
 // the object’s storage. This means reference types can be imported as
 // copyable to Swift, even when they are non-copyable in C++.
-enum class CxxValueSemanticsKind {
-  Unknown,
-  Copyable,
-  MoveOnly,
-  // A record that is either not copyable/movable or not destructible.
-  MissingLifetimeOperation,
-  // A record that has no copy and no move operations
-  UnavailableConstructors,
-};
+enum class CxxValueSemanticsKind { Unknown, Copyable, MoveOnly };
 
 struct CxxValueSemanticsDescriptor final {
   const clang::Type *type;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8480,103 +8480,118 @@ CxxValueSemanticsKind
 CxxValueSemantics::evaluate(Evaluator &evaluator,
                             CxxValueSemanticsDescriptor desc) const {
 
-  const auto *type = desc.type;
+  // A C++ type can be imported to Swift as Copyable or ~Copyable.
+  // We assume a type can be imported as Copyable unless:
+  // - There's no copy constructor
+  // - The type has a SWIFT_NONCOPYABLE annotation
+  // - The type has a SWIFT_COPYABLE_IF(T...) annotation, where at least one of T is ~Copyable
+  // - It is one of the STL types in `STLConditionalParams`
+
+  const auto *type = desc.type->getUnqualifiedDesugaredType();
   auto *importerImpl = desc.importerImpl;
 
-  auto desugared = type->getUnqualifiedDesugaredType();
-  const auto *recordType = desugared->getAs<clang::RecordType>();
-  if (!recordType)
-    return CxxValueSemanticsKind::Copyable;
+  llvm::SmallVector<clang::RecordDecl *, 4> stack;
+  // Keep track of Decls we've seen to avoid cycles
+  llvm::SmallDenseSet<clang::RecordDecl *, 4> seen;
 
-  auto recordDecl = recordType->getDecl();
+  auto maybePushToStack = [&](const clang::Type *type) {
+    auto recordDecl = type->getAsRecordDecl();
+    if (!recordDecl)
+      return;
 
-  // When a reference type is copied, the pointer’s value is copied rather than
-  // the object’s storage. This means reference types can be imported as
-  // copyable to Swift, even when they are non-copyable in C++.
-  if (recordHasReferenceSemantics(recordDecl, importerImpl))
-    return CxxValueSemanticsKind::Copyable;
+    if (seen.insert(recordDecl).second) {
+      // When a reference type is copied, the pointer’s value is copied rather
+      // than the object’s storage. This means reference types can be imported
+      // as copyable to Swift, even when they are non-copyable in C++.
+      if (recordHasReferenceSemantics(recordDecl, importerImpl))
+        return;
 
-  if (recordDecl->isInStdNamespace()) {
-    // Hack for a base type of std::optional from the Microsoft standard
-    // library.
-    if (recordDecl->getIdentifier() &&
-        recordDecl->getName() == "_Optional_construct_base")
-      return CxxValueSemanticsKind::Copyable;
-  }
-
-  if (!hasNonCopyableAttr(recordDecl)) {
-    auto injectedStlAnnotation =
-        recordDecl->isInStdNamespace()
-            ? STLConditionalParams.find(recordDecl->getName())
-            : STLConditionalParams.end();
-    auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
-                         ? injectedStlAnnotation->second
-                         : std::vector<int>();
-    auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
-
-    if (!STLParams.empty() || !conditionalParams.empty()) {
-      HeaderLoc loc{recordDecl->getLocation()};
-      std::function checkArgValueSemantics =
-          [&](clang::TemplateArgument &arg,
-              StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
-        if (arg.getKind() != clang::TemplateArgument::Type && importerImpl) {
-          importerImpl->diagnose(loc, diag::type_template_parameter_expected,
-                                 argToCheck);
-          return CxxValueSemanticsKind::Unknown;
-        }
-
-        auto argValueSemantics = evaluateOrDefault(
-            evaluator,
-            CxxValueSemantics(
-                {arg.getAsType()->getUnqualifiedDesugaredType(), importerImpl}),
-            {});
-        if (argValueSemantics != CxxValueSemanticsKind::Copyable)
-          return argValueSemantics;
-        return std::nullopt;
-      };
-
-      auto result = checkConditionalParams<CxxValueSemanticsKind>(
-          recordDecl, STLParams, conditionalParams, checkArgValueSemantics);
-      if (result.has_value())
-        return result.value();
-
-      if (importerImpl)
-        for (auto name : conditionalParams)
-          importerImpl->diagnose(loc, diag::unknown_template_parameter, name);
-
-      return CxxValueSemanticsKind::Copyable;
+      if (recordDecl->isInStdNamespace()) {
+        // Hack for a base type of std::optional from the Microsoft standard
+        // library.
+        if (recordDecl->getIdentifier() &&
+            recordDecl->getName() == "_Optional_construct_base")
+          return;
+      }
+      stack.push_back(recordDecl);
     }
-  }
+  };
 
-  const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
-  if (!cxxRecordDecl || !cxxRecordDecl->isCompleteDefinition()) {
-    if (hasNonCopyableAttr(recordDecl))
+  maybePushToStack(type);
+  while (!stack.empty()) {
+    clang::RecordDecl *recordDecl = stack.back();
+    stack.pop_back();
+
+    if (!hasNonCopyableAttr(recordDecl)) {
+      auto injectedStlAnnotation =
+          recordDecl->isInStdNamespace()
+              ? STLConditionalParams.find(recordDecl->getName())
+              : STLConditionalParams.end();
+      auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
+                           ? injectedStlAnnotation->second
+                           : std::vector<int>();
+      auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
+
+      if (!STLParams.empty() || !conditionalParams.empty()) {
+        HeaderLoc loc{recordDecl->getLocation()};
+        std::function checkArgValueSemantics =
+            [&](clang::TemplateArgument &arg,
+                StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
+          if (arg.getKind() != clang::TemplateArgument::Type) {
+            if (importerImpl)
+              importerImpl->diagnose(
+                  loc, diag::type_template_parameter_expected, argToCheck);
+            return CxxValueSemanticsKind::Unknown;
+          }
+          maybePushToStack(arg.getAsType()->getUnqualifiedDesugaredType());
+          // FIXME: return std::nullopt for now, while we don't refactor ClangTypeEscapability request
+          return std::nullopt;
+        };
+
+        checkConditionalParams<CxxValueSemanticsKind>(
+            recordDecl, STLParams, conditionalParams, checkArgValueSemantics);
+
+        if (importerImpl)
+          for (auto name : conditionalParams)
+            importerImpl->diagnose(loc, diag::unknown_template_parameter, name);
+
+        continue;
+      }
+    }
+
+    const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
+    if (!cxxRecordDecl || !cxxRecordDecl->isCompleteDefinition()) {
+      if (hasNonCopyableAttr(recordDecl))
+        return CxxValueSemanticsKind::MoveOnly;
+      continue;
+    }
+
+    bool isCopyable = !hasNonCopyableAttr(cxxRecordDecl) &&
+                      hasCopyTypeOperations(cxxRecordDecl);
+    bool isMovable = hasMoveTypeOperations(cxxRecordDecl);
+
+    if (!hasDestroyTypeOperations(cxxRecordDecl) ||
+        (!isCopyable && !isMovable)) {
+
+      if (hasConstructorWithUnsupportedDefaultArgs(cxxRecordDecl))
+        return CxxValueSemanticsKind::UnavailableConstructors;
+
+      return CxxValueSemanticsKind::MissingLifetimeOperation;
+    }
+
+    if (hasNonCopyableAttr(cxxRecordDecl) && isMovable)
       return CxxValueSemanticsKind::MoveOnly;
-    return CxxValueSemanticsKind::Copyable;
+
+    if (isCopyable)
+      continue;
+
+    if (isMovable)
+      return CxxValueSemanticsKind::MoveOnly;
+
+    llvm_unreachable("Could not classify C++ type.");
   }
 
-  bool isCopyable = !hasNonCopyableAttr(cxxRecordDecl) && 
-                    hasCopyTypeOperations(cxxRecordDecl);
-  bool isMovable = hasMoveTypeOperations(cxxRecordDecl);
-
-  if (!hasDestroyTypeOperations(cxxRecordDecl) || (!isCopyable && !isMovable)) {
-
-    if (hasConstructorWithUnsupportedDefaultArgs(cxxRecordDecl))
-      return CxxValueSemanticsKind::UnavailableConstructors;
-
-    return CxxValueSemanticsKind::MissingLifetimeOperation;
-  }
-
-  if (hasNonCopyableAttr(cxxRecordDecl) && isMovable)
-    return CxxValueSemanticsKind::MoveOnly;
-
-  if (isCopyable)
-    return CxxValueSemanticsKind::Copyable;
-
-  if (isMovable)
-    return CxxValueSemanticsKind::MoveOnly;
-
-  llvm_unreachable("Could not classify C++ type.");
+  return CxxValueSemanticsKind::Copyable;
 }
 
 void swift::simple_display(llvm::raw_ostream &out,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5403,10 +5403,9 @@ static const llvm::StringMap<std::vector<int>> STLConditionalParams{
 
 template <typename Kind>
 static bool checkConditionalParams(
-    clang::RecordDecl *recordDecl, ClangImporter::Implementation *impl,
+    const clang::RecordDecl *recordDecl, ClangImporter::Implementation *impl,
     const std::vector<int> &STLParams, std::set<StringRef> &conditionalParams,
-    std::function<void(const clang::Type *)> &maybePushToStack) {
-  HeaderLoc loc{recordDecl->getLocation()};
+    llvm::function_ref<void(const clang::Type *)> maybePushToStack) {
   bool foundErrors = false;
   auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
   SmallVector<std::pair<unsigned, StringRef>, 4> argumentsToCheck;
@@ -5437,7 +5436,8 @@ static bool checkConditionalParams(
       for (auto nonPackArg : nonPackArgs) {
         if (nonPackArg.getKind() != clang::TemplateArgument::Type) {
           if (impl)
-            impl->diagnose(loc, diag::type_template_parameter_expected,
+            impl->diagnose(HeaderLoc(recordDecl->getLocation()),
+                           diag::type_template_parameter_expected,
                            argToCheck.second);
           foundErrors = true;
         } else {
@@ -5448,7 +5448,7 @@ static bool checkConditionalParams(
     }
     if (hasInjectedSTLAnnotation)
       break;
-    clang::DeclContext *dc = specDecl;
+    const clang::DeclContext *dc = specDecl;
     specDecl = nullptr;
     while ((dc = dc->getParent())) {
       specDecl = dyn_cast<clang::ClassTemplateSpecializationDecl>(dc);
@@ -5495,19 +5495,33 @@ getConditionalCopyableAttrParams(const clang::RecordDecl *decl) {
 CxxEscapability
 ClangTypeEscapability::evaluate(Evaluator &evaluator,
                                 EscapabilityLookupDescriptor desc) const {
+
+  // Escapability inference rules:
+  // - array and vector types have the same escapability as their element type
+  // - pointer and reference types are currently imported as escapable
+  // (importing them as non-escapable broke backward compatibility)
+  // - a record type is escapable or non-escapable if it is explicitly annotated
+  // as such
+  // - a record type is escapable if it is annotated with SWIFT_ESCAPABLE_IF()
+  // and none of the annotation arguments are non-escapable
+  // - in all other cases, the record has unknown escapability (e.g. no
+  // escapability annotations, malformed escapability annotations)
+
   bool hasUnknown = false;
   auto desugared = desc.type->getUnqualifiedDesugaredType();
   if (const auto *recordType = desugared->getAs<clang::RecordType>()) {
     auto recordDecl = recordType->getDecl();
+    // If the root type has a SWIFT_ESCAPABLE annotation, we import the type as
+    // Escapable without entering the loop
     if (hasEscapableAttr(recordDecl))
       return CxxEscapability::Escapable;
   }
 
   llvm::SmallVector<const clang::Type *, 4> stack;
-  // Keep track of Decls we've seen to avoid cycles
+  // Keep track of Types we've seen to avoid cycles
   llvm::SmallDenseSet<const clang::Type *, 4> seen;
 
-  std::function maybePushToStack = [&](const clang::Type *type) {
+  auto maybePushToStack = [&](const clang::Type *type) {
     auto desugared = type->getUnqualifiedDesugaredType();
     if (seen.insert(desugared).second)
       stack.push_back(desugared);
@@ -5545,6 +5559,10 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
 
         continue;
       }
+      // The `annotationOnly` flag used to control which types we infered
+      // escapability for. Currently, this flag is always set to true, meaning
+      // that any type without an annotation (CxxRecordDecls, aggregates, decls
+      // lacking definition, etc.) will raise `hasUnknown`.
       if (desc.annotationOnly) {
         hasUnknown = true;
         continue;
@@ -5560,8 +5578,7 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
           maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
         continue;
       }
-    }
-    if (type->isArrayType()) {
+    } else if (type->isArrayType()) {
       auto elemTy = cast<clang::ArrayType>(type)
                         ->getElementType()
                         ->getUnqualifiedDesugaredType();
@@ -8467,21 +8484,25 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   // We assume a type can be imported as Copyable unless:
   // - There's no copy constructor
   // - The type has a SWIFT_NONCOPYABLE annotation
-  // - The type has a SWIFT_COPYABLE_IF(T...) annotation, where at least one of T is ~Copyable
-  // - It is one of the STL types in `STLConditionalParams`
+  // - The type has a SWIFT_COPYABLE_IF(T...) annotation, where at least one of
+  // T is ~Copyable
+  // - It is one of the STL types in `STLConditionalParams`, and at least one of
+  // its revelant types is ~Copyable
 
   const auto *type = desc.type->getUnqualifiedDesugaredType();
   auto *importerImpl = desc.importerImpl;
 
-  llvm::SmallVector<clang::RecordDecl *, 4> stack;
+  bool hasUnknown = false;
+  llvm::SmallVector<const clang::RecordDecl *, 4> stack;
   // Keep track of Decls we've seen to avoid cycles
-  llvm::SmallDenseSet<clang::RecordDecl *, 4> seen;
+  llvm::SmallDenseSet<const clang::RecordDecl *, 4> seen;
 
-  std::function maybePushToStack = [&](const clang::Type *type) {
-    auto recordDecl = type->getAsRecordDecl();
-    if (!recordDecl)
+  auto maybePushToStack = [&](const clang::Type *type) {
+    auto recordType = type->getAs<clang::RecordType>();
+    if (!recordType)
       return;
 
+    auto recordDecl = recordType->getDecl();
     if (seen.insert(recordDecl).second) {
       // When a reference type is copied, the pointer’s value is copied rather
       // than the object’s storage. This means reference types can be imported
@@ -8502,7 +8523,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
 
   maybePushToStack(type);
   while (!stack.empty()) {
-    clang::RecordDecl *recordDecl = stack.back();
+    const clang::RecordDecl *recordDecl = stack.back();
     stack.pop_back();
 
     if (!hasNonCopyableAttr(recordDecl)) {
@@ -8516,22 +8537,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
 
       if (!STLParams.empty() || !conditionalParams.empty()) {
-        HeaderLoc loc{recordDecl->getLocation()};
-        std::function checkArgValueSemantics =
-            [&](clang::TemplateArgument &arg,
-                StringRef argToCheck) -> std::optional<CxxValueSemanticsKind> {
-          if (arg.getKind() != clang::TemplateArgument::Type) {
-            if (importerImpl)
-              importerImpl->diagnose(
-                  loc, diag::type_template_parameter_expected, argToCheck);
-            return std::nullopt;
-          }
-          maybePushToStack(arg.getAsType()->getUnqualifiedDesugaredType());
-          // FIXME: return std::nullopt for now, while we don't refactor ClangTypeEscapability request
-          return std::nullopt;
-        };
-
-        checkConditionalParams<CxxValueSemanticsKind>(
+        hasUnknown &= checkConditionalParams<CxxValueSemanticsKind>(
             recordDecl, importerImpl, STLParams, conditionalParams,
             maybePushToStack);
 
@@ -8546,7 +8552,7 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     }
 
     const auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
-    if (!cxxRecordDecl || !cxxRecordDecl->isCompleteDefinition()) {
+    if (!cxxRecordDecl || !recordDecl->isCompleteDefinition()) {
       if (hasNonCopyableAttr(recordDecl))
         return CxxValueSemanticsKind::MoveOnly;
       continue;
@@ -8560,9 +8566,11 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
         (!isCopyable && !isMovable)) {
 
       if (hasConstructorWithUnsupportedDefaultArgs(cxxRecordDecl))
-        return CxxValueSemanticsKind::UnavailableConstructors;
-
-      return CxxValueSemanticsKind::MissingLifetimeOperation;
+        importerImpl->addImportDiagnostic(
+            cxxRecordDecl, Diagnostic(diag::record_unsupported_default_args),
+            cxxRecordDecl->getLocation());
+      hasUnknown = true;
+      continue;
     }
 
     if (hasNonCopyableAttr(cxxRecordDecl) && isMovable)
@@ -8577,7 +8585,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     llvm_unreachable("Could not classify C++ type.");
   }
 
-  return CxxValueSemanticsKind::Copyable;
+  return hasUnknown ? CxxValueSemanticsKind::Unknown
+                    : CxxValueSemanticsKind::Copyable;
 }
 
 void swift::simple_display(llvm::raw_ostream &out,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3076,8 +3076,7 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
       ctx.evaluator, 
       CxxValueSemantics({clangType->getTypeForDecl(), &ImporterImpl}), {});
 
-  if (valueSemanticsKind != CxxValueSemanticsKind::Copyable &&
-      valueSemanticsKind != CxxValueSemanticsKind::MoveOnly)
+  if (valueSemanticsKind == CxxValueSemanticsKind::Unknown)
     return nullptr;
 
   auto cxxRecordSemanticsKind = evaluateOrDefault(

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -193,10 +193,10 @@ public func noAnnotations() -> View {
     // CHECK-NO-LIFETIMES: nonescapable.h:56:39: error: template parameter 'Missing' does not exist
     i2()
     // CHECK: nonescapable.h:62:33: error: template parameter 'S' expected to be a type parameter
-    // CHECK: nonescapable.h:80:41: error: a function with a ~Escapable result needs a parameter to depend on
-    // CHECK: note: '@_lifetime(immortal)' can be used to indicate that values produced
     // CHECK-NO-LIFETIMES: nonescapable.h:62:33: error: template parameter 'S' expected to be a type parameter
     j1()
+    // CHECK: nonescapable.h:80:41: error: a function with a ~Escapable result needs a parameter to depend on
+    // CHECK: note: '@_lifetime(immortal)' can be used to indicate that values produced
     // CHECK-NO-LIFETIMES: nonescapable.h:80:41: error: a function cannot return a ~Escapable result
     j2()
     // CHECK: nonescapable.h:81:41: error: a function with a ~Escapable result needs a parameter to depend on


### PR DESCRIPTION
  - **Explanation**: This patch refactors the copyability and escapability requests to prevent request cycles from happening when we visit the fields and bases of the original type. Note that the previous implementation would never create cycles, because we would never visit fields and bases for either the requests (only template arguments). Instead this refactoring was necessary for a subsequent patch, where we actually start visiting fields and bases.
  - **Original PRs**: https://github.com/swiftlang/swift/pull/85485
  - **Risk**: Medium, this refactors the copyability and escapability requests which could potentially (but hopefully won't) introduce regressions.
  - **Testing**: No new tests were added because we already had a good set of tests for these requests, and no new functionality was introduced. 
  - **Reviewers**: @j-hui @Xazax-hun @hnrklssn 