### PR TITLE
[cxx-interop] Add support for subscripts of non-copyable types

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6247,9 +6247,9 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
 
   // Use 'address' or 'mutableAddress' accessors for non-copyable
   // types, unless the base accessor returns it by value.
-  bool useAddress = contextTy->isNoncopyable() &&
-                    (baseClassVar->getReadImpl() == ReadImplKind::Stored ||
-                     baseClassVar->getAccessor(AccessorKind::Address));
+  bool useAddress = baseClassVar->getAccessor(AccessorKind::Address) ||
+                    (contextTy->isNoncopyable() &&
+                     baseClassVar->getReadImpl() == ReadImplKind::Stored);
 
   ParameterList *bodyParams = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {
@@ -6397,12 +6397,6 @@ static ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
   }
 
   if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
-    auto contextTy =
-        newContext->mapTypeIntoEnvironment(subscript->getElementInterfaceType());
-    // Subscripts that return non-copyable types are not yet supported.
-    // See: https://github.com/apple/swift/issues/70047.
-    if (contextTy->isNoncopyable())
-      return nullptr;
     auto out = SubscriptDecl::create(
         subscript->getASTContext(), subscript->getName(), subscript->getStaticLoc(),
         subscript->getStaticSpelling(), subscript->getSubscriptLoc(),

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -16,8 +16,11 @@ module Test {
 
 struct NonCopyable {
     NonCopyable() = default;
+    NonCopyable(int x) : number(x) {}
     NonCopyable(const NonCopyable& other) = delete; // expected-note {{'NonCopyable' has been explicitly marked deleted here}}
     NonCopyable(NonCopyable&& other) = default;
+
+    int number = 0;
 };
 
 template <typename T>
@@ -202,6 +205,11 @@ struct FieldDependsOnMe { // used to trigger a request cycle
   OneField<NoFields<FieldDependsOnMe, NonCopyable>> field;
 };
 
+struct HasConstSubscript {
+    const NonCopyable &operator[](int idx) { return nc; }
+    NonCopyable nc;
+};
+
 //--- test.swift
 import Test
 import CxxStdlib
@@ -292,4 +300,10 @@ func couldCreateCycleOfCxxValueSemanticsRequests() {
 
   let d3 = FieldDependsOnMe()
   takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}
+}
+
+func useConstSubscript() {
+  var obj = HasConstSubscript(nc: NonCopyable(5))
+  _ = obj[42]
+  obj[42] = NonCopyable(7) // expected-error {{cannot assign through subscript: subscript is get-only}}
 }

--- a/test/Interop/Cxx/class/noncopyable.swift
+++ b/test/Interop/Cxx/class/noncopyable.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift %t%{fs-sep}test.swift -I %t%{fs-sep}Inputs -o %t%{fs-sep}out -cxx-interoperability-mode=default
+// RUN: %target-codesign %t%{fs-sep}out
+// RUN: %target-run %t%{fs-sep}out
+//
+// REQUIRES: executable_test
+
+//--- Inputs/module.modulemap
+module Test {
+    header "noncopyable.h"
+    requires cplusplus
+}
+
+//--- Inputs/noncopyable.h
+#include <string>
+
+struct NonCopyable {
+    NonCopyable() = default;
+    NonCopyable(int x) : number(x) {}
+    NonCopyable(const NonCopyable& other) = delete; 
+    NonCopyable(NonCopyable&& other) = default;
+
+    int number = 0;
+};
+
+template<typename T>
+struct HasSubscript {
+    T &operator[](int idx) { return element; }
+    T element;
+};
+
+using HasSubscriptInt = HasSubscript<int>;
+using HasSubscriptNonCopyable = HasSubscript<NonCopyable>;
+
+struct InheritsFromHasSubscript : public HasSubscript<NonCopyable> {};
+
+//--- test.swift
+import StdlibUnittest
+import Test
+
+var NonCopyableTestSuite = TestSuite("NonCopyable")
+
+func borrow(_ x: borrowing NonCopyable) -> Int32 { return x.number; }
+
+NonCopyableTestSuite.test("Use subscript") {
+    var o1 = HasSubscriptInt(element: 7)
+    expectEqual(o1[42], 7)
+
+    var o2 = HasSubscriptNonCopyable(element: NonCopyable(5))
+    expectEqual(borrow(o2[42]), 5)
+
+    var inherited = InheritsFromHasSubscript()
+    expectEqual(borrow(inherited[42]), 0)
+}
+
+NonCopyableTestSuite.test("Mutate subscript") {
+    var o1 = HasSubscriptInt(element: 7)
+    expectEqual(o1[42], 7)
+    o1[42] = 8
+    expectEqual(o1[42], 8)
+
+    var o2 = HasSubscriptNonCopyable(element: NonCopyable(5))
+    expectEqual(borrow(o2[42]), 5)
+    o2[42] = NonCopyable(16)
+    expectEqual(borrow(o2[42]), 16)
+
+    var inherited = InheritsFromHasSubscript()
+    expectEqual(borrow(inherited[42]), 0)
+    inherited[42] = NonCopyable(3)
+    expectEqual(borrow(inherited[42]), 3)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -32,13 +32,23 @@ using VectorOfImmortalRefPtr = std::vector<ImmortalRef *>;
 
 struct NonCopyable {
   NonCopyable() = default;
+  NonCopyable(int x) : number(x) {}
   NonCopyable(const NonCopyable &other) = delete;
   NonCopyable(NonCopyable &&other) = default;
   ~NonCopyable() {}
+
+  int number = 0;
 };
 
 using VectorOfNonCopyable = std::vector<NonCopyable>;
 using VectorOfPointer = std::vector<NonCopyable *>;
+
+inline VectorOfNonCopyable makeVectorOfNonCopyable() {
+  VectorOfNonCopyable vec;
+  vec.emplace_back(1);
+  vec.emplace_back(2);
+  return vec;
+}
 
 struct HasVector {
   std::vector<NonCopyable> field;

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -211,4 +211,24 @@ StdVectorTestSuite.test("VectorOfImmortalRefPtr").require(.stdlib_5_8).code {
     expectEqual(v[0]?.value, 123)
 }
 
+StdVectorTestSuite.test("Subscript of VectorOfNonCopyable") {
+    var v = makeVectorOfNonCopyable()
+    expectEqual(v.size(), 2)
+    expectFalse(v.empty())
+
+    func getNumber(_ x: borrowing NonCopyable) -> Int32 {
+        return x.number
+    }
+
+    expectEqual(getNumber(v[0]), 1)
+    expectEqual(getNumber(v[1]), 2)
+
+    v[0] = NonCopyable(3)
+    v[1] = NonCopyable(4)
+
+    expectEqual(getNumber(v[0]), 3)
+    expectEqual(getNumber(v[1]), 4)
+}
+
+
 runAllTests()


### PR DESCRIPTION
This adds support for reading from and modifying subscripts of non-copyable types, including the subscript of a non-copyable `std::vector`.

rdar://156698253
