### PR TITLE
docs/Wasm: remove incompatible `--libcxx` flags for `build-script`

### DIFF
--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -73,7 +73,7 @@ for WebAssembly is built and tested using the following command (exclude `--scca
 
 ```bash
 ./utils/build-script --sccache --build-wasm-stdlib --wasmkit --install-llvm --install-swift --swiftpm --install-swiftpm \
-  --libcxx --install-libcxx --llbuild --install-llbuild --swift-testing --install-swift-testing \
+  --llbuild --install-llbuild --swift-testing --install-swift-testing \
   --swift-testing-macros --install-swift-testing-macros --build-embedded-stdlib --build-embedded-stdlib-cross-compiling \
   '--llvm-install-components=llvm-ar;llvm-nm;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;dsymutil;LTO;clang-features-file;lld'
 ```


### PR DESCRIPTION
Freshly built libc++ introduces issues when building `swift-build`:

```
Undefined symbols for architecture arm64:
  "std::__1::__hash_memory(void const*, unsigned long)", referenced from:
      (anonymous namespace)::CAPIBuildDB::buildUpKeyCache(std::__1::vector<llbuild::core::KeyType, std::__1::allocator<llbuild::core::KeyType>>&) in BuildDB-C-API.cpp.o
      _llb_build_key_make in BuildKey-C-API.cpp.o
      _llb_build_key_make_command in BuildKey-C-API.cpp.o
      _llb_build_key_make_custom_task in BuildKey-C-API.cpp.o
      _llb_build_key_make_custom_task_with_data in BuildKey-C-API.cpp.o
      _llb_build_key_make_directory_contents in BuildKey-C-API.cpp.o
      _llb_build_key_make_filtered_directory_contents in BuildKey-C-API.cpp.o
      ...
ld: symbol(s) not found for architecture arm64
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
