### PR TITLE
[6.3][CAS|LLDB] Cleanup diagnostics in ExplicitCASModuleLoader

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2512,6 +2512,12 @@ struct ExplicitCASModuleLoader::Implementation {
   // Same as the regular explicit module map but must be loaded from
   // CAS, instead of a file that is not tracked by the dependency.
   void parseSwiftExplicitModuleMap(StringRef ID) {
+    // ModuleLoader can be setup with no explicit module map and explicitly
+    // setup each individual dependencies via `addExplicitModulePath` function.
+    // If the input CASID is empty, just return.
+    if (ID.empty())
+      return;
+
     ExplicitModuleMapParser parser(Allocator);
     llvm::StringMap<ExplicitClangModuleInputInfo> ExplicitClangModuleMap;
     llvm::StringMap<std::string> ModuleAliases;
@@ -2697,9 +2703,12 @@ bool ExplicitCASModuleLoader::findModule(
       Impl.CAS, Impl.Cache, Ctx.Diags, moduleCASID,
       file_types::ID::TY_SwiftModuleFile, moduleInfo.modulePath);
   if (!moduleBuf) {
-    // We cannot read the module content, diagnose.
-    Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_explicit_module_file,
-                       moduleInfo.modulePath);
+    // Cannot load the module. For any real issues like malformed CASID or
+    // module, the error has been diagnosed in
+    // `loadCachedCompileResultFromCacheKey`. The only way to reach here without
+    // error diagnostics is that the module is not found via loader, just return
+    // false in the case so the next loader can try findModule without hitting
+    // an error.
     return false;
   }
 


### PR DESCRIPTION
- **Explanation**: Cleanup some error diagnostics in ExplicitCASModuleLoader for LLDB's usage. This allows ExplicitCASModuleLoader to be used with other module loader as fallback without triggering an error when it failed to load.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This allows LLDB's new usage of ExplicitCASModuleLoader.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://166490023
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/86060
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Diagnostics Only.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Covered by LLDB tests.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->

