### PR TITLE
[RangeReplaceableCollection] Use `reserveCapacity` in default `append(contentsOf:)` impl

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -453,6 +453,7 @@ extension RangeReplaceableCollection {
   @inlinable
   public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
+    reserveCapacity(newElements.underestimatedCount)
     for element in newElements {
       append(element)
     }


### PR DESCRIPTION
By a quick look, I think there are more places that could use this "optimization" of reserving-capacity beforehand.

I'm doing this PR for now, just to see if I'm missing something or if this is an acceptable change.