### PR TITLE
[cxx-interop] Do not eagerly import non-field Clang members

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1300,9 +1300,10 @@ void swift::deriveAutomaticCxxConformances(
     return;
   case CxxStdType::set:
   case CxxStdType::unordered_set:
+    conformToCxxSet(Impl, result, clangDecl, /*isUniqueSet=*/true);
+    return;
   case CxxStdType::multiset:
-    conformToCxxSet(Impl, result, clangDecl,
-                    /*isUniqueSet=*/ty != CxxStdType::multiset);
+    conformToCxxSet(Impl, result, clangDecl, /*isUniqueSet=*/false);
     return;
   case CxxStdType::pair:
     conformToCxxPair(Impl, result, clangDecl);

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1153,69 +1153,113 @@ static void conformToCxxDictionary(ClangImporter::Implementation &impl,
                                    const clang::CXXRecordDecl *clangDecl) {
   PrettyStackTraceDecl trace("conforming to CxxDictionary", decl);
   ASTContext &ctx = decl->getASTContext();
+  clang::ASTContext &clangCtx = impl.getClangASTContext();
+  clang::Sema &clangSema = impl.getClangSema();
 
-  auto keyType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("key_type"));
-  auto valueType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("mapped_type"));
-  auto iterType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("const_iterator"));
-  auto mutableIterType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("iterator"));
-  auto sizeType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("size_type"));
-  auto keyValuePairType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
-      decl, ctx.getIdentifier("value_type"));
-  if (!keyType || !valueType || !iterType || !mutableIterType || !sizeType ||
-      !keyValuePairType)
-    return;
+#define lookup_type(member)                                                    \
+  auto *member = lookupCxxTypeMember(clangSema, clangDecl, #member,            \
+                                     /*mustBeComplete=*/true);                 \
+  if (!member)                                                                 \
+  return
 
-  auto insert = getInsertFunc(decl, keyValuePairType);
+  lookup_type(key_type);
+  lookup_type(mapped_type);
+  lookup_type(value_type);
+  lookup_type(size_type);
+  lookup_type(iterator);
+  lookup_type(const_iterator);
+#undef lookup_type
+
+  const clang::CXXMethodDecl *insert = nullptr;
+  {
+    // CxxDictionary requires the InsertionResult associated type, which is the
+    // return type of std::map (and co.)'s insert function. But there is no
+    // equivalent typedef in C++ we can use directly, so we need get it by
+    // converting the return type of this overload of the insert function:
+    //
+    //    insert_return_type insert(const value_type &value);
+    //
+    // See also: extended monologuing in conformToCxxSet().
+    auto R = clang::LookupResult(
+        clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
+        clang::SourceLocation(), clang::Sema::LookupMemberName);
+    R.suppressDiagnostics();
+    auto *Ctx = static_cast<const clang::DeclContext *>(clangDecl);
+    clangSema.LookupQualifiedName(R, const_cast<clang::DeclContext *>(Ctx));
+    switch (R.getResultKind()) {
+    case clang::LookupResultKind::Found:
+    case clang::LookupResultKind::FoundOverloaded:
+      break;
+    default:
+      return;
+    }
+
+    for (auto *nd : R) {
+      if (auto *insertOverload = dyn_cast<clang::CXXMethodDecl>(nd)) {
+        if (insertOverload->param_size() != 1)
+          continue;
+        auto *paramTy = (*insertOverload->param_begin())
+                            ->getType()
+                            ->getAs<clang::ReferenceType>();
+        if (!paramTy)
+          continue;
+        if (paramTy->getPointeeType()->getCanonicalTypeUnqualified() !=
+            clangCtx.getTypeDeclType(value_type)->getCanonicalTypeUnqualified())
+          continue;
+        if (!paramTy->getPointeeType().isConstQualified())
+          continue;
+        insert = insertOverload; // Found the insert() we're looking for
+        break;
+      }
+    }
+  }
   if (!insert)
     return;
 
-  ProtocolDecl *cxxInputIteratorProto =
-      ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator);
-  ProtocolDecl *cxxMutableInputIteratorProto =
-      ctx.getProtocol(KnownProtocolKind::UnsafeCxxMutableInputIterator);
-  if (!cxxInputIteratorProto || !cxxMutableInputIteratorProto)
+#define importTypeAlias(to, from)                                                       \
+  auto *to = dyn_cast_or_null<TypeAliasDecl>(                                  \
+      impl.importDecl(from, impl.CurrentVersion));                             \
+  if (!to)                                                                     \
+  return
+
+  importTypeAlias(Size, size_type);
+  importTypeAlias(Key, key_type);
+  importTypeAlias(Value, mapped_type);
+  importTypeAlias(Element, value_type);
+  importTypeAlias(RawIterator, const_iterator);
+  importTypeAlias(RawMutableIterator, iterator);
+#undef importTypeAlias
+
+  auto *Insert =
+      dyn_cast_or_null<FuncDecl>(impl.importDecl(insert, impl.CurrentVersion));
+  if (!Insert)
     return;
 
-  auto rawIteratorTy = iterType->getUnderlyingType();
-  auto rawMutableIteratorTy = mutableIterType->getUnderlyingType();
-
-  // Check if RawIterator conforms to UnsafeCxxInputIterator.
-  if (!checkConformance(rawIteratorTy, cxxInputIteratorProto))
-    return;
-
-  // Check if RawMutableIterator conforms to UnsafeCxxMutableInputIterator.
-  if (!checkConformance(rawMutableIteratorTy, cxxMutableInputIteratorProto))
-    return;
+  impl.addSynthesizedTypealias(decl, ctx.Id_Key, Key->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.Id_Value, Value->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.Id_Element,
+                               Element->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
+                               RawIterator->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawMutableIterator"),
+                               RawMutableIterator->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
+                               Size->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("InsertionResult"),
+                               Insert->getResultInterfaceType());
+  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxDictionary});
 
   // Make the original subscript that returns a non-optional value unavailable.
   // CxxDictionary adds another subscript that returns an optional value,
   // similarly to Swift.Dictionary.
+  //
+  // NOTE: this relies on the SubscriptDecl member being imported eagerly.
   for (auto member : decl->getCurrentMembersWithoutLoading()) {
     if (auto subscript = dyn_cast<SubscriptDecl>(member)) {
       impl.markUnavailable(subscript,
                            "use subscript with optional return value");
     }
   }
-
-  impl.addSynthesizedTypealias(decl, ctx.Id_Key, keyType->getUnderlyingType());
-  impl.addSynthesizedTypealias(decl, ctx.Id_Value,
-                               valueType->getUnderlyingType());
-  impl.addSynthesizedTypealias(decl, ctx.Id_Element,
-                               keyValuePairType->getUnderlyingType());
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
-                               rawIteratorTy);
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawMutableIterator"),
-                               rawMutableIteratorTy);
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
-                               sizeType->getUnderlyingType());
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("InsertionResult"),
-                               insert->getResultInterfaceType());
-  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxDictionary});
 }
 
 static void conformToCxxVector(ClangImporter::Implementation &impl,

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -135,29 +135,6 @@ static Decl *lookupDirectSingleWithoutExtensions(NominalTypeDecl *decl,
   return dyn_cast<Decl>(results.front());
 }
 
-static FuncDecl *getInsertFunc(NominalTypeDecl *decl,
-                               TypeAliasDecl *valueType) {
-  ASTContext &ctx = decl->getASTContext();
-
-  auto insertId = ctx.getIdentifier("__insertUnsafe");
-  auto inserts = lookupDirectWithoutExtensions(decl, insertId);
-  FuncDecl *insert = nullptr;
-  for (auto candidate : inserts) {
-    if (auto candidateMethod = dyn_cast<FuncDecl>(candidate)) {
-      auto params = candidateMethod->getParameters();
-      if (params->size() != 1)
-        continue;
-      auto param = params->front();
-      if (param->getTypeInContext()->getCanonicalType() !=
-          valueType->getUnderlyingType()->getCanonicalType())
-        continue;
-      insert = candidateMethod;
-      break;
-    }
-  }
-  return insert;
-}
-
 static ValueDecl *lookupOperator(NominalTypeDecl *decl, Identifier id,
                                  function_ref<bool(ValueDecl *)> isValid) {
   // First look for operator declared as a member.

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -18,7 +18,14 @@
 
 namespace swift {
 
-bool isIterator(const clang::CXXRecordDecl *clangDecl);
+/// Whether a C++ record decl contains a type member named "iterator_category",
+/// a heuristic we use to determine whether that record type is an iterator.
+///
+/// This function returns true if there is exactly one public type member named
+/// "iterator_category", but does not look for inherited members. Note that, as
+/// a result of these limitations, it may return false even if that record type
+/// is usable as an iterator.
+bool hasIteratorCategory(const clang::CXXRecordDecl *clangDecl);
 
 bool isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl);
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8376,7 +8376,7 @@ static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
             hasUnsafeAPIAttr(cxxRecord))
           return false;
 
-        if (hasIteratorAPIAttr(cxxRecord) || isIterator(cxxRecord))
+        if (hasIteratorAPIAttr(cxxRecord) || hasIteratorCategory(cxxRecord))
           return true;
 
         if (hasPointerInSubobjects(cxxRecord))
@@ -8497,7 +8497,7 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
   if (isSwiftClassType(cxxDecl))
     return CxxRecordSemanticsKind::SwiftClassType;
 
-  if (hasIteratorAPIAttr(cxxDecl) || isIterator(cxxDecl)) {
+  if (hasIteratorAPIAttr(cxxDecl) || hasIteratorCategory(cxxDecl)) {
     return CxxRecordSemanticsKind::Iterator;
   }
 
@@ -8760,7 +8760,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
 
         if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-            isIterator(cxxRecordReturnType))
+            hasIteratorCategory(cxxRecordReturnType))
           return false;
 
         // Mark this as safe to help our diganostics down the road.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2436,13 +2436,7 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
     if (!genericPointerType)
       addDiag(Diagnostic(diag::bridged_pointer_type_not_found, pointerKind));
     importedType = {genericPointerType, false};
-  } else if (!(isa<clang::RecordType>(returnType) ||
-               isa<clang::TemplateSpecializationType>(returnType)) ||
-             // TODO: we currently don't lazily load operator return types, but
-             // this should be trivial to add.
-             clangDecl->isOverloadedOperator() ||
-             // Dependant types are trivially mapped as Any.
-             returnType->isDependentType()) {
+  } else {
     // If importedType is already initialized, it means we found the enum that
     // was supposed to be used (instead of the typedef type).
     if (!importedType) {


### PR DESCRIPTION
Skipping these members makes importing structs much lazier, and greatly
reduces the chance we run into spurious template instantiation errors.

It also allows us to always import the return type of functions.