### PR TITLE
swift_nonatomic_unknownObjectRelease should use swift_nonatomic_release

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -646,7 +646,7 @@ void *swift::swift_nonatomic_unknownObjectRetain(void *object) {
 void swift::swift_nonatomic_unknownObjectRelease(void *object) {
   if (isObjCTaggedPointerOrNull(object)) return;
   if (objectUsesNativeSwiftReferenceCounting(object))
-    return swift_release(static_cast<HeapObject *>(object));
+    return swift_nonatomic_release(static_cast<HeapObject *>(object));
   return objc_release(static_cast<id>(object));
 }
 


### PR DESCRIPTION
This appears to be a typo. Thankfully, it is not a correctness issue, as the atomic version does the same thing just slower.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
