### PR TITLE
"[RemoteInspection] Read ContextDescriptor from symbol if available" and "[RemoteInspection] Factor out buildContextDescriptorManglingForSymbol"

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2660,6 +2660,26 @@ private:
   }
 
   Demangle::NodePointer
+  buildContextDescriptorManglingForSymbol(llvm::StringRef symbol,
+                                          Demangler &dem) {
+    if (auto demangledSymbol = buildContextManglingForSymbol(symbol, dem)) {
+      // Look through Type nodes since we're building up a mangling here.
+      if (demangledSymbol->getKind() == Demangle::Node::Kind::Type) {
+        demangledSymbol = demangledSymbol->getChild(0);
+      }
+      return demangledSymbol;
+    }
+
+    return nullptr;
+  }
+
+  Demangle::NodePointer
+  buildContextDescriptorManglingForSymbol(const std::string &symbol,
+                                          Demangler &dem) {
+    return buildContextDescriptorManglingForSymbol(dem.copyString(symbol), dem);
+  }
+
+  Demangle::NodePointer
   buildContextDescriptorMangling(const ParentContextDescriptorRef &descriptor,
                                  Demangler &dem, int recursion_limit) {
     if (recursion_limit <= 0) {
@@ -2672,15 +2692,7 @@ private:
     
     // Try to demangle the symbol name to figure out what context it would
     // point to.
-    auto demangledSymbol = buildContextManglingForSymbol(descriptor.getSymbol(),
-                                                         dem);
-    if (!demangledSymbol)
-      return nullptr;
-    // Look through Type notes since we're building up a mangling here.
-    if (demangledSymbol->getKind() == Demangle::Node::Kind::Type){
-      demangledSymbol = demangledSymbol->getChild(0);
-    }
-    return demangledSymbol;
+    return buildContextDescriptorManglingForSymbol(descriptor.getSymbol(), dem);
   }
 
   Demangle::NodePointer
@@ -2696,7 +2708,7 @@ private:
             Reader->resolvePointerAsSymbol(descriptor.getRemoteAddress())) {
       auto symbol = remoteAbsolutePointer->getSymbol();
       if (!symbol.empty()) {
-        if (auto demangledSymbol = buildContextManglingForSymbol(symbol, dem)) {
+        if (auto demangledSymbol = buildContextDescriptorManglingForSymbol(symbol, dem)) {
           return demangledSymbol;
         }
       }

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2690,6 +2690,18 @@ private:
       return nullptr;
     }
 
+    // Check if the Reader can provide a symbol for this descriptor, and if it 
+    // can, use that instead.
+    if (auto remoteAbsolutePointer =
+            Reader->resolvePointerAsSymbol(descriptor.getRemoteAddress())) {
+      auto symbol = remoteAbsolutePointer->getSymbol();
+      if (!symbol.empty()) {
+        if (auto demangledSymbol = buildContextManglingForSymbol(symbol, dem)) {
+          return demangledSymbol;
+        }
+      }
+    }
+
     // Read the parent descriptor.
     auto parentDescriptorResult = readParentContextDescriptor(descriptor);
 


### PR DESCRIPTION
• **Explanation**: If the MemoryReader can provide a symbol for the context descriptor, use that instead of building the mangle tree from metadata. This shouldn't hurt other clients, and would have a few benefits for LLDB:

- Small but numerous memory reads can be expensive for LLDB, building the mangle tree from a string should be much faster.

- For types with private discriminators, this allows LLDB to provide the same private discriminator that's in DWARF and in the swiftmodule (as opposed to using the memory address where the context descriptor lives at). This means that these private types would have the same mangled name in every run. LLDB persistently caches field descriptors by name, but since private discriminators aren't guaranteed to have the same mangled name over multiple runs, LLDB would often need to invalidate its entire cache and rebuild it. Using the stable UUID would solve that issue.
• **Scope**: This affects RemoteInspection clients that override resolvePointerAsSymbol, which effectively is just LLDB.
• **Risk**: Low, this only affects LLDB, and the existing code validates that the symbol LLDB provides is valid.
• **Problem**: rdar://165950673
• **Original PR**: https://github.com/swiftlang/swift/pull/85878 and https://github.com/swiftlang/swift/pull/85911
* **Reviewed by:** @mikeash   
