### PR TITLE
[cxx-interop] Fix compile error

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2951,7 +2951,8 @@ synthesizeFunctionConstructorBody(AbstractFunctionDecl *afd, void *context) {
   auto wrapperInstCtorIt =
       llvm::find_if(wrapperInstDecl->getMembers(), [&](Decl *member) -> bool {
         if (auto wrapperCtor = dyn_cast<ConstructorDecl>(member)) {
-          return wrapperCtor->isMemberwiseInitializer();
+          return wrapperCtor->isMemberwiseInitializer() ==
+                 MemberwiseInitKind::Regular;
         }
         return false;
       });


### PR DESCRIPTION
This fixes a compiler error introduced by ad56e061. The signature of `isMemberwiseInitializer()` changed after the CI ran on the PR.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
