### PR TITLE
Temporarily disable CrashWithThreads cosmetic test on Linux

### DIFF
--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: asan
 // REQUIRES: executable_test
 // REQUIRES: backtracing
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 
 #if canImport(Darwin)
   import Darwin


### PR DESCRIPTION
This test is destabilising the pipeline on Linux and only tests cosmetic functionality. Disable it for now.

rdar://165728982