### PR TITLE
[LLDB|CAS] Implement ExplicitCASModuleLoader::addExplicitModulePath() 

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -237,6 +237,8 @@ public:
   void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override;
 
+  void addExplicitModulePath(StringRef name, std::string path) override;
+
   ~ExplicitCASModuleLoader();
 };
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2791,6 +2791,22 @@ void ExplicitCASModuleLoader::collectVisibleTopLevelModuleNames(
   }
 }
 
+void ExplicitCASModuleLoader::addExplicitModulePath(StringRef name,
+                                                    std::string path) {
+  // This is used by LLDB to discover the paths to dependencies of binary Swift
+  // modules. Only do this if path exists in CAS, since there are use-cases
+  // where a binary Swift module produced on a different machine is provided and
+  // replacements for its dependencies are provided via the explicit module map.
+  auto ID = Impl.CAS.parseID(path);
+  if (!ID)
+    return llvm::consumeError(ID.takeError());
+  if (!Impl.CAS.getReference(*ID))
+    return;
+
+  ExplicitSwiftModuleInputInfo entry(path, {}, {}, {});
+  Impl.ExplicitModuleMap.try_emplace(name, std::move(entry));
+}
+
 std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
     ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,


### PR DESCRIPTION
This virtual function is called when parsing the control block of a Swift module to add the dependencies to the module loader's explicit Swift module map. For the compiler this has no practical effect since the explicit Swift module map should already cover all dependencies. LLDB doesn't have the explicit Swift module map and depends on this mechanism to discover dependencies.

rdar://166494766

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
