### PR TITLE
[NFC][RemoteInspection] Use existing cache to build conformance table

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -335,6 +335,13 @@ void TypeRefBuilder::ReflectionTypeDescriptorFinder::
   ProcessedReflectionInfoIndexes.insert(Index);
 }
 
+void TypeRefBuilder::ReflectionTypeDescriptorFinder::
+    ensureAllFieldDescriptorsCached() {
+  for (size_t i = 0; i < ReflectionInfos.size(); ++i) {
+    populateFieldTypeInfoCacheWithReflectionAtIndex(i);
+  }
+}
+
 std::optional<RemoteRef<FieldDescriptor>>
 TypeRefBuilder::ReflectionTypeDescriptorFinder::findFieldDescriptorAtIndex(
     size_t Index, const std::string &MangledName) {


### PR DESCRIPTION
• **Explanation**: There is an existing cache which is built when looking up FieldDescriptors. collectAllConformances ignores this cache and parses every FieldDescriptor again. Use the existing cache mechanism.
• **Scope**: This affects RemoteMirrors clients that use it to parse protocols conformances. As far as I know LLDB is the only client.
• **Risk**: Low, this only affects LLDB.
• **Problem**: rdar://166098516
• **Original PR**: https://github.com/swiftlang/swift/pull/85916
•  **Reviewed by:** @mikeash   
