### PR TITLE
[6.2] SILGen: Fix break/continue inside 'for ... in ... repeat' loop

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -524,6 +524,7 @@ public:
     // Loop over the pack, initializing each value with the appropriate
     // element.
     SGF.emitDynamicPackLoop(loc, FormalPackType, ComponentIndex, openedEnv,
+                            []() -> SILBasicBlock * { return nullptr; },
                             [&](SILValue indexWithinComponent,
                                 SILValue expansionIndex,
                                 SILValue packIndex) {
@@ -1313,6 +1314,7 @@ ResultPlanBuilder::buildPackExpansionIntoPack(SILValue packAddr,
   // we can emit a dynamic loop to do that now.
   if (init->canPerformInPlacePackInitialization(openedEnv, eltTy)) {
     SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex, openedEnv,
+                            []() -> SILBasicBlock * { return nullptr; },
                             [&](SILValue indexWithinComponent,
                                 SILValue expansionPackIndex,
                                 SILValue packIndex) {
@@ -1334,6 +1336,7 @@ ResultPlanBuilder::buildPackExpansionIntoPack(SILValue packAddr,
                                     SILType::getPrimitiveObjectType(tupleTy));
 
   SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex, openedEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue expansionPackIndex,
                               SILValue packIndex) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4430,6 +4430,7 @@ private:
     auto openedElementEnv = expansionExpr->getGenericEnvironment();
     SGF.emitDynamicPackLoop(expansionExpr, formalPackType,
                             packComponentIndex, openedElementEnv,
+                            []() -> SILBasicBlock * { return nullptr; },
                             [&](SILValue indexWithinComponent,
                                 SILValue packExpansionIndex,
                                 SILValue packIndex) {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -212,6 +212,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &SGF,
     auto formalPackType = CanPackType::get(SGF.getASTContext(), {type});
 
     SGF.emitDynamicPackLoop(loc, formalPackType, /*component*/0, openedEnv,
+                            []() -> SILBasicBlock * { return nullptr; },
                             [&](SILValue indexWithinComponent,
                                 SILValue packExpansionIndex,
                                 SILValue packIndex) {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -75,6 +75,7 @@ static void copyOrInitPackExpansionInto(SILGenFunction &SGF,
     SGF.Cleanups.forwardCleanup(componentCleanup);
 
   SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex, openedEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue packIndex) {

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -433,7 +433,8 @@ void SILGenFunction::emitIsolatingDestructor(DestructorDecl *dd) {
         B.createIntegerLiteral(loc, wordTy, 0);
 
     // Schedule isolated execution
-    B.createApply(loc, swiftDeinitOnExecutorFunc, {},
+    B.createApply(loc, swiftDeinitOnExecutorFunc,
+                  getForwardingSubstitutionMap(),
                   {castedSelf, castedDeallocator, executor, flagsInst});
   });
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1660,6 +1660,7 @@ RValueEmitter::visitPackExpansionExpr(PackExpansionExpr *E,
 
   SGF.emitDynamicPackLoop(E, formalPackType, /*component index*/ 0,
                           E->getGenericEnvironment(),
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue packIndex) {
@@ -7417,6 +7418,7 @@ static void emitIgnoredPackExpansion(SILGenFunction &SGF,
   auto openedElementEnv = E->getGenericEnvironment();
   SGF.emitDynamicPackLoop(E, formalPackType, /*component index*/ 0,
                           openedElementEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue packIndex) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -3155,6 +3155,7 @@ public:
   ///   within the loop; can be null to bind no elements
   /// \param reverse - if true, iterate the elements in reverse order,
   ///   starting at index limitWithinComponent - 1
+  /// \param emitLoopLatch - emit the entry block.
   /// \param emitBody - a function that will be called to emit the body of
   ///   the loop. It's okay if this has paths that exit the body of the loop,
   ///   but it should leave the insertion point set at the end.
@@ -3172,20 +3173,20 @@ public:
       SILLocation loc, CanPackType formalPackType, unsigned componentIndex,
       SILValue startingAfterIndexWithinComponent, SILValue limitWithinComponent,
       GenericEnvironment *openedElementEnv, bool reverse,
+      llvm::function_ref<SILBasicBlock *()> emitLoopLatch,
       llvm::function_ref<void(SILValue indexWithinComponent,
                               SILValue packExpansionIndex, SILValue packIndex)>
-          emitBody,
-      SILBasicBlock *loopLatch = nullptr);
+          emitBody);
 
   /// A convenience version of dynamic pack loop that visits an entire
   /// pack expansion component in forward order.
   void emitDynamicPackLoop(
       SILLocation loc, CanPackType formalPackType, unsigned componentIndex,
       GenericEnvironment *openedElementEnv,
+      llvm::function_ref<SILBasicBlock *()> emitLoopLatch,
       llvm::function_ref<void(SILValue indexWithinComponent,
                               SILValue packExpansionIndex, SILValue packIndex)>
-          emitBody,
-      SILBasicBlock *loopLatch = nullptr);
+          emitBody);
 
   /// Emit a transform on each element of a pack-expansion component
   /// of a pack, write the result into a pack-expansion component of

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4020,6 +4020,7 @@ ManagedValue ResultPlanner::expandPackExpansion(
   // expansion in the inner pack.
   SGF.emitDynamicPackLoop(Loc, innerFormalPackType, innerComponentIndex,
                           openedEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue innerPackIndex) {
@@ -4165,6 +4166,7 @@ ManagedValue TranslateArguments::expandPackExpansion(
   //   index.
   SGF.emitDynamicPackLoop(Loc, innerFormalPackType, innerComponentIndex,
                           openedEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue innerPackIndex) {
@@ -4301,6 +4303,7 @@ void ResultPlanner::Operation::emitReabstractTupleIntoPackExpansion(
 
   SGF.emitDynamicPackLoop(loc, innerFormalPackType, innerComponentIndex,
                           openedEnv,
+                          []() -> SILBasicBlock * { return nullptr; },
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue innerPackIndex) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -597,9 +597,11 @@ public:
                                                 {&substEltType});
 
       SGF.emitDynamicPackLoop(loc, inducedPackType, packComponentIndex,
-                              openedEnv, [&](SILValue indexWithinComponent,
-                                             SILValue expansionPackIndex,
-                                             SILValue packIndex) {
+                              openedEnv,
+                              []() -> SILBasicBlock * { return nullptr; },
+                              [&](SILValue indexWithinComponent,
+                                  SILValue expansionPackIndex,
+                                  SILValue packIndex) {
         componentInit->performPackExpansionInitialization(SGF, loc,
                                             indexWithinComponent,
                                             [&](Initialization *eltInit) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1245,30 +1245,32 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
         PackType::get(SGF.getASTContext(), expansion->getType())
             ->getCanonicalType());
 
-    JumpDest continueDest = createJumpDest(S->getBody());
-    JumpDest breakDest = createJumpDest(S->getBody());
+    std::optional<JumpDest> continueDest;
+    std::optional<JumpDest> breakDest;
 
     SGF.emitDynamicPackLoop(
         SILLocation(expansion), formalPackType, 0,
         expansion->getGenericEnvironment(),
+        [&]() -> SILBasicBlock * {
+          breakDest = createJumpDest(S->getBody());
+          continueDest = createJumpDest(S->getBody());
+          return continueDest->getBlock();
+        },
         [&](SILValue indexWithinComponent, SILValue packExpansionIndex,
             SILValue packIndex) {
           Scope innerForScope(SGF.Cleanups, CleanupLocation(S->getBody()));
           auto letValueInit =
-              SGF.emitPatternBindingInitialization(S->getPattern(), continueDest);
+              SGF.emitPatternBindingInitialization(S->getPattern(), *continueDest);
 
           SGF.emitExprInto(expansion->getPatternExpr(), letValueInit.get());
 
           // Set the destinations for 'break' and 'continue'.
-          SGF.BreakContinueDestStack.push_back({S, breakDest, continueDest});
+          SGF.BreakContinueDestStack.push_back({S, *breakDest, *continueDest});
           visit(S->getBody());
           SGF.BreakContinueDestStack.pop_back();
+        });
 
-          return;
-        },
-        continueDest.getBlock());
-
-    emitOrDeleteBlock(SGF, breakDest, S);
+    emitOrDeleteBlock(SGF, *breakDest, S);
 
     return;
   }

--- a/test/Interpreter/issue-78598.swift
+++ b/test/Interpreter/issue-78598.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple) | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/78598
+
+var counter = 0
+
+final class Entry<Results> {
+    var isEmpty: Bool { true }
+    init() {
+        counter += 1
+    }
+    deinit {
+        counter -= 1
+    }
+}
+
+struct Foo<each Results> {
+    private let entry: (repeat Entry<each Results>)
+    
+    init(_ entry: (repeat Entry<each Results>)) {
+        self.entry = entry
+        for entry in repeat each entry {
+            if entry.isEmpty {
+                break
+            }
+        }
+    }
+    
+    var hmmm: Void {
+        for entry in repeat each entry {
+            if !entry.isEmpty {
+                break
+            }
+        }
+    }
+}
+
+_ = Foo((
+    Entry<Any>()
+)).hmmm
+
+// CHECK: Counter: 0
+print("Counter: \(counter)")

--- a/test/Interpreter/pack_iteration.swift
+++ b/test/Interpreter/pack_iteration.swift
@@ -1,0 +1,47 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var packIter = TestSuite("PackIteration")
+
+packIter.test("break") {
+  func breakTest<each T: Hashable>(_ ts: (repeat (each T)?)) -> [AnyHashable] {
+    var result: [AnyHashable] = []
+
+    for t in repeat each ts {
+      if let t {
+        result.append(t)
+      } else {
+	    break
+      }
+    }
+
+    return result
+  }
+
+  let results = breakTest((0, "hello", nil as Bool?, 3.14))
+  expectEqual(results, [0, "hello"] as [AnyHashable])
+}
+
+packIter.test("break") {
+  func continueTest<each T: Hashable>(_ ts: (repeat (each T)?)) -> [AnyHashable] {
+    var result: [AnyHashable] = []
+
+    for t in repeat each ts {
+      if let t {
+        result.append(t)
+      } else {
+	    continue
+      }
+    }
+
+    return result
+  }
+
+  let results = continueTest((0, "hello", nil as Bool?, 3.14))
+  expectEqual(results, [0, "hello", 3.14] as [AnyHashable])
+}
+
+runAllTests()


### PR DESCRIPTION
- Explanation:

  We were creating the JumpDests too early, so lowering a 'break' or 'continue' statement would perform cleanups that were recorded while evaluating the pack expansion expression, which would cause SIL verifier errors and runtime crashes.

- Resolves: https://github.com/swiftlang/swift/issues/78598, rdar://131847933, rdar://166715315

- Main branch PR: https://github.com/swiftlang/swift/pull/85415 (was forwarded to 6.3 as well) 

- Risk: Low. Affects break/continue statements inside of loops that iterate over pack expansion elements.

- Reviewed By: @hborla 

- Testing: Added new test-cases to the suite.

(cherry picked from commit 522a6b7c8034da35e48d4fc24f3eda9d09692e85)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
