### PR TITLE
[Dependency Scanning] Add tracking of the number of dependency queries and emit them as remarks

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2432,6 +2432,22 @@ WARNING(dependency_scan_module_incompatible, none,
         "module file '%0' is incompatible with this Swift compiler: %1",
         (StringRef, StringRef))
 
+REMARK(dependency_scan_number_swift_queries, none,
+       "Number of Swift module queries: '%0'",
+       (uint32_t))
+REMARK(dependency_scan_number_named_clang_queries, none,
+       "Number of named Clang module queries: '%0'",
+       (uint32_t))
+REMARK(dependency_scan_number_swift_dependencies, none,
+       "Number of recorded Swift module dependencies: '%0'",
+       (uint32_t))
+REMARK(dependency_scan_number_named_clang_dependencies, none,
+       "Number of recorded Clang module dependencies queried by-name from a Swift client: '%0'",
+       (uint32_t))
+REMARK(dependency_scan_number_clang_dependencies, none,
+       "Number of recorded Clang module dependencies: '%0'",
+       (uint32_t))
+
 ERROR(clang_dependency_scan_error, none, "clang dependency scanning failure: %0", (StringRef))
 
 ERROR(clang_header_dependency_scan_error, none, "bridging header dependency scanning failure: %0", (StringRef))

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1111,6 +1111,11 @@ public:
   bool hasDependency(StringRef moduleName) const;
   /// Whether we have cached dependency information for the given Swift module.
   bool hasSwiftDependency(StringRef moduleName) const;
+  /// Report the number of recorded Clang dependencies
+  int numberOfClangDependencies() const;
+  /// Report the number of recorded Swift dependencies
+  /// (Textual + Binary)
+  int numberOfSwiftDependencies() const;
 
   const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &
   getAlreadySeenClangModules() const {

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -37,6 +37,68 @@ using ImportStatementInfoMap =
     std::unordered_map<ModuleDependencyID,
                        std::vector<ScannerImportStatementInfo>>;
 
+struct ScannerMetrics {
+  /// Number of performed queries for a Swift dependency with a given name
+  std::atomic<uint32_t> SwiftModuleQueries;
+  /// Number of performed queries for a Clang dependency with a given name
+  std::atomic<uint32_t> NamedClangModuleQueries;
+  /// Number of discovered Clang module dependencies which are directly
+  /// imported from a Swift module by-name
+  std::atomic<uint32_t> RecordedNamedClangModuleDependencies;
+};
+
+class DependencyScannerDiagnosticReporter {
+private:
+  DependencyScannerDiagnosticReporter(DiagnosticEngine &Diagnostics,
+                                      bool EmitScanRemarks);
+
+  /// Diagnose scanner failure and attempt to reconstruct the dependency
+  /// path from the main module to the missing dependency
+  void diagnoseModuleNotFoundFailure(
+      const ScannerImportStatementInfo &moduleImport,
+      const ModuleDependenciesCache &cache,
+      std::optional<ModuleDependencyID> dependencyOf,
+      std::optional<std::pair<ModuleDependencyID, std::string>>
+          resolvingSerializedSearchPath,
+      std::optional<
+          std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>>
+          foundIncompatibleCandidates = std::nullopt);
+
+  /// Upon query failure, if incompatible binary module
+  /// candidates were found, emit a failure diagnostic
+  void diagnoseFailureOnOnlyIncompatibleCandidates(
+      const ScannerImportStatementInfo &moduleImport,
+      const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
+          &candidates,
+      const ModuleDependenciesCache &cache,
+      std::optional<ModuleDependencyID> dependencyOf);
+
+  /// Emit warnings for each discovered binary Swift module
+  /// which was incompatible with the current compilation
+  /// when querying \c moduleName
+  void warnOnIncompatibleCandidates(
+      StringRef moduleName,
+      const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
+          &candidates);
+
+  /// If remark emission is enabled, increment the
+  /// corresponding metric.
+  void registerSwiftModuleQuery();
+  void registerNamedClangModuleQuery();
+  void registerNamedClangDependency();
+
+  /// Emit various metrics about the current scannig action
+  void emitScanMetrics(const ModuleDependenciesCache &cache) const;
+
+  DiagnosticEngine &Diagnostics;
+  bool EmitScanRemarks;
+  std::unique_ptr<ScannerMetrics> ScanMetrics;
+  std::unordered_set<std::string> ReportedMissing;
+  // Restrict access to the parent scanner classes.
+  friend class ModuleDependencyScanner;
+  friend class ModuleDependencyScanningWorker;
+};
+
 /// A dependency scanning worker which performs filesystem lookup
 /// of a named module dependency.
 class ModuleDependencyScanningWorker {
@@ -48,7 +110,8 @@ public:
       DependencyTracker &DependencyTracker,
       std::shared_ptr<llvm::cas::ObjectStore> CAS,
       std::shared_ptr<llvm::cas::ActionCache> ActionCache,
-      llvm::PrefixMapper *mapper, DiagnosticEngine &diags);
+      DependencyScannerDiagnosticReporter &DiagnosticReporter,
+      llvm::PrefixMapper *mapper);
 
 private:
   /// Query dependency information for a named Clang module
@@ -128,6 +191,9 @@ private:
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> ActionCache;
 
+  // The parent scanner's diagnostic reporter
+  DependencyScannerDiagnosticReporter &diagnosticReporter;
+
   // Base command line invocation for clang scanner queries (both module and header)
   std::vector<std::string> clangScanningBaseCommandLineArgs;
   // Command line invocation for clang by-name module lookups
@@ -173,46 +239,6 @@ private:
   std::map<std::string, FileEntry> TrackedFiles;
 };
 
-class ModuleDependencyIssueReporter {
-private:
-  ModuleDependencyIssueReporter(DiagnosticEngine &Diagnostics)
-      : Diagnostics(Diagnostics) {}
-
-  /// Diagnose scanner failure and attempt to reconstruct the dependency
-  /// path from the main module to the missing dependency
-  void diagnoseModuleNotFoundFailure(
-      const ScannerImportStatementInfo &moduleImport,
-      const ModuleDependenciesCache &cache,
-      std::optional<ModuleDependencyID> dependencyOf,
-      std::optional<std::pair<ModuleDependencyID, std::string>>
-          resolvingSerializedSearchPath,
-      std::optional<
-          std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>>
-          foundIncompatibleCandidates = std::nullopt);
-
-  /// Upon query failure, if incompatible binary module
-  /// candidates were found, emit a failure diagnostic
-  void diagnoseFailureOnOnlyIncompatibleCandidates(
-      const ScannerImportStatementInfo &moduleImport,
-      const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
-          &candidates,
-      const ModuleDependenciesCache &cache,
-      std::optional<ModuleDependencyID> dependencyOf);
-
-  /// Emit warnings for each discovered binary Swift module
-  /// which was incompatible with the current compilation
-  /// when querying \c moduleName
-  void warnOnIncompatibleCandidates(
-      StringRef moduleName,
-      const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
-          &candidates);
-
-  DiagnosticEngine &Diagnostics;
-  std::unordered_set<std::string> ReportedMissing;
-  // Restrict access to the parent scanner class.
-  friend class ModuleDependencyScanner;
-};
-
 class ModuleDependencyScanner {
 public:
   ModuleDependencyScanner(SwiftDependencyScanningService &ScanningService,
@@ -223,7 +249,8 @@ public:
                           DependencyTracker &DependencyTracker,
                           std::shared_ptr<llvm::cas::ObjectStore> CAS,
                           std::shared_ptr<llvm::cas::ActionCache> ActionCache,
-                          DiagnosticEngine &Diagnostics, bool ParallelScan);
+                          DiagnosticEngine &Diagnostics, bool ParallelScan,
+                          bool EmitScanRemarks);
 
   /// Identify the scanner invocation's main module's dependencies
   llvm::ErrorOr<ModuleDependencyInfo>
@@ -347,7 +374,7 @@ private:
   /// For the provided collection of unresolved imports
   /// belonging to identified Swift dependnecies, execute a parallel
   /// query to the Clang dependency scanner for each import's module identifier.
-  void performParallelClangModuleLookup(
+  void performClangModuleLookup(
       const ImportStatementInfoMap &unresolvedImportsMap,
       const ImportStatementInfoMap &unresolvedOptionalImportsMap,
       BatchClangModuleLookupResult &result);
@@ -396,7 +423,7 @@ private:
 private:
   const CompilerInvocation &ScanCompilerInvocation;
   ASTContext &ScanASTContext;
-  ModuleDependencyIssueReporter IssueReporter;
+  DependencyScannerDiagnosticReporter ScanDiagnosticReporter;
 
   /// The location of where the explicitly-built modules will be output to
   std::string ModuleOutputPath;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -399,6 +399,9 @@ public:
   /// The path at which to either serialize or deserialize the dependency scanner cache.
   std::string SerializedDependencyScannerCachePath;
 
+  /// Emit dependency scanning related remarks.
+  bool EmitDependencyScannerRemarks = false;
+
   /// Emit remarks indicating use of the serialized module dependency scanning cache.
   bool EmitDependencyScannerCacheRemarks = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -295,6 +295,9 @@ def dependency_scan_cache_path : Separate<["-"], "dependency-scan-cache-path">,
 def dependency_scan_cache_remarks : Flag<["-"], "Rdependency-scan-cache">,
   HelpText<"Emit remarks indicating use of the serialized module dependency scanning cache.">;
 
+def dependency_scan_remarks : Flag<["-"], "Rdependency-scan">,
+  HelpText<"Emit remarks for various steps taken by the dependency scanner.">;
+
 def parallel_scan : Flag<["-"], "parallel-scan">,
    HelpText<"Perform dependency scanning in-parallel.">;
 def no_parallel_scan : Flag<["-"], "no-parallel-scan">,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -772,6 +772,14 @@ bool ModuleDependenciesCache::hasSwiftDependency(StringRef moduleName) const {
   return findSwiftDependency(moduleName).has_value();
 }
 
+int ModuleDependenciesCache::numberOfClangDependencies() const {
+  return ModuleDependenciesMap.at(ModuleDependencyKind::Clang).size();
+}
+int ModuleDependenciesCache::numberOfSwiftDependencies() const {
+  return ModuleDependenciesMap.at(ModuleDependencyKind::SwiftInterface).size() +
+         ModuleDependenciesMap.at(ModuleDependencyKind::SwiftBinary).size();
+}
+
 void ModuleDependenciesCache::recordDependency(
     StringRef moduleName, ModuleDependencyInfo dependency) {
   auto dependenciesKind = dependency.getKind();
@@ -908,7 +916,6 @@ void ModuleDependenciesCache::setSwiftOverlayDependencies(
     ModuleDependencyID moduleID,
     const ArrayRef<ModuleDependencyID> dependencyIDs) {
   auto dependencyInfo = findKnownDependency(moduleID);
-  assert(dependencyInfo.getSwiftOverlayDependencies().empty());
 #ifndef NDEBUG
   for (const auto &depID : dependencyIDs)
     assert(depID.Kind != ModuleDependencyKind::Clang);
@@ -923,7 +930,6 @@ void ModuleDependenciesCache::setCrossImportOverlayDependencies(
     ModuleDependencyID moduleID,
     const ModuleDependencyIDCollectionView dependencyIDs) {
   auto dependencyInfo = findKnownDependency(moduleID);
-  assert(dependencyInfo.getCrossImportOverlayDependencies().empty());
   // Copy the existing info to a mutable one we can then replace it with,
   // after setting its overlay dependencies.
   auto updatedDependencyInfo = dependencyInfo;

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -213,16 +213,18 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     swift::DependencyTracker &DependencyTracker,
     std::shared_ptr<llvm::cas::ObjectStore> CAS,
     std::shared_ptr<llvm::cas::ActionCache> ActionCache,
-    llvm::PrefixMapper *Mapper, DiagnosticEngine &Diagnostics)
+    DependencyScannerDiagnosticReporter &DiagnosticReporter,
+    llvm::PrefixMapper *Mapper)
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
       clangScanningTool(*globalScanningService.ClangScanningService,
                         getClangScanningFS(CAS, ScanASTContext)),
-      CAS(CAS), ActionCache(ActionCache) {
+      CAS(CAS), ActionCache(ActionCache),
+      diagnosticReporter(DiagnosticReporter) {
   // Instantiate a worker-specific diagnostic engine and copy over
   // the scanner's diagnostic consumers (expected to be thread-safe).
   workerDiagnosticEngine = std::make_unique<DiagnosticEngine>(ScanASTContext.SourceMgr);
-  for (auto &scannerDiagConsumer : Diagnostics.getConsumers())
+  for (auto &scannerDiagConsumer : DiagnosticReporter.Diagnostics.getConsumers())
     workerDiagnosticEngine->addConsumer(*scannerDiagConsumer);
 
   workerASTContext = std::unique_ptr<ASTContext>(
@@ -299,6 +301,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
 SwiftModuleScannerQueryResult
 ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
     Identifier moduleName, bool isTestableImport) {
+  diagnosticReporter.registerSwiftModuleQuery();
   return swiftModuleScannerLoader->lookupSwiftModule(moduleName,
                                                      isTestableImport);
 }
@@ -309,6 +312,7 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     LookupModuleOutputCallback lookupModuleOutput,
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenModules) {
+  diagnosticReporter.registerNamedClangModuleQuery();
   auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
       moduleName.str(), clangScanningModuleCommandLineArgs,
       clangScanningWorkingDirectoryPath, alreadySeenModules,
@@ -323,7 +327,6 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
       });
     return std::nullopt;
   }
-
   return clangModuleDependencies.get();
 }
 
@@ -524,9 +527,11 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     swift::DependencyTracker &DependencyTracker,
     std::shared_ptr<llvm::cas::ObjectStore> CAS,
     std::shared_ptr<llvm::cas::ActionCache> ActionCache,
-    DiagnosticEngine &Diagnostics, bool ParallelScan)
+    DiagnosticEngine &Diagnostics, bool ParallelScan,
+    bool EmitScanRemarks)
     : ScanCompilerInvocation(ScanCompilerInvocation),
-      ScanASTContext(ScanASTContext), IssueReporter(Diagnostics),
+      ScanASTContext(ScanASTContext),
+      ScanDiagnosticReporter(Diagnostics, EmitScanRemarks),
       ModuleOutputPath(ScanCompilerInvocation.getFrontendOptions()
                        .ExplicitModulesOutputPath),
       SDKModuleOutputPath(ScanCompilerInvocation.getFrontendOptions()
@@ -557,7 +562,8 @@ ModuleDependencyScanner::ModuleDependencyScanner(
   for (size_t i = 0; i < NumThreads; ++i)
     Workers.emplace_front(std::make_unique<ModuleDependencyScanningWorker>(
         ScanningService, ScanCompilerInvocation, SILOptions, ScanASTContext,
-        DependencyTracker, CAS, ActionCache, PrefixMapper.get(), Diagnostics));
+        DependencyTracker, CAS, ActionCache, ScanDiagnosticReporter,
+        PrefixMapper.get()));
 }
 
 static std::set<ModuleDependencyID>
@@ -880,11 +886,12 @@ ModuleDependencyScanner::performDependencyScan(ModuleDependencyID rootModuleID) 
   if (ScanCompilerInvocation.getSearchPathOptions().BridgingHeaderChaining) {
     auto err = performBridgingHeaderChaining(rootModuleID, allModules);
     if (err)
-      IssueReporter.Diagnostics.diagnose(SourceLoc(),
+      ScanDiagnosticReporter.Diagnostics.diagnose(SourceLoc(),
                                          diag::error_scanner_extra,
                                          toString(std::move(err)));
   }
 
+  ScanDiagnosticReporter.emitScanMetrics(DependencyCache);
   return allModules.takeVector();
 }
 
@@ -1074,16 +1081,17 @@ void ModuleDependencyScanner::reQueryMissedModulesFromCache(
           unresolvedModuleID);
       DependencyCache.addVisibleClangModules(
           unresolvedImport.first, {unresolvedImport.second.importIdentifier});
+      ScanDiagnosticReporter.registerNamedClangDependency();
     } else {
       // Failed to resolve module dependency.
-      IssueReporter.diagnoseModuleNotFoundFailure(
+      ScanDiagnosticReporter.diagnoseModuleNotFoundFailure(
           unresolvedImport.second, DependencyCache, unresolvedImport.first,
           attemptToFindResolvingSerializedSearchPath(unresolvedImport.second));
     }
   }
 }
 
-void ModuleDependencyScanner::performParallelClangModuleLookup(
+void ModuleDependencyScanner::performClangModuleLookup(
     const ImportStatementInfoMap &unresolvedImportsMap,
     const ImportStatementInfoMap &unresolvedOptionalImportsMap,
     BatchClangModuleLookupResult &result) {
@@ -1160,6 +1168,8 @@ void ModuleDependencyScanner::cacheComputedClangModuleLookupResults(
           // Add the resolved dependency ID
           if (lookupResult.discoveredDependencyInfos.contains(
                   moduleIdentifier)) {
+            if (!DependencyCache.hasDependency(dependencyID))
+              ScanDiagnosticReporter.registerNamedClangDependency();
             auto dependencyInfo = lookupResult.discoveredDependencyInfos.at(
                 moduleImport.importIdentifier);
             allDiscoveredClangModules.insert(dependencyID);
@@ -1214,7 +1224,7 @@ void ModuleDependencyScanner::resolveAllClangModuleDependencies(
   // Execute parallel lookup of all unresolved import
   // identifiers as Clang modules.
   BatchClangModuleLookupResult lookupResult;
-  performParallelClangModuleLookup(
+  performClangModuleLookup(
       unresolvedImportsMap, unresolvedOptionalImportsMap, lookupResult);
 
   // Use the computed scan results to record directly-queried clang module
@@ -1368,7 +1378,7 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
           importedSwiftDependencies.insert(
               {moduleImport.importIdentifier,
                lookupResult.foundDependencyInfo->getKind()});
-          IssueReporter.warnOnIncompatibleCandidates(
+          ScanDiagnosticReporter.warnOnIncompatibleCandidates(
               moduleImport.importIdentifier,
               lookupResult.incompatibleCandidates);
           // Module was resolved from a cache
@@ -1377,9 +1387,9 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
           importedSwiftDependencies.insert(
               {moduleImport.importIdentifier, cachedInfo.value()->getKind()});
         else
-          IssueReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
-              moduleImport, lookupResult.incompatibleCandidates,
-              DependencyCache, std::nullopt);
+          ScanDiagnosticReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
+                     moduleImport, lookupResult.incompatibleCandidates,
+                     DependencyCache, std::nullopt);
       };
 
   for (const auto &importInfo : moduleDependencyInfo.getModuleImports())
@@ -1569,7 +1579,7 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
                                          *(lookupResult.foundDependencyInfo));
         swiftOverlayDependencies.insert(
             {moduleName, lookupResult.foundDependencyInfo->getKind()});
-        IssueReporter.warnOnIncompatibleCandidates(
+        ScanDiagnosticReporter.warnOnIncompatibleCandidates(
             moduleName, lookupResult.incompatibleCandidates);
         // Module was resolved from a cache
       } else if (auto cachedInfo =
@@ -1577,7 +1587,7 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
         swiftOverlayDependencies.insert(
             {moduleName, cachedInfo.value()->getKind()});
       else
-        IssueReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
+        ScanDiagnosticReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
             ScannerImportStatementInfo(moduleName),
             lookupResult.incompatibleCandidates, DependencyCache,
             std::nullopt);
@@ -2055,7 +2065,7 @@ ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
   return bridgedDependencyInfo;
 }
 
-void ModuleDependencyIssueReporter::diagnoseModuleNotFoundFailure(
+void DependencyScannerDiagnosticReporter::diagnoseModuleNotFoundFailure(
     const ScannerImportStatementInfo &moduleImport,
     const ModuleDependenciesCache &cache,
     std::optional<ModuleDependencyID> dependencyOf,
@@ -2166,7 +2176,7 @@ void ModuleDependencyIssueReporter::diagnoseModuleNotFoundFailure(
   ReportedMissing.insert(moduleImport.importIdentifier);
 }
 
-void ModuleDependencyIssueReporter::diagnoseFailureOnOnlyIncompatibleCandidates(
+void DependencyScannerDiagnosticReporter::diagnoseFailureOnOnlyIncompatibleCandidates(
     const ScannerImportStatementInfo &moduleImport,
     const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
         &candidates,
@@ -2195,7 +2205,14 @@ void ModuleDependencyIssueReporter::diagnoseFailureOnOnlyIncompatibleCandidates(
                                 candidates);
 }
 
-void ModuleDependencyIssueReporter::warnOnIncompatibleCandidates(
+DependencyScannerDiagnosticReporter::DependencyScannerDiagnosticReporter(
+    DiagnosticEngine &Diagnostics, bool EmitScanRemarks)
+    : Diagnostics(Diagnostics), EmitScanRemarks(EmitScanRemarks) {
+  if (EmitScanRemarks)
+    ScanMetrics = std::make_unique<ScannerMetrics>();
+}
+
+void DependencyScannerDiagnosticReporter::warnOnIncompatibleCandidates(
     StringRef moduleName,
     const std::vector<SwiftModuleScannerQueryResult::IncompatibleCandidate>
         &candidates) {
@@ -2205,6 +2222,48 @@ void ModuleDependencyIssueReporter::warnOnIncompatibleCandidates(
   for (const auto &candidate : candidates)
     Diagnostics.diagnose(SourceLoc(), diag::dependency_scan_module_incompatible,
                          candidate.path, candidate.incompatibilityReason);
+}
+
+void DependencyScannerDiagnosticReporter::registerSwiftModuleQuery() {
+  if (!EmitScanRemarks)
+    return;
+  assert(ScanMetrics);
+  ScanMetrics->SwiftModuleQueries++;
+}
+
+void DependencyScannerDiagnosticReporter::registerNamedClangModuleQuery() {
+  if (!EmitScanRemarks)
+    return;
+  assert(ScanMetrics);
+  ScanMetrics->NamedClangModuleQueries++;
+}
+
+void DependencyScannerDiagnosticReporter::registerNamedClangDependency() {
+  if (!EmitScanRemarks)
+    return;
+  assert(ScanMetrics);
+  ScanMetrics->RecordedNamedClangModuleDependencies++;
+}
+
+void DependencyScannerDiagnosticReporter::emitScanMetrics(
+    const ModuleDependenciesCache &cache) const {
+  if (!EmitScanRemarks || !ScanMetrics)
+    return;
+
+  Diagnostics.diagnose(SourceLoc(), diag::dependency_scan_number_swift_queries,
+                       ScanMetrics->SwiftModuleQueries);
+  Diagnostics.diagnose(SourceLoc(),
+                       diag::dependency_scan_number_named_clang_queries,
+                       ScanMetrics->NamedClangModuleQueries);
+  Diagnostics.diagnose(SourceLoc(),
+                       diag::dependency_scan_number_named_clang_dependencies,
+                       ScanMetrics->RecordedNamedClangModuleDependencies);
+  Diagnostics.diagnose(SourceLoc(),
+                       diag::dependency_scan_number_swift_dependencies,
+                       cache.numberOfSwiftDependencies());
+  Diagnostics.diagnose(SourceLoc(),
+                       diag::dependency_scan_number_clang_dependencies,
+                       cache.numberOfClangDependencies());
 }
 
 std::optional<std::pair<ModuleDependencyID, std::string>>

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1410,7 +1410,8 @@ performModuleScanImpl(
       instance->getASTContext(), *instance->getDependencyTracker(),
       instance->getSharedCASInstance(), instance->getSharedCacheInstance(),
       instance->getDiags(),
-      instance->getInvocation().getFrontendOptions().ParallelDependencyScan);
+      instance->getInvocation().getFrontendOptions().ParallelDependencyScan,
+      instance->getInvocation().getFrontendOptions().EmitDependencyScannerRemarks);
 
   // Identify imports of the main module and add an entry for it
   // to the dependency graph.
@@ -1462,7 +1463,9 @@ static llvm::ErrorOr<swiftscan_import_set_t> performModulePrescanImpl(
       instance->getASTContext(), *instance->getDependencyTracker(),
       instance->getSharedCASInstance(), instance->getSharedCacheInstance(),
       instance->getDiags(),
-      instance->getInvocation().getFrontendOptions().ParallelDependencyScan);
+      instance->getInvocation().getFrontendOptions().ParallelDependencyScan,
+      instance->getInvocation().getFrontendOptions().EmitDependencyScannerRemarks);
+
   // Execute import prescan, and write JSON output to the output stream
   auto mainDependencies =
       scanner.getMainModuleDependencyInfo(instance->getMainModule());

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -158,7 +158,10 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.SerializeDependencyScannerCache |= Args.hasArg(OPT_serialize_dependency_scan_cache);
   Opts.ReuseDependencyScannerCache |= Args.hasArg(OPT_reuse_dependency_scan_cache);
   Opts.ValidatePriorDependencyScannerCache |= Args.hasArg(OPT_validate_prior_dependency_scan_cache);
-  Opts.EmitDependencyScannerCacheRemarks |= Args.hasArg(OPT_dependency_scan_cache_remarks);
+  Opts.EmitDependencyScannerRemarks |= Args.hasArg(OPT_dependency_scan_remarks);
+  Opts.EmitDependencyScannerCacheRemarks |=
+      Args.hasArg(OPT_dependency_scan_cache_remarks) ||
+      Opts.EmitDependencyScannerRemarks;
   Opts.ParallelDependencyScan = Args.hasFlag(OPT_parallel_scan,
                                              OPT_no_parallel_scan,
                                              true);

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -152,7 +152,6 @@ import SubE
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-DAG:   "clang": "G"
-// CHECK-DAG:   "swift": "Swift"
 // CHECK-DAG:   "swift": "SwiftOnoneSupport"
 // CHECK: ],
 // CHECK-NEXT: "linkLibraries": [
@@ -173,10 +172,6 @@ import SubE
 /// --------Swift module E
 // CHECK: "swift": "E"
 // CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
-// CHECK: "directDependencies"
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -136,7 +136,6 @@ import SubE
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-DAG:   "clang": "G"
-// CHECK-DAG:   "swift": "Swift"
 // CHECK-DAG:   "swift": "SwiftOnoneSupport"
 // CHECK: ],
 // CHECK-NEXT: "linkLibraries": [
@@ -157,8 +156,6 @@ import SubE
 // CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 

--- a/test/ScanDependencies/Inputs/Swift/E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/E.swiftinterface
@@ -1,4 +1,3 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name E -autolink-force-load -module-link-name swiftyLibE
-import Swift
 public func funcE() { }

--- a/test/ScanDependencies/Inputs/Swift/G.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/G.swiftinterface
@@ -2,7 +2,6 @@
 // swift-module-flags: -module-name G -swift-version 5
 
 #if swift(>=5.0)
-import Swift
 @_exported import G
 public func overlayFuncG() { }
 

--- a/test/ScanDependencies/basic_query_metrics.swift
+++ b/test/ScanDependencies/basic_query_metrics.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test.swift -o %t/deps.json -I %t/inputs -Rdependency-scan &> %t/remarks.txt
+// RUN: cat %t/remarks.txt | %FileCheck %s
+
+// Ensure that despite being a common dependency to multiple Swift modules, only 1 query is performed to find 'C'
+// CHECK: remark: Number of Swift module queries: '6'
+// CHECK: remark: Number of named Clang module queries: '1'
+// CHEKC: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
+// CHECK: remark: Number of recorded Swift module dependencies: '2'
+// CHECK: remark: Number of recorded Clang module dependencies: '1'
+
+//--- test.swift
+import A
+import B
+public func test() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import C
+public func a() { }
+
+//--- inputs/B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import C
+public func b() { }
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/module.modulemap
+module C {
+  header "C.h"
+  export *
+}
+

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -2,10 +2,12 @@
 // RUN: mkdir -p %t/clang-module-cache
 
 // Run the scanner once, emitting the serialized scanner cache
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps_initial.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -enable-cross-import-overlays 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-SAVE
+// RUN: %target-swift-frontend -scan-dependencies -module-name FooReuse -module-load-mode prefer-interface -Rdependency-scan -validate-prior-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -o %t/deps_initial.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -enable-cross-import-overlays &> %t/remarks_save.txt
+// RUN: cat %t/remarks_save.txt | %FileCheck %s -check-prefix CHECK-REMARK-SAVE
 
 // Run the scanner again, but now re-using previously-serialized cache
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -enable-cross-import-overlays 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-LOAD
+// RUN: %target-swift-frontend -scan-dependencies -module-name FooReuse -module-load-mode prefer-interface -Rdependency-scan -validate-prior-dependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -enable-cross-import-overlays &> %t/remarks_load.txt
+// RUN: cat %t/remarks_load.txt | %FileCheck %s -check-prefix CHECK-REMARK-LOAD
 
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json &>/dev/null
@@ -19,13 +21,24 @@ import E
 import G
 import SubE
 
+// CHECK-REMARK-SAVE: remark: Number of named Clang module queries: '6'
+// CHECK-REMARK-SAVE: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '6'
+// CHECK-REMARK-SAVE: remark: Number of recorded Swift module dependencies: '8'
+// CHECK-REMARK-SAVE: remark: Number of recorded Clang module dependencies: '7'
 // CHECK-REMARK-SAVE: remark: Incremental module scan: Serializing module scanning dependency cache to:
-// CHECK-REMARK-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
 
-// CHECK: "mainModuleName": "deps"
+// CHECK-REMARK-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
+// FIXME: Today, we do not serialize dependencies of the main source module which results in a lookup for 'C' even though
+// it is fully redundant.
+// CHECK-REMARK-LOAD: remark: Number of named Clang module queries: '1'
+// CHECK-REMARK-LOAD: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '0'
+// CHECK-REMARK-LOAD: remark: Number of recorded Swift module dependencies: '8'
+// CHECK-REMARK-LOAD: remark: Number of recorded Clang module dependencies: '7'
+
+// CHECK: "mainModuleName": "FooReuse"
 
 /// --------Main module
-// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-LABEL: "modulePath": "FooReuse.swiftmodule",
 // CHECK-NEXT: sourceFiles
 // CHECK-NEXT: module_deps_cache_reuse.swift
 // CHECK-NEXT: ],
@@ -36,12 +49,7 @@ import SubE
 // CHECK-DAG:     "clang": "F"
 // CHECK-DAG:     "swift": "G"
 // CHECK-DAG:     "swift": "SubE"
-// CHECK-DAG:     "swift": "Swift"
-// CHECK-DAG:     "swift": "SwiftOnoneSupport"
-// CHECK-DAG:     "swift": "_Concurrency"
-// CHECK-DAG:     "swift": "_StringProcessing"
 // CHECK-DAG:     "swift": "_cross_import_E"
-// CHECK-DAG:     "clang": "_SwiftConcurrencyShims"
 // CHECK: ],
 
 // CHECK:      "contextHash":
@@ -105,9 +113,7 @@ import SubE
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
-// CHECK-DAG:     "clang": "F"
-// CHECK-DAG:     "swift": "Swift"
-// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK:     "clang": "F"
 // CHECK: ],
 
 /// --------Swift module A
@@ -116,15 +122,12 @@ import SubE
 // CHECK: directDependencies
 // CHECK-NEXT: {
 // CHECK-DAG:   "clang": "A"
-// CHECK-DAG:   "swift": "Swift"
 
 /// --------Swift module G
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-DAG:   "clang": "G"
-// CHECK-DAG:   "swift": "Swift"
-// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK:   "clang": "G"
 // CHECK: ],
 // CHECK-NEXT: "linkLibraries": [
 // CHECK-NEXT: ],
@@ -143,20 +146,5 @@ import SubE
 /// --------Swift module E
 // CHECK: "swift": "E"
 // CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
-// CHECK: "directDependencies"
-// CHECK-NEXT: {
-// CHECK: "swift": "Swift"
-
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
-
-/// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK: "clang": "SwiftShims"
-
-/// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",
-


### PR DESCRIPTION
This change adds collection of three metrics to the scanner:
- number of Swift module lookups
- number of named Clang module lookups
- recorded number of Clang modules which were imported into a Swift module by name

It re-uses the prior '-Rdependency-scan-cache', renaming it to '-Rdependency-scan' and adds emission of the above metrics as remarks when this flag is enabled. Followup changes will add further remarks about dependency scanner progress.
