### PR TITLE
test: disable CAS.path_remap on Windows

### DIFF
--- a/test/CAS/path_remap.swift
+++ b/test/CAS/path_remap.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
This test is not possible to support on windows as we do not use `-sysroot` and thus do not have any `-isysroot` flags in the invocation. As we pick up the "sysroot" through the environment or registry, there is not much to test here.