### PR TITLE
test: adjust the path compuation for plugins

### DIFF
--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -58,14 +58,14 @@
 /// Test plugin CAS.
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   %t/a.swift -o %t/plugin_deps.json -cache-compile-job -cas-path %t/cas-plugin -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext \
+// RUN:   %t/a.swift -o %t/plugin_deps.json -cache-compile-job -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) \
 // RUN:   -cas-plugin-option first-prefix=myfirst-
 
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/plugin_deps.json > %t/plugin_map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/plugin_map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/plugin_deps.json Test > %t/plugin_MyApp.cmd
-// RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext \
+// RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) \
 // RUN:   -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -77,9 +77,9 @@
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp-plugin.cmd
 
 /// Check switching CAS plugin path.
-// RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext > %t8.casid
-// RUN: ln -s %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext %t/libCASPluginTest%llvm_plugin_ext
+// RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) > %t8.casid
+// RUN: cp %plugin(CASPluginTest) %t/libCASPluginTest%llvm_plugin_ext
 // RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-base-key -- \
 // RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext > %t9.casid
 // RUN: diff %t8.casid %t9.casid

--- a/test/CAS/lit.local.cfg
+++ b/test/CAS/lit.local.cfg
@@ -1,4 +1,18 @@
-# FIXME: CAS file system doesn't support windows. Unsupported for now.
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+def get_target_os():
+    import re
+    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
+    return run_os
+
+import os
+
+if get_target_os() in ('windows-msvc',):
+    config.substitutions.insert(0, (r'%plugin\(([^)]+)\)', SubstituteCaptures(os.path.join(config.llvm_tools_dir, r'%target-library-name(\1)'))))
+else:
+    config.substitutions.insert(0, (r'%plugin\(([^)]+)\)', SubstituteCaptures(os.path.join(config.llvm_libs_dir, r'%target-library-name(\1)'))))
+
 import platform
 if platform.system() == 'Windows':
     config.unsupported = True


### PR DESCRIPTION
DLLs on Windows are built/installed into the binary directory while only import libraries are placed into the library directory to differentitate between the distributable and developer content. Introduce a helper to compute the appropriate plugin path.