### PR TITLE
DeadCodeElimination,SILCombine: don't insert destroys for removed values in dead-end blocks

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1561,14 +1561,6 @@ SILInstruction *SILCombiner::legacyVisitApplyInst(ApplyInst *AI) {
   }
 
   if (SF) {
-    if (SF->hasSemanticsAttr(semantics::ARRAY_UNINITIALIZED)) {
-      UserListTy Users;
-      // If the uninitialized array is only written into then it can be removed.
-      if (recursivelyCollectARCUsers(Users, AI)) {
-        if (eraseApply(AI, Users))
-          return nullptr;
-      }
-    }
     if (SF->hasSemanticsAttr(semantics::ARRAY_GET_CONTIGUOUSARRAYSTORAGETYPE)) {
       auto silTy = AI->getType();
       auto storageTy = AI->getType().getASTType();

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -12,6 +12,7 @@ public struct S {
 typealias Int1 = Builtin.Int1
 
 class C {}
+class D: C {}
 
 sil @getC : $@convention(thin) () -> @owned C
 sil @barrier : $@convention(thin) () -> ()
@@ -534,3 +535,32 @@ bb2:
   %17 = tuple ()
   return %17
 }
+
+// CHECK-LABEL: sil [ossa] @dont_insert_destroy_for_uninitialized_object :
+// CHECK-NOT:     destroy_value
+// CHECK-LABEL: } // end sil function 'dont_insert_destroy_for_uninitialized_object'
+sil [ossa] @dont_insert_destroy_for_uninitialized_object : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $D      // D might not be initialized due to dead-end loop -> will lead to crash if it is destroyed here
+  %1 = upcast %0 to $C
+  br bb1
+
+bb1:
+  br bb1
+}
+
+// CHECK-LABEL: sil [ossa] @dont_insert_arg_destroy_for_uninitialized_object :
+// CHECK-NOT:     destroy_value
+// CHECK-LABEL: } // end sil function 'dont_insert_arg_destroy_for_uninitialized_object'
+sil [ossa] @dont_insert_arg_destroy_for_uninitialized_object : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $D      // D might not be initialized due to dead-end loop -> will lead to crash if it is destroyed here
+  br bb1(%0)
+
+bb1(%2 : @owned $D):
+  br bb2
+
+bb2:
+  br bb2
+}
+

--- a/test/SILOptimizer/deadend-loop-crash.swift
+++ b/test/SILOptimizer/deadend-loop-crash.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift(-O -Xllvm -sil-disable-pass=deadobject-elim) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#elseif os(WASI)
+  import WASILibc
+#elseif canImport(Android)
+  import Android
+#elseif os(Windows)
+  import CRT
+#else
+#error("Unsupported platform")
+#endif
+
+@inline(never)
+public func hiddenExit() {
+  // CHECK: okay
+  print("okay")
+  exit(0)
+}
+
+func foo() -> Never {
+  while true {
+    hiddenExit()
+  }
+}
+
+func bar(_ x: Any...) {
+}
+
+bar(foo())

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -1037,3 +1037,22 @@ bb3:
   %rv = tuple()
   return %rv : $()
 }
+
+
+sil [_semantics "array.uninitialized"] [ossa] @adoptStorage : $@convention(thin) (@owned _ContiguousArrayStorage<Any>, Int) -> (@owned Array<Any>, UnsafeMutablePointer<Any>)
+
+// CHECK-LABEL: sil [ossa] @dont_remove_dead_adopt_storage :
+// CHECK-NOT:     destroy_value
+// CHECK-LABEL: } // end sil function 'dont_remove_dead_adopt_storage'
+sil [ossa] @dont_remove_dead_adopt_storage : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = integer_literal $Builtin.Word, 1
+  %2 = alloc_ref [tail_elems $Any * %1] $_ContiguousArrayStorage<Any>
+  %3 = function_ref @adoptStorage : $@convention(thin) (@owned _ContiguousArrayStorage<Any>, Int) -> (@owned Array<Any>, UnsafeMutablePointer<Any>)
+  %4 = apply %3(%2, %0) : $@convention(thin) (@owned _ContiguousArrayStorage<Any>, Int) -> (@owned Array<Any>, UnsafeMutablePointer<Any>)
+  // Array buffer is not initialized due to dead-end loop -> will lead to crash if buffer is destroyed here
+  br bb1
+bb1:
+  br bb1
+}
+


### PR DESCRIPTION
When an owned value has no lifetime ending uses it means that it is in a dead-end region.
We must not remove and inserting compensating destroys for it because that would potentially destroy the value too early.
Initialization of an object might be cut off and removed after a dead-end loop or an `unreachable`.
In this case a class destructor would see uninitialized fields.

Also fix the same problem in SILCombine for dead `Array.adoptStorage` calls.

Fixes a mis-compile
https://github.com/swiftlang/swift/issues/85851
rdar://165876726