### PR TITLE
[6.3][NFC] "SwiftVersion" → "LanguageMode" in `DiagnosticEngine::warnUntilSwiftVersion`, etc.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1554,9 +1554,9 @@ public:
   ///
   /// This is usually the check you want; for example, when introducing
   /// a new language feature which is only visible in Swift 5, you would
-  /// check for isSwiftVersionAtLeast(5).
-  bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
-    return LangOpts.isSwiftVersionAtLeast(major, minor);
+  /// check for isLanguageModeAtLeast(5).
+  bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
+    return LangOpts.isLanguageModeAtLeast(major, minor);
   }
 
   /// Check whether it's important to respect access control restrictions

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -388,8 +388,8 @@ namespace swift {
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    InFlightDiagnostic &limitBehaviorUntilSwiftVersion(
-        DiagnosticBehavior limit, unsigned majorVersion);
+    InFlightDiagnostic &limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
+                                                       unsigned majorVersion);
 
     /// Limits the diagnostic behavior to \c limit accordingly if
     /// preconcurrency applies. Otherwise, the behavior limit only applies
@@ -412,7 +412,7 @@ namespace swift {
         return limitBehavior(limit);
       }
 
-      return limitBehaviorUntilSwiftVersion(limit, languageMode);
+      return limitBehaviorUntilLanguageMode(limit, languageMode);
     }
 
     /// Limit the diagnostic behavior to warning until the next future
@@ -424,19 +424,19 @@ namespace swift {
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    InFlightDiagnostic &warnUntilFutureSwiftVersion();
+    InFlightDiagnostic &warnUntilFutureLanguageMode();
 
-    InFlightDiagnostic &warnUntilFutureSwiftVersionIf(bool shouldLimit) {
+    InFlightDiagnostic &warnUntilFutureLanguageModeIf(bool shouldLimit) {
       if (!shouldLimit)
         return *this;
-      return warnUntilFutureSwiftVersion();
+      return warnUntilFutureLanguageMode();
     }
 
     /// Limit the diagnostic behavior to warning until the specified version.
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    InFlightDiagnostic &warnUntilSwiftVersion(unsigned majorVersion);
+    InFlightDiagnostic &warnUntilLanguageMode(unsigned majorVersion);
 
     /// Limit the diagnostic behavior to warning if the context is a
     /// swiftinterface.
@@ -453,10 +453,10 @@ namespace swift {
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    InFlightDiagnostic &warnUntilSwiftVersionIf(bool shouldLimit,
+    InFlightDiagnostic &warnUntilLanguageModeIf(bool shouldLimit,
                                                 unsigned majorVersion) {
       if (!shouldLimit) return *this;
-      return warnUntilSwiftVersion(majorVersion);
+      return warnUntilLanguageMode(majorVersion);
     }
 
     /// Wraps this diagnostic in another diagnostic. That is, \p wrapper will be
@@ -887,7 +887,7 @@ namespace swift {
     version::Version languageVersion;
 
     /// The stats reporter used to keep track of Swift 6 errors
-    /// diagnosed via \c warnUntilSwiftVersion(6).
+    /// diagnosed via \c warnUntilLanguageMode(6).
     UnifiedStatsReporter *statsReporter = nullptr;
 
     /// Whether we are actively pretty-printing a declaration as part of

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -82,7 +82,7 @@ struct Feature {
 
   /// Get the major language version in which this feature was introduced, or
   /// \c None if it does not have such a version.
-  std::optional<unsigned> getLanguageVersion() const;
+  std::optional<unsigned> getLanguageMode() const;
 };
 
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -50,8 +50,8 @@
 // Swift compiler.
 //
 // OPTIONAL_LANGUAGE_FEATURE is the same as LANGUAGE_FEATURE, but describes
-// accepted features that can be enabled independently of language version and
-// are not scheduled to be enabled in some specific language version. Examples
+// accepted features that can be enabled independently of language mode and
+// are not scheduled to be enabled in some specific language mode. Examples
 // of optional language features include strict memory safety checking (SE-0458)
 // and Embedded Swift.
 //===----------------------------------------------------------------------===//
@@ -82,11 +82,11 @@
       defined(UPCOMING_FEATURE)
 #    error ambiguous defines when including Features.def
 #  elif defined(SUPPRESSIBLE_LANGUAGE_FEATURE)
-#    define SUPPRESSIBLE_UPCOMING_FEATURE(FeatureName, SENumber, Version) \
+#    define SUPPRESSIBLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode) \
        SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
 #  else
-#    define SUPPRESSIBLE_UPCOMING_FEATURE(FeatureName, SENumber, Version) \
-       UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#    define SUPPRESSIBLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode) \
+       UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)
 #  endif
 #endif
 
@@ -136,10 +136,10 @@
 // feature is disabled.
 #ifndef MIGRATABLE_UPCOMING_FEATURE
   #if defined(UPCOMING_FEATURE)
-    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
-      UPCOMING_FEATURE(FeatureName, SENumber, Version)
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)   \
+      UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)
   #else
-    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)   \
       LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
   #endif
 #endif
@@ -161,7 +161,7 @@
 #endif
 
 #ifndef UPCOMING_FEATURE
-  #define UPCOMING_FEATURE(FeatureName, SENumber, Version)                     \
+  #define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                \
     LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
 #endif
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -745,8 +745,8 @@ namespace swift {
     ///
     /// This is usually the check you want; for example, when introducing
     /// a new language feature which is only visible in Swift 5, you would
-    /// check for isSwiftVersionAtLeast(5).
-    bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
+    /// check for isLanguageModeAtLeast(5).
+    bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4182,7 +4182,7 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     // NOTE: it's important that we check if it's a convenience init only after
     // confirming it's not semantically final, or else there can be a request
     // evaluator cycle to determine the init kind for actors, which are final.
-    if (Ctx.isSwiftVersionAtLeast(5)) {
+    if (Ctx.isLanguageModeAtLeast(5)) {
       if (wantDynamicSelf)
         if (auto *classDecl = selfTy->getClassOrBoundGenericClass())
           if (!classDecl->isSemanticallyFinal() && CD->isConvenienceInit())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2194,7 +2194,7 @@ public:
     void verifyChecked(OptionalTryExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying OptionalTryExpr", E);
 
-      if (Ctx.LangOpts.isSwiftVersionAtLeast(5)) {
+      if (Ctx.isLanguageModeAtLeast(5)) {
         checkSameType(E->getType(), E->getSubExpr()->getType(),
                       "OptionalTryExpr and sub-expression");
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1231,9 +1231,8 @@ bool Decl::preconcurrency() const {
 
   // Variables declared in top-level code are @_predatesConcurrency
   if (const VarDecl *var = dyn_cast<VarDecl>(this)) {
-    const LangOptions &langOpts = getASTContext().LangOpts;
-    return !langOpts.isSwiftVersionAtLeast(6) && var->isTopLevelGlobal() &&
-           var->getDeclContext()->isAsyncContext();
+    return !getASTContext().isLanguageModeAtLeast(6) &&
+           var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext();
   }
 
   return false;
@@ -2835,7 +2834,7 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
     return true;
 
   // Also support the desugared 'Optional<T>' spelling.
-  if (!ctx.isSwiftVersionAtLeast(5)) {
+  if (!ctx.isLanguageModeAtLeast(5)) {
     if (typeRepr->isSimpleUnqualifiedIdentifier(ctx.Id_Void)) {
       return true;
     }
@@ -3016,7 +3015,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
   assert(defer->isDeferBody());
 
   // In Swift 6+, then yes.
-  if (defer->getASTContext().isSwiftVersionAtLeast(6))
+  if (defer->getASTContext().isLanguageModeAtLeast(6))
     return true;
 
   // If the defer is part of a function that is a member of an actor or
@@ -3090,7 +3089,7 @@ static bool isDirectToStorageAccess(const DeclContext *UseDC,
     // In Swift 5 and later, the access must also be a member access on 'self'.
     if (!isAccessOnSelf &&
         var->getDeclContext()->isTypeContext() &&
-        var->getASTContext().isSwiftVersionAtLeast(5))
+        var->getASTContext().isLanguageModeAtLeast(5))
       return false;
 
     // As a special case, 'read' and 'modify' coroutines with forced static
@@ -4058,7 +4057,7 @@ bool swift::conflicting(ASTContext &ctx,
     // Prior to Swift 5, we permitted redeclarations of variables as different
     // declarations if the variable was declared in an extension of a generic
     // type. Make sure we maintain this behaviour in versions < 5.
-    if (!ctx.isSwiftVersionAtLeast(5)) {
+    if (!ctx.isLanguageModeAtLeast(5)) {
       if ((sig1.IsVariable && sig1.InExtensionOfGenericType) ||
           (sig2.IsVariable && sig2.InExtensionOfGenericType)) {
         if (wouldConflictInSwift5)
@@ -4082,7 +4081,7 @@ bool swift::conflicting(ASTContext &ctx,
   // Swift 5, a variable not in an extension of a generic type got a null
   // overload type instead of a function type as it does now, so we really
   // follow that behaviour and warn if there's going to be a conflict in future.
-  if (!ctx.isSwiftVersionAtLeast(5)) {
+  if (!ctx.isLanguageModeAtLeast(5)) {
     auto swift4Sig1Type = sig1.IsVariable && !sig1.InExtensionOfGenericType
                               ? CanType()
                               : sig1Type;
@@ -12207,8 +12206,8 @@ ActorIsolation swift::getActorIsolationOfContext(
     if (dcToUse->isAsyncContext() ||
         ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete) {
       if (Type mainActor = ctx.getMainActorType())
-        return ActorIsolation::forGlobalActor(mainActor)
-            .withPreconcurrency(!ctx.isSwiftVersionAtLeast(6));
+        return ActorIsolation::forGlobalActor(mainActor).withPreconcurrency(
+            !ctx.isLanguageModeAtLeast(6));
     }
   }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -459,8 +459,8 @@ InFlightDiagnostic::limitBehavior(DiagnosticBehavior limit) {
 }
 
 InFlightDiagnostic &
-InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
-    DiagnosticBehavior limit, unsigned majorVersion) {
+InFlightDiagnostic::limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
+                                                   unsigned majorVersion) {
   if (!Engine->languageVersion.isVersionAtLeast(majorVersion)) {
     // If the behavior limit is a warning or less, wrap the diagnostic
     // in a message that this will become an error in a later Swift
@@ -487,14 +487,14 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
   return *this;
 }
 
-InFlightDiagnostic &InFlightDiagnostic::warnUntilFutureSwiftVersion() {
+InFlightDiagnostic &InFlightDiagnostic::warnUntilFutureLanguageMode() {
   using namespace version;
-  return warnUntilSwiftVersion(Version::getFutureMajorLanguageVersion());
+  return warnUntilLanguageMode(Version::getFutureMajorLanguageVersion());
 }
 
 InFlightDiagnostic &
-InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
-  return limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning,
+InFlightDiagnostic::warnUntilLanguageMode(unsigned majorVersion) {
+  return limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
                                         majorVersion);
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -610,7 +610,7 @@ static void recordShadowedDeclsAfterTypeMatch(
       // This is due to the fact that in Swift 4, we only gave custom overload
       // types to properties in extensions of generic types, otherwise we
       // used the null type.
-      if (!ctx.isSwiftVersionAtLeast(5) && isa<ValueDecl>(firstDecl)) {
+      if (!ctx.isLanguageModeAtLeast(5) && isa<ValueDecl>(firstDecl)) {
         auto secondSig = cast<ValueDecl>(secondDecl)->getOverloadSignature();
         auto firstSig = cast<ValueDecl>(firstDecl)->getOverloadSignature();
         if (firstSig.IsVariable && secondSig.IsVariable)

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -1040,14 +1040,16 @@ InferredGenericSignatureRequest::evaluate(
           continue;
 
         if (reduced->isTypeParameter()) {
-          ctx.Diags.diagnose(loc, diag::requires_generic_params_made_equal,
-                             genericParam, result->getSugaredType(reduced))
-            .warnUntilSwiftVersion(6);
+          ctx.Diags
+              .diagnose(loc, diag::requires_generic_params_made_equal,
+                        genericParam, result->getSugaredType(reduced))
+              .warnUntilLanguageMode(6);
         } else {
-          ctx.Diags.diagnose(loc,
-                             diag::requires_generic_param_made_equal_to_concrete,
-                             genericParam)
-            .warnUntilSwiftVersion(6);
+          ctx.Diags
+              .diagnose(loc,
+                        diag::requires_generic_param_made_equal_to_concrete,
+                        genericParam)
+              .warnUntilLanguageMode(6);
         }
       }
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5277,7 +5277,8 @@ getConcurrencyDiagnosticBehaviorLimitRec(
   // Metatypes that aren't Sendable were introduced in Swift 6.2, so downgrade
   // them to warnings prior to Swift 7.
   if (type->is<AnyMetatypeType>()) {
-    if (!type->getASTContext().LangOpts.isSwiftVersionAtLeast(7))
+    if (!type->getASTContext().isLanguageModeAtLeast(
+            version::Version::getFutureMajorLanguageVersion()))
       return DiagnosticBehavior::Warning;
   }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -379,7 +379,7 @@ ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) c
 
   // Previously we didn't perform the lookup of 'self' for anything outside
   // of a '[weak self]' closure, maintain that behavior until Swift 6 mode.
-  if (!Ctx.LangOpts.isSwiftVersionAtLeast(6) && !capturesSelfWeakly)
+  if (!Ctx.isLanguageModeAtLeast(6) && !capturesSelfWeakly)
     return nullptr;
 
   auto selfDecl = ASTScope::lookupSingleLocalDecl(DC->getParentSourceFile(),
@@ -413,7 +413,7 @@ ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) c
   // In these cases, using the Swift 6 lookup behavior doesn't affect
   // how the body is type-checked, so it can be used in Swift 5 mode
   // without breaking source compatibility for non-escaping closures.
-  if (!Ctx.LangOpts.isSwiftVersionAtLeast(6) &&
+  if (!Ctx.isLanguageModeAtLeast(6) &&
       !implicitSelfReferenceIsUnwrapped(selfDecl)) {
     return nullptr;
   }

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -42,7 +42,7 @@ llvm::StringRef Feature::getName() const {
 std::optional<Feature> Feature::getUpcomingFeature(llvm::StringRef name) {
   return llvm::StringSwitch<std::optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version)                       \
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \
   .Case(#FeatureName, Feature::FeatureName)
 #include "swift/Basic/Features.def"
       .Default(std::nullopt);
@@ -57,12 +57,12 @@ std::optional<Feature> Feature::getExperimentalFeature(llvm::StringRef name) {
       .Default(std::nullopt);
 }
 
-std::optional<unsigned> Feature::getLanguageVersion() const {
+std::optional<unsigned> Feature::getLanguageMode() const {
   switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version)                       \
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \
   case Feature::FeatureName:                                                   \
-    return Version;
+    return LanguageMode;
 #include "swift/Basic/Features.def"
   default:
     return std::nullopt;
@@ -71,7 +71,7 @@ std::optional<unsigned> Feature::getLanguageVersion() const {
 
 bool Feature::isMigratable() const {
   switch (kind) {
-#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
@@ -79,7 +79,7 @@ bool Feature::isMigratable() const {
 #include "swift/Basic/Features.def"
     return false;
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)            \
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)       \
   case Feature::FeatureName:
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)          \
   case Feature::FeatureName:

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -37,7 +37,7 @@ LangOptions::LangOptions() {
   // Add all promoted language features
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   enableFeature(Feature::FeatureName);
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)
 #define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #include "swift/Basic/Features.def"
@@ -334,8 +334,8 @@ LangOptions::FeatureState LangOptions::getFeatureState(Feature feature) const {
   if (state.isEnabled())
     return state;
 
-  if (auto version = feature.getLanguageVersion()) {
-    if (isSwiftVersionAtLeast(*version)) {
+  if (auto version = feature.getLanguageMode()) {
+    if (isLanguageModeAtLeast(*version)) {
       return FeatureState(feature, FeatureState::Kind::Enabled);
     }
   }
@@ -348,8 +348,8 @@ bool LangOptions::hasFeature(Feature feature, bool allowMigration) const {
   if (state.isEnabled())
     return true;
 
-  if (auto version = feature.getLanguageVersion()) {
-    if (isSwiftVersionAtLeast(*version))
+  if (auto version = feature.getLanguageMode()) {
+    if (isLanguageModeAtLeast(*version))
       return true;
   }
 

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -44,7 +44,7 @@ static std::vector<DiagGroupID> migratableCategories(Feature feature) {
 
     // Provide unreachable cases for all of the non-migratable features.
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description) case Feature::FeatureName:
-#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Name)
 #include "swift/Basic/Features.def"
@@ -82,7 +82,8 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
 
   std::array upcoming{
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version) Feature::FeatureName,
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \
+  Feature::FeatureName,
 #include "swift/Basic/Features.def"
   };
 
@@ -113,7 +114,7 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
       });
       out << "]";
     }
-    if (auto version = feature.getLanguageVersion()) {
+    if (auto version = feature.getLanguageMode()) {
       out << ", \"enabled_in\": \"" << *version << "\"";
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5979,7 +5979,7 @@ namespace {
 
       auto access = AccessLevel::Open;
       if (decl->hasAttr<clang::ObjCSubclassingRestrictedAttr>() &&
-          Impl.SwiftContext.isSwiftVersionAtLeast(5)) {
+          Impl.SwiftContext.isLanguageModeAtLeast(5)) {
         access = AccessLevel::Public;
       }
 

--- a/lib/DriverTool/sil_llvm_gen_main.cpp
+++ b/lib/DriverTool/sil_llvm_gen_main.cpp
@@ -354,8 +354,8 @@ int sil_llvm_gen_main(ArrayRef<const char *> argv, void *MainAddr) {
       exit(-1);
     }
 
-    if (auto firstVersion = feature->getLanguageVersion()) {
-      if (Invocation.getLangOptions().isSwiftVersionAtLeast(*firstVersion)) {
+    if (auto firstVersion = feature->getLanguageMode()) {
+      if (Invocation.getLangOptions().isLanguageModeAtLeast(*firstVersion)) {
         llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
                      << " is already enabled as of Swift version "
                      << *firstVersion << '\n';

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -765,8 +765,8 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       exit(-1);
     }
 
-    if (auto firstVersion = feature->getLanguageVersion()) {
-      if (Invocation.getLangOptions().isSwiftVersionAtLeast(*firstVersion)) {
+    if (auto firstVersion = feature->getLanguageMode()) {
+      if (Invocation.getLangOptions().isLanguageModeAtLeast(*firstVersion)) {
         llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
                      << " is already enabled as of Swift version "
                      << *firstVersion << '\n';

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -905,8 +905,8 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     // If the current language mode enables the feature by default then
     // diagnose and skip it.
-    if (auto firstVersion = feature->getLanguageVersion()) {
-      if (Opts.isSwiftVersionAtLeast(*firstVersion)) {
+    if (auto firstVersion = feature->getLanguageMode()) {
+      if (Opts.isLanguageModeAtLeast(*firstVersion)) {
         Diags.diagnose(SourceLoc(),
                        diag::warning_upcoming_feature_on_by_default,
                        feature->getName(), *firstVersion);
@@ -1283,8 +1283,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // Add a future feature if it is not already implied by the language version.
   auto addFutureFeatureIfNotImplied = [&](Feature feature) {
     // Check if this feature was introduced already in this language version.
-    if (auto firstVersion = feature.getLanguageVersion()) {
-      if (Opts.isSwiftVersionAtLeast(*firstVersion))
+    if (auto firstVersion = feature.getLanguageMode()) {
+      if (Opts.isLanguageModeAtLeast(*firstVersion))
         return;
     }
 
@@ -1454,7 +1454,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
                    OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
-                   Opts.isSwiftVersionAtLeast(5))) {
+                   Opts.isLanguageModeAtLeast(5))) {
     Opts.enableFeature(Feature::NonfrozenEnumExhaustivity);
   }
 
@@ -1867,7 +1867,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
       HadError = true;
     }
-  } else if (Opts.isSwiftVersionAtLeast(6)) {
+  } else if (Opts.isLanguageModeAtLeast(6)) {
     Opts.UseCheckedAsyncObjCBridging = true;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1520,7 +1520,7 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     }
     if (Invocation.getLangOptions().hasFeature(Feature::LibraryEvolution))
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
-    if (Invocation.getLangOptions().isSwiftVersionAtLeast(6))
+    if (Invocation.getLangOptions().isLanguageModeAtLeast(6))
       MainModule->setIsConcurrencyChecked(true);
     if (Invocation.getLangOptions().EnableCXXInterop &&
         Invocation.getLangOptions()

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -199,11 +199,11 @@ printModuleInterfaceIfNeeded(llvm::vfs::OutputBackend &outputBackend,
     return false;
 
   DiagnosticEngine &diags = M->getDiags();
-  if (!LangOpts.isSwiftVersionAtLeast(5)) {
-    assert(LangOpts.isSwiftVersionAtLeast(4));
+  if (!LangOpts.isLanguageModeAtLeast(5)) {
+    assert(LangOpts.isLanguageModeAtLeast(4));
     diags.diagnose(SourceLoc(),
                    diag::warn_unsupported_module_interface_swift_version,
-                   LangOpts.isSwiftVersionAtLeast(4, 2) ? "4.2" : "4");
+                   LangOpts.isLanguageModeAtLeast(4, 2) ? "4.2" : "4");
   }
   if (M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
     diags.diagnose(SourceLoc(),

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -739,12 +739,12 @@ static void computeEnabledFeatures(ASTContext &ctx,
 
   static const FeatureAndName features[] = {
 #define FEATURE_ENTRY(FeatureName) {Feature::FeatureName, #FeatureName},
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Version)
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)                     \
   FEATURE_ENTRY(FeatureName)
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version)                       \
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \
   FEATURE_ENTRY(FeatureName)
-#define OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Version)              \
+#define OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Description)          \
   FEATURE_ENTRY(FeatureName)
 #include "swift/Basic/Features.def"
   };

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4131,7 +4131,7 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
     consumeToken();
     if (Version.empty()) {
       // Versions cannot be empty (e.g. "0").
-      diagnose(Range.Start, D).warnUntilSwiftVersion(6);
+      diagnose(Range.Start, D).warnUntilLanguageMode(6);
       return true;
     }
     return false;
@@ -4172,7 +4172,7 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
 
   if (Version.empty()) {
     // Versions cannot be empty (e.g. "0.0").
-    diagnose(Range.Start, D).warnUntilSwiftVersion(6);
+    diagnose(Range.Start, D).warnUntilLanguageMode(6);
     return true;
   }
 
@@ -4210,7 +4210,7 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(SourceLoc atLoc) {
   if (isAtAttributeLParen(/*isCustomAttribute=*/true)) {
     if (getEndOfPreviousLoc() != Tok.getLoc()) {
       diagnose(getEndOfPreviousLoc(), diag::attr_extra_whitespace_before_lparen)
-          .warnUntilSwiftVersion(6);
+          .warnUntilLanguageMode(6);
     }
     // If we have no local context to parse the initial value into, create
     // one for the attribute.
@@ -4269,7 +4269,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
                                         bool isFromClangAttribute) {
   if (AtEndLoc != Tok.getLoc()) {
     diagnose(AtEndLoc, diag::attr_extra_whitespace_after_at)
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
   }
 
   bool hasModuleSelector = peekToken().is(tok::colon_colon);
@@ -4332,12 +4332,12 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
 
   // In Swift 5 and above, these become hard errors. In Swift 4.2, emit a
   // warning for compatibility. Otherwise, don't diagnose at all.
-  if (Context.isSwiftVersionAtLeast(5)) {
+  if (Context.isLanguageModeAtLeast(5)) {
     checkInvalidAttrName("_versioned", "usableFromInline",
                          DeclAttrKind::UsableFromInline, diag::attr_renamed);
     checkInvalidAttrName("_inlineable", "inlinable", DeclAttrKind::Inlinable,
                          diag::attr_renamed);
-  } else if (Context.isSwiftVersionAtLeast(4, 2)) {
+  } else if (Context.isLanguageModeAtLeast(4, 2)) {
     checkInvalidAttrName("_versioned", "usableFromInline",
                          DeclAttrKind::UsableFromInline,
                          diag::attr_renamed_warning);
@@ -4688,7 +4688,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
                                         bool justChecking) {
   if (AtEndLoc != Tok.getLoc()) {
     diagnose(AtEndLoc, diag::attr_extra_whitespace_after_at)
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
   }
 
   // If this not an identifier, the attribute is malformed.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -180,7 +180,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     // Per SE-0155, enum elements may not have empty parameter lists.
     if (paramContext == ParameterContextKind::EnumElement) {
       decltype(diag::enum_element_empty_arglist) diagnostic;
-      if (Context.isSwiftVersionAtLeast(5)) {
+      if (Context.isLanguageModeAtLeast(5)) {
         diagnostic = diag::enum_element_empty_arglist;
       } else {
         diagnostic = diag::enum_element_empty_arglist_swift4;
@@ -247,8 +247,9 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         }
         
         if (Tok.isContextualKeyword("isolated")) {
-          diagnose(Tok, diag::parameter_specifier_as_attr_disallowed, Tok.getText())
-                    .warnUntilSwiftVersion(6);
+          diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
+                   Tok.getText())
+              .warnUntilLanguageMode(6);
           // did we already find an 'isolated' type modifier?
           if (param.IsolatedLoc.isValid()) {
             diagnose(Tok, diag::parameter_specifier_repeated)
@@ -263,8 +264,9 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         }
 
         if (Tok.isContextualKeyword("_const")) {
-          diagnose(Tok, diag::parameter_specifier_as_attr_disallowed, Tok.getText())
-                    .warnUntilSwiftVersion(6);
+          diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
+                   Tok.getText())
+              .warnUntilLanguageMode(6);
           param.CompileConstLoc = consumeToken();
           continue;
         }
@@ -273,7 +275,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
             Tok.isContextualKeyword("sending")) {
           diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
                    Tok.getText())
-              .warnUntilSwiftVersion(6);
+              .warnUntilLanguageMode(6);
           if (param.SendingLoc.isValid()) {
             diagnose(Tok, diag::parameter_specifier_repeated)
                 .fixItRemove(Tok.getLoc());
@@ -456,9 +458,9 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                 diagnose(typeStartLoc, diag::parameter_unnamed)
                     .fixItInsert(typeStartLoc, "_: ");
             } else {
-                diagnose(typeStartLoc, diag::parameter_unnamed)
-                    .warnUntilSwiftVersion(6)
-                    .fixItInsert(typeStartLoc, "_: ");
+              diagnose(typeStartLoc, diag::parameter_unnamed)
+                  .warnUntilLanguageMode(6)
+                  .fixItInsert(typeStartLoc, "_: ");
             }
           }
         }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -607,7 +607,7 @@ SourceLoc Parser::consumeAttributeLParen() {
   SourceLoc LastTokenEndLoc = getEndOfPreviousLoc();
   if (LastTokenEndLoc != Tok.getLoc() && !isInSILMode()) {
     diagnose(LastTokenEndLoc, diag::attr_extra_whitespace_before_lparen)
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
   }
   return consumeToken(tok::l_paren);
 }
@@ -623,7 +623,7 @@ bool Parser::isAtAttributeLParen(bool isCustomAttr) {
   if (!Tok.isFollowingLParen())
     return false;
 
-  if (Context.isSwiftVersionAtLeast(6)) {
+  if (Context.isLanguageModeAtLeast(6)) {
     // No-space '(' are always arguments.
     if (getEndOfPreviousLoc() == Tok.getLoc())
       return true;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1423,7 +1423,7 @@ private:
       // because it's a diagnostic inflicted on /clients/, but it's close
       // enough. It really is invalid to call +new when -init is unavailable.
       StringRef annotationName = "SWIFT_UNAVAILABLE_MSG";
-      if (!getASTContext().isSwiftVersionAtLeast(5))
+      if (!getASTContext().isLanguageModeAtLeast(5))
         annotationName = "SWIFT_DEPRECATED_MSG";
       os << "+ (nonnull instancetype)new " << annotationName
          << "(\"-init is unavailable\");\n";

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -650,7 +650,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   MarkUninitializedInst::Kind MUIKind;
   if (isDelegating) {
     MUIKind = MarkUninitializedInst::DelegatingSelf;
-  } else if (getASTContext().isSwiftVersionAtLeast(5)) {
+  } else if (getASTContext().isLanguageModeAtLeast(5)) {
     MUIKind = MarkUninitializedInst::RootSelf;
   } else {
     auto *dc = ctor->getParent();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1295,7 +1295,7 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // FIXME: Much of this was copied from visitOptionalEvaluationExpr.
 
   // Prior to Swift 5, an optional try's subexpression is always wrapped in an additional optional
-  bool shouldWrapInOptional = !(SGF.getASTContext().LangOpts.isSwiftVersionAtLeast(5));
+  bool shouldWrapInOptional = !(SGF.getASTContext().isLanguageModeAtLeast(5));
   
   auto &optTL = SGF.getTypeLowering(E->getType());
 

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -474,7 +474,7 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
       diag.diagnose(illegalLoc.getSourceLoc(),
                     diag::isolated_property_mutation_in_nonisolated_context,
                     accessor->getStorage(), accessor->isSetter())
-          .warnUntilSwiftVersion(6);
+          .warnUntilLanguageMode(6);
       continue;
     }
 
@@ -486,7 +486,7 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
     diag.diagnose(illegalLoc.getSourceLoc(), diag::isolated_after_nonisolated,
                   forDeinit, var)
         .highlight(illegalLoc.getSourceRange())
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
 
     // after <verb><adjective> <subject>, ... can't use self anymore, etc ...
     //   example:

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -324,7 +324,7 @@ template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseError(ASTContext &context, SourceLoc loc,
                                         Diag<T...> diag, U &&...args) {
   return std::move(context.Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                       .warnUntilSwiftVersion(6));
+                       .warnUntilLanguageMode(6));
 }
 
 template <typename... T, typename... U>
@@ -1087,7 +1087,7 @@ private:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -1553,8 +1553,12 @@ public:
     // If the failure is due to an isolated conformance, downgrade the error
     // to a warning prior to Swift 7.
     if (isolationRegionInfo.getIsolationInfo().getIsolatedConformance() &&
-        !sendingOperand->get()->getType().getASTType()->getASTContext().LangOpts
-          .isSwiftVersionAtLeast(7))
+        !sendingOperand->get()
+             ->getType()
+             .getASTType()
+             ->getASTContext()
+             .isLanguageModeAtLeast(
+                 version::Version::getFutureMajorLanguageVersion()))
       return DiagnosticBehavior::Warning;
 
     return sendingOperand->get()->getType().getConcurrencyDiagnosticBehavior(
@@ -1866,7 +1870,7 @@ private:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -2481,7 +2485,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -3004,7 +3008,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -3135,7 +3139,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -3345,7 +3349,7 @@ struct NonSendableIsolationCrossingResultDiagnosticEmitter {
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>
@@ -3577,7 +3581,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilSwiftVersion(6));
+                         .warnUntilLanguageMode(6));
   }
 
   template <typename... T, typename... U>

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -301,7 +301,7 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
         ctx.evaluator, ConformanceAccessScopeRequest{dc, proto},
         std::make_pair(AccessScope::getPublic(), false));
 
-    if (!ctx.isSwiftVersionAtLeast(5) &&
+    if (!ctx.isLanguageModeAtLeast(5) &&
         !dc->getParentModule()->isResilient()) {
       // HACK: In pre-Swift-5, these typealiases were synthesized with the
       // same access level as the conforming type, which might be more
@@ -536,7 +536,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     // AsyncSequence.Failure. We'll infer it from the AsyncIterator.Failure
     // instead.
     if (isAsyncSequenceFailure(assocType) &&
-        !ctx.LangOpts.isSwiftVersionAtLeast(6) &&
+        !ctx.isLanguageModeAtLeast(6) &&
         assocType->getName() == typeDecl->getName())
       continue;;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3749,7 +3749,7 @@ namespace {
       //
       // The result is that in Swift 5, 'try?' avoids producing nested optionals.
       
-      if (!ctx.LangOpts.isSwiftVersionAtLeast(5)) {
+      if (!ctx.isLanguageModeAtLeast(5)) {
         // Nothing to do for Swift 4 and earlier!
         return simplifyExprType(expr);
       }
@@ -4316,7 +4316,7 @@ namespace {
       // be an optional type, leave any extra optionals on the source in place.
       // Only apply the latter condition in Swift 5 mode to best preserve
       // compatibility with Swift 4.1's casting behaviour.
-      if (isBridgeToAnyObject || (ctx.isSwiftVersionAtLeast(5) &&
+      if (isBridgeToAnyObject || (ctx.isLanguageModeAtLeast(5) &&
                                   destValueType->canDynamicallyBeOptionalType(
                                       /*includeExistential*/ false))) {
         auto destOptionalsCount = destOptionals.size() - destExtraOptionals;
@@ -5822,7 +5822,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr,
     concatLabels(labels, toLabelStr);
 
     using namespace version;
-    if (ctx.isSwiftVersionAtLeast(Version::getFutureMajorLanguageVersion())) {
+    if (ctx.isLanguageModeAtLeast(Version::getFutureMajorLanguageVersion())) {
       ctx.Diags.diagnose(expr->getLoc(), diag::reordering_tuple_shuffle,
                          fromLabelStr, toLabelStr);
     } else {
@@ -6189,7 +6189,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     // Both the caller and the allee are in the same module.
     if (dc->getParentModule() == decl->getModuleContext()) {
-      return !dc->getASTContext().isSwiftVersionAtLeast(6);
+      return !dc->getASTContext().isLanguageModeAtLeast(6);
     }
 
     // If we cannot figure out where the callee came from, let's conservatively
@@ -6366,7 +6366,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
         // to be used by value if parameter would return a function
         // type (it just needs to get wrapped into autoclosure expr),
         // otherwise argument must always form a call.
-        return ctx.isSwiftVersionAtLeast(5);
+        return ctx.isLanguageModeAtLeast(5);
       }
 
       return true;
@@ -7120,8 +7120,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // ```
       //
       // See also: https://github.com/apple/swift/issues/49345
-      if (ctx.isSwiftVersionAtLeast(4) &&
-          !ctx.isSwiftVersionAtLeast(5)) {
+      if (ctx.isLanguageModeAtLeast(4) &&
+          !ctx.isLanguageModeAtLeast(5)) {
         auto obj1 = fromType->getOptionalObjectType();
         auto obj2 = toType->getOptionalObjectType();
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1806,7 +1806,7 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   auto *unwrappedExpr = anchor->getValueProvidingExpr();
 
   if (auto *tryExpr = dyn_cast<OptionalTryExpr>(unwrappedExpr)) {
-    bool isSwift5OrGreater = getASTContext().isSwiftVersionAtLeast(5);
+    bool isSwift5OrGreater = getASTContext().isLanguageModeAtLeast(5);
     auto subExprType = getType(tryExpr->getSubExpr());
     bool subExpressionIsOptional = (bool)subExprType->getOptionalObjectType();
 
@@ -8160,7 +8160,7 @@ bool SendingMismatchFailure::diagnoseAsError() {
 bool SendingMismatchFailure::diagnoseArgFailure() {
   emitDiagnostic(diag::sending_function_wrong_sending, getFromType(),
                  getToType())
-      .warnUntilSwiftVersion(6);
+      .warnUntilLanguageMode(6);
   emitDiagnostic(diag::sending_function_param_with_sending_param_note);
   return true;
 }
@@ -8168,7 +8168,7 @@ bool SendingMismatchFailure::diagnoseArgFailure() {
 bool SendingMismatchFailure::diagnoseResultFailure() {
   emitDiagnostic(diag::sending_function_wrong_sending, getFromType(),
                  getToType())
-      .warnUntilSwiftVersion(6);
+      .warnUntilLanguageMode(6);
   emitDiagnostic(diag::sending_function_result_with_sending_param_note);
   return true;
 }
@@ -9423,7 +9423,7 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
 bool TupleLabelMismatchWarning::diagnoseAsError() {
   emitDiagnostic(diag::tuple_label_mismatch, getFromType(), getToType())
       .highlight(getSourceRange())
-      .warnUntilFutureSwiftVersion();
+      .warnUntilFutureLanguageMode();
   return true;
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -295,7 +295,8 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
     // Passing a static member reference as an argument needs to be downgraded
     // to a warning until future major mode to maintain source compatibility for
     // code with non-Sendable metatypes.
-    if (!cs.getASTContext().LangOpts.isSwiftVersionAtLeast(7)) {
+    if (!cs.getASTContext().isLanguageModeAtLeast(
+            version::Version::getFutureMajorLanguageVersion())) {
       auto *argLoc = cs.getConstraintLocator(locator);
       if (auto *argument = getAsExpr(simplifyLocatorToAnchor(argLoc))) {
         if (auto overload = cs.findSelectedOverloadFor(
@@ -330,7 +331,7 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
   }
 
   // Otherwise, warn until Swift 6.
-  if (!cs.getASTContext().LangOpts.isSwiftVersionAtLeast(6))
+  if (!cs.getASTContext().isLanguageModeAtLeast(6))
     return FixBehavior::DowngradeToWarning;
 
   return FixBehavior::Error;
@@ -1997,7 +1998,7 @@ bool AllowSendingMismatch::diagnose(const Solution &solution,
 AllowSendingMismatch *AllowSendingMismatch::create(ConstraintSystem &cs,
                                                    Type srcType, Type dstType,
                                                    ConstraintLocator *locator) {
-  auto fixBehavior = cs.getASTContext().LangOpts.isSwiftVersionAtLeast(6)
+  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(6)
                          ? FixBehavior::Error
                          : FixBehavior::DowngradeToWarning;
   return new (cs.getAllocator())
@@ -2779,7 +2780,7 @@ bool AllowFunctionSpecialization::diagnose(const Solution &solution,
 AllowFunctionSpecialization *
 AllowFunctionSpecialization::create(ConstraintSystem &cs, ValueDecl *decl,
                                     ConstraintLocator *locator) {
-  auto fixBehavior = cs.getASTContext().isSwiftVersionAtLeast(6)
+  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(6)
                          ? FixBehavior::Error
                          : FixBehavior::DowngradeToWarning;
   return new (cs.getAllocator())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1938,7 +1938,7 @@ namespace {
         // rdar://85263844, as it can affect the prioritization of bindings,
         // which can affect behavior for tuple matching as tuple subtyping is
         // currently a *weaker* constraint than tuple conversion.
-        if (!CS.getASTContext().isSwiftVersionAtLeast(6)) {
+        if (!CS.getASTContext().isLanguageModeAtLeast(6)) {
           auto paramTypeVar = CS.createTypeVariable(
               CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument),
               TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape |
@@ -2123,7 +2123,7 @@ namespace {
       // NB Keep adding the additional layer in Swift 5 and on if this 'try?'
       // applies to a delegation to an 'Optional' initializer, or else we won't
       // discern the difference between a failure and a constructed value.
-      if (CS.getASTContext().LangOpts.isSwiftVersionAtLeast(5) &&
+      if (CS.getASTContext().isLanguageModeAtLeast(5) &&
           !isDelegationToOptionalInit) {
         CS.addConstraint(ConstraintKind::Conversion,
                          CS.getType(expr->getSubExpr()), optTy,

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -566,7 +566,7 @@ bool CompareDeclSpecializationRequest::evaluate(
   //      x.i // ensure ambiguous.
   //    }
   //
-  if (C.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
+  if (C.isLanguageModeAtLeast(5) && !isDynamicOverloadComparison) {
     auto inProto1 = isa<ProtocolDecl>(outerDC1);
     auto inProto2 = isa<ProtocolDecl>(outerDC2);
     if (inProto1 != inProto2)
@@ -1307,7 +1307,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // compatibility under Swift 4 mode by ensuring we don't introduce any new
     // ambiguities. This will become a more general "is more specialised" rule
     // in Swift 5 mode.
-    if (!cs.getASTContext().isSwiftVersionAtLeast(5) &&
+    if (!cs.getASTContext().isLanguageModeAtLeast(5) &&
         choice1.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         choice2.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
@@ -1516,7 +1516,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   // All other things being equal, apply the Swift 4.1 compatibility hack for
   // preferring var members in concrete types over a protocol requirement
   // (see the comment above for the rationale of this hack).
-  if (!cs.getASTContext().isSwiftVersionAtLeast(5) && score1 == score2) {
+  if (!cs.getASTContext().isLanguageModeAtLeast(5) && score1 == score2) {
     score1 += isVarAndNotProtocol1;
     score2 += isVarAndNotProtocol2;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1783,7 +1783,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         // this is Swift version >= 5 where forwarding is not allowed,
         // argument would always be wrapped into an implicit closure
         // at the end, so we can safely match against result type.
-        if (ctx.isSwiftVersionAtLeast(5) || !isAutoClosureArgument(argExpr)) {
+        if (ctx.isLanguageModeAtLeast(5) || !isAutoClosureArgument(argExpr)) {
           // In Swift >= 5 mode there is no @autoclosure forwarding,
           // so let's match result types.
           if (auto *fnType = paramTy->getAs<FunctionType>()) {
@@ -2593,7 +2593,7 @@ static bool isSingleTupleParam(ASTContext &ctx,
   // let foo: ((Int, Int)?) -> Void = { _ in }
   //
   // bar(foo) // Ok
-  if (!ctx.isSwiftVersionAtLeast(5))
+  if (!ctx.isLanguageModeAtLeast(5))
     paramType = paramType->lookThroughAllOptionalTypes();
 
   // Parameter type should either a tuple or something that can become a
@@ -3398,7 +3398,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
             canImplodeParams(func1Params, /*destFn*/ func2)) {
           implodeParams(func1Params);
           increaseScore(SK_FunctionConversion, locator);
-        } else if (!ctx.isSwiftVersionAtLeast(5) &&
+        } else if (!ctx.isLanguageModeAtLeast(5) &&
                    isSingleTupleParam(ctx, func1Params) &&
                    canImplodeParams(func2Params,  /*destFn*/ func1)) {
           auto *simplified = locator.trySimplifyToExpr();
@@ -3485,8 +3485,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   // https://github.com/apple/swift/issues/49345
   // Add a super-narrow hack to allow '(()) -> T' to be passed in place
   // of '() -> T'.
-  if (getASTContext().isSwiftVersionAtLeast(4) &&
-      !getASTContext().isSwiftVersionAtLeast(5)) {
+  if (getASTContext().isLanguageModeAtLeast(4) &&
+      !getASTContext().isLanguageModeAtLeast(5)) {
     SmallVector<LocatorPathElt, 4> path;
     locator.getLocatorParts(path);
 
@@ -4669,7 +4669,7 @@ ConstraintSystem::matchTypesBindTypeVar(
             ->isLastElement<LocatorPathElt::ApplyArgument>();
 
     if (!(typeVar->getImpl().canBindToPack() && representsParameterList) ||
-        getASTContext().isSwiftVersionAtLeast(6)) {
+        getASTContext().isLanguageModeAtLeast(6)) {
       if (!shouldAttemptFixes())
         return getTypeMatchFailure(locator);
 
@@ -5049,8 +5049,7 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
 
   if (auto *optTryExpr = dyn_cast<OptionalTryExpr>(anchor)) {
     auto subExprType = cs.getType(optTryExpr->getSubExpr());
-    const bool isSwift5OrGreater =
-        cs.getASTContext().LangOpts.isSwiftVersionAtLeast(5);
+    const bool isSwift5OrGreater = cs.getASTContext().isLanguageModeAtLeast(5);
 
     if (subExprType->getOptionalObjectType()) {
       if (isSwift5OrGreater) {
@@ -5762,7 +5761,7 @@ bool ConstraintSystem::repairFailures(
           // (note that `swift_attr` in type contexts weren't supported
           // before) and for witnesses to adopt them gradually by matching
           // with a warning in non-strict concurrency mode.
-          if (!(Context.isSwiftVersionAtLeast(6) ||
+          if (!(Context.isLanguageModeAtLeast(6) ||
                 Context.LangOpts.StrictConcurrencyLevel ==
                     StrictConcurrency::Complete)) {
             auto strippedLHS = lhs->stripConcurrency(/*recursive=*/true,
@@ -8647,7 +8646,7 @@ ConstraintSystem::simplifyConstructionConstraint(
   // affect the prioritization of bindings, which can affect behavior for tuple
   // matching as tuple subtyping is currently a *weaker* constraint than tuple
   // conversion.
-  if (!getASTContext().isSwiftVersionAtLeast(6)) {
+  if (!getASTContext().isLanguageModeAtLeast(6)) {
     auto paramTypeVar = createTypeVariable(
         getConstraintLocator(locator, ConstraintLocator::ApplyArgument),
         TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape |
@@ -10814,7 +10813,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // Backward compatibility hack. In Swift 4, `init` and init were
   // the same name, so you could write "foo.init" to look up a
   // method or property named `init`.
-  if (!ctx.isSwiftVersionAtLeast(5) &&
+  if (!ctx.isLanguageModeAtLeast(5) &&
       memberName.getBaseName().isConstructor() && !isImplicitInit) {
     auto &compatLookup = lookupMember(instanceTy,
                                       DeclNameRef(ctx.getIdentifier("init")),
@@ -12739,7 +12738,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
   // type must be a (potentially optional) type variable, as only such a
   // constraint could have been previously been left unsolved.
   auto canUseCompatFix = [&]() {
-    if (Context.isSwiftVersionAtLeast(6))
+    if (Context.isLanguageModeAtLeast(6))
       return false;
 
     if (!rawType1->lookThroughAllOptionalTypes()->isTypeVariableOrMember())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -399,11 +399,13 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
             // If different isolated stored properties require different
             // global actors, it is impossible to initialize this type.
             if (existingIsolation != isolation) {
-              ctx.Diags.diagnose(decl->getLoc(),
-                  diag::conflicting_stored_property_isolation,
-                  ICK == ImplicitConstructorKind::Memberwise,
-                  decl->getDeclaredType(), existingIsolation, isolation)
-                .warnUntilSwiftVersion(6);
+              ctx.Diags
+                  .diagnose(decl->getLoc(),
+                            diag::conflicting_stored_property_isolation,
+                            ICK == ImplicitConstructorKind::Memberwise,
+                            decl->getDeclaredType(), existingIsolation,
+                            isolation)
+                  .warnUntilLanguageMode(6);
               if (previousVar) {
                 previousVar->diagnose(diag::property_requires_actor,
                                       previousVar, existingIsolation);
@@ -944,11 +946,12 @@ static void diagnoseMissingRequiredInitializer(
   }
 
   // Complain.
-  ctx.Diags.diagnose(insertionLoc, diag::required_initializer_missing,
-                     superInitializer->getName(),
-                     superInitializer->getDeclContext()->getDeclaredInterfaceType())
-    .warnUntilSwiftVersionIf(downgradeToWarning, 6)
-    .fixItInsert(insertionLoc, initializerText);
+  ctx.Diags
+      .diagnose(insertionLoc, diag::required_initializer_missing,
+                superInitializer->getName(),
+                superInitializer->getDeclContext()->getDeclaredInterfaceType())
+      .warnUntilLanguageModeIf(downgradeToWarning, 6)
+      .fixItInsert(insertionLoc, initializerText);
 
   ctx.Diags.diagnose(findNonImplicitRequiredInit(superInitializer),
                      diag::required_initializer_here);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5036,7 +5036,7 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   // get any special power from being formed in certain contexts, such
   // as the ability to assign to `let`s in initialization contexts, so
   // we pass null for the DC to `isSettable` here.)
-  if (!getASTContext().isSwiftVersionAtLeast(5)) {
+  if (!getASTContext().isLanguageModeAtLeast(5)) {
     // As a source-compatibility measure, continue to allow
     // WritableKeyPaths to be formed in the same conditions we did
     // in previous releases even if we should not be able to set

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -746,7 +746,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         //   subscript, or ObjC literal since it used to be accepted.
         // - member type expressions rooted on non-identifier types, e.g.
         //   '[X].Y' since they used to be accepted without the '.self'.
-        if (!Ctx.LangOpts.isSwiftVersionAtLeast(6)) {
+        if (!Ctx.isLanguageModeAtLeast(6)) {
           if (isa<SubscriptExpr>(ParentExpr) ||
               isa<DynamicSubscriptExpr>(ParentExpr) ||
               isa<ObjectLiteralExpr>(ParentExpr)) {
@@ -1897,7 +1897,7 @@ public:
 
     // Prior to Swift 6, use the old validation logic.
     auto &ctx = inClosure->getASTContext();
-    if (!ctx.isSwiftVersionAtLeast(6))
+    if (!ctx.isLanguageModeAtLeast(6))
       return selfDeclAllowsImplicitSelf510(DRE, ty, inClosure);
 
     return selfDeclAllowsImplicitSelf(DRE->getDecl(), ty, inClosure,
@@ -2282,7 +2282,7 @@ public:
 
   bool shouldRecordClosure(const AbstractClosureExpr *E) {
     // Record all closures in Swift 6 mode.
-    if (Ctx.isSwiftVersionAtLeast(6))
+    if (Ctx.isLanguageModeAtLeast(6))
       return true;
 
     // Only record closures requiring self qualification prior to Swift 6
@@ -2298,7 +2298,7 @@ public:
     std::optional<unsigned> warnUntilVersion;
     // Prior to Swift 6, we may need to downgrade to a warning for compatibility
     // with the 5.10 diagnostic behavior.
-    if (!Ctx.isSwiftVersionAtLeast(6) &&
+    if (!Ctx.isLanguageModeAtLeast(6) &&
         invalidImplicitSelfShouldOnlyWarn510(base, closure)) {
       warnUntilVersion.emplace(6);
     }
@@ -2306,12 +2306,12 @@ public:
     // macro to preserve compatibility with the Swift 6 diagnostic behavior
     // where we previously skipped diagnosing.
     auto futureVersion = version::Version::getFutureMajorLanguageVersion();
-    if (!Ctx.isSwiftVersionAtLeast(futureVersion) && isInMacro())
+    if (!Ctx.isLanguageModeAtLeast(futureVersion) && isInMacro())
       warnUntilVersion.emplace(futureVersion);
 
     auto diag = Ctx.Diags.diagnose(loc, ID, std::move(Args)...);
     if (warnUntilVersion)
-      diag.warnUntilSwiftVersion(*warnUntilVersion);
+      diag.warnUntilLanguageMode(*warnUntilVersion);
 
     return diag;
   }
@@ -2370,7 +2370,7 @@ public:
 
     if (memberLoc.isValid()) {
       const AbstractClosureExpr *parentDisallowingImplicitSelf = nullptr;
-      if (Ctx.isSwiftVersionAtLeast(6) && selfDRE && selfDRE->getDecl()) {
+      if (Ctx.isLanguageModeAtLeast(6) && selfDRE && selfDRE->getDecl()) {
         parentDisallowingImplicitSelf = parentClosureDisallowingImplicitSelf(
             selfDRE->getDecl(), selfDRE->getType(), ACE);
       }
@@ -5484,7 +5484,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
       // Do not warn on coercions from implicitly unwrapped optionals
       // for Swift versions less than 5.
-      if (!Ctx.isSwiftVersionAtLeast(5) &&
+      if (!Ctx.isLanguageModeAtLeast(5) &&
           hasImplicitlyUnwrappedResult(subExpr))
         return;
 
@@ -6491,7 +6491,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   maybeDiagnoseCallToKeyValueObserveMethod(E, DC);
   diagnoseExplicitUseOfLazyVariableStorage(E, DC);
   diagnoseComparisonWithNaN(E, DC);
-  if (!ctx.isSwiftVersionAtLeast(5))
+  if (!ctx.isLanguageModeAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
   if (!ctx.LangOpts.DisableAvailabilityChecking)
     diagnoseExprAvailability(E, const_cast<DeclContext*>(DC));

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2022,7 +2022,7 @@ bool PreCheckTarget::canSimplifyDiscardAssignmentExpr(
 bool PreCheckTarget::correctInterpolationIfStrange(
     InterpolatedStringLiteralExpr *ISLE) {
   // These expressions are valid in Swift 5+.
-  if (getASTContext().isSwiftVersionAtLeast(5))
+  if (getASTContext().isLanguageModeAtLeast(5))
     return true;
 
   /// Diagnoses appendInterpolation(...) calls with multiple
@@ -2709,7 +2709,7 @@ void PreCheckTarget::resolveKeyPathExpr(KeyPathExpr *KPE) {
 Expr *PreCheckTarget::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   // If constructor call is expected to produce an optional let's not attempt
   // this optimization because literal initializers aren't failable.
-  if (!getASTContext().LangOpts.isSwiftVersionAtLeast(5)) {
+  if (!getASTContext().isLanguageModeAtLeast(5)) {
     if (!ExprStack.empty()) {
       auto *parent = ExprStack.back();
       if (isa<BindOptionalExpr>(parent) || isa<ForceValueExpr>(parent))

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -92,7 +92,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   // Dynamic declarations were mistakenly not checked in Swift 4.2.
   // Do enforce the restriction even in pre-Swift-5 modes if the module we're
   // building is resilient, though.
-  if (D->shouldUseObjCDispatch() && !Context.isSwiftVersionAtLeast(5) &&
+  if (D->shouldUseObjCDispatch() && !Context.isLanguageModeAtLeast(5) &&
       !DC->getParentModule()->isResilient()) {
     return false;
   }
@@ -106,20 +106,20 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   // Swift 4.2 did not perform any checks for type aliases.
   if (isa<TypeAliasDecl>(D)) {
-    if (!Context.isSwiftVersionAtLeast(4, 2))
+    if (!Context.isLanguageModeAtLeast(4, 2))
       return false;
-    if (!Context.isSwiftVersionAtLeast(5))
+    if (!Context.isLanguageModeAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
   // Swift 4.2 did not check accessor accessibility.
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {
-    if (!accessor->isInitAccessor() && !Context.isSwiftVersionAtLeast(5))
+    if (!accessor->isInitAccessor() && !Context.isLanguageModeAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
-  if (isa<TypeAliasDecl>(DC) && !Context.isSwiftVersionAtLeast(6))
+  if (isa<TypeAliasDecl>(DC) && !Context.isLanguageModeAtLeast(6))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   auto diagID = diag::resilience_decl_unavailable;
@@ -196,7 +196,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD, definingModule->getNameStr(), D->getNameStr(),
                   static_cast<unsigned>(*reason), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilSwiftVersionIf(warnPreSwift6, 6);
+        .warnUntilLanguageModeIf(warnPreSwift6, 6);
   } else {
     ctx.Diags
         .diagnose(loc,
@@ -204,12 +204,12 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD, definingModule->getNameStr(), D->getNameStr(),
                   fragileKind.getSelector(), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilSwiftVersionIf(warnPreSwift6, 6);
+        .warnUntilLanguageModeIf(warnPreSwift6, 6);
   }
   D->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 
   if (originKind == DisallowedOriginKind::MissingImport &&
-      !ctx.LangOpts.isSwiftVersionAtLeast(6))
+      !ctx.isLanguageModeAtLeast(6))
     addMissingImport(loc, D, where);
 
   // If limited by an import, note which one.
@@ -370,7 +370,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
     ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_from_hidden_module, D,
                        fragileKind.getSelector(), definingModule->getName(),
                        static_cast<unsigned>(originKind))
-        .warnUntilSwiftVersionIf(downgradeToWarning == DowngradeToWarning::Yes,
+        .warnUntilLanguageModeIf(downgradeToWarning == DowngradeToWarning::Yes,
                                  6);
 
     if (originKind == DisallowedOriginKind::MissingImport &&
@@ -450,20 +450,20 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
   if (!reason.has_value())
     reason = ExportabilityReason::General;
 
-  ctx.Diags.diagnose(loc, diag::conformance_from_implementation_only_module,
-                     rootConf->getType(),
-                     rootConf->getProtocol()->getName(),
-                     static_cast<unsigned>(*reason),
-                     M->getName(),
-                     static_cast<unsigned>(originKind))
-      .warnUntilSwiftVersionIf((warnIfConformanceUnavailablePreSwift6 &&
-                                originKind != DisallowedOriginKind::SPIOnly &&
-                                originKind != DisallowedOriginKind::NonPublicImport) ||
-                               originKind == DisallowedOriginKind::MissingImport,
-                               6);
+  ctx.Diags
+      .diagnose(loc, diag::conformance_from_implementation_only_module,
+                rootConf->getType(), rootConf->getProtocol()->getName(),
+                static_cast<unsigned>(*reason), M->getName(),
+                static_cast<unsigned>(originKind))
+      .warnUntilLanguageModeIf(
+          (warnIfConformanceUnavailablePreSwift6 &&
+           originKind != DisallowedOriginKind::SPIOnly &&
+           originKind != DisallowedOriginKind::NonPublicImport) ||
+              originKind == DisallowedOriginKind::MissingImport,
+          6);
 
   if (originKind == DisallowedOriginKind::MissingImport &&
-      !ctx.LangOpts.isSwiftVersionAtLeast(6))
+      !ctx.isLanguageModeAtLeast(6))
     addMissingImport(loc, ext, where);
 
   // If limited by an import, note which one.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -334,7 +334,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     // TypeRepr into account).
 
     if (typeRepr && mayBeInferred &&
-        !Context.LangOpts.isSwiftVersionAtLeast(5) &&
+        !Context.isLanguageModeAtLeast(5) &&
         !useDC->getParentModule()->isResilient()) {
       // Swift 4.2 and earlier didn't check the Type when a TypeRepr was
       // present. However, this is a major hole when generic parameters are
@@ -556,7 +556,7 @@ void AccessControlCheckerBase::checkGenericParamAccess(
 
   auto &Context = ownerDecl->getASTContext();
   if (checkUsableFromInline) {
-    if (!Context.isSwiftVersionAtLeast(5))
+    if (!Context.isLanguageModeAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
 
     auto diagID = diag::generic_param_usable_from_inline;
@@ -955,7 +955,7 @@ public:
 
         // Swift versions before 5.0 did not check requirements on the
         // protocol's where clause, so emit a warning.
-        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
           downgradeToWarning = DowngradeToWarning::Yes;
       }
     });
@@ -1039,7 +1039,7 @@ public:
 
       auto outerDowngradeToWarning = DowngradeToWarning::No;
       if (superclassDecl->isGenericContext() &&
-          !CD->getASTContext().isSwiftVersionAtLeast(5)) {
+          !CD->getASTContext().isLanguageModeAtLeast(5)) {
         // Swift 4 failed to properly check this if the superclass was generic,
         // because the above loop was too strict.
         outerDowngradeToWarning = DowngradeToWarning::Yes;
@@ -1140,7 +1140,7 @@ public:
               declKind = declKindForType(type);
               // Swift versions before 5.0 did not check requirements on the
               // protocol's where clause, so emit a warning.
-              if (!proto->getASTContext().isSwiftVersionAtLeast(5))
+              if (!proto->getASTContext().isLanguageModeAtLeast(5))
                 downgradeToWarning = DowngradeToWarning::Yes;
             }
           });
@@ -1441,7 +1441,7 @@ public:
       : AccessControlCheckerBase(/*checkUsableFromInline=*/true) {}
 
   void visit(Decl *D) {
-    if (!D->getASTContext().isSwiftVersionAtLeast(4, 2))
+    if (!D->getASTContext().isLanguageModeAtLeast(4, 2))
       return;
 
     if (D->isInvalid() || D->isImplicit())
@@ -1528,7 +1528,7 @@ public:
           auto diagID = diag::pattern_type_not_usable_from_inline_inferred;
           if (fixedLayoutStructContext) {
             diagID = diag::pattern_type_not_usable_from_inline_inferred_frozen;
-          } else if (!Ctx.isSwiftVersionAtLeast(5)) {
+          } else if (!Ctx.isLanguageModeAtLeast(5)) {
             diagID = diag::pattern_type_not_usable_from_inline_inferred_warn;
           }
           Ctx.Diags.diagnose(NP->getLoc(), diagID, theVar->isLet(),
@@ -1567,7 +1567,7 @@ public:
           auto diagID = diag::pattern_type_not_usable_from_inline;
           if (fixedLayoutStructContext)
             diagID = diag::pattern_type_not_usable_from_inline_frozen;
-          else if (!Ctx.isSwiftVersionAtLeast(5))
+          else if (!Ctx.isLanguageModeAtLeast(5))
             diagID = diag::pattern_type_not_usable_from_inline_warn;
           auto diag = Ctx.Diags.diagnose(TP->getLoc(), diagID, anyVar->isLet(),
                                          isTypeContext);
@@ -1623,7 +1623,7 @@ public:
                         DowngradeToWarning downgradeToWarning,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::type_alias_underlying_type_not_usable_from_inline;
-      if (!TAD->getASTContext().isSwiftVersionAtLeast(5))
+      if (!TAD->getASTContext().isLanguageModeAtLeast(5))
         diagID = diag::type_alias_underlying_type_not_usable_from_inline_warn;
       auto diag = TAD->diagnose(diagID);
       highlightOffendingType(diag, complainRepr);
@@ -1645,7 +1645,7 @@ public:
             DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1660,7 +1660,7 @@ public:
                         DowngradeToWarning downgradeDiag,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::associated_type_not_usable_from_inline;
-      if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
+      if (!assocType->getASTContext().isLanguageModeAtLeast(5))
         diagID = diag::associated_type_not_usable_from_inline_warn;
       auto diag = assocType->diagnose(diagID, ACEK_DefaultDefinition);
       highlightOffendingType(diag, complainRepr);
@@ -1678,7 +1678,7 @@ public:
                                  DowngradeToWarning downgradeDiag,
                                  ImportAccessLevel importLimit) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1709,7 +1709,7 @@ public:
                           DowngradeToWarning downgradeToWarning,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::enum_raw_type_not_usable_from_inline;
-        if (!ED->getASTContext().isSwiftVersionAtLeast(5))
+        if (!ED->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::enum_raw_type_not_usable_from_inline_warn;
         auto diag = ED->diagnose(diagID);
         highlightOffendingType(diag, complainRepr);
@@ -1754,7 +1754,7 @@ public:
                           DowngradeToWarning downgradeToWarning,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::class_super_not_usable_from_inline;
-        if (!CD->getASTContext().isSwiftVersionAtLeast(5))
+        if (!CD->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::class_super_not_usable_from_inline_warn;
         auto diag = CD->diagnose(diagID, superclassLocIter->getTypeRepr() !=
                                              complainRepr);
@@ -1778,7 +1778,7 @@ public:
                           DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!proto->getASTContext().isSwiftVersionAtLeast(5))
+        if (!proto->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Refine);
         highlightOffendingType(diag, complainRepr);
@@ -1797,7 +1797,7 @@ public:
                                  DowngradeToWarning downgradeDiag,
                                  ImportAccessLevel importLimit) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!proto->getASTContext().isSwiftVersionAtLeast(5))
+        if (!proto->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1816,7 +1816,7 @@ public:
               DowngradeToWarning downgradeDiag,
               ImportAccessLevel importLimit) {
             auto diagID = diag::subscript_type_usable_from_inline;
-            if (!SD->getASTContext().isSwiftVersionAtLeast(5))
+            if (!SD->getASTContext().isLanguageModeAtLeast(5))
               diagID = diag::subscript_type_usable_from_inline_warn;
             auto diag = SD->diagnose(diagID, /*problemIsElement=*/false);
             highlightOffendingType(diag, complainRepr);
@@ -1831,7 +1831,7 @@ public:
                         DowngradeToWarning downgradeDiag,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::subscript_type_usable_from_inline;
-      if (!SD->getASTContext().isSwiftVersionAtLeast(5))
+      if (!SD->getASTContext().isLanguageModeAtLeast(5))
         diagID = diag::subscript_type_usable_from_inline_warn;
       auto diag = SD->diagnose(diagID, /*problemIsElement=*/true);
       highlightOffendingType(diag, complainRepr);
@@ -1867,7 +1867,7 @@ public:
                   DowngradeToWarning downgradeDiag,
                   ImportAccessLevel importLimit) {
                 auto diagID = diag::function_type_usable_from_inline;
-                if (!fn->getASTContext().isSwiftVersionAtLeast(5))
+                if (!fn->getASTContext().isLanguageModeAtLeast(5))
                   diagID = diag::function_type_usable_from_inline_warn;
                 auto diag = fn->diagnose(diagID, functionKind,
                                          /*problemIsResult=*/false,
@@ -1884,7 +1884,7 @@ public:
               DowngradeToWarning downgradeDiag,
               ImportAccessLevel importLimit) {
             auto diagID = diag::function_type_usable_from_inline;
-            if (!fn->getASTContext().isSwiftVersionAtLeast(5))
+            if (!fn->getASTContext().isLanguageModeAtLeast(5))
               diagID = diag::function_type_usable_from_inline_warn;
             auto diag = fn->diagnose(diagID, functionKind,
                                      /*problemIsResult=*/false,
@@ -1902,7 +1902,7 @@ public:
                           DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::function_type_usable_from_inline;
-        if (!fn->getASTContext().isSwiftVersionAtLeast(5))
+        if (!fn->getASTContext().isLanguageModeAtLeast(5))
           diagID = diag::function_type_usable_from_inline_warn;
         auto diag = fn->diagnose(diagID, functionKind,
                                  /*problemIsResult=*/true,
@@ -1927,7 +1927,7 @@ public:
               DowngradeToWarning downgradeToWarning,
               ImportAccessLevel importLimit) {
             auto diagID = diag::enum_case_usable_from_inline;
-            if (!EED->getASTContext().isSwiftVersionAtLeast(5))
+            if (!EED->getASTContext().isLanguageModeAtLeast(5))
               diagID = diag::enum_case_usable_from_inline_warn;
             auto diag = EED->diagnose(diagID);
             highlightOffendingType(diag, complainRepr);
@@ -2059,7 +2059,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
     // implementation-only import was also present. Downgrade to a warning
     // just in this case.
     if (howImported == RestrictedImportKind::MissingImport &&
-        !SF->getASTContext().isSwiftVersionAtLeast(6) &&
+        !SF->getASTContext().isLanguageModeAtLeast(6) &&
         !SF->hasImportsWithFlag(ImportFlags::ImplementationOnly)) {
       downgradeToWarning = DowngradeToWarning::Yes;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1309,7 +1309,7 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
             diagnose(attr->getLocation(),
                      diag::access_control_non_objc_open_member, VD)
                 .fixItReplace(attr->getRange(), "public")
-                .warnUntilFutureSwiftVersion();
+                .warnUntilFutureLanguageMode();
           }
         }
       }
@@ -2201,7 +2201,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
 
     if (candidates.empty()) {
       auto futureVersion = version::Version::getFutureMajorLanguageVersion();
-      bool shouldError = ctx.isSwiftVersionAtLeast(futureVersion);
+      bool shouldError = ctx.isLanguageModeAtLeast(futureVersion);
 
       // Diagnose as an error in resilient modules regardless of language
       // version since this will break the swiftinterface. Don't diagnose
@@ -2216,7 +2216,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
                   requiredAccessScope.requiredAccessForDiagnostics(),
                   /*isForSetter=*/false, /*useDefaultAccess=*/false,
                   /*updateAttr=*/false);
-      diag.warnUntilSwiftVersionIf(!shouldError, futureVersion);
+      diag.warnUntilLanguageModeIf(!shouldError, futureVersion);
 
       if (shouldError) {
         attr->setInvalid();
@@ -3034,7 +3034,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_deprecated,
              applicationMainKind)
-      .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
 
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_deprecated_use_attr_main)
@@ -3699,7 +3699,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    if (Ctx.isSwiftVersionAtLeast(4,2))
+    if (Ctx.isLanguageModeAtLeast(4, 2))
       diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline,
                             VD);
     return;
@@ -5627,7 +5627,7 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
     // properties of Objective-C protocols.
     auto D = diag::ownership_invalid_in_protocols;
     Diags.diagnose(attr->getLocation(), D, ownershipKind)
-        .warnUntilSwiftVersion(5)
+        .warnUntilLanguageMode(5)
         .fixItRemove(attr->getRange());
     attr->setInvalid();
   }
@@ -7887,10 +7887,9 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
     auto value = cast<ValueDecl>(D);
     ActorIsolation isolation = getActorIsolation(value);
     if (isolation.isActorIsolated()) {
-      diagnoseAndRemoveAttr(
-          attr, diag::sendable_isolated_sync_function,
-          isolation, value)
-        .warnUntilSwiftVersion(6);
+      diagnoseAndRemoveAttr(attr, diag::sendable_isolated_sync_function,
+                            isolation, value)
+          .warnUntilLanguageMode(6);
     }
   }
   // Prevent Sendable Attr from being added to methods of non-sendable types
@@ -7974,13 +7973,13 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
           if (var->hasAttachedPropertyWrapper()) {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-              .warnUntilSwiftVersionIf(attr->isImplicit(), 6)
-              .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+                .warnUntilLanguageModeIf(attr->isImplicit(), 6)
+                .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-              .warnUntilSwiftVersion(6)
-              .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+                .warnUntilLanguageMode(6)
+                .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
@@ -8060,7 +8059,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         if (!ctor->hasAsync()) {
           // the isolation for a synchronous init cannot be `nonisolated`.
           diagnoseAndRemoveAttr(attr, diag::nonisolated_actor_sync_init)
-            .warnUntilSwiftVersion(6);
+              .warnUntilLanguageMode(6);
           return;
         }
       }
@@ -8186,7 +8185,7 @@ void AttributeChecker::visitInheritActorContextAttr(
     diagnose(attr->getLocation(),
              diag::inherit_actor_context_only_on_sending_or_Sendable_params,
              attr)
-        .warnUntilFutureSwiftVersion();
+        .warnUntilFutureLanguageMode();
   }
 
   // Either `async` or `@isolated(any)`.
@@ -8195,7 +8194,7 @@ void AttributeChecker::visitInheritActorContextAttr(
         attr,
         diag::inherit_actor_context_only_on_async_or_isolation_erased_params,
         attr)
-        .warnUntilFutureSwiftVersion();
+        .warnUntilFutureLanguageMode();
   }
 }
 
@@ -8279,7 +8278,7 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
     bool inConcurrencyModule = D->getDeclContext()->getParentModule()->getName()
         .str() == "_Concurrency";
     auto diag = fn->diagnose(diag::unsafe_inherits_executor_deprecated);
-    diag.warnUntilSwiftVersion(6);
+    diag.warnUntilLanguageMode(6);
     diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
     replaceUnsafeInheritExecutorWithDefaultedIsolationParam(fn, diag);
   }
@@ -8662,7 +8661,7 @@ public:
                    diag::isolated_parameter_closure_combined_global_actor_attr,
                    param->getName())
               .fixItRemove(attr->getRangeWithAt())
-              .warnUntilSwiftVersion(6);
+              .warnUntilLanguageMode(6);
           attr->setInvalid();
           break; // don't need to complain about this more than once.
         }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1070,7 +1070,7 @@ static bool diagnosePotentialUnavailability(
     } else if (behaviorLimit >= DiagnosticBehavior::Warning) {
       err.limitBehavior(behaviorLimit);
     } else {
-      err.warnUntilSwiftVersion(6);
+      err.warnUntilLanguageMode(6);
     }
 
     // Direct a fixit to the error if an existing guard is nearly-correct
@@ -1769,7 +1769,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
                 shouldHideDomainNameForConstraintDiagnostic(constraint),
                 domainAndRange.getDomain(), EncodedMessage.Message)
       .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
-      .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
+      .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6, 6);
 
   switch (constraint.getReason()) {
   case AvailabilityConstraint::Reason::UnavailableUnconditionally:
@@ -2951,9 +2951,9 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     if (D->preconcurrency()) {
       diag.limitBehavior(DiagnosticBehavior::Warning);
     } else if (shouldWarnUntilFutureVersion()) {
-      diag.warnUntilFutureSwiftVersion();
+      diag.warnUntilFutureLanguageMode();
     } else {
-      diag.warnUntilSwiftVersion(6);
+      diag.warnUntilLanguageMode(6);
     }
 
     if (!attr->getRename().empty()) {
@@ -2975,9 +2975,9 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl, D,
                                    attr->Message);
     if (shouldWarnUntilFutureVersion()) {
-      diag.warnUntilFutureSwiftVersion();
+      diag.warnUntilFutureLanguageMode();
     } else {
-      diag.warnUntilSwiftVersion(6);
+      diag.warnUntilLanguageMode(6);
     }
   }
   D->diagnose(diag::decl_declared_here, D);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -449,7 +449,7 @@ GlobalActorAttributeRequest::evaluate(
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       if (!accessor->isGetter()) {
         decl->diagnose(diag::global_actor_disallowed, decl)
-            .warnUntilSwiftVersion(6)
+            .warnUntilLanguageMode(6)
             .fixItRemove(globalActorAttr->getRangeWithAt());
 
         auto &ctx = decl->getASTContext();
@@ -482,7 +482,7 @@ GlobalActorAttributeRequest::evaluate(
         }
 
         // In Swift 6, once the diag above is an error, it is disallowed.
-        if (ctx.isSwiftVersionAtLeast(6))
+        if (ctx.isLanguageModeAtLeast(6))
           return std::nullopt;
       }
     }
@@ -951,7 +951,7 @@ bool swift::diagnoseSendabilityErrorBasedOn(
 
         ctx.Diags
             .diagnose(importLoc, diag::add_predates_concurrency_import,
-                      ctx.LangOpts.isSwiftVersionAtLeast(6),
+                      ctx.isLanguageModeAtLeast(6),
                       nominal->getParentModule()->getName())
             .fixItInsert(importLoc, "@preconcurrency ");
 
@@ -1916,7 +1916,7 @@ static bool memberAccessHasSpecialPermissionInSwift5(
     ValueDecl const *member, SourceLoc memberLoc,
     std::optional<VarRefUseEnv> useKind) {
   // no need for this in Swift 6+
-  if (refCxt->getASTContext().isSwiftVersionAtLeast(6))
+  if (refCxt->getASTContext().isLanguageModeAtLeast(6))
     return false;
 
   // must be an access to an instance member.
@@ -1984,14 +1984,11 @@ static bool memberAccessHasSpecialPermissionInSwift5(
         useKind.value_or(VarRefUseEnv::Read));
 
     auto isolation = getActorIsolation(const_cast<ValueDecl *>(member));
-    diags.diagnose(
-        memberLoc, diag::actor_isolated_non_self_reference,
-        member,
-        useKindInt,
-        baseActor.kind + 1,
-        baseActor.globalActor,
-        isolation)
-    .warnUntilSwiftVersion(6);
+    diags
+        .diagnose(memberLoc, diag::actor_isolated_non_self_reference, member,
+                  useKindInt, baseActor.kind + 1, baseActor.globalActor,
+                  isolation)
+        .warnUntilLanguageMode(6);
 
     noteIsolatedActorMember(member, useKind);
     maybeNoteMutatingMethodSuggestion(C, member, memberLoc, refCxt, isolation, useKind);
@@ -2433,7 +2430,7 @@ namespace {
             if (behavior != DiagnosticBehavior::Note) {
               fn->diagnose(diag::invalid_isolated_calls_in_body,
                            globalActor->getString(), fn)
-                  .limitBehaviorUntilSwiftVersion(behavior, 6);
+                  .limitBehaviorUntilLanguageMode(behavior, 6);
             }
 
             // Overrides cannot be isolated to a global actor; the isolation
@@ -2483,7 +2480,7 @@ namespace {
           // Diagnose actor_isolated_non_self_reference as note
           // if there are multiple of these diagnostics
           ctx.Diags.diagnose(error.loc, error.diag)
-            .limitBehaviorUntilSwiftVersion(behavior, 6);
+              .limitBehaviorUntilLanguageMode(behavior, 6);
         }
       }
 
@@ -2516,7 +2513,7 @@ namespace {
           // if there are multiple actor-isolated function calls
           // from outside the actor
           ctx.Diags.diagnose(error.loc, error.diag)
-            .limitBehaviorUntilSwiftVersion(behavior, 6);
+              .limitBehaviorUntilLanguageMode(behavior, 6);
         }
       }
 
@@ -2708,7 +2705,7 @@ namespace {
                     fromType, toType);
 
                 if (warnUntilSwiftMode)
-                  diag.warnUntilSwiftVersion(*warnUntilSwiftMode);
+                  diag.warnUntilLanguageMode(*warnUntilSwiftMode);
               }
 
               for (auto type : nonSendableTypes) {
@@ -2743,7 +2740,7 @@ namespace {
                     .diagnose(funcConv->getLoc(),
                               diag::converting_func_loses_global_actor,
                               fromType, toType, fromActor)
-                    .warnUntilSwiftVersion(6);
+                    .warnUntilLanguageMode(6);
                 return;
               }
             }
@@ -2757,7 +2754,7 @@ namespace {
                 .diagnose(funcConv->getLoc(),
                           diag::isolated_any_conversion_to_synchronous_func,
                           fromFnType, toFnType)
-                .warnUntilFutureSwiftVersion();
+                .warnUntilFutureLanguageMode();
             return;
           }
 
@@ -3835,7 +3832,7 @@ namespace {
       }
 
       ctx.Diags.diagnose(loc, diag::shared_mutable_state_access, value)
-          .limitBehaviorUntilSwiftVersion(limit, 6)
+          .limitBehaviorUntilLanguageMode(limit, 6)
           // Preconcurrency global variables are warnings even in Swift 6
           .limitBehaviorIf(isPreconcurrencyImport, limit);
       value->diagnose(diag::kind_declared_here, value->getDescriptiveKind());
@@ -3877,7 +3874,7 @@ namespace {
               ctx.Diags.diagnose(apply->getLoc(),
                                  diag::actor_isolated_mutating_func,
                                  fnDecl->getName(), decl)
-                  .warnUntilSwiftVersionIf(downgradeToWarning, 6);
+                  .warnUntilLanguageModeIf(downgradeToWarning, 6);
               result = true;
               return;
             }
@@ -3980,10 +3977,11 @@ namespace {
         // parameter, e.g. `(isolated DA) -> Void`. Stage in the error as a
         // warning until Swift 6.
         if (var->getTypeInContext()->getAs<FunctionType>()) {
-          ctx.Diags.diagnose(declLoc,
-                             diag::distributed_actor_isolated_non_self_reference,
-                             decl)
-            .warnUntilSwiftVersion(6);
+          ctx.Diags
+              .diagnose(declLoc,
+                        diag::distributed_actor_isolated_non_self_reference,
+                        decl)
+              .warnUntilLanguageMode(6);
           noteIsolatedActorMember(decl, context);
           return std::nullopt;
         }
@@ -4612,10 +4610,11 @@ namespace {
                 options.contains(
                     ActorReferenceResult::Flags::CompatibilityDowngrade);
 
-            ctx.Diags.diagnose(
-                component.getLoc(), diag::actor_isolated_keypath_component,
-                isolation, decl)
-              .warnUntilSwiftVersionIf(downgrade, 6);
+            ctx.Diags
+                .diagnose(component.getLoc(),
+                          diag::actor_isolated_keypath_component, isolation,
+                          decl)
+                .warnUntilLanguageModeIf(downgrade, 6);
 
             diagnosed = !downgrade;
             break;
@@ -5311,7 +5310,7 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
           ctx.Diags.diagnose(attr->getLocation(), diag::unsafe_global_actor)
               .fixItRemove(attr->getArgs()->getSourceRange())
               .fixItInsert(attr->getLocation(), "@preconcurrency ")
-              .warnUntilSwiftVersion(6);
+              .warnUntilLanguageMode(6);
         }
       } else {
         ctx.Diags.diagnose(
@@ -5900,7 +5899,7 @@ static bool checkClassGlobalActorIsolation(
   // Complain about the mismatch.
   classDecl->diagnose(diag::actor_isolation_superclass_mismatch, isolation,
                       classDecl, superIsolation, superclassDecl)
-      .warnUntilSwiftVersionIf(downgradeToWarning, 6);
+      .warnUntilLanguageModeIf(downgradeToWarning, 6);
   return true;
 }
 
@@ -6055,7 +6054,7 @@ static void checkDeclWithIsolatedParameter(ValueDecl *value) {
       value
           ->diagnose(diag::isolated_parameter_combined_global_actor_attr, value)
           .fixItRemove(attr->first->getRangeWithAt())
-          .warnUntilSwiftVersion(6);
+          .warnUntilLanguageMode(6);
     }
   }
 
@@ -6064,7 +6063,7 @@ static void checkDeclWithIsolatedParameter(ValueDecl *value) {
     if (!attr->isImplicit()) {
       value->diagnose(diag::isolated_parameter_combined_nonisolated, value)
           .fixItRemove(attr->getRangeWithAt())
-          .warnUntilSwiftVersion(6);
+          .warnUntilLanguageMode(6);
     }
   }
 }
@@ -6256,7 +6255,7 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
           // non-strict concurrency modes (pre Swift 6).
           auto isolation =
               ActorIsolation::forGlobalActor(globalActor)
-                  .withPreconcurrency(!ctx.LangOpts.isSwiftVersionAtLeast(6));
+                  .withPreconcurrency(!ctx.isLanguageModeAtLeast(6));
           return {{{isolation, {}}, nullptr, {}}};
       }
 
@@ -6903,10 +6902,9 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
     if (enclosingIsolation != requiredIsolation) {
       bool preconcurrency =
           !isa<ParamDecl>(var) || requiredIsolation.preconcurrency();
-      var->diagnose(
-          diag::isolated_default_argument_context,
-          requiredIsolation, enclosingIsolation)
-        .warnUntilSwiftVersionIf(preconcurrency, 6);
+      var->diagnose(diag::isolated_default_argument_context, requiredIsolation,
+                    enclosingIsolation)
+          .warnUntilLanguageModeIf(preconcurrency, 6);
       return ActorIsolation::forUnspecified();
     }
   }
@@ -6998,10 +6996,10 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
         .defaultDiagnosticBehavior();
   }
 
-  value->diagnose(
-      diag::actor_isolation_override_mismatch, isolation,
-      value, overriddenIsolation)
-    .limitBehaviorUntilSwiftVersion(behavior, 6);
+  value
+      ->diagnose(diag::actor_isolation_override_mismatch, isolation, value,
+                 overriddenIsolation)
+      .limitBehaviorUntilLanguageMode(behavior, 6);
   overridden->diagnose(diag::overridden_here);
 }
 
@@ -7039,7 +7037,7 @@ void swift::checkGlobalIsolation(VarDecl *var) {
         diagVar);
   } else {
     diagVar->diagnose(diag::shared_mutable_state_decl, diagVar)
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
     diagnosed = true;
   }
 
@@ -7177,7 +7175,7 @@ static bool checkSendableInstanceStorage(
           && SendableCheckContext(dc, check)
                .defaultDiagnosticBehavior() != DiagnosticBehavior::Ignore) {
         sd->diagnose(diag::sendable_raw_storage, sd->getName())
-          .limitBehaviorUntilSwiftVersion(behavior, 6);
+            .limitBehaviorUntilLanguageMode(behavior, 6);
       }
       return true;
     }
@@ -7419,9 +7417,9 @@ bool swift::checkSendableConformance(
       conformanceDC->getOutermostParentSourceFile() !=
       nominal->getOutermostParentSourceFile()) {
     if (!(nominal->hasClangNode() && wasImplied)) {
-      conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,
-                                nominal)
-        .limitBehaviorUntilSwiftVersion(behavior, 6);
+      conformanceDecl
+          ->diagnose(diag::concurrent_value_outside_source_file, nominal)
+          .limitBehaviorUntilLanguageMode(behavior, 6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7435,7 +7433,7 @@ bool swift::checkSendableConformance(
     if (!classDecl->isSemanticallyFinal()) {
       classDecl->diagnose(diag::concurrent_value_nonfinal_class,classDecl->getName())
           .fixItInsert(classDecl->getStartLoc(), "final")
-          .limitBehaviorUntilSwiftVersion(behavior, 6);
+          .limitBehaviorUntilLanguageMode(behavior, 6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7450,7 +7448,7 @@ bool swift::checkSendableConformance(
               ->diagnose(diag::concurrent_value_inherit,
                          nominal->getASTContext().LangOpts.EnableObjCInterop,
                          classDecl->getName())
-              .limitBehaviorUntilSwiftVersion(behavior, 6);
+              .limitBehaviorUntilLanguageMode(behavior, 6);
 
           if (behavior == DiagnosticBehavior::Unspecified)
             return true;
@@ -8717,13 +8715,12 @@ namespace {
 
       ASTContext &ctx = fromDC->getASTContext();
       auto firstConformance = badIsolatedConformances.front();
-      ctx.Diags.diagnose(
-          loc, diag::isolated_conformance_wrong_domain,
-          firstConformance->getIsolation(),
-          firstConformance->getType(),
-          firstConformance->getProtocol()->getName(),
-          getContextIsolation())
-        .warnUntilSwiftVersion(6);
+      ctx.Diags
+          .diagnose(
+              loc, diag::isolated_conformance_wrong_domain,
+              firstConformance->getIsolation(), firstConformance->getType(),
+              firstConformance->getProtocol()->getName(), getContextIsolation())
+          .warnUntilLanguageMode(6);
       return true;
     }
   };

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -557,7 +557,7 @@ bool diagnoseIfAnyNonSendableTypes(
 
         if (!diagnosed) {
           ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
-              .limitBehaviorUntilSwiftVersion(behavior, 6)
+              .limitBehaviorUntilLanguageMode(behavior, 6)
               .limitBehaviorIf(preconcurrency);
           diagnosed = true;
         }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -695,10 +695,10 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       // In Swift 6.2 and below we incorrectly missed checking this rule for
       // methods, downgrade to a warning until the next language mode.
       auto futureVersion = version::Version::getFutureMajorLanguageVersion();
-      if (!anchor->hasCurriedSelf() || ctx.isSwiftVersionAtLeast(futureVersion))
+      if (!anchor->hasCurriedSelf() || ctx.isLanguageModeAtLeast(futureVersion))
         return Type();
 
-      diag.warnUntilFutureSwiftVersion();
+      diag.warnUntilFutureLanguageMode();
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -314,7 +314,7 @@ static bool inferFinalAndDiagnoseIfNeeded(ValueDecl *D, ClassDecl *cls,
   if (D->getFormalAccess() == AccessLevel::Open) {
     auto &context = D->getASTContext();
     auto diagID = diag::implicitly_final_cannot_be_open;
-    if (!context.isSwiftVersionAtLeast(5))
+    if (!context.isLanguageModeAtLeast(5))
       diagID = diag::implicitly_final_cannot_be_open_swift4;
     auto inFlightDiag = context.Diags.diagnose(D, diagID,
                                     static_cast<unsigned>(reason.value()));
@@ -408,11 +408,12 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
       if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
         if (classDecl->isAnyActor()) {
           // For an actor "convenience" is not required, but we'll honor it.
-          diags.diagnose(decl->getLoc(),
-                diag::no_convenience_keyword_init, "actors")
-            .fixItRemove(convenAttr->getLocation())
-            .warnInSwiftInterface(dc)
-            .warnUntilSwiftVersion(6);
+          diags
+              .diagnose(decl->getLoc(), diag::no_convenience_keyword_init,
+                        "actors")
+              .fixItRemove(convenAttr->getLocation())
+              .warnInSwiftInterface(dc)
+              .warnUntilLanguageMode(6);
 
         } else { // not an actor
           // Forbid convenience inits on Foreign CF types, as Swift does not yet
@@ -640,7 +641,7 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
       // be delegating because, well, we don't know the layout.
       // A dynamic replacement is permitted to be non-delegating.
       if (NTD->isResilient() ||
-          (ctx.isSwiftVersionAtLeast(5) &&
+          (ctx.isLanguageModeAtLeast(5) &&
            !decl->getAttrs().getAttribute<DynamicReplacementAttr>())) {
         if (decl->getParentModule() != NTD->getParentModule())
           Kind = BodyInitKind::Delegating;
@@ -842,7 +843,7 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
           if (VD->getFormalAccess() == AccessLevel::Open) {
             auto &context = decl->getASTContext();
             auto diagID = diag::implicitly_final_cannot_be_open;
-            if (!context.isSwiftVersionAtLeast(5))
+            if (!context.isLanguageModeAtLeast(5))
               diagID = diag::implicitly_final_cannot_be_open_swift4;
             auto inFlightDiag =
               context.Diags.diagnose(decl, diagID,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2893,7 +2893,7 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
                                      diagInfo.first, diagInfo.second,
                                      origDiagInfo.first, origDiagInfo.second,
                                      conflict.selector);
-      diag.warnUntilSwiftVersionIf(breakingInSwift5, 6);
+      diag.warnUntilLanguageModeIf(breakingInSwift5, 6);
 
       // Temporarily soften selector conflicts in objcImpl extensions; we're
       // seeing some that are caused by ObjCImplementationChecker improvements.
@@ -3052,10 +3052,11 @@ bool swift::diagnoseObjCCategoryConflicts(SourceFile &sf) {
           if (implCat != catToCheck)
             bestCat = implCat;
 
-        Ctx.Diags.diagnose(catToCheck, diag::objc_redecl_category_name,
-                           catToCheck->hasClangNode(),
-                           bestCat->hasClangNode(), catName)
-          .warnUntilSwiftVersion(6);
+        Ctx.Diags
+            .diagnose(catToCheck, diag::objc_redecl_category_name,
+                      catToCheck->hasClangNode(), bestCat->hasClangNode(),
+                      catName)
+            .warnUntilLanguageMode(6);
 
         Ctx.Diags.diagnose(bestCat, diag::invalid_redecl_prev_name, catName);
       }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -581,7 +581,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
             diags
                 .diagnose(decl, diag::override_sendability_mismatch,
                           decl->getName())
-                .limitBehaviorUntilSwiftVersion(limit, 6)
+                .limitBehaviorUntilLanguageMode(limit, 6)
                 .limitBehaviorIf(
                     fromContext.preconcurrencyBehavior(baseDeclClass));
             return false;
@@ -599,7 +599,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
       diags
           .diagnose(decl, diag::override_global_actor_isolation_mismatch,
                     decl->getName())
-          .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 6)
+          .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 6)
           .limitBehaviorIf(fromContext.preconcurrencyBehavior(baseDeclClass));
     }
     break;
@@ -1218,7 +1218,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
   // is helpful in several cases - just not this one.
   auto dc = decl->getDeclContext();
   auto classDecl = dc->getSelfClassDecl();
-  if (decl->getASTContext().isSwiftVersionAtLeast(5) &&
+  if (decl->getASTContext().isLanguageModeAtLeast(5) &&
       baseDecl->getInterfaceType()->hasDynamicSelfType() &&
       !decl->getInterfaceType()->hasDynamicSelfType() &&
       !classDecl->isSemanticallyFinal()) {
@@ -1926,7 +1926,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
          overrideASD->getAttrs().hasAttribute<LazyAttr>()) &&
         !overrideASD->hasObservers()) {
       bool downgradeToWarning = false;
-      if (!ctx.isSwiftVersionAtLeast(5) &&
+      if (!ctx.isLanguageModeAtLeast(5) &&
           overrideASD->getAttrs().hasAttribute<LazyAttr>()) {
         // Swift 4.0 had a bug where lazy properties were considered
         // computed by the time of this check. Downgrade this diagnostic to

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -137,9 +137,10 @@ public:
         diagnoseInvalid(repr, repr.getLoc(),
                         diag::conformance_repression_only_on_struct_class_enum,
                         ctx.getProtocol(*kp))
-            // Downgrade to a warning for `~BitwiseCopyable` because it was accepted
-            // in some incorrect positions before.
-            .warnUntilFutureSwiftVersionIf(kp == KnownProtocolKind::BitwiseCopyable);
+            // Downgrade to a warning for `~BitwiseCopyable` because it was
+            // accepted in some incorrect positions before.
+            .warnUntilFutureLanguageModeIf(kp ==
+                                           KnownProtocolKind::BitwiseCopyable);
         return Type();
       }
     }
@@ -276,7 +277,7 @@ static void checkInheritanceClause(
           isa<ProtocolDecl>(decl) &&
           Lexer::getTokenAtLocation(ctx.SourceMgr, sourceRange.Start)
               .is(tok::kw_class);
-      if (ctx.LangOpts.isSwiftVersionAtLeast(5) && isWrittenAsClass) {
+      if (ctx.isLanguageModeAtLeast(5) && isWrittenAsClass) {
         diags
             .diagnose(sourceRange.Start,
                       diag::anyobject_class_inheritance_deprecated)
@@ -290,7 +291,7 @@ static void checkInheritanceClause(
         auto knownIndex = inheritedAnyObject->first;
         auto knownRange = inheritedAnyObject->second;
         SourceRange removeRange = inheritedTypes.getRemovalRange(knownIndex);
-        if (!ctx.LangOpts.isSwiftVersionAtLeast(5) &&
+        if (!ctx.isLanguageModeAtLeast(5) &&
             isa<ProtocolDecl>(decl) &&
             Lexer::getTokenAtLocation(ctx.SourceMgr, knownRange.Start)
               .is(tok::kw_class)) {
@@ -1846,7 +1847,7 @@ static void diagnoseRetroactiveConformances(
             diags
                 .diagnose(loc, diag::retroactive_attr_does_not_apply, declForDiag,
                           isSameModule)
-                .warnUntilSwiftVersion(6)
+                .warnUntilLanguageMode(6)
                 .fixItRemove(SourceRange(loc, loc.getAdvancedLoc(1)));
             return TypeWalker::Action::Stop;
           }
@@ -4067,7 +4068,7 @@ void TypeChecker::checkParameterList(ParameterList *params,
           // cannot have more than one isolated parameter (SE-0313)
           param->diagnose(diag::isolated_parameter_duplicate)
               .highlight(param->getSourceRange())
-              .warnUntilSwiftVersion(6);
+              .warnUntilLanguageMode(6);
           // I'd love to describe the context in which there is an isolated parameter,
           // we had a DescriptiveDeclContextKind, but that only
           // exists for Decls.

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3211,8 +3211,9 @@ public:
       }
     }
 
-    Diags.diagnose(loc, message).highlight(highlight)
-      .warnUntilSwiftVersionIf(classification.shouldDowngradeToWarning(), 6);
+    Diags.diagnose(loc, message)
+        .highlight(highlight)
+        .warnUntilLanguageModeIf(classification.shouldDowngradeToWarning(), 6);
     maybeAddRethrowsNote(Diags, loc, reason);
 
     // If this is a call without expected 'try[?|!]', like this:
@@ -4806,9 +4807,9 @@ private:
       return;
 
     Ctx.Diags.diagnose(anchor->getStartLoc(), diag::async_expr_without_await)
-      .warnUntilSwiftVersionIf(downgradeToWarning, 6)
-      .fixItInsert(loc, insertText)
-      .highlight(anchor->getSourceRange());
+        .warnUntilLanguageModeIf(downgradeToWarning, 6)
+        .fixItInsert(loc, insertText)
+        .highlight(anchor->getSourceRange());
 
     for (const DiagnosticInfo &diag: errors) {
       switch (diag.reason.getKind()) {
@@ -4909,7 +4910,7 @@ private:
       Ctx.Diags
           .diagnose(loc, diag::actor_isolated_access_outside_of_actor_context,
                     declIsolation, declRef.getDecl(), isCall)
-          .warnUntilSwiftVersionIf(errorInfo.downgradeToWarning, 6)
+          .warnUntilLanguageModeIf(errorInfo.downgradeToWarning, 6)
           .fixItInsert(fixItLoc, insertText)
           .highlight(anchor->getSourceRange());
       return true;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -375,7 +375,7 @@ static bool checkProtocolSelfRequirementsImpl(
                        secondType.getString())
         // FIXME: This should become an unconditional error since violating
         // this invariant can introduce compiler and run time crashes.
-        .warnUntilFutureSwiftVersionIf(downgrade);
+        .warnUntilFutureLanguageModeIf(downgrade);
     return true;
   }
 
@@ -705,9 +705,9 @@ void TypeChecker::checkShadowedGenericParams(GenericContext *dc) {
       if (existingParamDecl->getDeclContext() == dc) {
         genericParamDecl->diagnose(diag::invalid_redecl, genericParamDecl);
       } else {
-        genericParamDecl->diagnose(
-            diag::shadowed_generic_param,
-            genericParamDecl).warnUntilSwiftVersion(6);
+        genericParamDecl
+            ->diagnose(diag::shadowed_generic_param, genericParamDecl)
+            .warnUntilLanguageMode(6);
       }
 
       if (existingParamDecl->getLoc()) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -699,9 +699,8 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
     if (isa<AccessorDecl>(decl) && role == MacroRole::Accessor) {
       auto *var = dyn_cast<VarDecl>(attachedTo);
       if (var && var->isLet()) {
-        ctx.Diags.diagnose(var->getLoc(),
-                           diag::let_accessor_expansion)
-          .warnUntilSwiftVersion(6);
+        ctx.Diags.diagnose(var->getLoc(), diag::let_accessor_expansion)
+            .warnUntilLanguageMode(6);
       }
 
       continue;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1078,9 +1078,9 @@ NullablePtr<Pattern> TypeChecker::trySimplifyExprPattern(ExprPattern *EP,
       ctx.Diags
           .diagnose(NLE->getLoc(), diag::value_type_comparison_with_nil_illegal,
                     patternTy)
-          .warnUntilSwiftVersion(6);
+          .warnUntilLanguageMode(6);
 
-      if (ctx.isSwiftVersionAtLeast(6))
+      if (ctx.isLanguageModeAtLeast(6))
         return nullptr;
     }
   }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1180,7 +1180,7 @@ namespace {
           return 6;
         };
 
-        diag.warnUntilSwiftVersion(shouldWarnUntilVersion());
+        diag.warnUntilLanguageMode(shouldWarnUntilVersion());
 
         mainDiagType = std::nullopt;
       }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4255,9 +4255,9 @@ NeverNullType TypeResolver::resolveASTFunctionType(
   unsigned numIsolatedParams = countIsolatedParamsUpTo(repr, 2);
   if (!repr->isWarnedAbout() && numIsolatedParams > 1) {
     diagnose(repr->getLoc(), diag::isolated_parameter_duplicate_type)
-        .warnUntilSwiftVersion(6);
+        .warnUntilLanguageMode(6);
 
-    if (ctx.LangOpts.isSwiftVersionAtLeast(6))
+    if (ctx.isLanguageModeAtLeast(6))
       return ErrorType::get(ctx);
     else
       repr->setWarned();
@@ -4270,7 +4270,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (globalActor && !globalActor->hasError() && !globalActorAttr->isInvalid()) {
       if (numIsolatedParams != 0) {
         diagnose(repr->getLoc(), diag::isolated_parameter_global_actor_type)
-            .warnUntilSwiftVersion(6);
+            .warnUntilLanguageMode(6);
         globalActorAttr->setInvalid();
       } else if (isolatedAttr) {
         diagnose(repr->getLoc(), diag::isolated_attr_global_actor_type,
@@ -5785,17 +5785,17 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     // Compiler should diagnose both `Int!` and `String!` as invalid,
     // but returning `ErrorType` from here would stop type resolution
     // after `Int!`.
-    if (ctx.isSwiftVersionAtLeast(swiftLangModeForError)) {
+    if (ctx.isLanguageModeAtLeast(swiftLangModeForError)) {
       repr->setInvalid();
     }
 
     Diag<> diagID = diag::iuo_deprecated_here;
-    if (ctx.isSwiftVersionAtLeast(swiftLangModeForError)) {
+    if (ctx.isLanguageModeAtLeast(swiftLangModeForError)) {
       diagID = diag::iuo_invalid_here;
     }
 
     diagnose(repr->getExclamationLoc(), diagID)
-        .warnUntilSwiftVersion(swiftLangModeForError);
+        .warnUntilLanguageMode(swiftLangModeForError);
 
     // Suggest a regular optional, but not when `T!` is the right-hand side of
     // a cast expression.
@@ -6864,7 +6864,7 @@ private:
     if (Ctx.LangOpts.getFeatureState(feature).isEnabledForMigration()) {
       diag->limitBehavior(DiagnosticBehavior::Warning);
     } else {
-      diag->warnUntilSwiftVersion(feature.getLanguageVersion().value());
+      diag->warnUntilLanguageMode(feature.getLanguageMode().value());
     }
 
     emitInsertAnyFixit(*diag, T);

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -3105,7 +3105,7 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
           // method without any applications at all, which would get
           // miscompiled into a function with undefined behavior. Warn for
           // source compatibility.
-          bool isWarning = !getASTContext().isSwiftVersionAtLeast(5);
+          bool isWarning = !getASTContext().isLanguageModeAtLeast(5);
           (void)recordFix(
               AllowInvalidPartialApplication::create(isWarning, *this, locator));
         } else if (level == 1) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -296,7 +296,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 
   StringRef SDKPath = ctx.SearchPathOpts.getSDKPath();
   // In Swift 6 mode, we do not inherit search paths from loaded non-SDK modules.
-  if (!ctx.LangOpts.isSwiftVersionAtLeast(6) &&
+  if (!ctx.isLanguageModeAtLeast(6) &&
       (SDKPath.empty() ||
        !Core->ModuleInputBuffer->getBufferIdentifier().starts_with(SDKPath))) {
     for (const auto &searchPath : Core->SearchPaths) {

--- a/test/lit.swift-features.cfg.inc
+++ b/test/lit.swift-features.cfg.inc
@@ -28,7 +28,8 @@ def language_feature(feature_name, enabled):
     if enabled or "asserts" in config.available_features:
         config.available_features.add("swift_feature_" + feature_name)
 
-#define UPCOMING_FEATURE(FeatureName, SENumber, Version) language_feature(#FeatureName, True)
+#define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \
+  language_feature(#FeatureName, True)
 #define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) language_feature(#FeatureName, #AvailableInProd == "true")
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   language_feature(#FeatureName, True)

--- a/unittests/AST/DiagnosticBehaviorTests.cpp
+++ b/unittests/AST/DiagnosticBehaviorTests.cpp
@@ -58,7 +58,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({5}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilSwiftVersion(4);
+            .warnUntilLanguageMode(4);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Error);
@@ -72,7 +72,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilSwiftVersion(5);
+            .warnUntilLanguageMode(5);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
@@ -90,7 +90,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilSwiftVersion(99);
+            .warnUntilLanguageMode(99);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);

--- a/unittests/AST/DiagnosticGroupsTests.cpp
+++ b/unittests/AST/DiagnosticGroupsTests.cpp
@@ -106,7 +106,7 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
 
           diags.diagnose(SourceLoc(), diagnostic);
           diags.diagnose(SourceLoc(), diagnostic)
-              .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
         },
         [](const DiagnosticInfo &info) {
           EXPECT_EQ(info.Kind, DiagnosticKind::Error);
@@ -138,7 +138,7 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
           diags.setWarningsAsErrorsRules(rules);
 
           diags.diagnose(SourceLoc(), diagnostic)
-              .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
         },
         [](const DiagnosticInfo &info) {
           EXPECT_EQ(info.Kind, DiagnosticKind::Error);

--- a/unittests/AST/DiagnosticInfoTests.cpp
+++ b/unittests/AST/DiagnosticInfoTests.cpp
@@ -103,7 +103,7 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Identifier_WrappedDiag) {
         diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Identifier);
 
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
@@ -159,7 +159,7 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group_WrappedDiag) {
         TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
                                   DiagGroupID::DeprecatedDeclaration);
         diags.diagnose(SourceLoc(), diagnostic)
-            .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
@@ -180,8 +180,8 @@ TEST(DiagnosticInfo, CategoryDeprecation) {
         EXPECT_TRUE(diags.isDeprecationDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag);
-        diags.diagnose(SourceLoc(), diag).warnUntilSwiftVersion(6);
-        diags.diagnose(SourceLoc(), diag).warnUntilSwiftVersion(99);
+        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(6);
+        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(99);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "deprecation");
@@ -197,8 +197,8 @@ TEST(DiagnosticInfo, CategoryNoUsage) {
         EXPECT_TRUE(diags.isNoUsageDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag);
-        diags.diagnose(SourceLoc(), diag).warnUntilSwiftVersion(6);
-        diags.diagnose(SourceLoc(), diag).warnUntilSwiftVersion(99);
+        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(6);
+        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(99);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "no-usage");
@@ -214,9 +214,9 @@ TEST(DiagnosticInfo, CategoryAPIDigesterBreakage) {
         EXPECT_TRUE(diags.isAPIDigesterBreakageDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag, StringRef());
-        diags.diagnose(SourceLoc(), diag, StringRef()).warnUntilSwiftVersion(6);
+        diags.diagnose(SourceLoc(), diag, StringRef()).warnUntilLanguageMode(6);
         diags.diagnose(SourceLoc(), diag, StringRef())
-            .warnUntilSwiftVersion(99);
+            .warnUntilLanguageMode(99);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "api-digester-breaking-change");

--- a/unittests/Frontend/FeatureParsingTest.cpp
+++ b/unittests/Frontend/FeatureParsingTest.cpp
@@ -21,7 +21,7 @@ FeatureParsingTest::FeatureParsingTest() : ArgParsingTest() {
 }
 
 FeatureWrapper::FeatureWrapper(Feature id) : id(id), name(id.getName().data()) {
-  auto langMode = id.getLanguageVersion();
+  auto langMode = id.getLanguageMode();
   if (langMode) {
     this->langMode = std::to_string(*langMode);
   }


### PR DESCRIPTION
- **Explanation**: Cherry-picking to avoid an extensive and unnecessary divergence between branches.
- **Scope**: —
- **Issues**: —
- **Original PRs**: https://github.com/swiftlang/swift/pull/85833
- **Risk**: None.
- **Testing**: Smoke testing.
- **Reviewers**: @hborla @xedin
