### PR TITLE
[Swiftify] don't add macro when required type is unavailable

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -383,8 +383,8 @@ struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
         ASSERT(Def && "pointer to concrete type without type definition?");
         const clang::Module *M = getOwningModule(ClangDecl);
 
-        if (!Owner && !M) {
-          DLOG("Both decls are in bridging header\n");
+        if (!M) {
+          DLOG("Concrete type is in bridging header, which is always imported\n");
           return Action::Continue;
         }
 
@@ -393,12 +393,6 @@ struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
           DLOG("Imported signature contains concrete type not available in bridging header, skipping\n");
           LLVM_DEBUG(DUMP(Def));
           return Action::Stop;
-        }
-        if (!M) {
-          ABORT([Def](auto &out) {
-            out << "Imported signature contains concrete type without an owning clang module:\n";
-            Def->dump(out);
-          });
         }
         if (!Owner->isModuleVisible(M)) {
           hasForwardDeclaredConcreteType = true;

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -1,0 +1,71 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
+// RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
+// RUN: %diff %t/imports.out %t/imports.expected
+
+//--- imports.expected
+imports for TMP_DIR/test.swift:
+	Swift
+	__ObjC
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+	A
+imports for A.foo:
+imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
+	Swift
+	__ObjC
+	lifetimebound
+	ptrcheck
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+
+//--- macro-expansions.expected
+@__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeBufferPointer { _pPtr in
+      return unsafe foo(len, _pPtr.baseAddress!, x)
+    }
+}
+------------------------------
+
+//--- test.swift
+import A
+
+func test(s: Span<a_t>, x: UnsafeMutablePointer<no_module_record_t>) {
+  unsafe foo(s, x)
+}
+
+//--- bridging.h
+// claim this header as part of bridging header, making it not belong to a module
+#include "no-module.h"
+
+//--- no-module.h
+#pragma once
+typedef int no_module_t;
+struct no_module_record_t {
+  int placeholder;
+};
+
+//--- a.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+// this module header now depends on a decl with no module
+#include "no-module.h"
+typedef int a_t;
+void foo(int len, const int * __counted_by(len) p __noescape, struct no_module_record_t *x);
+
+//--- module.modulemap
+module A {
+  header "a.h"
+}

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -16,6 +16,9 @@ imports for TMP_DIR/test.swift:
 	_StringProcessing
 	_SwiftConcurrencyShims
 	_Concurrency
+	A
+	B
+	C
 imports for __ObjC.foo:
 imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 	__ObjC
@@ -25,21 +28,73 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>) {
-    let len = Int32(exactly: p.count)!
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<a_t>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
+    let len = no_module_t(exactly: p.count)!
     return unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe foo(len, _pPtr.baseAddress!)
+      return unsafe foo(len, _pPtr.baseAddress!, x)
     }
 }
 ------------------------------
 
 //--- test.swift
-func test(s: Span<CInt>) {
-  foo(s)
+import A
+import B
+import C
+
+func test(s: Span<a_t>, x: UnsafeMutablePointer<no_module_record_t>) {
+  unsafe foo(s, x)
+}
+
+func test2(p: UnsafeMutablePointer<CInt>, len: CInt, y: UnsafeMutablePointer<b_t>) {
+  unsafe bar(len, p, y)
+}
+
+func test3(p: UnsafeMutablePointer<CInt>, len: CInt, z: UnsafeMutablePointer<c_t>) {
+  unsafe baz(len, p, z)
 }
 
 //--- bridging.h
 #include <ptrcheck.h>
 #include <lifetimebound.h>
 
-void foo(int len, const int * __counted_by(len) p __noescape);
+#include "no-module.h"
+#include "a.h"
+#include "c.h"
+
+struct no_module_record_t;
+void foo(no_module_t len, const a_t * __counted_by(len) p __noescape, struct no_module_record_t *x);
+
+struct b_t;
+void bar(int len, const int * __counted_by(len) p __noescape, struct b_t *y);
+
+void baz(int len, const int * __counted_by(len) p __noescape, struct c_t *z);
+
+//--- no-module.h
+typedef int no_module_t;
+struct no_module_record_t {
+  int placeholder;
+};
+
+//--- a.h
+typedef int a_t;
+
+//--- b.h
+struct b_t {
+  int placeholder;
+};
+
+//--- c.h
+struct c_t {
+  int placeholder;
+};
+
+//--- module.modulemap
+module A {
+  header "a.h"
+}
+module B {
+  header "b.h"
+}
+module C {
+  header "c.h"
+}

--- a/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
+++ b/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
@@ -1,0 +1,148 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}foo.h -verify-additional-file %t%{fs-sep}bar.h -verify-additional-file %t%{fs-sep}baz.h -verify-additional-file %t%{fs-sep}qux.h -Rmacro-expansions
+
+// Macro expansions in foo.h do not have access to the definition of `struct qux`,
+// so don't attach macro on functions that use contain that type in foo.h.
+// bar.h imports the type, so attach the macro.
+// baz.h imports bar.h which re-exports the type, so attach the macro there too.
+
+//--- foo.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+struct qux;
+// expected-note@+1{{'foo' declared here}}
+void foo(struct qux *x, int * __counted_by(len) p, int len);
+// expected-note@+1{{'fooReturn' declared here}}
+struct qux * fooReturn(int * __counted_by(len) p, int len);
+
+
+//--- bar.h
+#pragma once
+#include "qux.h"
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+// expected-expansion@+10:59{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bar(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(x, p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:6{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bar' here}}
+// }}
+void bar(struct qux *x, int * __counted_by(len) p, int len);
+// expected-expansion@+10:58{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func barReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe barReturn(p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'barReturn' here}}
+// }}
+struct qux * barReturn(int * __counted_by(len) p, int len);
+
+
+//--- baz.h
+#pragma once
+
+#include "bar.h"
+
+struct qux;
+// expected-expansion@+10:59{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func baz(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe baz(x, p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:6{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'baz' here}}
+// }}
+void baz(struct qux *x, int * __counted_by(len) p, int len);
+// expected-expansion@+10:58{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bazReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe bazReturn(p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:14{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bazReturn' here}}
+// }}
+struct qux * bazReturn(int * __counted_by(len) p, int len);
+
+
+//--- qux.h
+#pragma once
+
+struct qux { int placeholder; };
+
+
+//--- test.swift
+import Foo
+import Bar
+import Baz
+
+func callFoo(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+  unsafe foo(x, p, len)
+  let _: UnsafeMutablePointer<qux> = unsafe fooReturn(p, len)
+}
+
+func callFoo2(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutableBufferPointer<CInt>) {
+  // expected-error@+2{{missing argument for parameter #3 in call}}
+  // expected-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<Int32>'}}
+  unsafe foo(x, p)
+  // expected-error@+2{{missing argument for parameter #2 in call}}
+  // expected-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<Int32>'}}
+  let _: UnsafeMutablePointer<qux> = unsafe fooReturn(p)
+}
+
+
+func callBar(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+  unsafe bar(x, p, len)
+  let _: UnsafeMutablePointer<qux> = unsafe barReturn(p, len)
+}
+
+func callBar2(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bar(x, p)
+  let _: UnsafeMutablePointer<qux> = unsafe barReturn(p)
+}
+
+
+func callBaz(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+  unsafe baz(x, p, len)
+  let _: UnsafeMutablePointer<qux> = unsafe bazReturn(p, len)
+}
+
+func callBaz2(_ x: UnsafeMutablePointer<qux>, _ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe baz(x, p)
+  let _: UnsafeMutablePointer<qux> = unsafe bazReturn(p)
+}
+
+
+//--- module.modulemap
+module Foo {
+  header "foo.h"
+}
+module Bar {
+  header "bar.h"
+  export qux
+}
+module Baz {
+  header "baz.h"
+  export Bar
+}
+module qux {
+  header "qux.h"
+}


### PR DESCRIPTION
A Swift module only imports a type definition once. This means that some clang modules may have function signatures imported with `UnsafePointer<qux>` even if `qux` is only forward declared in that module (which would normally be imported as `OpaquePointer`), because some Swift file in the module imported the clang module with the definition, so ClangImporter sees the definition. The macro expansion only imports the imports of the clang module it belongs to however, so namelookup for `qux` fails. This patch detects when this will result in an error and avoids attaching the macro in those cases.

rdar://165864358