### PR TITLE
Fix the swiftCxxStdlib link with explicit module build on Windows

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -620,6 +620,23 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
       break;
     }
 
+    if (ScanASTContext.LangOpts.EnableCXXInterop) {
+      StringRef mainModuleName = mainModule->getName().str();
+      if (mainModuleName != CXX_MODULE_NAME)
+        mainDependencies.addModuleImport(CXX_MODULE_NAME, /* isExported */ false,
+                                         AccessLevel::Public,
+                                         &alreadyAddedModules);
+      if (llvm::none_of(llvm::ArrayRef<StringRef>{CXX_MODULE_NAME,
+                            ScanASTContext.Id_CxxStdlib.str(), "std"},
+                        [mainModuleName](StringRef Name) {
+                          return mainModuleName == Name;
+                        }))
+        mainDependencies.addModuleImport(ScanASTContext.Id_CxxStdlib.str(),
+                                         /* isExported */ false,
+                                         AccessLevel::Public,
+                                         &alreadyAddedModules);
+    }
+
     // Add any implicit module names.
     for (const auto &import : importInfo.AdditionalUnloadedImports) {
       mainDependencies.addModuleImport(

--- a/test/ScanDependencies/win-explicit-cxx-interop-cxxstdlib.swift
+++ b/test/ScanDependencies/win-explicit-cxx-interop-cxxstdlib.swift
@@ -1,0 +1,43 @@
+// REQUIRES: OS=windows-msvc
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -scan-dependencies -module-name NoCpp \
+// RUN:   -module-cache-path %t/clang-module-cache -disable-objc-interop \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   %t/NoCpp.swift -o %t/NoCpp-deps.json -I %t 2>&1
+// RUN: %target-swift-frontend -scan-dependencies -module-name Cpp \
+// RUN:   -module-cache-path %t/clang-module-cache -disable-objc-interop \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   %t/Cpp.swift -o %t/Cpp-deps.json -I %t 2>&1
+// RUN: %target-swift-frontend -scan-dependencies -module-name Crt \
+// RUN:   -module-cache-path %t/clang-module-cache -disable-objc-interop \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   %t/Crt.swift -o %t/Crt-deps.json -I %t 2>&1
+// RUN: %FileCheck %s --check-prefix=NOCPP < %t/NoCpp-deps.json
+// RUN: %FileCheck %s --check-prefix=CPP < %t/Cpp-deps.json
+// RUN: %FileCheck %s --check-prefix=CRT < %t/Crt-deps.json
+
+// NOCPP:      "mainModuleName": "NoCpp"
+// NOCPP:      "linkName": "swiftCxxStdlib",
+// NOCPP-NEXT: "isStatic": true,
+
+// CPP:        "mainModuleName": "Cpp"
+// CPP:        "linkName": "swiftCxxStdlib",
+// CPP-NEXT:   "isStatic": true,
+
+// CRT:        "mainModuleName": "Crt"
+// CRT:        "linkName": "swiftCxxStdlib",
+// CRT-NEXT:   "isStatic": true,
+
+//--- NoCpp.swift
+// Empty
+
+//--- Cpp.swift
+import CxxStdlib
+
+//--- Crt.swift
+import CRT
+
+
+


### PR DESCRIPTION
We currently support static linking swiftCxxStdlib only on Windows. When C++ interop is enabled but swiftCxxStdlib isn't actually used or only when its underlying std module is used, we incorrectly emitted the dynamic version of the lib name and caused the link error. This change fixes it by always adding it to the dependency.

Issue https://github.com/swiftlang/swift/issues/85876
