### PR TITLE
[6.2][Concurrency] Allow transferring `nonisolated(nonsending)` to isolati…

### DIFF
--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -143,11 +143,11 @@ func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
     normalAcceptsAsyncClosure { }
 
     // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     normalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     normalAcceptsSendableAsyncClosure { }
 }
 
@@ -174,11 +174,11 @@ func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await normalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await normalGlobalActorAcceptsSendableAsyncClosure { }
 }
 
@@ -251,11 +251,11 @@ func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
     // expected-ni-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalAcceptsSendableAsyncClosure { }
 }
 
@@ -290,11 +290,11 @@ func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
     await asyncNormalGlobalActorAcceptsSendableAsyncClosure { }
 }
 


### PR DESCRIPTION
…on boundary closures

- Explanation:

  Isolation boundary closures don't assume parent isolation and should be able to get `nonisolated(nonsending)` transferred to them jus like regular nonisolated closures do.

- Resolves: rdar://163792371, rdar://166713397

- Main Branch PR: https://github.com/swiftlang/swift/pull/85603
- 6.3 Branch PR: https://github.com/swiftlang/swift/pull/85617

- Risk: Low. Affects only isolation boundary closures (i.e. passed to a `@Sendable` parameter) when the parameter is also `nonisolated(nonsending)`.

- Reviewed By: @hborla 

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
