### PR TITLE
[lifetimes] add same-type default lifetime inference

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1117,7 +1117,8 @@ protected:
     bool nonEscapableSelf = isDiagnosedNonEscapable(dc->getSelfTypeInContext());
     if (nonEscapableSelf && accessor->getImplicitSelfDecl()->isInOut()) {
       // First, infer the dependency of the inout non-Escapable 'self'. This may
-      // result in two inferred dependencies for accessors.
+      // result in two inferred dependencies for accessors (one targetting
+      // selfIndex here, and one targetting resultIndex below).
       inferMutatingAccessor(accessor);
     }
     // Handle synthesized wrappers...
@@ -1255,6 +1256,9 @@ protected:
     if (!resultDeps)
       return; // .sil implicit initializers may have been annotated.
 
+    if (!resultDeps->empty())
+      return; // same-type inferrence applied; don't issue diagnostics.
+
     unsigned paramIndex = 0;
     for (auto *param : *afd->getParameters()) {
       SWIFT_DEFER { paramIndex++; };
@@ -1292,6 +1296,9 @@ protected:
     TargetDeps *resultDeps = depBuilder.getInferredTargetDeps(resultIndex);
     if (!resultDeps)
       return;
+
+    if (!resultDeps->empty())
+      return; // same-type inferrence applied; don't issue diagnostics.
 
     bool nonEscapableSelf = isDiagnosedNonEscapable(dc->getSelfTypeInContext());
     // Do not infer the result's dependence when the method is mutating and
@@ -1358,6 +1365,9 @@ protected:
     TargetDeps *resultDeps = depBuilder.getInferredTargetDeps(resultIndex);
     if (!resultDeps)
       return;
+
+    if (!resultDeps->empty())
+      return; // same-type inferrence applied; don't issue diagnostics.
 
     // Strict inference only handles a single escapable parameter,
     // which is an unambiguous borrow dependence.

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -20,12 +20,12 @@ func derive(_ ne1: NE, _ ne2: NE) -> NE {
 }
 
 @_lifetime // expected-error{{expected '(' after lifetime dependence specifier}}
-func testMissingLParenError(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
+func testMissingLParenError(_ ne: NE) -> NE {
   ne
 }
 
 @_lifetime() // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier}}
-func testMissingDependence(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
+func testMissingDependence(_ ne: NE) -> NE {
   ne
 }
 

--- a/test/Sema/lifetime_depend_noattr.swift
+++ b/test/Sema/lifetime_depend_noattr.swift
@@ -13,18 +13,18 @@
 struct EmptyNonEscapable: ~Escapable {} // OK - no dependence
 
 // Don't allow non-Escapable return values.
-func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow span)' or '@_lifetime(copy span)'}}
+func neReturn(span: RawSpan) -> RawSpan { span }
 
 func neInout(span: inout RawSpan) {} // OK - inferred
 
 struct S {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)}}
+  func neReturn(span: RawSpan) -> RawSpan { span }
 
   func neInout(span: inout RawSpan) {} // OK - inferred
 }
 
 class C {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
+  func neReturn(span: RawSpan) -> RawSpan { span }
 
   func neInout(span: inout RawSpan) {} // OK - inferred
 }


### PR DESCRIPTION
- **[docs] update lifetime defaults to prioritize the same-type rule**
  

- **[NFC] lifetime inference: check for prior defaults before error**
  Don't diagnose a lifetime error if a previous default already handled the
  non-Escapable output in question.
  

- **[lifetimes] add same-type default lifetime inference**
  Infer @lifetime(result: copy arg) for every (result: R, arg: A) pair
  such that R == A and 'arg' is not 'inout'.
  