### PR TITLE
[Tests] Allow wasmstdlib tests to be skipped

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -229,6 +229,7 @@ def _apply_default_arguments(args):
         args.test_swiftformat = False
         args.test_toolchainbenchmarks = False
         args.test_swiftdocc = False
+        args.test_wasmstdlib = False
 
     # --test implies --test-early-swift-driver
     # (unless explicitly skipped with `--skip-test-early-swift-driver`)
@@ -294,10 +295,6 @@ def _apply_default_arguments(args):
         args.test_watchos_host = False
         args.test_xros_host = False
         args.test_android_host = False
-
-    if args.build_wasmstdlib:
-        args.test_wasmstdlib = True
-
 
 def create_argument_parser():
     """Return a configured argument parser."""
@@ -862,8 +859,6 @@ def create_argument_parser():
     option(['--build-wasm-stdlib'], toggle_true('build_wasmstdlib'),
            help='build the stdlib for WebAssembly target into a'
                 'separate build directory ')
-    option('--test-wasm-stdlib', toggle_true('test_wasmstdlib'),
-           help='test stdlib for WebAssembly')
     option(['--wasmkit'], toggle_true('build_wasmkit'),
            help='build WasmKit')
     option(['--install-wasmkit'], toggle_true('install_wasmkit'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -605,7 +605,6 @@ EXPECTED_OPTIONS = [
     SetTrueOption('--swiftdocc', dest='build_swiftdocc'),
     SetTrueOption('--build-minimal-stdlib', dest='build_minimalstdlib'),
     SetTrueOption('--build-wasm-stdlib', dest='build_wasmstdlib'),
-    SetTrueOption('--test-wasm-stdlib', dest='test_wasmstdlib'),
     SetTrueOption('--wasmkit', dest='build_wasmkit'),
     SetTrueOption('--build-stdlib-docs'),
     SetTrueOption('--preview-stdlib-docs'),


### PR DESCRIPTION
For some reason the tests were always enabled when building the wasm stdlib. The build should respect the `-skip-test-wasmstdlib` flag.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
