### PR TITLE
[Dependency Scanning] Re-use cached queried Clang dependency info in subsequent scanning stages

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -277,10 +277,9 @@ public:
   /// The macro dependencies.
   std::map<std::string, MacroPluginDependency> macroDependencies;
 
-  /// A list of Clang modules that are visible to this Swift module. This
-  /// includes both direct Clang modules as well as transitive Clang
-  /// module dependencies when they are exported
-  llvm::StringSet<> visibleClangModules;
+  /// A list of Clang modules that are visible to this Swift module
+  /// as re-exported modular includes of its bridging header.
+  std::vector<std::string> bridgingHeaderVisibleClangModules;
 
   /// ModuleDependencyInfo is finalized (with all transitive dependencies
   /// and inputs).
@@ -893,14 +892,12 @@ public:
       llvm_unreachable("Unexpected module dependency kind");
   }
 
-  llvm::StringSet<> &getVisibleClangModules() const {
-    return storage->visibleClangModules;
+  ArrayRef<std::string> getHeaderVisibleClangModules() const {
+    return storage->bridgingHeaderVisibleClangModules;
   }
-
-  void
-  addVisibleClangModules(const std::vector<std::string> &moduleNames) const {
-    storage->visibleClangModules.insert(moduleNames.begin(),
-                                        moduleNames.end());
+  void setHeaderVisibleClangModules(
+      const std::vector<std::string> &moduleNames) const {
+    storage->bridgingHeaderVisibleClangModules = moduleNames;
   }
 
   /// Whether explicit input paths of all the module dependencies
@@ -1073,6 +1070,9 @@ class ModuleDependenciesCache {
 private:
   /// Discovered dependencies
   ModuleDependenciesKindMap ModuleDependenciesMap;
+  /// A map from Clang module name to all visible modules to a client
+  /// of a by-name import of this Clang module
+  llvm::StringMap<std::vector<std::string>> clangModulesVisibleFromNamedLookup;
   /// Set containing all of the Clang modules that have already been seen.
   llvm::DenseSet<clang::tooling::dependencies::ModuleID> alreadySeenClangModules;
   /// Name of the module under scan
@@ -1111,6 +1111,8 @@ public:
   bool hasDependency(StringRef moduleName) const;
   /// Whether we have cached dependency information for the given Swift module.
   bool hasSwiftDependency(StringRef moduleName) const;
+  /// Whether we have cached dependency information for the given Clang module.
+  bool hasClangDependency(StringRef moduleName) const;
   /// Report the number of recorded Clang dependencies
   int numberOfClangDependencies() const;
   /// Report the number of recorded Swift dependencies
@@ -1152,9 +1154,20 @@ public:
   /// Query all cross-import overlay dependencies
   llvm::ArrayRef<ModuleDependencyID>
   getCrossImportOverlayDependencies(const ModuleDependencyID &moduleID) const;
+
   /// Query all visible Clang modules for a given Swift dependency
-  llvm::StringSet<>&
-  getVisibleClangModules(ModuleDependencyID moduleID) const;
+  llvm::StringSet<>
+  getAllVisibleClangModules(ModuleDependencyID moduleID) const;
+  /// Query all Clang modules visible via a by-name lookup of given
+  /// Clang dependency
+  llvm::ArrayRef<std::string>
+  getVisibleClangModulesFromLookup(StringRef moduleName) const;
+  bool hasVisibleClangModulesFromLookup(StringRef moduleName) const;
+  /// Query all Clang modules visible from a given Swift module's
+  /// bridging header
+  llvm::ArrayRef<std::string>
+  getVisibleClangModulesViaHeader(ModuleDependencyID moduleID) const;
+  bool hasVisibleClangModulesViaHeader(ModuleDependencyID moduleID) const;
 
   /// Look for module dependencies for a module with the given ID
   ///
@@ -1230,8 +1243,8 @@ public:
     const ModuleDependencyIDCollectionView dependencyIDs);
   /// Add to this module's set of visible Clang modules
   void
-  addVisibleClangModules(ModuleDependencyID moduleID,
-                         const std::vector<std::string> &moduleNames);
+  setVisibleClangModulesFromLookup(ModuleDependencyID clangModuleID,
+                                   const std::vector<std::string> &moduleNames);
 
   StringRef getMainModuleName() const { return mainScanModuleName; }
 

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -41,7 +41,7 @@ using llvm::BCVBR;
 const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 10;
 /// Increment this on every change.
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 4;
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 5;
 
 /// Various identifiers in this format will rely on having their strings mapped
 /// using this ID.
@@ -81,6 +81,7 @@ using FileIDArrayIDField = IdentifierIDField;
 using ContextHashIDField = IdentifierIDField;
 using ModuleCacheKeyIDField = IdentifierIDField;
 using ImportArrayIDField = IdentifierIDField;
+using VisibleModulesArrayIDField = IdentifierIDField;
 using LinkLibrariesArrayIDField = IdentifierIDField;
 using MacroDependenciesArrayIDField = IdentifierIDField;
 using SearchPathArrayIDField = IdentifierIDField;
@@ -109,6 +110,7 @@ enum {
   MACRO_DEPENDENCY_ARRAY_NODE,
   SEARCH_PATH_NODE,
   SEARCH_PATH_ARRAY_NODE,
+  VISIBLE_MODULES_NODE,
   IMPORT_STATEMENT_NODE,
   IMPORT_STATEMENT_ARRAY_NODE,
   OPTIONAL_IMPORT_STATEMENT_ARRAY_NODE,
@@ -187,6 +189,14 @@ using SearchPathLayout =
 using SearchPathArrayLayout =
     BCRecordLayout<SEARCH_PATH_ARRAY_NODE, IdentifierIDArryField>;
 
+// A record capturing information about all Clang modules visible
+// from a given named Clang module dependency query
+using VisibleModulesLayout =
+  BCRecordLayout<VISIBLE_MODULES_NODE,        // ID
+                 IdentifierIDField,           // moduleIdentifier
+                 VisibleModulesArrayIDField   // visibleModulesArrayIdentifier
+                 >;
+
 // A record capturing information about a given 'import' statement
 // captured in a dependency node, including its source location.
 using ImportStatementLayout =
@@ -199,6 +209,7 @@ using ImportStatementLayout =
                    IsExportedImport,             // isExported
                    AccessLevelField              // accessLevel
                    >;
+
 using ImportStatementArrayLayout =
     BCRecordLayout<IMPORT_STATEMENT_ARRAY_NODE, IdentifierIDArryField>;
 using OptionalImportStatementArrayLayout =

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -959,10 +959,8 @@ llvm::StringSet<> ModuleDependenciesCache::getAllVisibleClangModules(
          moduleID.Kind == ModuleDependencyKind::SwiftInterface ||
          moduleID.Kind == ModuleDependencyKind::SwiftBinary);
   llvm::StringSet<> result;
-  if (hasVisibleClangModulesViaHeader(moduleID)) {
-    auto headerVisibleModules = getVisibleClangModulesViaHeader(moduleID);
-    result.insert(headerVisibleModules.begin(), headerVisibleModules.end());
-  }
+  auto headerVisibleModules = getVisibleClangModulesViaHeader(moduleID);
+  result.insert(headerVisibleModules.begin(), headerVisibleModules.end());
   for (const auto &clangDepID :
        findKnownDependency(moduleID).getImportedClangDependencies()) {
     assert(hasVisibleClangModulesFromLookup(clangDepID.ModuleName));
@@ -976,7 +974,6 @@ llvm::StringSet<> ModuleDependenciesCache::getAllVisibleClangModules(
 
 ArrayRef<std::string> ModuleDependenciesCache::getVisibleClangModulesFromLookup(
     StringRef moduleName) const {
-  ASSERT(hasVisibleClangModulesFromLookup(moduleName));
   return clangModulesVisibleFromNamedLookup.at(moduleName);
 }
 
@@ -988,14 +985,14 @@ bool ModuleDependenciesCache::hasVisibleClangModulesFromLookup(
 llvm::ArrayRef<std::string>
 ModuleDependenciesCache::getVisibleClangModulesViaHeader(
     ModuleDependencyID moduleID) const {
-  ASSERT(moduleID.Kind == ModuleDependencyKind::SwiftSource ||
+  assert(moduleID.Kind == ModuleDependencyKind::SwiftSource ||
          moduleID.Kind == ModuleDependencyKind::SwiftInterface ||
          moduleID.Kind == ModuleDependencyKind::SwiftBinary);
   return findKnownDependency(moduleID).getHeaderVisibleClangModules();
 }
 bool ModuleDependenciesCache::hasVisibleClangModulesViaHeader(
     ModuleDependencyID moduleID) const {
-  ASSERT(moduleID.Kind == ModuleDependencyKind::SwiftSource ||
+  assert(moduleID.Kind == ModuleDependencyKind::SwiftSource ||
          moduleID.Kind == ModuleDependencyKind::SwiftInterface ||
          moduleID.Kind == ModuleDependencyKind::SwiftBinary);
   return !getVisibleClangModulesViaHeader(moduleID).empty();

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -937,7 +937,7 @@ ModuleDependencyScanner::performDependencyScan(ModuleDependencyID rootModuleID) 
   // If scanning for an individual Clang module, simply resolve its imports
   if (rootModuleID.Kind == ModuleDependencyKind::Clang) {
     ModuleDependencyIDSetVector discoveredClangModules;
-    resolveAllClangModuleDependencies({}, discoveredClangModules);
+    resolveClangModuleDependencies({}, discoveredClangModules);
     return discoveredClangModules.takeVector();
   }
 
@@ -991,8 +991,8 @@ ModuleDependencyScanner::resolveImportedModuleDependencies(
   // This operation is done by gathering all unresolved import
   // identifiers and querying them in-parallel to the Clang
   // dependency scanner.
-  resolveAllClangModuleDependencies(discoveredSwiftModules.getArrayRef(),
-                                    allModules);
+  resolveClangModuleDependencies(discoveredSwiftModules.getArrayRef(),
+                                 allModules);
 
   // For each discovered Swift module which was built with a
   // bridging header, scan the header for module dependencies.
@@ -1043,13 +1043,22 @@ void ModuleDependencyScanner::resolveSwiftModuleDependencies(
   return;
 }
 
-static void
-gatherUnresolvedImports(ModuleDependenciesCache &cache,
-                        ASTContext &scanASTContext,
-                        ArrayRef<ModuleDependencyID> swiftModuleDependents,
-                        ModuleDependencyIDSetVector &allDiscoveredClangModules,
-                        ImportStatementInfoMap &unresolvedImportsMap,
-                        ImportStatementInfoMap &unresolvedOptionalImportsMap) {
+static void findAllReachableClangModules(ModuleDependencyID moduleID,
+                                         const ModuleDependenciesCache &cache,
+                                         ModuleDependencyIDSetVector &reachableClangModules) {
+  if (!reachableClangModules.insert(moduleID))
+    return;
+  for (const auto &depID : cache.getImportedClangDependencies(moduleID))
+    findAllReachableClangModules(depID, cache, reachableClangModules);
+}
+
+static void gatherUnresolvedImports(
+    ModuleDependenciesCache &cache, ASTContext &scanASTContext,
+    ArrayRef<ModuleDependencyID> swiftModuleDependents,
+    ModuleDependencyIDSetVector &allDiscoveredClangModules,
+    ImportStatementInfoMap &unresolvedImportsMap,
+    ImportStatementInfoMap &unresolvedOptionalImportsMap,
+    ModuleIDToModuleIDSetVectorMap &resolvedClangDependenciesMap) {
   for (const auto &moduleID : swiftModuleDependents) {
     auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
     auto unresolvedImports =
@@ -1061,33 +1070,48 @@ gatherUnresolvedImports(ModuleDependenciesCache &cache,
              .emplace(moduleID, std::vector<ScannerImportStatementInfo>())
              .first->second;
 
-    // If we have already resolved Clang dependencies for this module,
+    // If we have already fully resolved Clang dependencies for this module,
     // then we have the entire dependency sub-graph already computed for
     // it and ready to be added to 'allDiscoveredClangModules' without
     // additional scanning.
     if (!moduleDependencyInfo.getImportedClangDependencies().empty()) {
       auto directClangDeps = cache.getImportedClangDependencies(moduleID);
       ModuleDependencyIDSetVector reachableClangModules;
-      reachableClangModules.insert(directClangDeps.begin(),
-                                   directClangDeps.end());
-      for (unsigned currentModuleIdx = 0;
-           currentModuleIdx < reachableClangModules.size();
-           ++currentModuleIdx) {
-        auto moduleID = reachableClangModules[currentModuleIdx];
-        auto dependencies =
-            cache.findKnownDependency(moduleID).getImportedClangDependencies();
-        reachableClangModules.insert(dependencies.begin(), dependencies.end());
-      }
-      allDiscoveredClangModules.insert(reachableClangModules.begin(),
-                                       reachableClangModules.end());
+      for (const auto &depID : directClangDeps)
+        findAllReachableClangModules(depID, cache, reachableClangModules);
+      allDiscoveredClangModules.insert(
+          reachableClangModules.getArrayRef().begin(),
+          reachableClangModules.getArrayRef().end());
       continue;
     } else {
-      // We need to query the Clang dependency scanner for this module's
-      // non-Swift imports
       llvm::StringSet<> resolvedImportIdentifiers;
+      // Mark all import identifiers which were resolved to Swift dependencies
+      // as resolved
       for (const auto &resolvedDep :
            moduleDependencyInfo.getImportedSwiftDependencies())
         resolvedImportIdentifiers.insert(resolvedDep.ModuleName);
+
+      // Mark all import identifiers which can be fully resolved to a cached
+      // Clang dependency (including visible modules) as resolved
+      auto markCachedClangDependenciesResolved =
+          [&cache, &moduleID, &resolvedImportIdentifiers,
+           &resolvedClangDependenciesMap](
+              ArrayRef<ScannerImportStatementInfo> imports) {
+            for (const auto &import : imports) {
+              auto &importIdentifier = import.importIdentifier;
+              if (!resolvedImportIdentifiers.contains(importIdentifier) &&
+                  cache.hasClangDependency(importIdentifier) &&
+                  cache.hasVisibleClangModulesFromLookup(importIdentifier)) {
+                resolvedImportIdentifiers.insert(importIdentifier);
+                resolvedClangDependenciesMap[moduleID].insert(
+                    {importIdentifier, ModuleDependencyKind::Clang});
+              }
+            }
+          };
+      markCachedClangDependenciesResolved(
+          moduleDependencyInfo.getModuleImports());
+      markCachedClangDependenciesResolved(
+          moduleDependencyInfo.getOptionalModuleImports());
 
       // When querying a *clang* module 'CxxStdlib' we must
       // instead expect a module called 'std'...
@@ -1106,6 +1130,8 @@ gatherUnresolvedImports(ModuleDependenciesCache &cache,
             }
           };
 
+      // We need to query the Clang dependency scanner for all of this module's
+      // unresolved imports
       for (const auto &depImport : moduleDependencyInfo.getModuleImports())
         if (!resolvedImportIdentifiers.contains(depImport.importIdentifier))
           addCanonicalClangModuleImport(depImport, *unresolvedImports);
@@ -1118,10 +1144,8 @@ gatherUnresolvedImports(ModuleDependenciesCache &cache,
 }
 
 void ModuleDependencyScanner::reQueryMissedModulesFromCache(
-    const std::vector<std::pair<ModuleDependencyID, ScannerImportStatementInfo>>
-        &failedToResolveImports,
-    std::unordered_map<ModuleDependencyID, ModuleDependencyIDSetVector>
-        &resolvedClangDependenciesMap) {
+    const std::vector<ModuleIDImportInfoPair> &failedToResolveImports,
+    ModuleIDToModuleIDSetVectorMap &resolvedClangDependenciesMap) {
   // It is possible that a specific import resolution failed because we are
   // attempting to resolve a module which can only be brought in via a
   // modulemap of a different Clang module dependency which is not otherwise
@@ -1155,8 +1179,9 @@ void ModuleDependencyScanner::reQueryMissedModulesFromCache(
     if (optionalCachedModuleInfo) {
       resolvedClangDependenciesMap[unresolvedImport.first].insert(
           unresolvedModuleID);
-      DependencyCache.addVisibleClangModules(
-          unresolvedImport.first, {unresolvedImport.second.importIdentifier});
+      DependencyCache.setVisibleClangModulesFromLookup(
+          unresolvedModuleID,
+          {unresolvedImport.second.importIdentifier});
       ScanDiagnosticReporter.registerNamedClangDependency();
     } else {
       // Failed to resolve module dependency.
@@ -1215,61 +1240,76 @@ void ModuleDependencyScanner::performClangModuleLookup(
   ScanningThreadPool.wait();
 }
 
-void ModuleDependencyScanner::cacheComputedClangModuleLookupResults(
+void ModuleDependencyScanner::processBatchClangModuleQueryResult(
     const BatchClangModuleLookupResult &lookupResult,
     const ImportStatementInfoMap &unresolvedImportsMap,
     const ImportStatementInfoMap &unresolvedOptionalImportsMap,
-    ArrayRef<ModuleDependencyID> swiftModuleDependents,
     ModuleDependencyIDSetVector &allDiscoveredClangModules,
-    std::vector<std::pair<ModuleDependencyID, ScannerImportStatementInfo>>
-        &failedToResolveImports,
-    std::unordered_map<ModuleDependencyID, ModuleDependencyIDSetVector>
-        &resolvedClangDependenciesMap) {
-  for (const auto &moduleID : swiftModuleDependents) {
-    auto recordResolvedClangModuleImport =
-        [this, &lookupResult, &resolvedClangDependenciesMap,
-         &allDiscoveredClangModules, moduleID, &failedToResolveImports](
-            const ScannerImportStatementInfo &moduleImport,
-            bool optionalImport) {
-          auto &moduleIdentifier = moduleImport.importIdentifier;
-          auto dependencyID =
-              ModuleDependencyID{moduleIdentifier, ModuleDependencyKind::Clang};
+    std::vector<ModuleIDImportInfoPair> &failedToResolveImports,
+    ModuleIDToModuleIDSetVectorMap &resolvedClangDependenciesMap) {
 
-          // Add visible Clang modules for this query to the depending
-          // Swift module
-          if (lookupResult.visibleModules.contains(moduleIdentifier))
-            DependencyCache.addVisibleClangModules(
-                moduleID, lookupResult.visibleModules.at(moduleIdentifier));
+  llvm::StringSet<> cachedNamedDependencies;
+  auto recordResolvedClangModuleImport =
+      [this, &lookupResult, &resolvedClangDependenciesMap,
+       &allDiscoveredClangModules, &failedToResolveImports,
+       &cachedNamedDependencies](
+          const ModuleDependencyID &moduleID,
+          const ScannerImportStatementInfo &moduleImport, bool optionalImport) {
+        auto &moduleIdentifier = moduleImport.importIdentifier;
+        auto dependencyID =
+            ModuleDependencyID{moduleIdentifier, ModuleDependencyKind::Clang};
 
-          // Add the resolved dependency ID
+        // A successful named query will have returned a set of visible modules
+        if (lookupResult.visibleModules.contains(moduleIdentifier)) {
+          // If this dependency has already been recorded in the cache,
+          // mark it as resolved for the current dependent and exit.
+          if (!cachedNamedDependencies.insert(moduleIdentifier).second) {
+            resolvedClangDependenciesMap[moduleID].insert(dependencyID);
+            return;
+          }
+
+          ScanDiagnosticReporter.registerNamedClangDependency();
+          DependencyCache.setVisibleClangModulesFromLookup(
+              dependencyID, lookupResult.visibleModules.at(moduleIdentifier));
+          resolvedClangDependenciesMap[moduleID].insert(dependencyID);
+
+          // If this module was not seen before as a transitive dependency
+          // of another lookup, record it into the cache
           if (lookupResult.discoveredDependencyInfos.contains(
                   moduleIdentifier)) {
-            if (!DependencyCache.hasDependency(dependencyID))
-              ScanDiagnosticReporter.registerNamedClangDependency();
-            auto dependencyInfo = lookupResult.discoveredDependencyInfos.at(
-                moduleImport.importIdentifier);
             allDiscoveredClangModules.insert(dependencyID);
             DependencyCache.recordClangDependency(
-                dependencyInfo, ScanASTContext.Diags, [this](auto &clangDep) {
+                lookupResult.discoveredDependencyInfos.at(
+                    moduleImport.importIdentifier),
+                ScanASTContext.Diags, [this](auto &clangDep) {
                   return bridgeClangModuleDependency(clangDep);
                 });
-            resolvedClangDependenciesMap[moduleID].insert(dependencyID);
-          } else if (!optionalImport) {
-            // Otherwise, we failed to resolve this dependency. We will try
-            // again using the cache after all other imports have been
-            // resolved. If that fails too, a scanning failure will be
-            // diagnosed.
-            failedToResolveImports.push_back(
-                std::make_pair(moduleID, moduleImport));
+          } else {
+            // If the query produced a set of visible modules but not
+            // a `ModuleDeps` info for the queried module itself, then
+            // it has to have been included in the set of already-seen
+            // module dependencies from a prior query.
+            assert(DependencyCache.hasDependency(dependencyID));
           }
-        };
+        } else if (!optionalImport) {
+          // Otherwise, we failed to resolve this dependency. We will try
+          // again using the cache after all other imports have been
+          // resolved. If that fails too, a scanning failure will be
+          // diagnosed.
+          failedToResolveImports.push_back(
+              std::make_pair(moduleID, moduleImport));
+        }
+      };
 
-    for (const auto &unresolvedImport : unresolvedImportsMap.at(moduleID))
-      recordResolvedClangModuleImport(unresolvedImport, false);
-    for (const auto &unresolvedImport :
-         unresolvedOptionalImportsMap.at(moduleID))
-      recordResolvedClangModuleImport(unresolvedImport, true);
-  }
+  for (const auto &moduleUnresolvedImports : unresolvedImportsMap)
+    for (const auto &unresolvedImport : moduleUnresolvedImports.second)
+      recordResolvedClangModuleImport(moduleUnresolvedImports.first,
+                                      unresolvedImport, false);
+
+  for (const auto &moduleUnresolvedImports : unresolvedOptionalImportsMap)
+    for (const auto &unresolvedImport : moduleUnresolvedImports.second)
+      recordResolvedClangModuleImport(moduleUnresolvedImports.first,
+                                      unresolvedImport, true);
 
   // Use the computed scan results to record all transitive clang module
   // dependencies
@@ -1286,33 +1326,32 @@ void ModuleDependencyScanner::cacheComputedClangModuleLookupResults(
   }
 }
 
-void ModuleDependencyScanner::resolveAllClangModuleDependencies(
+void ModuleDependencyScanner::resolveClangModuleDependencies(
     ArrayRef<ModuleDependencyID> swiftModuleDependents,
     ModuleDependencyIDSetVector &allDiscoveredClangModules) {
-  // Gather all unresolved imports which must correspond to
+  // Gather all remaining unresolved imports which must correspond to
   // Clang modules (since no Swift module for them was found).
   ImportStatementInfoMap unresolvedImportsMap;
   ImportStatementInfoMap unresolvedOptionalImportsMap;
-  gatherUnresolvedImports(DependencyCache, ScanASTContext, swiftModuleDependents,
-                          allDiscoveredClangModules, unresolvedImportsMap,
-                          unresolvedOptionalImportsMap);
+  ModuleIDToModuleIDSetVectorMap resolvedClangDependenciesMap;
+  gatherUnresolvedImports(DependencyCache, ScanASTContext,
+                          swiftModuleDependents, allDiscoveredClangModules,
+                          unresolvedImportsMap, unresolvedOptionalImportsMap,
+                          resolvedClangDependenciesMap);
 
   // Execute parallel lookup of all unresolved import
   // identifiers as Clang modules.
   BatchClangModuleLookupResult lookupResult;
-  performClangModuleLookup(
-      unresolvedImportsMap, unresolvedOptionalImportsMap, lookupResult);
+  performClangModuleLookup(unresolvedImportsMap, unresolvedOptionalImportsMap,
+                           lookupResult);
 
   // Use the computed scan results to record directly-queried clang module
   // dependencies.
-  std::vector<std::pair<ModuleDependencyID, ScannerImportStatementInfo>>
-      failedToResolveImports;
-  std::unordered_map<ModuleDependencyID, ModuleDependencyIDSetVector>
-      resolvedClangDependenciesMap;
-  cacheComputedClangModuleLookupResults(
+  std::vector<ModuleIDImportInfoPair> failedToResolveImports;
+  processBatchClangModuleQueryResult(
       lookupResult, unresolvedImportsMap, unresolvedOptionalImportsMap,
-      swiftModuleDependents, allDiscoveredClangModules,
-      failedToResolveImports, resolvedClangDependenciesMap);
+      allDiscoveredClangModules, failedToResolveImports,
+      resolvedClangDependenciesMap);
 
   // Re-query some failed-to-resolve Clang imports from cache
   // in chance they were brought in as transitive dependencies.
@@ -1604,7 +1643,7 @@ void ModuleDependencyScanner::resolveHeaderDependenciesForModule(
                 bridgingHeaderCommandLine);
           moduleDependencyInfo.setHeaderSourceFiles(headerFileInputs);
           // Update the set of visible Clang modules
-          moduleDependencyInfo.addVisibleClangModules(
+          moduleDependencyInfo.setHeaderVisibleClangModules(
               headerScanResult->VisibleModules);
           // Update the dependency in the cache
           DependencyCache.updateDependency(moduleID, moduleDependencyInfo);
@@ -1621,7 +1660,7 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
   PrettyStackTraceStringAction trace(
       "Resolving Swift Overlay dependencies of module", moduleID.ModuleName);
   auto visibleClangDependencies =
-      DependencyCache.getVisibleClangModules(moduleID);
+      DependencyCache.getAllVisibleClangModules(moduleID);
 
   llvm::StringMap<SwiftModuleScannerQueryResult> swiftOverlayLookupResult;
   std::mutex lookupResultLock;
@@ -2027,8 +2066,8 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
           mainModuleDeps.setChainedBridgingHeaderBuffer(
               sourceBuffer->getBufferIdentifier(), sourceBuffer->getBuffer());
         // Update the set of visible Clang modules
-        mainModuleDeps.addVisibleClangModules(headerScanResult->VisibleModules);
-
+        mainModuleDeps.setHeaderVisibleClangModules(
+            headerScanResult->VisibleModules);
         // Update the dependency in the cache
         DependencyCache.updateDependency(rootModuleID, mainModuleDeps);
         return llvm::Error::success();

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1602,7 +1602,6 @@ void swift::dependencies::incremental::validateInterModuleDependenciesCache(
                       emitRemarks, visited, modulesRequiringRescan);
   for (const auto &outOfDateModID : modulesRequiringRescan)
     cache.removeDependency(outOfDateModID);
-
   // Regardless of invalidation, always re-scan main module.
   cache.removeDependency(rootModuleID);
 }

--- a/test/ScanDependencies/basic_query_metrics.swift
+++ b/test/ScanDependencies/basic_query_metrics.swift
@@ -9,7 +9,7 @@
 // Ensure that despite being a common dependency to multiple Swift modules, only 1 query is performed to find 'C'
 // CHECK: remark: Number of Swift module queries: '6'
 // CHECK: remark: Number of named Clang module queries: '1'
-// CHEKC: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
+// CHECK: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
 // CHECK: remark: Number of recorded Swift module dependencies: '2'
 // CHECK: remark: Number of recorded Clang module dependencies: '1'
 

--- a/test/ScanDependencies/duplicate_clang_queries_on_overlay.swift
+++ b/test/ScanDependencies/duplicate_clang_queries_on_overlay.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test.swift -o %t/deps.json -I %t/inputs -Rdependency-scan &> %t/remarks.txt
+// RUN: cat %t/remarks.txt | %FileCheck %s
+
+// Ensure that although the Swift overlay dependency 'A' shares a dependency on 'B' and 'C'
+// it does not incur additional namedqueries for them.
+//
+// CHECK: remark: Number of Swift module queries: '9'
+// CHECK: remark: Number of named Clang module queries: '2'
+// CHECK: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '2'
+// CHECK: remark: Number of recorded Swift module dependencies: '1'
+// CHECK: remark: Number of recorded Clang module dependencies: '3'
+
+//--- test.swift
+import B
+import C
+public func test() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import B
+import C
+public func a() { }
+
+//--- inputs/A.h
+void b(void);
+
+//--- inputs/B.h
+#include "A.h"
+void b(void);
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+module B {
+  header "B.h"
+  export *
+}
+module C {
+  header "C.h"
+  export *
+}

--- a/test/ScanDependencies/error_source_locations.swift
+++ b/test/ScanDependencies/error_source_locations.swift
@@ -6,16 +6,6 @@
 import P
 import FooBar
 
-
-// CHECK:      {{.*}}{{/|\\}}error_source_locations.swift:7:8: error: unable to resolve module dependency: 'FooBar'
-// CHECK-NEXT: 5 |
-// CHECK-NEXT: 6 | import P
-// CHECK-NEXT: 7 | import FooBar
-// CHECK-NEXT:   |        |- error: unable to resolve module dependency: 'FooBar'
-// CHECK-NEXT:   |        `- note: a dependency of main module 'deps'
-// CHECK-NEXT: 8 |
-// CHECK-NEXT: 9 |
-
 // CHECK:      {{.*}}{{/|\\}}Z.swiftinterface:3:8: error: unable to resolve module dependency: 'missing_module'
 // CHECK-NEXT: 1 | // swift-interface-format-version: 1.0
 // CHECK-NEXT: 2 | // swift-module-flags: -module-name Z
@@ -26,3 +16,12 @@ import FooBar
 // CHECK-NEXT:   |        |- note: a dependency of Swift module 'P': '{{.*}}{{/|\\}}P.swiftinterface'
 // CHECK-NEXT:   |        `- note: a dependency of main module 'deps'
 // CHECK-NEXT: 4 | public func funcZ() { }
+
+// CHECK:      {{.*}}{{/|\\}}error_source_locations.swift:7:8: error: unable to resolve module dependency: 'FooBar'
+// CHECK-NEXT: 5 |
+// CHECK-NEXT: 6 | import P
+// CHECK-NEXT: 7 | import FooBar
+// CHECK-NEXT:   |        |- error: unable to resolve module dependency: 'FooBar'
+// CHECK-NEXT:   |        `- note: a dependency of main module 'deps'
+// CHECK-NEXT: 8 |
+// CHECK-NEXT: 9 |

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -28,9 +28,7 @@ import SubE
 // CHECK-REMARK-SAVE: remark: Incremental module scan: Serializing module scanning dependency cache to:
 
 // CHECK-REMARK-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
-// FIXME: Today, we do not serialize dependencies of the main source module which results in a lookup for 'C' even though
-// it is fully redundant.
-// CHECK-REMARK-LOAD: remark: Number of named Clang module queries: '1'
+// CHECK-REMARK-LOAD: remark: Number of named Clang module queries: '0'
 // CHECK-REMARK-LOAD: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '0'
 // CHECK-REMARK-LOAD: remark: Number of recorded Swift module dependencies: '8'
 // CHECK-REMARK-LOAD: remark: Number of recorded Clang module dependencies: '7'

--- a/test/ScanDependencies/partial_scan_reuse.swift
+++ b/test/ScanDependencies/partial_scan_reuse.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test1.swift -o %t/deps.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_initial.txt
+// RUN: cat %t/remarks_initial.txt | %FileCheck %s --check-prefix=CHECK-INITIAL
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test2.swift -o %t/deps2.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_second.txt
+// RUN: cat %t/remarks_second.txt | %FileCheck %s --check-prefix=CHECK-REUSE
+
+// FIXME: We still have a lot of duplicate Swift lookups,
+// to be resolved in upcoming https://github.com/swiftlang/swift/pull/86091
+//
+// CHECK-INITIAL: remark: Number of Swift module queries: '9'
+// CHECK-INITIAL: remark: Number of named Clang module queries: '2'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '2'
+// CHECK-INITIAL: remark: Number of recorded Swift module dependencies: '1'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies: '3'
+
+// CHECK-REUSE: remark: Number of Swift module queries: '12'
+// CHECK-REUSE: remark: Number of named Clang module queries: '0'
+// CHECK-REUSE: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '0'
+// CHECK-REUSE: remark: Number of recorded Swift module dependencies: '1'
+// CHECK-REUSE: remark: Number of recorded Clang module dependencies: '3'
+
+//--- test1.swift
+import B
+import C
+public func test() {}
+
+//--- test2.swift
+import A
+import B
+import C
+public func test() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import B
+import C
+public func a() { }
+
+//--- inputs/A.h
+void b(void);
+
+//--- inputs/B.h
+#include "A.h"
+void b(void);
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+module B {
+  header "B.h"
+  export *
+}
+module C {
+  header "C.h"
+  export *
+}

--- a/test/ScanDependencies/partial_scan_reuse_added.swift
+++ b/test/ScanDependencies/partial_scan_reuse_added.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test1.swift -o %t/deps.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_initial.txt
+// RUN: cat %t/remarks_initial.txt | %FileCheck %s --check-prefix=CHECK-INITIAL
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test2.swift -o %t/deps2.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_second.txt
+// RUN: cat %t/remarks_second.txt | %FileCheck %s --check-prefix=CHECK-REUSE
+
+// CHECK-INITIAL: remark: Number of named Clang module queries: '3'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '3'
+// CHECK-INITIAL: remark: Number of recorded Swift module dependencies: '0'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies: '3'
+
+// CHECK-REUSE: remark: Number of named Clang module queries: '1'
+// CHECK-REUSE: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
+// CHECK-REUSE: remark: Number of recorded Swift module dependencies: '0'
+// CHECK-REUSE: remark: Number of recorded Clang module dependencies: '4'
+
+//--- test1.swift
+import A
+import B
+import C
+public func test() {}
+
+//--- test2.swift
+import A
+import B
+import C
+import D
+public func test() {}
+
+//--- inputs/A.h
+void b(void);
+
+//--- inputs/B.h
+#include "A.h"
+void b(void);
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/D.h
+void d(void);
+
+//--- inputs/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+module B {
+  header "B.h"
+  export *
+}
+module C {
+  header "C.h"
+  export *
+}
+module D {
+  header "D.h"
+  export *
+}

--- a/test/ScanDependencies/partial_scan_reuse_added_invalidated.swift
+++ b/test/ScanDependencies/partial_scan_reuse_added_invalidated.swift
@@ -1,0 +1,86 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test1.swift -o %t/deps.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_initial.txt
+// RUN: cat %t/remarks_initial.txt | %FileCheck %s --check-prefix=CHECK-INITIAL
+
+// Modify the header for A, invalidating modules A, and B
+// RUN: touch %t/inputs/A.h
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test2.swift -o %t/deps2.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_second.txt
+// RUN: cat %t/remarks_second.txt | %FileCheck %s --check-prefix=CHECK-SECOND
+
+// Modify the header for B, invalidating module B
+// RUN: touch %t/inputs/B.h
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test2.swift -o %t/deps2.json -I %t/inputs -Rdependency-scan -serialize-dependency-scan-cache -load-dependency-scan-cache -validate-prior-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -no-parallel-scan &> %t/remarks_third.txt
+// RUN: cat %t/remarks_third.txt | %FileCheck %s --check-prefix=CHECK-THIRD
+
+// Initial query looks up A, B, C
+// CHECK-INITIAL: remark: Number of named Clang module queries: '3'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '3'
+// CHECK-INITIAL: remark: Number of recorded Swift module dependencies: '0'
+// CHECK-INITIAL: remark: Number of recorded Clang module dependencies: '3'
+
+// CHECK-SECOND: remark: Incremental module scan: Dependency info for module 'A' invalidated due to a modified input since last scan
+// CHECK-SECOND: remark: Incremental module scan: Dependency info for module 'B' invalidated due to an out-of-date dependency.
+
+// This query looks up D (newly-added), A (invalidated), and B (invalidated)
+// CHECK-SECOND: remark: Number of named Clang module queries: '3'
+// CHECK-SECOND: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '3'
+// CHECK-SECOND: remark: Number of recorded Swift module dependencies: '0'
+// CHECK-SECOND: remark: Number of recorded Clang module dependencies: '4'
+
+// CHECK-THIRD: remark: Incremental module scan: Dependency info for module 'B' invalidated due to a modified input since last scan
+
+// This query looks up B (invalidated)
+// CHECK-THIRD: remark: Number of named Clang module queries: '1'
+// CHECK-THIRD: remark: Number of recorded Clang module dependencies queried by-name from a Swift client: '1'
+// CHECK-THIRD: remark: Number of recorded Swift module dependencies: '0'
+// CHECK-THIRD: remark: Number of recorded Clang module dependencies: '4'
+
+//--- test1.swift
+import A
+import B
+import C
+public func test() {}
+
+//--- test2.swift
+import A
+import B
+import C
+import D
+public func test() {}
+
+//--- inputs/A.h
+void b(void);
+
+//--- inputs/B.h
+#include "A.h"
+void b(void);
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/D.h
+void d(void);
+
+//--- inputs/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+module B {
+  header "B.h"
+  export *
+}
+module C {
+  header "C.h"
+  export *
+}
+module D {
+  header "D.h"
+  export *
+}


### PR DESCRIPTION
Dependency Scanning is recursive over discovered Swift module overlays and cross-import overlays. In the main 'resolveImportedModuleDependencies' routine, after all Swift and Clang dependencies of the main module are discovered, the scanner looks up Swift overlays for discovered Clang modules. For each such Swift overlay, the scanner will then proceed to call 'resolveImportedModuleDependencies' on the overlay module.

On these subsequent recursive calls to 'resolveImportedModuleDependencies', Clang dependency resolution will re-query all imports of the overlay module which do not resolve to Swift modules, even if they had been queried previously in a parent invocation. This change adds the ability to re-use previously-queried-and-cached Clang module dependency information by having the dependency cache also store the set of visible modules which resulted from each by-name lookup.