### PR TITLE
[Test][AutoDiff] Replace sed command with echo/cat for internal shell compatibility

### DIFF
--- a/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
@@ -4,12 +4,9 @@
 
 // https://github.com/apple/swift/issues/54526
 // Workaround because import declarations are not preserved in .sib files.
-// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: echo "import _Differentiation" > %t/tmp_preamble
+// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
-
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -80,13 +80,13 @@ bb0:
 // CHECK:   {{%.*}} = differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 == τ_0_0.TangentVector> @generic : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, Float) -> @out τ_0_0
 // CHECK: }
 
-// IRGEN: @fooWJrSUUpSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT:[0-9]+]]
-// IRGEN: @fooWJrSSUpSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @barWJrSUUpSUr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @barWJrSSUpSSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @generic16_Differentiation14DifferentiableRzlWJrSUpSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @generics18AdditiveArithmeticRz16_Differentiation14DifferentiableRzlWJrSSpSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @generic16_Differentiation14DifferentiableRz13TangentVector{{.*}}WJrSSpSr = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @fooWJrSUUpSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT:[0-9]+]]
+// IRGEN: @fooWJrSSUpSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @barWJrSUUpSUr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @barWJrSSUpSSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @generic16_Differentiation14DifferentiableRzlWJrSUpSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @generics18AdditiveArithmeticRz16_Differentiation14DifferentiableRzlWJrSSpSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @generic16_Differentiation14DifferentiableRz13TangentVector{{.*}}WJrSSpSr = external{{( dllimport)?}} global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
 
 // IRGEN-LABEL: define {{.*}} @test_derivative_witnesses()
 

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -10,17 +10,14 @@
 
 // https://github.com/apple/swift/issues/54526
 // Workaround because import declarations are not preserved in .sib files.
-// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: echo "import _Differentiation" > %t/tmp_preamble
+// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
 // IRGen test.
 
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=Simplification -emit-ir %s | %FileCheck %s --check-prefix=IRGEN --check-prefix %target-cpu
 // NOTE: `%target-cpu`-specific FileCheck lines exist because lowered function types in LLVM IR differ between architectures.
-
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
@@ -13,12 +13,9 @@
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.sil -module-name main
 // https://github.com/apple/swift/issues/54526
 // Workaround because import declarations are not preserved in .sib files.
-// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: echo "import _Differentiation" > %t/tmp_preamble
+// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
-
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiable_function_inst.sil
@@ -10,16 +10,13 @@
 
 // https://github.com/apple/swift/issues/54526
 // Workaround because import declarations are not preserved in .sib files.
-// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: echo "import _Differentiation" > %t/tmp_preamble
+// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
 // IRGen test.
 
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK-IRGEN
-
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
 
 // Would need to update for arm64e.
 // UNSUPPORTED: CPU=arm64e

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -10,16 +10,13 @@
 
 // https://github.com/apple/swift/issues/54526
 // Workaround because import declarations are not preserved in .sib files.
-// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: echo "import _Differentiation" > %t/tmp_preamble
+// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck --check-prefix=ROUNDTRIP %s
 
 // IRGen test.
 
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=IRGEN %s
-
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -51,7 +51,7 @@ sil_differentiability_witness [reverse] [parameters 0] [results 0] @externalFn1 
 // ROUNDTRIP:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @externalFn1WJrSpSr ={{( protected)?}} global { ptr, ptr } {
+// IRGEN-LABEL: @externalFn1WJrSpSr ={{( dllexport)?( protected)?}} global { ptr, ptr } {
 // IRGEN-SAME: @AD__externalFn1__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__externalFn1__vjp_src_0_wrt_0
 // IRGEN-SAME: }
@@ -75,7 +75,7 @@ sil_differentiability_witness [reverse] [parameters 0] [results 0] @externalFn2 
 // ROUNDTRIP:   vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @externalFn2WJrSpSr ={{( protected)?}} global { ptr, ptr } {
+// IRGEN-LABEL: @externalFn2WJrSpSr ={{( dllexport)?( protected)?}} global { ptr, ptr } {
 // IRGEN-SAME: @AD__externalFn2__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__externalFn2__vjp_src_0_wrt_0
 // IRGEN-SAME: }
@@ -122,7 +122,7 @@ sil_differentiability_witness [reverse] [parameters 0] [results 0] @foo : $@conv
 // ROUNDTRIP:   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @fooWJrSpSr ={{( protected)?}} global { ptr, ptr } {
+// IRGEN-LABEL: @fooWJrSpSr ={{( dllexport)?( protected)?}} global { ptr, ptr } {
 // IRGEN-SAME: @AD__foo__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__foo__vjp_src_0_wrt_0
 // IRGEN-SAME: }


### PR DESCRIPTION
Refactored `AutoDiff` test files that contains `REQUIRES: shell` by replacing the line:
```
// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
```
with `echo` and `cat` commands:
```
// RUN: echo "import _Differentiation" > %t/tmp_preamble
// RUN: cat %t/tmp_preamble %t/tmp.sil > %t/tmp_fixed.sil
```
to make it compatible with LLVM Lit internal shell.

Partially address https://github.com/swiftlang/swift/issues/84407