### PR TITLE
[cxx-interop] Move incomplete template specialization check

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
+++ b/test/Interop/Cxx/templates/Inputs/ForwardDeclaredSpecialization.h
@@ -60,4 +60,11 @@ struct PartialTemplate<T*, double> {
 };
 typedef PartialTemplate<int*, double> CompletePartial;
 
+// Some functions that use forward-declared specializations
+void TakesIncompleteSpecialization(BasicTemplate<int>);
+BasicTemplate<int> ReturnsIncompleteSpecialization();
+
+void TakesPtrToIncompleteSpecialization(BasicTemplate<int> *);
+BasicTemplate<int> *ReturnsPtrToIncompleteSpecialization();
+
 #endif

--- a/test/Interop/Cxx/templates/forward-declared-specialization.swift
+++ b/test/Interop/Cxx/templates/forward-declared-specialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -suppress-remarks -suppress-notes
 
 import ForwardDeclaredSpecialization
 
@@ -29,4 +29,18 @@ func testForwardDeclaredPartial(_ param: ForwardDeclaredPartial) {
 func testCompletePartial(_ param: CompletePartial) {
   let _ = param.ptr
   let _ = param.value
+}
+
+func testFunctionsUsingIncompleteSpec() {
+  let inc = ReturnsIncompleteSpecialization()
+  // expected-error@-1 {{return type is unavailable in Swift}}
+  // expected-warning@-2 {{constant 'inc' inferred to have type 'Never', which is an enum with no cases}}
+  TakesIncompleteSpecialization(inc)
+  // expected-error@-1 {{cannot find 'TakesIncompleteSpecialization' in scope}}
+}
+
+func testFunctionsUsingPtrToIncompleteSpec(_ ptr: OpaquePointer) {
+  let incPtr = ReturnsPtrToIncompleteSpecialization()
+  TakesPtrToIncompleteSpecialization(incPtr)
+  TakesPtrToIncompleteSpecialization(ptr)
 }


### PR DESCRIPTION
We were only previously doing this check when we had a typedef, because that is the scenario where we encountered this issue.

This patch moves the check closer to where we would actually instantiate the template, so that these cases can be stopped in more situations.