### PR TITLE
AST: Canonicalize opaque archetype substitution maps in the solver arena [6.3]

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6086,6 +6086,11 @@ GenericEnvironment *GenericEnvironment::forPrimary(GenericSignature signature) {
 /// outer substitutions.
 GenericEnvironment *GenericEnvironment::forOpaqueType(
     OpaqueTypeDecl *opaque, SubstitutionMap subs) {
+  // Don't preserve sugar if we have type variables, because this leads to
+  // excessive solver arena memory usage.
+  if (subs.getRecursiveProperties().hasTypeVariable())
+    subs = subs.getCanonical();
+
   auto &ctx = opaque->getASTContext();
 
   auto properties = ArchetypeType::archetypeProperties(


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86020.

* **Description:** Preserving sugar if we have type variables uses way too much memory. Canonicalize these substitution maps for now, as a (temporary?) workaround. In the future, if we decide preserving sugar is more important than a few dozen Mb of memory usage, we can also bump the arena memory limit, instead.

* **Origination:** Regression in space usage introduced by https://github.com/swiftlang/swift/pull/84299.

* **Radar:** Fixes rdar://166237860, rdar://165863647.

* **Tested:** The failure consists of rather complex SwiftUI Views that were already close to the 512Mb limit, now exceeding that limit. It's hard to come up with a self-contained test case. Observing the lack of sugar is difficult too, since the preservation of sugar was added to clean up some logic in the ASTPrinter for module interfaces, and in that case we don't have type variables. So there is no test case, but existing tests pass obviously.

* **Reviewed by:** @xedin 