### PR TITLE
CMake Android: ensure _Builtin_float is built before _math

### DIFF
--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -5,7 +5,8 @@ set_target_properties(swift_math PROPERTIES
   Swift_MODULE_NAME _math)
 target_link_libraries(swift_math PRIVATE
   SwiftAndroid
-  swiftCore)
+  swiftCore
+  swift_Builtin_float)
 
 install(TARGETS swift_math
   EXPORT SwiftOverlayTargets

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -167,6 +167,7 @@ add_swift_target_library(swift_math ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_O
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS "ANDROID"
     INSTALL_IN_COMPONENT sdk-overlay
+    SWIFT_MODULE_DEPENDS_ANDROID _Builtin_float
     DEPENDS android_modulemap)
 
 add_swift_target_library(swiftAndroid ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY


### PR DESCRIPTION
_math would be able to build against either the Swift or the clang module for _Builtin_float; however the build will fail if the Swift module is present but does not contain the architectures we need, with errors like

```
<unknown>:0: error: could not find module
'_Builtin_float' for target 'armv7-unknown-linux-android'; found:
aarch64-unknown-linux-android, x86_64-unknown-linux-android, at:
/home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64/lib/swift/android/_Builtin_float.swiftmodule/armv7-unknown-linux-android
```

In other words, in this situation we are not falling back to the clang module.

Addresses rdar://165768601