### PR TITLE
[NFC] Direct printCompileJobCacheKey to correct raw_ostream

### DIFF
--- a/lib/Frontend/CompileJobCacheKey.cpp
+++ b/lib/Frontend/CompileJobCacheKey.cpp
@@ -152,10 +152,10 @@ llvm::Error swift::printCompileJobCacheKey(llvm::cas::ObjectStore &CAS,
   if (Err)
     return Err;
 
-  llvm::outs() << "Cache Key " << CAS.getID(Key).toString() << "\n";
-  llvm::outs() << "Swift Compiler Invocation Info:\n";
-  llvm::outs() << BaseStr;
-  llvm::outs() << "Input index: " << InputIndex << "\n";
+  OS << "Cache Key " << CAS.getID(Key).toString() << "\n";
+  OS << "Swift Compiler Invocation Info:\n";
+  OS << BaseStr;
+  OS << "Input index: " << InputIndex << "\n";
 
   return llvm::Error::success();
 }


### PR DESCRIPTION
Make sure output of printCompileJobCacheKey is sent to the correct raw_ostream, not to llvm::outs() all the time.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
