### PR TITLE
[CSBindings] Disambiguate Sendable and non-Sendable function type bindings

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -592,15 +592,26 @@ public:
   void dump(llvm::raw_ostream &out, unsigned indent) const;
 
 private:
-  /// Add a new binding to the set.
+  /// Introduce a new binding to the set. The binding might not
+  /// actually be added due to subtyping or other rule like
+  /// CGFloat/Double implicit conversion. This method should be
+  /// be preferred over \c addBinding when adding new bindings.
   ///
   /// \param binding The binding to add.
   /// \param isTransitive Indicates whether this binding has been
   /// acquired through transitive inference and requires validity
   /// checking.
-  void addBinding(PotentialBinding binding, bool isTransitive);
+  void introduceBinding(PotentialBinding binding, bool isTransitive);
 
   void addLiteralRequirement(Constraint *literal);
+
+  /// Insert the given binding into \c Bindings.
+  ///
+  /// This method is going to compute referenced variables before
+  /// forwarding to the other overload.
+  void addBinding(const PotentialBinding &&binding);
+  void addBinding(const PotentialBinding &&binding,
+                  llvm::SmallPtrSetImpl<TypeVariableType *> &referencedVars);
 
   void addDefault(Constraint *constraint);
 

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -247,16 +247,19 @@ do {
     static func otherFn() {}
   }
 
-  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
   func fnRet(cond: Bool) -> () -> Void {
-    cond ? Test.fn : Test.otherFn // expected-error {{failed to produce diagnostic for expression}}
+    cond ? Test.fn : Test.otherFn // Ok
   }
 
   func forward<T>(_: T) -> T {
   }
 
-  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
-  let _: () -> Void = forward(Test.fn) // expected-error {{conflicting arguments to generic parameter 'T' ('@Sendable () -> ()' vs. '() -> Void')}}
+  let _: () -> Void = forward(Test.fn) // Ok
+
+  func test(fn1: (@Sendable () -> Void)?, fn2: @escaping () -> Void) {
+    let _: () -> Void = true ? fn1 : fn2
+    // expected-error@-1 {{cannot convert value of type '(@Sendable () -> Void)?' to specified type '() -> Void'}}
+  }
 }
 
 // https://github.com/swiftlang/swift/issues/77105

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -332,3 +332,20 @@ do {
     static func ff() {}
   }
 }
+
+// Ambiguity between `@Sendable` method and non-Sendable context injected into an Optional.
+do {
+  struct Test {
+    func action() -> Void {}
+
+    func onAction(_: (() -> Void)?) {}
+
+    func test() {
+      onAction(true ? action : nil) // Ok
+    }
+
+    func test(fn1: (@Sendable () -> Void)?, fn2: @escaping () -> Void) {
+      let _: () -> Void = fn1 ?? fn2 // Ok
+    }
+  }
+}


### PR DESCRIPTION
If the type variable prefers subtypes, diasambiguate a situation
when this type variable is simultaneously a supertype of `@Sendable`
function type and a subtype of a non-Sendable one by using a supertype
binding because it constitutes a "subtype" in this case.

For example:

```
@Sendable () -> Void conv $T
$T argument conv () -> Void
```

Either of the types could also be wrapped in a number of optionals. Even if
there is an optionality mismatch, let's still prefer a supertype binding
because that would be easier to diagnose.

In particular, this is helpful with ternary operators where the context is
non-Sendable, but one or both sides are.

Resolves: rdar://125948508
Resolves: rdar://136315240

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
