### PR TITLE
Embedded: allow generic class constructors

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -182,10 +182,12 @@ final public class ParamDecl: VarDecl {
 final public class SubscriptDecl: AbstractStorageDecl, GenericContext {}
 
 public class AbstractFunctionDecl: ValueDecl, GenericContext {
-  public var isOverridden: Bool { bridged.AbstractFunction_isOverridden() }
+  final public var isOverridden: Bool { bridged.AbstractFunction_isOverridden() }
 }
 
-final public class ConstructorDecl: AbstractFunctionDecl {}
+final public class ConstructorDecl: AbstractFunctionDecl {
+  public var isInheritable: Bool { bridged.Constructor_isInheritable() }
+}
 
 final public class DestructorDecl: AbstractFunctionDecl {
   final public var isIsolated: Bool { bridged.Destructor_isIsolated() }

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -351,6 +351,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool ProtocolDecl_requiresClass() const;
   BRIDGED_INLINE bool ProtocolDecl_isMarkerProtocol() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
+  BRIDGED_INLINE bool Constructor_isInheritable() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;
   BRIDGED_INLINE bool EnumElementDecl_hasAssociatedValues() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedParameterList

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -272,6 +272,10 @@ bool BridgedDeclObj::AbstractFunction_isOverridden() const {
   return getAs<swift::AbstractFunctionDecl>()->isOverridden();
 }
 
+bool BridgedDeclObj::Constructor_isInheritable() const {
+  return getAs<swift::ConstructorDecl>()->isInheritable();
+}
+
 bool BridgedDeclObj::Destructor_isIsolated() const {
   auto dd = getAs<swift::DestructorDecl>();
   auto ai = swift::getActorIsolation(dd);

--- a/lib/SIL/IR/SILVTable.cpp
+++ b/lib/SIL/IR/SILVTable.cpp
@@ -78,15 +78,14 @@ void SILVTable::updateVTableCache(const Entry &entry) {
 void SILVTable::replaceEntries(ArrayRef<Entry> newEntries) {
   auto entries = getMutableEntries();
   ASSERT(newEntries.size() <= entries.size());
-  for (unsigned i = 0; i < entries.size(); ++i) {
-    entries[i].getImplementation()->decrementRefCount();
-    if (i < newEntries.size()) {
-      entries[i] = newEntries[i];
-      entries[i].getImplementation()->incrementRefCount();
-      updateVTableCache(entries[i]);
-    } else {
-      removeFromVTableCache(entries[i]);
-    }
+  for (Entry &entry : getMutableEntries()) {
+    entry.getImplementation()->decrementRefCount();
+    removeFromVTableCache(entry);
+  }
+  for (unsigned i = 0; i < newEntries.size(); ++i) {
+    entries[i] = newEntries[i];
+    entries[i].getImplementation()->incrementRefCount();
+    updateVTableCache(entries[i]);
   }
   NumEntries = newEntries.size();
 }

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -8,31 +8,57 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 
-class MyClass {
+public class MyClass {
   init() { print("MyClass.init") }
   deinit { print("MyClass.deinit") }
   func foo() { print("MyClass.foo") }
 }
 
-class MySubClass: MyClass {
-  var x = 27
+public class MySubClass: MyClass {
+  var x: Int
 
-  override init() { print("MySubClass.init") }
+  override init() {
+    self.x = 27
+    print("MySubClass.init")
+  }
+
+  public init(p: some P) {
+    self.x = p.get()
+    super.init()
+    print("MySubClass.init")
+  }
+
   deinit { print("MySubClass.deinit") }
-  override func foo() { print("MySubClass.foo") }
+
+  override func foo() { print("MySubClass.foo: \(x)") }
 
   func printX() {
     print(x)
   }
 }
 
-class MySubSubClass: MySubClass {
-  override init() { print("MySubSubClass.init") }
+public protocol P {
+  func get() -> Int
+}
+
+struct S: P {
+  let i: Int
+
+  func get() -> Int { i }
+}
+
+public class MySubSubClass: MySubClass {
+  override init() {
+    print("MySubSubClass.init")
+    super.init()
+  }
+
   deinit { print("MySubSubClass.deinit") }
+
   override func foo() { print("MySubSubClass.foo") }
 }
 
-class OtherSubClass: MyClass {}
+public class OtherSubClass: MyClass {}
 
 func testCasting(_ title: StaticString, _ c: MyClass) {
   print(title, terminator: "")
@@ -81,9 +107,14 @@ struct Main {
     o.1!.foo()
     o.2!.foo()
     // CHECK: MyClass.foo
-    // CHECK: MySubClass.foo
+    // CHECK: MySubClass.foo: 27
     // CHECK: MySubSubClass.foo
     print("")
+
+    print("4b") // CHECK: 4b
+    o.1 = MySubClass(p: S(i: 42))
+    o.1!.foo()
+    // CHECK: MySubClass.foo: 42
 
     print("5") // CHECK: 5
     o.0 = nil


### PR DESCRIPTION
For example:

```
  public class C: MyClass {
    public init(p: some P) {
      // ...
    }
  }
```

Constructors are not called via the vtable (except "required" constructors).
Therefore we can allow generic constructors.

fixes: https://github.com/swiftlang/swift/issues/78150
rdar://138576752