### PR TITLE
[Dependency Scanning] Reduce the number of redundant dependency queries

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -893,7 +893,7 @@ public:
       llvm_unreachable("Unexpected module dependency kind");
   }
 
-  llvm::StringSet<> &getVisibleClangModules() const {
+  llvm::StringSet<> getVisibleClangModules() const {
     return storage->visibleClangModules;
   }
 
@@ -1076,6 +1076,11 @@ private:
   /// A set of module identifiers for which a scanning action failed
   /// to discover a Swift module dependency
   llvm::StringSet<> negativeSwiftDependencyCache;
+
+  /// A map from Clang module name to all visible modules to a client
+  /// of a by-name import of this Clang module
+  llvm::StringMap<std::vector<std::string>> clangModulesVisibleFrom;
+
   /// Set containing all of the Clang modules that have already been seen.
   llvm::DenseSet<clang::tooling::dependencies::ModuleID> alreadySeenClangModules;
   /// Name of the module under scan
@@ -1153,8 +1158,12 @@ public:
   llvm::ArrayRef<ModuleDependencyID>
   getCrossImportOverlayDependencies(const ModuleDependencyID &moduleID) const;
   /// Query all visible Clang modules for a given Swift dependency
-  llvm::StringSet<>&
+  llvm::StringSet<>
   getVisibleClangModules(ModuleDependencyID moduleID) const;
+  /// Query all Clang modules visible via a by-name lookup of given
+  /// Clang dependency
+  std::vector<std::string>
+  getVisibleClangModulesFrom(ModuleDependencyID moduleID) const;
 
   /// Look for module dependencies for a module with the given ID
   ///
@@ -1231,7 +1240,11 @@ public:
   /// Add to this module's set of visible Clang modules
   void
   addVisibleClangModules(ModuleDependencyID moduleID,
+                         ModuleDependencyID clangDependencyID,
                          const std::vector<std::string> &moduleNames);
+  void
+  addHeaderVisibleClangModules(ModuleDependencyID moduleID,
+                               const std::vector<std::string> &moduleNames);
   /// Add an identifier to the set of failed Swift module queries
   void cacheNegativeSwiftDependency(StringRef moduleIdentifier);
 

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1073,6 +1073,9 @@ class ModuleDependenciesCache {
 private:
   /// Discovered dependencies
   ModuleDependenciesKindMap ModuleDependenciesMap;
+  /// A set of module identifiers for which a scanning action failed
+  /// to discover a Swift module dependency
+  llvm::StringSet<> negativeSwiftDependencyCache;
   /// Set containing all of the Clang modules that have already been seen.
   llvm::DenseSet<clang::tooling::dependencies::ModuleID> alreadySeenClangModules;
   /// Name of the module under scan
@@ -1111,6 +1114,8 @@ public:
   bool hasDependency(StringRef moduleName) const;
   /// Whether we have cached dependency information for the given Swift module.
   bool hasSwiftDependency(StringRef moduleName) const;
+  /// Whether we have cached a failed lookup of a Swift dependency for the given identifier.
+  bool hasNegativeSwiftDependency(StringRef moduleName) const;
 
   const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &
   getAlreadySeenClangModules() const {
@@ -1227,6 +1232,8 @@ public:
   void
   addVisibleClangModules(ModuleDependencyID moduleID,
                          const std::vector<std::string> &moduleNames);
+  /// Add an identifier to the set of failed Swift module queries
+  void cacheNegativeSwiftDependency(StringRef moduleIdentifier);
 
   StringRef getMainModuleName() const { return mainScanModuleName; }
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -738,8 +738,6 @@ ModuleDependenciesCache::findSwiftDependency(StringRef moduleName) const {
     return found;
   if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftBinary))
     return found;
-  if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftSource))
-    return found;
   return std::nullopt;
 }
 
@@ -770,6 +768,10 @@ bool ModuleDependenciesCache::hasDependency(StringRef moduleName) const {
 
 bool ModuleDependenciesCache::hasSwiftDependency(StringRef moduleName) const {
   return findSwiftDependency(moduleName).has_value();
+}
+
+bool ModuleDependenciesCache::hasNegativeSwiftDependency(StringRef moduleName) const {
+  return negativeSwiftDependencyCache.contains(moduleName);
 }
 
 void ModuleDependenciesCache::recordDependency(
@@ -950,6 +952,11 @@ void ModuleDependenciesCache::addVisibleClangModules(
   auto updatedDependencyInfo = dependencyInfo;
   updatedDependencyInfo.addVisibleClangModules(moduleNames);
   updateDependency(moduleID, updatedDependencyInfo);
+}
+
+void ModuleDependenciesCache::cacheNegativeSwiftDependency(
+    StringRef moduleIdentifier) {
+  negativeSwiftDependencyCache.insert(moduleIdentifier);
 }
 
 llvm::StringSet<> &ModuleDependenciesCache::getVisibleClangModules(

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -26,6 +26,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/PrettyStackTrace.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
@@ -1337,6 +1338,13 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
     // Avoid querying the underlying Clang module here
     if (moduleID.ModuleName == dependsOn.importIdentifier)
       continue;
+    // Avoid querying Swift module dependencies previously discovered
+    if (DependencyCache.hasSwiftDependency(dependsOn.importIdentifier))
+      continue;
+    // Avoid querying Swift module dependencies which have already produced
+    // in a negative (not found) result
+    if (DependencyCache.hasNegativeSwiftDependency(dependsOn.importIdentifier))
+      continue;
     ScanningThreadPool.async(
         scanForSwiftModuleDependency,
         getModuleImportIdentifier(dependsOn.importIdentifier),
@@ -1376,10 +1384,13 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
                        moduleImport.importIdentifier))
           importedSwiftDependencies.insert(
               {moduleImport.importIdentifier, cachedInfo.value()->getKind()});
-        else
+        else {
           IssueReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
-              moduleImport, lookupResult.incompatibleCandidates,
-              DependencyCache, std::nullopt);
+                     moduleImport, lookupResult.incompatibleCandidates,
+                     DependencyCache, std::nullopt);
+          DependencyCache
+            .cacheNegativeSwiftDependency(moduleImport.importIdentifier);
+        }
       };
 
   for (const auto &importInfo : moduleDependencyInfo.getModuleImports())
@@ -1523,10 +1534,8 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
     auto moduleName = moduleIdentifier.str();
     {
       std::lock_guard<std::mutex> guard(lookupResultLock);
-      if (DependencyCache.hasDependency(moduleName,
-                                        ModuleDependencyKind::SwiftInterface) ||
-          DependencyCache.hasDependency(moduleName,
-                                        ModuleDependencyKind::SwiftBinary))
+      if (DependencyCache.hasSwiftDependency(moduleName) ||
+          DependencyCache.hasNegativeSwiftDependency(moduleName))
         return;
     }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1599,7 +1599,7 @@ void swift::dependencies::incremental::validateInterModuleDependenciesCache(
                       emitRemarks, visited, modulesRequiringRescan);
   for (const auto &outOfDateModID : modulesRequiringRescan)
     cache.removeDependency(outOfDateModID);
-
+  // ACTODO: Invalidate visible modules
   // Regardless of invalidation, always re-scan main module.
   cache.removeDependency(rootModuleID);
 }


### PR DESCRIPTION
- Add caching of unsuccessful Swift dependency lookups. Use it to avoid unnecessary re-queries of Swift dependencies during a given scanning action.
- Re-use cached queried Clang dependency info in subsequent scanning stages. Dependency Scanning is recursive over discovered Swift module overlays. In the main 'resolveImportedModuleDependencies' routine, after all Swift and Clang dependencies of the main module are discovered, the scanner looks up Swift overlays for discovered Clang modules. For each such Swift overlay, the scanner will then proceed to call 'resolveImportedModuleDependencies' on the overlay module.
On these subsequent recursive calls to 'resolveImportedModuleDependencies', Clang dependency resolution will re-query all imports of the overlay module which do not resolve to Swift modules, even if they had been queried previously in a parent invocation. This change adds the ability to re-use previously-queried-and-cached Clang module dependency information by having the dependency cache also store the set of visible modules which resulted from each by-name lookup.