### PR TITLE
Android: disable C++ Interop test that is failing with new @available stdlib 6.4 annotations in #82055

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -7,6 +7,9 @@
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
 
+// #84574 and #82055 have turned up an availability edge case on Android, disable till fixed.
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 //--- print-string.swift
 
 public func printString(_ s: String) {


### PR DESCRIPTION
@vanvoorden, this should [get the Android CI green](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/137/console) again, until we can figure out how we want to handle this matter.