### PR TITLE
[Test] Disable userdoc validation on freebsd

### DIFF
--- a/validation-test/docs/userdoc_indices.test
+++ b/validation-test/docs/userdoc_indices.test
@@ -1,6 +1,7 @@
 # REQUIRES: swift_swift_parser
 # REQUIRES: target-same-as-host
 # REQUIRES: swift_feature_BareSlashRegexLiterals
+# UNSUPPORTED: OS=freebsd
 
 # RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Currently failing to find Foundation when running
`generate-doc-index.swift`. This really only needs to run on a single platform anyway, so let's just disable it from freebsd for now.