### PR TITLE
test: introduce swift-target-frontend-plain for CAS tests

### DIFF
--- a/test/CAS/Xcc_args.swift
+++ b/test/CAS/Xcc_args.swift
@@ -19,7 +19,7 @@
 // CHECK-NOT: -ivfsoverlay
 // CHECK-NOT: -fmodule-map-file
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \

--- a/test/CAS/Xcc_objc_direct.swift
+++ b/test/CAS/Xcc_objc_direct.swift
@@ -9,7 +9,7 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \

--- a/test/CAS/block-list.swift
+++ b/test/CAS/block-list.swift
@@ -22,7 +22,7 @@
 // FS-DAG: blocklist.yml
 // FS-DAG: empty.yml
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -target %target-future-triple \
 // RUN:   -emit-ir -o - -cache-compile-job -cas-path %t/cas -O \
 // RUN:   -swift-version 5 -module-name Test \

--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -27,9 +27,9 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps-1.json -o %t/MyApp.cmd -b %t/header.cmd
 
-// RUN: %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend-plain @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend-plain @%t/header.cmd /^header/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
@@ -40,10 +40,10 @@
 // RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
-// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd /^tmp/test.swift \
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd /^tmp/test.swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
 // RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \

--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -22,16 +22,16 @@
 
 /// Check few working cases.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd > %t1.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp.cmd > %t1.casid
 /// A different CAS doesn't affect base key.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -cas-path %t > %t2.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -cas-path %t > %t2.casid
 /// Output path doesn't affect base key.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -o %t/test.o > %t3.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -o %t/test.o > %t3.casid
 /// Add -D will change.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -DTEST > %t4.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -DTEST > %t4.casid
 
 // RUN: diff %t1.casid %t2.casid
 // RUN: diff %t1.casid %t3.casid
@@ -42,21 +42,21 @@
 // RUN: echo "%t/a.swift" > %t/filelist-2
 // RUN: echo "%t/b.swift" > %t/filelist-3
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-1 -c @%t/MyApp.cmd > %t5.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job -filelist %t/filelist-1 -c @%t/MyApp.cmd > %t5.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-2 -c @%t/MyApp.cmd > %t6.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job -filelist %t/filelist-2 -c @%t/MyApp.cmd > %t6.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-3 -c @%t/MyApp.cmd > %t7.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job -filelist %t/filelist-3 -c @%t/MyApp.cmd > %t7.casid
 // RUN: diff %t5.casid %t6.casid
 // RUN: not diff %t5.casid %t7.casid
 
 /// Test output keys.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
 // RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o @%t/MyApp.cmd | %FileCheck %s
 
 /// Test plugin CAS.
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/a.swift -o %t/plugin_deps.json -cache-compile-job -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) \
 // RUN:   -cas-plugin-option first-prefix=myfirst-
@@ -67,7 +67,7 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/plugin_deps.json Test > %t/plugin_MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) \
 // RUN:   -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o @%t/plugin_MyApp.cmd | %FileCheck %s --check-prefix=CHECK --check-prefix=PLUGIN
 
@@ -78,10 +78,10 @@
 
 /// Check switching CAS plugin path.
 // RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) > %t8.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) > %t8.casid
 // RUN: cp %plugin(CASPluginTest) %t/libCASPluginTest%llvm_plugin_ext
 // RUN: %cache-tool -cas-path %t/cas-plugin -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext > %t9.casid
+// RUN:   %target-swift-frontend-plain -cache-compile-job %t/a.swift -c @%t/MyApp-plugin.cmd -cas-path %t/cas-plugin -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext > %t9.casid
 // RUN: diff %t8.casid %t9.casid
 
 

--- a/test/CAS/cache_replay.swift
+++ b/test/CAS/cache_replay.swift
@@ -22,23 +22,23 @@
 // RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 /// Run the command first time, expect cache miss.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 
 /// Expect cache hit for second time.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
 /// Expect cache miss a subset of outputs.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 
 /// Cache hit for retry.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
 /// Skip cache
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -cache-disable-replay %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job -cache-disable-replay %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
 
 // CACHE-MISS: remark: cache miss for input

--- a/test/CAS/cache_replay_multiple_files.swift
+++ b/test/CAS/cache_replay_multiple_files.swift
@@ -14,19 +14,19 @@
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
 /// Test compile multiple inputs with batch mode.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 
 /// Expect cache hit second time
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
 //--- test.swift

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -6,9 +6,9 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
-// RUN: %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
+// RUN: %target-swift-frontend-plain @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
+// RUN:   %target-swift-frontend-plain @%t/header.cmd %S/Inputs/objc.h -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
@@ -18,11 +18,13 @@
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %target-swift-frontend-plain  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:    %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -emit-module -o %t/test.swiftmodule > %t/cache_key.json
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
 
 #warning("this is a warning")  // expected-warning {{this is a warning}}
@@ -40,16 +42,16 @@ let _ : MyEnum? = .none // expected-warning {{assuming you mean 'Optional<MyEnum
 // CHECK: warning: this is a warning
 
 /// Check other DiagnosticConsumers.
-// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -verify
 // RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/test.diag
 
 /// Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA
 
-// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -Rcache-compile-job 2>&1 | %FileCheck %s -check-prefix CACHE-MISS
-// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -Rcache-compile-job 2>&1 | %FileCheck %s -check-prefix CACHE-HIT
 // CACHE-MISS: remark: cache miss
 // CACHE-HIT: remark: replay output file '<cached-diagnostics>'

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -19,7 +19,7 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %target-swift-frontend -diagnostic-style=swift \
+// RUN: %target-swift-frontend-plain -diagnostic-style=swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -external-plugin-path %t#%swift-plugin-server \

--- a/test/CAS/cached_diagnostics_pcm.swift
+++ b/test/CAS/cached_diagnostics_pcm.swift
@@ -22,7 +22,7 @@
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
 // RUN:   -emit-module -o %t/test.swiftmodule
 
 //--- module.modulemap

--- a/test/CAS/cached_diagnostics_remap.swift
+++ b/test/CAS/cached_diagnostics_remap.swift
@@ -7,11 +7,11 @@
 // RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map-paths %t /^test -scanner-output-dir %t.noremap
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
+// RUN: %target-swift-frontend-plain @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch > %t/keys.json
+// RUN:   %target-swift-frontend-plain @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch > %t/keys.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/keys.json -- \
-// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch -cache-replay-prefix-map /^test %t 2>&1 \
+// RUN:    %target-swift-frontend-plain @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch -cache-replay-prefix-map /^test %t 2>&1 \
 // RUN:    | %FileCheck %s -check-prefix BRIDGE -check-prefix BRIDGE-REMAP
 
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
@@ -26,12 +26,14 @@
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd \
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd \
 // RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift 2>&1 | %FileCheck %s
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- %target-swift-frontend -cache-compile-job -module-name Test \
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -module-name Test \
 // RUN:   -O -cas-path %t/cas @%t/MyApp.cmd \
 // RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift > %t/cache_key.json
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -cache-compile-job -module-name Test \
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -module-name Test \
 // RUN:   -O -cas-path %t/cas @%t/MyApp.cmd \
 // RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift -cache-replay-prefix-map /^test %t 2>&1 | %FileCheck %s --check-prefix REMAP
 

--- a/test/CAS/can-import.swift
+++ b/test/CAS/can-import.swift
@@ -30,7 +30,7 @@
 // CMD-NEXT: "0"
 // CMD-NEXT: "1000.0.0"
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -13,19 +13,19 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/Test.swift @%t/MyApp.cmd
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN: %target-swift-frontend-plain -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %t/Test.swift -cache-compile-job \
 // RUN:   -cas-path %t/cas -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib @%t/MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   %target-swift-frontend-plain -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %t/Test.swift -cache-compile-job \
 // RUN:   -cas-path %t/cas -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib @%t/MyApp.cmd > %t/keys.json
@@ -37,13 +37,13 @@
 // CACHE-KEY-NEXT: command-line
 // CACHE-KEY: Input index: 0
 
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN: %target-swift-frontend-plain -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -explicit-interface-module-build -Rcache-compile-job @%t/MyApp.cmd -input-file-key @%t/key 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix=CACHE-MISS
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN: %target-swift-frontend-plain -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/cas_output_backend.swift
+++ b/test/CAS/cas_output_backend.swift
@@ -17,9 +17,9 @@
 // RUN: not %target-swift-frontend -c -cache-compile-job %s -o %t/test.o @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=NOT-CONFIG
 // NOT-CONFIG: error: CAS cannot be initialized from the specified '-cas-*' options: no CAS options provided
 
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd > %t/cache_key.json
+// RUN:   %target-swift-frontend-plain -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd > %t/cache_key.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action validate-outputs %t/cache_key.json
 
 /// make sure validate fails if the cas is cleared.

--- a/test/CAS/cross_import.swift
+++ b/test/CAS/cross_import.swift
@@ -31,7 +31,7 @@
 // CMD-NEXT: [[CMI2:[B|C]]]
 // CMD-NEXT: [[CMI2]].swiftcrossimport{{/|\\}}A.swiftoverlay
 
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule  \
+// RUN: %target-swift-frontend-plain -emit-module -o %t/Test.swiftmodule  \
 // RUN:   -emit-module-interface-path %t/Test.swiftinterface \
 // RUN:   -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -enable-cross-import-overlays \

--- a/test/CAS/debuginfo_invariant.swift
+++ b/test/CAS/debuginfo_invariant.swift
@@ -11,7 +11,7 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
 // RUN: echo %t/main.swift > %t/inputs.FileList
-// RUN: %target-swift-frontend -emit-ir -o %t/main.ll -g -O \
+// RUN: %target-swift-frontend-plain -emit-ir -o %t/main.ll -g -O \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 \
 // RUN:   -disable-implicit-swift-modules -swift-version 5 -enable-cross-import-overlays \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/dependency_file.swift
+++ b/test/CAS/dependency_file.swift
@@ -11,7 +11,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -o %t/main.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -23,7 +23,7 @@
 // RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/main.d -DTMP=%t
 // DEPS: [[TMP]]{{/|\\}}main.o :
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -o %t/main-2.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -45,7 +45,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map-1.json > %t/map-1.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json Test > %t/MyApp-1.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -o %t/main-3.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -58,7 +58,7 @@
 
 /// Test replay from driver interface
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
-// RUN:   %target-swift-frontend \
+// RUN:   %target-swift-frontend-plain \
 // RUN:   -c -o %t/main-4.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -67,7 +67,7 @@
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d > %t/key.casid
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
-// RUN:   %target-swift-frontend \
+// RUN:   %target-swift-frontend-plain \
 // RUN:   -c -o %t/main-4.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/embedded-Xcc.swift
+++ b/test/CAS/embedded-Xcc.swift
@@ -11,7 +11,7 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
 // RUN: echo %t/main.swift > %t/inputs.FileList
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -g -O \
+// RUN: %target-swift-frontend-plain -emit-module -o %t/Test.swiftmodule -g -O \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 \
 // RUN:   -disable-implicit-swift-modules -swift-version 5 -enable-cross-import-overlays \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/include-tree.swift
+++ b/test/CAS/include-tree.swift
@@ -11,7 +11,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -19,7 +19,7 @@
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
 /// Test that if there are non-existing module-map file passed through -Xcc, this still compiles.
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/index-store.swift
+++ b/test/CAS/index-store.swift
@@ -21,14 +21,14 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -o %t/Test.swiftmodule \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -o %t/Test.swiftmodule \
 // RUN:  -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:  -disable-implicit-swift-modules -explicit-swift-module-map-file @%t/map.casid \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd -index-system-modules -index-store-path %t/db 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 // RUN: ls %t/db
 
 /// Cache hit with a different index-store-path. Note cache hit will skip replay index data.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -o %t/Test.swiftmodule \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -o %t/Test.swiftmodule \
 // RUN:  -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:  -disable-implicit-swift-modules -explicit-swift-module-map-file @%t/map.casid \
 // RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd -index-system-modules -index-store-path %t/db2 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s

--- a/test/CAS/loc-directive-diagnostics.swift
+++ b/test/CAS/loc-directive-diagnostics.swift
@@ -9,13 +9,13 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/test.module \
+// RUN: %target-swift-frontend-plain -emit-module -emit-module-path %t/test.module \
 // RUN:   -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd %s 2>&1 | %FileCheck %s
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
+// RUN:   %target-swift-frontend-plain -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd %s > %t/cache_key.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json --  \
-// RUN:   %target-swift-frontend -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
+// RUN:   %target-swift-frontend-plain -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd %s 2>&1 | %FileCheck %s
 
 #sourceLocation(file: "anything.swift", line: 1)

--- a/test/CAS/macro_deps.swift
+++ b/test/CAS/macro_deps.swift
@@ -12,7 +12,7 @@
 // RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/test.swift -module-name Test -o %t/include/Test.swiftmodule -I %t/include \
 // RUN:   -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -swift-version 5 -external-plugin-path %t#%swift-plugin-server
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -I %t/include \
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t#%swift-plugin-server
 
@@ -39,7 +39,7 @@
 // PLUGIN_SEARCH-NOT: -external-plugin-path
 // RESOLVED-COUNT-2: -load-resolved-plugin
 
-// RUN: %target-swift-frontend -diagnostic-style=swift \
+// RUN: %target-swift-frontend-plain -diagnostic-style=swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -external-plugin-path %t#%swift-plugin-server \

--- a/test/CAS/macro_option_set.swift
+++ b/test/CAS/macro_option_set.swift
@@ -13,7 +13,7 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -plugin-path %swift-plugin-dir \

--- a/test/CAS/macro_plugin.swift
+++ b/test/CAS/macro_plugin.swift
@@ -15,7 +15,7 @@
 // RUN:   %S/../Macros/Inputs/syntax_macro_definitions.swift \
 // RUN:   -g -no-toolchain-stdlib-rpath
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -load-plugin-library %t/plugins/%target-library-name(MacroDefinition)
 
@@ -25,7 +25,7 @@
 // FS: MacroDefinition
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp -O \
 // RUN:   -load-plugin-library %t/plugins/%target-library-name(MacroDefinition) \

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -35,7 +35,7 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
@@ -61,7 +61,7 @@
 // CMD-REMAP-NEXT: -load-resolved-plugin
 // CMD-REMAP-NEXT: /^test/plugins/[[LIB]]#/^bin/swift-plugin-server#MacroDefinition
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -emit-module-interface-path %t/Macro.swiftinterface \
 // RUN:   -swift-version 5 -O \
@@ -77,7 +77,7 @@
 // MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test/plugins/[[LIB]]#/^bin/swift-plugin-server#MacroDefinition'
 
 /// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -emit-module-interface-path %t/Macro.swiftinterface \
 // RUN:   -swift-version 5 -O \
@@ -89,7 +89,7 @@
 
 /// Update timestamp, the build should still work.
 // RUN: touch %t/plugins/%target-library-name(MacroDefinition)
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -emit-module-interface-path %t/Macro.swiftinterface \
 // RUN:   -swift-version 5 -O \
@@ -99,7 +99,7 @@
 
 /// Typecheck swift interface with macro plugin.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend \
+// RUN:   %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -emit-module-interface-path %t/Macro.swiftinterface \
 // RUN:   -swift-version 5 -O \
@@ -108,7 +108,7 @@
 // RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json /^test/macro.swift > %t/key
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck-module-from-interface %t/Macro.swiftinterface \
 // RUN:   -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -O \
@@ -119,7 +119,7 @@
 
 /// Change the dylib content, this will fail the build.
 // RUN: echo " " >> %t/plugins/%target-library-name(MacroDefinition)
-// RUN: not %target-swift-frontend \
+// RUN: not %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -emit-module-interface-path %t/Macro.swiftinterface \
 // RUN:   -swift-version 5 -O \

--- a/test/CAS/module_dep_path.swift
+++ b/test/CAS/module_dep_path.swift
@@ -18,7 +18,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/B-map.json > %t/B-map.casid
 
 // RUN: echo %t/B.swift > %t/inputs.FileList
-// RUN: %target-swift-frontend -emit-module -o %t/B.swiftmodule -g \
+// RUN: %target-swift-frontend-plain -emit-module -o %t/B.swiftmodule -g \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 6 \
 // RUN:   -module-name B -swift-module-file=A=@%t/A.casid \
 // RUN:   -explicit-swift-module-map-file @%t/B-map.casid \
@@ -35,7 +35,7 @@
 
 // RUN: rm %t/A.swiftmodule %t/A.swift
 // RUN: echo %s > %t/inputs.FileList
-// RUN: %target-swift-frontend -emit-module -o %t/Main.swiftmodule -g \
+// RUN: %target-swift-frontend-plain -emit-module -o %t/Main.swiftmodule -g \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 6 \
 // RUN:   -module-name Main -swift-module-file=B=@%t/B.casid \
 // RUN:   -explicit-swift-module-map-file @%t/map.casid \

--- a/test/CAS/module_trace.swift
+++ b/test/CAS/module_trace.swift
@@ -11,7 +11,7 @@
 // RUN:   -emit-module-interface-path %t/A.swiftinterface -enable-library-evolution -I %t \
 // RUN:   %t/A.swift
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas -swift-version 5
 
@@ -27,7 +27,7 @@
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -cache-compile-job -cas-path %t/cas \
 // RUN:   -disable-implicit-swift-modules -o %t/test.o\
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/no-cas-path-dependency.swift
+++ b/test/CAS/no-cas-path-dependency.swift
@@ -14,7 +14,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -40,7 +40,7 @@
 // RUN: llvm-cas --cas %t/cas-2 --make-blob --data %t/map-2.json > %t/map-2.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-2.json Test > %t/MyApp-2.cmd
 
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -c -cache-compile-job -cas-path %t/cas-2 \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/CAS/opt-record.swift
+++ b/test/CAS/opt-record.swift
@@ -6,13 +6,13 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -cas-path %t/cas -O \
 // RUN:   -save-optimization-record -save-optimization-record-path %t/record.yaml \
 // RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   @%t/MyApp.cmd %s -o %t/test.o -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
 
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -cas-path %t/cas -O \
 // RUN:   -save-optimization-record -save-optimization-record-path %t/record-1.yaml \
 // RUN:   -swift-version 5 -module-name Test \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \

--- a/test/CAS/reproducer.swift
+++ b/test/CAS/reproducer.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -module-cache-path %t/clang-module-cache \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O -module-cache-path %t/clang-module-cache \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -import-objc-header %t/Bridging.h -scanner-output-dir %t -auto-bridging-header-chaining -scanner-debug-write-output \
 // RUN:   %t/test.swift %t/foo.swift -I %t/include -o %t/deps.json -cache-compile-job -cas-path %t/cas
@@ -9,9 +9,10 @@
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend-plain @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend-plain @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
@@ -23,7 +24,7 @@
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend %t/test.swift %t/foo.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend-plain %t/test.swift %t/foo.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd -gen-reproducer -gen-reproducer-dir %t/crash
 
 // RUN: %FileCheck %s --input-file=%t/crash/reproduce.sh

--- a/test/CAS/swift-scan-diagnostics-batch.swift
+++ b/test/CAS/swift-scan-diagnostics-batch.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/a.swift %t/b.swift %t/c.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
@@ -11,26 +11,27 @@
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
-// RUN:   %target-swift-frontend -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
 // RUN:   -c -emit-dependencies -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key0.casid
 
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 1 -- \
-// RUN:   %target-swift-frontend -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
 // RUN:   -c -emit-dependencies -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key1.casid
 
-// RUN: %target-swift-frontend -cache-compile-job \
+// RUN: %target-swift-frontend-plain -cache-compile-job \
 // RUN:  -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
 // RUN:  -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas @%t/MyApp.cmd
 
-// RUN: %target-swift-frontend -cache-compile-job \
+// RUN: %target-swift-frontend-plain -cache-compile-job \
 // RUN:  %t/a.swift %t/b.swift -primary-file %t/c.swift \
 // RUN:  -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/c.o -cas-path %t/cas @%t/MyApp.cmd
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key0.casid -- %target-swift-frontend -cache-compile-job \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key0.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job \
 // RUN:   -primary-file %t/a.swift -primary-file %t/b.swift  %t/c.swift \
 // RUN:   -c -emit-dependencies -module-name Test -o %t/a2.o -o %t/b2.o -cas-path %t/cas \
 // RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/a2.dia -serialize-diagnostics-path %t/b2.dia \
@@ -42,7 +43,8 @@
 // A-WARN: warning: This is a warning
 // B-WARN: warning: This is also a warning
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key1.casid -- %target-swift-frontend -cache-compile-job \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key1.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job \
 // RUN:   -primary-file %t/a.swift -primary-file %t/b.swift  %t/c.swift \
 // RUN:   -c -emit-dependencies -module-name Test -o %t/a2.o -o %t/b2.o -cas-path %t/cas \
 // RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/a2.dia -serialize-diagnostics-path %t/b2.dia \

--- a/test/CAS/swift-scan-diagnostics.swift
+++ b/test/CAS/swift-scan-diagnostics.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
@@ -9,11 +9,13 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key.casid
 
-// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %target-swift-frontend -cache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key1.casid
 
@@ -21,13 +23,14 @@
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
-// RUN: %target-swift-frontend -cache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend-plain -cache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -serialize-diagnostics -serialize-diagnostics-path %t/test.dia \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job %s \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
 // RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/test2.dia \
 // RUN:   @%t/MyApp.cmd
@@ -43,7 +46,8 @@
 // CHECK-QUERY-NEXT: swiftmodule: llvmcas://
 // CHECK-QUERY-NEXT: cached-diagnostics: llvmcas://
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job %s \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
 // RUN:   -frontend-parseable-output -serialize-diagnostics -serialize-diagnostics-path %t/test3.dia \
 // RUN:   @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=PARSEABLE

--- a/test/CAS/swift-scan-response-file.swift
+++ b/test/CAS/swift-scan-response-file.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
@@ -9,7 +9,7 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/cmd.resp
 
@@ -25,7 +25,7 @@
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/cmd2.resp
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %swift_frontend_plain @%t/cmd2.resp

--- a/test/CAS/swift-scan-test-llvm-args.swift
+++ b/test/CAS/swift-scan-test-llvm-args.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
@@ -9,18 +9,20 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd -Xllvm -aarch64-use-tbi > %t/key.casid
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd -Xllvm -aarch64-use-tbi
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -threads 10 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -threads 10 -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd -Xllvm -aarch64-use-tbi
 

--- a/test/CAS/swift-scan-test.swift
+++ b/test/CAS/swift-scan-test.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
 
@@ -9,11 +9,13 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key.casid
 
-// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key1.casid
 
@@ -21,12 +23,13 @@
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd
 

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph1
@@ -11,8 +11,10 @@
 
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
-// RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+
+// RUN: %target-swift-frontend-plain -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -explicit-swift-module-map-file @%t/map.casid \
@@ -22,7 +24,8 @@
 // CACHE-MISS: remark: cache miss for input
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
-// RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+
+// RUN: %target-swift-frontend-plain -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -explicit-swift-module-map-file @%t/map.casid \
@@ -36,7 +39,7 @@
 
 /// Test replay from driver interface
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
-// RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   %target-swift-frontend-plain -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -explicit-swift-module-map-file @%t/map.casid \
@@ -44,7 +47,7 @@
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job > %t/key.casid
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
-// RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   %target-swift-frontend-plain -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -explicit-swift-module-map-file @%t/map.casid \

--- a/test/CAS/uncached-casfs.swift
+++ b/test/CAS/uncached-casfs.swift
@@ -9,9 +9,9 @@
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd -b %t/header.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
-// RUN: %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %target-swift-frontend-plain @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN:   %target-swift-frontend-plain @%t/header.cmd %t/base/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
 
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
@@ -25,7 +25,7 @@
 
 // RUN: sed -e "s@VFS_DIR@%{/t:regex_replacement}/base@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/modified@g" %t/base.yaml > %t/overlay.yaml
 
-// RUN: %target-swift-frontend %t/base/test.swift %t/base/foo.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend-plain %t/base/test.swift %t/base/foo.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd -vfsoverlay %t/overlay.yaml -module-import-from-cas
 
 

--- a/test/CAS/vfsoverlay.swift
+++ b/test/CAS/vfsoverlay.swift
@@ -21,7 +21,7 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
-// RUN: %target-swift-frontend \
+// RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas -vfsoverlay %t/overlay.yaml \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1620,6 +1620,7 @@ if run_vendor == 'apple':
         (config.swift_frontend, target_options, config.variant_sdk, maccatalyst_extra_frameworks,
          config.swift_test_options, config.swift_frontend_test_options,
          swift_frontend_platform_remap_config))
+    config.target_swift_frontend_plain = "%s %s" % (config.swift_frontend, target_options)
     subst_target_swift_frontend_mock_sdk = (
         "%s %s -sdk %r %s %s %s" %
         (config.swift_frontend, target_options_for_mock_sdk, config.variant_sdk,
@@ -1762,6 +1763,12 @@ elif run_os in ['windows-msvc']:
                                                config.swift_system_overlay_opt,  \
                                                config.swift_test_options,        \
                                                config.swift_frontend_test_options))
+
+    config.target_swift_frontend_plain =                                         \
+            "%r -target %s %s %s" % (config.swift_frontend,                      \
+                                     config.variant_triple,                      \
+                                     config.resource_dir_opt,                    \
+                                     mcp_opt)
 
     config.target_codesign = 'echo'
 
@@ -1914,6 +1921,10 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         '%s -target %s %s %s %s %s '
         % (config.swift_frontend, config.variant_triple, config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options))
+    config.target_swift_frontend_plain = (
+        '%s -target %s %s' % (config.swift_frontend,
+                              config.variant_triple,
+                              config.resource_dir_opt))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = ''
@@ -2009,6 +2020,11 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-target', config.variant_triple,
         '-sdk', config.variant_sdk, config.resource_dir_opt,
         mcp_opt, config.swift_test_options, config.swift_frontend_test_options])
+    config.target_swift_frontend_plain = ' '.join([
+        config.swift_frontend,
+        '-target', config.variant_triple,
+        config.resource_dir_opt,
+    ])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = make_path(config.swift_src_root, 'utils', 'android', 'adb_test_runner.py')
@@ -2097,6 +2113,11 @@ elif kIsWASI:
 	'-sdk', config.variant_sdk,
         config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options])
+    config.target_swift_frontend_plain = ' '.join([
+        config.swift_frontend,
+        '-target', config.variant_triple,
+        config.resource_dir_opt,
+    ])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = os.path.join(config.swift_utils, 'wasm-run.py')
@@ -2180,6 +2201,11 @@ elif config.external_embedded_platform:
         '-target', config.variant_triple, embedded_swift_frontend_flags,
         config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options])
+    config.target_swift_frontend_plain = ' '.join([
+        config.swift_frontend,
+        '-target', config.variant_triple,
+        config.resource_dir_opt,
+    ])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = embedded_test_support + ' --device %s run --elf-file ' % device
@@ -2924,6 +2950,7 @@ config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk),
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk_after)))))
+config.substitutions.append(('%target-swift-frontend-plain', config.target_swift_frontend_plain))
 config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
 
 


### PR DESCRIPTION
This introduces a new substitution for use in the CAS tests. The plain
variant of the target frontend invokes the tool with the variant target
triple and resource dir only. This allows us to properly invoke the
frontend for the CAS tests.