### PR TITLE
SIL: Adjust pack `isa` after upstream LLVM implementation change

### DIFF
--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1119,10 +1119,8 @@ bool SILType::isEscapable(const SILFunction &function) const {
   // TODO: Support ~Escapable in parameter packs.
   //
   // Treat all other SIL-specific types as Escapable.
-  if (isa<SILBlockStorageType,
-          SILBoxType,
-          SILPackType,
-          SILTokenType>(ty)) {
+  if (isa<SILBlockStorageType>(ty) || isa<SILBoxType>(ty) ||
+      isa<SILPackType>(ty) || isa<SILTokenType>(ty)) {
     return true;
   }
   return ty->isEscapable();
@@ -1157,10 +1155,8 @@ bool SILType::isMoveOnly(bool orWrapped) const {
     return false;
 
   // Treat all other SIL-specific types as Copyable.
-  if (isa<SILBlockStorageType,
-          SILBoxType,
-          SILPackType,
-          SILTokenType>(ty)) {
+  if (isa<SILBlockStorageType>(ty) || isa<SILBoxType>(ty) ||
+      isa<SILPackType>(ty) || isa<SILTokenType>(ty)) {
     return false;
   }
 


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/161403.

These `isa` calls with a `CanType` no longer compile with LLVM next because the implementation now unfolds directly to `CastInfo` calls rather than non-variadic `isa` calls that resolve to our partial specializations here:

https://github.com/swiftlang/swift/blob/e293876e4f3e376b29cdb225962e1f76cfcfbed7/include/swift/AST/Type.h#L600

We should partially specialize `CastInfo` instead of `isa` et al. For now, just use the non-variadic `isa`.