### PR TITLE
Serialization: Minor improvements to the error on conformance mismatch

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1092,8 +1092,8 @@ NOTE(modularization_issue_conformance_xref_note,none,
      "Breaks conformances of '%0' to %1",
      (StringRef, DeclName))
 ERROR(modularization_issue_conformance_error,none,
-      "Conformances of '%0' "
-      "do not match requirement signature of %1; "
+      "Listed conformances of '%0' "
+      "do not match current requirement signature of %1; "
       "%2 conformances for %3 requirements",
       (StringRef, DeclName, unsigned int, unsigned int))
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9119,13 +9119,13 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
 
         // Print context to stderr.
         PrintOptions Opts;
-        llvm::errs() << "Requirements:\n";
+        llvm::errs() << "Requirements seen by this invocation:\n";
         for (auto req: requirements) {
           req.print(llvm::errs(), Opts);
           llvm::errs() << "\n";
         }
 
-        llvm::errs() << "Conformances:\n";
+        llvm::errs() << "\nConformances written in the swiftmodule:\n";
         for (auto req: reqConformances) {
           req.print(llvm::errs());
           llvm::errs() << "\n";

--- a/test/Serialization/Recovery/conformance-xref.swift
+++ b/test/Serialization/Recovery/conformance-xref.swift
@@ -62,10 +62,10 @@ extension Counter: SimpleProto {}
 public protocol ProtoUser {
   associatedtype Element
 #if DROP_REQUIREMENT
-// CHECK-REMARK-REQUIREMENT: MiddleLib.swiftmodule:1:1: error: Conformances of 'OneToAThousand' do not match requirement signature of 'ProtoUser'; 5 conformances for 6 requirements
-// CHECK-REMARK-REQUIREMENT: Requirements:
+// CHECK-REMARK-REQUIREMENT: MiddleLib.swiftmodule:1:1: error: Listed conformances of 'OneToAThousand' do not match current requirement signature of 'ProtoUser'; 5 conformances for 6 requirements
+// CHECK-REMARK-REQUIREMENT: Requirements seen by this invocation:
 // Skipping implicits.
-// CHECK-REMARK-REQUIREMENT: Conformances:
+// CHECK-REMARK-REQUIREMENT: Conformances written in the swiftmodule:
 // Skipping implicits.
 // CHECK-REMARK-REQUIREMENT: (specialized_conformance type="OneToAThousand.Impl" protocol="SimpleProto"
 // CHECK-REMARK-REQUIREMENT:   (normal_conformance type="Counter<T>" protocol="SimpleProto"{{.*}} lazy))


### PR DESCRIPTION
This change clarifies the sources of information shown in the error when a conformance reference in a swiftmodule doesn't match with the requirements seen by the reader. This error may be raised when reading from a stale swiftmodule file containing inconsistent information, usually because of SDK roots or if an upstream library was updated without rebuilding its clients. 