### PR TITLE
Allow CustomStringConvertible et al: ~Copyable

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -590,6 +590,9 @@ extension String {
   // also preserve source compatibility for clients which accidentally  
   // used init(stringInterpolationSegment:) through constructs like 
   // myArray.map(String.init).
+  //
+  // Unfortunately they create ambiguity by being parallel to each
+  // other, so many overloads are required.
 
   /// Creates a string representing the given value.
   ///
@@ -631,8 +634,98 @@ extension String {
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   @inlinable
+  @_alwaysEmitIntoClient
+  public init<Subject: CustomStringConvertible & ~Copyable>(describing instance: borrowing Subject) {
+    self = instance.description
+  }
+
+  /// Creates a string representing the given value.
+  ///
+  /// Use this initializer to convert an instance of any type to its preferred
+  /// representation as a `String` instance. The initializer creates the
+  /// string representation of `instance` in one of the following ways,
+  /// depending on its protocol conformance:
+  ///
+  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
+  ///   result is obtained by calling `instance.write(to: s)` on an empty
+  ///   string `s`.
+  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
+  ///   result is `instance.description`.
+  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
+  ///   the result is `instance.debugDescription`.
+  /// - An unspecified result is supplied automatically by the Swift standard
+  ///   library.
+  ///
+  /// For example, this custom `Point` struct uses the default representation
+  /// supplied by the standard library.
+  ///
+  ///     struct Point {
+  ///         let x: Int, y: Int
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     print(String(describing: p))
+  ///     // Prints "Point(x: 21, y: 30)"
+  ///
+  /// After adding `CustomStringConvertible` conformance by implementing the
+  /// `description` property, `Point` provides its own custom representation.
+  ///
+  ///     extension Point: CustomStringConvertible {
+  ///         var description: String {
+  ///             return "(\(x), \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     print(String(describing: p))
+  ///     // Prints "(21, 30)"
   public init<Subject: CustomStringConvertible>(describing instance: Subject) {
     self = instance.description
+  }
+
+  /// Creates a string representing the given value.
+  ///
+  /// Use this initializer to convert an instance of any type to its preferred
+  /// representation as a `String` instance. The initializer creates the
+  /// string representation of `instance` in one of the following ways,
+  /// depending on its protocol conformance:
+  ///
+  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
+  ///   result is obtained by calling `instance.write(to: s)` on an empty
+  ///   string `s`.
+  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
+  ///   result is `instance.description`.
+  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
+  ///   the result is `instance.debugDescription`.
+  /// - An unspecified result is supplied automatically by the Swift standard
+  ///   library.
+  ///
+  /// For example, this custom `Point` struct uses the default representation
+  /// supplied by the standard library.
+  ///
+  ///     struct Point {
+  ///         let x: Int, y: Int
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     print(String(describing: p))
+  ///     // Prints "Point(x: 21, y: 30)"
+  ///
+  /// After adding `CustomStringConvertible` conformance by implementing the
+  /// `description` property, `Point` provides its own custom representation.
+  ///
+  ///     extension Point: CustomStringConvertible {
+  ///         var description: String {
+  ///             return "(\(x), \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     print(String(describing: p))
+  ///     // Prints "(21, 30)"
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init<Subject: TextOutputStreamable & ~Copyable>(describing instance: borrowing Subject) {
+    self.init()
+    instance.write(to: &self)
   }
 
   /// Creates a string representing the given value.
@@ -678,6 +771,53 @@ extension String {
   public init<Subject: TextOutputStreamable>(describing instance: Subject) {
     self.init()
     instance.write(to: &self)
+  }
+
+  /// Creates a string representing the given value.
+  ///
+  /// Use this initializer to convert an instance of any type to its preferred
+  /// representation as a `String` instance. The initializer creates the
+  /// string representation of `instance` in one of the following ways,
+  /// depending on its protocol conformance:
+  ///
+  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
+  ///   result is obtained by calling `instance.write(to: s)` on an empty
+  ///   string `s`.
+  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
+  ///   result is `instance.description`.
+  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
+  ///   the result is `instance.debugDescription`.
+  /// - An unspecified result is supplied automatically by the Swift standard
+  ///   library.
+  ///
+  /// For example, this custom `Point` struct uses the default representation
+  /// supplied by the standard library.
+  ///
+  ///     struct Point {
+  ///         let x: Int, y: Int
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     print(String(describing: p))
+  ///     // Prints "Point(x: 21, y: 30)"
+  ///
+  /// After adding `CustomStringConvertible` conformance by implementing the
+  /// `description` property, `Point` provides its own custom representation.
+  ///
+  ///     extension Point: CustomStringConvertible {
+  ///         var description: String {
+  ///             return "(\(x), \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     print(String(describing: p))
+  ///     // Prints "(21, 30)"
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init<Subject>(describing instance: borrowing Subject)
+    where Subject: CustomStringConvertible & TextOutputStreamable & ~Copyable
+  {
+    self = instance.description
   }
 
   /// Creates a string representing the given value.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -634,51 +634,10 @@ extension String {
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   @inlinable
-  @_alwaysEmitIntoClient
-  public init<Subject: CustomStringConvertible & ~Copyable>(describing instance: borrowing Subject) {
-    self = instance.description
-  }
-
-  /// Creates a string representing the given value.
-  ///
-  /// Use this initializer to convert an instance of any type to its preferred
-  /// representation as a `String` instance. The initializer creates the
-  /// string representation of `instance` in one of the following ways,
-  /// depending on its protocol conformance:
-  ///
-  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
-  ///   result is obtained by calling `instance.write(to: s)` on an empty
-  ///   string `s`.
-  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
-  ///   result is `instance.description`.
-  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
-  ///   the result is `instance.debugDescription`.
-  /// - An unspecified result is supplied automatically by the Swift standard
-  ///   library.
-  ///
-  /// For example, this custom `Point` struct uses the default representation
-  /// supplied by the standard library.
-  ///
-  ///     struct Point {
-  ///         let x: Int, y: Int
-  ///     }
-  ///
-  ///     let p = Point(x: 21, y: 30)
-  ///     print(String(describing: p))
-  ///     // Prints "Point(x: 21, y: 30)"
-  ///
-  /// After adding `CustomStringConvertible` conformance by implementing the
-  /// `description` property, `Point` provides its own custom representation.
-  ///
-  ///     extension Point: CustomStringConvertible {
-  ///         var description: String {
-  ///             return "(\(x), \(y))"
-  ///         }
-  ///     }
-  ///
-  ///     print(String(describing: p))
-  ///     // Prints "(21, 30)"
-  public init<Subject: CustomStringConvertible>(describing instance: Subject) {
+  @_preInverseGenerics
+  public init<Subject: CustomStringConvertible & ~Copyable>(
+    describing instance: borrowing Subject
+  ) {
     self = instance.description
   }
 
@@ -722,8 +681,10 @@ extension String {
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   @inlinable
-  @_alwaysEmitIntoClient
-  public init<Subject: TextOutputStreamable & ~Copyable>(describing instance: borrowing Subject) {
+  @_preInverseGenerics
+  public init<Subject: TextOutputStreamable & ~Copyable>(
+    describing instance: borrowing Subject
+  ) {
     self.init()
     instance.write(to: &self)
   }
@@ -768,101 +729,10 @@ extension String {
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   @inlinable
-  public init<Subject: TextOutputStreamable>(describing instance: Subject) {
-    self.init()
-    instance.write(to: &self)
-  }
-
-  /// Creates a string representing the given value.
-  ///
-  /// Use this initializer to convert an instance of any type to its preferred
-  /// representation as a `String` instance. The initializer creates the
-  /// string representation of `instance` in one of the following ways,
-  /// depending on its protocol conformance:
-  ///
-  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
-  ///   result is obtained by calling `instance.write(to: s)` on an empty
-  ///   string `s`.
-  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
-  ///   result is `instance.description`.
-  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
-  ///   the result is `instance.debugDescription`.
-  /// - An unspecified result is supplied automatically by the Swift standard
-  ///   library.
-  ///
-  /// For example, this custom `Point` struct uses the default representation
-  /// supplied by the standard library.
-  ///
-  ///     struct Point {
-  ///         let x: Int, y: Int
-  ///     }
-  ///
-  ///     let p = Point(x: 21, y: 30)
-  ///     print(String(describing: p))
-  ///     // Prints "Point(x: 21, y: 30)"
-  ///
-  /// After adding `CustomStringConvertible` conformance by implementing the
-  /// `description` property, `Point` provides its own custom representation.
-  ///
-  ///     extension Point: CustomStringConvertible {
-  ///         var description: String {
-  ///             return "(\(x), \(y))"
-  ///         }
-  ///     }
-  ///
-  ///     print(String(describing: p))
-  ///     // Prints "(21, 30)"
-  @inlinable
-  @_alwaysEmitIntoClient
-  public init<Subject>(describing instance: borrowing Subject)
-    where Subject: CustomStringConvertible & TextOutputStreamable & ~Copyable
-  {
-    self = instance.description
-  }
-
-  /// Creates a string representing the given value.
-  ///
-  /// Use this initializer to convert an instance of any type to its preferred
-  /// representation as a `String` instance. The initializer creates the
-  /// string representation of `instance` in one of the following ways,
-  /// depending on its protocol conformance:
-  ///
-  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
-  ///   result is obtained by calling `instance.write(to: s)` on an empty
-  ///   string `s`.
-  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
-  ///   result is `instance.description`.
-  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
-  ///   the result is `instance.debugDescription`.
-  /// - An unspecified result is supplied automatically by the Swift standard
-  ///   library.
-  ///
-  /// For example, this custom `Point` struct uses the default representation
-  /// supplied by the standard library.
-  ///
-  ///     struct Point {
-  ///         let x: Int, y: Int
-  ///     }
-  ///
-  ///     let p = Point(x: 21, y: 30)
-  ///     print(String(describing: p))
-  ///     // Prints "Point(x: 21, y: 30)"
-  ///
-  /// After adding `CustomStringConvertible` conformance by implementing the
-  /// `description` property, `Point` provides its own custom representation.
-  ///
-  ///     extension Point: CustomStringConvertible {
-  ///         var description: String {
-  ///             return "(\(x), \(y))"
-  ///         }
-  ///     }
-  ///
-  ///     print(String(describing: p))
-  ///     // Prints "(21, 30)"
-  @inlinable
-  public init<Subject>(describing instance: Subject)
-    where Subject: CustomStringConvertible & TextOutputStreamable
-  {
+  @_preInverseGenerics
+  public init<Subject: CustomStringConvertible & TextOutputStreamable & ~Copyable>(
+    describing instance: borrowing Subject
+  ) {
     self = instance.description
   }
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -99,7 +99,7 @@ extension TextOutputStream {
 /// To add `TextOutputStreamable` conformance to a custom type, implement the
 /// required `write(to:)` method. Call the given output stream's `write(_:)`
 /// method in your implementation.
-public protocol TextOutputStreamable {
+public protocol TextOutputStreamable: ~Copyable {
   /// Writes a textual representation of this instance into the given output
   /// stream.
   func write<Target: TextOutputStream>(to target: inout Target)
@@ -147,7 +147,7 @@ public protocol TextOutputStreamable {
 ///
 ///     print(p)
 ///     // Prints "(21, 30)"
-public protocol CustomStringConvertible {
+public protocol CustomStringConvertible: ~Copyable {
   /// A textual representation of this instance.
   ///
   /// Calling this property directly is discouraged. Instead, convert an
@@ -182,7 +182,7 @@ public protocol CustomStringConvertible {
 /// The description property of a conforming type must be a value-preserving
 /// representation of the original value. As such, it should be possible to
 /// re-create an instance from its string representation.
-public protocol LosslessStringConvertible: CustomStringConvertible {
+public protocol LosslessStringConvertible: CustomStringConvertible, ~Copyable {
   /// Instantiates an instance of the conforming type from a string
   /// representation.
   init?(_ description: String)
@@ -239,7 +239,7 @@ public protocol LosslessStringConvertible: CustomStringConvertible {
 ///
 ///     print(String(reflecting: p))
 ///     // Prints "(21, 30)"
-public protocol CustomDebugStringConvertible {
+public protocol CustomDebugStringConvertible: ~Copyable {
   /// A textual representation of this instance, suitable for debugging.
   ///
   /// Calling this property directly is discouraged. Instead, convert an

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -105,8 +105,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: TextOutputStreamable, T: CustomStringConvertible
+  @_preInverseGenerics
+  public mutating func appendInterpolation<T>(_ value: borrowing T)
+    where T: TextOutputStreamable, T: CustomStringConvertible, T: ~Copyable
   {
     value.write(to: &self)
   }
@@ -127,8 +128,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: TextOutputStreamable
+  @_preInverseGenerics
+  public mutating func appendInterpolation<T>(_ value: borrowing T)
+    where T: TextOutputStreamable & ~Copyable
   {
     value.write(to: &self)
   }
@@ -151,8 +153,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: CustomStringConvertible
+  @_preInverseGenerics
+  public mutating func appendInterpolation<T>(_ value: borrowing T)
+    where T: CustomStringConvertible, T: ~Copyable
   {
     value.description.write(to: &self)
   }
@@ -175,7 +178,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T) {
+  public mutating func appendInterpolation<T>(_ value: borrowing T) {
     #if !$Embedded
     _print_unlocked(value, &self)
     #else
@@ -217,13 +220,15 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
+  @_preInverseGenerics
   public mutating func appendInterpolation<T>(
-    _ value: T?,
+    _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable, T: CustomStringConvertible {
-    if let value {
+  ) where T: TextOutputStreamable, T: CustomStringConvertible, T: ~Copyable {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -247,13 +252,15 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
+  @_preInverseGenerics
   public mutating func appendInterpolation<T>(
-    _ value: T?,
+    _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable {
-    if let value {
+  ) where T: TextOutputStreamable & ~Copyable {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -277,13 +284,15 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
+  @_preInverseGenerics
   public mutating func appendInterpolation<T>(
-    _ value: T?, 
+    _ value: borrowing T?, 
     default: @autoclosure () -> some StringProtocol
-  ) where T: CustomStringConvertible {
-    if let value {
+  ) where T: CustomStringConvertible, T: ~Copyable {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -311,9 +320,10 @@ extension DefaultStringInterpolation {
     _ value: T?, 
     default: @autoclosure () -> some StringProtocol
   ) {
-    if let value {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -106,9 +106,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
   @_preInverseGenerics
-  public mutating func appendInterpolation<T>(_ value: borrowing T)
-    where T: TextOutputStreamable, T: CustomStringConvertible, T: ~Copyable
-  {
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & CustomStringConvertible & ~Copyable
+  >(_ value: borrowing T) {
     value.write(to: &self)
   }
   
@@ -129,9 +129,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
   @_preInverseGenerics
-  public mutating func appendInterpolation<T>(_ value: borrowing T)
-    where T: TextOutputStreamable & ~Copyable
-  {
+  public mutating func appendInterpolation<T: TextOutputStreamable & ~Copyable>(
+    _ value: borrowing T
+  ) {
     value.write(to: &self)
   }
   
@@ -154,9 +154,9 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
   @_preInverseGenerics
-  public mutating func appendInterpolation<T>(_ value: borrowing T)
-    where T: CustomStringConvertible, T: ~Copyable
-  {
+  public mutating func appendInterpolation<T: CustomStringConvertible & ~Copyable>(
+    _ value: borrowing T
+  ) {
     value.description.write(to: &self)
   }
   
@@ -220,11 +220,12 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  @_preInverseGenerics
-  public mutating func appendInterpolation<T>(
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & CustomStringConvertible & ~Copyable
+  >(
     _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable, T: CustomStringConvertible, T: ~Copyable {
+  ) {
     switch value {
     case let value?:
       self.appendInterpolation(value)
@@ -252,11 +253,10 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  @_preInverseGenerics
-  public mutating func appendInterpolation<T>(
+  public mutating func appendInterpolation<T: TextOutputStreamable & ~Copyable>(
     _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable & ~Copyable {
+  ) {
     switch value {
     case let value?:
       self.appendInterpolation(value)
@@ -284,11 +284,10 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  @_preInverseGenerics
-  public mutating func appendInterpolation<T>(
+  public mutating func appendInterpolation<T: CustomStringConvertible & ~Copyable>(
     _ value: borrowing T?, 
     default: @autoclosure () -> some StringProtocol
-  ) where T: CustomStringConvertible, T: ~Copyable {
+  ) {
     switch value {
     case let value?:
       self.appendInterpolation(value)

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -101,6 +101,7 @@ Func Substring.withCString(encodedAs:_:) is now without rethrows
 Func Substring.withUTF8(_:) has generic signature change from <R> to <R, E where E : Swift.Error>
 Func Substring.withUTF8(_:) is now without rethrows
 
+Protocol LosslessStringConvertible has generic signature change from <Self : Swift.CustomStringConvertible> to <Self : Swift.CustomStringConvertible, Self : ~Copyable>
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self : Swift.BitwiseCopyable, Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
 
 Protocol AdditiveArithmetic has added inherited protocol Copyable
@@ -119,7 +120,6 @@ Protocol CodingKey has added inherited protocol Copyable
 Protocol CodingKey has added inherited protocol Escapable
 Protocol Collection has added inherited protocol Copyable
 Protocol Collection has added inherited protocol Escapable
-Protocol CustomDebugStringConvertible has added inherited protocol Copyable
 Protocol CustomDebugStringConvertible has added inherited protocol Escapable
 Protocol CustomLeafReflectable has added inherited protocol Copyable
 Protocol CustomLeafReflectable has added inherited protocol Escapable
@@ -127,7 +127,6 @@ Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Copyabl
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Escapable
 Protocol CustomReflectable has added inherited protocol Copyable
 Protocol CustomReflectable has added inherited protocol Escapable
-Protocol CustomStringConvertible has added inherited protocol Copyable
 Protocol CustomStringConvertible has added inherited protocol Escapable
 Protocol Decodable has added inherited protocol Copyable
 Protocol Decodable has added inherited protocol Escapable
@@ -173,7 +172,6 @@ Protocol LazyCollectionProtocol has added inherited protocol Copyable
 Protocol LazyCollectionProtocol has added inherited protocol Escapable
 Protocol LazySequenceProtocol has added inherited protocol Copyable
 Protocol LazySequenceProtocol has added inherited protocol Escapable
-Protocol LosslessStringConvertible has added inherited protocol Copyable
 Protocol LosslessStringConvertible has added inherited protocol Escapable
 Protocol MirrorPath has added inherited protocol Copyable
 Protocol MirrorPath has added inherited protocol Escapable
@@ -220,7 +218,6 @@ Protocol StringProtocol has added inherited protocol Copyable
 Protocol StringProtocol has added inherited protocol Escapable
 Protocol TextOutputStream has added inherited protocol Copyable
 Protocol TextOutputStream has added inherited protocol Escapable
-Protocol TextOutputStreamable has added inherited protocol Copyable
 Protocol TextOutputStreamable has added inherited protocol Escapable
 Protocol UnicodeCodec has added inherited protocol Copyable
 Protocol UnicodeCodec has added inherited protocol Escapable
@@ -467,3 +464,12 @@ Func Hasher.combine(_:) has parameter 0 changing from Default to Shared
 Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result, E where Self : Swift.Sequence, E : Swift.Error, Result : ~Copyable>
 Func Sequence.reduce(_:_:) has parameter 0 changing from Default to Owned
 
+// CustomStringConvertible etc: ~Copyable
+Accessor CustomDebugStringConvertible.debugDescription.Get() has generic signature change from <Self where Self : Swift.CustomDebugStringConvertible> to <Self where Self : Swift.CustomDebugStringConvertible, Self : ~Copyable>
+Accessor CustomStringConvertible.description.Get() has generic signature change from <Self where Self : Swift.CustomStringConvertible> to <Self where Self : Swift.CustomStringConvertible, Self : ~Copyable>
+Constructor LosslessStringConvertible.init(_:) has generic signature change from <Self where Self : Swift.LosslessStringConvertible> to <Self where Self : Swift.LosslessStringConvertible, Self : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable> to <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible> to <T where T : Swift.CustomStringConvertible, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.TextOutputStreamable> to <T where T : Swift.TextOutputStreamable, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has parameter 0 changing from Default to Shared
+Func TextOutputStreamable.write(to:) has generic signature change from <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream> to <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream, Self : ~Copyable>

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -200,6 +200,7 @@ Subscript MutableCollection.subscript(_:) has been removed
 Protocol SIMDScalar has added inherited protocol BitwiseCopyable
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self : Swift.BitwiseCopyable, Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
 Protocol _Pointer has added inherited protocol BitwiseCopyable
+Protocol LosslessStringConvertible has generic signature change from <Self : Swift.CustomStringConvertible> to <Self : Swift.CustomStringConvertible, Self : ~Copyable>
 
 Protocol AdditiveArithmetic has added inherited protocol Copyable
 Protocol AdditiveArithmetic has added inherited protocol Escapable
@@ -217,7 +218,6 @@ Protocol CodingKey has added inherited protocol Copyable
 Protocol CodingKey has added inherited protocol Escapable
 Protocol Collection has added inherited protocol Copyable
 Protocol Collection has added inherited protocol Escapable
-Protocol CustomDebugStringConvertible has added inherited protocol Copyable
 Protocol CustomDebugStringConvertible has added inherited protocol Escapable
 Protocol CustomLeafReflectable has added inherited protocol Copyable
 Protocol CustomLeafReflectable has added inherited protocol Escapable
@@ -225,7 +225,6 @@ Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Copyabl
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Escapable
 Protocol CustomReflectable has added inherited protocol Copyable
 Protocol CustomReflectable has added inherited protocol Escapable
-Protocol CustomStringConvertible has added inherited protocol Copyable
 Protocol CustomStringConvertible has added inherited protocol Escapable
 Protocol Decodable has added inherited protocol Copyable
 Protocol Decodable has added inherited protocol Escapable
@@ -271,7 +270,6 @@ Protocol LazyCollectionProtocol has added inherited protocol Copyable
 Protocol LazyCollectionProtocol has added inherited protocol Escapable
 Protocol LazySequenceProtocol has added inherited protocol Copyable
 Protocol LazySequenceProtocol has added inherited protocol Escapable
-Protocol LosslessStringConvertible has added inherited protocol Copyable
 Protocol LosslessStringConvertible has added inherited protocol Escapable
 Protocol MirrorPath has added inherited protocol Copyable
 Protocol MirrorPath has added inherited protocol Escapable
@@ -317,7 +315,6 @@ Protocol StringProtocol has added inherited protocol Copyable
 Protocol StringProtocol has added inherited protocol Escapable
 Protocol TextOutputStream has added inherited protocol Copyable
 Protocol TextOutputStream has added inherited protocol Escapable
-Protocol TextOutputStreamable has added inherited protocol Copyable
 Protocol TextOutputStreamable has added inherited protocol Escapable
 Protocol UnicodeCodec has added inherited protocol Copyable
 Protocol UnicodeCodec has added inherited protocol Escapable
@@ -973,5 +970,19 @@ Func _hashValue(for:) has generic signature change from <H where H : Swift.Hasha
 Func _hashValue(for:) has mangled name changing from 'Swift._hashValue<A where A: Swift.Hashable>(for: A) -> Swift.Int' to 'Swift._hashValue<A where A: Swift.Hashable, A: ~Swift.Copyable, A: ~Swift.Escapable>(for: A) -> Swift.Int'
 Func _hashValue(for:) has parameter 0 changing from Default to Shared
 Func _hashValue(for:) is now with @_preInverseGenerics
+
+// CustomStringConvertible etc: ~Copyable
+Accessor CustomDebugStringConvertible.debugDescription.Get() has generic signature change from <Self where Self : Swift.CustomDebugStringConvertible> to <Self where Self : Swift.CustomDebugStringConvertible, Self : ~Copyable>
+Accessor CustomStringConvertible.description.Get() has generic signature change from <Self where Self : Swift.CustomStringConvertible> to <Self where Self : Swift.CustomStringConvertible, Self : ~Copyable>
+Constructor LosslessStringConvertible.init(_:) has generic signature change from <Self where Self : Swift.LosslessStringConvertible> to <Self where Self : Swift.LosslessStringConvertible, Self : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable> to <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible> to <T where T : Swift.CustomStringConvertible, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.TextOutputStreamable> to <T where T : Swift.TextOutputStreamable, T : ~Copyable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has mangled name changing from 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.CustomStringConvertible, A: Swift.TextOutputStreamable>(A) -> ()' to 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.CustomStringConvertible, A: Swift.TextOutputStreamable, A: ~Swift.Copyable>(A) -> ()'
+Func DefaultStringInterpolation.appendInterpolation(_:) has mangled name changing from 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.CustomStringConvertible>(A) -> ()' to 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.CustomStringConvertible, A: ~Swift.Copyable>(A) -> ()'
+Func DefaultStringInterpolation.appendInterpolation(_:) has mangled name changing from 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.TextOutputStreamable>(A) -> ()' to 'Swift.DefaultStringInterpolation.appendInterpolation<A where A: Swift.TextOutputStreamable, A: ~Swift.Copyable>(A) -> ()'
+Func DefaultStringInterpolation.appendInterpolation(_:) has parameter 0 changing from Default to Shared
+Func DefaultStringInterpolation.appendInterpolation(_:) is now with @_preInverseGenerics
+Func TextOutputStreamable.write(to:) has generic signature change from <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream> to <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream, Self : ~Copyable>
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1024,7 +1024,7 @@ func testNormalProtocols(
 ) {}
 
 @abi(
-  func testNormalProtocolsGeneric<A, B: CustomStringConvertible>( // expected-error {{generic signature '<A, B where A : Copyable, A : Escapable, B : CustomStringConvertible>' in '@abi' is not compatible with '<A, B where A : CustomStringConvertible, B : Copyable, B : Escapable>'}}
+  func testNormalProtocolsGeneric<A, B: CustomStringConvertible>( // expected-error {{generic signature '<A, B where A : Copyable, A : Escapable, B : Copyable, B : CustomStringConvertible>' in '@abi' is not compatible with '<A, B where A : Copyable, A : CustomStringConvertible, B : Copyable, B : Escapable>'}}
     _: A, _: B
   )
 )

--- a/test/stdlib/NoncopyableCustomStringConvertible.swift
+++ b/test/stdlib/NoncopyableCustomStringConvertible.swift
@@ -1,0 +1,67 @@
+//===--- NoncopyableEquatable.swift - tests for Equatable: ~Copyable ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let NoncopyableCustomStringConvertibleTests = TestSuite("NoncopyableCustomStringConvertible")
+
+struct Noncopyable<Wrapped: ~Copyable & CustomStringConvertible>: ~Copyable {
+  var wrapped: Wrapped
+}
+
+// This approach is not necessarily what we would expect users to do, but for now we do
+// not have a generalized solution for reflection-based stringifying of noncopyable types,
+// so using this technique for testing purposes.
+extension Noncopyable: CustomStringConvertible where Wrapped: CustomStringConvertible & ~Copyable {
+    var description: String {
+        "No copying the value \(wrapped)"
+    }
+ }
+
+extension Noncopyable: CustomDebugStringConvertible where Wrapped: CustomStringConvertible & ~Copyable {
+    var debugDescription: String {
+        "Noncopyable(wrapping: \(wrapped))"
+    }
+ }
+
+extension Noncopyable<Int>: LosslessStringConvertible {
+    init?(_ description: String) {
+        guard let i: Int = .init(description) else { return nil }
+        self.wrapped = i
+    }
+}
+
+extension LosslessStringConvertible where Self: ~Copyable {
+    init(riskily with: String) {
+        self = .init(with)!
+    }
+}
+
+func debug(value: borrowing some CustomDebugStringConvertible & ~Copyable) -> String {
+    value.debugDescription
+}
+
+NoncopyableCustomStringConvertibleTests.test("noncopyable interpolation") {
+  let a: Noncopyable<Int> = .init(riskily: "99")
+  let b: Noncopyable<Noncopyable<Int>> = Noncopyable(wrapped: Noncopyable(riskily: "42"))
+
+  expectEqual("NC: \(a)", "NC: No copying the value 99")
+  expectEqual("Noncopyable(wrapping: 99)", debug(value: a))
+
+  expectEqual("NC: \(b)", "NC: No copying the value No copying the value 42")
+  expectEqual("Noncopyable(wrapping: No copying the value 42)", debug(value: b))
+
+}
+
+runAllTests()


### PR DESCRIPTION
Under review [here](https://forums.swift.org/t/se-0499-support-copyable-escapable-in-simple-standard-library-protocols/83297). Multi-part version of #85079.