### PR TITLE
[Diagnostics] Don't attempt to synthesize arguments when destructurin…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2747,6 +2747,12 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
       args.pop_back();
       for (const auto &elt : tuple->getElements())
         args.emplace_back(elt.getType(), elt.getName());
+
+      // If unpacking a tuple results in more arguments than parameters
+      // it would be diagnosed as a general mismatch because it's unclear
+      // whether it's a problem with missing or extraneous parameters.
+      if (args.size() > params.size())
+        return true;
     } else if (auto *typeVar = argType->getAs<TypeVariableType>()) {
       auto isParam = [](const Expr *expr) {
         if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {

--- a/validation-test/compiler_crashers_fixed/fixMissingArguments-ef29fe.swift
+++ b/validation-test/compiler_crashers_fixed/fixMissingArguments-ef29fe.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","languageMode":6,"signature":"fixMissingArguments(swift::constraints::ConstraintSystem&, swift::ASTNode, llvm::SmallVectorImpl<swift::AnyFunctionType::Param>&, llvm::ArrayRef<swift::AnyFunctionType::Param>, unsigned int, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]"}
-// RUN: not --crash %target-swift-frontend -typecheck -swift-version 6 %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 6 %s
 func a((Int, Int, Int)) a > {
   b, c in


### PR DESCRIPTION
…g a single tuple argument results in an overrun

If arguments are represented by a single tuple it's possible that the issue is not about missing parameters but instead about tuple destructuring. Fix `fixMissingArguments` to check for overruns after destructuring and stop if that produces more arguments then parameters because such situations are better diagnosed as a general conversion failure rather than a missing argument(s) problem.

Resolves: rdar://159408715

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
