### PR TITLE
Remove autorelease workaround for x86_64

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -30,7 +30,7 @@
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 size_t swift_stdlib_NSStringHashValue(NSString *str,
                                       bool isASCII) {
-    return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
+  return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
@@ -38,7 +38,7 @@ size_t
 swift_stdlib_NSStringHashValuePointer(void *opaque, bool isASCII) {
   NSString __unsafe_unretained *str =
       (__bridge NSString __unsafe_unretained *)opaque;
-    return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
+  return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
 }
 
 #else

--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -27,23 +27,10 @@
 // pool which might be scoped such that repeatedly placing objects into it
 // results in unbounded memory growth.
 
-// On i386 the remove from autorelease pool optimization is foiled by the
-// decomposedStringWithCanonicalMapping implementation. Instead, we use a local
-// autorelease pool to prevent leaking of the temporary object into the callers
-// autorelease pool.
-#if defined(__i386__)
-#define AUTORELEASEPOOL @autoreleasepool
-#else
-// On other platforms we rely on the remove from autorelease pool optimization.
-#define AUTORELEASEPOOL
-#endif
-
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 size_t swift_stdlib_NSStringHashValue(NSString *str,
                                       bool isASCII) {
-  AUTORELEASEPOOL {
     return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
-  }
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
@@ -51,9 +38,7 @@ size_t
 swift_stdlib_NSStringHashValuePointer(void *opaque, bool isASCII) {
   NSString __unsafe_unretained *str =
       (__bridge NSString __unsafe_unretained *)opaque;
-  AUTORELEASEPOOL {
     return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
-  }
 }
 
 #else

--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -31,17 +31,7 @@
 // decomposedStringWithCanonicalMapping implementation. Instead, we use a local
 // autorelease pool to prevent leaking of the temporary object into the callers
 // autorelease pool.
-//
-//
-// FIXME: Right now we force an autoreleasepool here on x86_64 where we really
-// do not want to do so. The reason why is that without the autoreleasepool (or
-// really something like a defer), we tail call
-// objc_retainAutoreleasedReturnValue which blocks the hand shake. Evidently
-// this is something that we do not want to do. See:
-// b79ff50f1bca97ecfd053372f5f6dc9d017398bc. Until that is resolved, just create
-// an autoreleasepool here on x86_64. On arm/arm64 we do not have such an issue
-// since we use an assembly marker instead.
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__)
 #define AUTORELEASEPOOL @autoreleasepool
 #else
 // On other platforms we rely on the remove from autorelease pool optimization.


### PR DESCRIPTION
LLVM no longer tail-calls this on x86_64, so we do not need an autorelease pool.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
