### PR TITLE
Sema: New StrictAccessControl upcoming feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -303,6 +303,7 @@ MIGRATABLE_UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 MIGRATABLE_UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
 MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 UPCOMING_FEATURE(ImmutableWeakCaptures, 481, 7)
+UPCOMING_FEATURE(StrictAccessControl, 0, 7)
 
 // Optional language features / modes
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -500,6 +500,7 @@ static bool usesFeatureTildeSendable(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(AnyAppleOSAvailability)
+UNINTERESTING_FEATURE(StrictAccessControl)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -119,7 +119,9 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
-  if (isa<TypeAliasDecl>(DC) && !Context.isLanguageModeAtLeast(6))
+  if (isa<TypeAliasDecl>(DC) &&
+      !Context.LangOpts.hasFeature(Feature::StrictAccessControl) &&
+      !Context.isLanguageModeAtLeast(6))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   auto diagID = diag::resilience_decl_unavailable;
@@ -207,7 +209,8 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   }
   D->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 
-  if (originKind == DisallowedOriginKind::MissingImport &&
+  if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&
+      originKind == DisallowedOriginKind::MissingImport &&
       !ctx.isLanguageModeAtLeast(6))
     addMissingImport(loc, D, where);
 
@@ -460,7 +463,8 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
               originKind == DisallowedOriginKind::MissingImport,
           6);
 
-  if (originKind == DisallowedOriginKind::MissingImport &&
+  if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&
+      originKind == DisallowedOriginKind::MissingImport &&
       !ctx.isLanguageModeAtLeast(6))
     addMissingImport(loc, ext, where);
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1087,7 +1087,7 @@ static bool diagnosePotentialUnavailability(
       // Don't downgrade
     } else if (behaviorLimit >= DiagnosticBehavior::Warning) {
       err.limitBehavior(behaviorLimit);
-    } else {
+    } else if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
       err.warnUntilLanguageMode(6);
     }
 
@@ -2179,7 +2179,8 @@ bool diagnoseExplicitUnavailability(
   // obsolete decls still map to valid ObjC runtime names, so behave correctly
   // at runtime, even though their use would produce an error outside of a
   // #keyPath expression.
-  auto limit = Flags.contains(DeclAvailabilityFlag::ForObjCKeyPath)
+  auto limit = (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&
+                Flags.contains(DeclAvailabilityFlag::ForObjCKeyPath))
                   ? DiagnosticBehavior::Warning
                   : DiagnosticBehavior::Unspecified;
 
@@ -2968,10 +2969,12 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
                                    attr->getMessage());
     if (D->preconcurrency()) {
       diag.limitBehavior(DiagnosticBehavior::Warning);
-    } else if (shouldWarnUntilFutureVersion()) {
-      diag.warnUntilFutureLanguageMode();
-    } else {
-      diag.warnUntilLanguageMode(6);
+    } else if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
+      if (shouldWarnUntilFutureVersion()) {
+        diag.warnUntilFutureLanguageMode();
+      } else {
+        diag.warnUntilLanguageMode(6);
+      }
     }
 
     if (!attr->getRename().empty()) {
@@ -2992,10 +2995,12 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     SourceLoc diagLoc = call ? call->getLoc() : R.Start;
     auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl, D,
                                    attr->Message);
-    if (shouldWarnUntilFutureVersion()) {
-      diag.warnUntilFutureLanguageMode();
-    } else {
-      diag.warnUntilLanguageMode(6);
+    if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
+      if (shouldWarnUntilFutureVersion()) {
+        diag.warnUntilFutureLanguageMode();
+      } else {
+        diag.warnUntilLanguageMode(6);
+      }
     }
   }
   D->diagnose(diag::decl_declared_here, D);

--- a/test/Sema/Inputs/strict_access_control_other.swift
+++ b/test/Sema/Inputs/strict_access_control_other.swift
@@ -1,0 +1,1 @@
+public struct ImplementationOnly {}

--- a/test/Sema/strict_access_control.swift
+++ b/test/Sema/strict_access_control.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Other.swiftmodule %S/Inputs/strict_access_control_other.swift -module-name Other -swift-version 5
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature StrictAccessControl -swift-version 5 -enable-library-evolution -I %t -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_StrictAccessControl
+
+@_implementationOnly import Other
+// expected-warning@-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
+
+private struct PrivateType {}
+// expected-note@-1 {{struct 'PrivateType' is not '@usableFromInline' or public}}
+
+@inlinable public func localTypeAliasTest() {
+  typealias Bad = PrivateType
+  // expected-error@-1 {{struct 'PrivateType' is private and cannot be referenced from an '@inlinable' function}}
+}
+
+private protocol PrivateProtocol {}
+// expected-note@-1 2{{type declared here}}
+
+public typealias BadRequirements<T> = T where T: PrivateProtocol
+// expected-error@-1 {{generic type alias cannot be declared public because its generic requirement uses a private type}}
+
+public struct S {
+  public subscript<T>(_: T) -> T where T: PrivateProtocol { fatalError() }
+  // expected-error@-1 {{subscript cannot be declared public because its generic requirement uses a private type}}
+}
+
+@_spi(Testing)
+public func badImplementationOnlyExport(_: ImplementationOnly) {}
+// expected-error@-1 {{cannot use struct 'ImplementationOnly' here; 'Other' has been imported as implementation-only}}


### PR DESCRIPTION
Some access control holes were unconditionally downgraded to warnings, and others were conditional on Swift 6 language mode. Let's hang them off an upcoming feature instead.