### PR TITLE
[Concurrency] Add Swift Task Stealers

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2701,6 +2701,7 @@ enum class JobKind : size_t {
   DefaultActorOverride,
   NullaryContinuation,
   IsolatedDeinit,
+  TaskStealer,
 };
 
 /// The priority of a job.  Higher priorities are larger values.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -78,6 +78,13 @@ extern const HeapMetadata *jobHeapMetadataPtr;
 extern const HeapMetadata *taskHeapMetadataPtr;
 
 /// A schedulable job.
+///
+/// In general, the header fields of a Job that is currently enqueued
+/// must not be mutated. The executor owns that memory and expects
+/// it to be immutable or (in the case of the schedule-private
+/// storage) under its control until it dequeues the job. Once the
+/// executor calls swift_job_run, the job regains ownership of the
+/// header fields and is generally permitted to change them again.
 class alignas(2 * alignof(void*)) Job :
   // For async-let tasks, the refcount bits are initialized as "immortal"
   // because such a task is allocated with the parent's stack allocator.
@@ -85,9 +92,6 @@ class alignas(2 * alignof(void*)) Job :
 public:
   // Indices into SchedulerPrivate, for use by the runtime.
   enum {
-    /// The next waiting task link, an AsyncTask that is waiting on a future.
-    NextWaitingTaskIndex = 0,
-
     // The Dispatch object header is one pointer and two ints, which is
     // equivalent to three pointers on 32-bit and two pointers 64-bit. Set the
     // indexes accordingly so that DispatchLinkageIndex points to where Dispatch
@@ -102,7 +106,13 @@ public:
     DispatchQueueIndex = DispatchHasLongObjectHeader ? 0 : 1,
   };
 
-  // Reserved for the use of the scheduler.
+  // This field is reserved for the use of the scheduler between:
+  // - When someone passes the job to the executor's enqueue
+  // - When the executor either enqueues the job to
+  //   another executor or passes it to swift_job_run
+  // Note that this is tied to the lifecycle of the Job. If
+  // this Job is a Task, this field may still be reserved for
+  // the Job's executor at any time in the Task's lifecycle
   void *SchedulerPrivate[2];
 
   /// WARNING: DO NOT MOVE.
@@ -190,6 +200,10 @@ public:
   void runSimpleInFullyEstablishedContext() {
     return RunJob(this); // 'return' forces tail call
   }
+
+  /// Gets the 32-bit Job ID from the job or the 64-bit
+  /// Task ID if this is an AsyncTask or AsyncTaskStealer
+  uint64_t getJobTaskId() const;
 };
 
 // The compiler will eventually assume these.
@@ -299,6 +313,31 @@ struct ResultTypeInfo {
 ///
 /// * The future fragment is dynamic in size, based on the future result type
 ///   it can hold, and thus must be the *last* fragment.
+///
+/// Since Tasks are often repeatedly enqueued as Jobs, some extra care must
+/// be taken with them because of the runtime's use of TaskStealer Jobs.
+/// When a Task's priority is increased while it is enqueued, the runtime
+/// will enqueue a Job with the higher priority on the same executor to
+/// try to take over the responsibility of running the task. Because the
+/// Task may have started running on behalf of a TaskStealer Job, the Task
+/// object (considered as a Job) may still be enqueued on some executor
+/// even while the Task is logically running, suspended, or complete.
+/// This also means that regular enqueues to resume the Task may enqueue a
+/// TaskStealer Job instead and enqueues to escalate priority may enqueue
+/// the Task's Job if it is available. So while code that's acting on
+/// behalf of the current running Task is free to assume exclusive access
+/// to most of the Task structure, it cannot generally modify the Task's Job
+/// header unless it knows that the Task object is not presently enqueued
+/// as a Job this way. (This is tracked dynamically in the task status.)
+///
+/// However, an important exception to that rule exists for the task resume
+/// function and context. Importantly, these fields are not directly accessed by
+/// executors. Tasks and task stealer jobs coordinate so that only one of them
+/// will advance the task at once. This coordination establishes a rule that any
+/// outstanding jobs (possibly including the Task itself) that were enqueued
+/// for previous suspensions of the task will never actually start running
+/// long enough to access these fields. As a result, code running on behalf
+/// of the current task can freely set the resume fields before suspending.
 class AsyncTask : public Job {
 public:
   // On 32-bit targets, there is a word of tail padding remaining
@@ -394,7 +433,7 @@ public:
 
   /// Set the task's ID field to the next task ID.
   void setTaskId();
-  uint64_t getTaskId();
+  uint64_t getTaskId() const;
 
   /// Get the task's resume function, for logging purposes only. This will
   /// attempt to see through the various adapters that are sometimes used, and
@@ -416,6 +455,57 @@ public:
     return ResumeTask(ResumeContext); // 'return' forces tail call
   }
 
+  // An exclusion value is a token that represents if a Job is allowed
+  // to invoke a Task. It generally shouldn't be observed or manipulated
+  // outside of tryStartRunning and swift_task_enqueueSelfOrStealer
+  struct ExclusionValue {
+    uint8_t value;
+
+    bool operator==(ExclusionValue const &other) const noexcept {
+      return value == other.value;
+    }
+    bool operator!=(ExclusionValue const &other) const noexcept {
+      return value != other.value;
+    }
+  };
+
+  enum InvokeFlags : uint32_t {
+    InvokeFlagsFromTask = 0x00,
+    InvokeFlagsFromStealer = 0x01,
+  };
+  /// Try to flag that the current thread is going to run this task.
+  /// If there are multiple jobs trying to run the task, this requires
+  /// claiming the right to run the task, which can fail if another job
+  /// wins the race. This may also require increasing changing the priority
+  /// of the current thread, if the current task executor supports that.
+  ///
+  /// Generally, this should be done immediately after updating ActiveTask.
+  ///
+  /// allowedExclusionValue is the local exclusion value of the Job invoking
+  /// this Task. For the Task's Job, this is LocalStealerExclusionValue from
+  /// the Task's private data. For a TaskStealer Job, this is ExclusionValue.
+  ///
+  /// invokeFlags is what type of Job is invoking this
+  /// Task. It's either InvokeFlagsFromTask for the Task's
+  /// Job or InvokeFlagsFromStealer for a TaskStealer Job.
+  ///
+  /// The first (bool) return value is the sucess of this call.
+  /// If this return value is false, the caller should not finish
+  /// establishing the context to run the Task and must not run the Task.
+  ///
+  /// The second return value is an opaque value used to restore the state of
+  /// the thread before returning to the context invoking this Task (either the
+  /// executor or the caller of Task.immediate). When flagAsRunning succeeds,
+  /// Dispatch is the default executor, and priority escalation is enabled,
+  /// this value must be passed to swift_dispatch_thread_reset_override_self.
+  ///
+  /// This function is for when the task starts running after fully suspending.
+  /// If a task starts to suspend itself, but then finds out that it didn't
+  /// need to, it should instead call resumeRunningAfterFailedSuspend,
+  /// which avoids a lot of the extra complexity of this operation.
+  std::pair<bool, uint32_t>
+  tryStartRunning(ExclusionValue allowedExclusionValue,
+                  InvokeFlags invokeFlags = InvokeFlagsFromTask);
   /// A task can have the following states:
   ///   * suspended: In this state, a task is considered not runnable
   ///   * enqueued: In this state, a task is considered runnable
@@ -430,30 +520,17 @@ public:
   ///       running -> completed
   ///       running -> enqueued
   ///
-  /// The 4 methods below are how a task switches from one state to another.
+  /// The methods below are how a task switches from one state to another.
 
-  /// Flag that this task is now running.  This can update
-  /// the priority stored in the job flags if the priority has been
-  /// escalated.
-  ///
-  /// Generally this should be done immediately after updating
-  /// ActiveTask.
-  ///
-  /// When Dispatch is used for the default executor:
-  /// * If the return value is non-zero, it must be passed
-  ///   to swift_dispatch_thread_reset_override_self
-  ///   before returning to the executor.
-  /// * If the return value is zero, it may be ignored or passed to
-  ///   the aforementioned function (which will ignore values of zero).
-  /// The current implementation will always return zero
-  /// if you call flagAsRunning again before calling
-  /// swift_dispatch_thread_reset_override_self with the
-  /// initial value. This supports suspending and immediately
-  /// resuming a Task without returning up the callstack.
-  ///
-  /// For all other default executors, flagAsRunning
-  /// will return zero which may be ignored.
-  uint32_t flagAsRunning();
+  /// This variant may be called if you are resuming immediately
+  /// after suspending. That is, you are on the same thread, you
+  /// have not enqueued onto any executor, and you have not called
+  /// swift_dispatch_thread_reset_override_self or done any other
+  /// cleanup work. This is intended for situations such as awaiting
+  /// where you may mark yourself as suspended but find out during
+  /// atomic state update that you may actually resume immediately.
+  void resumeRunningAfterFailedSuspend(
+      InvokeFlags invokeFlags = InvokeFlagsFromTask);
 
   /// Flag that this task is now suspended with information about what it is
   /// waiting on.
@@ -465,6 +542,8 @@ private:
   // Helper function
   void flagAsSuspended(TaskDependencyStatusRecord *dependencyStatusRecord);
   void destroyTaskDependency(TaskDependencyStatusRecord *dependencyRecord);
+  uint32_t taskFlagAsRunningWithoutDependency(InvokeFlags invokeFlags);
+  void taskRemoveEnqueued();
 
 public:
   /// Flag that the task is to be enqueued on the provided executor and actually
@@ -874,12 +953,10 @@ public:
   }
 
 private:
-  /// Access the next waiting task, which establishes a singly linked list of
-  /// tasks that are waiting on a future.
-  AsyncTask *&getNextWaitingTask() {
-    return reinterpret_cast<AsyncTask *&>(
-        SchedulerPrivate[NextWaitingTaskIndex]);
-  }
+  /// Access the next waiting task, which establishes a singly linked
+  /// list of tasks that are waiting on a future. This function
+  /// assumes that this Task is suspended waiting on a another Task.
+  AsyncTask *&getNextWaitingTask();
 };
 
 // The compiler will eventually assume these.

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -394,36 +394,34 @@ class TaskDependencyStatusRecord : public TaskStatusRecord {
     EnqueuedOnExecutor,
   } DependencyKind;
 
-  // The task that has this task status record - ie a backpointer from the
-  // record to the task with the record. This is not its own +1, we rely on the
-  // fact that since this status record is linked into a task, the task is
-  // already alive and maintained by someone and we can safely borrow the
-  // reference.
-  AsyncTask *WaitingTask;
+  // When the dependency kind is waiting on Task, this pointer contains
+  // the next link in the wait queue of the Task it is waiting on. This
+  // pointer should only be used through the wait queue's functions.
+  AsyncTask *NextWaitingTask;
 
 public:
-  TaskDependencyStatusRecord(AsyncTask *waitingTask, AsyncTask *task) :
-    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnTask), WaitingTask(waitingTask) {
-      DependentOn.Task = task;
+  TaskDependencyStatusRecord(AsyncTask *task)
+      : TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnTask) {
+    DependentOn.Task = task;
   }
 
-  TaskDependencyStatusRecord(AsyncTask *waitingTask, ContinuationAsyncContext *context) :
-    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnContinuation), WaitingTask(waitingTask) {
-      DependentOn.Continuation = context;
+  TaskDependencyStatusRecord(ContinuationAsyncContext *context)
+      : TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnContinuation) {
+    DependentOn.Continuation = context;
   }
 
-  TaskDependencyStatusRecord(AsyncTask *waitingTask, TaskGroup *taskGroup) :
-    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnTaskGroup), WaitingTask(waitingTask){
-      DependentOn.TaskGroup = taskGroup;
+  TaskDependencyStatusRecord(TaskGroup *taskGroup)
+      : TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnTaskGroup) {
+    DependentOn.TaskGroup = taskGroup;
   }
 
-  TaskDependencyStatusRecord(AsyncTask *waitingTask, SerialExecutorRef executor) :
-    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(EnqueuedOnExecutor), WaitingTask(waitingTask) {
-      DependentOn.Executor = executor;
+  TaskDependencyStatusRecord(SerialExecutorRef executor)
+      : TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(EnqueuedOnExecutor) {
+    DependentOn.Executor = executor;
   }
 
   static bool classof(const TaskStatusRecord *record) {
@@ -435,8 +433,11 @@ public:
     DependentOn.Executor = executor;
   }
 
-  void performEscalationAction(
-      JobPriority oldPriority, JobPriority newPriority);
+  void performEscalationAction(AsyncTask *task, JobPriority oldPriority,
+                               JobPriority newPriority);
+
+  // Assumes that this record is of kind WaitingOnTask
+  AsyncTask *&getNextWaitingTask();
 };
 
 } // end namespace swift

--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -15,6 +15,15 @@
 
 #include "Concurrency.h"
 
+// The values in this struct should be considered opaque
+struct swift_dispatch_priority_token_s {
+  uint32_t priority;
+
+#if __cplusplus
+  bool isSet() const noexcept { return priority != 0; }
+#endif
+};
+
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
 #include <dispatch/swift_concurrency_private.h>
 
@@ -57,13 +66,17 @@ swift_dispatch_thread_override_self(qos_class_t override_qos) {
   return 0;
 }
 
-static inline uint32_t
-swift_dispatch_thread_override_self_with_base(qos_class_t override_qos, qos_class_t base_qos) {
+static inline struct swift_dispatch_priority_token_s
+swift_dispatch_thread_override_self_with_base(qos_class_t override_qos,
+                                              qos_class_t base_qos) {
+  struct swift_dispatch_priority_token_s token = {};
 
 #if DISPATCH_SWIFT_CONCURRENCY_PRIVATE_INTERFACE_VERSION >= 1
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
-    return dispatch_thread_override_self_with_base(override_qos, base_qos);
-  } else
+    token.priority =
+        dispatch_thread_override_self_with_base(override_qos, base_qos);
+    return token;
+  }
 #endif
   if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
     // If we don't have the ability to set our base qos correctly, at least set the override
@@ -71,15 +84,15 @@ swift_dispatch_thread_override_self_with_base(qos_class_t override_qos, qos_clas
     (void) dispatch_thread_override_self(override_qos);
   }
 
-  return 0;
+  return token;
 }
 
-static inline void
-swift_dispatch_thread_reset_override_self(uint32_t opaque) {
+static inline void swift_dispatch_thread_reset_override_self(
+    struct swift_dispatch_priority_token_s opaque) {
 
 #if DISPATCH_SWIFT_CONCURRENCY_PRIVATE_INTERFACE_VERSION >= 1
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
-    dispatch_thread_reset_override_self(opaque);
+    dispatch_thread_reset_override_self(opaque.priority);
   }
 #endif
 }

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -16,6 +16,7 @@
 ///===----------------------------------------------------------------------===///
 
 #include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/DispatchShims.h"
 #include <atomic>
 #include <new>
 #if __has_feature(ptrauth_calls)
@@ -212,6 +213,41 @@ ExecutorTrackingInfo::ActiveInfoInThread;
 
 } // end anonymous namespace
 
+/// This function establishes the Task's context and attempts to invoke
+/// it. The invocation may fail and the Task may not be run if the
+/// passed in exclusion value is not what is in the ActiveTaskStatus
+/// during the cas loop to mark the Task as running. If Task
+/// priority escalation is not enabled, this will always succeed.
+SWIFT_ALWAYS_INLINE
+static inline void taskInvokeWithExclusionValue(
+    AsyncTask *task, SerialExecutorRef serialExecutor,
+    TaskExecutorRef taskExecutor,
+    AsyncTask::ExclusionValue allowedStealerExclusionValue,
+    AsyncTask::InvokeFlags invokeFlags = AsyncTask::InvokeFlagsFromTask) {
+  // Update the task status to say that it's running on the current
+  // thread.  If the task suspends somewhere, it should update the
+  // task status appropriately; we don't need to update it afterwards.
+  [[maybe_unused]] auto [mayRun, dispatchOpaquePriority] =
+      task->tryStartRunning(allowedStealerExclusionValue, invokeFlags);
+  if (mayRun) {
+    // Update the active task in the current thread.
+    auto oldTask = ActiveTask::swap(task);
+
+    auto traceHandle =
+        concurrency::trace::job_run_begin(task, serialExecutor, taskExecutor);
+    task->runInFullyEstablishedContext();
+    concurrency::trace::job_run_end(traceHandle);
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    swift_dispatch_thread_reset_override_self(dispatchOpaquePriority);
+#endif
+
+    assert(ActiveTask::get() == nullptr &&
+           "active task wasn't cleared before suspending?");
+    if (oldTask) ActiveTask::set(oldTask);
+  }
+}
+
 void swift::runJobInEstablishedExecutorContext(Job *job,
                                                SerialExecutorRef serialExecutor,
                                                TaskExecutorRef taskExecutor) {
@@ -223,28 +259,9 @@ void swift::runJobInEstablishedExecutorContext(Job *job,
 #endif
 
   if (auto task = dyn_cast<AsyncTask>(job)) {
-    // Update the active task in the current thread.
-    auto oldTask = ActiveTask::swap(task);
-
-    // Update the task status to say that it's running on the
-    // current thread.  If the task suspends somewhere, it should
-    // update the task status appropriately; we don't need to update
-    // it afterwards.
-    [[maybe_unused]]
-    uint32_t dispatchOpaquePriority = task->flagAsRunning();
-
-    auto traceHandle =
-        concurrency::trace::job_run_begin(job, serialExecutor, taskExecutor);
-    task->runInFullyEstablishedContext();
-    concurrency::trace::job_run_end(traceHandle);
-
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    swift_dispatch_thread_reset_override_self(dispatchOpaquePriority);
-#endif
-
-    assert(ActiveTask::get() == nullptr &&
-           "active task wasn't cleared before suspending?");
-    if (oldTask) ActiveTask::set(oldTask);
+    taskInvokeWithExclusionValue(task, serialExecutor, taskExecutor,
+                                 task->_private().LocalStealerExclusionValue,
+                                 AsyncTask::InvokeFlagsFromTask);
   } else {
     // There's no extra bookkeeping to do for simple jobs besides swapping in
     // the voucher.
@@ -255,6 +272,25 @@ void swift::runJobInEstablishedExecutorContext(Job *job,
 #if SWIFT_OBJC_INTEROP
   objc_autoreleasePoolPop(pool);
 #endif
+}
+
+/// Runs the Task embedded in the stealer using the stealer's exclusion value.
+/// The stealer holds a reference to the Task which is released here. Stealers
+/// are not reference counted so the object is directly destroyed here.
+inline void AsyncTaskStealer::process(Job *_job) {
+  auto *stealer = cast<AsyncTaskStealer>(_job);
+  SWIFT_TASK_DEBUG_LOG("Running stealer %p for Task %p", _job, stealer->Task);
+
+  auto *trackingInfo = ExecutorTrackingInfo::current();
+
+  taskInvokeWithExclusionValue(stealer->Task, trackingInfo->getActiveExecutor(),
+                               trackingInfo->getTaskExecutor(),
+                               stealer->ExclusionValue,
+                               AsyncTask::InvokeFlagsFromStealer);
+
+  swift_release(stealer->Task);
+
+  swift_cxx_deleteObject(stealer);
 }
 
 void swift::adoptTaskVoucher(AsyncTask *task) {
@@ -1514,6 +1550,9 @@ TaskExecutorRef TaskExecutorRef::fromTaskExecutorPreference(Job *job) {
   if (auto task = dyn_cast<AsyncTask>(job)) {
     return task->getPreferredTaskExecutor();
   }
+  if (auto stealer = dyn_cast<AsyncTaskStealer>(job)) {
+    return stealer->Task->getPreferredTaskExecutor();
+  }
   return TaskExecutorRef::undefined();
 }
 
@@ -1871,11 +1910,8 @@ static void defaultActorDrain(DefaultActorImpl *actor) {
         break;
       }
     } else {
-      auto taskExecutor = TaskExecutorRef::undefined();
-      if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-        taskExecutor = task->getPreferredTaskExecutor();
-        trackingInfo.setTaskExecutor(taskExecutor);
-      }
+      auto taskExecutor = TaskExecutorRef::fromTaskExecutorPreference(job);
+      trackingInfo.setTaskExecutor(taskExecutor);
 
       // This thread is now going to follow the task on this actor.
       // It may hop off the actor
@@ -2493,6 +2529,15 @@ static void runOnAssumedThread(AsyncTask *task, SerialExecutorRef executor,
     asImpl(executor.getDefaultActor())->unlock(true);
 }
 
+#if SWIFT_TASK_DEBUG_LOG_ENABLED
+static inline const char *safeGetIdentityDebugName(SerialExecutorRef exec) {
+  if (exec.isGeneric())
+    return exec.isForSynchronousStart() ? " (GenericExecutor/SynchronousStart)"
+                                        : " (GenericExecutor)";
+  return "";
+}
+#endif
+
 SWIFT_CC(swiftasync)
 static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
                                   TaskContinuationFunction *resumeFunction,
@@ -2507,17 +2552,15 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   auto currentTaskExecutor = (trackingInfo ? trackingInfo->getTaskExecutor()
                                            : TaskExecutorRef::undefined());
   auto newTaskExecutor = task->getPreferredTaskExecutor();
-  SWIFT_TASK_DEBUG_LOG("Task %p trying to switch executors: executor %p%s to "
-                       "new serial executor: %p%s; task executor: from %p%s to %p%s",
-                       task,
-                       currentExecutor.getIdentity(),
-                       currentExecutor.getIdentityDebugName(),
-                       newExecutor.getIdentity(),
-                       newExecutor.getIdentityDebugName(),
-                       currentTaskExecutor.getIdentity(),
-                       currentTaskExecutor.isDefined() ? "" : " (undefined)",
-                       newTaskExecutor.getIdentity(),
-                       newTaskExecutor.isDefined() ? "" : " (undefined)");
+  SWIFT_TASK_DEBUG_LOG(
+      "Task %p trying to switch executors: executor %p%s to "
+      "new serial executor: %p%s; task executor: from %p%s to %p%s",
+      task, currentExecutor.getIdentity(),
+      safeGetIdentityDebugName(currentExecutor), newExecutor.getIdentity(),
+      newExecutor.getIdentityDebugName(), currentTaskExecutor.getIdentity(),
+      currentTaskExecutor.isDefined() ? "" : " (undefined)",
+      newTaskExecutor.getIdentity(),
+      newTaskExecutor.isDefined() ? "" : " (undefined)");
 
   // If the current executor is compatible with running the new executor,
   // we can just immediately continue running with the resume function
@@ -2732,13 +2775,11 @@ extern "C" SWIFT_CC(swift) void _swift_task_makeAnyTaskExecutor(
 SWIFT_CC(swift)
 static void swift_task_enqueueImpl(Job *job, SerialExecutorRef serialExecutorRef) {
 #ifndef NDEBUG
-  auto _taskExecutorRef = TaskExecutorRef::undefined();
-  if (auto task = dyn_cast<AsyncTask>(job)) {
-    _taskExecutorRef = task->getPreferredTaskExecutor();
-  }
-  SWIFT_TASK_DEBUG_LOG("enqueue job %p on serial serialExecutor %p, taskExecutor = %p", job,
-                       serialExecutorRef.getIdentity(),
-                       _taskExecutorRef.getIdentity());
+  [[maybe_unused]]
+  auto _taskExecutorRef = TaskExecutorRef::fromTaskExecutorPreference(job);
+  SWIFT_TASK_DEBUG_LOG(
+      "enqueue job %p on serial serialExecutor %p, taskExecutor = %p", job,
+      serialExecutorRef.getIdentity(), taskExecutorRef.getIdentity());
 #endif
 
   assert(job && "no job provided");
@@ -2748,22 +2789,19 @@ static void swift_task_enqueueImpl(Job *job, SerialExecutorRef serialExecutorRef
   _swift_tsan_release(job);
 
   if (serialExecutorRef.isGeneric()) {
-    if (auto task = dyn_cast<AsyncTask>(job)) {
-      auto taskExecutorRef = task->getPreferredTaskExecutor();
-      if (taskExecutorRef.isDefined()) {
+    auto taskExecutorRef = TaskExecutorRef::fromTaskExecutorPreference(job);
+    if (taskExecutorRef.isDefined()) {
 #if SWIFT_CONCURRENCY_EMBEDDED
-        swift_unreachable("task executors not supported in embedded Swift");
+      swift_unreachable("task executors not supported in embedded Swift");
 #else
-        auto taskExecutorIdentity = taskExecutorRef.getIdentity();
-        auto taskExecutorType = swift_getObjectType(taskExecutorIdentity);
-        auto taskExecutorWtable = taskExecutorRef.getTaskExecutorWitnessTable();
+      auto taskExecutorIdentity = taskExecutorRef.getIdentity();
+      auto taskExecutorType = swift_getObjectType(taskExecutorIdentity);
+      auto taskExecutorWtable = taskExecutorRef.getTaskExecutorWitnessTable();
 
-        return _swift_task_enqueueOnTaskExecutor(
-            job,
-            taskExecutorIdentity, taskExecutorType, taskExecutorWtable);
+      return _swift_task_enqueueOnTaskExecutor(
+          job, taskExecutorIdentity, taskExecutorType, taskExecutorWtable);
 #endif // SWIFT_CONCURRENCY_EMBEDDED
-      } // else, fall-through to the default global enqueue
-    }
+    } // else, fall-through to the default global enqueue
     return swift_task_enqueueGlobal(job);
   }
 
@@ -2799,13 +2837,33 @@ swift_actor_escalate(DefaultActorImpl *actor, AsyncTask *task, JobPriority newPr
 SWIFT_CC(swift)
 void swift::swift_executor_escalate(SerialExecutorRef executor, AsyncTask *task,
   JobPriority newPriority) {
-  if (executor.isGeneric()) {
-    // TODO (rokhinip): We'd push a stealer job for the task on the executor.
-    return;
-  }
+  SWIFT_TASK_DEBUG_LOG("Escalating executor %p to %#x",
+                       (void *)executor.getIdentity(), newPriority);
 
   if (executor.isDefaultActor()) {
     return swift_actor_escalate(asImpl(executor.getDefaultActor()), task, newPriority);
+  }
+
+  // If the task is enqueued on any other executor, we can enqueue
+  // a task stealer job on that executor. For now, don't do this if it's
+  // a custom executor, just in case the custom executor has a
+  // problem with enqueuing non-task jobs.
+  if (executor.isGeneric() && !task->hasTaskExecutorPreferenceRecord()) {
+    SWIFT_TASK_DEBUG_LOG("Enqueuing stealer for %p on %p", (void *)task,
+                         (void *)executor.getIdentity());
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    // Even though we are in the "enqueue stealer" path, this could
+    // enqueue the original Task if another stealer had previously
+    // been enqueued and still is but the original Task did manage to
+    // run at some point (while rare, this wouldn't be unexpected)
+    //
+    // Because this is in the escalation path, this stealer is being added
+    // in order to escalate the Task while it is enqueued on an executor
+    // so it is only an optimization and not manditory like the normal
+    // enqueue path is
+    swift_task_enqueueSelfOrStealer(task, executor, EnqueueFlagsForEscalation);
+#endif
+    return;
   }
 
   // TODO (rokhinip): This is either the main actor or an actor with a custom

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -185,9 +185,11 @@ void swift::swift_asyncLet_begin(AsyncLet *alet,
                                  void *closureEntryPoint,
                                  HeapObject *closureContext,
                                  void *resultBuffer) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   SWIFT_TASK_DEBUG_LOG("creating async let buffer of type %s at %p",
                        swift_getTypeName(futureResultType, true).data,
                        resultBuffer);
+#endif
 
   auto flags = TaskCreateFlags();
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL

--- a/stdlib/public/Concurrency/ExecutorImpl.h
+++ b/stdlib/public/Concurrency/ExecutorImpl.h
@@ -100,12 +100,10 @@ typedef struct {
 
 /// Indexes in the schedulerPrivate array
 enum {
-  SwiftJobNextWaitingTaskIndex = 0,
-
   // These are only relevant for the Dispatch executor
   SwiftJobDispatchHasLongObjectHeader = sizeof(void *) == sizeof(int),
   SwiftJobDispatchLinkageIndex = SwiftJobDispatchHasLongObjectHeader ? 1 : 0,
-  SwiftJobDispatchQueueIndex = SwiftJobDispatchHasLongObjectHeader? 0 : 1
+  SwiftJobDispatchQueueIndex = SwiftJobDispatchHasLongObjectHeader ? 0 : 1
 };
 
 /// Get the kind of a job, by directly accessing the flags field.

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -141,14 +141,7 @@ bool swift::swift_executor_isComplexEquality(SerialExecutorRef ref) {
 }
 
 uint64_t swift::swift_task_getJobTaskId(Job *job) {
-  if (auto task = dyn_cast<AsyncTask>(job)) {
-    // TaskID is actually:
-    //   32bits of Job's Id
-    // + 32bits stored in the AsyncTask
-    return task->getTaskId();
-  } else {
-    return job->getJobId();
-  }
+  return job->getJobTaskId();
 }
 
 extern "C" void *swift_job_alloc(SwiftJob *job, size_t size) {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -132,12 +132,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
                            waitingTask, this);
       _swift_tsan_acquire(static_cast<Job *>(this));
       if (suspendedWaiter) {
-        // This will always return zero because we were just
-        // running this Task so its BasePriority (which is
-        // immutable) should've already been set on the thread.
-        [[maybe_unused]]
-        uint32_t opaque = waitingTask->flagAsRunning();
-        assert(opaque == 0);
+        waitingTask->resumeRunningAfterFailedSuspend();
       }
       // The task is done; we don't need to wait.
       return queueHead.getStatus();
@@ -188,7 +183,8 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
 #else
     // Put the waiting task at the beginning of the wait queue.
     // NOTE: this acquire-release synchronizes with `completeFuture`.
-    waitingTask->getNextWaitingTask() = queueHead.getTask();
+    auto nextWaitingTask = queueHead.getTask();
+    waitingTask->getNextWaitingTask() = nextWaitingTask;
     auto newQueueHead = WaitQueueItem::get(Status::Executing, waitingTask);
     if (fragment->waitQueue.compare_exchange_weak(
             queueHead, newQueueHead,
@@ -196,6 +192,9 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
             /*failure*/ std::memory_order_acquire)) {
 
       _swift_task_clearCurrent();
+      SWIFT_TASK_DEBUG_LOG("Task %p added to wait queue of Task %p. Next Task "
+                           "in the queue is %p",
+                           waitingTask, this, nextWaitingTask);
       return FutureFragment::Status::Executing;
     }
 #endif /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
@@ -368,10 +367,25 @@ void AsyncTask::setTaskId() {
   _private().Id = (Fetched >> 32) & 0xffffffff;
 }
 
-uint64_t AsyncTask::getTaskId() {
+uint64_t AsyncTask::getTaskId() const {
   // Reconstitute a full 64-bit task ID from the 32-bit job ID and the upper
   // 32 bits held in _private().
   return ((uint64_t)_private().Id << 32) | (uint64_t)Id;
+}
+
+/// Gets the 32-bit Job ID from the job or the 64-bit
+/// Task ID if this is an AsyncTask or AsyncTaskStealer
+uint64_t Job::getJobTaskId() const {
+  if (auto task = dyn_cast<AsyncTask>(this)) {
+    // TaskID is actually:
+    //   32bits of Job's Id
+    // + 32bits stored in the AsyncTask
+    return task->getTaskId();
+  } else if (auto stealer = dyn_cast<AsyncTaskStealer>(this)) {
+    return stealer->Task->getTaskId();
+  } else {
+    return this->getJobId();
+  }
 }
 
 SWIFT_CC(swift)
@@ -1687,11 +1701,7 @@ static void swift_continuation_awaitImpl(ContinuationAsyncContext *context) {
   // we try to tail-call.
   } while (false);
 #else
-  // This will always return zero because we were just running this Task so its
-  // BasePriority (which is immutable) should've already been set on the thread.
-  [[maybe_unused]]
-  uint32_t opaque = task->flagAsRunning();
-  assert(opaque == 0);
+  task->resumeRunningAfterFailedSuspend();
 #endif /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
 
   if (context->isExecutorSwitchForced())

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1821,12 +1821,7 @@ reevaluate_if_taskgroup_has_results:;
     // We're going back to running the task, so if we suspended before,
     // we need to flag it as running again.
     if (hasSuspended) {
-      // This will always return zero because we were just
-      // running this Task so its BasePriority (which is
-      // immutable) should've already been set on the thread.
-      [[maybe_unused]]
-      uint32_t opaque = waitingTask->flagAsRunning();
-      assert(opaque == 0);
+      waitingTask->resumeRunningAfterFailedSuspend();
     }
 
     // Success! We are allowed to poll.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -493,7 +493,7 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     /// use the task executor preference when we'd otherwise be running on
     /// the generic global pool.
     HasTaskExecutorPreference = 0x8000,
-    
+
     HasActiveTaskCancellationShield = 0x10000,
   };
 
@@ -546,8 +546,8 @@ public:
 
   /// Is the task currently cancelled?
   /// This does take into account cancellation shields, i.e. while a shield is active this function will always return 'false'.
-  bool isCancelled(bool ignoreShield = false) const { 
-    return (Flags & IsCancelled) && (ignoreShield || !(Flags & HasActiveTaskCancellationShield)); 
+  bool isCancelled(bool ignoreShield = false) const {
+    return (Flags & IsCancelled) && (ignoreShield || !(Flags & HasActiveTaskCancellationShield));
   }
   bool isCancelledIgnoringShield() const { return Flags & IsCancelled; }
   ActiveTaskStatus withCancelled() const {
@@ -556,8 +556,8 @@ public:
 #else
     return ActiveTaskStatus(Record, Flags | IsCancelled);
 #endif
-  }  
-  
+  }
+
   bool hasCancellationShield() const { return Flags & HasActiveTaskCancellationShield; }
   ActiveTaskStatus withCancellationShield() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
@@ -1042,7 +1042,6 @@ inline uint32_t AsyncTask::flagAsRunning() {
   dispatch_thread_override_info_s threadOverrideInfo;
   threadOverrideInfo = swift_dispatch_thread_get_current_override_qos_floor();
   qos_class_t overrideFloor = threadOverrideInfo.override_qos_floor;
-  qos_class_t basePriorityCeil = overrideFloor;
   qos_class_t taskBasePriority = (qos_class_t) _private().BasePriority;
 #endif
 
@@ -1063,13 +1062,15 @@ inline uint32_t AsyncTask::flagAsRunning() {
       // need to apply a self-override. In either case, call into dispatch to
       // do this.
       qos_class_t maxTaskPriority = (qos_class_t) oldStatus.getStoredPriority();
-      if (threadOverrideInfo.can_override && (taskBasePriority != basePriorityCeil || maxTaskPriority > overrideFloor)) {
+      if (threadOverrideInfo.can_override && (taskBasePriority != qos_class_self() || maxTaskPriority > overrideFloor)) {
         SWIFT_TASK_DEBUG_LOG("[Override] Self-override thread with oq_floor %#x to match task %p's max priority %#x and base priority %#x",
                              overrideFloor, this, maxTaskPriority, taskBasePriority);
 
-        dispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
+        uint32_t newDispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
+        if (!dispatchOpaquePriority) {
+          dispatchOpaquePriority = newDispatchOpaquePriority;
+        }
         overrideFloor = maxTaskPriority;
-        basePriorityCeil = taskBasePriority;
       }
 #endif
       // Set self as executor and remove escalation bit if any - the task's
@@ -1104,13 +1105,15 @@ inline uint32_t AsyncTask::flagAsRunning() {
       // need to apply a self-override. In either case, call into dispatch to
       // do this.
       qos_class_t maxTaskPriority = (qos_class_t) oldStatus.getStoredPriority();
-      if (threadOverrideInfo.can_override && (taskBasePriority != basePriorityCeil || maxTaskPriority > overrideFloor)) {
+      if (threadOverrideInfo.can_override && (taskBasePriority != qos_class_self() || maxTaskPriority > overrideFloor)) {
         SWIFT_TASK_DEBUG_LOG("[Override] Self-override thread with oq_floor %#x to match task %p's max priority %#x and base priority %#x",
                              overrideFloor, this, maxTaskPriority, taskBasePriority);
 
-        dispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
+        uint32_t newDispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
+        if (!dispatchOpaquePriority) {
+          dispatchOpaquePriority = newDispatchOpaquePriority;
+        }
         overrideFloor = maxTaskPriority;
-        basePriorityCeil = taskBasePriority;
       }
 #endif
       // Set self as executor and remove escalation bit if any - the task's
@@ -1373,13 +1376,13 @@ inline bool AsyncTask::cancellationShieldPush() {
 
     auto newStatus = oldStatus.withCancellationShield();
     assert(newStatus.hasCancellationShield());
-    
+
     if (_private()._status().compare_exchange_weak(oldStatus, newStatus,
               /* success */ std::memory_order_relaxed,
               /* failure */ std::memory_order_relaxed)) {
       return true; // we did successfully install the shield
     }
-  } 
+  }
 }
 
 inline void AsyncTask::cancellationShieldPop() {
@@ -1391,13 +1394,13 @@ inline void AsyncTask::cancellationShieldPop() {
 
     auto newStatus = oldStatus.withoutCancellationShield();
     assert(!newStatus.hasCancellationShield());
-    
+
     if (_private()._status().compare_exchange_weak(oldStatus, newStatus,
               /* success */ std::memory_order_relaxed,
               /* failure */ std::memory_order_relaxed)) {
       return;
     }
-  } 
+  }
 }
 
 } // end namespace swift

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -158,6 +158,29 @@ swift_executor_escalate(SerialExecutorRef executor, AsyncTask *task, JobPriority
 
 /*************** Methods for Status records manipulation ******************/
 
+/// This function grabs the status record lock of the input task and invokes
+/// `fn` while holding the StatusRecordLock of the input task.
+///
+/// Prefer to use the helper functions below when possible
+/// because they can proactively use lockless algorithms. This
+/// is only to be used when you *must* hold the lock for some
+/// operation and there is no better way to accomplish that.
+///
+/// If the client of withStatusRecordLock has already loaded the status of the
+/// task, they may pass it into this function to avoid a double-load.
+///
+/// The input `fn` is invoked once while holding the status record lock.
+///
+/// The optional `statusUpdate` is invoked while releasing the StatusRecordLock
+/// from the ActiveTaskStatus so that callers may make additional modifications
+/// to ActiveTaskStatus flags. `statusUpdate` can be called multiple times in a
+/// RMW loop and so much be idempotent.
+void withStatusRecordLock(
+    AsyncTask *task, ActiveTaskStatus status,
+    llvm::function_ref<void(ActiveTaskStatus)> fn,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)>
+        statusUpdate = nullptr);
+
 /// Add a status record to the input task.
 ///
 /// Clients can optionally pass in the status of the task if they have already
@@ -232,6 +255,16 @@ SWIFT_CC(swift)
 void removeStatusRecord(AsyncTask *task, TaskStatusRecord *record,
      llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>fn = nullptr);
 
+/// Similar to the above functions, attempt to remove record from
+/// task. If condition returns false, record is considered invalid
+/// and won't be attempted to be removed. It may be called multiple
+/// times to ensure it is checked atomically with the removal.
+SWIFT_CC(swift)
+bool removeStatusRecordIf(
+    AsyncTask *task, TaskStatusRecord *record, ActiveTaskStatus &status,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)> fn,
+    llvm::function_ref<bool(ActiveTaskStatus)> condition);
+
 /// Update the status record by scanning through all records and removing
 /// those which match the condition. This can also be used to inspect
 /// "remaining" records.
@@ -289,10 +322,12 @@ void removeStatusRecordFromSelf(TaskStatusRecord *record,
 /// from the current status and does not include modifications made by previous
 /// runs through the loop
 SWIFT_CC(swift)
-void updateStatusRecord(AsyncTask *task, TaskStatusRecord *record,
-     llvm::function_ref<void()>updateRecord,
-     ActiveTaskStatus& status,
-     llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>fn = nullptr);
+void updateStatusRecord(
+    AsyncTask *task, TaskStatusRecord *record,
+    llvm::function_ref<void(ActiveTaskStatus)> updateRecord,
+    ActiveTaskStatus &status,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)> fn =
+        nullptr);
 
 /// A helper function for updating a new child task that is created with
 /// information from the parent or the group that it was going to be added to.
@@ -442,7 +477,10 @@ public:
 ///     enforced by static asserts below.
 class alignas(2 * sizeof(void*)) ActiveTaskStatus {
   enum : uint32_t {
-    /// The max priority of the task. This is always >= basePriority in the task
+    /// The max priority of the task. This is always >= basePriority
+    /// in the task. Currently, this stores an entire TaskPriority even
+    /// though there are few valid values. If more bits are needed here
+    /// in the future, this can be compressed to only the valid values.
     PriorityMask = 0xFF,
 
     /// Has the task been cancelled?
@@ -465,17 +503,18 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     /// whether or not it is running.
     IsRunning = 0x800,
 #endif
-    /// Task is intrusively enqueued somewhere - either in the default executor
-    /// pool, or in an actor. Currently, due to lack of task stealers, this bit
-    /// is cleared when a task starts running on a thread, suspends or is
-    /// completed.
+    /// The Job portion of this Task is directly enqueued somewhere -
+    /// either in the default executor pool, an actor, or another executor.
     ///
-    /// TODO (rokhinip): Once we have task stealers, this bit refers to the
-    /// enqueued-ness on the specific queue that the task is linked into and
-    /// therefore, can only be cleared when the intrusively linkage is cleaned
-    /// up. The enqueued-ness then becomes orthogonal to the other states of
-    /// running/suspended/completed.
-    IsEnqueued = 0x1000,
+    /// Task is a subclass of Job so the Task object itself may be enqueued
+    /// on an executor. A TaskStealer Job may also refer to a Task and
+    /// invoke it. If this bit is set, the Task's Job is currently enqueued
+    /// on an executor and may not be reused. If it is unset, the Task's
+    /// Job is currently unused and may be mutated and enqueued elsewhere.
+    ///
+    /// This bit may be set or unset at any point in the Task's lifecycle and
+    /// is orthgonal to if the Task has an EnqueuedOnExecutor dependency record.
+    IsDirectlyEnqueued = 0x1000,
     /// Task has been completed.  This is purely used to enable an assertion
     /// that the task is completed when we destroy it.
     IsComplete = 0x2000,
@@ -495,6 +534,38 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     HasTaskExecutorPreference = 0x8000,
 
     HasActiveTaskCancellationShield = 0x10000,
+
+    // If this bit is set, there is more than one object (either this one
+    // intrusively linked or an AsyncTaskStealer) that has the current
+    // StealerExclusionValue. In order to run this Task, the exclusion value
+    // must be incremented to invalidate those other objects. At that time,
+    // this bit must also be reset. If this bit is not set, the only other
+    // enqueued objects that may exist that refer to this Task have older
+    // exclusion values so it is safe to run this Task without incrementing it.
+    HasActiveStealers = 0x20000,
+    // Swift Tasks typically don't need an additional retain while they
+    // are enqueued. However, if a stealer is enqueued and the original
+    // Task remains intrusively linked on a low priority queue, it may stay
+    // there after the Task completes and is otherwise forgotten about by
+    // anyone other than the executor. To ensure it is not disposed until
+    // after it is finally dequeued, an additional retain is added when
+    // the first stealer is enqueued which this bit tracks. The balancing
+    // release happens when the intrusively linked Task is dequeued.
+    HasRetainForInstrusiveLinkage = 0x40000,
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    /// The Task's intrusive link or a Stealer may only run if its
+    /// exclusion value is equal to this value. This number increases
+    /// only when running a Task after it was escalated while it
+    /// was dependent on the Dispatch default global executor.
+    ///
+    /// There are only 5 values of JobPriority and this value can only
+    /// increase at most once for each priority transition so this
+    /// could just use 3 bits (along with PriorityMask) if needed.
+    StealerExclusionShift = 20,
+    StealerExclusionMax = 0xF,
+    StealerExclusionMask = StealerExclusionMax << StealerExclusionShift,
+#endif
   };
 
   // Note: this structure is mirrored by ActiveTaskStatusWithEscalation and
@@ -528,6 +599,14 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     : Flags(flags), Record(record) {}
 #endif
 
+  ActiveTaskStatus withFlags(uintptr_t flags) const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return ActiveTaskStatus(Record, flags, ExecutionLock);
+#else
+    return ActiveTaskStatus(Record, flags);
+#endif
+  }
+
 public:
 #ifdef __GLIBCXX__
   /// We really don't want to provide this constructor, but in old
@@ -544,75 +623,72 @@ public:
       : Flags(uintptr_t(priority)), Record(nullptr) {}
 #endif
 
+  // Getters / setters for flags (in flag order)
+
+  // Priority
+  JobPriority getStoredPriority() const {
+    return JobPriority(Flags & PriorityMask);
+  }
+  /// Creates a new active task status for a task with the specified priority
+  /// and masks away any existing priority related flags on the task status. All
+  /// other flags about the task are unmodified. This is only safe to use when
+  /// we know that the task we're modifying is not running.
+  ActiveTaskStatus withNewPriority(JobPriority priority) const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    assert(ExecutionLock == DLOCK_OWNER_NULL);
+#endif
+    return withFlags((Flags & ~PriorityMask) | uintptr_t(priority));
+  }
+  ActiveTaskStatus withEscalatedPriority(JobPriority priority) const {
+    assert(priority > getStoredPriority());
+    return withFlags((Flags & ~PriorityMask) | IsEscalated |
+                     uintptr_t(priority));
+  }
+
+  // IsCancelled
   /// Is the task currently cancelled?
-  /// This does take into account cancellation shields, i.e. while a shield is active this function will always return 'false'.
+  /// This does take into account cancellation shields, i.e. while a shield is
+  /// active this function will always return 'false'.
   bool isCancelled(bool ignoreShield = false) const {
-    return (Flags & IsCancelled) && (ignoreShield || !(Flags & HasActiveTaskCancellationShield));
+    return (Flags & IsCancelled) &&
+           (ignoreShield || !(Flags & HasActiveTaskCancellationShield));
   }
   bool isCancelledIgnoringShield() const { return Flags & IsCancelled; }
   ActiveTaskStatus withCancelled() const {
+    return withFlags(Flags | IsCancelled);
+  }
+
+  // IsStatusRecordLocked
+  /// Does some thread hold the status record lock?
+  bool isStatusRecordLocked() const { return Flags & IsStatusRecordLocked; }
+  ActiveTaskStatus withStatusRecordLocked() const {
+    assert(!isStatusRecordLocked());
+    return withFlags(Flags | IsStatusRecordLocked);
+  }
+  ActiveTaskStatus withoutStatusRecordLocked() const {
+    assert(isStatusRecordLocked());
+    return withFlags(Flags & ~IsStatusRecordLocked);
+  }
+
+  // IsEscalated
+  bool isStoredPriorityEscalated() const { return Flags & IsEscalated; }
+  ActiveTaskStatus withoutStoredPriorityEscalation() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | IsCancelled, ExecutionLock);
+    return ActiveTaskStatus(Record, Flags & ~IsEscalated, ExecutionLock);
 #else
-    return ActiveTaskStatus(Record, Flags | IsCancelled);
+    return ActiveTaskStatus(Record, Flags & ~IsEscalated);
 #endif
   }
 
-  bool hasCancellationShield() const { return Flags & HasActiveTaskCancellationShield; }
-  ActiveTaskStatus withCancellationShield() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | HasActiveTaskCancellationShield, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | HasActiveTaskCancellationShield);
-#endif
-  }
-  ActiveTaskStatus withoutCancellationShield() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~HasActiveTaskCancellationShield, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags & ~HasActiveTaskCancellationShield);
-#endif
-  }
-
-  bool isEnqueued() const { return Flags & IsEnqueued; }
-  ActiveTaskStatus withEnqueued() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | IsEnqueued, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | IsEnqueued);
-#endif
-  }
-  ActiveTaskStatus withoutEnqueued() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~IsEnqueued, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags & ~IsEnqueued);
-#endif
-  }
-
+  // IsRunning
   /// Is the task currently running? Also known as whether it is drain locked.
   bool isRunning() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-  return dispatch_lock_is_locked(ExecutionLock);
+    return dispatch_lock_is_locked(ExecutionLock);
 #else
     return Flags & IsRunning;
 #endif
   }
-
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-  static size_t executionLockOffset() {
-    return offsetof(ActiveTaskStatus, ExecutionLock);
-  }
-#endif
-
-  uint32_t currentExecutionLockOwner() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-  return dispatch_lock_owner(ExecutionLock);
-#else
-  return 0;
-#endif
-  }
-
   ActiveTaskStatus withRunning(bool isRunning) const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
   if (isRunning) {
@@ -627,114 +703,137 @@ public:
 #endif
   }
 
-  bool isComplete() const {
-    return Flags & IsComplete;
+  // IsDirectlyEnqueued
+  bool isDirectlyEnqueued() const { return Flags & IsDirectlyEnqueued; }
+  ActiveTaskStatus withIntrusivelyLinked() const {
+    return withFlags(Flags | IsDirectlyEnqueued);
+  }
+  ActiveTaskStatus withoutIntrusivelyLinked() const {
+    return withFlags(Flags & ~IsDirectlyEnqueued);
+  }
+  static bool atomicRemoveIntrusivelyLinked(char *storage) {
+    // To do an atomic AND, we have to use the underlying storage and
+    // cast it. This cast could be done in a simpler way since Flags
+    // should always be at the start and should always be a uint32_t.
+    // But to be more resilient, I get the offsets and types correctly
+    auto *flags =
+        reinterpret_cast<std::atomic<decltype(ActiveTaskStatus::Flags)> *>(
+            storage + offsetof(ActiveTaskStatus, Flags));
+    // Release memory ordering so that other threads can not decide to reuse
+    // this Task's intrusive linkage before all of our earlier uses have
+    // completed
+    auto oldFlags =
+        flags->fetch_and(~(IsDirectlyEnqueued | HasRetainForInstrusiveLinkage),
+                         std::memory_order_release);
+
+    // Tell the caller if it needs to do a release on the Task
+    return (oldFlags & HasRetainForInstrusiveLinkage) != 0;
   }
 
+  // IsComplete
+  bool isComplete() const { return Flags & IsComplete; }
   ActiveTaskStatus withComplete() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | IsComplete, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | IsComplete);
-#endif
+    return withFlags(Flags | IsComplete);
   }
 
-  /// Does some thread hold the status record lock?
-  bool isStatusRecordLocked() const { return Flags & IsStatusRecordLocked; }
-  ActiveTaskStatus withStatusRecordLocked() const {
-    assert(!isStatusRecordLocked());
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | IsStatusRecordLocked,
-                            ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | IsStatusRecordLocked);
-#endif
-  }
-  ActiveTaskStatus withoutStatusRecordLocked() const {
-    assert(isStatusRecordLocked());
-
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~IsStatusRecordLocked,
-                            ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags & ~IsStatusRecordLocked);
-#endif
-  }
-
+  // HasTaskDependency
   /// Is there a dependencyRecord in the linked list of status records?
   bool hasTaskDependency() const { return Flags & HasTaskDependency; }
   ActiveTaskStatus withTaskDependency() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | HasTaskDependency, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | HasTaskDependency);
-#endif
+    return withFlags(Flags | HasTaskDependency);
   }
   ActiveTaskStatus withoutTaskDependency() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~HasTaskDependency, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags & ~HasTaskDependency);
-#endif
+    return withFlags(Flags & ~HasTaskDependency);
   }
 
+  // HasTaskExecutorPreference
   /// Is there a task preference record in the linked list of status records?
   bool hasTaskExecutorPreference() const {
     return Flags & HasTaskExecutorPreference;
   }
   ActiveTaskStatus withTaskExecutorPreference() const {
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | HasTaskExecutorPreference, ExecutionLock);
-#else
-    return ActiveTaskStatus(Record, Flags | HasTaskExecutorPreference);
-#endif
+    return withFlags(Flags | HasTaskExecutorPreference);
   }
   ActiveTaskStatus withoutTaskExecutorPreference() const {
+    return withFlags(Flags & ~HasTaskExecutorPreference);
+  }
+
+  // HasActiveTaskCancellationShield
+  bool hasCancellationShield() const {
+    return Flags & HasActiveTaskCancellationShield;
+  }
+  ActiveTaskStatus withCancellationShield() const {
+    return withFlags(Flags | HasActiveTaskCancellationShield);
+  }
+  ActiveTaskStatus withoutCancellationShield() const {
+    return withFlags(Flags & ~HasActiveTaskCancellationShield);
+  }
+
+  // HasActiveStealers
+  bool hasActiveStealers() const { return Flags & HasActiveStealers; }
+  ActiveTaskStatus withActiveStealers() const {
+    return withFlags(Flags | HasActiveStealers);
+  }
+  ActiveTaskStatus withoutActiveStealers() const {
+    return withFlags(Flags & ~HasActiveStealers);
+  }
+
+  // HasRetainForInstrusiveLinkage
+  bool hasRetainForInstrusiveLinkage() const {
+    return Flags & HasRetainForInstrusiveLinkage;
+  }
+  ActiveTaskStatus withRetainForInstrusiveLinkage() const {
+    return withFlags(Flags | HasRetainForInstrusiveLinkage);
+  }
+  ActiveTaskStatus withoutRetainForInstrusiveLinkage() const {
+    return withFlags(Flags & ~HasRetainForInstrusiveLinkage);
+  }
+
+  // StealerExclusion
+  AsyncTask::ExclusionValue getStealerExclusionValue() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~HasTaskExecutorPreference, ExecutionLock);
+    return AsyncTask::ExclusionValue{(Flags & StealerExclusionMask) >>
+                                     StealerExclusionShift};
 #else
-    return ActiveTaskStatus(Record, Flags & ~HasTaskExecutorPreference);
+    return {0};
 #endif
   }
-
-  JobPriority getStoredPriority() const {
-    return JobPriority(Flags & PriorityMask);
-  }
-  bool isStoredPriorityEscalated() const {
-    return Flags & IsEscalated;
-  }
-
-  /// Creates a new active task status for a task with the specified priority
-  /// and masks away any existing priority related flags on the task status. All
-  /// other flags about the task are unmodified. This is only safe to use when
-  /// we know that the task we're modifying is not running.
-  ActiveTaskStatus withNewPriority(JobPriority priority) const {
+  ActiveTaskStatus withNextStealerExclusionValue() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    assert(ExecutionLock == DLOCK_OWNER_NULL);
-#endif
-    assert(!isEnqueued());
-    return ActiveTaskStatus(Record,
-                            (Flags & ~PriorityMask) | uintptr_t(priority));
-  }
+    auto currentStealerExclusionValue = getStealerExclusionValue().value;
+    auto newStealerExclusionValue = currentStealerExclusionValue;
+    if (__builtin_add_overflow(currentStealerExclusionValue, 1,
+                               &newStealerExclusionValue) ||
+        newStealerExclusionValue > StealerExclusionMax) {
+      assert(false && "Somehow overflowed stealer exclusion value");
+    }
+    SWIFT_TASK_DEBUG_LOG("Updating exclusion value from %d to %d",
+                         currentStealerExclusionValue,
+                         newStealerExclusionValue);
 
-  ActiveTaskStatus withEscalatedPriority(JobPriority priority) const {
-    assert(priority > getStoredPriority());
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record,
-                            (Flags & ~PriorityMask)
-                               | IsEscalated | uintptr_t(priority), ExecutionLock);
+    auto NewFlags = Flags & ~StealerExclusionMask;
+    NewFlags |= (newStealerExclusionValue << StealerExclusionShift);
+    return ActiveTaskStatus(Record, NewFlags, ExecutionLock);
 #else
-    return ActiveTaskStatus(Record, (Flags & ~PriorityMask) | IsEscalated | uintptr_t(priority));
+    return *this;
 #endif
   }
 
-  ActiveTaskStatus withoutStoredPriorityEscalation() const {
+  // Getters for ExecutionLock
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags & ~IsEscalated, ExecutionLock);
+  static size_t executionLockOffset() {
+    return offsetof(ActiveTaskStatus, ExecutionLock);
+  }
+#endif
+  uint32_t currentExecutionLockOwner() const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return dispatch_lock_owner(ExecutionLock);
 #else
-    return ActiveTaskStatus(Record, Flags & ~IsEscalated);
+    return 0;
 #endif
   }
+
+  // Getters / Setters for Record
 
   /// Return the innermost cancellation record.  Code running
   /// asynchronously with this task should not access this record
@@ -764,19 +863,28 @@ public:
     bool cancelled = isCancelled();
     bool escalated = isStoredPriorityEscalated();
     bool running = isRunning();
-    bool enqueued = isEnqueued();
+    bool enqueued = isDirectlyEnqueued();
     bool wasRunning = oldStatus.isRunning();
 
     if (!isStarting &&
         maxPriority == static_cast<uint8_t>(oldStatus.getStoredPriority()) &&
         cancelled == oldStatus.isCancelled() &&
         escalated == oldStatus.isStoredPriorityEscalated() &&
-        running == wasRunning && enqueued == oldStatus.isEnqueued())
+        running == wasRunning && enqueued == oldStatus.isDirectlyEnqueued())
       return;
 
     concurrency::trace::task_status_changed(task, maxPriority, cancelled,
                                             escalated, isStarting, running,
                                             enqueued, wasRunning);
+  }
+
+  bool operator!=(const ActiveTaskStatus &other) const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return Record != other.Record || Flags != other.Flags ||
+           ExecutionLock != other.ExecutionLock;
+#else
+    return Record != other.Record || Flags != other.Flags;
+#endif
   }
 };
 
@@ -879,7 +987,10 @@ struct AsyncTask::PrivateStorage {
   /// The top 32 bits of the task ID. The bottom 32 bits are in Job::Id.
   uint32_t Id;
 
-  // Another four bytes of padding here too (on 64-bit)
+#if __SIZEOF_POINTER__ == 8
+  AsyncTask::ExclusionValue LocalStealerExclusionValue = {0};
+#endif
+  // Three bytes of padding (on 64-bit)
 
   /// Base priority of Task - set only at creation time of task.
   /// Current max priority of task is ActiveTaskStatus.
@@ -895,6 +1006,12 @@ struct AsyncTask::PrivateStorage {
 
   // The lock used to protect more complicated operations on the task status.
   RecursiveMutex statusLock;
+
+#if __SIZEOF_POINTER__ == 4
+  // See the comment on the declaration of this above
+  AsyncTask::ExclusionValue LocalStealerExclusionValue = {0};
+#endif
+  // On 32-bit, there are 7 bytes remaining
 
   // Always create an async task with max priority in ActiveTaskStatus = base
   // priority. It will be updated later if needed.
@@ -938,7 +1055,6 @@ struct AsyncTask::PrivateStorage {
       // Remove drainer, enqueued and override bit if any
       auto newStatus = oldStatus.withRunning(false);
       newStatus = newStatus.withoutStoredPriorityEscalation();
-      newStatus = newStatus.withoutEnqueued();
       newStatus = newStatus.withComplete();
 
       // This can fail since the task can still get concurrently cancelled or
@@ -1036,100 +1152,523 @@ inline bool AsyncTask::isCancelled(bool ignoreShield = false) const {
                           .isCancelled(ignoreShield);
 }
 
-inline uint32_t AsyncTask::flagAsRunning() {
+/// Remove the enqueued bit in the ActiveTaskStatus atomically. This must be
+/// done when a Task's intrusive link is dequeued but after reading the local
+/// stealer exclusion value. This should not be called from any other context.
+inline void AsyncTask::taskRemoveEnqueued() {
+  SWIFT_TASK_DEBUG_LOG("Removing enqueued bit from Task %p", this);
+  // In theory, we could do plumbing so that this happens as a part of a later
+  // CAS when possible (and prevents a single forced CAS fail in some cases).
+  if (ActiveTaskStatus::atomicRemoveIntrusivelyLinked(
+          _private().StatusStorage)) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    // This balances with the retain in swift_task_enqueueSelfOrStealer which
+    // happens when adding the first stealer after a direct enqueue. See the
+    // comment under
+    swift_release(this);
+#endif
+  }
+}
 
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+struct ThreadPriorityManager {
   dispatch_thread_override_info_s threadOverrideInfo;
-  threadOverrideInfo = swift_dispatch_thread_get_current_override_qos_floor();
-  qos_class_t overrideFloor = threadOverrideInfo.override_qos_floor;
-  qos_class_t taskBasePriority = (qos_class_t) _private().BasePriority;
+  qos_class_t overrideFloor;
+  qos_class_t taskBasePriority;
+  swift_dispatch_priority_token_s opaquePriority;
+
+  ThreadPriorityManager(AsyncTask const &task) {
+    threadOverrideInfo = swift_dispatch_thread_get_current_override_qos_floor();
+    overrideFloor = threadOverrideInfo.override_qos_floor;
+    taskBasePriority = (qos_class_t)task._private().BasePriority;
+    opaquePriority = {};
+  }
+  ThreadPriorityManager(ThreadPriorityManager &&) = delete;
+
+  void overrideIfNeeded(JobPriority storedPriority) {
+    // If the base priority is not equal to the current override
+    // floor then dispqatch may need to apply the base priority
+    // to the thread. If the current priority is higher than
+    // the override floor, then dispatch may need to apply a
+    // self-override. In either case, call into dispatch to do this.
+    qos_class_t maxTaskPriority = (qos_class_t)storedPriority;
+    if (threadOverrideInfo.can_override &&
+        (taskBasePriority != qos_class_self() ||
+         maxTaskPriority > overrideFloor)) {
+      SWIFT_TASK_DEBUG_LOG(
+          "[Override] Self-override thread with oq_floor %#x to match task's "
+          "max priority %#x and base priority %#x",
+          overrideFloor, maxTaskPriority, taskBasePriority);
+
+      auto previousPriority = swift_dispatch_thread_override_self_with_base(
+          maxTaskPriority, taskBasePriority);
+      // Dispatch will only return a value if the base priority had to
+      // be set which should only happen the first time. Let's make sure
+      // that we don't overwrite it and that our assumption is correct.
+      if (!opaquePriority.isSet()) {
+        opaquePriority = previousPriority;
+      }
+      overrideFloor = maxTaskPriority;
+    }
+  }
+
+  void resetIfNeeded() {
+    // At this point, we may have run the above update code
+    // so we might need to undo setting the base priority
+    if (opaquePriority.isSet()) {
+      swift_dispatch_thread_reset_override_self(opaquePriority);
+      opaquePriority = 0;
+    }
+  }
+};
+#endif
+
+inline uint32_t AsyncTask::taskFlagAsRunningWithoutDependency(
+    AsyncTask::InvokeFlags invokeFlags) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  auto threadPriorityManager = ThreadPriorityManager(*this);
 #endif
 
   auto oldStatus = _private()._status().load(std::memory_order_relaxed);
   assert(!oldStatus.isRunning());
   assert(!oldStatus.isComplete());
+  // This function isn't meant to be called if the function has
+  // been enqueued onto an executor since the last suspension
+  assert(!oldStatus.hasTaskDependency());
 
-  uint32_t dispatchOpaquePriority = 0;
-  if (!oldStatus.hasTaskDependency()) {
-    SWIFT_TASK_DEBUG_LOG("%p->flagAsRunning() with no task dependency", this);
-    assert(_private().dependencyRecord == nullptr);
+  SWIFT_TASK_DEBUG_LOG("%p->taskFlagAsRunningWithoutDependency()", this);
+  assert(_private().dependencyRecord == nullptr);
 
-    while (true) {
+  while (true) {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-      // If the base priority is not equal to the current override floor then
-      // dispqatch may need to apply the base priority to the thread. If the
-      // current priority is higher than the override floor, then dispatch may
-      // need to apply a self-override. In either case, call into dispatch to
-      // do this.
-      qos_class_t maxTaskPriority = (qos_class_t) oldStatus.getStoredPriority();
-      if (threadOverrideInfo.can_override && (taskBasePriority != qos_class_self() || maxTaskPriority > overrideFloor)) {
-        SWIFT_TASK_DEBUG_LOG("[Override] Self-override thread with oq_floor %#x to match task %p's max priority %#x and base priority %#x",
-                             overrideFloor, this, maxTaskPriority, taskBasePriority);
-
-        uint32_t newDispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
-        if (!dispatchOpaquePriority) {
-          dispatchOpaquePriority = newDispatchOpaquePriority;
-        }
-        overrideFloor = maxTaskPriority;
-      }
+    threadPriorityManager.overrideIfNeeded(oldStatus.getStoredPriority());
 #endif
-      // Set self as executor and remove escalation bit if any - the task's
-      // priority escalation has already been reflected on the thread.
-      auto newStatus = oldStatus.withRunning(true);
-      newStatus = newStatus.withoutStoredPriorityEscalation();
-      newStatus = newStatus.withoutEnqueued();
+    // Set self as executor and remove escalation bit if any - the task's
+    // priority escalation has already been reflected on the thread.
+    auto newStatus = oldStatus.withRunning(true);
+    if (!(invokeFlags & AsyncTask::InvokeFlagsFromStealer)) {
+      newStatus = newStatus.withoutIntrusivelyLinked();
+    }
+    newStatus = newStatus.withoutStoredPriorityEscalation();
 
-      if (_private()._status().compare_exchange_weak(oldStatus, newStatus,
-               /* success */ std::memory_order_relaxed,
-               /* failure */ std::memory_order_relaxed)) {
-        newStatus.traceStatusChanged(this, oldStatus, true);
-        adoptTaskVoucher(this);
-        swift_task_enterThreadLocalContext(
-            (char *)&_private().ExclusivityAccessSet[0]);
-        break;
+    if (_private()._status().compare_exchange_weak(
+            oldStatus, newStatus,
+            /* success */ std::memory_order_relaxed,
+            /* failure */ std::memory_order_relaxed)) {
+      newStatus.traceStatusChanged(this, oldStatus, true);
+      adoptTaskVoucher(this);
+      swift_task_enterThreadLocalContext(
+          (char *)&_private().ExclusivityAccessSet[0]);
+      break;
+    }
+  }
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  return threadPriorityManager.opaquePriority;
+#else
+  return 0;
+#endif
+}
+
+inline void AsyncTask::resumeRunningAfterFailedSuspend(
+    [[maybe_unused]] InvokeFlags invokeFlags) {
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  // The intention of this function is to only be called in
+  // places where the thread is already set up for the correct
+  // base priority so we shouldn't need to call resetIfNeeded
+  auto threadPriorityManager = ThreadPriorityManager(*this);
+  // It shouldn't be possible for newer stealers to have been enqueued but we
+  // don't know what the original exclusion value was when this task started
+  // running so we can't double check in an assert that it's still accurate
+#endif
+
+  auto oldStatus = _private()._status().load(std::memory_order_relaxed);
+
+  assert(!oldStatus.isRunning());
+  assert(!oldStatus.isComplete());
+
+  // We asserted above that the exclusion value is correct
+  // for oldStatus so the dependency record is correct
+  if (!oldStatus.hasTaskDependency()) {
+    assert(_private().dependencyRecord == nullptr);
+    [[maybe_unused]]
+    uint32_t opaque = taskFlagAsRunningWithoutDependency(invokeFlags);
+    // In this function, we should always see zero
+    assert(opaque == 0);
+    return;
+  }
+
+  // In this function, the dependency record will always be
+  // accurate and is always a dependency on something other than an
+  // executor. If it was a dependency on an executor, that would
+  // make our assumptions about not racing with stealers invalid
+  auto dependencyRecord = _private().dependencyRecord;
+  SWIFT_TASK_DEBUG_LOG("[Dependency] %p->resumeRunningAfterFailedSuspend() and "
+                       "remove dependencyRecord %p",
+                       this, dependencyRecord);
+  // We can't directly assert that dependencyRecord->DependencyKind
+  // != EnqueuedOnExecutor but that is the expected condition here
+
+  removeStatusRecord(
+      this, dependencyRecord, oldStatus,
+      [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+        threadPriorityManager.overrideIfNeeded(oldStatus.getStoredPriority());
+        assert(threadPriorityManager.opaquePriority == 0);
+#endif
+        // Set self as executor and remove escalation bit if any - the task's
+        // priority escalation has already been reflected on the thread.
+        newStatus = newStatus.withRunning(true);
+        newStatus = newStatus.withoutStoredPriorityEscalation();
+        newStatus = newStatus.withoutTaskDependency();
+      });
+
+  this->destroyTaskDependency(dependencyRecord);
+
+  adoptTaskVoucher(this);
+  swift_task_enterThreadLocalContext(
+      (char *)&_private().ExclusivityAccessSet[0]);
+
+  return;
+}
+
+inline std::pair<bool, uint32_t>
+AsyncTask::tryStartRunning(AsyncTask::ExclusionValue allowedExclusionValue,
+                           AsyncTask::InvokeFlags invokeFlags) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  auto threadPriorityManager = ThreadPriorityManager(*this);
+  SWIFT_TASK_DEBUG_LOG("%p run with flags %x, exclusion value %d", this,
+                       invokeFlags, allowedExclusionValue);
+
+  // Stealers are only enabled with priority escalation
+  auto oldStatus = _private()._status().load(std::memory_order_relaxed);
+  if (oldStatus.getStealerExclusionValue() != allowedExclusionValue) {
+    if (!(invokeFlags & AsyncTask::InvokeFlagsFromStealer))
+      taskRemoveEnqueued();
+    return {false, 0};
+  }
+#else
+  auto oldStatus = _private()._status().load(std::memory_order_relaxed);
+#endif
+
+  assert(!oldStatus.isRunning());
+  assert(!oldStatus.isComplete());
+
+  // We've already checked that the exclusion value is correct for oldStatus
+  // so whether we have a task dependency is correct. If we do not have
+  // one, then we haven't been enqueued so no newer stealer can exist
+  if (!oldStatus.hasTaskDependency()) {
+    assert(_private().dependencyRecord == nullptr);
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    assert(oldStatus.getStealerExclusionValue() == allowedExclusionValue);
+#endif
+    SWIFT_TASK_DEBUG_LOG(
+        "tryStartRunning succeeds for %p with no dependency record", this);
+    return {true, taskFlagAsRunningWithoutDependency(invokeFlags)};
+  }
+
+  // In this case, we were enqueued so we may
+  // race with a stealer and have to bail out
+
+  // The dependency record could be invalid here. If the exclusion value
+  // is allowed, then it will be valid and there will be no races. Thus,
+  // we can't even assert that the record isn't null here (because this
+  // value isn't atomic, if it was, we could bail out early if it was null).
+  auto dependencyRecord = _private().dependencyRecord;
+  SWIFT_TASK_DEBUG_LOG("[Dependency] %p->tryStartRunning() and "
+                       "remove dependencyRecord %p",
+                       this, dependencyRecord);
+
+  if (!removeStatusRecordIf(
+          this, dependencyRecord, oldStatus,
+          [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+            threadPriorityManager.overrideIfNeeded(
+                oldStatus.getStoredPriority());
+#endif
+            // Set self as executor and remove escalation bit if any - the
+            // task's priority escalation has already been reflected on the
+            // thread.
+            newStatus = newStatus.withRunning(true);
+            newStatus = newStatus.withoutStoredPriorityEscalation();
+            newStatus = newStatus.withoutTaskDependency();
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+            if (oldStatus.hasActiveStealers()) {
+              newStatus = newStatus.withNextStealerExclusionValue();
+            }
+            newStatus = newStatus.withoutActiveStealers();
+#endif
+          },
+          [&](ActiveTaskStatus toCheck) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+            return toCheck.getStealerExclusionValue() == allowedExclusionValue;
+#else
+            return true;
+#endif
+          })) {
+    // Status record not removed
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    threadPriorityManager.resetIfNeeded();
+#endif
+    if (!(invokeFlags & AsyncTask::InvokeFlagsFromStealer)) {
+      taskRemoveEnqueued();
+    }
+    SWIFT_TASK_DEBUG_LOG("tryStartRunning fails for %p on record removal",
+                         this);
+    return {false, 0};
+  }
+
+  // Because we got here, we did not bail out early. Thus, the exclusion
+  // value is allowed meaning that the dependencyRecord that we
+  // obtained is correct and has been removed and may now be destroyed
+  this->destroyTaskDependency(dependencyRecord);
+
+  adoptTaskVoucher(this);
+  swift_task_enterThreadLocalContext(
+      (char *)&_private().ExclusivityAccessSet[0]);
+
+  if (!(invokeFlags & AsyncTask::InvokeFlagsFromStealer)) {
+    taskRemoveEnqueued();
+  }
+  SWIFT_TASK_DEBUG_LOG("tryStartRunning succeeds for %p", this);
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  return {true, threadPriorityManager.opaquePriority};
+#else
+  return {true, 0};
+#endif
+}
+
+/// A Job that acts as a proxy for a Task when the Task itself can't be
+/// enqueued. Holds a reference to the Task and an exclusion value that causes
+/// this Job to do nothing if it doesn't match what's in the Task's Status.
+class AsyncTaskStealer : public Job {
+public:
+  AsyncTask *Task;
+  AsyncTask::ExclusionValue ExclusionValue;
+
+  AsyncTaskStealer(AsyncTask *task, JobPriority priority,
+                   AsyncTask::ExclusionValue exclusionValue)
+      : Job({JobKind::TaskStealer, priority}, &process), Task(task),
+        ExclusionValue{exclusionValue} {
+    swift_retain(Task);
+  }
+
+  // Implemented in Actor.cpp to make use of taskInvokeWithExclusionValue
+  SWIFT_CC(swiftasync)
+  static void process(Job *job);
+
+  static bool classof(const Job *job) {
+    return job->Flags.getKind() == JobKind::TaskStealer;
+  }
+};
+
+/// When this task has a valid dependent on executor record, and is
+/// holding the TaskStatusLock, this function will enqueue the Task on
+/// the provided executor either directly or with a stealer if needed.
+///
+/// This is an internal function needed to support regular enqueues, and
+/// additional enqueues due to escalation while a Task is still enqueued
+/// on an executor. Most external callers shoud not be using this function
+/// and should instead call flagAsRunningFrom* on the Task instead.
+///
+/// This function was designed to be called by
+/// swift_executor_escalate and flagAsAndEnqueueOnExecutor.
+///
+/// In those cases, we call this instead of swift_task_enqueue
+/// directly for Tasks in case the Task is already
+/// intrusively linked somewhere due to stealers.
+///
+/// This function has some important and complicated syncronization
+/// requirements. It must be syncronized with marking the Task as running in
+/// resumeRunningAfterFailedSuspend and tryStartRunning such that this function
+/// may not be called once the Task has sucessfully been marked as running.
+/// This is because once a Task is running, it must be escalated by escalating
+/// the thread it is running on rather than by enqueuing a stealer. Thus
+/// this function can only be called while there is an enqueued on executor
+/// dependency record which points to the executor we are escalating here.
+///
+/// For the purposes of this comment, "enqueued" means that the Task
+/// is "runnable" (has a dependent on executor dependency record) and
+/// there is an object enqueued with the current exclusion value even
+/// if there are objects with older exclusion values still enqueued.
+///
+/// The possible intrusive link of this Task and any
+/// stealers that have old exclusion values will always
+/// fail resumeRunningAfterFailedSuspend reguardless of this
+/// function so there is sufficient syncronization between them.
+///
+/// flagAsAndEnqueueOnExecutor can only be called either on Task
+/// initialization, a running Task, or a Task being resumed.
+/// These are mutually exclusive between them by nature.
+///  * During Task initialization, there are no stealers, thus there
+///    is trivial syncronization with flagAsAndEnqueueOnExecutor
+///  * While running a Task (e.g. swapping executors),
+///    because the Task is running, all stealers must have old
+///    exclusion values because active stealers can't exist for
+///    Tasks without dependent on executor dependency records
+///  * Resuming a suspended Task, the Task must have a dependency
+///    record on something other than an executor so any stealers
+///    must have an old exclusion value for the same reason as above
+///
+/// An important note though is that flagAsAndEnqueueOnExecutor adds
+/// the dependent on executor record to the Task before calling this
+/// function. As soon as it does so, swift_task_escalate may attempt to
+/// call this function to add a stealer. To ensure that does not race,
+/// flagAsAndEnqueueOnExecutor must take the Task Status Lock, add the
+/// dependency record, then call this function before releasing the
+/// lock. swift_task_escalate calls all escalation actions including
+/// the one that calls this function under the lock so it can not call
+/// this function until flagAsAndEnqueueOnExecutor has finished its work.
+///
+/// swift_executor_escalate is only called when there is a "dependent on
+/// executor" dependency record so it only needs to syncronize with itself and
+/// with flagAsRunningFrom*. It does this by holding the Task Status Lock which
+/// mutually excludes itself. The flagAsRunningFrom* functions will attempt
+/// to atomically remove the dependency record if there is no one else trying
+/// to hold the lock. So if there is contention, it will attempt to take the
+/// lock. This syncronizes access to the Task Status and dependency record.
+/// If flagAsRunningFrom* wins, it will remove the dependency record before
+/// swift_executor_escalate gets the lock so this function will never be called.
+/// If it looses, then this function will run, enqueue a stealer, and update the
+/// state which flagAsRunningFrom* will then observe in it's exclusive region.
+///
+/// Once there are multiple active stealers, they will also have to syncronize
+/// against each other in flagAsRunningFrom*. Two stealers will both use
+/// atomics to syncronize if no one is holding / attempting to hold the lock.
+/// They will check that their exclusion value is still the most recent and
+/// check the bit that indicates if there are multiple stealers. If they
+/// see that bit, they know that they may be racing with other stealers
+/// so they clear the bit and update the exclusion value. Whoever wins
+/// doing that is able to run and all other racing stealers notice that the
+/// exclusion value is now different so they must fail to flag as running.
+///
+/// Any new calls to this function need to be careful to ensure that
+/// they are only called in a way that syncronizes with all other
+/// uses. It is likely possible to write this function in such a way
+/// that it self-syncronizes with tryStartRunning rather than relying
+/// on the Task Status Lock being held and this function only being
+/// called if the Task is not yet running. However, that would make
+/// this function failable. I leave that as an exersise for the future.
+enum EnqueueFlags : uint32_t {
+  EnqueueFlagsRegular = 0x0,
+  EnqueueFlagsForEscalation = 0x1,
+};
+static inline void
+swift_task_enqueueSelfOrStealer(AsyncTask *task, SerialExecutorRef newExecutor,
+                                EnqueueFlags flags) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  // Assertions / Logging, these initial values need not have
+  // strong syncronization with other callers as it is for
+  // debug perposes only. They will be set again in the CAS loop
+  SWIFT_TASK_DEBUG_LOG("Starting enqueue for %p on %p", (void *)task,
+                       (void *)newExecutor.getIdentity());
+  auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
+  auto needsStealer = oldStatus.isDirectlyEnqueued();
+  auto isAsyncLet = task->Flags.task_isAsyncLetTask();
+  if (isAsyncLet) {
+    // Async let Tasks are allocated on the async stack of their parent task,
+    // so their Task objects can't outlive the scope of their let binding.
+    // Task Stealers can allow the Task to finish while the Task object
+    // itself is still enqueued somewhere. When the async let Task finishes,
+    // its parent may leave the scope of the let binding, freeing the memory
+    // that is still in use by the Task object being enqueued. We don't
+    // want to delay waking up the parent Task an exiting the async let's
+    // scope until all these extra references resolve themselves either. For
+    // now, just don't ever enqueue task stealers for async let tasks, even
+    // though this means we can still have priority inversions when they're
+    // enqueued. Thus, if we are on the escalation path, return immediatly.
+    if (flags & EnqueueFlagsForEscalation) {
+      SWIFT_TASK_DEBUG_LOG(
+          "AsyncLet Task %p, skipping stealer enqueue from escalate", task);
+      return;
+    }
+    // Assert that we didn't get into a situation where we needed a stealer
+    assert(!needsStealer);
+  }
+  SWIFT_TASK_DEBUG_LOG("needsStealer: %d", needsStealer);
+
+  auto needsExtraRetain = false;
+  // CAS loop to determine if the behaviour of this function
+  // will be to use a stealer object or to enqueue the Task
+  // directly. This syncronizes with concurrent callers
+  ActiveTaskStatus newStatus = oldStatus;
+  do {
+    newStatus = oldStatus;
+    if (!oldStatus.isDirectlyEnqueued()) {
+      newStatus = newStatus.withIntrusivelyLinked();
+      needsStealer = false;
+    } else {
+      needsStealer = true;
+      newStatus = newStatus.withRetainForInstrusiveLinkage();
+      if (!oldStatus.hasRetainForInstrusiveLinkage()) {
+        needsExtraRetain = true;
+      } else {
+        needsExtraRetain = false;
       }
     }
+
+    if (flags & EnqueueFlagsForEscalation) {
+      newStatus = newStatus.withActiveStealers();
+    }
+
+    SWIFT_TASK_DEBUG_LOG(
+        "Needs to update based on %d || %d. Needs stealer %d. Exclusion value "
+        "is %d. Setting active stealers from %d to %d",
+        flags, !oldStatus.isDirectlyEnqueued(), needsStealer,
+        newStatus.getStealerExclusionValue(), oldStatus.hasActiveStealers(),
+        newStatus.hasActiveStealers());
+    // This can always be relaxed because it only needs to be read
+    // either by a thread syncronizing with the status lock or someone
+    // reading the stealer which we will later publish on this thread.
+  } while ((newStatus != oldStatus) &&
+           !task->_private()._status().compare_exchange_weak(
+               oldStatus, newStatus,
+               /*success*/ std::memory_order_relaxed,
+               /*failure*/ std::memory_order_relaxed));
+
+  SWIFT_TASK_DEBUG_LOG("Update value: %d, needsStealer: %d", flags,
+                       needsStealer);
+
+  if (needsStealer) {
+    if (needsExtraRetain) {
+      // This balances with the release in taskRemoveEnqueued since
+      // enqueuing a stealer means that the direct enqueue may live
+      // after the Task completes. We only add a retain the first
+      // time we add a stealer and decrement it once the intrusive
+      // linkage is dequeued and observes that this bit was set.
+      swift_retain(task);
+    }
+
+    auto *stealer = swift_cxx_newObject<AsyncTaskStealer>(
+        task, static_cast<JobPriority>(newStatus.getStoredPriority()),
+        newStatus.getStealerExclusionValue());
+    SWIFT_TASK_DEBUG_LOG(
+        "Enqueuing stealer %p at priority %#x with exclusion value %d",
+        (void *)stealer, newStatus.getStoredPriority(),
+        stealer->ExclusionValue);
+    swift_task_enqueue(stealer, newExecutor);
   } else {
-    auto dependencyRecord = _private().dependencyRecord;
-    assert(dependencyRecord != nullptr);
-    SWIFT_TASK_DEBUG_LOG("[Dependency] %p->flagAsRunning() and remove dependencyRecord %p",
-                    this, dependencyRecord);
-
-    removeStatusRecord(this, dependencyRecord, oldStatus, [&](ActiveTaskStatus unused,
-                       ActiveTaskStatus& newStatus) {
-
-#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-      // If the base priority is not equal to the current override floor then
-      // dispqatch may need to apply the base priority to the thread. If the
-      // current priority is higher than the override floor, then dispatch may
-      // need to apply a self-override. In either case, call into dispatch to
-      // do this.
-      qos_class_t maxTaskPriority = (qos_class_t) oldStatus.getStoredPriority();
-      if (threadOverrideInfo.can_override && (taskBasePriority != qos_class_self() || maxTaskPriority > overrideFloor)) {
-        SWIFT_TASK_DEBUG_LOG("[Override] Self-override thread with oq_floor %#x to match task %p's max priority %#x and base priority %#x",
-                             overrideFloor, this, maxTaskPriority, taskBasePriority);
-
-        uint32_t newDispatchOpaquePriority = swift_dispatch_thread_override_self_with_base(maxTaskPriority, taskBasePriority);
-        if (!dispatchOpaquePriority) {
-          dispatchOpaquePriority = newDispatchOpaquePriority;
-        }
-        overrideFloor = maxTaskPriority;
-      }
-#endif
-      // Set self as executor and remove escalation bit if any - the task's
-      // priority escalation has already been reflected on the thread.
-      newStatus = newStatus.withRunning(true);
-      newStatus = newStatus.withoutStoredPriorityEscalation();
-      newStatus = newStatus.withoutEnqueued();
-      newStatus = newStatus.withoutTaskDependency();
-    });
-    this->destroyTaskDependency(dependencyRecord);
-
-    adoptTaskVoucher(this);
-    swift_task_enterThreadLocalContext(
-        (char *)&_private().ExclusivityAccessSet[0]);
+    // Enqueuing the Task's Job directly
+    // Update the priority in the Task's Job
+    task->Flags.setPriority(newStatus.getStoredPriority());
+    concurrency::trace::task_flags_changed(
+        task, static_cast<uint8_t>(task->Flags.getPriority()),
+        task->Flags.task_isChildTask(), task->Flags.task_isFuture(),
+        task->Flags.task_isGroupChildTask(), task->Flags.task_isAsyncLetTask());
+    // Update the exclusion value represented by the Task's Job
+    task->_private().LocalStealerExclusionValue =
+        newStatus.getStealerExclusionValue();
+    swift_task_enqueue(task, newExecutor);
   }
-  return dispatchOpaquePriority;
+#else
+  auto status = task->_private()._status().load(std::memory_order_relaxed);
+  task->Flags.setPriority(status.getStoredPriority());
+  concurrency::trace::task_flags_changed(
+      task, static_cast<uint8_t>(task->Flags.getPriority()),
+      task->Flags.task_isChildTask(), task->Flags.task_isFuture(),
+      task->Flags.task_isGroupChildTask(), task->Flags.task_isAsyncLetTask());
+  swift_task_enqueue(task, newExecutor);
+#endif
 }
 
 /// TODO (rokhinip): We need the handoff of the thread to the next executor to
@@ -1154,33 +1693,46 @@ AsyncTask::flagAsAndEnqueueOnExecutor(SerialExecutorRef newExecutor) {
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
   assert(false && "Should not enqueue any tasks to execute in task-to-thread model");
 #else /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
-  auto oldStatus = _private()._status().load(std::memory_order_relaxed);
-  assert(!oldStatus.isEnqueued());
+  // swift_task_escalate will first increase the priority in the
+  // ActiveTaskStatus without taking the Task Status Lock, then
+  // early out if there is no dependency record, then take the lock
+  // to iterate the dependency records. So we need to take the lock,
+  // add or modify the dependency record, check the priority in
+  // the ActiveTaskStatus, then enqueue the Task at that priority.
 
+  // First, check which transition we are making thus
+  // determining if we are updating or adding a dependency record
+  auto oldStatus = _private()._status().load(std::memory_order_relaxed);
   if (!oldStatus.isRunning() && oldStatus.hasTaskDependency()) {
-    // Task went from suspended --> enqueued and has a previous
-    // dependency record.
-    //
-    // Atomically update the existing dependency record with new dependency
-    // information.
+    // Task went from suspended --> enqueued and has a previous dependency
+    // record. Update it to indicate the executor we are now suspended on
     TaskDependencyStatusRecord *dependencyRecord = _private().dependencyRecord;
     assert(dependencyRecord != nullptr);
 
     SWIFT_TASK_DEBUG_LOG("[Dependency] %p->flagAsAndEnqueueOnExecutor() and update dependencyRecord %p",
       this, dependencyRecord);
 
-    updateStatusRecord(this, dependencyRecord, [&] {
+    updateStatusRecord(
+        this, dependencyRecord,
+        [&](ActiveTaskStatus lockedStatus) {
+          // Update dependency record to the new dependency
+          dependencyRecord->updateDependencyToEnqueuedOn(newExecutor);
 
-      // Update dependency record to the new dependency
-      dependencyRecord->updateDependencyToEnqueuedOn(newExecutor);
-
-    }, oldStatus, [&](ActiveTaskStatus unused, ActiveTaskStatus &newStatus) {
-
-      // Remove escalation bits + set enqueued bit
-      newStatus = newStatus.withoutStoredPriorityEscalation();
-      newStatus = newStatus.withEnqueued();
-      assert(newStatus.hasTaskDependency());
-    });
+          // Even though we are not in the "enqueue stealer" path, this
+          // may still enqueue a stealer because we may have previously
+          // run from a stealer and the original Task is still enqueued.
+          swift_task_enqueueSelfOrStealer(this, newExecutor,
+                                          EnqueueFlagsRegular);
+        },
+        oldStatus,
+        [&](ActiveTaskStatus unused, ActiveTaskStatus &newStatus) {
+          // Remove escalation bits + set enqueued bit
+          newStatus = newStatus.withoutStoredPriorityEscalation();
+#if !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+          newStatus = newStatus.withIntrusivelyLinked();
+#endif
+          assert(newStatus.hasTaskDependency());
+        });
   } else {
     // 2 subcases:
     // * Task went from running on this thread --> enqueued on executor
@@ -1188,48 +1740,51 @@ AsyncTask::flagAsAndEnqueueOnExecutor(SerialExecutorRef newExecutor) {
     // dependency record (Eg. newly created)
     assert(_private().dependencyRecord == nullptr);
 
-    // TODO: do we need to do tracking for task executors...? I guess no since
-    // they can't escalate.
+    // Allocate a new dependency record since we don't have one
     void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-    TaskDependencyStatusRecord *dependencyRecord = _private().dependencyRecord = ::new (allocation) TaskDependencyStatusRecord(this, newExecutor);
+    TaskDependencyStatusRecord *dependencyRecord = _private().dependencyRecord =
+        ::new (allocation) TaskDependencyStatusRecord(newExecutor);
     SWIFT_TASK_DEBUG_LOG("[Dependency] %p->flagAsAndEnqueueOnExecutor() with dependencyRecord %p", this,
       dependencyRecord);
 
-    addStatusRecord(this, dependencyRecord, oldStatus, [&](ActiveTaskStatus unused,
-                    ActiveTaskStatus &newStatus) {
+    withStatusRecordLock(this, oldStatus, [&](ActiveTaskStatus lockedStatus) {
+      addStatusRecord(
+          this, dependencyRecord, oldStatus,
+          [&](ActiveTaskStatus unused, ActiveTaskStatus &newStatus) {
+            newStatus = newStatus.withRunning(false);
+            newStatus = newStatus.withoutStoredPriorityEscalation();
+            newStatus = newStatus.withTaskDependency();
+#if !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+            newStatus = newStatus.withIntrusivelyLinked();
+#endif
+            return true;
+          });
 
-      newStatus = newStatus.withRunning(false);
-      newStatus = newStatus.withoutStoredPriorityEscalation();
-      newStatus = newStatus.withEnqueued();
-      newStatus = newStatus.withTaskDependency();
-
-      return true;
-    });
-
-    if (oldStatus.isRunning()) {
+      if (oldStatus.isRunning()) {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-      // The thread was previously running the task, now that we aren't and
-      // we've successfully escalated the thing the task is waiting on. We need
-      // to remove any task escalation on the thread as a result of the task.
-      if (oldStatus.isStoredPriorityEscalated()) {
-        SWIFT_TASK_DEBUG_LOG("[Override] Reset override %#x on thread from task %p",
-          oldStatus.getStoredPriority(), this);
-        swift_dispatch_lock_override_end((qos_class_t) oldStatus.getStoredPriority());
-      }
+        // The thread was previously running the task, now that we aren't and
+        // we've successfully escalated the thing the task is waiting on. We
+        // need to remove any task escalation on the thread as a result of the
+        // task.
+        if (oldStatus.isStoredPriorityEscalated()) {
+          SWIFT_TASK_DEBUG_LOG(
+              "[Override] Reset override %#x on thread from task %p",
+              oldStatus.getStoredPriority(), this);
+          swift_dispatch_lock_override_end(
+              (qos_class_t)oldStatus.getStoredPriority());
+        }
 #endif /* SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION */
-      swift_task_exitThreadLocalContext((char *)&_private().ExclusivityAccessSet[0]);
-      restoreTaskVoucher(this);
-    }
+        swift_task_exitThreadLocalContext(
+            (char *)&_private().ExclusivityAccessSet[0]);
+        restoreTaskVoucher(this);
+      }
+
+      // Even though we are not in the "enqueue stealer" path, this
+      // may still enqueue a stealer because we may have previously
+      // run from a stealer and the original Task is still enqueued.
+      swift_task_enqueueSelfOrStealer(this, newExecutor, EnqueueFlagsRegular);
+    });
   }
-
-  // Set up task for enqueue to next location by setting the Job priority field
-  Flags.setPriority(oldStatus.getStoredPriority());
-  concurrency::trace::task_flags_changed(
-      this, static_cast<uint8_t>(Flags.getPriority()), Flags.task_isChildTask(),
-      Flags.task_isFuture(), Flags.task_isGroupChildTask(),
-      Flags.task_isAsyncLetTask());
-
-  swift_task_enqueue(this, newExecutor);
 #endif /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
 }
 
@@ -1243,7 +1798,7 @@ void AsyncTask::flagAsSuspended(TaskDependencyStatusRecord *dependencyStatusReco
   auto oldStatus = _private()._status().load(std::memory_order_relaxed);
   // We can only be suspended if we were previously running. See state
   // transitions listed out in Task.h
-  assert(oldStatus.isRunning() && !oldStatus.isEnqueued());
+  assert(oldStatus.isRunning());
 
   addStatusRecord(this, dependencyStatusRecord, oldStatus, [&](ActiveTaskStatus unused,
                   ActiveTaskStatus &newStatus) {
@@ -1263,8 +1818,7 @@ void AsyncTask::flagAsSuspended(TaskDependencyStatusRecord *dependencyStatusReco
     // published it in the ActiveTaskStatus since someone else could
     // concurrently made us runnable.
     dependencyStatusRecord->performEscalationAction(
-        oldStatus.getStoredPriority(),
-        newStatus.getStoredPriority());
+        this, oldStatus.getStoredPriority(), newStatus.getStoredPriority());
 
     // Always add the dependency status record
     return true;
@@ -1292,13 +1846,23 @@ inline void AsyncTask::destroyTaskDependency(TaskDependencyStatusRecord *depende
   _private().dependencyRecord = nullptr;
 }
 
+inline AsyncTask *&AsyncTask::getNextWaitingTask() {
+#ifndef NDEBUG
+  auto status = _private()._status().load(std::memory_order_relaxed);
+  assert(status.hasTaskDependency());
+#endif
+  auto *dependency = _private().dependencyRecord;
+  assert(dependency != nullptr);
+  return dependency->getNextWaitingTask();
+}
+
 // this -> task which is suspending
 // Input task -> task we are waiting on
 inline void AsyncTask::flagAsSuspendedOnTask(AsyncTask *task) {
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(this, task);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(task);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on task %p", allocation, task);
   _private().dependencyRecord = record;
 
@@ -1309,7 +1873,7 @@ inline void AsyncTask::flagAsSuspendedOnContinuation(ContinuationAsyncContext *c
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(this, context);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(context);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on continuation %p", allocation, context);
   _private().dependencyRecord = record;
 
@@ -1320,7 +1884,7 @@ inline void AsyncTask::flagAsSuspendedOnTaskGroup(TaskGroup *taskGroup) {
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(this, taskGroup);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(taskGroup);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on taskGroup %p", allocation, taskGroup);
   _private().dependencyRecord = record;
 

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -48,11 +48,11 @@ ActiveTaskStatus::getStatusRecordParent(TaskStatusRecord *ptr) {
 /// from the ActiveTaskStatus so that callers may make additional modifications
 /// to ActiveTaskStatus flags. `statusUpdate` can be called multiple times in a
 /// RMW loop and so much be idempotent.
-static void withStatusRecordLock(
+void swift::withStatusRecordLock(
     AsyncTask *task, ActiveTaskStatus status,
     llvm::function_ref<void(ActiveTaskStatus)> fn,
     llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)>
-        statusUpdate = nullptr) {
+        statusUpdate) {
   // We need to acquire the lock AND set the is-locked bit in the status so that
   // other threads attempting lockless operations can atomically check whether
   // another thread holds the lock. Various operations can be done with a
@@ -311,6 +311,90 @@ void swift::removeStatusRecord(AsyncTask *task, TaskStatusRecord *record,
   }
 }
 
+// For when we are trying to remove a record but can only do
+// so if a certain condition of the active task status is true
+SWIFT_CC(swift)
+bool swift::removeStatusRecordIf(
+    AsyncTask *task, TaskStatusRecord *record, ActiveTaskStatus &oldStatus,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)> fn,
+    llvm::function_ref<bool(ActiveTaskStatus)> condition) {
+
+  SWIFT_TASK_DEBUG_LOG("remove status record = %p, from task = %p", record,
+                       task);
+
+  bool didRemove = false;
+  while (true) {
+    // If the record is locked, then either we wait for the lock or we own the
+    // lock. Either way, acquire the status record lock and perform the removal.
+    // If the record to be removed is not the innermost record, then we need to
+    // acquire the lock to safely remove it.
+    if (oldStatus.isStatusRecordLocked() ||
+        oldStatus.getInnermostRecord() != record) {
+      withStatusRecordLock(
+          task, oldStatus,
+          [&](ActiveTaskStatus lockedStatus) {
+            // Now that we have locked the status, evaluate the condition
+            if (!condition(lockedStatus)) {
+              return;
+            }
+            didRemove = true;
+            // If the record is the innermost (always was, or became that way
+            // while we waited) then we have to remove it in the status change
+            // function, since changing the head of the list requires changing
+            // the status. If it's not the innermost then we can remove it here.
+            if (lockedStatus.getInnermostRecord() != record) {
+              removeNonInnermostStatusRecordLocked(lockedStatus, record);
+            }
+          },
+          [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+            // If the condition allows us to remove
+            // the record, update the ActiveTaskStatus
+            if (didRemove) {
+              // If this record is the innermost record,
+              // set a new status with the record removed.
+              if (newStatus.getInnermostRecord() == record)
+                newStatus = newStatus.withInnermostRecord(record->getParent());
+
+              // Requested status updates
+              if (fn) {
+                fn(oldStatus, newStatus);
+              }
+            }
+          });
+      // Taking the lock never requires a retry
+      break;
+    }
+
+    // Nobody holds the lock, and the record is the
+    // innermost record. Attempt to remove it locklessly.
+    if (!condition(oldStatus)) {
+      // Condition has decided we no longer want to attempt removal
+      break;
+    }
+
+    // Remove the record
+    auto newStatus = oldStatus.withInnermostRecord(record->getParent());
+
+    // Requested status updates
+    if (fn) {
+      fn(oldStatus, newStatus);
+    }
+
+    if (task->_private()._status().compare_exchange_weak(
+            oldStatus, newStatus,
+            /*success*/ std::memory_order_relaxed,
+            /*failure*/ std::memory_order_relaxed)) {
+      newStatus.traceStatusChanged(task, oldStatus, false);
+      didRemove = true;
+      break;
+    }
+
+    // We failed to remove the record locklessly. Go back to the top and retry
+    // removing it.
+  }
+  return didRemove;
+}
+
 // For when we are trying to remove a record and also optionally trying to
 // modify some flags in the ActiveTaskStatus at the same time.
 SWIFT_CC(swift)
@@ -415,10 +499,11 @@ void swift::removeStatusRecordFromSelf(TaskStatusRecord *record,
 }
 
 SWIFT_CC(swift)
-void swift::updateStatusRecord(AsyncTask *task, TaskStatusRecord *record,
-     llvm::function_ref<void()>updateRecord,
-     ActiveTaskStatus& status,
-     llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>fn) {
+void swift::updateStatusRecord(
+    AsyncTask *task, TaskStatusRecord *record,
+    llvm::function_ref<void(ActiveTaskStatus)> updateRecord,
+    ActiveTaskStatus &status,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)> fn) {
 
   SWIFT_TASK_DEBUG_LOG("Updating status record %p of task %p", record, task);
   withStatusRecordLock(task, status, [&](ActiveTaskStatus lockedStatus) {
@@ -432,7 +517,7 @@ void swift::updateStatusRecord(AsyncTask *task, TaskStatusRecord *record,
     }
     assert(foundRecord);
 #endif
-    updateRecord();
+    updateRecord(lockedStatus);
   }, fn);
 }
 
@@ -475,7 +560,7 @@ TaskExecutorRef AsyncTask::getPreferredTaskExecutor(bool assumeHasRecord) {
   }
 
   TaskExecutorRef preference = TaskExecutorRef::undefined();
-  withStatusRecordLock(this, [&](ActiveTaskStatus status) {
+  ::withStatusRecordLock(this, [&](ActiveTaskStatus status) {
     for (auto record : status.records()) {
       if (record->getKind() == TaskStatusRecordKind::TaskExecutorPreference) {
         auto executorPreferenceRecord =
@@ -782,9 +867,8 @@ void swift::_swift_taskGroup_detachChild(TaskGroup *group,
   // though, just that it's not concurrently running.
   auto parent = child->childFragment()->getParent();
 
-  withStatusRecordLock(parent, [&](ActiveTaskStatus unused) {
-    group->removeChildTask(child);
-  });
+  ::withStatusRecordLock(
+      parent, [&](ActiveTaskStatus unused) { group->removeChildTask(child); });
 }
 
 /// Cancel the task group and all the child tasks that belong to `group`.
@@ -813,7 +897,7 @@ void swift::_swift_taskGroup_cancel_unlocked(TaskGroup *group,
   if (!group->getTaskRecord()->getFirstChild())
     return;
 
-  withStatusRecordLock(owningTask, [&group](ActiveTaskStatus status) {
+  ::withStatusRecordLock(owningTask, [&group](ActiveTaskStatus status) {
     _swift_taskGroup_cancel(group);
   });
 }
@@ -924,7 +1008,7 @@ static void swift_task_cancelImpl(AsyncTask *task) {
 /**************************************************************************/
 
 /// Perform any escalation actions required by the given record.
-static void performEscalationAction(TaskStatusRecord *record,
+static void performEscalationAction(AsyncTask *task, TaskStatusRecord *record,
                                     JobPriority oldPriority,
                                     JobPriority newPriority) {
   switch (record->getKind()) {
@@ -956,7 +1040,7 @@ static void performEscalationAction(TaskStatusRecord *record,
     auto dependencyRecord = cast<TaskDependencyStatusRecord>(record);
     SWIFT_TASK_DEBUG_LOG("[Dependency] Escalating a task dependency record %p from %#x to %#x",
                     record, oldPriority, newPriority);
-    dependencyRecord->performEscalationAction(oldPriority, newPriority);
+    dependencyRecord->performEscalationAction(task, oldPriority, newPriority);
     return;
   }
 
@@ -994,7 +1078,7 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
       return oldPriority;
     }
 
-    if (oldStatus.isRunning() || oldStatus.isEnqueued()) {
+    if (oldStatus.isRunning()) {
       // Regardless of whether status record is locked or not, update the
       // priority and RO bit on the task status
       newStatus = oldStatus.withEscalatedPriority(newPriority);
@@ -1003,7 +1087,7 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
       SWIFT_TASK_DEBUG_LOG("Escalated a task %p which had completed, do nothing", task);
       return oldStatus.getStoredPriority();
     } else {
-      // Task is suspended.
+      // Task is suspended or enqueued.
       newStatus = oldStatus.withNewPriority(newPriority);
     }
 
@@ -1031,25 +1115,23 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
     swift_dispatch_lock_override_start_with_debounce(
         executionLock, newStatus.currentExecutionLockOwner(), (qos_class_t) newPriority);
 #endif
-  } else if (newStatus.isEnqueued()) {
-    //  Task is not running, it's enqueued somewhere waiting to be run
+  } else {
+    //  Task is not running, it's either enqueued waiting to run or suspended
     //
-    // TODO (rokhinip): Add a stealer to escalate the thread request for
-    //  the task. Still mark the task has having been escalated so that the
-    //  thread will self override when it starts draining the task
-    //
-    // TODO (rokhinip): Add a signpost to flag that this is a potential
-    //  priority inversion
-    SWIFT_TASK_DEBUG_LOG("[Override] Escalating %p which is enqueued", task);
-
+    // When tasks are enqueued on any executor, they will have an
+    // EnqueuedOnExecutor TaskDependencyStatusRecord which will have
+    // performEscalationAction called on it below. This will call
+    // swift_executor_escalate which will enqueue a stealer if needed.
+    SWIFT_TASK_DEBUG_LOG("[Override] Escalating %p which isn't running", task);
   }
 
   if (newStatus.getInnermostRecord() == NULL) {
     return newStatus.getStoredPriority();
   }
 
-  SWIFT_TASK_DEBUG_LOG("[Override] Escalating %p which is suspended from %#x to %#x",
-                       task, oldPriority, newPriority);
+  SWIFT_TASK_DEBUG_LOG(
+      "[Override] Escalating %p which has status records from %#x to %#x", task,
+      oldPriority, newPriority);
   // We must have at least one record - the task dependency one.
   assert(newStatus.getInnermostRecord() != NULL);
 
@@ -1057,7 +1139,7 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
     // We know that none of the escalation actions will recursively
     // modify the task status record list by adding or removing task records
     for (auto cur: status.records()) {
-      performEscalationAction(cur, oldPriority, newPriority);
+      performEscalationAction(task, cur, oldPriority, newPriority);
     }
   });
 
@@ -1065,7 +1147,7 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
 }
 
 void TaskDependencyStatusRecord::performEscalationAction(
-    JobPriority oldPriority, JobPriority newPriority) {
+    AsyncTask *task, JobPriority oldPriority, JobPriority newPriority) {
   switch (this->DependencyKind) {
     case WaitingOnTask:
       SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent task %p noted in %p record",
@@ -1087,11 +1169,18 @@ void TaskDependencyStatusRecord::performEscalationAction(
         this->DependentOn.TaskGroup, this);
       break;
     case EnqueuedOnExecutor:
-      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent executor %p noted in %p record from %#x to %#x",
-        this->DependentOn.Executor, this, oldPriority, newPriority);
-      swift_executor_escalate(this->DependentOn.Executor, this->WaitingTask, newPriority);
+      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent executor %p noted "
+                           "in %p record from %#x to %#x",
+                           (void *)this->DependentOn.Executor.getIdentity(),
+                           (void *)this, oldPriority, newPriority);
+      swift_executor_escalate(this->DependentOn.Executor, task, newPriority);
       break;
   }
+}
+
+AsyncTask *&TaskDependencyStatusRecord::getNextWaitingTask() {
+  assert(this->DependencyKind == WaitingOnTask);
+  return this->NextWaitingTask;
 }
 
 #define OVERRIDE_TASK_STATUS COMPATIBILITY_OVERRIDE

--- a/stdlib/public/Concurrency/TracingSignpost.h
+++ b/stdlib/public/Concurrency/TracingSignpost.h
@@ -126,29 +126,25 @@ inline void actor_deallocate(HeapObject *actor) {
 }
 
 inline void actor_enqueue(HeapObject *actor, Job *job) {
-  if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-    ENSURE_LOGS();
-    auto metadata = swift_getObjectType(actor);
-    auto descriptor = (const void *)metadata->getTypeContextDescriptor();
-    auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
-    os_signpost_event_emit(
-        ActorLog, id, SWIFT_LOG_ACTOR_ENQUEUE_NAME,
-        "actor=%p task=%" PRId64 " taskPointer=%p metadata=%p descriptor=%p",
-        actor, task->getTaskId(), task, metadata, descriptor);
-  }
+  ENSURE_LOGS();
+  auto metadata = swift_getObjectType(actor);
+  auto descriptor = (const void *)metadata->getTypeContextDescriptor();
+  auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
+  os_signpost_event_emit(ActorLog, id, SWIFT_LOG_ACTOR_ENQUEUE_NAME,
+                         "actor=%p task=%" PRId64
+                         " taskPointer=%p metadata=%p descriptor=%p",
+                         actor, job->getJobTaskId(), job, metadata, descriptor);
 }
 
 inline void actor_dequeue(HeapObject *actor, Job *job) {
-  if (AsyncTask *task = dyn_cast_or_null<AsyncTask>(job)) {
-    ENSURE_LOGS();
-    auto metadata = swift_getObjectType(actor);
-    auto descriptor = (const void *)metadata->getTypeContextDescriptor();
-    auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
-    os_signpost_event_emit(
-        ActorLog, id, SWIFT_LOG_ACTOR_DEQUEUE_NAME,
-        "actor=%p task=%" PRId64 " taskPointer=%p metadata=%p descriptor=%p",
-        actor, task->getTaskId(), task, metadata, descriptor);
-  }
+  ENSURE_LOGS();
+  auto metadata = swift_getObjectType(actor);
+  auto descriptor = (const void *)metadata->getTypeContextDescriptor();
+  auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
+  os_signpost_event_emit(ActorLog, id, SWIFT_LOG_ACTOR_DEQUEUE_NAME,
+                         "actor=%p task=%" PRId64
+                         " taskPointer=%p metadata=%p descriptor=%p",
+                         actor, job->getJobTaskId(), job, metadata, descriptor);
 }
 
 inline void actor_state_changed(HeapObject *actor, Job *firstJob, uint8_t state,
@@ -308,24 +304,20 @@ inline void task_continuation_resume(ContinuationAsyncContext *context,
 }
 
 inline void job_enqueue_global(Job *job) {
-  if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-    ENSURE_LOGS();
-    auto id = os_signpost_id_make_with_pointer(TaskLog, job);
-    os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_GLOBAL_NAME,
-                           "task=%" PRId64 " taskPointer=%p",
-                           task->getTaskId(), task);
-  }
+  ENSURE_LOGS();
+  auto id = os_signpost_id_make_with_pointer(TaskLog, job);
+  os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_GLOBAL_NAME,
+                         "task=%" PRId64 " taskPointer=%p", job->getJobTaskId(),
+                         job);
 }
 
 inline void job_enqueue_global_with_delay(unsigned long long delay, Job *job) {
-  if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-    ENSURE_LOGS();
-    auto id = os_signpost_id_make_with_pointer(TaskLog, job);
-    os_signpost_event_emit(
-        TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_GLOBAL_WITH_DELAY_NAME,
-        "task=%" PRId64 " delay=%llu taskPointer=%p",
-        task->getTaskId(), delay, task);
-  }
+  ENSURE_LOGS();
+  auto id = os_signpost_id_make_with_pointer(TaskLog, job);
+  os_signpost_event_emit(TaskLog, id,
+                         SWIFT_LOG_JOB_ENQUEUE_GLOBAL_WITH_DELAY_NAME,
+                         "task=%" PRId64 " delay=%llu taskPointer=%p",
+                         job->getJobTaskId(), delay, job);
 }
 
 inline TracingExecutorKind classifyExecutor(SerialExecutorRef serialExecutor,
@@ -343,23 +335,21 @@ inline TracingExecutorKind classifyExecutor(SerialExecutorRef serialExecutor,
 
 inline void job_enqueue_executor(Job *job, SerialExecutorRef serialExecutor,
                                   TaskExecutorRef taskExecutor) {
-  if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-    ENSURE_LOGS();
-    HeapObject *executorIdentity =
-        serialExecutor.isGeneric() ? nullptr : serialExecutor.getIdentity();
-    auto metadata =
-        executorIdentity ? swift_getObjectType(executorIdentity) : nullptr;
-    auto descriptor = metadata
-        ? (const void *)metadata->getTypeContextDescriptor() : nullptr;
-    auto executorKind = classifyExecutor(serialExecutor, taskExecutor);
-    auto id = os_signpost_id_make_with_pointer(TaskLog, job);
-    os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_EXECUTOR_NAME,
-                           "task=%" PRId64 " taskPointer=%p"
-                           " executor=%p metadata=%p descriptor=%p"
-                           " executorKind=%u",
-                           task->getTaskId(), task, executorIdentity, metadata,
-                           descriptor, (unsigned)executorKind);
-  }
+  ENSURE_LOGS();
+  HeapObject *executorIdentity =
+      serialExecutor.isGeneric() ? nullptr : serialExecutor.getIdentity();
+  auto metadata =
+      executorIdentity ? swift_getObjectType(executorIdentity) : nullptr;
+  auto descriptor =
+      metadata ? (const void *)metadata->getTypeContextDescriptor() : nullptr;
+  auto executorKind = classifyExecutor(serialExecutor, taskExecutor);
+  auto id = os_signpost_id_make_with_pointer(TaskLog, job);
+  os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_EXECUTOR_NAME,
+                         "task=%" PRId64 " taskPointer=%p"
+                         " executor=%p metadata=%p descriptor=%p"
+                         " executorKind=%u",
+                         job->getJobTaskId(), job, executorIdentity, metadata,
+                         descriptor, (unsigned)executorKind);
 }
 
 inline job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,


### PR DESCRIPTION
When Swift Tasks are enqueued onto the cooperative pool, the queue they are placed onto is based on their current priority. If the Task is further escalated, it will be marked as such so that when it runs, it will self-escalate the thread to the required priority, but while it is enqueued, nothing will happen. If the Task was originally enqueued at a low priority, it may not be able to run because it is waiting on other items ahead and the system doesn’t have enough room to do low priority work. This is a priority inversion since this now-higher-priority Task is unable to run.
    
This commit implements a "stealer" object for Tasks that is similar to the existing Actor stealer called AsyncTaskStealer. These would be used only when Dispatch is the default global executor and priority escalation is enabled. To an executor of any kind (Dispatch or custom), stealer objects would look like any other Job. This avoids edge cases when a Task is enqueued to multiple types of executors through its lifetime (e.g. global, Actor, custom). Stealer objects have to be created any time the Task needs to be enqueued while the Task object itself is still enqueued somewhere (which in Dispatch executors is via an intrusive linked list thus only allowing the Task to be enqueued in one place). If it does eventually become dequeued, it may be enqueued directly the next time it needs to be enqueued. In order to ensure that the Task is only run when it should, it needs to contain a counter that increments each time it finishes an execution. Each stealer object contains a field indicating at which value of the counter is it able to run and the Task itself has one in its private data for the direct enqueued copy. If the Task or stealer is run but the Task’s current counter is not equal to the one that is allowed to be run, the invocation will do nothing.
    
Because flagAsRunning can now fail and a previous commit introduced an opaque return value, there is a split between two cases where flagAsRunning can be called. When the Task is being resumed immediately after suspension without being enqueued again, flagAsRunning is infailable and will always return zero for the opaque value. When initially running from swift_task_run, it is failable and may return an opaque value. I've refactored flagAsRunning to separate these cases and try my best to reduce some redundant code.
    
rdar://160967177

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
