### PR TITLE
[6.3 🍒][Dependency Scanning] Do not re-query a given clang module identifier more than once

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1113,17 +1113,20 @@ void ModuleDependencyScanner::performParallelClangModuleLookup(
   };
 
   // Enque asynchronous lookup tasks
+  llvm::StringSet<> queriedIdentifiers;
   for (const auto &unresolvedImports : unresolvedImportsMap)
     for (const auto &unresolvedImportInfo : unresolvedImports.second)
-      ScanningThreadPool.async(
-          scanForClangModuleDependency,
-          getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
+        ScanningThreadPool.async(
+            scanForClangModuleDependency,
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
 
   for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
     for (const auto &unresolvedImportInfo : unresolvedImports.second)
-      ScanningThreadPool.async(
-          scanForClangModuleDependency,
-          getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
+        ScanningThreadPool.async(
+            scanForClangModuleDependency,
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
 
   ScanningThreadPool.wait();
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/85849
--------------------------
• **Explanation**: During parallel clang module dependency resolution, an unintended side-effect of https://github.com/swiftlang/swift/pull/84929 is that we stopped uniquing the module identifiers we query to the Clang dependency scanner.
This change ensures we do not query the same identifier more than once.
• **Scope**: This affects all dependency scanning actions for targets which have Clang module dependencies which occur more than once in the dependency graph.
• **Risk**: Low, this change should not, in expectation, affect scanner output, it simply de-duplicates specific Clang dependency query tasks.
• **Problem**: rdar://165133617
• **Original PR**: https://github.com/swiftlang/swift/pull/85849
