### PR TITLE
[CS] Improve member resolution lookup when theres a ProtocolCompositionType

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -280,7 +280,7 @@ bool BindingSet::isDelayed() const {
       if (Bindings.empty())
         return true;
 
-      if (Bindings[0].BindingType->is<ProtocolType>()) {
+      if (Bindings[0].BindingType->isConstraintType()) {
         auto *bindingLoc = Bindings[0].getLocator();
         // This set shouldn't be delayed because there won't be any
         // other inference sources when the protocol binding got
@@ -421,7 +421,7 @@ bool BindingSet::isPotentiallyIncomplete() const {
     // let's consider this binding set to be potentially incomplete since
     // that's done as a last resort effort at resolving first member.
     if (auto *constraint = binding.getSource()) {
-      if (binding.BindingType->is<ProtocolType>() &&
+      if (binding.BindingType->is<ProtocolType, ProtocolCompositionType>() &&
           (constraint->getKind() == ConstraintKind::ConformsTo ||
            constraint->getKind() == ConstraintKind::NonisolatedConformsTo))
         return true;
@@ -811,9 +811,12 @@ void BindingSet::inferTransitiveUnresolvedMemberRefBindings() {
         // \endcode
         inferTransitiveProtocolRequirements();
 
+        SmallVector<Type, 4> protocols;
+        std::optional<Constraint*> constraintSource;
         if (TransitiveProtocols.has_value()) {
           for (auto *constraint : *TransitiveProtocols) {
             Type protocolTy = constraint->getSecondType();
+            assert(protocolTy->is<ProtocolType>());
 
             // Compiler-known marker protocols cannot be extended with members,
             // so do not consider them.
@@ -838,9 +841,17 @@ void BindingSet::inferTransitiveUnresolvedMemberRefBindings() {
                   continue;
               }
             }
-
-            addBinding({protocolTy, AllowedBindingKind::Fallback, constraint});
-
+            protocols.push_back(protocolTy);
+            if (!constraintSource.has_value())
+              constraintSource = constraint;
+          }
+          if (protocols.size() > 0) {
+            assert(constraintSource.has_value());
+            auto ty = ProtocolCompositionType::get(CS.getASTContext(),
+                                                   protocols,
+                                                   InvertibleProtocolSet(),
+                                                   false /*anyObject*/);
+            addBinding({ty, AllowedBindingKind::Fallback, constraintSource.value()});
             // Note the fact that we modified the binding set.
             markDirty();
           }
@@ -2119,7 +2130,8 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     // type of a chain, Result should always be a concrete type which conforms
     // to the protocol inferred for the base.
     if (constraint->getKind() == ConstraintKind::UnresolvedMemberChainBase &&
-        kind == AllowedBindingKind::Subtypes && type->is<ProtocolType>()) {
+        kind == AllowedBindingKind::Subtypes &&
+        type->is<ProtocolType, ProtocolCompositionType>()) {
       DEBUG_BAILOUT("Unresolved member chain base");
       return std::nullopt;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10711,23 +10711,26 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         return;
       }
 
-      // Cannot instantiate a protocol or reference a member on
-      // protocol composition type.
-      if (isa<ConstructorDecl>(decl) ||
-          instanceTy->is<ProtocolCompositionType>()) {
-        result.addUnviable(candidate,
-                           MemberLookupResult::UR_TypeMemberOnInstance);
+      if (getConcreteReplacementForProtocolSelfType(decl)) {
+        result.addViable(candidate);
         return;
       }
 
-      if (getConcreteReplacementForProtocolSelfType(decl)) {
-        result.addViable(candidate);
-      } else {
-        result.addUnviable(
+      // Cannot instantiate a protocol or reference a member on
+      // protocol composition type.
+      if (!memberLocator->isLastElement<LocatorPathElt::UnresolvedMember>()) {
+        if (isa<ConstructorDecl>(decl) ||
+            instanceTy->is<ProtocolCompositionType>()) {
+          result.addUnviable(candidate,
+                             MemberLookupResult::UR_TypeMemberOnInstance);
+          return;
+        }
+      }
+      result.addUnviable(
             candidate,
             MemberLookupResult::UR_InvalidStaticMemberOnProtocolMetatype);
-      }
       return;
+
     } else {
       if (!hasStaticMembers) {
         result.addUnviable(candidate,
@@ -11995,7 +11998,7 @@ ConstraintSystem::simplifyUnresolvedMemberChainBaseConstraint(
     return SolutionKind::Unsolved;
   }
 
-  if (baseTy->is<ProtocolType>()) {
+  if (baseTy->is<ProtocolType, ProtocolCompositionType>()) {
     auto *baseExpr =
         castToExpr<UnresolvedMemberChainResultExpr>(locator.getAnchor())
             ->getChainBase();
@@ -12007,10 +12010,22 @@ ConstraintSystem::simplifyUnresolvedMemberChainBaseConstraint(
 
     auto *memberRef = findResolvedMemberRef(memberLoc);
     if (memberRef && (memberRef->isStatic() || isa<TypeAliasDecl>(memberRef))) {
-      return simplifyConformsToConstraint(
-          resultTy, baseTy, ConstraintKind::ConformsTo,
-          getConstraintLocator(memberLoc, ConstraintLocator::MemberRefBase),
-          flags);
+      auto layout = baseTy->getExistentialLayout();
+      ASSERT(!layout.explicitSuperclass);
+      auto locator =
+        getConstraintLocator(memberLoc, ConstraintLocator::MemberRefBase);
+      auto lFlags = getDefaultDecompositionOptions(flags);
+
+      for (auto *proto : layout.getProtocols()) {
+        auto solution =
+          simplifyConformsToConstraint(resultTy, proto,
+                                       ConstraintKind::ConformsTo,
+                                       locator, lFlags);
+        if (solution == SolutionKind::Error) {
+          return SolutionKind::Error;
+        }
+      }
+      return SolutionKind::Solved;
     }
   }
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -847,3 +847,10 @@ func testCompoundLeadingDot() {
   let _: S = .foo(x:)(0)
   let _: S = .foo(x:)(x: 0) // expected-error {{extraneous argument label 'x:' in call}}
 }
+
+/// Make sure that anyObject is handled correctly on .init member lookup
+class E {}
+
+func foofoo() -> some E {
+  return .init() //ok
+}


### PR DESCRIPTION
Code with Protocol Composition parameters had not been taking into account that a parameter would conform to all protocols in the composition on member resolution and could fail to find a member for one protocol on static lookups, resulting in a diagnostic that was incorrect even on correct programs.

For example
protocol P {
 static var boo
}
protocol Q {
}
func t<T: P&Q>(x: T) { }
t(.boo)

Diagnostic of Q does not have member boo

(Yes, other diagnostics are required in this code)

This occured because P and Q were considered one path at a time. After the change, the P&Q path is considered together instead.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
