### PR TITLE
[6.3][cxx-interop] Fix crashing on recursive enums

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -15,10 +15,12 @@
 
 #include "OutputLanguageMode.h"
 
+#include "PrintClangFunction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
 // for OptionalTypeKind
+#include "swift/AST/TypeRepr.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "llvm/ADT/StringSet.h"
 
@@ -56,6 +58,7 @@ public:
 private:
   class Implementation;
   friend class Implementation;
+  friend class DeclAndTypeClangFunctionPrinter;
 
   ModuleDecl &M;
   raw_ostream &os;
@@ -69,6 +72,7 @@ private:
   bool requiresExposedAttribute;
   llvm::StringSet<> &exposedModules;
   OutputLanguageMode outputLang;
+  llvm::DenseMap<Type, std::optional<ClangRepresentation>> typeRepresentations;
 
   /// The name 'CFTypeRef'.
   ///

--- a/test/Interop/SwiftToCxx/enums/recursive-enum.swift
+++ b/test/Interop/SwiftToCxx/enums/recursive-enum.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public enum E {
+  case foo([E?])
+}
+
+// CHECK: class SWIFT_SYMBOL("s:5Enums1EO") E final {
+// CHECK: SWIFT_INLINE_THUNK swift::Array<swift::Optional<E>> getFoo() const;


### PR DESCRIPTION
Explanation: Checking whether an Enum can be exported to C++ included checking whether all the enum cases are exportable. When one of these cases refer to the original enum we got into an infinte recursion. This PR adds a cache that is also used to cut the recursion in these cases.
Issues: rdar://164153038
Original PRs: #85980
Risk: Low, this only adds a cache.
Testing: Added a compiler test.
Reviewers: @egorzhdan @j-hui @susmonteiro

