### PR TITLE
[RemoteInspection] Read ContextDescriptor from symbol if available

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2674,6 +2674,18 @@ private:
       return nullptr;
     }
 
+    // Check if the Reader can provide a symbol for this descriptor, and if it 
+    // can, use that instead.
+    if (auto remoteAbsolutePointer =
+            Reader->resolvePointerAsSymbol(descriptor.getRemoteAddress())) {
+      auto symbol = remoteAbsolutePointer->getSymbol();
+      if (!symbol.empty()) {
+        if (auto demangledSymbol = buildContextManglingForSymbol(symbol, dem)) {
+          return demangledSymbol;
+        }
+      }
+    }
+
     // Read the parent descriptor.
     auto parentDescriptorResult = readParentContextDescriptor(descriptor);
 


### PR DESCRIPTION
If the MemoryReader can provide a symbol for the context descriptor, use that instead of building the mangle tree from metadata. This shouldn't hurt other clients, and would have a few benefits for LLDB:

- Small but numerous memory reads can be expensive for LLDB, building the mangle tree from a string should be much faster.

- For types with private discriminators, this allows LLDB to provide the same private discriminator that's in DWARF and in the swiftmodule (as opposed to using the memory address where the context descriptor lives at). This means that these private types would have the same mangled name in every run. LLDB persistently caches field descriptors by name, but since private discriminators aren't guaranteed to have the same mangled name over multiple runs, LLDB would often need to invalidate its entire cache and rebuild it. Using the stable UUID would solve that issue.

rdar://165950673
