### PR TITLE
[6.3][IRGen] Use proper linkage for async function pointers to partial app…

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1846,6 +1846,15 @@ public:
 
   bool isAlwaysSharedLinkage() const;
 
+  /// Partial apply forwarders always need real private linkage,
+  /// to ensure the correct implementation is used in case of
+  /// colliding symbols.
+  bool privateMeansPrivate() const {
+    return getKind() == Kind::PartialApplyForwarder ||
+           getKind() == Kind::PartialApplyForwarderAsyncFunctionPointer ||
+           getKind() == Kind::PartialApplyForwarderCoroFunctionPointer;
+  }
+
   /// Whether the link entity's definitions must be considered non-unique.
   ///
   /// This applies only in the Embedded Swift linkage model, and is used for

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -89,6 +89,11 @@ entry(%e : $EmptyType, %b : $WeakBox<τ_0_0>):
   unreachable
 }
 
+// CHECK-DAG: @"$s7takingQTATu" = internal
+// CHECK-DAG: @"$s11takingQAndSTATu" = internal
+// CHECK-DAG: @"$s13inner_closureTATu" = internal
+// CHECK-DAG: @"$s15returns_closureTATu" = internal
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context(
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(
 sil public @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_guaranteed () -> () {


### PR DESCRIPTION
…ly forwarders

rdar://163631865

Under certain circumstances the same symbol can be used for different implementations of the forwarders. The forwarders themselves are already emitted with "internal" LLVM linkage, but some particularities in the mapping from SILLinkage to LLVM linkage caused async function pointers to partial apply forwarders to be emitted with linkonce_odr instead, which caused the wrong forwarder to be called at runtime, causing unexpected behavior and crashes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
