### PR TITLE
[NFC][RemoteInspection] Use existing cache to build conformance table

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -335,6 +335,13 @@ void TypeRefBuilder::ReflectionTypeDescriptorFinder::
   ProcessedReflectionInfoIndexes.insert(Index);
 }
 
+void TypeRefBuilder::ReflectionTypeDescriptorFinder::
+    ensureAllFieldDescriptorsCached() {
+  for (size_t i = 0; i < ReflectionInfos.size(); ++i) {
+    populateFieldTypeInfoCacheWithReflectionAtIndex(i);
+  }
+}
+
 std::optional<RemoteRef<FieldDescriptor>>
 TypeRefBuilder::ReflectionTypeDescriptorFinder::findFieldDescriptorAtIndex(
     size_t Index, const std::string &MangledName) {


### PR DESCRIPTION
There is an existing cache which is built when looking up FieldDescriptors. collectAllConformances ignored this cache and would parse every FieldDescriptor again. Use the existing cache mechanism.

rdar://166098516
