### PR TITLE
[cxx-interop] Remove compatibility versions

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -753,13 +753,6 @@ namespace swift {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
-    /// Whether the C++ interoperability compatibility version is at least
-    /// 'major'.
-    bool isCxxInteropCompatVersionAtLeast(unsigned major,
-                                          unsigned minor = 0) const {
-      return cxxInteropCompatVersion.isVersionAtLeast(major, minor);
-    }
-
     /// Sets the "_hasAtomicBitWidth" conditional.
     void setHasAtomicBitWidth(llvm::Triple triple);
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -333,10 +333,6 @@ namespace swift {
     /// disabled because it is not complete.
     bool EnableCXXInterop = false;
 
-    /// The C++ interoperability source compatibility version. Defaults
-    /// to the Swift language version.
-    version::Version cxxInteropCompatVersion;
-
     /// What version of C++ interoperability a textual interface was originally
     /// generated with (if at all).
     std::optional<version::Version> FormalCxxInteropMode;

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -184,11 +184,6 @@ StringRef getCurrentCompilerSerializationTag();
 /// same serialization tag.
 StringRef getCurrentCompilerChannel();
 
-/// Retrieves the value of the upcoming C++ interoperability compatibility
-/// version that's going to be presented as some new concrete version to the
-/// users.
-unsigned getUpcomingCxxInteropCompatVersion();
-
 /// Retrieves the version of the running compiler. It could be a tag or
 /// a "development" version that only has major/minor.
 std::string getCompilerVersion();

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -330,10 +330,6 @@ StringRef getCurrentCompilerChannel() {
   return StringRef();
 }
 
-unsigned getUpcomingCxxInteropCompatVersion() {
-  return SWIFT_VERSION_MAJOR + 1;
-}
-
 std::string getCompilerVersion() {
   std::string buf;
   llvm::raw_string_ostream OS(buf);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -624,17 +624,6 @@ public:
   void getMangledName(clang::MangleContext *mangler,
                       const clang::NamedDecl *clangDecl, raw_ostream &os);
 
-  /// Whether the C++ interoperability compatibility version is at least
-  /// 'major'.
-  ///
-  /// Use the
-  /// `isCxxInteropCompatVersionAtLeast(version::getUpcomingCxxInteropCompatVersion())`
-  /// check when making a source breaking C++ interop change.
-  bool isCxxInteropCompatVersionAtLeast(unsigned major,
-                                        unsigned minor = 0) const {
-    return SwiftContext.LangOpts.isCxxInteropCompatVersionAtLeast(major, minor);
-  }
-
 private:
   /// The Importer may be configured to load modules of a different OS Version
   /// than the underlying Swift compilation. This is the `TargetOptions`

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -667,17 +667,9 @@ static std::pair<CxxCompatMode, version::Version>
 validateCxxInteropCompatibilityMode(StringRef mode) {
   if (mode == "off")
     return {CxxCompatMode::off, {}};
-  if (mode == "default")
+  if (mode == "default" || mode == "upcoming-swift" || mode == "swift-6" ||
+      mode == "swift-5.9")
     return {CxxCompatMode::enabled, {}};
-  if (mode == "upcoming-swift")
-    return {CxxCompatMode::enabled,
-            version::Version({version::getUpcomingCxxInteropCompatVersion()})};
-  if (mode == "swift-6")
-    return {CxxCompatMode::enabled, version::Version({6})};
-  // Swift-5.9 corresponds to the Swift 5 language mode when
-  // Swift 5 is the default language version.
-  if (mode == "swift-5.9")
-    return {CxxCompatMode::enabled, version::Version({5})};
   // Note: If this is updated, corresponding code in
   // InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl needs
   // to be updated also.
@@ -709,13 +701,6 @@ void LangOptions::setCxxInteropFromArgs(ArgList &Args,
     auto interopCompatMode = validateCxxInteropCompatibilityMode(A->getValue());
     EnableCXXInterop |=
         (interopCompatMode.first == CxxCompatMode::enabled);
-    if (EnableCXXInterop) {
-      cxxInteropCompatVersion = interopCompatMode.second;
-      // The default is tied to the current language version.
-      if (cxxInteropCompatVersion.empty())
-        cxxInteropCompatVersion =
-            EffectiveLanguageVersion.asMajorVersion();
-    }
 
     if (interopCompatMode.first == CxxCompatMode::invalid)
       diagnoseCxxInteropCompatMode(A, Args, Diags);
@@ -725,11 +710,6 @@ void LangOptions::setCxxInteropFromArgs(ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::enable_interop_flag_deprecated);
     Diags.diagnose(SourceLoc(), diag::swift_will_maintain_compat);
     EnableCXXInterop |= true;
-    // Using the deprecated option only forces the 'swift-5.9' compat
-    // mode.
-    if (cxxInteropCompatVersion.empty())
-      cxxInteropCompatVersion =
-          validateCxxInteropCompatibilityMode("swift-5.9").second;
   }
 
   if (Arg *A = Args.getLastArg(options::OPT_formal_cxx_interoperability_mode)) {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2026,23 +2026,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   if (langOpts.EnableCXXInterop) {
     // Modelled after a reverse of validateCxxInteropCompatibilityMode
     genericSubInvocation.getLangOptions().EnableCXXInterop = true;
-    genericSubInvocation.getLangOptions().cxxInteropCompatVersion =
-        langOpts.cxxInteropCompatVersion;
-    std::string compatVersion;
-    if (langOpts.cxxInteropCompatVersion.empty())
-      compatVersion = "default";
-    else if (langOpts.cxxInteropCompatVersion[0] == 5)
-      compatVersion = "swift-5.9";
-    else if (langOpts.cxxInteropCompatVersion[0] == 6)
-      compatVersion = "swift-6";
-    else if (langOpts.cxxInteropCompatVersion[0] ==
-             version::getUpcomingCxxInteropCompatVersion())
-      compatVersion = "upcoming-swift";
-    else // TODO: This may need to be updated once more versions are added
-      compatVersion = "default";
-
-    GenericArgs.push_back(
-        ArgSaver.save("-cxx-interoperability-mode=" + compatVersion));
+    GenericArgs.push_back(ArgSaver.save("-cxx-interoperability-mode=default"));
 
     if (!langOpts.isUsingPlatformDefaultCXXStdlib() &&
         langOpts.CXXStdlib == CXXStdlibKind::Libcxx) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4626,22 +4626,8 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableObjCInterop =
         llvm::Triple(options::Triple).isOSDarwin();
   }
-  if (options::EnableCxxInterop) {
+  if (options::EnableCxxInterop || !options::CxxInteropVersion.empty()) {
     InitInvok.getLangOptions().EnableCXXInterop = true;
-  }
-  if (!options::CxxInteropVersion.empty()) {
-    InitInvok.getLangOptions().EnableCXXInterop = true;
-    if (options::CxxInteropVersion == "upcoming-swift")
-      InitInvok.getLangOptions().cxxInteropCompatVersion =
-          version::Version({version::getUpcomingCxxInteropCompatVersion()});
-    else if (options::CxxInteropVersion == "swift-6")
-      InitInvok.getLangOptions().cxxInteropCompatVersion =
-          version::Version({6});
-    else if (options::CxxInteropVersion == "swift-5.9")
-      InitInvok.getLangOptions().cxxInteropCompatVersion =
-          version::Version({5, 9});
-    else
-      llvm::errs() << "invalid CxxInteropVersion\n";
   }
   if (options::CxxInteropGettersSettersAsProperties) {
     InitInvok.getLangOptions().CxxInteropGettersSettersAsProperties = true;


### PR DESCRIPTION
This removes the C++ interop compat version mechanism. It was added in mid-2023 and was never used. It complicates the testing story, and makes it harder to reason about the compiler's behavior. It also isn't compatible with explicit module builds.

The flag `-cxx-interoperability-mode` is preserved, so projects that use the flag will continue to build normally.

rdar://165919353