### PR TITLE
[CxxInterop] use [[msvc::no_unique_address]] on Windows (NFC)

### DIFF
--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -5,7 +5,7 @@
 #include <type_traits>
 #include <optional>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_MSC_VER)
 #define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
 #define NO_UNIQUE_ADDRESS [[no_unique_address]]

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -5,6 +5,12 @@
 #include <type_traits>
 #include <optional>
 
+#if defined(_WIN32) || defined(_WIN64)
+#define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
+#define NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
 class MyClass {
 public:
   const int const_member = 23;
@@ -17,11 +23,11 @@ struct Empty {
 
 struct HasZeroSizedField {
   int a;
-  [[no_unique_address]] Empty b;
+  NO_UNIQUE_ADDRESS Empty b;
   short c;
-  [[no_unique_address]] Empty d;
+  NO_UNIQUE_ADDRESS Empty d;
   int* e;
-  [[no_unique_address]] Empty f;
+  NO_UNIQUE_ADDRESS Empty f;
 
   int get_a() const { return a; }
   short get_c() const { return c; }
@@ -29,7 +35,7 @@ struct HasZeroSizedField {
 };
 
 struct ReuseOptionalFieldPadding {
-  [[no_unique_address]] std::optional<int> a = {2};
+  NO_UNIQUE_ADDRESS std::optional<int> a = {2};
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
@@ -40,7 +46,7 @@ struct ReuseOptionalFieldPadding {
 using OptInt = std::optional<int>;
 
 struct ReuseOptionalFieldPaddingWithTypedef {
-  [[no_unique_address]] OptInt a;
+  NO_UNIQUE_ADDRESS OptInt a;
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
@@ -59,7 +65,7 @@ public:
 static_assert(std::is_standard_layout_v<NonStandardLayoutClass<int>> == false);
 
 struct ReuseNonStandardLayoutFieldPadding {
-  [[no_unique_address]] NonStandardLayoutClass<int> a;
+  NO_UNIQUE_ADDRESS NonStandardLayoutClass<int> a;
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
@@ -69,7 +75,7 @@ struct ReuseNonStandardLayoutFieldPadding {
 
 template<typename T>
 struct ReuseDependentFieldPadding {
-  [[no_unique_address]] struct { private: T x; public: char pad_me; } a;
+  NO_UNIQUE_ADDRESS struct { private: T x; public: char pad_me; } a;
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
@@ -94,7 +100,7 @@ struct EmptyNotImported {
 
 struct LastFieldNoUniqueAddress {
   char c;
-  [[no_unique_address]] EmptyNotImported p0;
+  NO_UNIQUE_ADDRESS EmptyNotImported p0;
 
   LastFieldNoUniqueAddress(const LastFieldNoUniqueAddress &other) {}
   LastFieldNoUniqueAddress(LastFieldNoUniqueAddress &&other) {}

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -48,7 +48,15 @@ module MemoryLayout {
   requires cplusplus
 }
 
-module MemberVariables {
+// This header is shared between 3 test cases. It's built with -verify in
+// test/Interop/Cxx/class/member-variables-typechecker.swift, which is defeated
+// if the test just picks up a cached module. We could set the module cache path
+// explicitly, but that would rebuild CxxStdlib which is really slow.
+module MemberVariablesNoDiagnostics {
+  header "member-variables.h"
+  requires cplusplus
+}
+module MemberVariablesDiagnostics {
   header "member-variables.h"
   requires cplusplus
 }

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariables -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariablesNoDiagnostics -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MyClass {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/member-variables-typechecker.swift
+++ b/test/Interop/Cxx/class/member-variables-typechecker.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
-import MemberVariables
+import MemberVariablesDiagnostics
 
 var s = MyClass()
 s.const_member = 42 // expected-error {{cannot assign to property: 'const_member' setter is inaccessible}}

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -4,7 +4,7 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-import MemberVariables
+import MemberVariablesNoDiagnostics
 
 var FieldsTestSuite = TestSuite("Generating code with zero sized fields")
 


### PR DESCRIPTION
This test case uses [[no_unique_address]], which is not supported on Windows. Resolves https://github.com/swiftlang/swift/issues/86095