### PR TITLE
Add several headers to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -596,5 +596,35 @@ module WinSDK [system] {
 
     link "wlanapi.lib"
   }
+
+  module WTypesBase {
+    header "../shared/wtypesbase.h"
+    export *
+  }
+
+  module WTypes {
+    header "../shared/wtypes.h"
+    export *
+  }
+
+  module RoApi {
+    header "../winrt/roapi.h"
+    export *
+  }
+
+  module MinWinDef {
+    header "../shared/minwindef.h"
+    export *
+  }
+
+  module SDKDDKVer {
+    header "../shared/sdkddkver.h"
+    export *
+  }
+
+  module WinError {
+    header "../shared/winerror.h"
+    export *
+  }
 }
 


### PR DESCRIPTION
This was needed for explicit module builds to work for internal apps.
