### PR TITLE
Diagnosing a private setter being accessed from the inlinable function.

### DIFF
--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -314,6 +314,43 @@ public struct HasInternalSetProperty {
   }
 }
 
+public struct HasUsableFromInlinePrivateSetProperty {
+  @usableFromInline private(set) var bytes: UnsafeMutableRawPointer // expected-note 2 {{setter for property 'bytes' is not '@usableFromInline' or public}}
+  public init() {
+      self.bytes = UnsafeMutableRawPointer.allocate(byteCount: 1024, alignment: 8)
+  }
+  @usableFromInline
+  func modifyPointer(_ ptr: inout UnsafeMutableRawPointer) {
+    ptr = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+  }
+  @usableFromInline
+  func readPointer(_ ptr: UnsafeMutableRawPointer) {
+    _ = ptr
+  }
+  // writes should trigger diagnostic
+  @inlinable
+  public mutating func writeDirect() {
+      self.bytes = UnsafeMutableRawPointer.allocate(byteCount: 2048, alignment: 8) // expected-warning {{setter for property 'bytes' is private and cannot be referenced from an '@inlinable' function}}
+  }
+  @inlinable
+  public mutating func writeFunc() {
+    modifyPointer(&self.bytes) // expected-warning {{setter for property 'bytes' is private and cannot be referenced from an '@inlinable' function}}
+  }
+  // reads should be ok
+  @inlinable
+  public func usesBytes() -> UnsafeMutableRawPointer {
+    _ = self.bytes
+  }
+  @inlinable
+  public func readsViaLoad() -> Int {
+    return self.bytes.load(as: Int.self)
+  }
+  @inlinable
+  public func readsViaFunc() {
+    readPointer(self.bytes)  // OK
+  }
+}
+
 @usableFromInline protocol P {
   typealias T = Int
 }


### PR DESCRIPTION
Swift compiler allowed accessing a private setter from an @inlinable function. This change detects and diagnose it with a  corresponding error.

rdar://81879146

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
