### PR TITLE
DriverTool: adjust `argv[0]` scanning for CAS

### DIFF
--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -196,7 +196,9 @@ private:
     }
     // drop swift-frontend executable path and leading `-frontend` from
     // command-line.
-    if (StringRef(FrontendArgs[0]).ends_with("swift-frontend"))
+    llvm::SmallString<261> path;
+    llvm::sys::path::native(Twine{FrontendArgs[0]}, path);
+    if (llvm::sys::path::filename(path).starts_with("swift-frontend"))
       FrontendArgs.erase(FrontendArgs.begin());
     if (StringRef(FrontendArgs[0]) == "-frontend")
       FrontendArgs.erase(FrontendArgs.begin());


### PR DESCRIPTION
Ensure that we nativize the path and consider only the filename starting prefix to account for file suffixes (e.g. `.exe` on Windows). This ensures that we properly support other platforms.