### PR TITLE
[Dependency Scanning] Add a compiler statistic for # of dependency module queries and a simple test for it

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -26,6 +26,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/PrettyStackTrace.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
@@ -52,6 +53,12 @@
 #include <optional>
 
 using namespace swift;
+
+#define DEBUG_TYPE "DependencyScanner"
+STATISTIC(DepScanSwiftModuleQueries,
+          "# of times the dependency scanner performed a named lookup of a Swift module");
+STATISTIC(DepScanClangModuleQueries,
+          "# of times the dependency scanner performed a named lookup of a Clang module");
 
 static void findPath_dfs(ModuleDependencyID X, ModuleDependencyID Y,
                          ModuleDependencyIDSet &visited,
@@ -299,6 +306,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
 SwiftModuleScannerQueryResult
 ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
     Identifier moduleName, bool isTestableImport) {
+  DepScanSwiftModuleQueries++;
   return swiftModuleScannerLoader->lookupSwiftModule(moduleName,
                                                      isTestableImport);
 }
@@ -309,6 +317,7 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     LookupModuleOutputCallback lookupModuleOutput,
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenModules) {
+  DepScanClangModuleQueries++;
   auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
       moduleName.str(), clangScanningModuleCommandLineArgs,
       clangScanningWorkingDirectoryPath, alreadySeenModules,

--- a/test/ScanDependencies/basic_query_stats.swift
+++ b/test/ScanDependencies/basic_query_stats.swift
@@ -1,0 +1,39 @@
+// REQUIRES: asserts
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test.swift -o %t/deps.json -I %t/inputs -print-stats &> %t/stats.txt
+// RUN: cat %t/stats.txt | %FileCheck %s
+
+// Ensure that despite being a common dependency to multiple Swift modules, only 1 query is performed to find 'C'
+// CHECK: ... Statistics Collected ...
+// CHECK:    1 DependencyScanner - # of times the dependency scanner performed a named lookup of a Clang module
+
+//--- test.swift
+import A
+import B
+public func test() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import C
+public func a() { }
+
+//--- inputs/B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import C
+public func b() { }
+
+//--- inputs/c.h
+void c(void);
+
+//--- inputs/module.modulemap
+module C {
+  header "C.h"
+  export *
+}
+


### PR DESCRIPTION
This adds a compiler statistic for # of named lookups the scanner performed.
This change is a follow-up to https://github.com/swiftlang/swift/pull/85849 to ensure we do not encounter a similar regression in the future. 

Furthermore, these stats have shown that we have some redundancy in our Swift module dependency queries which I intend to address in a follow-up PR.

I also intend to begin using these statistics to add more-concrete verification of incremental dependency scanning. They will help ensure in the lit test suite that we successfully minimize re-queries on a given incremental scan.
