### PR TITLE
Sema: Fix 'generic parameter mentioned in signature' check edge case with subscripts

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -538,6 +538,16 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
   // Collect all generic params referenced in parameter types and
   // return type.
   auto *funcTy = decl->getInterfaceType()->castTo<GenericFunctionType>();
+
+  // Generic parameters of the outer context are implicitly referenced, but a
+  // subscript's interface type doesn't include the (Self) -> ... part, for
+  // historical reasons.
+  if (isa<SubscriptDecl>(decl)) {
+    collectReferencedGenericParams(
+        decl->getDeclContext()->getSelfInterfaceType(),
+        referencedGenericParams);
+  }
+
   for (const auto &param : funcTy->getParams())
     collectReferencedGenericParams(param.getPlainType(), referencedGenericParams);
   collectReferencedGenericParams(funcTy->getResult(), referencedGenericParams);

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -96,3 +96,16 @@ func boo<T1, T2:Q, T3:Q, T4:Q, T5:Q, T6:Q> (x: T6)
 //expected-error@+1{{generic parameter 'U' is not used in function signature}}
 func baz<U:P>(_ d: U.A) {
 }
+
+
+// https://github.com/swiftlang/swift/issues/50917
+extension Collection {
+  subscript<C: Collection>(i i: Index, j j: C.Index) -> C.Element where Element == C {
+    return self[i][j]
+  }
+
+  subscript<C: Collection>(ii i: Index, jj j: C.Index) -> C.Element {
+  // expected-error@-1 {{generic parameter 'C' is not used in function signature}}
+    fatalError()
+  }
+}


### PR DESCRIPTION
If a generic parameter is same-type-constrained to an outer type parameter, it doesn't have to appear in the subscript's signature.

- Fixes https://github.com/swiftlang/swift/issues/50917.