### PR TITLE
[LLDB] Add LLDB accessor for ModuleInterfaceLoaderOptions

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -558,6 +558,9 @@ public:
                                 IgnoreSwiftSourceInfoFile));
   }
 
+  /// Accessor used by LLDB.
+  ModuleInterfaceLoaderOptions &getOptions();
+
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.
   void collectVisibleTopLevelModuleNames(

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1304,6 +1304,10 @@ ModuleInterfaceLoaderOptions::ModuleInterfaceLoaderOptions(
   }
 }
 
+ModuleInterfaceLoaderOptions &ModuleInterfaceLoader::getOptions() {
+  return InterfaceChecker.Opts;
+}
+
 bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
   return InterfaceChecker.isCached(DepPath);
 }


### PR DESCRIPTION
LLDB needs to control whether implicit Swift modules are on or off within a single ASTContext:

- when importing the context of a Swift module in an EBM project only explicit modules should be allowed

- when evaluating arbitrary expressions (which may include `import` directives) implicit modules should be enabled

rdar://166494895
(cherry picked from commit b72afc76918c897787aa07d6fa6c6845cdb8aa59)

- **Explanation**: Implement an accessor for LLDB
- **Scope**: Debugging EBM-enabled projects
- **Issues**: rdar://166494895
- **Original PRs**: https://github.com/swiftlang/swift/pull/86036
- **Risk**: NFC for the compiler
- **Testing**: In LLDB.
- **Reviewers**: @artemcm 