### PR TITLE
[Backtracing] Fix threads=all in SWIFT_BACKTRACE parameters

### DIFF
--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -1176,10 +1176,10 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
     backtracer_argv[16] = "preset";
     break;
   case ThreadsToShow::All:
-    backtracer_argv[16] = "all";
+    backtracer_argv[16] = "true";
     break;
   case ThreadsToShow::Crashed:
-    backtracer_argv[16] = "crashed";
+    backtracer_argv[16] = "false";
     break;
   }
 


### PR DESCRIPTION
If you added threads=all to the SWIFT_BACKTRACE settings, it actually prevented all threads from being shown.

Note: the workaround is easy, the default if threads= is not specified is for all threads to be shown.

rdar://166532079