### PR TITLE
[LLDB|CAS] Implement ExplicitCASModuleLoader::addExplicitModulePath()

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -237,6 +237,8 @@ public:
   void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override;
 
+  void addExplicitModulePath(StringRef name, std::string path) override;
+
   ~ExplicitCASModuleLoader();
 };
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2807,6 +2807,22 @@ void ExplicitCASModuleLoader::collectVisibleTopLevelModuleNames(
   }
 }
 
+void ExplicitCASModuleLoader::addExplicitModulePath(StringRef name,
+                                                    std::string path) {
+  // This is used by LLDB to discover the paths to dependencies of binary Swift
+  // modules. Only do this if path exists in CAS, since there are use-cases
+  // where a binary Swift module produced on a different machine is provided and
+  // replacements for its dependencies are provided via the explicit module map.
+  auto ID = Impl.CAS.parseID(path);
+  if (!ID)
+    return llvm::consumeError(ID.takeError());
+  if (!Impl.CAS.getReference(*ID))
+    return;
+
+  ExplicitSwiftModuleInputInfo entry(path, {}, {}, {});
+  Impl.ExplicitModuleMap.try_emplace(name, std::move(entry));
+}
+
 std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
     ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,


### PR DESCRIPTION
This virtual function is called when parsing the control block of a Swift module to add the dependencies to the module loader's explicit Swift module map. For the compiler this has no practical effect since the explicit Swift module map should already cover all dependencies. LLDB doesn't have the explicit Swift module map and depends on this mechanism to discover dependencies.

rdar://166494766
(cherry picked from commit 7327c6b1931aee3e7cf9097c8f3dd75bfb781c19)

- **Explanation**: Implement automatic CAS module dependency registration for LLDB
- **Scope**: Debugging a CAS-enabled project
- **Issues**: rdar://166494766
- **Original PRs**: https://github.com/swiftlang/swift/pull/86035
- **Risk**: NFC for the compiler
- **Testing**: In LLDB.
- **Reviewers**: @cachemeifyoucan 