### PR TITLE
[Demangler] Handle invertible reqs for extensions in `findDeclContext`

### DIFF
--- a/test/IDE/rdar165639044.swift
+++ b/test/IDE/rdar165639044.swift
@@ -1,0 +1,15 @@
+// RUN: %batch-code-completion
+
+struct S<T: ~Copyable> {}
+protocol P: ~Copyable {}
+
+extension S where T: P {
+  var bar: Int { 0 }
+}
+struct R: P {}
+
+// Make sure USR round-tripping works here.
+func foo(_ x: S<R>) {
+  x.#^COMPLETE^#
+  // COMPLETE: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+}

--- a/test/TypeDecoder/extensions.swift
+++ b/test/TypeDecoder/extensions.swift
@@ -58,3 +58,19 @@ extension Generic where T: AnyObject {
 // DEMANGLE-DECL: $s10extensions7GenericVAARlzClE18NestedViaAnyObjectV
 // CHECK-DECL: extensions.(file).Generic extension.NestedViaAnyObject
 
+// Invertible Constraints
+
+struct GenericNonCopyable<T: ~Copyable> {}
+protocol ProtoNonCopyable: ~Copyable {}
+
+extension GenericNonCopyable where T: ProtoNonCopyable/*, T: Copyable*/ {
+  struct Nested {}
+}
+
+struct NonCopyableType: ProtoNonCopyable {}
+
+// DEMANGLE-DECL: $s10extensions18GenericNonCopyableVA2A05ProtocD0RzlE6NestedV
+// CHECK-DECL: extensions.(file).GenericNonCopyable extension.Nested
+
+// DEMANGLE-TYPE: $s10extensions18GenericNonCopyableVA2A05ProtocD0RzlE6NestedVyAA0cD4TypeV_GD
+// CHECK-TYPE: GenericNonCopyable<NonCopyableType>.Nested


### PR DESCRIPTION
If we didn't find an extension result, try again disregarding invertible requirements since `demangleGenericSignature` won't include them. This is just meant to be a quick low risk fix that we can cherry-pick, the proper fix here is to delete all this logic and just return the nominal along with the ABI module name to filter lookup results.

rdar://165639044