### PR TITLE
stdlib: Fix OpenBSD typo in preprocessor in `Concurrency/Clock.cpp`

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -240,7 +240,7 @@ void swift_sleep(
     delay = deadline - now;
   }
 #elif defined(__linux__) || defined(__APPLE__) || defined(__wasi__) \
-  || defined(__OpenBSD) || defined(__FreeBSD__)
+  || defined(__OpenBSD__) || defined(__FreeBSD__)
   struct timespec ts;
   ts.tv_sec = seconds;
   ts.tv_nsec = nanoseconds;


### PR DESCRIPTION
As a result, openbsd was falling back to the std::chrono::duration_cast code.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
