### PR TITLE
[ASTScopes] Remove ModuleDecl param from `findChildContaining`

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -327,18 +327,15 @@ private:
 
 protected:
   /// Not const because may reexpand some scopes.
-  ASTScopeImpl *findInnermostEnclosingScope(ModuleDecl *,
-                                            SourceLoc,
+  ASTScopeImpl *findInnermostEnclosingScope(SourceLoc,
                                             NullablePtr<raw_ostream>);
-  ASTScopeImpl *findInnermostEnclosingScopeImpl(ModuleDecl *,
-                                                SourceLoc,
+  ASTScopeImpl *findInnermostEnclosingScopeImpl(SourceLoc,
                                                 NullablePtr<raw_ostream>,
                                                 SourceManager &,
                                                 ScopeCreator &);
 
 private:
-  NullablePtr<ASTScopeImpl> findChildContaining(ModuleDecl *,
-                                                SourceLoc loc,
+  NullablePtr<ASTScopeImpl> findChildContaining(SourceLoc loc,
                                                 SourceManager &sourceMgr) const;
 
 #pragma mark - - lookup- per scope

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -286,8 +286,7 @@ void ASTSourceFileScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
   auto sr = AFD->getOriginalBodySourceRange();
   if (sr.isInvalid())
     return;
-  ASTScopeImpl *bodyScope =
-      findInnermostEnclosingScope(AFD->getParentModule(), sr.Start, nullptr);
+  ASTScopeImpl *bodyScope = findInnermostEnclosingScope(sr.Start, nullptr);
   if (!bodyScope->getWasExpanded())
     bodyScope->expandAndBeCurrent(*scopeCreator);
 }

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -68,8 +68,7 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
   if (actualSF != sourceFile)
     fileScope = actualSF->getScope().impl;
 
-  const auto *innermost = fileScope->findInnermostEnclosingScope(
-      sourceFile->getParentModule(), loc, nullptr);
+  const auto *innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
   ASTScopeAssert(innermost->getWasExpanded(),
                  "If looking in a scope, it must have been expanded.");
 
@@ -77,23 +76,22 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
 }
 
 ASTScopeImpl *
-ASTScopeImpl::findInnermostEnclosingScope(ModuleDecl *parentModule,
-                                          SourceLoc loc,
+ASTScopeImpl::findInnermostEnclosingScope(SourceLoc loc,
                                           NullablePtr<raw_ostream> os) {
-  return findInnermostEnclosingScopeImpl(parentModule, loc, os,
-                                         getSourceManager(), getScopeCreator());
+  return findInnermostEnclosingScopeImpl(loc, os, getSourceManager(),
+                                         getScopeCreator());
 }
 
 ASTScopeImpl *ASTScopeImpl::findInnermostEnclosingScopeImpl(
-    ModuleDecl *parentModule, SourceLoc loc, NullablePtr<raw_ostream> os,
-    SourceManager &sourceMgr, ScopeCreator &scopeCreator) {
+    SourceLoc loc, NullablePtr<raw_ostream> os, SourceManager &sourceMgr,
+    ScopeCreator &scopeCreator) {
   if (!getWasExpanded())
     expandAndBeCurrent(scopeCreator);
-  auto child = findChildContaining(parentModule, loc, sourceMgr);
+  auto child = findChildContaining(loc, sourceMgr);
   if (!child)
     return this;
-  return child.get()->findInnermostEnclosingScopeImpl(parentModule, loc, os,
-                                                      sourceMgr, scopeCreator);
+  return child.get()->findInnermostEnclosingScopeImpl(loc, os, sourceMgr,
+                                                      scopeCreator);
 }
 
 /// If the \p loc is in a new buffer but \p range is not, consider the location
@@ -111,8 +109,7 @@ static SourceLoc translateLocForReplacedRange(SourceManager &sourceMgr,
 }
 
 NullablePtr<ASTScopeImpl>
-ASTScopeImpl::findChildContaining(ModuleDecl *parentModule,
-                                  SourceLoc loc,
+ASTScopeImpl::findChildContaining(SourceLoc loc,
                                   SourceManager &sourceMgr) const {
   if (loc.isInvalid())
     return nullptr;
@@ -596,8 +593,7 @@ llvm::SmallVector<LabeledStmt *, 4>
 ASTScopeImpl::lookupLabeledStmts(SourceFile *sourceFile, SourceLoc loc) {
   // Find the innermost scope from which to start our search.
   auto *const fileScope = sourceFile->getScope().impl;
-  const auto *innermost = fileScope->findInnermostEnclosingScope(
-      sourceFile->getParentModule(), loc, nullptr);
+  const auto *innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
   ASTScopeAssert(innermost->getWasExpanded(),
                  "If looking in a scope, it must have been expanded.");
 
@@ -625,8 +621,7 @@ std::pair<CaseStmt *, CaseStmt *> ASTScopeImpl::lookupFallthroughSourceAndDest(
     SourceFile *sourceFile, SourceLoc loc) {
   // Find the innermost scope from which to start our search.
   auto *const fileScope = sourceFile->getScope().impl;
-  const auto *innermost = fileScope->findInnermostEnclosingScope(
-      sourceFile->getParentModule(), loc, nullptr);
+  const auto *innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
   ASTScopeAssert(innermost->getWasExpanded(),
                  "If looking in a scope, it must have been expanded.");
 
@@ -660,8 +655,7 @@ void ASTScopeImpl::lookupEnclosingMacroScope(
     return;
 
   auto *fileScope = sourceFile->getScope().impl;
-  auto *scope = fileScope->findInnermostEnclosingScope(
-      sourceFile->getParentModule(), loc, nullptr);
+  auto *scope = fileScope->findInnermostEnclosingScope(loc, nullptr);
   do {
     if (auto expansionScope = dyn_cast<MacroExpansionDeclScope>(scope)) {
       auto *expansionDecl = expansionScope->decl;
@@ -692,8 +686,7 @@ lookupEnclosingABIAttributeScope(SourceFile *sourceFile, SourceLoc loc) {
     return nullptr;
 
   auto *fileScope = sourceFile->getScope().impl;
-  auto *scope = fileScope->findInnermostEnclosingScope(
-      sourceFile->getParentModule(), loc, nullptr);
+  auto *scope = fileScope->findInnermostEnclosingScope(loc, nullptr);
   do {
     if (auto abiAttrScope = dyn_cast<ABIAttributeScope>(scope)) {
       return abiAttrScope->attr;
@@ -744,8 +737,7 @@ CatchNode ASTScopeImpl::lookupCatchNode(ModuleDecl *module, SourceLoc loc) {
     return nullptr;
 
   auto *fileScope = sourceFile->getScope().impl;
-  const auto *innermost = fileScope->findInnermostEnclosingScope(
-      module, loc, nullptr);
+  const auto *innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
   ASTScopeAssert(innermost->getWasExpanded(),
                  "If looking in a scope, it must have been expanded.");
 

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -53,8 +53,7 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
   llvm::errs() << "***Scope at " << lineColumn.first << ":" << lineColumn.second
                << "***\n";
-  auto *parentModule = getSourceFile()->getParentModule();
-  auto *locScope = findInnermostEnclosingScope(parentModule, loc, &llvm::errs());
+  auto *locScope = findInnermostEnclosingScope(loc, &llvm::errs());
   locScope->print(llvm::errs(), 0, false, false);
 
   namelookup::ASTScopeDeclGatherer gatherer;


### PR DESCRIPTION
This is no longer necessary.