### PR TITLE
[cxx-interop] Avoid miscompiling calls to function templates with added metatype parameters

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4784,6 +4784,14 @@ void ClangImporter::Implementation::getMangledName(
   }
 }
 
+void ClangImporter::Implementation::getItaniumMangledName(
+    const clang::NamedDecl *clangDecl, raw_ostream &os) {
+  auto &clangCtx = clangDecl->getASTContext();
+  std::unique_ptr<clang::ItaniumMangleContext> mangler{
+      clang::ItaniumMangleContext::create(clangCtx, clangCtx.getDiagnostics())};
+  return getMangledName(mangler.get(), clangDecl, os);
+}
+
 void ClangImporter::Implementation::configureOptionsForCodeGen(
     clang::DiagnosticsEngine &Diags, clang::CompilerInvocation *CI) {
   clang::TargetInfo *targetInfo = nullptr;
@@ -7818,6 +7826,24 @@ ClangImporter::getCXXFunctionTemplateSpecialization(SubstitutionMap subst,
   if (!inserted)
     return ConcreteDeclRef(fnIt->second);
 
+  bool needsThunkForMetatypes =
+      newFn->getNumParams() != decl->getParameterList()->size();
+  // Before we proceed to import the newly instantiated C++ function, make sure
+  // it gets a unique name in Swift. In particular, it must have a different
+  // name from all the other instantiations of the same function template, to
+  // prevent Swift from incorrectly deduplicating the multiple instantiations,
+  // which would cause a silent miscompile. The naming itself is not important,
+  // since this will only get called from synthesized code. Let's use the
+  // mangled Clang name of this instantiation as the swift_name.
+  if (needsThunkForMetatypes) {
+    std::string mangledNewFn;
+    llvm::raw_string_ostream mangleRawStream(mangledNewFn);
+    mangleRawStream << "__swift_specializedThunk_";
+    Impl.getItaniumMangledName(newFn, mangleRawStream);
+    newFn->addAttr(clang::SwiftNameAttr::CreateImplicit(newFn->getASTContext(),
+                                                        mangledNewFn));
+  }
+
   auto *newDecl = cast_or_null<ValueDecl>(
       decl->getASTContext().getClangModuleLoader()->importDeclDirectly(newFn));
   if (!newDecl)
@@ -7832,7 +7858,7 @@ ClangImporter::getCXXFunctionTemplateSpecialization(SubstitutionMap subst,
   if (auto *fn = dyn_cast<FuncDecl>(decl)) {
     newDecl = addThunkForDependentTypes(fn, cast<FuncDecl>(newDecl));
 
-    if (newFn->getNumParams() != fn->getParameters()->size()) {
+    if (needsThunkForMetatypes) {
       newDecl = generateThunkForExtraMetatypes(subst, fn,
                                                cast<FuncDecl>(newDecl));
     }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -624,6 +624,11 @@ public:
   void getMangledName(clang::MangleContext *mangler,
                       const clang::NamedDecl *clangDecl, raw_ostream &os);
 
+  /// Writes the Itanium mangled name (even on platforms that do not use Itanium
+  /// mangling, such as Windows) of \p clangDecl to \p os.
+  void getItaniumMangledName(const clang::NamedDecl *clangDecl,
+                             raw_ostream &os);
+
 private:
   /// The Importer may be configured to load modules of a different OS Version
   /// than the underlying Swift compilation. This is the `TargetOptions`

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2768,7 +2768,6 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
   assert(param->hasDefaultArg() && "must have a C++ default argument");
 
   ASTContext &ctx = ImporterImpl.SwiftContext;
-  clang::ASTContext &clangCtx = param->getASTContext();
   auto clangFunc =
       cast<clang::FunctionDecl>(param->getParentFunctionOrMethod());
   if (isa<clang::CXXConstructorDecl>(clangFunc))
@@ -2778,10 +2777,8 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
 
   std::string s;
   llvm::raw_string_ostream os(s);
-  std::unique_ptr<clang::ItaniumMangleContext> mangler{
-      clang::ItaniumMangleContext::create(clangCtx, clangCtx.getDiagnostics())};
   os << "__defaultArg_" << param->getFunctionScopeIndex() << "_";
-  ImporterImpl.getMangledName(mangler.get(), clangFunc, os);
+  ImporterImpl.getItaniumMangledName(clangFunc, os);
 
   // Synthesize `func __defaultArg_XYZ() -> ParamTy { ... }`.
   DeclName funcName(ctx, DeclBaseName(ctx.getIdentifier(s)),

--- a/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
+++ b/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
@@ -16,7 +16,19 @@ struct Struct {
 };
 
 template <typename T>
-void templateTypeParamNotUsedInSignature() {}
+struct is_bool {
+  constexpr static bool value = false;
+};
+
+template <>
+struct is_bool<bool> {
+  constexpr static bool value = true;
+};
+
+template <typename T>
+bool templateTypeParamNotUsedInSignature() {
+  return is_bool<T>::value;
+}
 
 template <typename T, typename U>
 void multiTemplateTypeParamNotUsedInSignature() {}

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs | %FileCheck %s
+
+import TemplateTypeParameterNotInSignature
+
+_ = templateTypeParamNotUsedInSignature(T: Int.self)
+_ = templateTypeParamNotUsedInSignature(T: Bool.self)
+
+
+// CHECK: sil [transparent] [serialized] [ossa] @$sSC35templateTypeParamNotUsedInSignatureySbSimF : $@convention(thin) (@thin Int.Type) -> Bool {
+// CHECK: bb0(%0 : $@thin Int.Type):
+// CHECK:   {{.*}} = function_ref @$sSo69__swift_specializedThunk__Z35templateTypeParamNotUsedInSignatureI{{l|x}}EbvSbyFTo : $@convention(c) () -> Bool
+// CHECK: } // end sil function '$sSC35templateTypeParamNotUsedInSignatureySbSimF'
+
+// CHECK: sil [transparent] [serialized] [ossa] @$sSC35templateTypeParamNotUsedInSignatureyS2bmF : $@convention(thin) (@thin Bool.Type) -> Bool {
+// CHECK: bb0(%0 : $@thin Bool.Type):
+// CHECK:   {{.*}} = function_ref @$sSo69__swift_specializedThunk__Z35templateTypeParamNotUsedInSignatureIbEbvSbyFTo : $@convention(c) () -> Bool
+// CHECK: } // end sil function '$sSC35templateTypeParamNotUsedInSignatureyS2bmF'

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
@@ -19,8 +19,12 @@ TemplateNotInSignatureTestSuite.test("Function with defaulted template type para
 
 TemplateNotInSignatureTestSuite.test("Instantiate the same function template twice.") {
   // Intentionally test the same thing twice.
-  templateTypeParamNotUsedInSignature(T: Int.self)
-  templateTypeParamNotUsedInSignature(T: Int.self)
+  let res1 = templateTypeParamNotUsedInSignature(T: Int.self)
+  expectFalse(res1)
+  let res2 = templateTypeParamNotUsedInSignature(T: Int.self)
+  expectFalse(res2)
+  let res3 = templateTypeParamNotUsedInSignature(T: Bool.self)
+  expectTrue(res3)
 }
 
 TemplateNotInSignatureTestSuite.test("Pointer types") {


### PR DESCRIPTION
C++ allows function templates that do not use all of their template parameters in the signature, such as:
```
template <typename T>
bool foo();
```

This is not compatible with Swift's generic model, so to let clients call such functions from Swift, ClangImporter generates an extra metatype parameter:
```
func foo<T>(T: T.Type) -> Bool

// Usage:
foo(Int.self)
foo(Bool.self)
```

That logic had a flaw that surfaced when the C++ function's behavior differs depending on the templated parameter. Instead of instantiating the function template with all of the required template parameters, and using the corresponding instantiation for each call, Swift was (correctly) instantiating the template for the necessary types, but then silently dropping all of the instantiations except for one, and using the remaining one for all callsites. This happened because all of the instantiations were getting the same name in Swift, and therefore had the exact same mangled name, which caused SILGen to pick one and discard the others.

This makes sure that if the extra metatype parameter was added to a function template, all of the function instantiations get unique mangled names.

rdar://166184513

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
