### PR TITLE
Retain more debug info in SIL optimization passes

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
@@ -180,6 +180,12 @@ private func tryEliminate(copy: CopyLikeInstruction, _ context: FunctionPassCont
       use.set(to: copy.destinationAddress, context)
     }
   }
+
+  // Salvage the debug variable attribute, if present.
+  if let debugVariable = allocStack.debugVariable {
+    let builder = Builder(before: firstUseOfAllocStack, location: allocStack.location, context)
+    builder.createDebugValue(value: copy.destinationAddress, debugVariable: debugVariable)
+  }
   context.erase(instruction: allocStack)
   context.erase(instructionIncludingAllUsers: copy.loadingInstruction)
 }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -210,6 +210,7 @@ extension MutatingContext {
 
   public func erase(instructionIncludingDebugUses inst: Instruction) {
     precondition(inst.results.allSatisfy { $0.uses.ignoreDebugUses.isEmpty })
+    salvageDebugInfo(of: inst)
     erase(instructionIncludingAllUsers: inst)
   }
 
@@ -217,4 +218,9 @@ extension MutatingContext {
     _bridged.eraseBlock(block.bridged)
   }
 
+  /// Transfer debug info associated with (the result of) `instruction` to a
+  /// new `debug_value` instruction before `instruction` is deleted.
+  public func salvageDebugInfo(of instruction: Instruction) {
+    BridgedContext.salvageDebugInfo(instruction.bridged)
+  }
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1558,6 +1558,7 @@ struct BridgedContext {
   BRIDGED_INLINE void eraseBlock(BridgedBasicBlock block) const;
   static BRIDGED_INLINE void moveInstructionBefore(BridgedInstruction inst, BridgedInstruction beforeInst);
   static BRIDGED_INLINE void copyInstructionBefore(BridgedInstruction inst, BridgedInstruction beforeInst);
+  static BRIDGED_INLINE void salvageDebugInfo(BridgedInstruction inst);
 
     // SSAUpdater
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -41,6 +41,7 @@
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/SILWitnessTable.h"
 #include "swift/SILOptimizer/Utils/ConstExpr.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SIL/SILConstants.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -3219,6 +3220,10 @@ void BridgedContext::moveInstructionBefore(BridgedInstruction inst, BridgedInstr
 
 void BridgedContext::copyInstructionBefore(BridgedInstruction inst, BridgedInstruction beforeInst) {
   inst.unbridged()->clone(beforeInst.unbridged());
+}
+
+void BridgedContext::salvageDebugInfo(BridgedInstruction inst) {
+  swift::salvageDebugInfo(inst.unbridged());
 }
 
 OptionalBridgedFunction BridgedContext::lookupStdlibFunction(BridgedStringRef name) const {

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -321,9 +321,8 @@ splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
   }
 
   // Preserve the original load's debug information.
-  if (pass.preserveDebugInfo) {
-    swift::salvageLoadDebugInfo(loadInst);
-  }
+  swift::salvageLoadDebugInfo(loadInst);
+
   // Remove the now unused borrows.
   for (auto *borrow : borrows)
     nextII = killInstAndIncidentalUses(borrow, nextII, pass);

--- a/test/DebugInfo/self-nostorage.swift
+++ b/test/DebugInfo/self-nostorage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -O -o - | %FileCheck %s
 
 public struct S {
   func f() {

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -71,3 +71,26 @@ bb3:
 
 
 // CHECK-IR: ![[DBG_VAR]] = !DILocalVariable(name: "hello"
+
+struct T {
+  @_hasStorage let x: Builtin.Int32 { get }
+  init(x: Builtin.Int32)
+}
+
+// This test verifies that splitAggregateLoad in CanonicalizeInstruction.cpp
+// salvages debug info attached to the loaded aggregate in optimized builds.
+//
+// CHECK-LABEL: sil @split_aggregate_load : $@convention(thin) (@in T) -> Builtin.Int32 {
+// CHECK:       bb0([[ARG:%[0-9]+]] : $*T):
+// CHECK-NEXT:    [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[ARG]] : $*T, #T.x
+// CHECK-NEXT:    [[ELEM:%[0-9]+]] = load [[ELEM_ADDR]]
+// CHECK-NEXT:    debug_value [[ARG]] : $*T, let, name "var", expr op_deref
+// CHECK-NEXT:    return [[ELEM]] : $Builtin.Int32
+// CHECK-LABEL: } // end sil function 'split_aggregate_load'
+sil @split_aggregate_load : $@convention(thin) (@in T) -> Builtin.Int32 {
+bb0(%0 : $*T):
+  %1 = load %0
+  debug_value %1, let, name "var"
+  %2 = struct_extract %1, #T.x
+  return %2
+}

--- a/test/DebugInfo/simplify_builtin.sil
+++ b/test/DebugInfo/simplify_builtin.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -simplification -simplify-instruction=builtin -sil-print-debuginfo | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+// This verifies that debug information attached to the arguments of builtin
+// instructions is preserved when those instructions are constant-folded.
+//
+// CHECK-LABEL: sil @preserve_bitwise_operands : $@convention(thin) () -> Builtin.Int32 {
+// CHECK:       bb0:
+// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "x", expr op_constu:1
+// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "y", expr op_constu:2
+// CHECK-NEXT:    [[THREE:%[0-9]+]] = integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    return [[THREE]] : $Builtin.Int32
+// CHECK-LABEL: } // end sil function 'preserve_bitwise_operands'
+sil @preserve_bitwise_operands : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 1
+  debug_value %0, let, name "x"
+  %1 = integer_literal $Builtin.Int32, 2
+  debug_value %1, let, name "y"
+  %2 = builtin "or_Int32"(%0, %1) : $Builtin.Int32
+  return %2
+}
+
+// CHECK-LABEL: sil @preserve_add_operands : $@convention(thin) () -> Builtin.Int32 {
+// CHECK:       bb0:
+// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "x", expr op_consts:4294967295
+// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "y", expr op_constu:2
+// CHECK-NEXT:    [[ONE:%[0-9]+]] = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    return [[ONE]] : $Builtin.Int32
+// CHECK-LABEL: } // end sil function 'preserve_add_operands'
+sil @preserve_add_operands : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, -1
+  debug_value %0, let, name "x"
+  %1 = integer_literal $Builtin.Int32, 2
+  debug_value %1, let, name "y"
+  %2 = builtin "add_Int32"(%0, %1) : $Builtin.Int32
+  return %2
+}

--- a/test/DebugInfo/simplify_struct_extract.sil
+++ b/test/DebugInfo/simplify_struct_extract.sil
@@ -1,0 +1,27 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -simplification -simplify-instruction=struct_extract -sil-print-debuginfo | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Builtin
+import Swift
+
+struct T {
+  var x: Builtin.Int32
+}
+
+// This verifies that tryReplaceRedundantInstructionPair in OptUtils.swift
+// salvages debug info attached to the first instruction of the pair,
+// in this case the struct.
+//
+// CHECK-LABEL: sil @redundant_pair : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// CHECK:       bb0([[VAR:%[0-9]+]] : $Builtin.Int32):
+// CHECK-NEXT:    debug_value [[VAR]] : $Builtin.Int32, let, name "var", type $T, expr op_fragment:#T.x
+// CHECK-NEXT:    return [[VAR]]
+// CHECK-LABEL: } // end sil function 'redundant_pair'
+sil @redundant_pair : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : $Builtin.Int32):
+  %1 = struct $T(%0)
+  debug_value %1, let, name "var"
+  %2 = struct_extract %1, #T.x
+  return %2
+}

--- a/test/DebugInfo/temp_lvalue_elimination.sil
+++ b/test/DebugInfo/temp_lvalue_elimination.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt -sil-print-types -sil-verify-all -temp-lvalue-elimination %s | %FileCheck %s
+sil_stage canonical
+
+// REQUIRES: swift_in_compiler
+
+import Builtin
+
+// This verifies that the TempLValueElimination pass correctly salvages the
+// debug variable attribute of alloc_stack instructions.
+//
+// CHECK-LABEL: sil @stack_var_elimination : $@convention(thin) (Builtin.Int32) -> @out Builtin.Int32 {
+// CHECK:       bb0([[X:%[0-9]+]] : $*Builtin.Int32, [[VAL:%[0-9]+]] : $Builtin.Int32):
+// CHECK-NEXT:    debug_value [[X]] : $*Builtin.Int32, var, name "x"
+// CHECK-NEXT:    store [[VAL]] to [[X]] : $*Builtin.Int32
+// CHECK-NEXT:    [[E:%[0-9]+]] = tuple ()
+// CHECK-NEXT:    return [[E]] : $()
+// CHECK-LABEL: } // end sil function 'stack_var_elimination'
+sil @stack_var_elimination : $@convention(thin) (Builtin.Int32) -> @out Builtin.Int32 {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  %2 = alloc_stack [var_decl] $Builtin.Int32, var, name "x"
+  store %1 to %2
+  copy_addr %2 to %0
+  dealloc_stack %2
+  %3 = tuple ()
+  return %3
+}


### PR DESCRIPTION
The original PR (#85244) was reverted (#85836) due to rdar://165667449

This version fixes the aforementioned issue, and (potentially) improves overall debug info retention by salvaging info in `erase(instructionIncludingDebugUses:)`, rather than inserting many explicit `salvageDebugInfo` calls throughout the code to make the test cases pass.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
