### PR TITLE
Fix swiftinterface printing of accessors and inferred lifetime dependencies when Lifetimes feature is enabled

### DIFF
--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -77,3 +77,15 @@ extension Container {
     }
   }
 }
+
+public struct RigidArray : ~Copyable {
+  @usableFromInline let _ptr: UnsafeRawBufferPointer
+
+  public var span: RawSpan {
+    @_lifetime(borrow self)
+    get {
+      return RawSpan(_unsafeBytes: _ptr)
+    }
+  }
+}
+

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -2,7 +2,6 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature Lifetimes \
-// RUN:     -enable-experimental-feature Lifetimes \
 // RUN:     -o %t/lifetime_underscored_dependence.swiftmodule \
 // RUN:     -emit-module-interface-path %t/lifetime_underscored_dependence.swiftinterface \
 // RUN:     %S/Inputs/lifetime_underscored_dependence.swift
@@ -105,8 +104,22 @@ import lifetime_underscored_dependence
 // CHECK:}
 // CHECK:#endif
 
-// Check that an implicitly dependent variable accessor is guarded by LifetimeDependence.
-//
 // CHECK: extension lifetime_underscored_dependence.Container {
-// CHECK-NEXT: #if compiler(>=5.3) && $LifetimeDependence
+// CHECK-NEXT: #if compiler(>=5.3) && $Lifetimes
 // CHECK-NEXT:   public var storage: lifetime_underscored_dependence.BufferView {
+
+// CHECK: public struct RigidArray : ~Swift.Copyable {
+// CHECK:   @usableFromInline
+// CHECK:   internal let _ptr: Swift.UnsafeRawBufferPointer
+// CHECK:   #if compiler(>=5.3) && $Lifetimes
+// CHECK:   public var span: Swift.RawSpan {
+// CHECK:     @_lifetime(borrow self)
+// CHECK:     get
+// CHECK:   }
+// CHECK:   #else
+// CHECK:   public var span: Swift.RawSpan {
+// CHECK:     @lifetime(borrow self)
+// CHECK:     get
+// CHECK:   }
+// CHECK:   #endif
+// CHECK: }


### PR DESCRIPTION
Fixes rdar://165010670 