### PR TITLE
[6.3] [SourceKit] Allow converting functions containing shorthand ifs to async

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -725,6 +725,10 @@ public:
   bool rebindsSelf(ASTContext &Ctx, bool requiresCaptureListRef = false,
                    bool requireLoadExpr = false) const;
 
+  /// Returns the synthesized RHS for a shorthand if let (eg. `if let x`), or
+  /// null if this element does not represent a shorthand if let.
+  Expr *getSynthesizedShorthandInitOrNull() const;
+
   SourceLoc getStartLoc() const;
   SourceLoc getEndLoc() const;
   SourceRange getSourceRange() const;

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -597,6 +597,28 @@ bool StmtConditionElement::rebindsSelf(ASTContext &Ctx,
   return false;
 }
 
+Expr *StmtConditionElement::getSynthesizedShorthandInitOrNull() const {
+  auto *init = getInitializerOrNull();
+  if (!init)
+    return nullptr;
+
+  auto *pattern = dyn_cast_or_null<OptionalSomePattern>(getPattern());
+  if (!pattern)
+    return nullptr;
+
+  auto *var = pattern->getSubPattern()->getSingleVar();
+  if (!var)
+    return nullptr;
+
+  // If the right-hand side has the same location as the variable, it was
+  // synthesized.
+  if (var->getLoc().isValid() && var->getLoc() == init->getStartLoc() &&
+      init->getStartLoc() == init->getEndLoc()) {
+    return init;
+  }
+  return nullptr;
+}
+
 SourceRange ConditionalPatternBindingInfo::getSourceRange() const {
   SourceLoc Start;
   if (IntroducerLoc.isValid())

--- a/lib/Refactoring/Async/AsyncRefactoring.h
+++ b/lib/Refactoring/Async/AsyncRefactoring.h
@@ -969,6 +969,10 @@ class AsyncConverter : private SourceEntityWalker {
   SmallString<0> Buffer;
   llvm::raw_svector_ostream OS;
 
+  // Any initializer expressions in a shorthand if that we need to skip (as it
+  // points to the same identifier as the declaration itself).
+  llvm::DenseSet<const Expr *> shorthandIfInits;
+
   // Decls where any force unwrap or optional chain of that decl should be
   // elided, e.g for a previously optional closure parameter that has become a
   // non-optional local.

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4713,37 +4713,7 @@ private:
     // Make a note of any initializers that are the synthesized right-hand side
     // for an "if let x".
     for (const auto &condition: stmt->getCond()) {
-      switch (condition.getKind()) {
-      case StmtConditionElement::CK_Availability:
-      case StmtConditionElement::CK_Boolean:
-      case StmtConditionElement::CK_HasSymbol:
-        continue;
-
-      case StmtConditionElement::CK_PatternBinding:
-        break;
-      }
-
-      auto init = condition.getInitializer();
-      if (!init)
-        continue;
-
-      auto pattern = condition.getPattern();
-      if (!pattern)
-        continue;
-
-      auto optPattern = dyn_cast<OptionalSomePattern>(pattern);
-      if (!optPattern)
-        continue;
-
-      auto var = optPattern->getSubPattern()->getSingleVar();
-      if (!var)
-        continue;
-
-      // If the right-hand side has the same location as the variable, it was
-      // synthesized.
-      if (var->getLoc().isValid() &&
-          var->getLoc() == init->getStartLoc() &&
-          init->getStartLoc() == init->getEndLoc())
+      if (auto *init = condition.getSynthesizedShorthandInitOrNull())
         synthesizedIfLetInitializers.insert(init);
     }
   }

--- a/test/refactoring/ConvertAsync/convert_shorthand_if.swift
+++ b/test/refactoring/ConvertAsync/convert_shorthand_if.swift
@@ -1,0 +1,25 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+func foo(_ fn: @escaping (String, Error?) -> Void) {}
+func foo() async throws -> String { return "" }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck %s
+func shorthandIf(completion: @escaping (String?, Error?) -> Void) {
+  foo { str, error in
+    if let error {
+      completion(nil, error)
+    } else {
+      completion(str, nil)
+    }
+  }
+}
+// CHECK:      func shorthandIf() async throws -> String {
+// CHECK-NEXT:   return try await withCheckedThrowingContinuation { continuation in
+// CHECK-NEXT:     foo { str, error in
+// CHECK-NEXT:       if let error {
+// CHECK-NEXT:         continuation.resume(throwing: error)
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         continuation.resume(returning: str)
+// CHECK-NEXT:     }


### PR DESCRIPTION
*6.3 cherry-pick of #85973*

- Explanation: Fixes a crash that could occur when attempting to perform an async refactoring on a function containing a shorthand conditional binding e.g `if let x {}`
- Scope: Affects async refactoring
- Issue: rdar://154753663
- Risk: Low, the fix is fairly straightforward and should only affect async refactoring
- Testing: Added tests to test suite
- Reviewer: Hamish Knight