### PR TITLE
[test] Fix expectations in `Concurrency/toplevel/main.swift`

### DIFF
--- a/test/Concurrency/toplevel/Inputs/foo.swift
+++ b/test/Concurrency/toplevel/Inputs/foo.swift
@@ -1,3 +1,0 @@
-func foo() -> Int {
-    a + 10
-}

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level -swift-version 5 %s -verify
+// RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -swift-version 5 %s -verify
 
-// enable-experimental-async-top-level is passed and an await is used in the
-// top-level, so the top-level code is a concurrent context. Variables are
-// declared with `@_predatesConcurrency @MainActor`, and the top-level is run on
-// the main actor.
+// An await is used in the top-level, so the top-level code is a concurrent
+// context. Variables are declared with `@_predatesConcurrency @MainActor`, and
+// the top-level is run on the main actor.
 
 var a = 10 // expected-note {{mutation of this var is only permitted within the actor}}
 

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level -swift-version 6 %s -verify
+// RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -swift-version 6 %s -verify
 
 var a = 10
 // expected-note@-1 2 {{var declared here}}

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 
-// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -enable-experimental-async-top-level -swift-version 6 -verify-additional-prefix swift6-
-// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -enable-experimental-async-top-level -swift-version 5 -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -swift-version 6 -verify-additional-prefix swift6-
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -swift-version 5 -verify-additional-prefix swift5-
 
 //--- foo.swift
 func foo() -> Int {

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -1,44 +1,43 @@
-// RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 6 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift6-CHECK,CHECK'
-// RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 5 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift5-CHECK,CHECK'
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
 
-var a = 10
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -enable-experimental-async-top-level -swift-version 6 -verify-additional-prefix swift6-
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/foo.swift -enable-experimental-async-top-level -swift-version 5 -verify-additional-prefix swift5-
+
+//--- foo.swift
+func foo() -> Int {
+  // expected-swift6-note@-1 {{add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'}}
+  a + 10
+  // expected-swift6-error@-1 {{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
+}
+
+//--- main.swift
+var a = 10 // expected-swift6-note 2{{var declared here}}
 
 @MainActor
-var b = 14
-// CHECK: top-level code variables cannot have a global actor
+var b = 14 // expected-error {{top-level code variables cannot have a global actor}}
 
 func nonIsolatedSynchronous() {
+  // expected-swift6-note@-1 {{add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'}}
     print(a)
-// Swift6-CHECK: main actor-isolated var 'a' can not be referenced from a nonisolated context
-// Swift6-CHECK: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
-
-// Swift5-CHECK-NOT: main actor-isolated var 'a' can not be referenced from a nonisolated context
-// Swift5-CHECK-NOT: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
+// expected-swift6-error@-1 {{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
 }
 
 func nonIsolatedAsync() async {
-    print(a)
-// CHECK: expression is 'async' but is not marked with 'await'
-// CHECK: property access is 'async'
+  print(a)
+  // expected-swift6-error@-1 {{main actor-isolated var 'a' cannot be accessed from outside of the actor}}
+  // expected-swift5-warning@-2 {{main actor-isolated var 'a' cannot be accessed from outside of the actor}}
 }
 
 await nonIsolatedAsync()
 
-// Swift6-CHECK: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a nonisolated context
-// Swift6-CHECK-DAG: var declared here
-// Swift6-CHECK-DAG: add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
-
-// Swift5-CHECK-NOT: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a nonisolated context
-// Swift5-CHECK-NOT: var declared here
-// Swift5-CHECK-NOT: add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
-
 @MainActor
 func isolated() {
-    print(a)
+  print(a)
 }
 
 func asyncFun() async {
-    await print(a)
+  await print(a)
 }
 
 await asyncFun()

--- a/test/Concurrency/toplevel/no-async-5-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-5-top-level.swift
@@ -1,9 +1,7 @@
-// RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level -swift-version 5 %s -verify
 // RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -swift-version 5 %s -verify
 
-// Even though enable-experimental-async-top-level is enabled, there are no
-// `await`s made from the top-level, so it is not an async context. `a` is just
-// a normal top-level global variable with no actor isolation.
+// There are no `await`s made from the top-level, so it is not an async context.
+// `a` is just a normal top-level global variable with no actor isolation.
 
 var a = 10
 

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -1,9 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -swift-version 6 %s -verify
 
-// Even though enable-experimental-async-top-level is enabled, there are no
-// 'await's made from the top-level, thus the top-level is not an asynchronous
-// context. `a` is just a normal top-level global variable with no actor
-// isolation.
+// There are no 'await's made from the top-level, thus the top-level is not an
+// asynchronous context. `a` is just a normal top-level global variable with no
+// actor isolation.
 
 var a = 10 // expected-note 2 {{var declared here}}
 // expected-note@-1 2{{mutation of this var is only permitted within the actor}}

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level -strict-concurrency=complete -typecheck -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -typecheck -verify %s
 
 var a = 10 // expected-note{{var declared here}}
 

--- a/test/SILGen/top_level_captures.swift
+++ b/test/SILGen/top_level_captures.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-experimental-async-top-level -emit-silgen %s | %FileCheck %s
 // RUN: %target-swift-frontend -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-inlinable-function-bodies-without-types -emit-silgen %s | %FileCheck -check-prefix=SKIPPED-FUNC-EMITTED %s
 
 guard let x: Int = nil else { while true { } }

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -Xllvm -sil-full-demangle %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-async-top-level %s | %FileCheck %s
 
 enum MyError : Error {
   case A, B

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -Xllvm -sil-full-demangle -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -Xllvm -sil-full-demangle -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int


### PR DESCRIPTION
FileCheck was matching against its own CHECK lines in the diagnostic output here so the test always succeeded. Convert to using the diagnostic verifier now we have `-verify-additional-prefix`. While here, also remove uses of `-enable-experimental-async-top-level` from tests since that's now the default and the option is redundant.