### PR TITLE
[CSSimplify] Parameter pack wrapping logic incorrectly considers tuple `LValueType`s to not be tuples

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7401,6 +7401,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // Notable exceptions here are: `Any` which doesn't require wrapping and
   // would be handled by an existential promotion in cases where it's allowed,
   // and `Optional<T>` which would be handled by optional injection.
+  //
+  // `LValueType`s are also ignored at this stage to avoid accidentally wrapping them. If they
+  //  are valid wrapping targets, they will be tuple-wrapped after the lvalue is converted.
   if (isTupleWithUnresolvedPackExpansion(origType1) ||
       isTupleWithUnresolvedPackExpansion(origType2)) {
     auto isTypeVariableWrappedInOptional = [](Type type) {
@@ -7409,21 +7412,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
       return false;
     };
-
-    // Ignore the l-valueness when checking for wrapping
-    bool type1IsTuple = desugar1->getWithoutSpecifierType()->is<TupleType>();
-    bool type2IsTuple = desugar2->getWithoutSpecifierType()->is<TupleType>();
-
-    if (type1IsTuple != type2IsTuple &&
+    if (isa<TupleType>(desugar1) != isa<TupleType>(desugar2) &&
         !isa<InOutType>(desugar1) && !isa<InOutType>(desugar2) &&
+        !isa<LValueType>(desugar1) && !isa<LValueType>(desugar2) &&
         !isTypeVariableWrappedInOptional(desugar1) &&
         !isTypeVariableWrappedInOptional(desugar2) &&
         !desugar1->isAny() &&
         !desugar2->isAny()) {
       return matchTypes(
-                       type1IsTuple ? type1
+          desugar1->is<TupleType>() ? type1
                                     : TupleType::get({type1}, getASTContext()),
-                       type2IsTuple ? type2
+          desugar2->is<TupleType>() ? type2
                                     : TupleType::get({type2}, getASTContext()),
           kind, flags, locator);
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7409,16 +7409,21 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
       return false;
     };
-    if (isa<TupleType>(desugar1) != isa<TupleType>(desugar2) &&
+
+    // Ignore the l-valueness when checking for wrapping
+    bool type1IsTuple = desugar1->getWithoutSpecifierType()->is<TupleType>();
+    bool type2IsTuple = desugar2->getWithoutSpecifierType()->is<TupleType>();
+
+    if (type1IsTuple != type2IsTuple &&
         !isa<InOutType>(desugar1) && !isa<InOutType>(desugar2) &&
         !isTypeVariableWrappedInOptional(desugar1) &&
         !isTypeVariableWrappedInOptional(desugar2) &&
         !desugar1->isAny() &&
         !desugar2->isAny()) {
       return matchTypes(
-          desugar1->is<TupleType>() ? type1
+                       type1IsTuple ? type1
                                     : TupleType::get({type1}, getASTContext()),
-          desugar2->is<TupleType>() ? type2
+                       type2IsTuple ? type2
                                     : TupleType::get({type2}, getASTContext()),
           kind, flags, locator);
     }

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -301,16 +301,16 @@ func test_one_element_tuple_vs_non_tuple_matching() {
   }
 }
 
-// MARK: lValue'd packing (Issue 85924)
+// Ensure correct behavior of lvalue tuple parameters
 
 /**
- Before a fix in #85924, `var`-backed parameters would end up wrapped
- in an extraneous tuple wrapping (from #65125) for the `var` parameter,
- leading to less-than-efficient parameter packing.
+ Previously `var`-backed parameters would end up wrapped
+ in an extraneous tuple level, leading to leading to incorrect
+ nesting in the output type due to the `LValueType` not being unwrapped.
 
  https://github.com/swiftlang/swift/issues/85924
  */
-func test_var_let_tuple_append_equivalence() {
+func test_var_let_tuple_merge_equivalence() {
   func merge<each A, each B>(_ a: (repeat each A), _ b: (repeat each B)) -> (repeat each A, repeat each B) {
     return (repeat each a, repeat each b)
   }

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -300,3 +300,169 @@ func test_one_element_tuple_vs_non_tuple_matching() {
     test(V<Int>.self) // Ok
   }
 }
+
+// MARK: lValue'd packing (Issue 85924)
+
+/**
+ Before a fix in #85924, `var`-backed parameters would end up wrapped
+ in an extraneous tuple wrapping (from #65125) for the `var` parameter,
+ leading to less-than-efficient parameter packing.
+
+ https://github.com/swiftlang/swift/issues/85924
+ */
+func test_var_let_tuple_append_equivalence() {
+  func merge<each A, each B>(_ a: (repeat each A), _ b: (repeat each B)) -> (repeat each A, repeat each B) {
+    return (repeat each a, repeat each b)
+  }
+
+  let allLetsTupleFirst: (String, Int, String) = {
+    let a = ("a", 2) // (String, Int)
+    let b = "c" // String
+    return merge(a, b)
+  }()
+
+  // Before #85924 was fixed, this would type as ((String, Int), String)
+  let varFirstTupleFirst: (String, Int, String) = {
+    var a = ("a", 2) // @lvalue (String, Int)
+    let b = "c" // String
+    return merge(a, b)
+  }()
+
+  let varSecondTupleFirst: (String, Int, String) = {
+    let a = ("a", 2) // (String, Int)
+    var b = "c" // @lvalue String
+    return merge(a, b)
+  }()
+
+  let allVarsTupleFirst: (String, Int, String) = {
+    var a = ("a", 2) // @lvalue (String, Int)
+    var b = "c" // @lvalue String
+    return merge(a, b)
+  }()
+
+  let allLetsTupleSecond: (String, Int, String) = {
+    let a = "a"
+    let b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let varFirstTupleSecond: (String, Int, String) = {
+    var a = "a"
+    let b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let varSecondTupleSecond: (String, Int, String) = {
+    let a = "a"
+    var b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let allVarsTupleSecond: (String, Int, String) = {
+    var a = "a"
+    var b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let allLetsMultiTuple: (String, Int, String) = {
+    let a = ("a")
+    let b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let varFirstMultiTuple: (String, Int, String) = {
+    var a = ("a")
+    let b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let varSecondMultiTuple: (String, Int, String) = {
+    let a = ("a")
+    var b = (2, "c")
+    return merge(a, b)
+  }()
+
+  let allVarsMultiTuple: (String, Int, String) = {
+    var a = ("a")
+    var b = (2, "c")
+    return merge(a, b)
+  }()
+}
+
+func test_var_let_tuple_append_equivalence() {
+  func append<each A, B>(_ a: (repeat each A), _ b: B) -> (repeat each A, B) {
+      return (repeat each a, b)
+  }
+
+  let allLetsTupleFirst: (String, Int, String) = {
+    let a = ("a", 2) // (String, Int)
+    let b = "c" // String
+    return append(a, b)
+  }()
+
+  let varFirstTupleFirst: (String, Int, String) = {
+    var a = ("a", 2) // @lvalue (String, Int)
+    let b = "c" // String
+    return append(a, b)
+  }()
+
+  let varSecondTupleFirst: (String, Int, String) = {
+    let a = ("a", 2) // (String, Int)
+    var b = "c" // @lvalue String
+    return append(a, b)
+  }()
+
+  let allVarsTupleFirst: (String, Int, String) = {
+    var a = ("a", 2) // @lvalue (String, Int)
+    var b = "c" // @lvalue String
+    return append(a, b)
+  }()
+
+  let allLetsTupleSecond: (String, (Int, String)) = {
+    let a = "a"
+    let b = (2, "c")
+    return append(a, b)
+  }()
+
+  let varFirstTupleSecond: (String, (Int, String)) = {
+    var a = "a"
+    let b = (2, "c")
+    return append(a, b)
+  }()
+
+  let varSecondTupleSecond: (String, (Int, String)) = {
+    let a = "a"
+    var b = (2, "c")
+    return append(a, b)
+  }()
+
+  let allVarsTupleSecond: (String, (Int, String)) = {
+    var a = "a"
+    var b = (2, "c")
+    return append(a, b)
+  }()
+
+  let allLetsMultiTuple: (String, (Int, String)) = {
+    let a = ("a")
+    let b = (2, "c")
+    return append(a, b)
+  }()
+
+  let varFirstMultiTuple: (String, (Int, String)) = {
+    var a = ("a")
+    let b = (2, "c")
+    return append(a, b)
+  }()
+
+  let varSecondMultiTuple: (String, (Int, String)) = {
+    let a = ("a")
+    var b = (2, "c")
+    return append(a, b)
+  }()
+
+  let allVarsMultiTuple: (String, (Int, String)) = {
+    var a = ("a")
+    var b = (2, "c")
+    return append(a, b)
+  }()
+}

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -315,75 +315,99 @@ func test_var_let_tuple_merge_equivalence() {
     return (repeat each a, repeat each b)
   }
 
-  let allLetsTupleFirst: (String, Int, String) = {
+  // allLets, TupleFirst
+  let _: (String, Int, String) = {
     let a = ("a", 2) // (String, Int)
     let b = "c" // String
     return merge(a, b)
   }()
 
   // Before #85924 was fixed, this would type as ((String, Int), String)
-  let varFirstTupleFirst: (String, Int, String) = {
+  // varFirst, TupleFirst
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a", 2) // @lvalue (String, Int)
     let b = "c" // String
     return merge(a, b)
   }()
 
-  let varSecondTupleFirst: (String, Int, String) = {
+  // varSecond, TupleFirst
+  let _: (String, Int, String) = {
     let a = ("a", 2) // (String, Int)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = "c" // @lvalue String
     return merge(a, b)
   }()
 
-  let allVarsTupleFirst: (String, Int, String) = {
+  // allVars, TupleFirst
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a", 2) // @lvalue (String, Int)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = "c" // @lvalue String
     return merge(a, b)
   }()
 
-  let allLetsTupleSecond: (String, Int, String) = {
+  // allLets, TupleSecond
+  let _: (String, Int, String) = {
     let a = "a"
     let b = (2, "c")
     return merge(a, b)
   }()
 
-  let varFirstTupleSecond: (String, Int, String) = {
+  // varFirst, TupleSecond
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = "a"
     let b = (2, "c")
     return merge(a, b)
   }()
 
-  let varSecondTupleSecond: (String, Int, String) = {
+  // varSecond, TupleSecond
+  let _: (String, Int, String) = {
     let a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return merge(a, b)
   }()
 
-  let allVarsTupleSecond: (String, Int, String) = {
+  // allVars, TupleSecond
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return merge(a, b)
   }()
 
-  let allLetsMultiTuple: (String, Int, String) = {
+  // allLets, MultiTuple
+  let _: (String, Int, String) = {
     let a = ("a")
     let b = (2, "c")
     return merge(a, b)
   }()
 
-  let varFirstMultiTuple: (String, Int, String) = {
+  // varFirst, MultiTuple
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a")
     let b = (2, "c")
     return merge(a, b)
   }()
 
-  let varSecondMultiTuple: (String, Int, String) = {
+  // varSecond, MultiTuple
+  let _: (String, Int, String) = {
     let a = ("a")
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return merge(a, b)
   }()
 
-  let allVarsMultiTuple: (String, Int, String) = {
+  // allVars, MultiTuple
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a")
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return merge(a, b)
   }()
@@ -394,75 +418,201 @@ func test_var_let_tuple_append_equivalence() {
       return (repeat each a, b)
   }
 
-  let allLetsTupleFirst: (String, Int, String) = {
+  // allLets, TupleFirst
+  let _: (String, Int, String) = {
     let a = ("a", 2) // (String, Int)
     let b = "c" // String
     return append(a, b)
   }()
 
-  let varFirstTupleFirst: (String, Int, String) = {
+  // varFirst, TupleFirst
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a", 2) // @lvalue (String, Int)
     let b = "c" // String
     return append(a, b)
   }()
 
-  let varSecondTupleFirst: (String, Int, String) = {
+  // varSecond, TupleFirst
+  let _: (String, Int, String) = {
     let a = ("a", 2) // (String, Int)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = "c" // @lvalue String
     return append(a, b)
   }()
 
-  let allVarsTupleFirst: (String, Int, String) = {
+  // allVars, TupleFirst
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a", 2) // @lvalue (String, Int)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = "c" // @lvalue String
     return append(a, b)
   }()
 
-  let allLetsTupleSecond: (String, (Int, String)) = {
+  // allLets, TupleSecond
+  let _: (String, (Int, String)) = {
     let a = "a"
     let b = (2, "c")
     return append(a, b)
   }()
 
-  let varFirstTupleSecond: (String, (Int, String)) = {
+  // varFirst, TupleSecond
+  let _: (String, (Int, String)) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = "a"
     let b = (2, "c")
     return append(a, b)
   }()
 
-  let varSecondTupleSecond: (String, (Int, String)) = {
+  // varSecond, TupleSecond
+  let _: (String, (Int, String)) = {
     let a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return append(a, b)
   }()
 
-  let allVarsTupleSecond: (String, (Int, String)) = {
+  // allVars, TupleSecond
+  let _: (String, (Int, String)) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return append(a, b)
   }()
 
-  let allLetsMultiTuple: (String, (Int, String)) = {
+  // allLets, MultiTuple
+  let _: (String, (Int, String)) = {
     let a = ("a")
     let b = (2, "c")
     return append(a, b)
   }()
 
-  let varFirstMultiTuple: (String, (Int, String)) = {
+  // varFirst, MultiTuple
+  let _: (String, (Int, String)) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a")
     let b = (2, "c")
     return append(a, b)
   }()
 
-  let varSecondMultiTuple: (String, (Int, String)) = {
+  // varSecond, MultiTuple
+  let _: (String, (Int, String)) = {
     let a = ("a")
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return append(a, b)
   }()
 
-  let allVarsMultiTuple: (String, (Int, String)) = {
+  // allVars, MultiTuple
+  let _: (String, (Int, String)) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
     var a = ("a")
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
     var b = (2, "c")
     return append(a, b)
+  }()
+}
+
+func test_var_let_tuple_prefixOnto_equivalence() {
+  func prefixOnto<A, each B>(_ a: A, _ b: (repeat each B)) -> (A, repeat each B) {
+      return (a, repeat each b)
+  }
+
+  // allLets, TupleFirst
+  let _: ((String, Int), String) = {
+    let a = ("a", 2) 
+    let b = "c"
+    return prefixOnto(a, b)
+  }()
+
+  // varFirst, TupleFirst
+  let _: ((String, Int), String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = ("a", 2)
+    let b = "c"
+    return prefixOnto(a, b)
+  }()
+
+  // varSecond, TupleFirst
+  let _: ((String, Int), String) = {
+    let a = ("a", 2)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = "c"
+    return prefixOnto(a, b)
+  }()
+
+  // allVars, TupleFirst
+  let _: ((String, Int), String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = ("a", 2)
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = "c"
+    return prefixOnto(a, b)
+  }()
+
+  // allLets, TupleSecond
+  let _: (String, Int, String) = {
+    let a = "a"
+    let b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // varFirst, TupleSecond
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = "a"
+    let b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // varSecond, TupleSecond
+  let _: (String, Int, String) = {
+    let a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // allVars, TupleSecond
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = "a"
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // allLets, MultiTuple
+  let _: (String, Int, String) = {
+    let a = ("a")
+    let b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // varFirst, MultiTuple
+  let _: (String, Int, String) = {
+    // expected-warning@+1{{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = ("a")
+    let b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // varSecond, MultiTuple
+  let _: (String, Int, String) = {
+    let a = ("a")
+    // expected-warning@+1{{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = (2, "c")
+    return prefixOnto(a, b)
+  }()
+
+  // allVars, MultiTuple
+  let _: (String, Int, String) = {
+    // expected-warning@+1 {{variable 'a' was never mutated; consider changing to 'let' constant}}
+    var a = ("a")
+    // expected-warning@+1 {{variable 'b' was never mutated; consider changing to 'let' constant}}
+    var b = (2, "c")
+    return prefixOnto(a, b)
   }()
 }

--- a/test/Sema/issue-85837.swift
+++ b/test/Sema/issue-85837.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+// Verifies fix for Github Issue #85837
+// https://github.com/swiftlang/swift/issues/85837
+//
+// 
+
+@resultBuilder public enum TupleBuilder {
+    public static func buildPartialBlock<T>(first: T) -> (T) {
+        return first
+    }
+
+    public static func buildPartialBlock<each A, B>(accumulated: (repeat each A), next: B) -> (repeat each A, B) {
+        return (repeat each accumulated, next)
+    }
+}
+
+func builder<each A>(@TupleBuilder content: ()->(repeat each A)) -> (repeat each A) {
+    return content()
+}
+
+// Ensure this optimally packs parameters
+let built: (String, Int, String) = builder {
+        "a"
+        2
+        "c"
+    }
+
+/*
+// Ideally we should be able to fall back to this legacy type?
+let legacy: ((String, Int), String) = builder {
+    "a"
+    2
+    "c"
+}
+*/

--- a/test/Sema/issue-85837.swift
+++ b/test/Sema/issue-85837.swift
@@ -25,12 +25,3 @@ let built: (String, Int, String) = builder {
         2
         "c"
     }
-
-/*
-// Ideally we should be able to fall back to this legacy type?
-let legacy: ((String, Int), String) = builder {
-    "a"
-    2
-    "c"
-}
-*/


### PR DESCRIPTION
In #65125 (and beyond) `matchTypes`, has logic to attempt to wrap an incoming parameter in a tuple under certain conditions that might help with type expansion.

In the case the incoming type was backed by a `var`, it would be wrapped by an `LValueType` then be subsequently mis-diagnosed as not-a-tuple.

More details in #85924 , this this is also the cause of (and fix for)  #85837 as well...