### PR TITLE
test: migrate additional tests to `swift-build-modules`

### DIFF
--- a/test/CAS/coverage-dir.swift
+++ b/test/CAS/coverage-dir.swift
@@ -5,10 +5,8 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -profile-coverage-mapping -profile-generate
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/A.cmd
 
-// RUN: %FileCheck %s --input-file=%t/shim.cmd
 // RUN: %FileCheck %s --input-file=%t/A.cmd
 
 // CHECK: -direct-clang-cc1-module-build


### PR DESCRIPTION
Migrate two more instances of the lit test `RUN` lines to `swift-build-modules` to ensure that all the modules are available for the CAS build.