### PR TITLE
[6.3][concurrency] Hide Concurrency StackNesting builtins behind a feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -277,6 +277,7 @@ LANGUAGE_FEATURE(LifetimeDependenceMutableAccessors, 0, "Support mutable accesso
 LANGUAGE_FEATURE(InoutLifetimeDependence, 0, "Support @_lifetime(&)")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NonexhaustiveAttribute, 487, "Nonexhaustive Enums")
 LANGUAGE_FEATURE(ModuleSelector, 491, "Module selectors (`Module::name` syntax)")
+LANGUAGE_FEATURE(BuiltinConcurrencyStackNesting, 0, "Concurrency Stack Nesting Builtins")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -347,6 +347,10 @@ static bool usesFeatureClosureBodyMacro(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinConcurrencyStackNesting(Decl *decl) {
+  return false;
+}
+
 UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(LibraryEvolution)
 UNINTERESTING_FEATURE(SafeInteropWrappers)

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -125,11 +125,30 @@ func __withTaskPriorityEscalationHandler0<T, E>(
   onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void,
   isolation: isolated (any Actor)? = #isolation
 ) async throws(E) -> T {
+#if $BuiltinConcurrencyStackNesting
   let record =
     unsafe Builtin.taskAddPriorityEscalationHandler(handler: handler0)
   defer {
     unsafe Builtin.taskRemovePriorityEscalationHandler(record: record)
   }
+#else
+  let record = unsafe _taskAddPriorityEscalationHandler(handler: handler0)
+  defer { unsafe _taskRemovePriorityEscalationHandler(record: record) }
+#endif
 
   return try await operation()
 }
+
+@usableFromInline
+@available(SwiftStdlib 6.2, *)
+@_silgen_name("swift_task_addPriorityEscalationHandler")
+func _taskAddPriorityEscalationHandler(
+  handler: (UInt8, UInt8) -> Void
+) -> UnsafeRawPointer /*EscalationNotificationStatusRecord*/
+
+@usableFromInline
+@available(SwiftStdlib 6.2, *)
+@_silgen_name("swift_task_removePriorityEscalationHandler")
+func _taskRemovePriorityEscalationHandler(
+  record: UnsafeRawPointer /*EscalationNotificationStatusRecord*/
+)


### PR DESCRIPTION
Explanation: This is a cherry-pick to 6.3 of some code to prevent a cond_fail due to some new added builtins.
Original PR: #85972
Risk: Low. We are just hiding the builtins behind a feature flag.
Testing: N/A
Reviewers: @xedin 

rdar://166244033
(cherry picked from commit 7b9281fcb89aa110e8248e13f814f9d6aad6d1da)
