### PR TITLE
test: attempt to reduce use of `-fbuiltin-headers-in-system-modules`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -467,17 +467,20 @@ config.swift_system_overlay_opt = ""
 config.clang_system_overlay_opt = ""
 config.windows_vfs_overlay_opt = ""
 if kIsWindows and run_os in ['windows-msvc']:
-    # ucrt.modulemap currently requires -fbuiltin-headers-in-system-modules. -strict-implicit-module-context
-    # is necessary for -Xcc arguments to be passed through ModuleInterfaceLoader.
-    config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+    # -strict-implicit-module-context is necessary for -Xcc arguments to be
+    # passed through ModuleInterfaceLoader.
+    config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
-    # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
-    # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
-    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+
+    # This variant is for `extract-symbolgraph` which doesn't accept all the
+    # same arugments as `swiftc` so the extra ceremony lets us pass in the
+    # relevant pieces needed for Windows SDK access.
+    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -strict-implicit-module-context".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
-    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+
+    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {}".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
 config.substitutions.append( ('%windows_vfs_overlay_opt', config.windows_vfs_overlay_opt) )


### PR DESCRIPTION
Remove the use of this flags during testing, following the other platforms. This improves the ability to run the CAS test suite on Windows.