### PR TITLE
Minor fix in `HasShortDescription` doc-comments

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -12,8 +12,8 @@
 
 import Basic
 
-/// Types conforming to `HasName` will be displayed by their name (instead of the
-/// full object) in collection descriptions.
+/// Types conforming to `HasShortDescription` will be displayed by their name (instead
+/// of the full object) in collection descriptions.
 ///
 /// This is useful to make collections, e.g. of BasicBlocks or Functions, readable.
 public protocol HasShortDescription {


### PR DESCRIPTION
Just a small doc-comment correction.