### PR TITLE
SuppressedAssociatedTypesWithDefaults: make scoping pay attention to root

### DIFF
--- a/lib/AST/RequirementMachine/ApplyInverses.cpp
+++ b/lib/AST/RequirementMachine/ApplyInverses.cpp
@@ -204,7 +204,8 @@ void swift::rewriting::applyInverses(
     //       func f() where Self: ~Copyable
     //     }
     //
-    if (representativeGPs.find(canSubject) == representativeGPs.end()) {
+    auto subjectRoot = canSubject->getDependentMemberRoot()->getCanonicalType();
+    if (representativeGPs.find(subjectRoot) == representativeGPs.end()) {
       errors.push_back(
           RequirementError::forInvalidInverseOuterSubject(inverse));
       continue;

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -156,10 +156,8 @@ protocol Veggie<A> {
 }
 protocol Carrot: Veggie
   where Self.NeedsCopyable: ~Copyable {} // expected-error {{'Self.NeedsCopyable' required to be 'Copyable' but is marked with '~Copyable'}}
-  // expected-error @-1{{cannot suppress '~Copyable' on generic parameter 'Self.NeedsCopyable' defined in outer scope}}
 
 protocol CarrotCake: Carrot where Self.A: ~Copyable {} // expected-error {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
-// expected-error @-1{{cannot suppress '~Copyable' on generic parameter 'Self.A' defined in outer scope}}
 
 func ex1<Cucumber: ~Copyable, Potato>(_ nc: any Veggie<Cucumber>, c: any Veggie<Potato>) {
   reqC(nc.a()) // expected-error {{global function 'reqC' requires that 'Cucumber' conform to 'Copyable'}}
@@ -171,8 +169,6 @@ protocol Bird {
 }
 
 protocol Eagle: Bird where Self.Song: ~Copyable {}// expected-error {{'Self.Song' required to be 'Copyable' but is marked with '~Copyable'}}
-// expected-error @-1{{cannot suppress '~Copyable' on generic parameter 'Self.Song' defined in outer scope}}
-
 
 protocol Pushable<Element> {
   associatedtype Element: ~Copyable

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -53,7 +53,7 @@ protocol Iterable<Element>: ~Copyable {
 
 struct ReqC<T: Copyable> {}
 
-func reqC<T: Copyable>(_ t: T) {} // expected-note 8{{'where T: Copyable' is implicit here}}
+func reqC<T: Copyable>(_ t: T) {} // expected-note 14{{'where T: Copyable' is implicit here}}
 
 
 protocol ProvideA<A>: ~Copyable {
@@ -130,9 +130,29 @@ func checkExistential(_ s: any Gen) {
   reqC(s.i().e().i().e())
 }
 
+func checkExistential2<R: ~Copyable>(_ s: any Gen<R>) {
+  reqC(s.e()) // expected-error {{global function 'reqC' requires that 'R' conform to 'Copyable'}}
+  reqC(s.e().e()) // expected-error {{value of type 'R' has no member 'e'}}
+
+  reqC(s.i()) // expected-error {{requires that 'T' conform to 'Copyable'}}
+  reqC(s.i().e())
+  reqC(s.i().e().i()) // expected-error {{requires that 'T' conform to 'Copyable'}}
+  reqC(s.i().e().i().e())
+}
+
+// Suppression on the constrained existential only goes far down
+// as possible to suppress on the generic type parameter itself.
+func checkExistential3<R>(_ s: any Gen<R>) where R: Gen, R: ~Copyable, R.E: ~Copyable {
+  reqC(s.e()) // expected-error {{global function 'reqC' requires that 'R' conform to 'Copyable'}}
+  reqC(s.e().e()) // expected-error {{global function 'reqC' requires that 'R.E' conform to 'Copyable'}}
+  reqC(s.e().e().e())
+}
+
 protocol Veggie<A> {
   associatedtype A: ~Copyable
   associatedtype NeedsCopyable
+
+  func a() -> A
 }
 protocol Carrot: Veggie
   where Self.NeedsCopyable: ~Copyable {} // expected-error {{'Self.NeedsCopyable' required to be 'Copyable' but is marked with '~Copyable'}}
@@ -141,6 +161,10 @@ protocol Carrot: Veggie
 protocol CarrotCake: Carrot where Self.A: ~Copyable {} // expected-error {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
 // expected-error @-1{{cannot suppress '~Copyable' on generic parameter 'Self.A' defined in outer scope}}
 
+func ex1<Cucumber: ~Copyable, Potato>(_ nc: any Veggie<Cucumber>, c: any Veggie<Potato>) {
+  reqC(nc.a()) // expected-error {{global function 'reqC' requires that 'Cucumber' conform to 'Copyable'}}
+  reqC(c.a())
+}
 
 protocol Bird {
   associatedtype Song

--- a/test/Generics/inverse_extensions.swift
+++ b/test/Generics/inverse_extensions.swift
@@ -16,8 +16,7 @@ protocol HasAssoc {
   associatedtype A
 }
 extension HasAssoc where Self.A: ~Copyable {}
-// expected-error@-1 {{cannot suppress '~Copyable' on generic parameter 'Self.A' defined in outer scope}}
-// expected-error@-2 {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
+// expected-error@-1 {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
 
 class Box<T: ~Copyable> {}
 extension Box where T: ~Copyable {}


### PR DESCRIPTION
The scoping rule with `SuppressedAssociatedTypes*` is too eagerly complaining about invalid scopes. We'll diagnose invalid suppressions anyway in that case.