### PR TITLE
[windows] fix build.ps1 sccache expansion on ARM64

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1223,6 +1223,7 @@ function Get-Dependencies {
       param
       (
           [string]$SourceName,
+          [string]$BinaryCache,
           [string]$DestinationName
       )
       $Source = Join-Path -Path $BinaryCache -ChildPath $SourceName
@@ -1369,12 +1370,14 @@ function Get-Dependencies {
 
     if ($EnableCaching) {
       $SCCache = Get-SCCache
-      $FileExtension = [System.IO.Path]::GetExtension($SCCache.URL)
-      DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion.$FileExtension" $SCCache.SHA256
-      if ($FileExtension -eq "tar.gz") {
-        Expand-TapeArchive sccache-$SCCacheVersion.$FileExtension $BinaryCache sccache-$SCCacheVersion
+      $FileExtension = if ($SCCache.URL -match '/[^/]+(\..+)$') { $Matches[1] } else {
+          throw "Invalid sccache URL"
+      }
+      DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion$FileExtension" $SCCache.SHA256
+      if ($FileExtension -eq ".tar.gz") {
+        Expand-TapeArchive "sccache-$SCCacheVersion$FileExtension" $BinaryCache "sccache-$SCCacheVersion"
       } else {
-        Expand-ZipFile sccache-$SCCacheVersion.$FileExtension $BinaryCache sccache-$SCCacheVersion
+        Expand-ZipFile "sccache-$SCCacheVersion$FileExtension" $BinaryCache "sccache-$SCCacheVersion"
       }
       Write-Success "sccache $SCCacheVersion"
     }


### PR DESCRIPTION
This patch fixes how we expand the sccache tar ball on ARM64 Windows.

There are 2 problems:

- `[System.IO.Path]::GetExtension` returns `.gz` instead of `.tar.gz`.
- `Expand-TapeArchive` was missing a parameter in its definition.