### PR TITLE
[build-script] Don't use the just-built dsymutil by default

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -107,7 +107,7 @@ KNOWN_SETTINGS=(
     darwin-deployment-version-watchos             "6.0"             "minimum deployment target version for watchOS"
     darwin-deployment-version-xros                "1.0"             "minimum deployment target version for xrOS"
     darwin-install-extract-symbols                ""                "whether to extract symbols with dsymutil during installations"
-    darwin-install-extract-symbols-use-just-built-dsymutil "1"       "whether we should extract symbols using the just built dsymutil"
+    darwin-install-extract-symbols-use-just-built-dsymutil ""       "whether we should extract symbols using the just built dsymutil"
     darwin-symroot-path-filters                   ""                "space-separated list of path patterns to consider for symbol generation"
     darwin-overlay-target                         ""                "single overlay target to build, dependencies are computed later"
     darwin-sdk-deployment-targets                 "xctest-ios-8.0"  "semicolon-separated list of triples like 'fookit-ios-9.0;barkit-watchos-9.0'"


### PR DESCRIPTION
Doing so may have made sense back then, but at this point we should default to the one in the toolchain. When building with asserts, the just-built dsymutil will run the DWARF verifier which is slow and not really desirable in this context.