### PR TITLE
[CS] Do member lookup last when binding dynamic member overload

### DIFF
--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -616,3 +616,39 @@ class TestDynamicSelf {
     fatalError()
   }
 }
+
+@dynamicMemberLookup
+protocol P1 {}
+
+extension P1 {
+  subscript<T>(dynamicMember dynamicMemberLookup: KeyPath<TestOverloaded.S2, T>) -> T {
+    fatalError()
+  }
+}
+
+struct TestOverloaded {
+  struct S1: P1 {
+    subscript(x: String) -> Int {
+      fatalError()
+    }
+    func f(_ x: String) -> Int {
+      return self[x]
+    }
+  }
+  struct S2: P1 {}
+}
+
+@dynamicMemberLookup
+struct SingleLens<T> {
+  var value: T
+  init(_ value: T) {
+    self.value = value
+  }
+  subscript<U>(dynamicMember keyPath: KeyPath<T, U>) -> U {
+    value[keyPath: keyPath]
+  }
+}
+
+func testRecursiveSingleSubscript(_ x: SingleLens<SingleLens<SingleLens<SingleLens<[Int]>>>>) {
+  _ = x[0]
+}


### PR DESCRIPTION
Otherwise if the member lookup gets simplified immediately and we  have a recursive dynamic member lookup we will crash since we wouldn't have introduced the corresponding applicable function constraint.

rdar://164321858