### PR TITLE
SE-0492: Allow any @convention(c) function conversions

### DIFF
--- a/lib/Sema/LegalConstExprVerifier.cpp
+++ b/lib/Sema/LegalConstExprVerifier.cpp
@@ -241,7 +241,8 @@ checkSupportedWithSectionAttribute(const Expr *expr,
               functionConvExpr->getType()->getAs<AnyFunctionType>()) {
         if (targetFnTy->getExtInfo().getRepresentation() ==
             FunctionTypeRepresentation::CFunctionPointer) {
-          expressionsToCheck.push_back(functionConvExpr->getSubExpr());
+          // Do not check the inner expression -- if it converts to
+          // CFunctionPointer successfully, then it's constant foldable.
           continue;
         }
       }

--- a/test/ConstValues/SectionSyntactic.swift
+++ b/test/ConstValues/SectionSyntactic.swift
@@ -93,6 +93,14 @@ extension Q { @section("mysection") static let invalidFuncRef8: (Int)->() = stat
 struct W {
   @section("mysection") static let closure7: @convention(c) (Int) -> Int = { x in x * 2 } // ok
 }
+func g() {
+    @Sendable func f() { }
+    @Sendable func h() async { }
+    enum E {
+        @section("mysection") static let record: @convention(c) () -> () = { f() } // ok
+        @section("mysection") static let record2: @convention(c) () -> () = { _ = h } // ok
+    }
+}
 
 let capturedVar = 10
 class TestClass {}


### PR DESCRIPTION
Bugfix for `@section` support. See the attached testcase, where we currently reject the closure because the AST representation does represent "f" as a capture. But for any legal `@convention(c)` function conversion, we don't need to impose any requirements on the closure, because we are guaranteed that it'll be a single function pointer after lowering.