### PR TITLE
[Index] Fix missing constructor reference for Self.NestedType() calls

### DIFF
--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -57,3 +57,20 @@ func castExpr(x: Any) {
     // CHECK: [[@LINE+1]]:15 | struct/Swift | S1 | [[S1_USR]] | Ref
     _ = x as? S1
 }
+
+// Test that initializers are indexed when called through Self.NestedType
+// CHECK: [[@LINE+1]]:7 | class(internal)/Swift | Container | [[Container_USR:.*]] | Def
+class Container {
+    // CHECK: [[@LINE+1]]:11 | class(internal)/Swift | NestedType | [[NestedType_USR:.*]] | Def
+    class NestedType {
+        // CHECK: [[@LINE+1]]:9 | constructor(internal)/Swift | init(value:) | [[NestedType_init_USR:.*]] | Def
+        init(value: Int) {}
+    }
+
+    func someFunc() {
+        // CHECK: [[@LINE+3]]:13 | class/Swift | Container | [[Container_USR]] | Ref
+        // CHECK: [[@LINE+2]]:18 | class/Swift | NestedType | [[NestedType_USR]] | Ref
+        // CHECK: [[@LINE+1]]:18 | constructor/Swift | init(value:) | [[NestedType_init_USR]] | Ref,Call
+        _ = Self.NestedType(value: 1)
+    }
+}


### PR DESCRIPTION
Constructors called via Self.NestedType() weren't being indexed because the AST uses DotSyntaxCallExpr (not ConstructorRefCallExpr), causing the implicit DeclRefExpr to the constructor to be skipped.

Fix by:
1. Not skipping implicit constructor DeclRefExpr when CtorRefs is empty (i.e., when not already handled by ConstructorRefCallExpr)
2. Unwrapping AutoClosureExpr/CallExpr in isBeingCalled() to correctly detect the call context and add the Call role