### PR TITLE
Sema: Re-visit @specialize attribute where clause in interface resolution stage [6.3]

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3590,6 +3590,12 @@ void AttributeChecker::visitAbstractSpecializeAttr(AbstractSpecializeAttr *attr)
   }
 
   (void)attr->getSpecializedSignature(FD);
+
+  // Force resolution of interface types written in requirements here to check
+  // that generic types satisfy generic requirements, and so on.
+  WhereClauseOwner(FD, attr)
+      .visitRequirements(TypeResolutionStage::Interface,
+                         [](Requirement, RequirementRepr *) { return false; });
 }
 
 GenericSignature

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -602,7 +602,8 @@ static void checkGenericParams(GenericContext *ownerCtx) {
     checkInheritanceClause(gp);
   }
 
-  // Force resolution of interface types written in requirements here.
+  // Force resolution of interface types written in requirements here to check
+  // that generic types satisfy generic requirements, and so on.
   WhereClauseOwner(ownerCtx)
       .visitRequirements(TypeResolutionStage::Interface,
                          [](Requirement, RequirementRepr *) { return false; });

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -405,3 +405,9 @@ func nonGenericParam2(x: Int) {}
 @_specialize(where T == Int)
 @_specialize(where T == Int)
 func genericParamDuplicate<T>(t: T) {}
+
+struct GG<T: P> {}
+
+// expected-error@+1 {{type 'String' does not conform to protocol 'P'}}
+@_specialize(where T == GG<String>)
+func genericArgInvalidSpecialize<T>(t: T) {}


### PR DESCRIPTION
* **Description:** As with all other where clauses, we must resolve the requirements twice; first in structural stage to build the generic signature, and second in interface stage to check that any generic types that appear within satisfy requirements. We weren't doing the latter for `@specialize`, which would result in SIL crashes if such invalid types appeared therein.

* **Risk:** This might cause us to reject invalid code that was not diagnosed before, but such code would probably crash later in the SIL pipeline anyway (like the example in the radar).

* **Radar:** Fixes rdar://165909327.

* **Reviewed by:** @DougGregor 