### PR TITLE
stdlib: add `withTemporaryAllocation` using `OutputSpan`

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -261,12 +261,20 @@ public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
 ) throws(E) -> R where T : ~Copyable, R : ~Copyable {
   try withUnsafeTemporaryAllocation(of: type, capacity: capacity) { (buffer) throws(E) in
     var span = OutputSpan(buffer: buffer, initializedCount: 0)
-    defer {
+
+    do throws(E) {
+      let result = try body(&span)
+
       let initializedCount = span.finalize(for: buffer)
       buffer.extracting(..<initializedCount).deinitialize()
-    }
 
-    return try body(&span)
+      return result
+    } catch {
+      let initializedCount = span.finalize(for: buffer)
+      buffer.extracting(..<initializedCount).deinitialize()
+
+      throw error
+    }
   }
 }
 

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -133,7 +133,7 @@ internal func _withUnsafeTemporaryAllocation<
     MemoryLayout<T>.stride._builtinWordValue,
     alignment._builtinWordValue
   )
-  
+
   // The multiple calls to Builtin.stackDealloc() are because defer { } produces
   // a child function at the SIL layer and that conflicts with the verifier's
   // idea of a stack allocation's lifetime.
@@ -250,6 +250,24 @@ public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
   }
 
   return try result.get()
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_alwaysEmitIntoClient @_transparent
+public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
+  of type: T.Type,
+  capacity: Int,
+  _ body: (inout OutputSpan<T>) throws(E) -> R
+) throws(E) -> R where T : ~Copyable, R : ~Copyable {
+  try withUnsafeTemporaryAllocation(of: type, capacity: capacity) { (buffer) throws(E) in
+    var span = OutputSpan(buffer: buffer, initializedCount: 0)
+    defer {
+      let initializedCount = span.finalize(for: buffer)
+      buffer.extracting(..<initializedCount).deinitialize()
+    }
+
+    return try body(&span)
+  }
 }
 
 /// Provides scoped access to a raw buffer pointer with the specified byte count

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -261,20 +261,13 @@ public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
 ) throws(E) -> R where T : ~Copyable, R : ~Copyable {
   try withUnsafeTemporaryAllocation(of: type, capacity: capacity) { (buffer) throws(E) in
     var span = OutputSpan(buffer: buffer, initializedCount: 0)
-
-    do throws(E) {
-      let result = try body(&span)
-
+    defer {
       let initializedCount = span.finalize(for: buffer)
+      span = OutputSpan()
       buffer.extracting(..<initializedCount).deinitialize()
-
-      return result
-    } catch {
-      let initializedCount = span.finalize(for: buffer)
-      buffer.extracting(..<initializedCount).deinitialize()
-
-      throw error
     }
+
+    return try body(&span)
   }
 }
 

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -254,19 +254,38 @@ public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_alwaysEmitIntoClient @_transparent
+@safe
 public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
   of type: T.Type,
   capacity: Int,
   _ body: (inout OutputSpan<T>) throws(E) -> R
 ) throws(E) -> R where T : ~Copyable, R : ~Copyable {
   try withUnsafeTemporaryAllocation(of: type, capacity: capacity) { (buffer) throws(E) in
-    var span = OutputSpan(buffer: buffer, initializedCount: 0)
+    var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     defer {
-      let initializedCount = span.finalize(for: buffer)
+      let initializedCount = unsafe span.finalize(for: buffer)
       span = OutputSpan()
-      buffer.extracting(..<initializedCount).deinitialize()
+      unsafe buffer.extracting(..<initializedCount).deinitialize()
     }
 
+    return try body(&span)
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_alwaysEmitIntoClient @_transparent
+@safe
+public func withTemporaryAllocation<R: ~Copyable, E: Error>(
+  byteCount: Int,
+  alignment: Int,
+  _ body: (inout OutputRawSpan) throws(E) -> R
+) throws(E) -> R where R: ~Copyable {
+  try withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: alignment) { (buffer) throws(E) in
+    var span = unsafe OutputRawSpan(buffer: buffer, initializedCount: 0)
+    defer {
+      _ = unsafe span.finalize(for: buffer)
+      span = OutputRawSpan()
+    }
     return try body(&span)
   }
 }

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -36,7 +36,9 @@ internal func _byteCountForTemporaryAllocation<T: ~Copyable>(
   // emitting equivalent compile-time diagnostics because the call to
   // Builtin.stackAlloc() becomes unreachable.
   if _isComputed(capacity) {
-    _precondition(capacity >= 0, "Allocation capacity must be greater than or equal to zero")
+    _precondition(
+      capacity >= 0, "Allocation capacity must be greater than or equal to zero"
+    )
   }
   let stride = MemoryLayout<T>.stride
   let (byteCount, overflow) = capacity.multipliedReportingOverflow(by: stride)
@@ -62,7 +64,9 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
   // non-power-of-two alignments.
   if _isComputed(alignment) {
     _precondition(alignment > 0, "Alignment value must be greater than zero")
-    _precondition(_isPowerOf2(alignment), "Alignment value must be a power of two")
+    _precondition(
+      _isPowerOf2(alignment), "Alignment value must be a power of two"
+    )
   }
 
   // If the alignment is larger than MaximumAlignment, the allocation is always
@@ -97,7 +101,8 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 /// - Parameters:
 ///   - type: The type of the elements in the buffer being temporarily
 ///     allocated. For untyped buffers, use `Int8.self`.
-///   - capacity: The number of elements to allocate. `capacity` must not be negative.
+///   - capacity: The number of elements to allocate. `capacity` must not be
+///     negative.
 ///   - alignment: The alignment of the new, temporary region of allocated
 ///     memory, in bytes. `alignment` must be a whole power of 2.
 ///   - body: A closure to invoke and to which the allocated buffer pointer
@@ -120,7 +125,9 @@ internal func _withUnsafeTemporaryAllocation<
   let byteCount = _byteCountForTemporaryAllocation(of: type, capacity: capacity)
 
   guard _isStackAllocationSafe(byteCount: byteCount, alignment: alignment) else {
-    return _fallBackToHeapAllocation(byteCount: byteCount, alignment: alignment, body)
+    return _fallBackToHeapAllocation(
+      byteCount: byteCount, alignment: alignment, body
+    )
   }
 
   // This declaration must come BEFORE Builtin.stackAlloc() or
@@ -155,7 +162,9 @@ internal func _withUnprotectedUnsafeTemporaryAllocation<
   let byteCount = _byteCountForTemporaryAllocation(of: type, capacity: capacity)
 
   guard _isStackAllocationSafe(byteCount: byteCount, alignment: alignment) else {
-    return _fallBackToHeapAllocation(byteCount: byteCount, alignment: alignment, body)
+    return _fallBackToHeapAllocation(
+      byteCount: byteCount, alignment: alignment, body
+    )
   }
 
   // This declaration must come BEFORE Builtin.unprotectedStackAlloc() or
@@ -259,7 +268,8 @@ public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
   capacity: Int,
   _ body: (inout OutputSpan<T>) throws(E) -> R
 ) throws(E) -> R where T : ~Copyable, R : ~Copyable {
-  try withUnsafeTemporaryAllocation(of: type, capacity: capacity) { (buffer) throws(E) in
+  try withUnsafeTemporaryAllocation(of: type, capacity: capacity) {
+    (buffer) throws(E) in
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     defer {
       let initializedCount = unsafe span.finalize(for: buffer)
@@ -278,7 +288,8 @@ public func withTemporaryAllocation<R: ~Copyable, E: Error>(
   alignment: Int,
   _ body: (inout OutputRawSpan) throws(E) -> R
 ) throws(E) -> R where R: ~Copyable {
-  try withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: alignment) { (buffer) throws(E) in
+  try withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: alignment) {
+    (buffer) throws(E) in
     var span = unsafe OutputRawSpan(buffer: buffer, initializedCount: 0)
     defer {
       _ = unsafe span.finalize(for: buffer)

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -254,7 +254,6 @@ public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_alwaysEmitIntoClient @_transparent
-@safe
 public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
   of type: T.Type,
   capacity: Int,
@@ -274,7 +273,6 @@ public func withTemporaryAllocation<T: ~Copyable, R: ~Copyable, E: Error>(
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_alwaysEmitIntoClient @_transparent
-@safe
 public func withTemporaryAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
   alignment: Int,

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -136,7 +136,9 @@ TemporaryAllocationTestSuite.test("spanOnHeap") {
 }
 
 TemporaryAllocationTestSuite.test("unprotectedTypedAllocationOnStack") {
-  unsafe _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(
+    of: Int.self, capacity: 1
+  ) { buffer in
     unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
@@ -145,7 +147,9 @@ TemporaryAllocationTestSuite.test("unprotectedTypedAllocationOnHeap") {
   // EXPECTATION: a very large allocated buffer is heap-allocated. (Note if
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
-  unsafe _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 100_000) { buffer in
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(
+    of: Int.self, capacity: 100_000
+  ) { buffer in
     unsafe expectNotStackAllocated(buffer.baseAddress!)
   }
 }
@@ -214,7 +218,8 @@ case forgot
 
 TemporaryAllocationTestSuite.test("typedAllocationWithThrow") {
   do throws(HomeworkError) {
-    try withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { (buffer) throws(HomeworkError) -> Void in
+    try withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) {
+      (buffer) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
     expectUnreachable("did not throw!?!")
@@ -225,7 +230,8 @@ TemporaryAllocationTestSuite.test("typedAllocationWithThrow") {
 
 TemporaryAllocationTestSuite.test("spanWithThrow") {
   do throws(HomeworkError) {
-    try withTemporaryAllocation(of: Int.self, capacity: 1) { (span) throws(HomeworkError) -> Void in
+    try withTemporaryAllocation(of: Int.self, capacity: 1) {
+      (span) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
     expectUnreachable("did not throw!?!")
@@ -305,7 +311,8 @@ TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment")
 
 TemporaryAllocationTestSuite.test("rawSpanWithThrow") {
   do throws(HomeworkError) {
-    try withTemporaryAllocation(byteCount: 8, alignment: 1) { (rawSpan) throws(HomeworkError) -> Void in
+    try withTemporaryAllocation(byteCount: 8, alignment: 1) {
+      (rawSpan) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
     expectUnreachable("did not throw")

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -217,7 +217,7 @@ TemporaryAllocationTestSuite.test("typedAllocationWithThrow") {
     try withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { (buffer) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
-    fatalError("did not throw!?!")
+    expectUnreachable("did not throw!?!")
   } catch {
     expectEqual(error, .forgot)
   }
@@ -228,7 +228,7 @@ TemporaryAllocationTestSuite.test("spanWithThrow") {
     try withTemporaryAllocation(of: Int.self, capacity: 1) { (span) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
-    fatalError("did not throw!?!")
+    expectUnreachable("did not throw!?!")
   } catch {
     expectEqual(error, .forgot)
   }
@@ -308,7 +308,7 @@ TemporaryAllocationTestSuite.test("rawSpanWithThrow") {
     try withTemporaryAllocation(byteCount: 8, alignment: 1) { (rawSpan) throws(HomeworkError) -> Void in
       throw HomeworkError.forgot
     }
-    fatalError("did not throw")
+    expectUnreachable("did not throw")
   } catch {
     expectEqual(error, .forgot)
   }

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -153,15 +153,6 @@ TemporaryAllocationTestSuite.test("typedEmptyAllocationIsStackAllocated") {
   }
 }
 
-TemporaryAllocationTestSuite.test("emptySpanHasNoBuffer") {
-  withTemporaryAllocation(of: Int.self, capacity: 0) { span in
-    span.withUnsafeMutableBufferPointer { buffer, initializedCount in
-      expectTrue(buffer.baseAddress == nil)
-      initializedCount = 0
-    }
-  }
-}
-
 TemporaryAllocationTestSuite.test("voidAllocationIsStackAllocated") {
   withUnsafeTemporaryAllocation(of: Void.self, capacity: 1) { buffer in
     expectStackAllocated(buffer.baseAddress!)
@@ -235,6 +226,86 @@ TemporaryAllocationTestSuite.test("spanWithThrow") {
       throw HomeworkError.forgot
     }
     fatalError("did not throw!?!")
+  } catch {
+    expectEqual(error, .forgot)
+  }
+}
+
+// MARK: Raw bytes span
+
+TemporaryAllocationTestSuite.test("rawSpanOnStack") {
+  withTemporaryAllocation(byteCount: 8, alignment: 1) { rawSpan in
+    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      expectStackAllocated(buffer.baseAddress!)
+      initializedCount = 0
+    }
+  }
+}
+
+TemporaryAllocationTestSuite.test("rawSpanOnHeap") {
+  withTemporaryAllocation(byteCount: 100_000, alignment: 1) { rawSpan in
+    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      expectNotStackAllocated(buffer.baseAddress!)
+      initializedCount = 0
+    }
+  }
+}
+
+TemporaryAllocationTestSuite.test("rawSpanEmptyAllocationIsStackAllocated") {
+  withTemporaryAllocation(byteCount: 0, alignment: 1) { rawSpan in
+    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      expectStackAllocated(buffer.baseAddress!)
+      initializedCount = 0
+    }
+  }
+}
+
+TemporaryAllocationTestSuite.test("rawSpanIsAligned") {
+  withTemporaryAllocation(byteCount: 1, alignment: 8) { rawSpan in
+    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      let pointerBits = Int(bitPattern: buffer.baseAddress!)
+      let alignmentMask = 0b111
+      expectEqual(pointerBits & alignmentMask, 0)
+      initializedCount = 0
+    }
+  }
+}
+
+TemporaryAllocationTestSuite.test("rawSpanAppendAndByteCount") {
+  withTemporaryAllocation(byteCount: 4, alignment: 1) { rawSpan in
+    expectEqual(rawSpan.byteCount, 0)
+    expectEqual(rawSpan.freeCapacity, 4)
+    expectTrue(rawSpan.isEmpty)
+    rawSpan.append(UInt8(0xAB))
+    rawSpan.append(UInt8(0xCD))
+    expectEqual(rawSpan.byteCount, 2)
+    expectEqual(rawSpan.freeCapacity, 2)
+    expectFalse(rawSpan.isEmpty)
+  }
+}
+
+#if !os(WASI)
+TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount") {
+  expectCrash {
+    let byteCount = Int.random(in: -2 ..< -1)
+    withTemporaryAllocation(byteCount: byteCount, alignment: 1) { _ in }
+  }
+}
+
+TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment") {
+  expectCrash {
+    let alignment = Int.random(in: -2 ..< -1)
+    withTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }
+  }
+}
+#endif
+
+TemporaryAllocationTestSuite.test("rawSpanWithThrow") {
+  do throws(HomeworkError) {
+    try withTemporaryAllocation(byteCount: 8, alignment: 1) { (rawSpan) throws(HomeworkError) -> Void in
+      throw HomeworkError.forgot
+    }
+    fatalError("did not throw")
   } catch {
     expectEqual(error, .forgot)
   }

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -73,21 +73,21 @@ TemporaryAllocationTestSuite.test("untypedEmptyAllocationIsStackAllocated") {
   }
 }
 
-#if !os(WASI)
-TemporaryAllocationTestSuite.test("crashOnNegativeByteCount") {
+TemporaryAllocationTestSuite.test("crashOnNegativeByteCount")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: 1) { _ in }
   }
 }
 
-TemporaryAllocationTestSuite.test("crashOnNegativeAlignment") {
+TemporaryAllocationTestSuite.test("crashOnNegativeAlignment")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }
   }
 }
-#endif
 
 TemporaryAllocationTestSuite.test("untypedAllocationIsAligned") {
   withUnsafeTemporaryAllocation(byteCount: 1, alignment: 8) { buffer in
@@ -171,21 +171,21 @@ TemporaryAllocationTestSuite.test("voidSpanIsStackAllocated") {
   }
 }
 
-#if !os(WASI)
-TemporaryAllocationTestSuite.test("crashOnNegativeValueCount") {
+TemporaryAllocationTestSuite.test("crashOnNegativeValueCount")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(of: Int.self, capacity: capacity) { _ in }
   }
 }
 
-TemporaryAllocationTestSuite.test("spanCrashOnNegativeValueCount") {
+TemporaryAllocationTestSuite.test("spanCrashOnNegativeValueCount")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(of: Int.self, capacity: capacity) { _ in }
   }
 }
-#endif
 
 TemporaryAllocationTestSuite.test("typedAllocationIsAligned") {
   withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in
@@ -287,21 +287,21 @@ TemporaryAllocationTestSuite.test("rawSpanAppendAndByteCount") {
   }
 }
 
-#if !os(WASI)
-TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount") {
+TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(byteCount: byteCount, alignment: 1) { _ in }
   }
 }
 
-TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment") {
+TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }
   }
 }
-#endif
 
 TemporaryAllocationTestSuite.test("rawSpanWithThrow") {
   do throws(HomeworkError) {

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swift(-strict-memory-safety)
 // REQUIRES: executable_test
 
 import StdlibUnittest
@@ -9,15 +9,15 @@ var TemporaryAllocationTestSuite = TestSuite("TemporaryAllocation")
 func isStackAllocated(_ pointer: UnsafeRawPointer) -> Bool? {
     var stackBegin: UInt = 0
     var stackEnd: UInt = 0
-    if _swift_stdlib_getCurrentStackBounds(&stackBegin, &stackEnd) {
-        var pointerValue = UInt(bitPattern: pointer)
+    if unsafe _swift_stdlib_getCurrentStackBounds(&stackBegin, &stackEnd) {
+        let pointerValue = UInt(bitPattern: pointer)
         return pointerValue >= stackBegin && pointerValue < stackEnd
     }
     return nil
 }
 
 func expectStackAllocated(_ pointer: UnsafeRawPointer) {
-    if let stackAllocated = isStackAllocated(pointer) {
+    if let stackAllocated = unsafe isStackAllocated(pointer) {
         expectTrue(stackAllocated)
     } else {
         // Could not read stack bounds. Skip.
@@ -25,7 +25,7 @@ func expectStackAllocated(_ pointer: UnsafeRawPointer) {
 }
 
 func expectNotStackAllocated(_ pointer: UnsafeRawPointer) {
-    if let stackAllocated = isStackAllocated(pointer) {
+    if let stackAllocated = unsafe isStackAllocated(pointer) {
         expectFalse(stackAllocated)
     } else {
         // Could not read stack bounds. Skip.
@@ -36,7 +36,7 @@ func expectNotStackAllocated(_ pointer: UnsafeRawPointer) {
 
 TemporaryAllocationTestSuite.test("untypedAllocationOnStack") {
   withUnsafeTemporaryAllocation(byteCount: 8, alignment: 1) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
@@ -45,13 +45,14 @@ TemporaryAllocationTestSuite.test("untypedAllocationOnHeap") {
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
   withUnsafeTemporaryAllocation(byteCount: 100_000, alignment: 1) { buffer in
-      expectNotStackAllocated(buffer.baseAddress!)
+    unsafe expectNotStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("unprotectedUntypedAllocationOnStack") {
-  _withUnprotectedUnsafeTemporaryAllocation(byteCount: 8, alignment: 1) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(byteCount: 8, alignment: 1) {
+    buffer in
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
@@ -59,14 +60,16 @@ TemporaryAllocationTestSuite.test("unprotectedUntypedAllocationOnHeap") {
   // EXPECTATION: a very large allocated buffer is heap-allocated. (Note if
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
-  _withUnprotectedUnsafeTemporaryAllocation(byteCount: 100_000, alignment: 1) { buffer in
-      expectNotStackAllocated(buffer.baseAddress!)
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(
+    byteCount: 100_000, alignment: 1
+  ) { buffer in
+    unsafe expectNotStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("untypedEmptyAllocationIsStackAllocated") {
   withUnsafeTemporaryAllocation(byteCount: 0, alignment: 1) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
@@ -98,14 +101,14 @@ TemporaryAllocationTestSuite.test("untypedAllocationIsAligned") {
 
 TemporaryAllocationTestSuite.test("typedAllocationOnStack") {
   withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("spanOnStack") {
   withTemporaryAllocation(of: Int.self, capacity: 1) { span in
-    span.withUnsafeMutableBufferPointer { buffer, initializedCount in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe span.withUnsafeMutableBufferPointer { buffer, initializedCount in
+      unsafe expectStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
@@ -116,7 +119,7 @@ TemporaryAllocationTestSuite.test("typedAllocationOnHeap") {
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
   withUnsafeTemporaryAllocation(of: Int.self, capacity: 100_000) { buffer in
-      expectNotStackAllocated(buffer.baseAddress!)
+    unsafe expectNotStackAllocated(buffer.baseAddress!)
   }
 }
 
@@ -125,16 +128,16 @@ TemporaryAllocationTestSuite.test("spanOnHeap") {
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
   withTemporaryAllocation(of: Int.self, capacity: 100_000) { span in
-    span.withUnsafeMutableBufferPointer { buffer, initializedCount in
-      expectNotStackAllocated(buffer.baseAddress!)
+    unsafe span.withUnsafeMutableBufferPointer { buffer, initializedCount in
+      unsafe expectNotStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
 }
 
 TemporaryAllocationTestSuite.test("unprotectedTypedAllocationOnStack") {
-  _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
@@ -142,27 +145,27 @@ TemporaryAllocationTestSuite.test("unprotectedTypedAllocationOnHeap") {
   // EXPECTATION: a very large allocated buffer is heap-allocated. (Note if
   // swift_stdlib_isStackAllocationSafe() gets fleshed out, this test may need
   // to be changed.)
-  _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 100_000) { buffer in
-      expectNotStackAllocated(buffer.baseAddress!)
+  unsafe _withUnprotectedUnsafeTemporaryAllocation(of: Int.self, capacity: 100_000) { buffer in
+    unsafe expectNotStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("typedEmptyAllocationIsStackAllocated") {
   withUnsafeTemporaryAllocation(of: Int.self, capacity: 0) { buffer in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("voidAllocationIsStackAllocated") {
   withUnsafeTemporaryAllocation(of: Void.self, capacity: 1) { buffer in
-    expectStackAllocated(buffer.baseAddress!)
+    unsafe expectStackAllocated(buffer.baseAddress!)
   }
 }
 
 TemporaryAllocationTestSuite.test("voidSpanIsStackAllocated") {
   withTemporaryAllocation(of: Void.self, capacity: 1) { span in
-    span.withUnsafeMutableBufferPointer { buffer, initializedCount in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe span.withUnsafeMutableBufferPointer { buffer, initializedCount in
+      unsafe expectStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
@@ -194,7 +197,7 @@ TemporaryAllocationTestSuite.test("typedAllocationIsAligned") {
 
 TemporaryAllocationTestSuite.test("spanIsAligned") {
   withTemporaryAllocation(of: Int.self, capacity: 1) { span in
-    span.withUnsafeMutableBufferPointer { buffer, initializedCount in
+    unsafe span.withUnsafeMutableBufferPointer { buffer, initializedCount in
       let pointerBits = Int(bitPattern: buffer.baseAddress!)
       let alignmentMask = MemoryLayout<Int>.alignment - 1
       expectEqual(pointerBits & alignmentMask, 0)
@@ -235,8 +238,8 @@ TemporaryAllocationTestSuite.test("spanWithThrow") {
 
 TemporaryAllocationTestSuite.test("rawSpanOnStack") {
   withTemporaryAllocation(byteCount: 8, alignment: 1) { rawSpan in
-    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      unsafe expectStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
@@ -244,8 +247,8 @@ TemporaryAllocationTestSuite.test("rawSpanOnStack") {
 
 TemporaryAllocationTestSuite.test("rawSpanOnHeap") {
   withTemporaryAllocation(byteCount: 100_000, alignment: 1) { rawSpan in
-    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
-      expectNotStackAllocated(buffer.baseAddress!)
+    unsafe rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      unsafe expectNotStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
@@ -253,8 +256,8 @@ TemporaryAllocationTestSuite.test("rawSpanOnHeap") {
 
 TemporaryAllocationTestSuite.test("rawSpanEmptyAllocationIsStackAllocated") {
   withTemporaryAllocation(byteCount: 0, alignment: 1) { rawSpan in
-    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
-      expectStackAllocated(buffer.baseAddress!)
+    unsafe rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+      unsafe expectStackAllocated(buffer.baseAddress!)
       initializedCount = 0
     }
   }
@@ -262,7 +265,7 @@ TemporaryAllocationTestSuite.test("rawSpanEmptyAllocationIsStackAllocated") {
 
 TemporaryAllocationTestSuite.test("rawSpanIsAligned") {
   withTemporaryAllocation(byteCount: 1, alignment: 8) { rawSpan in
-    rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
+    unsafe rawSpan.withUnsafeMutableBytes { buffer, initializedCount in
       let pointerBits = Int(bitPattern: buffer.baseAddress!)
       let alignmentMask = 0b111
       expectEqual(pointerBits & alignmentMask, 0)


### PR DESCRIPTION
Implementation of accepted [SE-0524: Add withTemporaryAllocation using Output(Raw)Span](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0524-span-temporary-allocation.md).