### PR TITLE
[6.3][DeclChecker] Skip contextualization of initializers associated with …

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2692,6 +2692,15 @@ public:
       if (!PBD->isInitialized(i))
         continue;
 
+      if (PBD->isInitializerSubsumed(i)) {
+        auto *var = PBD->getSingleVar();
+        // The initializer of a property wrapped variable gets transferred
+        // the synthesized backing storage property, let have it contextualized
+        // there.
+        if (var && var->hasAttachedPropertyWrapper())
+          continue;
+      }
+
       if (!PBD->isInitializerChecked(i)) {
         TypeCheckExprOptions options;
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar163562182.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar163562182.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+enum CustomError: Error {
+}
+
+struct ValidationError: Error {
+}
+
+func parseOption(_: String) throws -> Int {
+  42
+}
+
+@propertyWrapper
+public struct Option<Value> {
+  public var wrappedValue: Value
+
+  public init(
+    wrappedValue: Value,
+    transform: @Sendable @escaping (String) throws -> Value
+  ) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct Test {
+  @Option(transform: {
+    do {
+      return try parseOption($0)
+    } catch let error as CustomError {
+      throw ValidationError()
+    }
+  })
+  var prop: Int = 0
+}


### PR DESCRIPTION
…property wrapped variables

- Explanation:

  Fixes a double-contextualization that results in an assert because properties with property wrappers have the same initializer in two places - original property (which becomes computed) and backing storage property - that's where the initializer is copied.

  Contextualization of the fully type-checked initializer should happen as part of backing storage property processing by the declaration checker.

- Resolves: rdar://163562182

- Main branch PR: https://github.com/swiftlang/swift/pull/86024

-  Risk: Low. Affects only specific situations with property wrappers with extra arguments that require non-exhaustive rethrows checking.

- Reviewed By: @hborla  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 5e815b9728d0387758bc4c9c4aea0d81167ca364)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
