### PR TITLE
[Parse] Fix buffer overrun in `advanceIfMultilineDelimiter`

### DIFF
--- a/validation-test/compiler_crashers_fixed/Parser-consumeTokenWithoutFeedingReceiver-dff2d1.swift
+++ b/validation-test/compiler_crashers_fixed/Parser-consumeTokenWithoutFeedingReceiver-dff2d1.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+
+// RUN: echo '#"' > %t/main1.swift
+// RUN: echo -n '#"' > %t/main2.swift
+
+// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not %target-swift-frontend -typecheck %t/main1.swift
+// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not %target-swift-frontend -typecheck %t/main2.swift
+
+// guardmalloc is incompatible with ASAN
+// REQUIRES: no_asan


### PR DESCRIPTION
Make sure we don't scan off the end of the buffer, and scan for the delimiter before attempting the lookahead.

rdar://165774720