### PR TITLE
[CSBindings] Store the originator type variable in a transitive binding

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -84,14 +84,20 @@ struct PotentialBinding {
   /// because they are synthetic, they have a locator instead.
   PointerUnion<Constraint *, ConstraintLocator *> BindingSource;
 
+  /// When the binding is transferred through a subtype chain, this
+  /// marks a type variable for which it was originally inferred.
+  TypeVariableType *Originator;
+
   PotentialBinding(Type type, AllowedBindingKind kind,
-                   PointerUnion<Constraint *, ConstraintLocator *> source)
-      : BindingType(type), Kind(kind), BindingSource(source) {}
+                   PointerUnion<Constraint *, ConstraintLocator *> source,
+                   TypeVariableType *originator)
+      : BindingType(type), Kind(kind), BindingSource(source),
+        Originator(originator) {}
 
   PotentialBinding(Type type, AllowedBindingKind kind, Constraint *source)
       : PotentialBinding(
-            type, kind,
-            PointerUnion<Constraint *, ConstraintLocator *>(source)) {}
+            type, kind, PointerUnion<Constraint *, ConstraintLocator *>(source),
+            /*originator=*/nullptr) {}
 
   bool isDefaultableBinding() const {
     if (auto *constraint = BindingSource.dyn_cast<Constraint *>())
@@ -124,12 +130,19 @@ struct PotentialBinding {
   Constraint *getSource() const { return cast<Constraint *>(BindingSource); }
 
   PotentialBinding withType(Type type) const {
-    return {type, Kind, BindingSource};
+    return {type, Kind, BindingSource, Originator};
   }
 
   PotentialBinding withSameSource(Type type, AllowedBindingKind kind) const {
-    return {type, kind, BindingSource};
+    return {type, kind, BindingSource, Originator};
   }
+
+  PotentialBinding asTransitiveFrom(TypeVariableType *originator) const {
+    ASSERT(originator);
+    return {BindingType, Kind, BindingSource, originator};
+  }
+
+  bool isTransitive() const { return bool(Originator); }
 
   /// Determine whether this binding could be a viable candidate
   /// to be "joined" with some other binding. It has to be at least
@@ -140,12 +153,13 @@ struct PotentialBinding {
                                   ConstraintLocator *locator) {
     return {PlaceholderType::get(typeVar->getASTContext(), typeVar),
             AllowedBindingKind::Exact,
-            /*source=*/locator};
+            /*source=*/locator, /*originator=*/nullptr};
   }
 
   static PotentialBinding forPlaceholder(Type placeholderTy) {
     return {placeholderTy, AllowedBindingKind::Exact,
-            PointerUnion<Constraint *, ConstraintLocator *>()};
+            PointerUnion<Constraint *, ConstraintLocator *>(),
+            /*originator=*/nullptr};
   }
 
   void print(llvm::raw_ostream &out, const PrintOptions &PO) const;
@@ -473,7 +487,7 @@ public:
   /// \param isTransitive Indicates whether this binding has been
   /// acquired through transitive inference and requires extra
   /// checking.
-  bool isViable(PotentialBinding &binding, bool isTransitive);
+  bool isViable(PotentialBinding &binding);
 
   /// Determine whether this set has any "viable" (or non-hole) bindings.
   ///
@@ -602,10 +616,7 @@ private:
   /// Add a new binding to the set.
   ///
   /// \param binding The binding to add.
-  /// \param isTransitive Indicates whether this binding has been
-  /// acquired through transitive inference and requires validity
-  /// checking.
-  void addBinding(PotentialBinding binding, bool isTransitive);
+  void addBinding(PotentialBinding binding);
 
   void addLiteralRequirement(Constraint *literal);
 

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -145,6 +145,7 @@ public:
         /// of a PotentialBinding.
         Type BindingType;
         PointerUnion<Constraint *, ConstraintLocator *> BindingSource;
+        TypeVariableType *Originator;
       } Binding;
 
       ConstraintFix *TheFix;

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -334,6 +334,7 @@ SolverTrail::Change::RetractedBinding(TypeVariableType *typeVar,
   result.Binding.TypeVar = typeVar;
   result.Binding.BindingType = binding.BindingType;
   result.Binding.BindingSource = binding.BindingSource;
+  result.Binding.Originator = binding.Originator;
   result.Options = unsigned(binding.Kind);
 
   return result;
@@ -563,9 +564,8 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
     break;
 
   case ChangeKind::RetractedBinding: {
-    PotentialBinding binding(Binding.BindingType,
-                             AllowedBindingKind(Options),
-                             Binding.BindingSource);
+    PotentialBinding binding(Binding.BindingType, AllowedBindingKind(Options),
+                             Binding.BindingSource, Binding.Originator);
 
     auto &bindings = cg[BindingRelation.TypeVar].getPotentialBindings();
     bindings.Bindings.push_back(binding);


### PR DESCRIPTION
Instead of using a flag in `addBinding`, let's record what type variable does the binding belong to in `PotentialBinding` itself. This is going to help remove bindings introduced transitively when the inference is done lazily.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
