### PR TITLE
[cxx-interop] Fix miscompilation for inferred shared references

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -216,8 +216,12 @@ public:
                                           DeclContext *newContext,
                                           ClangInheritanceInfo inheritance) = 0;
 
-  /// Returnes the original method if \param decl is a clone from a base class
+  /// Returns the original method if \param decl is a clone from a base class
   virtual ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) = 0;
+
+  /// Returns true if we synthesize this member for every type so no need to
+  /// clone it for the derived classes.
+  virtual bool isMemberSynthesizedPerType(const ValueDecl *decl) = 0;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -650,6 +650,7 @@ public:
                                   ClangInheritanceInfo inheritance) override;
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) override;
+  bool isMemberSynthesizedPerType(const ValueDecl *decl) override;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -500,7 +500,7 @@ struct CustomRefCountingOperationResult {
 
   CustomRefCountingOperationResultKind kind;
   ValueDecl *operation;
-  std::string name;
+  StringRef name;
 };
 
 class CustomRefCountingOperation

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -48,6 +48,7 @@
 #include "clang/Serialization/ModuleFileExtension.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallBitVector.h"
@@ -692,6 +693,7 @@ private:
 
   // Map all cloned methods back to the original member
   llvm::DenseMap<ValueDecl *, ValueDecl *> clonedMembers;
+  llvm::DenseSet<const ValueDecl *> membersSynthesizedPerType;
 
   // Keep track of methods that are unavailale in each class.
   // We need this set because these methods will be imported lazily. We don't
@@ -714,6 +716,8 @@ public:
                                   ClangInheritanceInfo inheritance);
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl);
+  bool isMemberSynthesizedPerType(const ValueDecl *decl);
+  void markMemberSynthesizedPerType(const ValueDecl *decl);
 
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
 
@@ -2230,6 +2234,11 @@ getImplicitObjectParamAnnotation(const clang::FunctionDecl *FD) {
   }
   return nullptr;
 }
+
+/// Find a unique base class that is annotated as SHARED_REFERENCE if any.
+const clang::RecordDecl *
+getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
+                   ClangImporter::Implementation *importerImpl);
 
 } // end namespace importer
 } // end namespace swift

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -16,6 +16,8 @@
 #include "ImporterImpl.h"
 #include "swift/AST/Decl.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
+#include "clang/AST/DeclCXX.h"
 
 namespace swift {
 
@@ -355,6 +357,14 @@ public:
   /// that calls that destroy operation.
   void addExplicitDeinitIfRequired(
       NominalTypeDecl *nominal, const clang::RecordDecl *clangType);
+
+  /// When a base class is marked as SHARED_REFERENCE, synthesize a call to
+  /// the ref counting operations. This call does the derived to base conversion
+  /// that is responsible for all the offset adjustments on the pointer.
+  std::pair<CustomRefCountingOperationResult, CustomRefCountingOperationResult>
+  addRefCountOperations(ClassDecl *decl, clang::CXXRecordDecl *clangDecl,
+                        const ClassDecl *baseDecl,
+                        const clang::CXXRecordDecl *baseClangDecl);
 
   /// Synthesize a Swift function that calls the Clang runtime predicate
   /// function for the availability domain represented by `var`.

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -109,8 +109,8 @@ __attribute__((swift_attr("release:immortal"))) ImmortalRefType {};
 ImmortalRefType *returnImmortalRefType() { return new ImmortalRefType(); };
 
 struct DerivedFromImmortalRefType : ImmortalRefType {};
-DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() { // expected-note {{annotate 'returnDerivedFromImmortalRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
-    return new DerivedFromImmortalRefType();
+DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() {
+  return new DerivedFromImmortalRefType();
 };
 
 } // namespace ImmortalRefereceExample

--- a/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
@@ -112,8 +112,8 @@ struct StaticRetainRelease {
 } SWIFT_SHARED_REFERENCE(.staticRetain, .staticRelease);
 
 struct DerivedStaticRetainRelease : StaticRetainRelease {
-// expected-error@-1 {{cannot find retain function '.staticRetain' for reference type 'DerivedStaticRetainRelease'}}
-// expected-error@-2 {{cannot find release function '.staticRelease' for reference type 'DerivedStaticRetainRelease'}}
+// expected-error@-1 {{specified release function '.staticRelease' is a static function; expected an instance function}}
+// expected-error@-2 {{specified retain function '.staticRetain' is a static function; expected an instance function}}
   int secondValue = 1;
   DerivedStaticRetainRelease(int value, int secondValue)
       : StaticRetainRelease(value), secondValue(secondValue) {}

--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -85,3 +85,10 @@ private:
   explicit Payload(int value) : m_value(value) {}
   int m_value;
 };
+
+struct FirstBase {
+  int a, b, c;
+  virtual ~FirstBase() {}
+};
+
+struct DerivedFRT : FirstBase, SharedFRT {};

--- a/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import LoggingFrts
+
+func go() {
+    let frt = DerivedFRT()
+    let copy = frt
+}
+
+go()
+
+// CHECK: RefCount: 1, message: Ctor
+// CHECK: RefCount: 2, message: retain
+// CHECK: RefCount: 1, message: release
+// CHECK: RefCount: 0, message: release
+// CHECK: RefCount: 0, message: Dtor

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -6,7 +6,7 @@
 import Inheritance
 
 let _ = ImmortalRefereceExample.returnImmortalRefType()
-let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType() // expected-warning {{cannot infer ownership of foreign reference value returned by 'returnDerivedFromImmortalRefType()'}}
+let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType()
 
 let _ = ExplicitAnnotationHasPrecedence1.returnValueType()
 let _ = ExplicitAnnotationHasPrecedence1.returnRefType() // expected-warning {{cannot infer ownership of foreign reference value returned by 'returnRefType()'}}


### PR DESCRIPTION
When a base class is annotated as shared reference we can occasionally infer that the derived types also need to be shared references. Unfortunately, we did not generate the correct code for some of those scenarios. When the reference counted base is not at the offset zero we need to do offset adjustments before we pass the pointer to the reference counting functions. We did not do those offset calculations.

I looked into implementing the codegen for the offset calculation directly in Swift but it needed significantly more work than I anticipated. We need to invoke the frontend to get the path to the base class and we also need to deal with virtual inheritance, alignment and some other considerations.

This PR ends up generating a Clang shim instead and the derived to base conversion happens in this shim. As a result, we piggy-back on Clang making all the correct offset calculations. This patch also had to change how certain aspects of shared references are implemented to be compatible with this approach:
* Instead of always looking at the base classes to querry the retain/release operations we now propagate the corresponding annotations once per types. This also has the beneficial effects that we traverse the inheritance hierarchy less often.
* To generate the correct diagnostics, I reuse the result of the refcount operation query.
* We do not want these generated functions to be inherited, so added a set to exempt them from cloning.
* Tweaked the lookup logic for retain/release a bit as these generated clang methods are not found by lookup. We rely on looking up the imported methods instead.

rdar://166227787
