### PR TITLE
CMake: StringProcessing: More apple flags

### DIFF
--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -42,6 +42,7 @@ include(EmitSwiftInterface)
 include(InstallSwiftInterface)
 include(PlatformInfo)
 include(ResourceEmbedding)
+include(CatalystSupport)
 
 option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
 set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${PROJECT_NAME}_INSTALL_NESTED_SUBDIR>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>")

--- a/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
@@ -22,4 +22,5 @@ install(TARGETS swiftRegexBuilder
 emit_swift_interface(swiftRegexBuilder)
 install_swift_interface(swiftRegexBuilder)
 
+generate_plist(swiftRegexBuilder "${CMAKE_PROJECT_VERSION}" swiftRegexBuilder)
 embed_manifest(swiftRegexBuilder)

--- a/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
@@ -45,4 +45,5 @@ install(TARGETS swift_RegexParser
 emit_swift_interface(swift_RegexParser)
 install_swift_interface(swift_RegexParser)
 
+generate_plist(swiftRegexParser "${CMAKE_PROJECT_VERSION}" swift_RegexParser)
 embed_manifest(swift_RegexParser)

--- a/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
@@ -87,4 +87,5 @@ install(TARGETS swift_StringProcessing
 emit_swift_interface(swift_StringProcessing)
 install_swift_interface(swift_StringProcessing)
 
+generate_plist(swiftStringProcessing "${CMAKE_PROJECT_VERSION}" swift_StringProcessing)
 embed_manifest(swift_StringProcessing)


### PR DESCRIPTION
 - Adding catalyst zippering to StringProcessing libraries.
 - rdar://165944416: Adding embedded plists to StringProcessing libraries. 