### PR TITLE
[6.3] [SourceKit] Always check buffer in `SemanticAnnotator`

### DIFF
--- a/test/SourceKit/SemanticTokens/issue-85705.swift
+++ b/test/SourceKit/SemanticTokens/issue-85705.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/macro.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %sourcekitd-test -req=semantic-tokens %t/main.swift -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) > %t/result.response
+// RUN: diff -u %t/expected.response %t/result.response
+
+// REQUIRES: swift_swift_parser
+
+//--- macro.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct LogMacro: BodyMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+        in context: some MacroExpansionContext,
+    ) throws -> [CodeBlockItemSyntax] {
+        return ["print()"]
+    }
+}
+//--- main.swift
+@attached(body)
+public macro log() = #externalMacro(module: "MacroDefinition", type: "LogMacro")
+
+// Make sure we don't walk into the macro expanded body here.
+@log func foo() {}
+
+//--- expected.response
+{
+  key.semantic_tokens: [
+    {
+      key.kind: source.lang.swift.ref.macro,
+      key.offset: 161,
+      key.length: 3
+    }
+  ]
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1027,12 +1027,11 @@ public:
     if (!Range.isValid())
       return;
 
-    // If we are walking into macro expansions, make sure we only report ranges
-    // from the requested buffer, not any buffers of child macro expansions.
-    if (IsWalkingMacroExpansionBuffer &&
-        SM.findBufferContainingLoc(Range.getStart()) != BufferID) {
+    // Make sure we only report from the requested buffer, not any buffers of
+    // child macro expansions.
+    if (SM.findBufferContainingLoc(Range.getStart()) != BufferID)
       return;
-    }
+
     unsigned ByteOffset = SM.getLocOffsetInBuffer(Range.getStart(), BufferID);
     unsigned Length = Range.getByteLength();
     auto Kind = ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(D);


### PR DESCRIPTION
*6.3 cherry-pick of part of #85952*

- Explanation: Fixes a SourceKit crash that could occur when attempting to retrieve the semantic tokens of a SourceFile that uses a body macro
- Scope: Affects SourceKit semantic tokens
- Issue: rdar://165420658, https://github.com/swiftlang/swift/issues/85705
- Risk: Low, only affects SourceKit, and the fix applies existing logic in more cases
- Testing: Added tests to test suite
- Reviewer: TBD