### PR TITLE
test: acount for plugin extension on Windows

### DIFF
--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -59,7 +59,7 @@
 
 // CMD-REMAP: -resolved-plugin-verification
 // CMD-REMAP-NEXT: -load-resolved-plugin
-// CMD-REMAP-NEXT: /^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server#MacroDefinition
+// CMD-REMAP-NEXT: /^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition
 
 // RUN: %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
@@ -74,7 +74,7 @@
 /// Encoded PLUGIN_SEARCH_OPTION is remapped.
 // RUN: llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)
 
-// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server#MacroDefinition'
+// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
 
 /// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
 // RUN: %target-swift-frontend-plain \


### PR DESCRIPTION
The plugin server on Windows is an executable and thus has the `.exe` extension that we did not match. Adjust the test for this naming difference.