### PR TITLE
[Test][Embedded] Make dependencies print compatible with lit shell

### DIFF
--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -4,7 +4,7 @@
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// RUN: %if target-os-linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt && comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt && comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
+// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt && comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt && comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
 
 //--- allowed-dependencies_macos.txt
 ___stack_chk_fail

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -4,37 +4,28 @@
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt %}
 // RUN: %if OS=linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt %} %else %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt %}
 // RUN: test ! -s %t/extra.txt
 
 //--- allowed-dependencies_macos.txt
-___stack_chk_fail
-___stack_chk_guard
 ___divti3
 ___modti3
+___stack_chk_fail
+___stack_chk_guard
 _memmove
 _memset
 _putchar
 
 //--- allowed-dependencies_linux.txt
-__stack_chk_fail
-__stack_chk_guard
 __divti3
 __modti3
+__stack_chk_fail
+__stack_chk_guard
 memmove
 memset
 putchar
 
 //--- test.swift
-// DEP: ___stack_chk_fail
-// DEP: ___stack_chk_guard
-// DEP: ___divti3
-// DEP: ___modti3
-// DEP: _memmove
-// DEP: _memset
-// DEP: _putchar
-
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -4,13 +4,9 @@
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt %}
-// RUN: %if OS=linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt %}
-// RUN: %if OS=linux-gnu %{ test ! -s %t/extra.txt %}
-
-// RUN: %if OS=macosx %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt %}
-// RUN: %if OS=macosx %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt %}
-// RUN: %if OS=macosx %{ test ! -s %t/extra.txt %}
+// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt %}
+// RUN: %if OS=linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt %} %else %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt %}
+// RUN: test ! -s %t/extra.txt
 
 //--- allowed-dependencies_macos.txt
 ___stack_chk_fail

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -24,7 +24,6 @@ __stack_chk_guard
 memmove
 memset
 putchar
-
 //--- test.swift
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -4,7 +4,7 @@
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// RUN: %if target-os-linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
+// RUN: %if target-os-linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt && comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt && comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
 
 //--- allowed-dependencies_macos.txt
 ___stack_chk_fail

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -1,16 +1,30 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -no-allocations %s -c -o %t/a.o
-
-// RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
-
-// Linux/ELF doesn't use the "_" prefix in symbol mangling.
-// RUN: if [ %target-os == "linux-gnu" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -no-allocations %t/test.swift -c -o %t/a.o
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
-// RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
+// RUN: %if target-os-linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
 
+//--- allowed-dependencies_macos.txt
+___stack_chk_fail
+___stack_chk_guard
+___divti3
+___modti3
+_memmove
+_memset
+_putchar
+
+//--- allowed-dependencies_linux.txt
+__stack_chk_fail
+__stack_chk_guard
+__divti3
+__modti3
+memmove
+memset
+putchar
+
+//--- test.swift
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
 // DEP: ___divti3

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -4,7 +4,13 @@
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
-// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt && comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %} %else %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt && comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt && test ! -s %t/extra.txt %}
+// RUN: %if OS=linux-gnu %{ sort %t/allowed-dependencies_linux.txt -o %t/allowed-dependencies_linux.txt %}
+// RUN: %if OS=linux-gnu %{ comm -13 %t/allowed-dependencies_linux.txt %t/actual-dependencies.txt > %t/extra.txt %}
+// RUN: %if OS=linux-gnu %{ test ! -s %t/extra.txt %}
+
+// RUN: %if OS=macosx %{ sort %t/allowed-dependencies_macos.txt -o %t/allowed-dependencies_macos.txt %}
+// RUN: %if OS=macosx %{ comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt %}
+// RUN: %if OS=macosx %{ test ! -s %t/extra.txt %}
 
 //--- allowed-dependencies_macos.txt
 ___stack_chk_fail


### PR DESCRIPTION
Partially addresses #84407 

```
#85881 fixed:
- test/embedded/dependencies-print.swift
```


Reference:
- [Option or command for finding whether a file is empty](https://askubuntu.com/questions/746040/option-or-command-for-finding-whether-a-file-is-empty)