### PR TITLE
🍒 [6.3][cxx-interop] Implicitly defined copy and move constructors

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -736,6 +736,12 @@ ValueDecl *getImportedMemberOperator(const DeclBaseName &name,
 /// as permissive as the input C++ access.
 AccessLevel convertClangAccess(clang::AccessSpecifier access);
 
+/// Lookup and return the copy constructor of \a decl
+///
+/// Returns nullptr if \a decl doesn't have a valid copy constructor
+const clang::CXXConstructorDecl *
+findCopyConstructor(const clang::CXXRecordDecl *decl);
+
 /// Read file IDs from 'private_fileid' Swift attributes on a Clang decl.
 ///
 /// May return >1 fileID when a decl is annotated more than once, which should

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-ignore-unrelated
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -Xcc -std=c++20 -verify-additional-prefix cpp20- -D CPP20 -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-ignore-unrelated
 
 //--- Inputs/module.modulemap
 module Test {
@@ -12,10 +12,11 @@ module Test {
 //--- Inputs/noncopyable.h
 #include "swift/bridging"
 #include <string>
+#include <vector>
 
 struct NonCopyable {
     NonCopyable() = default;
-    NonCopyable(const NonCopyable& other) = delete;
+    NonCopyable(const NonCopyable& other) = delete; // expected-note {{'NonCopyable' has been explicitly marked deleted here}}
     NonCopyable(NonCopyable&& other) = default;
 };
 
@@ -79,9 +80,62 @@ struct SWIFT_NONCOPYABLE NonCopyableNonMovable { // expected-note {{record 'NonC
     NonCopyableNonMovable(NonCopyableNonMovable&& other) = delete;
 };
 
+struct ImplicitCopyConstructor {
+  NonCopyable element;
+};
+
+template <typename T, typename P, typename R>
+struct TemplatedImplicitCopyConstructor {
+  T element;
+  P *pointer;
+  R &reference;
+};
+
+using NonCopyableT = TemplatedImplicitCopyConstructor<NonCopyable, int, int>;
+using NonCopyableP = TemplatedImplicitCopyConstructor<int, NonCopyable, int>;
+using NonCopyableR = TemplatedImplicitCopyConstructor<int, int, NonCopyable>;
+
+struct DefaultedCopyConstructor {
+  NonCopyable element; // expected-note {{copy constructor of 'DefaultedCopyConstructor' is implicitly deleted because field 'element' has a deleted copy constructor}}
+  DefaultedCopyConstructor(const DefaultedCopyConstructor&) = default; 
+  // expected-warning@-1 {{explicitly defaulted copy constructor is implicitly deleted}}
+  // expected-note@-2 {{replace 'default' with 'delete'}}
+  DefaultedCopyConstructor(DefaultedCopyConstructor&&) = default;
+};
+
+template<typename T>
+struct TemplatedDefaultedCopyConstructor {
+  T element;
+  TemplatedDefaultedCopyConstructor(const TemplatedDefaultedCopyConstructor&) = default;
+  TemplatedDefaultedCopyConstructor(TemplatedDefaultedCopyConstructor&&) = default;
+};
+
+template<typename T>
+struct DerivedTemplatedDefaultedCopyConstructor : TemplatedDefaultedCopyConstructor<T> {};
+
+using CopyableDefaultedCopyConstructor = TemplatedDefaultedCopyConstructor<NonCopyableP>;
+using NonCopyableDefaultedCopyConstructor = TemplatedDefaultedCopyConstructor<NonCopyable>;
+using CopyableDerived = DerivedTemplatedDefaultedCopyConstructor<NonCopyableR>;
+using NonCopyableDerived = DerivedTemplatedDefaultedCopyConstructor<NonCopyable>;
+
 template<typename T> struct SWIFT_COPYABLE_IF(T) DisposableContainer {};
 struct POD { int x; float y; }; // special members are implicit, but should be copyable
 using DisposablePOD = DisposableContainer<POD>; // should also be copyable
+
+struct DerivesFromMe : MyPair<DisposableContainer<DerivesFromMe>, std::vector<NonCopyable>> {};
+struct DerivesFromMeToo : MyPair<std::vector<NonCopyable>, DisposableContainer<DerivesFromMe>> {};
+
+template <typename T>
+struct OneField {
+    T field;
+};
+
+template <typename F, typename S>
+struct SWIFT_COPYABLE_IF(F, S) NoFields {};
+
+struct FieldDependsOnMe { // used to trigger a request cycle
+  OneField<NoFields<FieldDependsOnMe, NonCopyable>> field;
+};
 
 //--- test.swift
 import Test
@@ -133,6 +187,34 @@ func missingLifetimeOperation() {
     takeCopyable(s)
 }
 
+func implicitCopyConstructor(i: borrowing ImplicitCopyConstructor, t: borrowing NonCopyableT, p: borrowing NonCopyableP, r: borrowing NonCopyableR) {
+  takeCopyable(i) // expected-error {{global function 'takeCopyable' requires that 'ImplicitCopyConstructor' conform to 'Copyable'}}
+  takeCopyable(t) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableT' (aka 'TemplatedImplicitCopyConstructor<NonCopyable, CInt, CInt>') conform to 'Copyable'}}
+  
+  // References and pointers to non-copyable types are still copyable
+  takeCopyable(p)
+  takeCopyable(r)
+}
+
+func defaultCopyConstructor(d: borrowing DefaultedCopyConstructor, d1: borrowing CopyableDefaultedCopyConstructor, d2: borrowing NonCopyableDefaultedCopyConstructor, d3: borrowing CopyableDerived, d4: borrowing NonCopyableDerived) {
+  takeCopyable(d) // expected-error {{global function 'takeCopyable' requires that 'DefaultedCopyConstructor' conform to 'Copyable'}}
+  takeCopyable(d1)
+  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableDefaultedCopyConstructor' (aka 'TemplatedDefaultedCopyConstructor<NonCopyable>') conform to 'Copyable'}}
+  takeCopyable(d3)
+  takeCopyable(d4) // expected-error {{global function 'takeCopyable' requires that 'NonCopyableDerived' (aka 'DerivedTemplatedDefaultedCopyConstructor<NonCopyable>') conform to 'Copyable'}}
+}
+
 func copyableDisposablePOD(p: DisposablePOD) {
   takeCopyable(p)
+}
+
+func couldCreateCycleOfCxxValueSemanticsRequests() {
+  let d1 = DerivesFromMe()
+  takeCopyable(d1) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
+
+  let d2 = DerivesFromMeToo()
+  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
+
+  let d3 = FieldDependsOnMe()
+  takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}
 }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -99,3 +99,9 @@ module CustomSmartPtr {
   requires cplusplus
   export *
 }
+
+module StdExpected {
+  header "std-expected.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-expected.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-expected.h
@@ -1,0 +1,23 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+
+#include <memory>
+#include <expected>
+
+using NonCopyableExpected = std::expected<std::unique_ptr<bool>, int>;
+
+template<typename T>
+class UniqueRef {
+public:
+  std::unique_ptr<T> _field;
+};
+
+struct Decoder {};
+enum Error {
+  DoomA,
+  DoomB
+};
+
+using DecoderOrError = std::expected<UniqueRef<Decoder>, Error>;
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -89,4 +89,9 @@ struct CountCopies {
 
 inline std::unique_ptr<CountCopies> getCopyCountedUniquePtr() { return std::make_unique<CountCopies>(); }
 
+struct HasUniqueIntVector {
+  HasUniqueIntVector() = default;
+  std::vector<std::unique_ptr<int>> x;
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -40,4 +40,10 @@ struct NonCopyable {
 using VectorOfNonCopyable = std::vector<NonCopyable>;
 using VectorOfPointer = std::vector<NonCopyable *>;
 
+struct HasVector {
+  std::vector<NonCopyable> field;
+};
+
+struct BaseHasVector : HasVector {};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H

--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+// TODO <expected> not yet supported with libstdc++
+// XFAIL: OS=linux-gnu
+
+// https://github.com/apple/swift/issues/70226
+// UNSUPPORTED: OS=windows-msvc
+
+import StdExpected
+import CxxStdlib
+
+func takeCopyable<T: Copyable>(_ x: T) {} 
+
+let nonCopExpected = NonCopyableExpected()
+takeCopyable(nonCopExpected)
+// CHECK: error: global function 'takeCopyable' requires that 'NonCopyableExpected' (aka {{.*}}) conform to 'Copyable'
+
+let doe = DecoderOrError()
+takeCopyable(doe)
+// CHECK: error: global function 'takeCopyable' requires that 'DecoderOrError' (aka {{.*}}) conform to 'Copyable'
+
+// CHECK-NOT: error

--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,7 +1,7 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 // TODO <expected> not yet supported with libstdc++
-// XFAIL: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu
 
 // https://github.com/apple/swift/issues/70226
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
@@ -10,3 +10,7 @@ func takeCopyable<T: Copyable>(_ x: T) {}
 let vecUniquePtr = getVectorNonCopyableUniquePtr()
 takeCopyable(vecUniquePtr)
 // CHECK: error: global function 'takeCopyable' requires that 'std{{.*}}vector{{.*}}unique_ptr{{.*}}NonCopyable{{.*}}' conform to 'Copyable'
+
+let uniqueIntVec = HasUniqueIntVector()
+takeCopyable(uniqueIntVec)
+// CHECK: error: global function 'takeCopyable' requires that 'HasUniqueIntVector' conform to 'Copyable'

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -29,3 +29,11 @@ let vecFloat = VectorOfFloat()
 takeCopyable(vecFloat)
 takeCxxVector(vecFloat)
 // CHECK-NOT: error
+
+let hasVector = HasVector()
+takeCopyable(hasVector)
+// CHECK: error: global function 'takeCopyable' requires that 'HasVector' conform to 'Copyable'
+
+let baseHasVector = BaseHasVector()
+takeCopyable(baseHasVector)
+// CHECK: error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'


### PR DESCRIPTION
  - **Explanation**: Previously, we would eagerly ask Clang to define the copy constructor (if the user didn't provide its definition). Since a `std::vector` is always copy constructible, Clang would define a copy constructor for a record that has a `std::vector<std::unique_ptr<...>>`, and we would incorrectly import the type as copyable. Now, we push back the copy constructor's definition to IRGen, and also only ask Clang to provide its definition if the `CxxValueSemantics` request concludes the type should be imported as copyable. 
  - **Original PRs**: https://github.com/swiftlang/swift/pull/85642, https://github.com/swiftlang/swift/pull/85816
  - **Risk**: Medium, this postpones the definition of copy and move constructors to IRGen. Also increases the number of types that will be imported as `~Copyable`, but all of these types would have been unusable from Swift previously. 
  - **Testing**: Added a few tests for `std::unique_ptr` and `std::expected`, which used to trigger obscure C++ errors when used from Swift. Also added a few tests that could create request cycles before https://github.com/swiftlang/swift/pull/85834
  - **Reviewers**: @Xazax-hun @egorzhdan 