### PR TITLE
SIL: Handle address ReturnInsts from borrow accessors as yielding uses.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -139,7 +139,12 @@ extension AddressUseVisitor {
       let svi = operand.instruction as! SingleValueInstruction
       return loadedAddressUse(of: operand, intoValue: svi)
 
-    case is YieldInst:
+    case is YieldInst,
+    // Return should only occur in a borrow or inout accessor, in which case the
+    // returned address should be structurally used as if it were a projected
+    // use in the caller, even though there is no code here in the callee to
+    // formally end the access.
+         is ReturnInst:
       return yieldedAddressUse(of: operand)
 
     case let sdai as SourceDestAddrInstruction

--- a/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
+++ b/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowAndMutateAccessors -verify %s
+
+struct Butt<T: ~Escapable>: ~Escapable {
+	var x: T
+
+	var xx: T {
+		@_lifetime(copy self)
+		borrow {
+			return x
+		}
+	}
+}
+
+struct Tubb<T>: ~Escapable {
+	var x: T
+
+	@_lifetime(immortal)
+	init() { fatalError() }
+
+	var xx: T {
+		borrow {
+			return x
+		}
+	}
+}

--- a/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
+++ b/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowAndMutateAccessors -verify %s
 
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
 struct Butt<T: ~Escapable>: ~Escapable {
 	var x: T
 


### PR DESCRIPTION
This avoids a spurious lifetime error when an address-only borrow accessor returns a non-`Escapable` value from a non-`Escapable` aggregate.