### PR TITLE
[Dependency Scanning] Add caching of unsuccessful Swift dependency lookups 

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1081,6 +1081,9 @@ private:
   /// A map from Clang module name to all visible modules to a client
   /// of a by-name import of this Clang module
   llvm::StringMap<std::vector<std::string>> clangModulesVisibleFromNamedLookup;
+  /// A set of module identifiers for which a scanning action failed
+  /// to discover a Swift module dependency
+  llvm::StringSet<> negativeSwiftDependencyCache;
   /// Set containing all of the Clang modules that have already been seen.
   llvm::DenseSet<clang::tooling::dependencies::ModuleID> alreadySeenClangModules;
   /// Name of the module under scan
@@ -1115,12 +1118,14 @@ public:
   /// Whether we have cached dependency information for the given module.
   bool hasDependency(StringRef moduleName,
                      std::optional<ModuleDependencyKind> kind) const;
-  /// Whether we have cached dependency information for the given module Name.
-  bool hasDependency(StringRef moduleName) const;
-  /// Whether we have cached dependency information for the given Swift module.
-  bool hasSwiftDependency(StringRef moduleName) const;
   /// Whether we have cached dependency information for the given Clang module.
   bool hasClangDependency(StringRef moduleName) const;
+
+  /// Whether we have cached dependency information for the given Swift module,
+  /// or have previously failed a lookup of a Swift dependency for the
+  /// given identifier.
+  bool hasQueriedSwiftDependency(StringRef moduleName) const;
+
   /// Report the number of recorded Clang dependencies
   int numberOfClangDependencies() const;
   /// Report the number of recorded Swift dependencies
@@ -1253,6 +1258,8 @@ public:
   void
   setVisibleClangModulesFromLookup(ModuleDependencyID clangModuleID,
                                    const std::vector<std::string> &moduleNames);
+  /// Add an identifier to the set of failed Swift module queries
+  void recordFailedSwiftDependencyLookup(StringRef moduleIdentifier);
 
   StringRef getMainModuleName() const { return mainScanModuleName; }
 

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -26,6 +26,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/PrettyStackTrace.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
@@ -1294,7 +1295,7 @@ void ModuleDependencyScanner::processBatchClangModuleQueryResult(
             // a `ModuleDeps` info for the queried module itself, then
             // it has to have been included in the set of already-seen
             // module dependencies from a prior query.
-            assert(DependencyCache.hasDependency(dependencyID));
+            assert(DependencyCache.hasClangDependency(moduleIdentifier));
           }
         } else if (!optionalImport) {
           // Otherwise, we failed to resolve this dependency. We will try
@@ -1467,23 +1468,16 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
   auto scanForSwiftModuleDependency =
       [this, &lookupResultLock,
        &moduleLookupResult](Identifier moduleIdentifier, bool isTestable) {
-        auto moduleName = moduleIdentifier.str().str();
-        {
-          std::lock_guard<std::mutex> guard(lookupResultLock);
-          if (DependencyCache.hasSwiftDependency(moduleName))
-            return;
-        }
-
         auto moduleDependencies = withDependencyScanningWorker(
             [moduleIdentifier,
              isTestable](ModuleDependencyScanningWorker *ScanningWorker) {
               return ScanningWorker->scanFilesystemForSwiftModuleDependency(
                   moduleIdentifier, isTestable);
             });
-
         {
           std::lock_guard<std::mutex> guard(lookupResultLock);
-          moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
+          moduleLookupResult.insert_or_assign(moduleIdentifier.str().str(),
+                                              moduleDependencies);
         }
       };
 
@@ -1491,6 +1485,9 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
   for (const auto &dependsOn : moduleDependencyInfo.getModuleImports()) {
     // Avoid querying the underlying Clang module here
     if (moduleID.ModuleName == dependsOn.importIdentifier)
+      continue;
+    // Avoid querying Swift module dependencies previously looked up
+    if (DependencyCache.hasQueriedSwiftDependency(dependsOn.importIdentifier))
       continue;
     ScanningThreadPool.async(
         scanForSwiftModuleDependency,
@@ -1531,10 +1528,13 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
                        moduleImport.importIdentifier))
           importedSwiftDependencies.insert(
               {moduleImport.importIdentifier, cachedInfo.value()->getKind()});
-        else
+        else {
           ScanDiagnosticReporter.diagnoseFailureOnOnlyIncompatibleCandidates(
                      moduleImport, lookupResult.incompatibleCandidates,
                      DependencyCache, std::nullopt);
+          DependencyCache
+            .recordFailedSwiftDependencyLookup(moduleImport.importIdentifier);
+        }
       };
 
   for (const auto &importInfo : moduleDependencyInfo.getModuleImports())
@@ -1672,43 +1672,36 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
 
   // A scanning task to query a Swift module by-name. If the module already
   // exists in the cache, do nothing and return.
-  auto scanForSwiftDependency = [this, &moduleID, &lookupResultLock,
-                                 &swiftOverlayLookupResult](
-                                    Identifier moduleIdentifier) {
-    auto moduleName = moduleIdentifier.str();
-    {
-      std::lock_guard<std::mutex> guard(lookupResultLock);
-      if (DependencyCache.hasDependency(moduleName,
-                                        ModuleDependencyKind::SwiftInterface) ||
-          DependencyCache.hasDependency(moduleName,
-                                        ModuleDependencyKind::SwiftBinary))
-        return;
-    }
+  auto scanForSwiftDependency =
+      [this, &lookupResultLock,
+       &swiftOverlayLookupResult](Identifier moduleIdentifier) {
+        auto moduleDependencies = withDependencyScanningWorker(
+            [moduleIdentifier](ModuleDependencyScanningWorker *ScanningWorker) {
+              return ScanningWorker->scanFilesystemForSwiftModuleDependency(
+                  moduleIdentifier, /* isTestableImport */ false);
+            });
+        {
+          std::lock_guard<std::mutex> guard(lookupResultLock);
+          swiftOverlayLookupResult.insert_or_assign(moduleIdentifier.str(),
+                                                    moduleDependencies);
+        }
+      };
 
+  // Enque asynchronous lookup tasks
+  for (const auto &clangDep : visibleClangDependencies) {
+    auto clangDepName = clangDep.getKey().str();
     // Avoid Swift overlay lookup for the underlying clang module of a known
     // Swift module. i.e. When computing set of Swift Overlay dependencies
     // for module 'A', which depends on a Clang module 'A', ensure we don't
     // lookup Swift module 'A' itself here.
-    if (moduleName == moduleID.ModuleName)
-      return;
-
-    auto moduleDependencies = withDependencyScanningWorker(
-        [moduleIdentifier](ModuleDependencyScanningWorker *ScanningWorker) {
-          return ScanningWorker->scanFilesystemForSwiftModuleDependency(
-              moduleIdentifier, /* isTestableImport */ false);
-        });
-                                      
-    {
-      std::lock_guard<std::mutex> guard(lookupResultLock);
-      swiftOverlayLookupResult.insert_or_assign(moduleName, moduleDependencies);
-    }
-  };
-
-  // Enque asynchronous lookup tasks
-  for (const auto &clangDep : visibleClangDependencies)
-    ScanningThreadPool.async(
-        scanForSwiftDependency,
-        getModuleImportIdentifier(clangDep.getKey().str()));
+    if (clangDepName == moduleID.ModuleName)
+      continue;
+    // Avoid querying Swift module dependencies previously looked up
+    if (DependencyCache.hasQueriedSwiftDependency(clangDepName))
+      continue;
+    ScanningThreadPool.async(scanForSwiftDependency,
+                             getModuleImportIdentifier(clangDepName));
+  }
   ScanningThreadPool.wait();
 
   // Aggregate both previously-cached and freshly-scanned module results

--- a/test/ScanDependencies/basic_query_metrics.swift
+++ b/test/ScanDependencies/basic_query_metrics.swift
@@ -7,7 +7,7 @@
 // RUN: cat %t/remarks.txt | %FileCheck %s
 
 // Ensure that despite being a common dependency to multiple Swift modules, only 1 query is performed to find 'C'
-// CHECK: remark: Number of Swift module queries: '6'
+// CHECK: remark: Number of Swift module queries: '3'
 // CHECK: remark: Number of named Clang module queries: '1'
 // CHECK: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
 // CHECK: remark: Number of recorded Swift module dependencies: '2'

--- a/test/ScanDependencies/duplicate_clang_queries_on_overlay.swift
+++ b/test/ScanDependencies/duplicate_clang_queries_on_overlay.swift
@@ -9,7 +9,7 @@
 // Ensure that although the Swift overlay dependency 'A' shares a dependency on 'B' and 'C'
 // it does not incur additional namedqueries for them.
 //
-// CHECK: remark: Number of Swift module queries: '9'
+// CHECK: remark: Number of Swift module queries: '3'
 // CHECK: remark: Number of named Clang module queries: '2'
 // CHECK: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '2'
 // CHECK: remark: Number of recorded Swift module dependencies: '1'

--- a/test/ScanDependencies/partial_scan_reuse.swift
+++ b/test/ScanDependencies/partial_scan_reuse.swift
@@ -12,13 +12,13 @@
 // FIXME: We still have a lot of duplicate Swift lookups,
 // to be resolved in upcoming https://github.com/swiftlang/swift/pull/86091
 //
-// CHECK-INITIAL: remark: Number of Swift module queries: '9'
+// CHECK-INITIAL: remark: Number of Swift module queries: '3'
 // CHECK-INITIAL: remark: Number of named Clang module queries: '2'
 // CHECK-INITIAL: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '2'
 // CHECK-INITIAL: remark: Number of recorded Swift module dependencies: '1'
 // CHECK-INITIAL: remark: Number of recorded Clang module dependencies: '3'
 
-// CHECK-REUSE: remark: Number of Swift module queries: '12'
+// CHECK-REUSE: remark: Number of Swift module queries: '2'
 // CHECK-REUSE: remark: Number of named Clang module queries: '0'
 // CHECK-REUSE: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '0'
 // CHECK-REUSE: remark: Number of recorded Swift module dependencies: '1'


### PR DESCRIPTION
Use it to avoid unnecessary re-queries of Swift dependencies during a given scanning action.

Refactor `hasSwiftDependency` API into `hasQueriedSwiftDependency` to instead report whether or not the cache has recorded a prior lookup of a given Swift dependency.