### PR TITLE
[Swiftify] don't swiftify functions with sugared parameter lists

### DIFF
--- a/test/Interop/C/swiftify-import/Inputs/counted-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by.h
@@ -62,3 +62,5 @@ void hexLiteral(int * __counted_by(0xfa) p);
 void binaryLiteral(int * __counted_by(0b10) p);
 
 void octalLiteral(int * __counted_by(0777) p);
+
+void variadic(int len, int * __counted_by(len) p, ...);

--- a/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
+++ b/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
@@ -16,3 +16,4 @@
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} longLiteral
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} sizeofType
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} sizeofParam
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} variadic

--- a/test/Interop/ObjC/swiftify-import/Inputs/objc-no-swiftify.h
+++ b/test/Interop/ObjC/swiftify-import/Inputs/objc-no-swiftify.h
@@ -7,3 +7,14 @@
 void autoreleaseParam(SomeClass * __autoreleasing * __counted_by(len) p, int len); // expected-note{{declared here}}
 
 SomeClass * __autoreleasing * __counted_by(len) autoreleaseReturn(int len);
+
+@interface NSError
+@end
+
+@interface NSData
+@end
+
+@protocol Foo
+- (void)errorAsTry:(int) len : (int * __counted_by(len)) p error:(NSError * *) error;
+- (void)completionHandlerAsAsync:(int) len : (int * __counted_by(len)) p completionHandler:(void (^)(NSData * data, NSError *)) completionHandler;
+@end

--- a/test/Interop/ObjC/swiftify-import/objc-no-swiftify.swift
+++ b/test/Interop/ObjC/swiftify-import/objc-no-swiftify.swift
@@ -7,8 +7,7 @@
 
 import NoSwiftifyClang
 
-// CHECK-NOT: @_alwaysEmitIntoClient @_disfavoredOverload public func callAutoreleaseParam
-// CHECK-NOT: @_alwaysEmitIntoClient @_disfavoredOverload public func callAutoreleaseReturn
+// CHECK-NOT: @_alwaysEmitIntoClient @_disfavoredOverload
 
 public func callAutoreleaseParam(_ p: UnsafeMutableBufferPointer<SomeClass>) {
     // expected-error@+2{{missing argument for parameter #2 in call}}
@@ -19,4 +18,14 @@ public func callAutoreleaseParam(_ p: UnsafeMutableBufferPointer<SomeClass>) {
 public func callAutoreleaseReturn() {
     // expected-error@+1{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<SomeClass?>?' to specified type 'UnsafeMutableBufferPointer<SomeClass>'}}
     let p: UnsafeMutableBufferPointer<SomeClass> = autoreleaseReturn(10)
+}
+
+public func callErrorAsTry(_ x: Foo, _ p: UnsafeMutablePointer<CInt>, _ error: AutoreleasingUnsafeMutablePointer<NSError?>) {
+  x.error(asTry: 10, p, error: error)
+}
+
+public func callCompletionHandlerAsAsync(_ x: Foo, _ p: UnsafeMutablePointer<CInt>) {
+  x.completionHandler(asAsync: 10, p, completionHandler: { (a: NSData?, b: NSError?) in
+    print("asdf")
+  })
 }


### PR DESCRIPTION
These cases would trigger an assert in both release and debug builds. With this change they are ignored in release mode, and cases that are both unhandled and unknown trigger an assert in debug mode.

rdar://166569705