### PR TITLE
[6.3][Concurrency] Add `ApproachableConcurrency` as a pseudo upcoming feat…

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -871,6 +871,12 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
       continue;
     }
 
+    if (isUpcomingFeatureFlag &&
+        argValue.compare("ApproachableConcurrency") == 0) {
+      psuedoFeatures.push_back(argValue);
+      continue;
+    }
+
     // For all other features, the argument format is `<name>[:migrate]`.
     StringRef featureName;
     std::optional<StringRef> featureMode;
@@ -984,6 +990,15 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
           Opts.StrictConcurrencyLevel = *level;
         }
       }
+      continue;
+    }
+
+    if (featureName->compare("ApproachableConcurrency") == 0) {
+      Opts.enableFeature(Feature::DisableOutwardActorInference);
+      Opts.enableFeature(Feature::GlobalActorIsolatedTypesUsability);
+      Opts.enableFeature(Feature::InferIsolatedConformances);
+      Opts.enableFeature(Feature::InferSendableFromCaptures);
+      Opts.enableFeature(Feature::NonisolatedNonsendingByDefault);
       continue;
     }
 

--- a/test/Concurrency/approachable_concurrency.swift
+++ b/test/Concurrency/approachable_concurrency.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-emit-silgen %s -verify -enable-upcoming-feature ApproachableConcurrency -default-isolation MainActor | %FileCheck %s
+
+// REQUIRES: concurrency
+
+struct S {
+  func test() {
+  }
+}
+
+func takesSendable<T: Sendable>(_: T) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24approachable_concurrency21testSendableInference1syAA1SV_tF : $@convention(thin) (S) -> ()
+// CHECK: function_ref @$s24approachable_concurrency21testSendableInference1syAA1SV_tFyyYbcAEYbcfu_ : $@convention(thin) @Sendable (S) -> @owned @Sendable @callee_guaranteed () -> ()
+// CHECK: } // end sil function '$s24approachable_concurrency21testSendableInference1syAA1SV_tF'
+func testSendableInference(s: S) {
+  takesSendable(s.test)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24approachable_concurrency25testNonisolatedNonSendingyyyyYaYCXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> ()
+func testNonisolatedNonSending(_: () async -> Void) async {
+}
+
+// GlobalActorIsolatedTypesUsability
+@MainActor
+struct GAITU {
+  nonisolated var x: Int = 0
+}
+
+extension GAITU: Equatable {
+  static nonisolated func ==(lhs: GAITU, rhs: GAITU) -> Bool {
+    return lhs.x == rhs.x // okay
+  }
+}
+
+// CHECK: // static IsolatedConformances.__derived_struct_equals(_:_:)
+// CHECK-NEXT: // Isolation: global_actor. type: MainActor
+// CHECK-LABEL: sil hidden [ossa] @$s24approachable_concurrency20IsolatedConformancesV23__derived_struct_equalsySbAC_ACtFZ : $@convention(method) (IsolatedConformances, IsolatedConformances, @thin IsolatedConformances.Type) -> Bool
+struct IsolatedConformances: Equatable {
+  let x: Int = 0
+}

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -27,6 +27,8 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("test/attr/feature_requirement.swift"),
     # Tests completion with features both enabled and disabled
     pathlib.Path("test/IDE/complete_decl_attribute_feature_requirement.swift"),
+    # Uses the pseudo-feature ApproachableConcurrency
+    pathlib.Path("test/Concurrency/approachable_concurrency.swift"),
 ]
 
 ENABLE_FEATURE_RE = re.compile(


### PR DESCRIPTION
…ure flag

- Explanation:

  The change makes it easy to control the concurrency features as a group which is beneficial for use-cases like SwiftPM manifests and enabling them manually.

  Enables upcoming features that aim to provide a more approachable path to Swift Concurrency:
   - `DisableOutwardActorInference`
   - `GlobalActorIsolatedTypesUsability`
   - `InferIsolatedConformances`
   - `InferSendableFromCaptures`
   - `NonisolatedNonsendingByDefault`

- Resolves: rdar://166244164

- Main branch PR: https://github.com/swiftlang/swift/pull/85964

-  Risk: Very Low. Adds a new pseudo-feature that is not enabled by default.

- Reviewed By: @hborla  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 6526dca9db9cfd0d270c09db1120ea241aab691d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
