### PR TITLE
[TEST-ONLY] Add utility to perform explicit module build

### DIFF
--- a/test/CAS/Xcc_args.swift
+++ b/test/CAS/Xcc_args.swift
@@ -8,16 +8,8 @@
 // RUN:   -Xcc -I%t/empty.hmap -module-load-mode prefer-serialized \
 // RUN:   -file-compilation-dir %t
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shims.cmd
-// RUN: %swift_frontend_plain @%t/shims.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Macro > %t/Macro.cmd
-// RUN: %swift_frontend_plain @%t/Macro.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: %FileCheck %s --input-file=%t/MyApp.cmd
 
 // CHECK: "-direct-clang-cc1-module-build"
@@ -29,9 +21,8 @@
 
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/test.swift @%t/MyApp.cmd
 
 //--- test.swift

--- a/test/CAS/Xcc_objc_direct.swift
+++ b/test/CAS/Xcc_objc_direct.swift
@@ -7,25 +7,12 @@
 // RUN:   -file-compilation-dir %t \
 // RUN:   -I %t/include -module-load-mode prefer-serialized
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shims.cmd
-// RUN: %swift_frontend_plain @%t/shims.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/B.cmd
-// RUN: %swift_frontend_plain @%t/B.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
-// RUN: %swift_frontend_plain @%t/A.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/test.swift @%t/MyApp.cmd
 
 //--- test.swift

--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -25,28 +25,21 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-2.json Test casFSRootID > %t/root-2.casid
 // RUN: diff %t/root-1.casid %t/root-2.casid
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json bridgingHeader > %t/header.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps-1.json -o %t/MyApp.cmd -b %t/header.cmd
+
 // RUN: %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"/^header/Bridging.h\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps-1.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd /^tmp/test.swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -4,28 +4,19 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas -module-load-mode prefer-serialized -scanner-output-dir %t
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/objc.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s

--- a/test/CAS/cached_diagnostics_empty_filename.swift
+++ b/test/CAS/cached_diagnostics_empty_filename.swift
@@ -7,12 +7,6 @@
 // RUN:   -disable-implicit-string-processing-module-import \
 // RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -module-load-mode prefer-serialized
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:_SwiftConcurrencyShims > %t/cshim.cmd
-// RUN: %swift_frontend_plain @%t/cshim.cmd
-
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-MISS
 
@@ -25,14 +19,8 @@
 // CHECK: warning: warning a.h
 // CACHE-HIT: remark: replay output file
 
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
 // RUN:   -emit-module -o %t/test.swiftmodule -require-explicit-sendable -strict-concurrency=complete

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -16,20 +16,14 @@
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
 
 // FS: MacroDefinition
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
 // RUN: %target-swift-frontend -diagnostic-style=swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -external-plugin-path %t#%swift-plugin-server \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid -O \
 // RUN:   %t/main.swift @%t/MyApp.cmd -serialize-diagnostics-path %t/Test.diag 2> %t/diag2.txt
 
 // RUN: diff %t/diag1.txt %t/diag2.txt

--- a/test/CAS/cached_diagnostics_pcm.swift
+++ b/test/CAS/cached_diagnostics_pcm.swift
@@ -5,9 +5,6 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -module-load-mode prefer-serialized
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-MISS
 
@@ -20,15 +17,10 @@
 // CHECK: warning: warning a.h
 // CACHE-HIT: remark: replay output file
 
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
 // RUN:   -emit-module -o %t/test.swiftmodule

--- a/test/CAS/coverage-dir.swift
+++ b/test/CAS/coverage-dir.swift
@@ -6,9 +6,7 @@
 // RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -profile-coverage-mapping -profile-generate
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
-// RUN: %swift_frontend_plain @%t/A.cmd
 
 // RUN: %FileCheck %s --input-file=%t/shim.cmd
 // RUN: %FileCheck %s --input-file=%t/A.cmd

--- a/test/CAS/cross_import.swift
+++ b/test/CAS/cross_import.swift
@@ -21,15 +21,8 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
 // RUN:   -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-cross-import-overlays -module-load-mode prefer-serialized
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:C > %t/C.cmd
-// RUN: %swift_frontend_plain @%t/C.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json %t > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: %FileCheck %s --input-file=%t/MyApp.cmd --check-prefix CMD
 // CMD: -swift-module-cross-import
 // CMD-NEXT: [[CMI1:[B|C]]]
@@ -41,9 +34,9 @@
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule  \
 // RUN:   -emit-module-interface-path %t/Test.swiftinterface \
 // RUN:   -cache-compile-job -cas-path %t/cas \
-// RUN:   -disable-implicit-swift-modules -swift-version 5 -enable-cross-import-overlays \
+// RUN:   -swift-version 5 -enable-cross-import-overlays \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   -module-name Test \
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
 // RUN: %FileCheck %s --input-file=%t/Test.swiftinterface

--- a/test/CAS/macro_deps.swift
+++ b/test/CAS/macro_deps.swift
@@ -28,25 +28,12 @@
 // APP-DEPS: MacroTwo
 
 /// Build all dependencies.
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Foo > %t/Foo.cmd
-// RUN: %swift_frontend_plain @%t/Foo.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Bar > %t/Bar.cmd
-// RUN: %swift_frontend_plain @%t/Bar.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Baz > %t/Baz.cmd
-// RUN: %swift_frontend_plain @%t/Baz.cmd
 
 // RUN: %FileCheck %s --check-prefix=PLUGIN_SEARCH --input-file=%t/Bar.cmd
 // PLUGIN_SEARCH-NOT: -external-plugin-path
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %FileCheck %s --check-prefix=PLUGIN_SEARCH --check-prefix=RESOLVED --input-file=%t/MyApp.cmd
 // PLUGIN_SEARCH-NOT: -external-plugin-path
@@ -54,10 +41,9 @@
 
 // RUN: %target-swift-frontend -diagnostic-style=swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -external-plugin-path %t#%swift-plugin-server \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid -O \
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
 //--- macro-1.swift

--- a/test/CAS/macro_option_set.swift
+++ b/test/CAS/macro_option_set.swift
@@ -11,20 +11,13 @@
 
 // FS: SwiftMacros
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -plugin-path %swift-plugin-dir \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %s @%t/MyApp.cmd
 
 import Swift

--- a/test/CAS/macro_plugin.swift
+++ b/test/CAS/macro_plugin.swift
@@ -24,20 +24,12 @@
 
 // FS: MacroDefinition
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -load-plugin-library %t/plugins/%target-library-name(MacroDefinition) \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %s @%t/MyApp.cmd
 
 @attached(extension, conformances: P, names: named(requirement))

--- a/test/CAS/opt-record.swift
+++ b/test/CAS/opt-record.swift
@@ -4,25 +4,18 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
 // RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
 // RUN:   -save-optimization-record -save-optimization-record-path %t/record.yaml \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   @%t/MyApp.cmd %s -o %t/test.o -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
 
 // RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
 // RUN:   -save-optimization-record -save-optimization-record-path %t/record-1.yaml \
-// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   @%t/MyApp.cmd %s -o %t/test.o -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
 // RUN: %FileCheck %s --check-prefix=YAML --input-file=%t/record.yaml

--- a/test/CAS/reproducer.swift
+++ b/test/CAS/reproducer.swift
@@ -6,12 +6,7 @@
 // RUN:   -import-objc-header %t/Bridging.h -scanner-output-dir %t -auto-bridging-header-chaining -scanner-debug-write-output \
 // RUN:   %t/test.swift %t/foo.swift -I %t/include -o %t/deps.json -cache-compile-job -cas-path %t/cas
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:Dummy > %t/dummy.cmd
-// RUN: %swift_frontend_plain @%t/dummy.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Simple > %t/simple.cmd
-// RUN: %swift_frontend_plain @%t/simple.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
@@ -19,21 +14,14 @@
 // RUN:   %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/Bridging.h\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend %t/test.swift %t/foo.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd -gen-reproducer -gen-reproducer-dir %t/crash
@@ -47,6 +35,9 @@
 // RUN: %swift_frontend_plain @%t/crash/reproduce.sh
 
 /// Also test module jobs.
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:Dummy > %t/dummy.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Simple > %t/simple.cmd
 // RUN: %swift_frontend_plain @%t/dummy.cmd -gen-reproducer -gen-reproducer-dir %t/crash-2
 // RUN: %FileCheck %s --input-file=%t/crash-2/reproduce.sh
 // RUN: %swift_frontend_plain @%t/crash-2/reproduce.sh

--- a/test/CAS/uncached-casfs.swift
+++ b/test/CAS/uncached-casfs.swift
@@ -6,13 +6,7 @@
 // RUN:   -import-objc-header %t/base/Bridging.h -scanner-output-dir %t -auto-bridging-header-chaining -scanner-debug-write-output \
 // RUN:   %t/base/test.swift %t/base/foo.swift -I %t/include -o %t/deps.json -cache-compile-job -cas-path %t/cas
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:Dummy > %t/dummy.cmd
-// RUN: %swift_frontend_plain @%t/dummy.cmd
-
-// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
@@ -20,18 +14,14 @@
 // RUN:   %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/base/Bridging.h\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: sed -e "s@VFS_DIR@%{/t:regex_replacement}/base@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/modified@g" %t/base.yaml > %t/overlay.yaml
 

--- a/test/ScanDependencies/bridging-header-autochaining.swift
+++ b/test/ScanDependencies/bridging-header-autochaining.swift
@@ -15,28 +15,15 @@
 
 /// Try build then import from a non-caching compilation.
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %swift_frontend_plain @%t/shim.cmd
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/B.cmd
-// RUN: %swift_frontend_plain @%t/B.cmd
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
-// RUN: %swift_frontend_plain @%t/A.cmd
-
-// RUN: %{python} %S/../CAS/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
-
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
-// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/Bridging.h\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
-// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
-// RUN: echo "\"%t/map.json\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend -module-name Test -O @%t/MyApp.cmd %t/test.swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule
@@ -63,15 +50,13 @@
 // HEADER1: #include
 // HEADER1-SAME: Bridging.h
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps2.json bridgingHeader > %t/header1.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps2.json -o %t/User.cmd -b %t/header1.cmd
+
 // RUN: %target-swift-frontend @%t/header1.cmd -disable-implicit-swift-modules -O -o %t/bridging1.pch
 
-// RUN: %{python} %S/../CAS/Inputs/GenerateExplicitModuleMap.py %t/deps2.json > %t/map2.json
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps2.json User > %t/User.cmd
 // RUN: %target-swift-frontend -module-name User -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -disable-implicit-swift-modules \
-// RUN:   -import-pch %t/bridging1.pch \
-// RUN:   -explicit-swift-module-map-file %t/map2.json @%t/User.cmd %t/user.swift \
+// RUN:   -import-pch %t/bridging1.pch @%t/User.cmd %t/user.swift \
 // RUN:   -emit-module -o %t/User.swiftmodule -emit-module-interface-path %t/User.swiftinterface -enable-library-evolution
 
 /// Make sure the emitted content is compatible with original. The embedded header path needs to be original header and no bridging header module leaking into interface.
@@ -107,25 +92,18 @@
 // DEPS_JSON-NEXT: "sourceFiles":
 // DEPS_JSON-NEXT: Bridging2.h
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps3.json clang:SwiftShims > %t/shim2.cmd
-// RUN: %swift_frontend_plain @%t/shim2.cmd
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps3.json clang:B > %t/B2.cmd
-// RUN: %swift_frontend_plain @%t/B2.cmd
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps3.json clang:A > %t/A2.cmd
-// RUN: %swift_frontend_plain @%t/A2.cmd
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps3.json bridgingHeader > %t/header2.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps3.json -o %t/User2.cmd -b %t/header2.cmd
+
 // RUN: %target-swift-frontend @%t/header2.cmd -disable-implicit-swift-modules -O -o %t/bridging2.pch
 
-// RUN: %{python} %S/../CAS/Inputs/GenerateExplicitModuleMap.py %t/deps3.json > %t/map3.json
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps3.json User > %t/User2.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/User2.cmd
 // RUN: echo "\"%t/Bridging2.h\"" >> %t/User2.cmd
 // RUN: echo "\"-import-pch\"" >> %t/User2.cmd
 // RUN: echo "\"%t/bridging2.pch\"" >> %t/User2.cmd
 
 // RUN: %target-swift-frontend -module-name User -O \
-// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -disable-implicit-swift-modules \
-// RUN:   -explicit-swift-module-map-file %t/map3.json @%t/User2.cmd %t/user2.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   @%t/User2.cmd %t/user2.swift \
 // RUN:   -emit-objc-header -emit-objc-header-path %t/User-Swift.h \
 // RUN:   -emit-module -o %t/User2.swiftmodule
 
@@ -160,19 +138,18 @@
 // RUN:   -dependency-scan-cache-path %t/cache.moddepcache 2>&1 | %FileCheck %s -check-prefix=CACHE-LOAD
 // CACHE-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
 
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps4.json bridgingHeader > %t/header3.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps3.json -o %t/User3.cmd -b %t/header3.cmd
+
 // RUN: %target-swift-frontend @%t/header3.cmd -disable-implicit-swift-modules -O -o %t/bridging3.pch
 
-// RUN: %{python} %S/../CAS/Inputs/GenerateExplicitModuleMap.py %t/deps4.json > %t/map4.json
-// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps4.json User > %t/User3.cmd
 // RUN: echo "\"-import-pch\"" >> %t/User3.cmd
 // RUN: echo "\"%t/bridging3.pch\"" >> %t/User3.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/User3.cmd
 // RUN: echo "\"%t/Bridging3.h\"" >> %t/User3.cmd
 
 // RUN: %target-swift-frontend -module-name User -O \
-// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -disable-implicit-swift-modules \
-// RUN:   -explicit-swift-module-map-file %t/map4.json @%t/User3.cmd %t/user2.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   @%t/User3.cmd %t/user2.swift \
 // RUN:   -emit-module -o %t/User3.swiftmodule
 
 /// Verify the encoded here is just the `-import-objc-header` option.

--- a/utils/swift-build-modules.py
+++ b/utils/swift-build-modules.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# This tool helps building swift explicit module from the JSON output of the scan-dependencies command. It will build all the module dependencies from JSON and construct a response file for the common arguments for main module build.
+# Usage:
+#   /path/to/bin/dir/swift-build-modules.py /path/to/swift-frontend /path/to/depscan.json /path/to/output-resp
+#
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def writeOutputResponseFile(filename, cmd):
+    with open(filename, 'w') as output:
+        for c in cmd:
+            output.write('"{}"\n'.format(c))
+
+
+def build_module(swift_frontend, mode, detail):
+    cmd = [swift_frontend] + detail['details'][mode]['commandLine']
+    subprocess.check_call(cmd)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('swift_frontend', help="path to swift-frontend")
+    parser.add_argument('input', help="path to json output from scan-dependencies")
+    parser.add_argument('-c', '--cas', metavar='<CAS directory>')
+    parser.add_argument('--llvm-cas-tool', metavar='<path>', default="llvm-cas")
+    parser.add_argument('-o', '--output', metavar="<output>",
+                        help="output response file for building main module")
+    parser.add_argument('-b', '--bridging-header-resp', metavar="<response file>",
+                        help="output response file for building bridging header")
+    args = parser.parse_args()
+
+    with open(args.input, 'r') as file:
+        # Read input json file.
+        deps = json.load(file)
+        modules = []
+        # Traverse the module name and detail pair in reverse order assuming that is the order of dependencies.
+        # Skip the first module since that is the main module.
+        module_names = reversed(deps['modules'][2::2])
+        module_details = reversed(deps['modules'][3::2])
+        for name, detail in zip(module_names, module_details):
+            module = {}
+            module["isFramework"] = False
+            if 'clang' in name:
+                build_module(args.swift_frontend, 'clang', detail)
+                module["moduleName"] = name['clang']
+                module["clangModulePath"] = detail["modulePath"]
+                if "moduleCacheKey" in detail["details"]['clang']:
+                    module["clangModuleCacheKey"] = detail["details"]['clang']["moduleCacheKey"]
+            if 'swift' in name:
+                build_module(args.swift_frontend, 'swift', detail)
+                module["moduleName"] = name['swift']
+                module["modulePath"] = detail["modulePath"]
+                if "moduleCacheKey" in detail["details"]['swift']:
+                    module["moduleCacheKey"] = detail["details"]['swift']["moduleCacheKey"]
+            if 'swiftPrebuiltExternal' in name:
+                module["moduleName"] = name['swiftPrebuiltExternal']
+                module["modulePath"] = detail["modulePath"]
+                if "moduleCacheKey" in detail["details"]['swiftPrebuiltExternal']:
+                    module["moduleCacheKey"] = detail["details"]['swiftPrebuiltExternal']["moduleCacheKey"]
+            modules.append(module)
+
+        # Write output response file if requested.
+        if args.output:
+            cmd = deps['modules'][1]['details']['swift']['commandLine']
+            # Add some helpful flags for explicit module build.
+            cmd.extend(['-disable-implicit-swift-modules'])
+            # Write explicit module map.
+            module_map_out = args.output + ".map"
+            with open(module_map_out, 'w') as mapfile:
+                json.dump(modules, mapfile, indent=2)
+            # If using caching, create the map in CAS.
+            if args.cas:
+                casid = subprocess.check_output(
+                    [args.llvm_cas_tool, '--cas', args.cas, '--make-blob', '--data', module_map_out], text=True).strip()
+                cmd.extend(['-explicit-swift-module-map-file', casid])
+            else:
+                cmd.extend(['-explicit-swift-module-map-file', module_map_out])
+            writeOutputResponseFile(args.output, cmd)
+
+        # Write bridging header response file if request.
+        if args.bridging_header_resp:
+            info = deps['modules'][1]['details']['swift']
+            # the first argument is `-frontend`
+            cmd = info['bridgingHeader']['commandLine'][1:]
+            # print input file name if using chained bridging header.
+            if "chainedBridgingHeaderPath" in info:
+                cmd.append(info['chainedBridgingHeaderPath'])
+            writeOutputResponseFile(args.bridging_header_resp, cmd)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a script to build all dependencies for explicit module build in one step. This reduces the boiling plate code needed to write a test for explicit module build and allows the test to be more cross platform and resilient to module dependencies changes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
