### PR TITLE
Fix a bug with binding parameters under a vanishing tuple AP

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -167,7 +167,7 @@ struct SILArgumentConvention {
   }
 
   /// Returns true if \p Value is a non-aliasing indirect parameter.
-  bool isExclusiveIndirectParameter() {
+  bool isExclusiveIndirectParameter() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
     case SILArgumentConvention::Indirect_Out:
@@ -190,7 +190,7 @@ struct SILArgumentConvention {
   }
 
   /// Returns true if \p Value is an indirect-out parameter.
-  bool isIndirectOutParameter() {
+  bool isIndirectOutParameter() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Pack_Out:
@@ -207,6 +207,29 @@ struct SILArgumentConvention {
     case SILArgumentConvention::Pack_Inout:
     case SILArgumentConvention::Pack_Owned:
     case SILArgumentConvention::Pack_Guaranteed:
+      return false;
+    }
+    llvm_unreachable("covered switch isn't covered?!");
+  }
+
+  /// Returns true if \p Value is a pack parameter.
+  bool isPackParameter() const {
+    switch (Value) {
+    case SILArgumentConvention::Pack_Inout:
+    case SILArgumentConvention::Pack_Owned:
+    case SILArgumentConvention::Pack_Guaranteed:
+    case SILArgumentConvention::Pack_Out:
+      return true;
+
+    case SILArgumentConvention::Indirect_Out:
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_InoutAliasable:
+    case SILArgumentConvention::Indirect_In_CXX:
+    case SILArgumentConvention::Direct_Unowned:
+    case SILArgumentConvention::Direct_Guaranteed:
+    case SILArgumentConvention::Direct_Owned:
       return false;
     }
     llvm_unreachable("covered switch isn't covered?!");

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -3207,6 +3207,22 @@ public:
                               SILValue packExpansionIndex, SILValue packIndex)>
           emitBody);
 
+  /// Emit an operation for each element of a pack expansion component of
+  /// a pack, automatically projecting and managing ownership of it properly
+  /// for each iteration.
+  ///
+  /// The projection and management does not itself generate control flow and
+  /// so can be safely composed with further projection and management.
+  void emitPackForEach(SILLocation loc,
+                       ManagedValue inputPackAddr,
+                       CanPackType inputFormalPackType,
+                       unsigned inputComponentIndex,
+                       GenericEnvironment *openedElementEnv,
+                       SILType inputEltTy,
+                       llvm::function_ref<void(SILValue indexWithinComponent,
+                                               SILValue expansionPackIndex,
+                                               ManagedValue input)> emitBody);
+
   /// Emit a transform on each element of a pack-expansion component
   /// of a pack, write the result into a pack-expansion component of
   /// another pack.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -17,6 +17,7 @@
 #include "ManagedValue.h"
 #include "SILGenFunction.h"
 #include "Scope.h"
+#include "TupleGenerators.h"
 
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/DiagnosticsSIL.h"
@@ -99,6 +100,8 @@ struct LoweredParamGenerator {
   bool isNoImplicitCopy = false;
   LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None;
   bool isImplicitParameter = false;
+  SILArgumentConvention currentConvention
+    = SILArgumentConvention::Direct_Guaranteed; // will be overwritten
 
   void configureParamData(ParamDecl *paramDecl, bool isNoImplicitCopy,
                           LifetimeAnnotation lifetimeAnnotation) {
@@ -131,7 +134,19 @@ struct LoweredParamGenerator {
     ManagedValue mv = SGF.B.createInputFunctionArgument(
         paramType, paramDecl, isNoImplicitCopy, lifetimeAnnotation,
         /*isClosureCapture*/ false, isFormalParameterPack, isImplicitParameter);
+    currentConvention =
+      cast<SILFunctionArgument>(SGF.F.begin()->getArguments().back())
+        ->getArgumentConvention();
     return mv;
+  }
+
+  SILArgumentConvention getCurrentConvention() const {
+    // This is only actually called after building a pack parameter.
+    assert(currentConvention.isPackParameter());
+    return currentConvention;
+  }
+  void finishCurrent(ManagedValue packAddr) {
+    // Ignore: we don't care about residual cleanups on the pack.
   }
 
   std::optional<SILParameterInfo> peek() const {
@@ -186,11 +201,7 @@ struct WritebackReabstractedInoutCleanup final : Cleanup {
   }
 };
 
-class EmitBBArguments : public CanTypeVisitor<EmitBBArguments,
-                                              /*RetTy*/ ManagedValue,
-                                              /*ArgTys...*/ AbstractionPattern,
-                                              Initialization *>
-{
+class EmitBBArguments {
 public:
   SILGenFunction &SGF;
   SILLocation loc;
@@ -216,7 +227,26 @@ public:
                           /*emitInto*/ nullptr,
                           /*inout*/ false, /*addressable*/ true);
     }
-    return visit(substType, origType, /*emitInto*/ nullptr);
+    // The client handles pack expansions when there's a meaningful
+    // abstraction pattern, but for now, at least, we can also end up
+    // here when there's an unabstracted pack expansion type. Fortunately,
+    // the lack of abstraction means we can just bind the parameter pack
+    // directly as the argument value.
+    if (isa<PackExpansionType>(substType)) {
+      return handleScalar(origType,
+                          CanPackType::get(SGF.getASTContext(), {substType}),
+                          /*emitInto*/ nullptr);
+    }
+
+    return handleValue(origType, substType, /*emitInto*/ nullptr);
+  }
+
+  ManagedValue handleValue(AbstractionPattern origType, CanType substType,
+                           Initialization *emitInto) {
+    if (origType.isTuple()) {
+      return handleExpansion(origType, substType, emitInto);
+    }
+    return handleScalar(origType, substType, emitInto);
   }
 
   ManagedValue handlePackComponent(FunctionInputGenerator &formalParam) {
@@ -287,8 +317,8 @@ public:
     });
   }
 
-  ManagedValue visitType(CanType t, AbstractionPattern orig,
-                         Initialization *emitInto) {
+  ManagedValue handleScalar(AbstractionPattern orig, CanType t,
+                            Initialization *emitInto) {
     auto mv = claimNextParameter();
     return handleScalar(mv, orig, t, emitInto,
                         /*inout*/ false,
@@ -406,219 +436,234 @@ public:
     return mv;
   }
 
-  ManagedValue visitPackExpansionType(CanPackExpansionType t,
-                                      AbstractionPattern orig,
-                                      Initialization *emitInto) {
-    // Pack expansions in the formal parameter list are made
-    // concrete as packs.
-    return visitType(PackType::get(SGF.getASTContext(), {t})
-                       ->getCanonicalType(),
-                     orig, emitInto);
+  static bool shouldForceIntoTemporary(const TypeLowering &tl) {
+    // If the type is loadable, we never need this.
+    if (tl.isLoadable()) return false;
+
+
+    // Otherwise, we have an address-only type.
+    return false;
   }
 
-  ManagedValue visitTupleType(CanTupleType t, AbstractionPattern orig,
-                              Initialization *emitInto) {
-    // Only destructure if the abstraction pattern is also a tuple.
-    if (!orig.isTuple())
-      return visitType(t, orig, emitInto);
+  ManagedValue handleExpansion(AbstractionPattern origType, CanType substType,
+                               Initialization *init) {
+    assert(origType.isTuple());
 
-    auto &tl = SGF.SGM.Types.getTypeLowering(t, SGF.getTypeExpansionContext());
+    auto &substTL =
+      SGF.SGM.Types.getTypeLowering(substType, SGF.getTypeExpansionContext());
 
-    // If the tuple contains pack expansions, and we're not emitting
-    // into an initialization already, create a temporary so that we're
-    // always emitting into an initialization.
-    if (t.containsPackExpansionType() && !emitInto) {
-      auto temporary = SGF.emitTemporary(loc, tl);
+    ExpandedTupleInputGenerator expansion(SGF.getASTContext(), parameters,
+                                          origType, substType);
 
-      auto result = expandTuple(orig, t, tl, temporary.get());
-      assert(result.isInContext()); (void) result;
+    // If the original tuple vanishes, the type lowering and initialization
+    // are actually for its surviving element.
+    bool tupleVanishes = expansion.doesOrigTupleVanish();
 
-      return temporary->getManagedAddress();
+    // If we're not already emitting into an initialization, there are
+    // several situations where we want to do so.
+    bool emitIntoTemporary = [&] {
+      if (init) return false;
+
+      // We don't need to do this if the orig tuple vanishes. (It may end up
+      // being a tuple in the substituted type, but we should defer the decision
+      // to create a temporary; the tuple might end up being passed as a single
+      // pack element.)
+      if (tupleVanishes) return false;
+
+      // All of the situations that want a temporary are exclusive with
+      // having a loadable tuple.
+      if (substTL.isLoadable()) return false;
+
+      // If the substituted type contains pack expansions, we always need a
+      // a temporary (even with SIL opaque values) because we currently have
+      // no way of directly generating scalar tuples that contain expansions.
+      if (auto tupleTy = substTL.getLoweredType().getAs<TupleType>()) {
+        if (tupleTy.containsPackExpansionType())
+          return true;
+      }
+
+      // If SIL opaque values are disabled, we always need a temporary to
+      // reconstitute an address-only tuple.
+      if (SGF.silConv.useLoweredAddresses())
+        return true;
+
+      // Otherwise, we don't need a temporary.
+      return false;
+    }();
+
+    TemporaryInitializationPtr temporary;
+    if (emitIntoTemporary) {
+      temporary = SGF.emitTemporary(loc, substTL);
+      init = temporary.get();
     }
 
-    return expandTuple(orig, t, tl, emitInto);
-  }
-
-  ManagedValue expandTuple(AbstractionPattern orig, CanTupleType t,
-                           const TypeLowering &tl, Initialization *init) {
-    assert((!t.containsPackExpansionType() || init) &&
-           "should always have an emission context when expanding "
-           "a tuple containing pack expansions");
-
-    bool canBeGuaranteed = tl.isLoadable();
-
-    // We only use specific initializations here that can always be split.
+    // If we're emitting into an initialization, and the tuple doesn't
+    // vanish, split the tuple initialization. We're only ever given
+    // specific kinds of initialization that can always be split.
     SmallVector<InitializationPtr, 8> eltInitsBuffer;
     MutableArrayRef<InitializationPtr> eltInits;
-    if (init) {
+    if (init && !tupleVanishes) {
       assert(init->canSplitIntoTupleElements());
-      eltInits = init->splitIntoTupleElements(SGF, loc, t, eltInitsBuffer);
+      eltInits = init->splitIntoTupleElements(SGF, loc, substType,
+                                              eltInitsBuffer);
     }
 
-    // Collect the exploded elements.
-    //
-    // Reabstraction can give us original types that are pack
-    // expansions without having pack expansions in the result.
-    // In this case, we do not need to force emission into a pack
-    // expansion.
-    SmallVector<ManagedValue, 4> elements;
-    orig.forEachTupleElement(t, [&](TupleElementGenerator &elt) {
-      auto origEltType = elt.getOrigType();
-      auto substEltTypes = elt.getSubstTypes();
-      if (!elt.isOrigPackExpansion()) {
-        auto eltValue =
-          visit(substEltTypes[0], origEltType,
-                init ? eltInits[elt.getSubstIndex()].get() : nullptr);
-        assert((init != nullptr) == (eltValue.isInContext()));
-        if (!eltValue.isInContext())
-          elements.push_back(eltValue);
+    // Iterate over the elements in order, either emitting them into the
+    // initialization or collecting scalar values from them.
+    auto expectedNumElts = (init ? 0 :
+                            tupleVanishes ? 1 :
+                            cast<TupleType>(substType)->getNumElements());
+    SmallVector<ManagedValue, 4> eltMVs;
+    eltMVs.reserve(expectedNumElts);
 
-        if (eltValue.hasCleanup())
-          canBeGuaranteed = false;
-      } else {
-        assert(init);
-        expandPack(origEltType, substEltTypes, elt.getSubstIndex(),
-                   eltInits.slice(elt.getSubstIndex(), substEltTypes.size()),
-                   elements);
-      }
-    });
+    // Remember if we saw anything that would force us to copy in order to
+    // form the tuple:
+    // - if any of the scalar components have cleanups, since we can't mix
+    //   owned and guaranteed values in the tuple, or
+    // - if the tuple overall is address-only, since that's a representation
+    //   change that the address lowering can't reliably eliminate without
+    //   ownership.
+    // This is only used in the path where we construct a tuple.
+    bool tupleValueCanBeGuaranteed = substTL.isLoadable();
 
-    // If we emitted into a context, we're done.
-    if (init) {
-      init->finishInitialization(SGF);
-      return ManagedValue::forInContext();
-    }
-
-    if (tl.isLoadable() || !SGF.silConv.useLoweredAddresses()) {
-      SmallVector<SILValue, 4> elementValues;
-      if (canBeGuaranteed) {
-        // If all of the elements were guaranteed, we can form a guaranteed tuple.
-        for (auto element : elements)
-          elementValues.push_back(element.getUnmanagedValue());
-      } else {
-        // Otherwise, we need to move or copy values into a +1 tuple.
-        for (auto element : elements) {
-          SILValue value = element.hasCleanup()
-            ? element.forward(SGF)
-            : element.copyUnmanaged(SGF, loc).forward(SGF);
-          elementValues.push_back(value);
+    for (; !expansion.isFinished(); expansion.advance()) {
+      Initialization *componentInit = nullptr;
+      if (init) {
+        if (tupleVanishes) {
+          componentInit = init;
+        } else {
+          componentInit = eltInits[expansion.getSubstElementIndex()].get();
         }
       }
-      auto tupleValue = SGF.B.createTuple(loc, tl.getLoweredType(),
-                                          elementValues);
-      if (tupleValue->getOwnershipKind() == OwnershipKind::None)
-        return ManagedValue::forObjectRValueWithoutOwnership(tupleValue);
-      return canBeGuaranteed ? ManagedValue::forBorrowedObjectRValue(tupleValue)
-                             : SGF.emitManagedRValueWithCleanup(tupleValue);
-    } else {
-      // If the type is address-only, we need to move or copy the elements into
-      // a tuple in memory.
-      // TODO: It would be a bit more efficient to use a preallocated buffer
-      // in this case.
-      auto buffer = SGF.emitTemporaryAllocation(loc, tl.getLoweredType());
-      for (auto i : indices(elements)) {
-        auto element = elements[i];
-        auto elementBuffer = SGF.B.createTupleElementAddr(loc, buffer,
-                                        i, element.getType().getAddressType());
-        if (element.hasCleanup())
-          element.forwardInto(SGF, loc, elementBuffer);
-        else
-          element.copyInto(SGF, loc, elementBuffer);
-      }
-      return SGF.emitManagedRValueWithCleanup(buffer);
-    }
-  }
 
-  void expandPack(AbstractionPattern origExpansionType,
-                  CanTupleEltTypeArrayRef substEltTypes,
-                  size_t firstSubstEltIndex,
-                  MutableArrayRef<InitializationPtr> eltInits,
-                  SmallVectorImpl<ManagedValue> &eltMVs) {
-    assert(substEltTypes.size() == eltInits.size());
+      // If the original element is not from a pack expansion, just
+      // recursively collect it.
+      if (!expansion.isOrigPackExpansion()) {
+        auto eltResult =
+          handleValue(expansion.getOrigType(), expansion.getSubstType(),
+                      componentInit);
+        assert((init != nullptr) == (eltResult.isInContext()));
 
-    // The next parameter is a pack which corresponds to some number of
-    // components in the tuple.  Some of them may be pack expansions.
-    // Either copy/move them into the tuple (necessary if there are any
-    // pack expansions) or collect them in eltMVs.
+        if (!eltResult.isInContext()) {
+          eltMVs.push_back(eltResult);
+          if (eltResult.hasCleanup())
+            tupleValueCanBeGuaranteed = false;
+        }
 
-    // Claim the next parameter, remember whether it was +1, and forward
-    // the cleanup.  We can get away with just forwarding the cleanup
-    // up front, not destructuring it, because we assume that the work
-    // we're doing here won't ever unwind.
-    ManagedValue packAddrMV = claimNextParameter();
-    CleanupCloner cloner(SGF, packAddrMV);
-    SILValue packAddr = packAddrMV.forward(SGF);
-    auto packTy = packAddr->getType().castTo<SILPackType>();
-
-    auto origPatternType = origExpansionType.getPackExpansionPatternType();
-
-    auto inducedPackType =
-      CanPackType::get(SGF.getASTContext(), substEltTypes);
-
-    for (auto packComponentIndex : indices(substEltTypes)) {
-      CanType substComponentType = substEltTypes[packComponentIndex];
-      Initialization *componentInit =
-        eltInits.empty() ? nullptr : eltInits[packComponentIndex].get();
-      auto packComponentTy = packTy->getSILElementType(packComponentIndex);
-
-      auto substExpansionType =
-        dyn_cast<PackExpansionType>(substComponentType);
-
-      // In the scalar case, project out the element address from the
-      // pack and use the normal scalar path to trigger initialization.
-      if (!substExpansionType) {
-        auto packIndex =
-          SGF.B.createScalarPackIndex(loc, packComponentIndex, inducedPackType);
-        auto eltAddr =
-          SGF.B.createPackElementGet(loc, packIndex, packAddr,
-                                     packComponentTy);
-        auto eltAddrMV = cloner.clone(eltAddr);
-        auto result = handleScalar(eltAddrMV, origPatternType,
-                                   substComponentType, componentInit,
-                                   /*inout*/ false,
-                                   /*addressable*/ false);
-        assert(result.isInContext() == (componentInit != nullptr));
-        if (!result.isInContext())
-          eltMVs.push_back(result);
         continue;
       }
 
-      // In the pack-expansion case, do the exact same thing,
-      // but in a pack loop.
+      // Otherwise, we're starting with a pack parameter. Project out
+      // the substituted component.
+      auto componentMV = expansion.projectPackComponent(SGF, loc);
+
+      // If the substituted element type is not a pack expansion,
+      // we can just use the substituted component in the scalar path.
+      if (!expansion.isSubstPackExpansion()) {
+        auto eltResult = handleScalar(componentMV, expansion.getOrigType(),
+                                      expansion.getSubstType(), componentInit,
+                                      /*inout*/ false,
+                                      /*addressable*/ false);
+        assert((init != nullptr) == (eltResult.isInContext()));
+
+        if (!eltResult.isInContext()) {
+          eltMVs.push_back(eltResult);
+          if (eltResult.hasCleanup())
+            tupleValueCanBeGuaranteed = false;
+        }
+
+        continue;
+      }
+
+      // Otherwise, we need to emit a pack loop over the expansion
+      // component. Since the substituted type always contains a pack
+      // expansion, we should've forced the existence of an init earlier.
       assert(componentInit);
       assert(componentInit->canPerformPackExpansionInitialization());
+
+      auto packComponentIndex = expansion.getPackComponentIndex();
+      auto packComponentTy = expansion.getPackComponentType();
+      auto substComponentType = expansion.getSubstType();
 
       SILType eltTy;
       CanType substEltType;
       auto openedEnv =
         SGF.createOpenedElementValueEnvironment({packComponentTy},
                                                 {&eltTy},
-                                                {substExpansionType},
+                                                {substComponentType},
                                                 {&substEltType});
 
-      SGF.emitDynamicPackLoop(loc, inducedPackType, packComponentIndex,
-                              openedEnv,
-                              []() -> SILBasicBlock * { return nullptr; },
-                              [&](SILValue indexWithinComponent,
-                                  SILValue expansionPackIndex,
-                                  SILValue packIndex) {
+      auto inducedPackType = expansion.getFormalPackType();
+
+      SGF.emitPackForEach(loc, componentMV, inducedPackType,
+                          packComponentIndex, openedEnv, eltTy,
+                          [&](SILValue indexWithinComponent,
+                              SILValue expansionPackIndex,
+                              ManagedValue eltAddrMV) {
         componentInit->performPackExpansionInitialization(SGF, loc,
                                             indexWithinComponent,
                                             [&](Initialization *eltInit) {
-          // Project out the pack element and enter a managed value for it.
-          auto eltAddr =
-            SGF.B.createPackElementGet(loc, packIndex, packAddr, eltTy);
-          auto eltAddrMV = cloner.clone(eltAddr);
-
-          auto result = handleScalar(eltAddrMV, origPatternType, substEltType,
-                                     eltInit,
-                                     /*inout*/ false,
-                                     /*addressable*/ false);
-          assert(result.isInContext()); (void) result;
+          auto eltResult = handleScalar(eltAddrMV, expansion.getOrigType(),
+                                        substEltType, eltInit,
+                                        /*inout*/ false,
+                                        /*addressable*/ false);
+          assert(eltResult.isInContext()); (void) eltResult;
         });
       });
       componentInit->finishInitialization(SGF);
     }
+    expansion.finish();
+
+    // If we emitted into an initialization, we're done.
+    if (init) {
+      // Make sure we finish the tuple initialization if we split it before.
+      if (!tupleVanishes)
+        init->finishInitialization(SGF);
+
+      // If we created the initialization ourselves, return the managed
+      // address.
+      if (emitIntoTemporary)
+        return temporary->getManagedAddress();
+
+      // Otherwise, signal that we emitted into the provided intialization.
+      return ManagedValue::forInContext();
+    }
+
+    // Okay, there's no initialization, so we have to return a scalar value.
+
+    // If the tuple pattern vanishes, the loop above should have produced a
+    // single "element".
+    if (tupleVanishes) {
+      assert(eltMVs.size() == 1);
+      return eltMVs[0];
+    }
+
+    // If the tuple doesn't vanish, we need to build the scalar element
+    // values into a scalar tuple values.
+    SmallVector<SILValue, 4> eltValues;
+    eltValues.reserve(eltMVs.size());
+
+    // If all of the elements were guaranteed, we can form a guaranteed tuple.
+    if (tupleValueCanBeGuaranteed) {
+      for (auto element : eltMVs) {
+        eltValues.push_back(element.getUnmanagedValue());
+      }
+
+    // Otherwise, we need to move or copy values into a +1 tuple.
+    } else {
+      for (auto element : eltMVs) {
+        SILValue value = element.hasCleanup()
+          ? element.forward(SGF)
+          : element.copyUnmanaged(SGF, loc).forward(SGF);
+        eltValues.push_back(value);
+      }
+    }
+    auto tupleValue = SGF.B.createTuple(loc, substTL.getLoweredType(), eltValues);
+    if (tupleValue->getOwnershipKind() == OwnershipKind::None)
+      return ManagedValue::forObjectRValueWithoutOwnership(tupleValue);
+    return tupleValueCanBeGuaranteed
+             ? ManagedValue::forBorrowedObjectRValue(tupleValue)
+             : SGF.emitManagedRValueWithCleanup(tupleValue);
   }
 };
 

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -343,13 +343,13 @@ func testDebugValue(_ a : Int, b : SimpleProtocol) -> Int {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testAddressOnlyTupleArgument
 func testAddressOnlyTupleArgument(_ bounds: (start: SimpleProtocol, pastEnd: Int)) {
 // CHECK:       bb0(%0 : $*any SimpleProtocol, %1 : $Int):
-// CHECK-NEXT:    %2 = alloc_stack [lexical] [var_decl] $(start: any SimpleProtocol, pastEnd: Int), let, name "bounds", argno 1
-// CHECK-NEXT:    %3 = tuple_element_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int), 0
-// CHECK-NEXT:    copy_addr %0 to [init] %3 : $*any SimpleProtocol
-// CHECK-NEXT:    %5 = tuple_element_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int), 1
-// CHECK-NEXT:    store %1 to [trivial] %5 : $*Int
-// CHECK-NEXT:    destroy_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int)
-// CHECK-NEXT:    dealloc_stack %2 : $*(start: any SimpleProtocol, pastEnd: Int)
+// CHECK-NEXT:    [[TUPLE:%.*]] = alloc_stack [lexical] [var_decl] $(start: any SimpleProtocol, pastEnd: Int), let, name "bounds", argno 1
+// CHECK-NEXT:    [[TUPLE_0:%.*]] = tuple_element_addr [[TUPLE]] : $*(start: any SimpleProtocol, pastEnd: Int), 0
+// CHECK-NEXT:    [[TUPLE_1:%.*]] = tuple_element_addr [[TUPLE]] : $*(start: any SimpleProtocol, pastEnd: Int), 1
+// CHECK-NEXT:    copy_addr %0 to [init] [[TUPLE_0]] : $*any SimpleProtocol
+// CHECK-NEXT:    store %1 to [trivial] [[TUPLE_1]] : $*Int
+// CHECK-NEXT:    destroy_addr [[TUPLE]] : $*(start: any SimpleProtocol, pastEnd: Int)
+// CHECK-NEXT:    dealloc_stack [[TUPLE]] : $*(start: any SimpleProtocol, pastEnd: Int)
 }
 
 

--- a/test/SILGen/protocol_packs.swift
+++ b/test/SILGen/protocol_packs.swift
@@ -225,8 +225,8 @@ struct ConsumingBorrowingAccepterImpl: BorrowingAccepter {
 // CHECK:       bb2:
 // CHECK-NEXT:    [[PACK_INDEX:%.*]] = dynamic_pack_index [[INDEX]] of $Pack{repeat NonTrivialGeneric<each τ_0_0>}
 // CHECK-NEXT:    open_pack_element [[PACK_INDEX]] of <each τ_0_0> at <Pack{repeat each τ_0_0}>, shape $each τ_0_0, uuid [[UUID:".*"]]
-// CHECK-NEXT:    [[TEMP_ELT_ADDR:%.*]] = tuple_pack_element_addr [[PACK_INDEX]] of [[TEMP_TUPLE]] as $*NonTrivialGeneric<@pack_element([[UUID]]) each τ_0_0>
 // CHECK-NEXT:    [[ARG_ADDR:%.*]] = pack_element_get [[PACK_INDEX]] of %0 as $*NonTrivialGeneric<@pack_element([[UUID]]) each τ_0_0>
+// CHECK-NEXT:    [[TEMP_ELT_ADDR:%.*]] = tuple_pack_element_addr [[PACK_INDEX]] of [[TEMP_TUPLE]] as $*NonTrivialGeneric<@pack_element([[UUID]]) each τ_0_0>
 // CHECK-NEXT:    [[BORROW:%.*]] = load_borrow [[ARG_ADDR]]
 // CHECK-NEXT:    [[COPY:%.*]] = copy_value [[BORROW]]
 // CHECK-NEXT:    store [[COPY]] to [init] [[TEMP_ELT_ADDR]]

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -148,9 +148,9 @@ extension P {
   //
   // Initialize the RValue. (This is here to help pattern matching).
   // CHECK:   [[ZERO_ADDR:%.*]] = tuple_element_addr [[RVALUE]] : $*(index: C, value: Self), 0
+  // CHECK:   [[ONE_ADDR:%.*]] = tuple_element_addr [[RVALUE]] : $*(index: C, value: Self), 1
   // CHECK:   [[TUP0_COPY:%.*]] = copy_value [[TUP0]]
   // CHECK:   store [[TUP0_COPY]] to [init] [[ZERO_ADDR]]
-  // CHECK:   [[ONE_ADDR:%.*]] = tuple_element_addr [[RVALUE]] : $*(index: C, value: Self), 1
   // CHECK:   copy_addr [[TUP1]] to [init] [[ONE_ADDR]]
   //
   // What we are actually trying to check. Note that there is no actual use of

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -88,8 +88,8 @@ public struct Container<each T> {
 // CHECK:       bb2:
 // CHECK-NEXT:    [[INDEX:%.*]] = dynamic_pack_index [[IDX]] of $Pack{repeat Stored<each T>}
 // CHECK-NEXT:    open_pack_element [[INDEX]] of <each T> at <Pack{repeat each T}>, shape $each T, uuid [[UUID:".*"]]
-// CHECK-NEXT:    [[ARG_COPY_ELT_ADDR:%.*]] = tuple_pack_element_addr [[INDEX]] of [[ARG_COPY]] : $*(repeat Stored<each T>) as $*Stored<@pack_element([[UUID]]) each T>
 // CHECK-NEXT:    [[PACK_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %0 : $*Pack{repeat Stored<each T>} as $*Stored<@pack_element([[UUID]]) each T>
+// CHECK-NEXT:    [[ARG_COPY_ELT_ADDR:%.*]] = tuple_pack_element_addr [[INDEX]] of [[ARG_COPY]] : $*(repeat Stored<each T>) as $*Stored<@pack_element([[UUID]]) each T>
 // CHECK-NEXT:    [[ELT_VALUE:%.*]] = load [trivial] [[PACK_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) each T>
 // CHECK-NEXT:    store [[ELT_VALUE]] to [trivial] [[ARG_COPY_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) each T>
 // CHECK-NEXT:    [[NEXT_IDX:%.*]] = builtin "add_Word"([[IDX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -335,17 +335,14 @@ struct TestGenericTuple<T, U> {
   //
   // CHECK: bb0([[A_REF:%.*]] : $*T, [[B_REF:%.*]] : $*(T, U), [[A_VALUE:%.*]] : $*T, [[B_VALUE:%.*]] : $*T, [[C_VALUE:%.*]] : $*U, [[METATYPE:%.*]] : $@thin TestGenericTuple<T, U>.Type):
   //
-  // CHECK: [[INIT_VALUE_1:%.*]] = alloc_stack $(T, U)
-  // CHECK-NEXT: [[INIT_VALUE_1_0:%.*]] = tuple_element_addr [[INIT_VALUE_1]] : $*(T, U), 0
-  // CHECK-NEXT: copy_addr [take] [[B_VALUE]] to [init] [[INIT_VALUE_1_0]]
-  // CHECK-NEXT: [[INIT_VALUE_1_1:%.*]] = tuple_element_addr [[INIT_VALUE_1]] : $*(T, U), 1
-  // CHECK-NEXT: copy_addr [take] [[C_VALUE]] to [init] [[INIT_VALUE_1_1]]
-
-  // CHECK-NEXT: [[INIT_VALUE_2:%.*]] = alloc_stack [lexical] [var_decl] $(T, (T, U))
-  // CHECK-NEXT: [[INIT_VALUE_2_0:%.*]] = tuple_element_addr [[INIT_VALUE_2]] : $*(T, (T, U)), 0
-  // CHECK-NEXT: copy_addr [take] [[A_VALUE]] to [init] [[INIT_VALUE_2_0]]
-  // CHECK-NEXT: [[INIT_VALUE_2_1:%.*]] = tuple_element_addr [[INIT_VALUE_2]] : $*(T, (T, U)), 1
-  // CHECK-NEXT: copy_addr [take] [[INIT_VALUE_1]] to [init] [[INIT_VALUE_2_1]]
+  // CHECK:      [[TUPLE:%.*]] = alloc_stack [lexical] [var_decl] $(T, (T, U))
+  // CHECK-NEXT: [[TUPLE_0:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, (T, U)), 0
+  // CHECK-NEXT: [[TUPLE_1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, (T, U)), 1
+  // CHECK-NEXT: copy_addr [take] [[A_VALUE]] to [init] [[TUPLE_0]]
+  // CHECK-NEXT: [[TUPLE_1_0:%.*]] = tuple_element_addr [[TUPLE_1]] : $*(T, U), 0
+  // CHECK-NEXT: [[TUPLE_1_1:%.*]] = tuple_element_addr [[TUPLE_1]] : $*(T, U), 1
+  // CHECK-NEXT: copy_addr [take] [[B_VALUE]] to [init] [[TUPLE_1_0]]
+  // CHECK-NEXT: copy_addr [take] [[C_VALUE]] to [init] [[TUPLE_1_1]]
 
   var data: (T, (T, U)) {
     @storageRestrictions(initializes: a, b)


### PR DESCRIPTION
This is the test case from https://github.com/swiftlang/swift/issues/69028#issuecomment-2161771611.

Parameter binding usually doesn't have an abstraction pattern that's meaningfully different from the formal types of the parameters, but it can when we're emitting a closure in an abstracted type context. A tuple parameter with a type like (repeat each T) is actually passed as a pack of elements. The binding logic handled some of the cases here, but because it was primarily type-matching on the substituted type rather than the AP, it was not properly handling the vanishing tuple case where T is a singleton pack and therefore (repeat each T) is no longer a tuple.