### PR TITLE
[build-script] Don't use the just-built dsymutil by default

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -107,7 +107,7 @@ KNOWN_SETTINGS=(
     darwin-deployment-version-watchos             "6.0"             "minimum deployment target version for watchOS"
     darwin-deployment-version-xros                "1.0"             "minimum deployment target version for xrOS"
     darwin-install-extract-symbols                ""                "whether to extract symbols with dsymutil during installations"
-    darwin-install-extract-symbols-use-just-built-dsymutil "1"       "whether we should extract symbols using the just built dsymutil"
+    darwin-install-extract-symbols-use-just-built-dsymutil ""       "whether we should extract symbols using the just built dsymutil"
     darwin-symroot-path-filters                   ""                "space-separated list of path patterns to consider for symbol generation"
     darwin-overlay-target                         ""                "single overlay target to build, dependencies are computed later"
     darwin-sdk-deployment-targets                 "xctest-ios-8.0"  "semicolon-separated list of triples like 'fookit-ios-9.0;barkit-watchos-9.0'"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3093,7 +3093,7 @@ for host in "${ALL_HOSTS[@]}"; do
             printJSONStartTimestamp dsymutil
             (cd "${host_symroot}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path} --verify-dwarf none ${EXTRA_DSYMUTIL_ARGS[@]})
+               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path} --verify-dwarf=none ${EXTRA_DSYMUTIL_ARGS[@]})
             printJSONEndTimestamp dsymutil
 
             # Strip executables, shared libraries and static libraries in

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3093,7 +3093,7 @@ for host in "${ALL_HOSTS[@]}"; do
             printJSONStartTimestamp dsymutil
             (cd "${host_symroot}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path} ${EXTRA_DSYMUTIL_ARGS[@]})
+               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path} --verify-dwarf none ${EXTRA_DSYMUTIL_ARGS[@]})
             printJSONEndTimestamp dsymutil
 
             # Strip executables, shared libraries and static libraries in

--- a/validation-test/BuildSystem/extra_dsymutil_args.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args.test
@@ -4,11 +4,11 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=none --verbose"  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=--verify-dwarf=none,--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=none" --extra-dsymutil-args=--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto --verbose"  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=--verify-dwarf=auto,--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto" --extra-dsymutil-args=--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "
-# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil --verify-dwarf=none --verbose
+# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil --verify-dwarf=none --verify-dwarf=auto --verbose
 # CHECK: { "command": "dsymutil", "end": "

--- a/validation-test/BuildSystem/extra_dsymutil_args_empty.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args_empty.test
@@ -11,5 +11,5 @@
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "
-# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil{{$}}
+# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil --verify-dwarf=none{{$}}
 # CHECK: { "command": "dsymutil", "end": "


### PR DESCRIPTION
Doing so may have made sense back then, but at this point we should default to the one in the toolchain. When building with asserts, the just-built dsymutil will run the DWARF verifier which is slow and not really desirable in this context.