### PR TITLE
[6.3🍒][ClangImporter] Do not import enum when already imported via DeclContext

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1613,6 +1613,14 @@ namespace {
       if (!dc)
         return nullptr;
 
+      // It's possible that we already encountered and imported decl while
+      // importing its decl context. If we are able to find a cached result,
+      // use it to avoid making a duplicate imported decl.
+      auto alreadyImported =
+          Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
+      if (alreadyImported != Impl.ImportedDecls.end())
+        return alreadyImported->second;
+
       auto name = importedName.getBaseIdentifier(Impl.SwiftContext);
 
       // Create the enum declaration and record it.

--- a/test/ClangImporter/circular-import-as-member.swift
+++ b/test/ClangImporter/circular-import-as-member.swift
@@ -1,0 +1,37 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=default -module-name main %t/program.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -cxx-interoperability-mode=off -module-name main %t/program.swift
+// REQUIRES: objc_interop
+
+//--- Inputs/module.modulemap
+module TheModule {
+    header "the-header.h"
+}
+
+//--- Inputs/the-header.h
+#pragma once
+
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#if (__cplusplus)
+#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#else
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
+#endif
+
+typedef CF_OPTIONS(unsigned, TheFlags) {
+  TheFlagsFoo = (1 << 1),
+  TheFlagsBar = (1 << 2)
+} CF_SWIFT_NAME(The.Flags);
+
+typedef TheFlags DaFlags;
+
+struct TheContext {
+  TheFlags flags;
+} CF_SWIFT_NAME(The);
+
+//--- program.swift
+import TheModule
+
+func f(_ _: DaFlags) {}


### PR DESCRIPTION
Explanation: import-as-member can cause import cycles that lead us to import duplicate Swift decls corresponding to the same Clang decl, which can cause errors later during CodeGen. This patch adds a check that eliminates the original import if it is made redundant by a nested import.

Risk: low, the check looks at a scenario that was not previously considered/handled by the importer logic

Testing: I added a test case that, when combined with an assertion checking for duplicate members, crashes before the patch and is succeeds after the patch. (That assertion is not yet safe to add to ClangImporter due to other instances of duplicate imports.)

Reviewers: @Xazax-hun @egorzhdan @hnrklssn 

Problem: rdar://162317760

Original PR: #85424
