### PR TITLE
ResultBuilders use `var`s instead of `let`s internally, leading to unexpected parameter packing

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1597,7 +1597,7 @@ VarDecl *ResultBuilder::buildVar(SourceLoc loc) {
   Identifier name =
       ctx.getIdentifier(("$__builder" + Twine(VarCounter++)).str());
   auto var = new (ctx)
-      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var, loc, name, DC);
+      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Let, loc, name, DC);
   var->setImplicit();
   return var;
 }


### PR DESCRIPTION
It appears that using `ResultBuilder`s to create a parameter-pack type via `buildPartial(first:)` / `buildPartial(accumulated:next:)`, the resulting packing is not optimal.

For reasons that weren't initialy clear, each round of creating a tuple via a result builder would result in deeper and deeper tuple nesting.

## Background

I've detailed my findings in #85924, but I found the solution to this via a chance change to `BuilderTransform` while doing other work to try to erase the `@lValue`-ness of parameters created in `BuilderTransform::buildCall`.

After making a chance change ("Why are these `var`s and not `let`s may as well change this..."), the compiler I was building suddenly worked, when all I had added otherwise was logging!

In this light, the solution to #85837 is simply this change:
```diff
lib/Sema/BuilderTransform.cpp
VarDecl *ResultBuilder::buildVar(SourceLoc loc) {
  auto &ctx = DC->getASTContext();
  // Create the implicit variable.
  Identifier name =
      ctx.getIdentifier(("$__builder" + Twine(VarCounter++)).str());
  auto var = new (ctx)
-      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var, loc, name, DC);
+      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Let, loc, name, DC);
  var->setImplicit();
  return var;
}
```

## Repro

Given this result builder:
```swift
@resultBuilder public enum TupleBuilder {
    public static func buildPartialBlock<T>(first: T) -> (T) {
        return first
    }

    public static func buildPartialBlock<each A, B>(accumulated: (repeat each A), next: B) -> (repeat each A, B) {
        return (repeat each accumulated, next)
    }
}

func builder<each A>(@TupleBuilder content: ()->(repeat each A)) -> (repeat each A) {
    return content()
}
```

I would expect this code ([Example](https://github.com/user-attachments/files/24062113/ReproBuilder.swift.txt), [Constraints](https://github.com/user-attachments/files/24062114/ReproBuilderConstraints.txt)):
```swift
let test = builder {
    "a"
    2
    "c"
    4
}
```

To be equivalent to ([Example](https://github.com/user-attachments/files/24062149/ReproManual.swift.txt), [Constraints](https://github.com/user-attachments/files/24062150/ReproManualConstraints.txt)):
```swift
let test = {
    let __builder0 = "a"
    let __builder1 = 2
    let __builder2 = "c"
    let __builder3 = TupleBuilder.buildPartialBlock(first: __builder0)
    let __builder4 = TupleBuilder.buildPartialBlock(accumulated: __builder3, next: __builder1) 
    let __builder5 = TupleBuilder.buildPartialBlock(accumulated: __builder4, next: __builder2)
    return __builder5 // (String, Int, String)
}()
```

But it is _in fact_ constructed like so:
```swift
let test = {
    var __builder0 = "a"
    var __builder1 = 2
    var __builder2 = "c"
    var __builder3 = TupleBuilder.buildPartialBlock(first: __builder0)
    var __builder4 = TupleBuilder.buildPartialBlock(accumulated: __builder3, next: __builder1) 
    var __builder5 = TupleBuilder.buildPartialBlock(accumulated: __builder4, next: __builder2)
    return __builder5 // ((String, Int), String)
}()
```

## Issue

I've documented this behavior in #85924 , but when parameter-packed generics are passed a reference to a `var` value, the 

If you continue you end up with tuples packed like:
```swift
(((String, Int), String), Int)
((((String, Int), String), Int) String)
(((((String, Int), String), Int), String), Int)
/* and so on */
```

## Change

The change is pretty straight forward, just make all the `VarDecl`'s into `let`s:
```diff
lib/Sema/BuilderTransform.cpp
VarDecl *ResultBuilder::buildVar(SourceLoc loc) {
  auto &ctx = DC->getASTContext();
  // Create the implicit variable.
  Identifier name =
      ctx.getIdentifier(("$__builder" + Twine(VarCounter++)).str());
  auto var = new (ctx)
-      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var, loc, name, DC);
+      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Let, loc, name, DC);
  var->setImplicit();
  return var;
}
```

## Concerns

This is the way _I'd_ expect this to act, but I'm not sure if everyone agrees or if there's not existing code that might be dependent on this behavior.

I've documented my thoughts in #85837 and in the [thread in the Swift forums](https://forums.swift.org/t/different-result-type-using-parameter-packs-in-a-result-builder/78854/5).


## Impact

This changes all result builders to have different semantics internally and in _at least_ this case, the type returned from a builder could be substantively different.

This would allow for maximally-flattened tuples [without workarounds](https://forums.swift.org/t/different-result-type-using-parameter-packs-in-a-result-builder/78854/3), but it might break any clients explicitly depending on this nested-packing behavior.


## Altertative/Enhanced Options



### Multiple constraints:

Is it possible to have have both options as constraints? As in generate one constraint with `let` which takes prescidence, but if specifically requested, fall back to the `var` equivalent?

I'm not sure what the constraint solver overhead for this maneuver is.


### Fix #85924 (Parameter packed functions pack less efficiently if the input is a `var`) Edit: fixed in #85962:

Solving what seems like the root issue would potentially obviate the need for this particular fix. The scope/impact of the change would be greatly increased, though. It seems like it carries considerably more risk to the system.


### Apply this change _and_ fix #85924 :

Unless I'm missing something (do...result builders support `inout`s?), it seems sub-optimal, or at least unecessary, to have every value generated by a builder be a `var` and never mutated.

If there's a larger fix for #85924 that also fixes this issue, it might still be worth taking this change.

## Misc

My first interaction with parameter packs was also me finding this bug, so I'm not entirely sure how they're _supposed_ to work, packing wise (are less optimal packings still valid)?

Mainly `(String, Int, String)` seems like it should be the right "choice", but I'm [unclear on if](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0393-parameter-packs.md#pack-expansion-type) `((String, Int), String)` is _also_ a vailid option. 

If the latter is a valid option there may be additional bugs (see #85924).  There also may be existing code that depends on the `((String, Int), String)`-style choice.