### PR TITLE
Fix issue when creating a `some` type from a type with a parameter pack

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1402,8 +1402,12 @@ static void bindArchetypesFromContext(
     auto genericSig = parentDC->getGenericSignatureOfContext();
     for (auto *paramTy : genericSig.getGenericParams()) {
       Type contextTy = cs.DC->mapTypeIntoEnvironment(paramTy);
-      if (paramTy->isParameterPack())
-        contextTy = PackType::getSingletonPackExpansion(contextTy);
+      // For pack parameters, we bind directly to the pack archetype rather
+      // than wrapping in a singleton pack expansion. The pack expansion
+      // structure is handled separately when opening pack expansion types.
+      // This ensures that when same-type requirements with pack expansions
+      // are checked, the pattern types match correctly (e.g., 'each T' matches
+      // the opened type variable bound to the pack archetype 'each T').
       bindPrimaryArchetype(paramTy, contextTy);
     }
 

--- a/test/type/opaque_variadic_extension.swift
+++ b/test/type/opaque_variadic_extension.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -target %target-swift-5.9-abi-triple -typecheck -verify %s
+
+// https://forums.swift.org/t/opaque-return-type-fails-when-using-variadic-generics/81120
+// Opaque return types fail in extensions with pack expansion same-type constraints.
+
+struct S1<each T> { }
+struct S2<each T, U> { }
+
+extension S2 where U == S1<repeat each T> {
+  // These should compile - opaque return types in extensions with pack expansion
+  // same-type constraints are valid.
+  var property: some Any { () }
+  func function() -> some Any { () }
+}


### PR DESCRIPTION


Fixes https://github.com/swiftlang/swift/issues/83055
Forum thread: https://forums.swift.org/t/opaque-return-type-fails-when-using-variadic-generics/81120

This is my first commit and I used Claude liberally so sorry if I'm misunderstanding something here!

Changes:
- CSSimplify.cpp: Added logic to unwrap singleton pack expansions when comparing shapes.                                                        
- TypeOfReference.cpp: Removed the singleton pack expansion wrapping when binding pack type variables from context. Pack type variables now bind directly to the pack archetype, allowing pattern matching to work correctly.
