### PR TITLE
[Overlays] Set `use-external-names` to true in overlay file

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -6,7 +6,7 @@ file(CONFIGURE
 ---
 version: 0
 case-sensitive: false
-use-external-names: false
+use-external-names: true
 roots:
   - name: "@CMAKE_ANDROID_NDK@/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include"
     type: directory

--- a/Runtimes/Overlay/Linux/glibc/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Linux/glibc/clang/CMakeLists.txt
@@ -8,7 +8,7 @@ file(CONFIGURE
 ---
 version: 0
 case-sensitive: false
-use-external-names: false
+use-external-names: true
 roots:
   - name: "/usr/include"
     type: directory

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -11,7 +11,7 @@ file(CONFIGURE
 ---
 version: 0
 case-sensitive: false
-use-external-names: false
+use-external-names: true
 roots:
   - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um"
     type: directory


### PR DESCRIPTION
`use-external-names` needs to be true in the overlay file, otherwise the incremental build will not work. If the value is false, the dependency scanner is reporting virtual path as dependency, thus build system cannot correctly validate if the dependencies are up-to-date since it does not know the on disk representation.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
