### PR TITLE
[Concurrency] warn about 'final' on actors being ineffective

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5699,6 +5699,9 @@ ERROR(async_objc_dynamic_self,none,
 ERROR(actor_inheritance,none,
       "%select{actor|distributed actor}0 types do not support inheritance",
       (bool))
+WARNING(actor_final_no_effect,none,
+        "'final' on %kind0 has no effect",
+        (const ValueDecl*))
 
 ERROR(actor_protocol_illegal_inheritance,none,
       "non-actor type %0 cannot conform to the %1 protocol",

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3284,8 +3284,14 @@ public:
 
     TypeChecker::checkDeclAttributes(CD);
 
-    if (CD->isActor())
+    if (CD->isActor()) {
       TypeChecker::checkConcurrencyAvailability(CD->getLoc(), CD);
+
+      if (CD->isFinal()) {
+        CD->diagnose(diag::actor_final_no_effect, CD)
+            .fixItRemove(CD->getAttrs().getAttribute<FinalAttr>()->getLocation());
+      }
+    }
 
     for (Decl *Member : CD->getABIMembers())
       visit(Member);

--- a/test/Distributed/distributed_actor_basic.swift
+++ b/test/Distributed/distributed_actor_basic.swift
@@ -23,3 +23,5 @@ distributed actor Second {
     try! await first.one(second: self)
   }
 }
+
+final distributed actor WarnAboutMe { } // expected-warning{{'final' on distributed actor 'WarnAboutMe' has no effect}}

--- a/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
@@ -16,7 +16,7 @@
 // REQUIRES: concurrency
 
 @_expose(Cxx)
-public final actor ActorWithField {
+public final actor ActorWithField { // expected-warning{{'final' on actor 'ActorWithField' has no effect}}
   var field: Int64
 
   public init() {


### PR DESCRIPTION
Add a warning about 'final' in front of actor declarations. We've never started rejecting it, however it doesn't do anything, so we should warn about it because otherwise people may think this is actually doing something