### PR TITLE
[Parser] Accept raw/multiline string literal in #sourceLocation etc.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -90,8 +90,6 @@ WARNING(escaped_parameter_name,none,
 
 ERROR(forbidden_interpolated_string,none,
       "%0 cannot be an interpolated string literal", (StringRef))
-ERROR(forbidden_extended_escaping_string,none,
-      "%0 cannot be an extended escaping string literal", (StringRef))
 
 ERROR(expected_identifier_in_module_selector,none,
       "expected module name in module selector", ())

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1170,12 +1170,6 @@ std::optional<StringRef>
 Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText) {
   assert(Tok.is(tok::string_literal));
 
-  // FIXME: Support extended escaping string literal.
-  if (Tok.getCustomDelimiterLen()) {
-    diagnose(Loc, diag::forbidden_extended_escaping_string, DiagText);
-    return std::nullopt;
-  }
-
   SmallVector<Lexer::StringSegment, 1> Segments;
   L->getStringLiteralSegments(Tok, Segments);
   if (Segments.size() != 1 ||
@@ -1184,8 +1178,13 @@ Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText) {
     return std::nullopt;
   }
 
-  return SourceMgr.extractText(CharSourceRange(Segments.front().Loc,
-                                               Segments.front().Length));
+  llvm::SmallString<256> Buf;
+  StringRef EncodedStr = L->getEncodedStringSegment(Segments.front(), Buf);
+  if (!Buf.empty()) {
+    EncodedStr = Context.AllocateCopy(EncodedStr);
+  }
+
+  return EncodedStr;
 }
 
 struct ParserUnit::Implementation {

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -88,12 +88,12 @@ emptyMessage()
 // expected-error@-1{{'emptyMessage()' is unavailable:  }}
 // expected-note@-3{{'emptyMessage()' has been explicitly marked unavailable here}}
 
-// expected-error@+1{{'message' cannot be an extended escaping string literal}}
+// OK.
 @available(*, unavailable, message: #"""
   foobar message.
   """#)
 func extendedEscapedMultilineMessage() {}
 
-// expected-error@+1{{'renamed' cannot be an extended escaping string literal}}
+// OK.
 @available(*, unavailable, renamed: #"available()"#)
 func extendedEscapedRenamed() {}

--- a/test/Parse/line-directive-executable.swift
+++ b/test/Parse/line-directive-executable.swift
@@ -62,3 +62,16 @@ check() // CHECK-NEXT: .swift:[[@LINE]]
 
 
 check() // CHECK-NEXT: {{^}}k.swift:1002
+
+#sourceLocation(file: #"C:\l.swift"#, line: 1100)
+check() // CHECK-NEXT: {{^}}C:\l.swift:1100
+
+#sourceLocation(file: """
+   m.swift
+   n.swift
+   """,
+   line: 1200
+)
+check()
+// CHECK-NEXT: {{^}}m.swift
+// CHECK-NEXT: {{^}}n.swift:1200


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift/issues/85958
`swift-syntax` PR is incoming

There's no reason to reject these string literals in `#sourceLocation` or `@available(..., message:, renamed:)` etc. We just want to reject string interpolation.

Also previously escaped strings are literally used i.e.
```swift
#sourceLocation(file: "foo\\bar", line: 1)
print(#file)
```
printed `foo\\bar` instead of `foo\bar` which was wrong. Correctly unescape the literal as regular string literals.
