### PR TITLE
[Diagnostics] effect warnings on try/unsafe should have remove fixits 

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4658,10 +4658,10 @@ private:
       Ctx.Diags.diagnose(E->getTryLoc(),
                          diag::effect_marker_on_single_value_stmt,
                          "try", SVE->getStmt()->getKind())
-        .highlight(E->getTryLoc());
+        .highlight(E->getTryLoc()).fixItRemove(E->getTryLoc());
       return;
     }
-    Ctx.Diags.diagnose(E->getTryLoc(), diag::no_throw_in_try);
+    Ctx.Diags.diagnose(E->getTryLoc(), diag::no_throw_in_try).fixItRemove(E->getTryLoc());
   }
 
   void diagnoseRedundantAwait(AwaitExpr *E) const {
@@ -4700,7 +4700,7 @@ private:
       Ctx.Diags.diagnose(loc,
                          diag::effect_marker_on_single_value_stmt,
                          "unsafe", SVE->getStmt()->getKind())
-        .highlight(E->getUnsafeLoc());
+        .highlight(E->getUnsafeLoc()).fixItRemove(E->getUnsafeLoc());
       return;
     }
 


### PR DESCRIPTION
adds remove fixits (https://github.com/swiftlang/swift/issues/85882) in order of remove redundant cases of try/unsafe expressions when that is diagnosed in some cases.