### PR TITLE
[Diagnostics] TildeSendable: Suggest `Sendable` suppression in explic…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8987,6 +8987,9 @@ NOTE(sendable_conformance_is_suppressed, none,
      "%kind0 explicitly suppresses conformance to 'Sendable' protocol",
      (const NominalTypeDecl *))
 
+NOTE(suppress_sendable_conformance,none,
+     "consider suppressing conformance to 'Sendable' protocol", ())
+
 ERROR(non_sendable_type_suppressed,none,
       "cannot both conform to and suppress conformance to 'Sendable'", ())
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1453,6 +1453,17 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     }
   }
 
+  // Note to supress Sendable conformance is feature is enabled.
+  if (ctx.LangOpts.hasFeature(Feature::TildeSendable)) {
+    auto note = nominal->diagnose(diag::suppress_sendable_conformance);
+    auto inheritance = nominal->getInherited();
+    if (inheritance.empty()) {
+      note.fixItInsertAfter(nominal->getNameLoc(), ": ~Sendable");
+    } else {
+      note.fixItInsertAfter(inheritance.getEndLoc(), ", ~Sendable");
+    }
+  }
+
   // Note to disable the warning.
   {
     auto note = nominal->diagnose(diag::explicit_disable_sendable, nominal);

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -swift-version 5 -enable-experimental-feature TildeSendable
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -swift-version 5 -enable-experimental-feature TildeSendable -Wwarning ExplicitSendable
 
 // REQUIRES: swift_feature_TildeSendable
 
@@ -134,5 +134,21 @@ do {
 
   actor A: ~Sendable {
     // expected-error@-1 {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
+  }
+}
+
+// ExplicitSendable + ~Sendable tests
+
+public struct TestExplicitSendable1 { // expected-warning {{public struct 'TestExplicitSendable1' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1 {{consider making struct 'TestExplicitSendable1' conform to the 'Sendable' protocol}}
+  // expected-note@-2 {{consider suppressing conformance to 'Sendable' protocol}} {{36-36=: ~Sendable}}
+  // expected-note@-3 {{make struct 'TestExplicitSendable1' explicitly non-Sendable to suppress this warning}}
+}
+
+public class TestExplicitSendableWithParent: ExpressibleByIntegerLiteral { // expected-warning {{public class 'TestExplicitSendableWithParent' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1 {{consider suppressing conformance to 'Sendable' protocol}} {{73-73=, ~Sendable}}
+  // expected-note@-2 {{make class 'TestExplicitSendableWithParent' explicitly non-Sendable to suppress this warning}}
+
+  public required init(integerLiteral: Int) {
   }
 }


### PR DESCRIPTION
…it Senable warning

Add a note to missing explicit `Sendable` conformance warning (produced by `-Wwarning ExplicitSendable`) and a fix-it with a suggestion to suppress `Senable` conformance  via `~Sendable`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
