### PR TITLE
[AST] suppress compiler warning

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -26,7 +26,7 @@ public class Decl: CustomStringConvertible, Hashable {
   /// The parent DeclContext.
   final public var parentDeclContext: DeclContext? {
     if let decl = bridged.getParent().decl {
-      return decl as! DeclContext
+      return (decl as! DeclContext)
     }
     if let bridgedDeclContext = BridgedDeclContext(bridged: bridged.getDeclContext()) {
       // A DeclContext which is not a Decl.


### PR DESCRIPTION
### Issue
Warning when building the compiler
````
[1429/1722][ 82%][5851.879s] Building swift module AST
/mnt/storage/work/swift-project/swift/SwiftCompilerSources/Sources/AST/Declarations.swift:29:19: warning: treating a forced downcast to 'any DeclContext' as optional will nev
er produce 'nil'
 27 |   final public var parentDeclContext: DeclContext? {
 28 |     if let decl = bridged.getParent().decl {
 29 |       return decl as! DeclContext
    |              |    | `- note: use 'as?' to perform a conditional downcast to 'any DeclContext'
    |              |    `- warning: treating a forced downcast to 'any DeclContext' as optional will never produce 'nil'
    |              `- note: add parentheses around the cast to silence this warning
 30 |     }
 31 |     if let bridgedDeclContext = BridgedDeclContext(bridged: bridged.getDeclContext()) {
````

The compiler emits a diagnostic in parentDeclContext indicating that a forced cast is being treated as if it could produce nil. This occurs because the return type is DeclContext? and the ungrouped as! expression causes the warning.

### Changes

Added parens to suppress the warning as recommended by the diagnostic.