### PR TITLE
Create closure destructors with internal linkage

### DIFF
--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -76,7 +76,8 @@ public:
   /// As a convenience, build a metadata object with internal linkage
   /// consisting solely of the standard heap metadata.
   llvm::Constant *getPrivateMetadata(IRGenModule &IGM,
-                                     llvm::Constant *captureDescriptor) const;
+                                     llvm::Constant *captureDescriptor,
+                                     const llvm::Twine &name) const;
 };
 
 class HeapNonFixedOffsets : public NonFixedOffsetsImpl {

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -9,7 +9,7 @@
 
 // -- partial_apply context metadata
 
-// CHECK-DAG: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { ptr {{.*}}@objectdestroy{{(\.ptrauth.*)?}}, ptr null, %swift.type { i64 1024 }, i32 16, ptr @"\01l__swift5_reflection_descriptor" }
+// CHECK-DAG: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { ptr {{.*}}@__swift_closure_destructor{{(\.ptrauth.*)?}}, ptr null, %swift.type { i64 1024 }, i32 16, ptr @"\01l__swift5_reflection_descriptor" }
 
 func a(i i: Int) -> (Int) -> Int {
   return { x in i }

--- a/test/IRGen/empty-noncopyable-with-deinit.swift
+++ b/test/IRGen/empty-noncopyable-with-deinit.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s
 
-// CHECK: [[BOX_1:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_1:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_2:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_2:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9.]+]],
+// CHECK: [[BOX_1:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_1:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_2:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_2:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9._]+]],
 
 // We don't really need to test arm64e, and doing so would mean tweaking the
 // test to cope with ptrauth.

--- a/test/IRGen/fixed-noncopyable-with-deinit.swift
+++ b/test/IRGen/fixed-noncopyable-with-deinit.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s
 
-// CHECK: [[BOX_1:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_1:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_2:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_2:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9.]+]],
-// CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9.]+]],
+// CHECK: [[BOX_1:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_1:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_2:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_2:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9._]+]],
+// CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9._]+]],
 
 // We don't really need to test arm64e, and doing so would mean tweaking the
 // test to cope with ptrauth.


### PR DESCRIPTION
This makes these symbols visible in backtraces, at the cost of binary size (partially reverts 5e9e68c568163f6a3d38a1fdf8c6067b4db2edfe).

The long-term goal is to generate these functions with LinkOnceODRLinkage, using the contents of the HeapLayout to produce a mangled name, so they can be deduplicated across modules.

rdar://149084103

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
