### PR TITLE
Improve Task documentation.

### DIFF
--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -253,15 +253,13 @@ extension Task where Failure == ${FAILURE_TYPE} {
 % end
   ///
 % if IS_DETACHED:
-  /// In most cases, an "attached" unstructured task (created via `Task.init`)
-  /// is a more appropriate choice than a detached unstructured task. Attached
-  /// tasks inherit the priority and task-local storage from the enclosing task
-  /// during which they are created. You need to handle these considerations
-  /// manually with a detached task.
-  ///
-  /// A detached `Task` has the same cancellation mechanism as any other `Task`;
-  /// it can only become cancelled via an explicit `cancel()` method call.
+  /// A detached `Task` will not inherit task priority or task-local storage
+  /// from a parent task. You will need to handle these considerations manually.
 % end
+  ///
+  /// Asynchronous operations modeled with `Task` are ["unstructured concurrency"](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Unstructured-Concurrency).
+  /// Among other concerns, an unstructured task will not inherit cancellation
+  /// from a parent task.
   ///
   /// You need to keep a reference to the task
   /// if you want to cancel it by calling the `Task.cancel()` method.

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -253,11 +253,14 @@ extension Task where Failure == ${FAILURE_TYPE} {
 % end
   ///
 % if IS_DETACHED:
-  /// Don't use a detached unstructured task if it's possible
-  /// to model the operation using structured concurrency features like child tasks.
-  /// Child tasks inherit the parent task's priority and task-local storage,
-  /// and canceling a parent task automatically cancels all of its child tasks.
-  /// You need to handle these considerations manually with a detached task.
+  /// In most cases, an "attached" unstructured task (created via `Task.init`)
+  /// is a more appropriate choice than a detached unstructured task. Attached
+  /// tasks inherit the priority and task-local storage from the enclosing task
+  /// during which they are created. You need to handle these considerations
+  /// manually with a detached task.
+  ///
+  /// A detached `Task` has the same cancellation mechanism as any other `Task`;
+  /// it can only become cancelled via an explicit `cancel()` method call.
 % end
   ///
   /// You need to keep a reference to the task

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -250,17 +250,19 @@ extension Task where Failure == ${FAILURE_TYPE} {
   /// If the `operation` throws an error, it is caught by the `Task` and will be
   /// rethrown only when the task's `value` is awaited. Take care to not accidentally
   /// dismiss errors by not awaiting on the task's resulting value.
+  ///
 % end
+  /// Asynchronous work modeled with `Task` is unstructured concurrency.
+  /// Don't use an unstructured task if it's possible to model the operation
+  /// using structured concurrency features like child tasks (such as `async let`
+  /// or task groups). Child tasks automatically become cancelled when their
+  /// parent task becomes cancelled.
   ///
 % if IS_DETACHED:
   /// A detached `Task` will not inherit task priority or task-local storage
   /// from a parent task. You will need to handle these considerations manually.
+  ///
 % end
-  ///
-  /// Asynchronous operations modeled with `Task` are ["unstructured concurrency"](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Unstructured-Concurrency).
-  /// Among other concerns, an unstructured task will not inherit cancellation
-  /// from a parent task.
-  ///
   /// You need to keep a reference to the task
   /// if you want to cancel it by calling the `Task.cancel()` method.
   /// Discarding your reference to a task

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -81,7 +81,7 @@ import Swift
 /// method is explicitly invoked. No other mechanism can cancel a `Task`, 
 /// including any instance of `Task` created within the scope of another 
 /// cancelled task. To propagate cancellation from an enclosing task, provide a 
-/// cancellation handler via ``Task/withTaskCancellationHandler(operation:onCancel:isolation:)``.
+/// cancellation handler via ``withTaskCancellationHandler(operation:onCancel:isolation:)``.
 ///
 /// Any instance of `Task` that you initialize for yourself is a top-level,
 /// _unstructured_ task. For more information about the implications of

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -77,32 +77,11 @@ import Swift
 /// This reflects the fact that a task can be canceled for many reasons,
 /// and additional reasons can accrue during the cancellation process.
 ///
-/// A `Task` becomes cancelled when its `cancel()` method is called on it. There
-/// is no other mechanism by which a `Task` can become cancelled. This is true
-/// even of a `Task` instance which is created inside the operation of another
-/// `Task`. You can manually propagate cancellation from an enclosing `Task` to
-/// another task created during its operation via `withTaskCancellationHandler(operation:onCancel:isolation:)`:
-///
-/// ```swift
-/// let outer = Task {
-///     let inner = Task {
-///         // The next statement will not throw an error unless cancellation of
-///         // the `outer` task is manually propagated to the `inner` task via a
-///         // cancellation handler:
-///         try Task.checkCancellation()
-///         return try await work()
-///     }
-///     return try await withTaskCancellationHandler {
-///         try await inner.value
-///     } onCancel: {
-///         inner.cancel()
-///     }
-/// }
-///
-/// // When `outer` becomes cancelled, the `onCancel` handler above will run,
-/// // causing `inner` to become cancelled, too.
-/// outer.cancel()
-/// ```
+/// An instance of `Task` becomes cancelled only when its ``Task/cancel()`` 
+/// method is explicitly invoked. No other mechanism can cancel a `Task`, 
+/// including any instance of `Task` created within the scope of another 
+/// cancelled task. To propagate cancellation from an enclosing task, provide a 
+/// cancellation handler via ``Task/withTaskCancellationHandler(operation:onCancel:isolation:)``.
 ///
 /// Any instance of `Task` that you initialize for yourself is a top-level,
 /// _unstructured_ task. For more information about the implications of
@@ -232,16 +211,15 @@ extension Task {
   ///
   /// - It flags the task as canceled.
   /// - It causes any active cancellation handlers on the task to run, once.
-  /// - It cancels any child tasks (lowercase-t tasks, like `async let` and
-  ///   other forms of structured concurrency, not capital-t `Task` instances)
-  ///   and task groups of the task, including those created in the future. If
-  ///   those tasks have cancellation handlers, they also are triggered.
+  /// - It cancels any child tasks (`async let` and other forms of structured
+  ///   concurrency, not other `Task` instances) and task groups of the task,
+  ///   including those created in the future. If those tasks have cancellation
+  ///   handlers, they also are triggered.
   ///
-  /// Cancelling a `Task` does _not_ cancel other instances of `Task` that were
+  /// Cancelling a `Task` does not cancel other instances of `Task` that were
   /// or will be created during its operation. Those other instances will not
   /// become cancelled until and unless they are explicitly cancelled via
-  /// their `cancel()` methods being called on them. Read the "Task Cancellation"
-  /// section of the `Task` documentation for more information.
+  /// their `cancel()` methods being called on them.
   ///
   /// Task cancellation is cooperative and idempotent.
   ///
@@ -711,7 +689,7 @@ extension Task where Success == Never, Failure == Never {
 /// To query the current task without saving a reference to it,
 /// use properties like `currentPriority`.
 /// If you need to store a reference to a task, create an unstructured task using
-/// `Task.init(name:priority:operation:)` or `Task.detached(priority:operation:)` instead.
+/// ``Task.init(name:priority:operation:)`` or ``Task.detached(priority:operation:)`` instead.
 ///
 /// - Parameters:
 ///   - body: A closure that takes an `UnsafeCurrentTask` parameter.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -47,6 +47,11 @@ import Swift
 /// Unless you're implementing a custom executor,
 /// you don't directly interact with partial tasks.
 ///
+/// Asynchronous work modeled with `Task` is unstructured concurrency.
+/// Don't use an unstructured task if it's possible to model the operation
+/// using structured concurrency features like child tasks (such as `async let`
+/// or task groups).
+///
 /// For information about the language-level concurrency model that `Task` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
@@ -82,11 +87,6 @@ import Swift
 /// including any instance of `Task` created within the scope of another 
 /// cancelled task. To propagate cancellation from an enclosing task, provide a 
 /// cancellation handler via ``withTaskCancellationHandler(operation:onCancel:isolation:)``.
-///
-/// Any instance of `Task` that you initialize for yourself is a top-level,
-/// _unstructured_ task. For more information about the implications of
-/// unstructured tasks, read the ["Unstructured Concurrency"](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Unstructured-Concurrency)
-/// portion of the Swift Programming Language book.
 ///
 /// ### Task closure lifetime
 /// Tasks are initialized by passing a closure containing the code that will be executed by a given task.


### PR DESCRIPTION
## Explanation
 
Clarifies that Task instances do not inherit cancellation from an enclosing Task within which they are created. Clarifies that the term "child task" does not refer to such tasks. Clarifies some language which had previously made it seem like non-detached Tasks would inherit cancellation (they do not).

## Scope
 
The changes are limited exclusively to documentation. There is no impact on ABI.

## Issues
  
N/A

## Original PRs

N/A

## Risk

Risk is minimal to zero, as these changes affect only the documentation.

## Testing
 
N/A

## Reviewers
 
Pending...