### PR TITLE
[6.3] CMake Android: ensure _Builtin_float is built before _math

### DIFF
--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -5,7 +5,8 @@ set_target_properties(swift_math PROPERTIES
   Swift_MODULE_NAME _math)
 target_link_libraries(swift_math PRIVATE
   SwiftAndroid
-  swiftCore)
+  swiftCore
+  swift_Builtin_float)
 
 install(TARGETS swift_math
   EXPORT SwiftOverlayTargets

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -167,6 +167,7 @@ add_swift_target_library(swift_math ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_O
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS "ANDROID"
     INSTALL_IN_COMPONENT sdk-overlay
+    SWIFT_MODULE_DEPENDS_ANDROID _Builtin_float
     DEPENDS android_modulemap)
 
 add_swift_target_library(swiftAndroid ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY


### PR DESCRIPTION
- **Explanation**:
Add an explicit dependency on the _Builtin_float overlay to the Android _math overlay -- this will ensure we are always able to build, since this way we will never get in a situation in which the _Builtin_float swiftmodule is present in the build folder but missing the architecture we are targeting (thus preventing to fall back to the _Builtin_float module exposed by Clang)
- **Scope**:
CMake target that generates the _math overlay for Android SDKs -- that is currently used by the Windows toolchain and Android package jobs in CI 
- **Issues**:
rdar://165768601
https://github.com/swiftlang/swift-docker/issues/510
- **Original PRs**:
https://github.com/swiftlang/swift/pull/85872
- **Risk**:
Low

    * this only affects configurations that generates the Android SDK
    * in the worst case, the change has not effect and we will keep hitting failures when building _math

- **Testing**:
    * built the affected package preset at desk, then manually removed a slice for  _Builtin_float swiftmodule and rebuilt _math -- verified that _Builtin_float is rebuilt
    * CI testing of the Windows toolchain to ensure the changes in the Runtimes build system work
- **Reviewers**:
@finagolfin @compnerd 
