### PR TITLE
[Sema] Isolated keyword should not be permitted in inheritance clause

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5661,10 +5661,9 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
 NeverNullType
 TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                       TypeResolutionOptions options) {
-  // isolated is only value for non-EnumCaseDecl parameters.
-  if ((!options.is(TypeResolverContext::FunctionInput) ||
-       options.hasBase(TypeResolverContext::EnumElementDecl)) &&
-      !options.is(TypeResolverContext::Inherited)) {
+  // isolated is only valid for non-EnumCaseDecl parameters.
+  if (!options.is(TypeResolverContext::FunctionInput) ||
+      options.hasBase(TypeResolverContext::EnumElementDecl)) {
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::attr_only_on_parameters,
         "isolated");
@@ -5685,8 +5684,7 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
     unwrappedType = dynamicSelfType->getSelfType();
   }
 
-  if (inStage(TypeResolutionStage::Interface) &&
-      !options.is(TypeResolverContext::Inherited)) {
+  if (inStage(TypeResolutionStage::Interface)) {
     if (auto *env = resolution.getGenericSignature().getGenericEnvironment())
       unwrappedType = env->mapTypeIntoEnvironment(unwrappedType);
 

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -379,3 +379,8 @@ func testLocalFunctionAndAutoclosure() {
     checkWithClosure { local() } // Ok
   }
 }
+
+protocol A {}
+protocol B {}
+extension C: isolated A {}          // expected-error {{'isolated' may only be used on parameters}}
+struct MultiProtocols: isolated B, isolated C {} // expected-error 2{{'isolated' may only be used on parameters}}


### PR DESCRIPTION
As stated in #83538, Isolated keyword should not be permitted in inheritance clause
