### PR TITLE
[SILOpt] Don't apply `@_specialize` attribute to ObjC methods

### DIFF
--- a/test/SILOptimizer/Inputs/NoObjCSpecialization.h
+++ b/test/SILOptimizer/Inputs/NoObjCSpecialization.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern __attribute__((visibility("default")))
+@protocol NoObjCSpecialization<NSObject>
+
+- (BOOL)fooWithValue:(id)value
+             andBool:(BOOL)boolValue
+               error:(NSError *_Nullable *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/SILOptimizer/no_objc_specialization.swift
+++ b/test/SILOptimizer/no_objc_specialization.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/NoObjCSpecialization.h -O -emit-sil %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+final class NoObjCSpecializationImpl<Value>: NSObject, NoObjCSpecialization {
+
+    // CHECK-NOT: @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFToyt_Tg5 : $@convention(objc_method)
+    // CHECK-LABEL: sil private [thunk] @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFTo : $@convention(objc_method)
+    // CHECK: [[FUNC:%.*]] = function_ref @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFTf4nnd_n : $@convention(thin) <τ_0_0> (@in_guaranteed Any, Bool) -> @error any Error
+    // CHECK: try_apply [[FUNC]]<Value>({{%.*}}, {{%.*}}) : $@convention(thin) <τ_0_0> (@in_guaranteed Any, Bool) -> @error any Error
+    // CHECK-LABEL: sil shared @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFyt_Tg5Tf4nnd_n : $@convention(thin) (@in_guaranteed Any, Bool) -> @error any Error {
+    // CHECK-LABEL: sil shared @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFTf4nnd_n : $@convention(thin) <Value> (@in_guaranteed Any, Bool) -> @error any Error {
+    // CHECK: [[FUNC:%.*]] = function_ref @$s22no_objc_specialization24NoObjCSpecializationImplC3foo9withValue7andBoolyyp_SbtKFyt_Tg5Tf4nnd_n : $@convention(thin) (@in_guaranteed Any, Bool) -> @error any Error
+    // CHECK: apply [nothrow] [[FUNC]]({{%.*}}, {{%.*}}) : $@convention(thin) (@in_guaranteed Any, Bool) -> @error any Error
+    @_specialize(where Value == Void)
+    func foo(withValue value: Any, andBool bool: Bool) throws {
+        if Value.self == Void.self {
+            print("Is Void with \(bool)")
+        } else {
+            print("Is \(value) with \(bool)")
+        }
+    }
+}


### PR DESCRIPTION
rdar://164200332

The specialization should only apply to the Swift version of the method, which gets called by the ObjC version anyway, so the specialization is still in effect.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
