### PR TITLE
[cxx-interop] [NFC] Refactor ClangDerivedConformances 

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -22,61 +22,9 @@ bool isIterator(const clang::CXXRecordDecl *clangDecl);
 
 bool isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl);
 
-/// If the decl is a C++ input iterator, synthesize a conformance to the
-/// UnsafeCxxInputIterator protocol, which is defined in the Cxx module.
-void conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
-                                  NominalTypeDecl *decl,
-                                  const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl defines `operator bool()`, synthesize a conformance to the
-/// CxxConvertibleToBool protocol, which is defined in the Cxx module.
-void conformToCxxConvertibleToBoolIfNeeded(
-    ClangImporter::Implementation &impl, NominalTypeDecl *decl,
-    const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::optional`, synthesize a
-/// conformance to CxxOptional protocol, which is defined in the Cxx module.
-void conformToCxxOptionalIfNeeded(ClangImporter::Implementation &impl,
-                                  NominalTypeDecl *decl,
-                                  const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is a C++ sequence, synthesize a conformance to the CxxSequence
-/// protocol, which is defined in the Cxx module.
-void conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
-                                  NominalTypeDecl *decl,
-                                  const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::set`, `std::unordered_set` or
-/// `std::multiset`, synthesize a conformance to CxxSet, which is defined in the
-/// Cxx module.
-void conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
-                             NominalTypeDecl *decl,
-                             const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::pair`, synthesize a conformance
-/// to CxxPair, which is defined in the Cxx module.
-void conformToCxxPairIfNeeded(ClangImporter::Implementation &impl,
-                              NominalTypeDecl *decl,
-                              const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::map` or `std::unordered_map`,
-/// synthesize a conformance to CxxDictionary, which is defined in the Cxx module.
-void conformToCxxDictionaryIfNeeded(ClangImporter::Implementation &impl,
-                                    NominalTypeDecl *decl,
+void deriveAutomaticCxxConformances(ClangImporter::Implementation &Impl,
+                                    NominalTypeDecl *result,
                                     const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::vector`, synthesize a
-/// conformance to CxxVector, which is defined in the Cxx module.
-void conformToCxxVectorIfNeeded(ClangImporter::Implementation &impl,
-                                NominalTypeDecl *decl,
-                                const clang::CXXRecordDecl *clangDecl);
-
-/// If the decl is an instantiation of C++ `std::span`, synthesize a
-/// conformance to CxxSpan, which is defined in the Cxx module.
-void conformToCxxSpanIfNeeded(ClangImporter::Implementation &impl,
-                                NominalTypeDecl *decl,
-                                const clang::CXXRecordDecl *clangDecl);
-
 } // namespace swift
 
 #endif // SWIFT_CLANG_DERIVED_CONFORMANCES_H

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3293,29 +3293,14 @@ namespace {
 
       validatePrivateFileIDAttributes(decl);
 
-      // If this module is declared as a C++ module, try to synthesize
-      // conformances to Swift protocols from the Cxx module.
-      auto clangModule = Impl.getClangOwningModule(result->getClangNode());
-      if (!clangModule || requiresCPlusPlus(clangModule)) {
-        if (auto nominalDecl = dyn_cast<NominalTypeDecl>(result)) {
-          conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxConvertibleToBoolIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxSetIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxDictionaryIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxPairIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxOptionalIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxVectorIfNeeded(Impl, nominalDecl, decl);
-          conformToCxxSpanIfNeeded(Impl, nominalDecl, decl);
+      if (auto *nominalResult = dyn_cast<NominalTypeDecl>(result)) {
+        deriveAutomaticCxxConformances(Impl, nominalResult, decl);
 
-          if (Impl.needsClosureConstructor(decl)) {
-            if (auto closureCtor =
-                    synthesizer.makeClosureConstructor(nominalDecl))
-              nominalDecl->addMember(closureCtor);
-          }
+        if (Impl.needsClosureConstructor(decl)) {
+          if (auto *ctor = synthesizer.makeClosureConstructor(nominalResult))
+            nominalResult->addMember(ctor);
         }
       }
-
       return result;
     }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -970,11 +970,8 @@ public:
   ClangModuleUnit *getClangModuleForDecl(const clang::Decl *D,
                                          bool allowForwardDeclaration = false);
 
-  /// Returns the module \p MI comes from, or \c None if \p MI does not have
-  /// a valid associated module.
-  ///
-  /// The returned module may be null (but not \c None) if \p MI comes from
-  /// an imported header.
+  /// Returns the module \p Node comes from, or \c nullptr if \p Node does not
+  /// have a valid owning module.
   const clang::Module *getClangOwningModule(ClangNode Node) const;
 
   /// Whether NSUInteger can be imported as Int in certain contexts. If false,


### PR DESCRIPTION
This refactoring restructures the code in a couple of ways:

- move all the "conformToXXXIfNeeded()" functions into a single function
  and remove them from the ClangDerivedConformances.h interface
- unify the check for isInStdNamespace() for the C++ stdlib types
- unify the name comparisons into a single llvm::StringSwitch
- unify redundant nullptr assert()s, and upgrade them to ASSERT()
- move the known stdlib type name-checking logic out of the
  "conformToCxxSTDLIBTYPEIfNeeded()" functions, and rename them to drop
  the "IfNeeded" suffix.

This patch also introduces a local CxxStdType enum class that enumerates
(and thus documents) all of the known (and thus supported) types from
the C++ stdlib types.

The ultimate goal is to organize the code such that by the time we call
"conformToCxxSTDLIBTYPE()" we are already sure that the type is (or at
least claims to be, based on its name and DeclContext) the C++ stdlib
type we think it is, rather than interleaving such checks with the
conformance synthesis logic.

The main observable difference should be the logging: now, we will no
longer have PrettyStackTraceDecls logging for C++ stdlib types like
"conforming to CxxVector" unless we are already certain we are looking
at a relevant type, e.g., std::vector.

Otherwise, the functional behavior of this code should be the same as
before.
