### PR TITLE
AST: Canonicalize opaque archetype substitution maps in the solver arena

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6086,6 +6086,11 @@ GenericEnvironment *GenericEnvironment::forPrimary(GenericSignature signature) {
 /// outer substitutions.
 GenericEnvironment *GenericEnvironment::forOpaqueType(
     OpaqueTypeDecl *opaque, SubstitutionMap subs) {
+  // Don't preserve sugar if we have type variables, because this leads to
+  // excessive solver arena memory usage.
+  if (subs.getRecursiveProperties().hasTypeVariable())
+    subs = subs.getCanonical();
+
   auto &ctx = opaque->getASTContext();
 
   auto properties = ArchetypeType::archetypeProperties(


### PR DESCRIPTION
Preserving sugar if we have type variables uses way too much memory.

Canonicalize these substitution maps for now, as a (temporary?) workaround.

In the future, if we decide preserving sugar is more important than a few dozen Mb of memory usage, we can also bump the arena memory limit, instead.

Fixes rdar://166237860.
Fixes rdar://165863647.