### PR TITLE
[6.3] [Demangler] Handle invertible reqs for extensions in `findDeclContext`

### DIFF
--- a/test/IDE/rdar165639044.swift
+++ b/test/IDE/rdar165639044.swift
@@ -1,0 +1,15 @@
+// RUN: %batch-code-completion
+
+struct S<T: ~Copyable> {}
+protocol P: ~Copyable {}
+
+extension S where T: P {
+  var bar: Int { 0 }
+}
+struct R: P {}
+
+// Make sure USR round-tripping works here.
+func foo(_ x: S<R>) {
+  x.#^COMPLETE^#
+  // COMPLETE: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+}

--- a/test/TypeDecoder/extensions.swift
+++ b/test/TypeDecoder/extensions.swift
@@ -58,3 +58,19 @@ extension Generic where T: AnyObject {
 // DEMANGLE-DECL: $s10extensions7GenericVAARlzClE18NestedViaAnyObjectV
 // CHECK-DECL: extensions.(file).Generic extension.NestedViaAnyObject
 
+// Invertible Constraints
+
+struct GenericNonCopyable<T: ~Copyable> {}
+protocol ProtoNonCopyable: ~Copyable {}
+
+extension GenericNonCopyable where T: ProtoNonCopyable/*, T: Copyable*/ {
+  struct Nested {}
+}
+
+struct NonCopyableType: ProtoNonCopyable {}
+
+// DEMANGLE-DECL: $s10extensions18GenericNonCopyableVA2A05ProtocD0RzlE6NestedV
+// CHECK-DECL: extensions.(file).GenericNonCopyable extension.Nested
+
+// DEMANGLE-TYPE: $s10extensions18GenericNonCopyableVA2A05ProtocD0RzlE6NestedVyAA0cD4TypeV_GD
+// CHECK-TYPE: GenericNonCopyable<NonCopyableType>.Nested


### PR DESCRIPTION
*6.3 cherry-pick of #85897*

- Explanation: Fixes an issue where the demangler could not reconstruct a nested type in an extension with an invertible constraint
- Scope: Affects demangling type reconstruction
- Issue: rdar://165639044
- Risk: Low, the fix is done as a separate check at the point at which it would have previously failed, so it should be a strict improvement
- Testing: Added tests to test suite
- Reviewer: Slava Pestov