### PR TITLE
[cxx-interop] Import operators renamed via `swift_name` consistently

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3727,6 +3727,11 @@ namespace {
                                clang::OverloadedOperatorKind cxxOperatorKind) {
       if (cxxOperatorKind == clang::OverloadedOperatorKind::OO_None)
         return true;
+      // If this operator was renamed via swift_name attribute, the imported
+      // Swift function already has the specified name. Do not apply any special
+      // handling to it.
+      if (importedName.hasCustomName())
+        return true;
 
       auto dc = func->getDeclContext();
       auto typeDecl = dc->getSelfNominalTypeDecl();

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -17,3 +17,8 @@ module NonMemberOutOfLine {
   header "non-member-out-of-line.h"
   requires cplusplus
 }
+
+module RenamedOperators {
+  header "renamed-operators.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/operators/Inputs/renamed-operators.h
+++ b/test/Interop/Cxx/operators/Inputs/renamed-operators.h
@@ -1,0 +1,16 @@
+struct HasRenamedOperatorStar {
+  int value;
+
+  const int &operator*() const __attribute__((swift_name("dereference()"))) {
+    return value;
+  }
+};
+
+struct HasRenamedOperatorPlusPlus {
+  int value;
+
+  HasRenamedOperatorPlusPlus &operator++() __attribute__((swift_name("plusPlus()"))) {
+    value++;
+    return *this;
+  }
+};

--- a/test/Interop/Cxx/operators/renamed-operators-module-interface.swift
+++ b/test/Interop/Cxx/operators/renamed-operators-module-interface.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=RenamedOperators -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: struct HasRenamedOperatorStar {
+// CHECK-NOT: prefix static func * (lhs: HasRenamedOperatorStar)
+// CHECK:   func dereference() -> UnsafePointer<Int32>
+// CHECK: }
+
+// CHECK: struct HasRenamedOperatorPlusPlus {
+// CHECK-NOT: prefix static func ++ (lhs: HasRenamedOperatorPlusPlus)
+// CHECK:   mutating func plusPlus() -> UnsafeMutablePointer<HasRenamedOperatorPlusPlus>
+// CHECK: }

--- a/test/Interop/Cxx/operators/renamed-operators-typechecker.swift
+++ b/test/Interop/Cxx/operators/renamed-operators-typechecker.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import RenamedOperators
+
+let star = HasRenamedOperatorStar(value: 123)
+_ = *star // expected-error {{'*' is not a prefix unary operator}}
+
+let plusPlus = HasRenamedOperatorStar(value: 123)
+plusPlus++ // expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}}


### PR DESCRIPTION
Normally Swift imports `T& operator*` as `var pointee: T`. However, when the C++ operator has `swift_name` attribute attached to it, the importing was inconsistent: the renamed function was marked as deprecated, and an additional undesired overload was created.

For instance:
```
const std::string& operator*() const SWIFT_NAME(dereference());
```
was imported as an unavailable/deprecated `func dereference()`, and an additional overload of `func *(_:)` was created.

rdar://163500978

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
