### PR TITLE
Test: disable flaky bit of manual_ownership.swift

### DIFF
--- a/test/SIL/manual_ownership.swift
+++ b/test/SIL/manual_ownership.swift
@@ -423,13 +423,24 @@ extension FixedWidthInteger {
     }
 }
 
-struct CollectionOf32BitLittleEndianIntegers<BaseCollection: Collection> where BaseCollection.Element == UInt8 {
-    var baseCollection: BaseCollection
+// FIXME(rdar://164852821): Some of the diagnostic message tailoring for assignments
+// are unstable when targeting platforms like the simulator, since we seem to emit
+// slightly different SIL which then throws off the heuristics. For example,
+//
+// <snip>/swift/test/SIL/manual_ownership.swift:431:68: error: incorrect message found
+//           self.baseCollection = baseCollection
+//           // x-warning@-1 {{accessing 'baseCollection' may produce a copy}}
+//                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//            closure capture of 'baseCollection' requires independent copy of it; write [baseCollection = copy baseCollection] in the closure's capture list to acknowledge
+//
 
-    init(_ baseCollection: BaseCollection) {
-        precondition(baseCollection.count % 4 == 0)
-        self.baseCollection = baseCollection // expected-warning {{accessing 'baseCollection' may produce a copy}}
-    } // expected-warning {{accessing 'self' may produce a copy}}
-
-    // FIXME: the above initializer shouldn't have any diagnostics
-}
+// struct CollectionOf32BitLittleEndianIntegers<BaseCollection: Collection> where BaseCollection.Element == UInt8 {
+//     var baseCollection: BaseCollection
+//
+//     init(_ baseCollection: BaseCollection) {
+//         precondition(baseCollection.count % 4 == 0)
+//         self.baseCollection = baseCollection // x-warning {{accessing 'baseCollection' may produce a copy}}
+//     } // x-warning {{accessing 'self' may produce a copy}}
+//
+//     // FIXME: the above initializer shouldn't have any diagnostics
+// }


### PR DESCRIPTION
The diagnostic messages are not yet stabilized, so we're getting a differently-worded message for the same
fundamental issue, depending on the kind of stdlib build.

rdar://164852821
