### PR TITLE
[cxx-interop] Use Clang lookup for type members when deriving Clang conformances

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -72,8 +72,7 @@ lookupCxxTypeMember(clang::Sema &Sema, const clang::CXXRecordDecl *Rec,
                                clang::SourceLocation(),
                                clang::Sema::LookupMemberName);
   R.suppressDiagnostics();
-  auto *Ctx = static_cast<const clang::DeclContext *>(Rec);
-  Sema.LookupQualifiedName(R, const_cast<clang::DeclContext *>(Ctx));
+  Sema.LookupQualifiedName(R, const_cast<clang::CXXRecordDecl *>(Rec));
 
   if (auto *td = R.getAsSingle<clang::TypeDecl>()) {
     if (auto *paths = R.getBasePaths();
@@ -1014,8 +1013,8 @@ static void conformToCxxSet(ClangImporter::Implementation &impl,
         clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
         clang::SourceLocation(), clang::Sema::LookupMemberName);
     R.suppressDiagnostics();
-    auto *Ctx = static_cast<const clang::DeclContext *>(clangDecl);
-    clangSema.LookupQualifiedName(R, const_cast<clang::DeclContext *>(Ctx));
+    clangSema.LookupQualifiedName(
+        R, const_cast<clang::CXXRecordDecl *>(clangDecl));
     switch (R.getResultKind()) {
     case clang::LookupResultKind::Found:
     case clang::LookupResultKind::FoundOverloaded:
@@ -1152,8 +1151,8 @@ static void conformToCxxDictionary(ClangImporter::Implementation &impl,
         clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
         clang::SourceLocation(), clang::Sema::LookupMemberName);
     R.suppressDiagnostics();
-    auto *Ctx = static_cast<const clang::DeclContext *>(clangDecl);
-    clangSema.LookupQualifiedName(R, const_cast<clang::DeclContext *>(Ctx));
+    clangSema.LookupQualifiedName(
+        R, const_cast<clang::CXXRecordDecl *>(clangDecl));
     switch (R.getResultKind()) {
     case clang::LookupResultKind::Found:
     case clang::LookupResultKind::FoundOverloaded:

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1300,9 +1300,10 @@ void swift::deriveAutomaticCxxConformances(
     return;
   case CxxStdType::set:
   case CxxStdType::unordered_set:
+    conformToCxxSet(Impl, result, clangDecl, /*isUniqueSet=*/true);
+    return;
   case CxxStdType::multiset:
-    conformToCxxSet(Impl, result, clangDecl,
-                    /*isUniqueSet=*/ty != CxxStdType::multiset);
+    conformToCxxSet(Impl, result, clangDecl, /*isUniqueSet=*/false);
     return;
   case CxxStdType::pair:
     conformToCxxPair(Impl, result, clangDecl);

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1284,22 +1284,36 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
   clang::ASTContext &clangCtx = impl.getClangASTContext();
   clang::Sema &clangSema = impl.getClangSema();
 
-  auto elementType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("element_type"));
-  auto sizeType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("size_type"));
-
-  if (!elementType || !sizeType)
+  auto *element_type = lookupCxxTypeMember(clangSema, clangDecl, "element_type",
+                                           /*mustBeComplete=*/true);
+  auto *size_type = lookupCxxTypeMember(clangSema, clangDecl, "size_type",
+                                        /*mustBeComplete=*/true);
+  auto *pointer = lookupCxxTypeMember(clangSema, clangDecl, "pointer",
+                                      /*mustBeComplete=*/true);
+  if (!element_type || !size_type || !pointer)
     return;
 
-  auto pointerTypeDecl = lookupCxxTypeMember(clangSema, clangDecl, "pointer");
-  auto countTypeDecl = lookupCxxTypeMember(clangSema, clangDecl, "size_type");
+  auto pointerType = clangCtx.getTypeDeclType(pointer);
+  auto sizeType = clangCtx.getTypeDeclType(size_type);
 
-  if (!pointerTypeDecl || !countTypeDecl)
+  auto *Element = dyn_cast_or_null<TypeAliasDecl>(
+      impl.importDecl(element_type, impl.CurrentVersion));
+  auto *Size = dyn_cast_or_null<TypeAliasDecl>(
+      impl.importDecl(size_type, impl.CurrentVersion));
+  if (!Element || !Size)
     return;
+
+  impl.addSynthesizedTypealias(decl, ctx.Id_Element,
+                               Element->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
+                               Size->getUnderlyingType());
+
+  if (pointerType->getPointeeType().isConstQualified())
+    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSpan});
+  else
+    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxMutableSpan});
 
   // create fake variable for pointer (constructor arg 1)
-  clang::QualType pointerType = clangCtx.getTypeDeclType(pointerTypeDecl);
   auto fakePointerVarDecl = clang::VarDecl::Create(
       clangCtx, /*DC*/ clangCtx.getTranslationUnitDecl(),
       clang::SourceLocation(), clang::SourceLocation(), /*Id*/ nullptr,
@@ -1311,15 +1325,14 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
       clang::ExprValueKind::VK_LValue, clang::SourceLocation());
 
   // create fake variable for count (constructor arg 2)
-  auto countType = clangCtx.getTypeDeclType(countTypeDecl);
   auto fakeCountVarDecl = clang::VarDecl::Create(
       clangCtx, /*DC*/ clangCtx.getTranslationUnitDecl(),
       clang::SourceLocation(), clang::SourceLocation(), /*Id*/ nullptr,
-      countType, clangCtx.getTrivialTypeSourceInfo(countType),
+      sizeType, clangCtx.getTrivialTypeSourceInfo(sizeType),
       clang::StorageClass::SC_None);
 
   auto fakeCount = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, fakeCountVarDecl, false, countType,
+      clangCtx, fakeCountVarDecl, false, sizeType,
       clang::ExprValueKind::VK_LValue, clang::SourceLocation());
 
   // Use clangSema.BuildCxxTypeConstructExpr to create a CXXTypeConstructExpr,
@@ -1352,17 +1365,6 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
   importedConstructor->addAttribute(attr);
 
   decl->addMember(importedConstructor);
-
-  impl.addSynthesizedTypealias(decl, ctx.Id_Element,
-                               elementType->getUnderlyingType());
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
-                               sizeType->getUnderlyingType());
-
-  if (pointerType->getPointeeType().isConstQualified()) {
-    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSpan});
-  } else {
-    impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxMutableSpan});
-  }
 }
 
 void swift::deriveAutomaticCxxConformances(

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -135,29 +135,6 @@ static Decl *lookupDirectSingleWithoutExtensions(NominalTypeDecl *decl,
   return dyn_cast<Decl>(results.front());
 }
 
-static FuncDecl *getInsertFunc(NominalTypeDecl *decl,
-                               TypeAliasDecl *valueType) {
-  ASTContext &ctx = decl->getASTContext();
-
-  auto insertId = ctx.getIdentifier("__insertUnsafe");
-  auto inserts = lookupDirectWithoutExtensions(decl, insertId);
-  FuncDecl *insert = nullptr;
-  for (auto candidate : inserts) {
-    if (auto candidateMethod = dyn_cast<FuncDecl>(candidate)) {
-      auto params = candidateMethod->getParameters();
-      if (params->size() != 1)
-        continue;
-      auto param = params->front();
-      if (param->getTypeInContext()->getCanonicalType() !=
-          valueType->getUnderlyingType()->getCanonicalType())
-        continue;
-      insert = candidateMethod;
-      break;
-    }
-  }
-  return insert;
-}
-
 static ValueDecl *lookupOperator(NominalTypeDecl *decl, Identifier id,
                                  function_ref<bool(ValueDecl *)> isValid) {
   // First look for operator declared as a member.

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -18,7 +18,14 @@
 
 namespace swift {
 
-bool isIterator(const clang::CXXRecordDecl *clangDecl);
+/// Whether a C++ record decl contains a type member named "iterator_category",
+/// a heuristic we use to determine whether that record type is an iterator.
+///
+/// This function returns true if there is exactly one public type member named
+/// "iterator_category", but does not look for inherited members. Note that, as
+/// a result of these limitations, it may return false even if that record type
+/// is usable as an iterator.
+bool hasIteratorCategory(const clang::CXXRecordDecl *clangDecl);
 
 bool isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl);
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8376,7 +8376,7 @@ static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
             hasUnsafeAPIAttr(cxxRecord))
           return false;
 
-        if (hasIteratorAPIAttr(cxxRecord) || isIterator(cxxRecord))
+        if (hasIteratorAPIAttr(cxxRecord) || hasIteratorCategory(cxxRecord))
           return true;
 
         if (hasPointerInSubobjects(cxxRecord))
@@ -8497,7 +8497,7 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
   if (isSwiftClassType(cxxDecl))
     return CxxRecordSemanticsKind::SwiftClassType;
 
-  if (hasIteratorAPIAttr(cxxDecl) || isIterator(cxxDecl)) {
+  if (hasIteratorAPIAttr(cxxDecl) || hasIteratorCategory(cxxDecl)) {
     return CxxRecordSemanticsKind::Iterator;
   }
 
@@ -8760,7 +8760,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
 
         if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-            isIterator(cxxRecordReturnType))
+            hasIteratorCategory(cxxRecordReturnType))
           return false;
 
         // Mark this as safe to help our diganostics down the road.


### PR DESCRIPTION
This patch set refactors the conformance logic in ClangDerivedConformances.cpp to use primarily use Clang lookups to find the member typedefs and functions needed to synthesize the typealiases used as associated types for each conformance. Doing so removes its reliance on the eager member importing behavior of the SwiftDeclConverter, and brings us a step closer toward making it lazier.

In particular, for each of the standard library types, the conformance logic is rewritten to uniformly follow this structure:


    look up members from Clang
    if any are missing:
        return

    import those members to Swift
    if any of those failed:
        return

    use types extracted from those imported members to synthesize typealiases
    attach synthesized protocol conformance attr

    (optionally, patch the type)

This greatly simplifies and unifies the control flow of each conformance routine.

Any eager conformance-checking logic is removed here, e.g., that a `std::vector`'s `iterator` conforms to `CxxIterator`. This further simplifies the derived conformance control flow. We optimistically assume that if a type is _named_ `std::CONTAINER` then it conforms to the standard. This conformance-checking was not being done consistently for each requirement, and it's not clear what value it brought, since we do not emit any diagnostics to warn the user that we are appear to be importing some non-standard-conforming `std`-type. In any case, checking that associated types conform to requirements should be (and maybe already is?) lazier, and performed only when we are checking conformance for the CxxStdlib protocol we're currently synthesizing.

Patching is performed on `std::optional`, `std::span`, and `std::map`. In the first two cases, we are add a constructor, whereas in the latter case, we are marking the imported subscript method as unavailable so that the `CxxDictionary` can provide a safer overload.

This refactoring doesn't yet address the Clang derived conformances for `Sequence`, `Iterator`, and `ConvertibleToBool`, which are performed on _every_ type. As of this refactoring still rely on eager import behavior, though only on eagerly imported operators.

None of this refactoring is intended to change any behavior, which is why I have not added tests. Each commit in this patch set is independent and can be reviewed on its own.
