### PR TITLE
[6.3] API digester support for Xcc options

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1556,7 +1556,7 @@ def Xfrontend : Separate<["-"], "Xfrontend">, Flags<[HelpHidden]>,
 
 def Xcc : Separate<["-"], "Xcc">,
   Flags<[FrontendOption, SwiftSymbolGraphExtractOption,
-         SwiftSynthesizeInterfaceOption]>,
+         SwiftSynthesizeInterfaceOption, SwiftAPIDigesterOption]>,
   MetaVarName<"<arg>">,
   HelpText<"Pass <arg> to the C/C++/Objective-C compiler">;
 

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2274,6 +2274,7 @@ private:
   std::string ResourceDir;
   std::string ModuleCachePath;
   bool DisableFailOnError;
+  std::vector<std::string> ClangImporterArgs;
 
 public:
   SwiftAPIDigesterInvocation(const std::string &ExecPath)
@@ -2377,6 +2378,7 @@ public:
         ParsedArgs.getAllArgValues(OPT_use_interface_for_module);
     ResourceDir = ParsedArgs.getLastArgValue(OPT_resource_dir).str();
     ModuleCachePath = ParsedArgs.getLastArgValue(OPT_module_cache_path).str();
+    ClangImporterArgs = ParsedArgs.getAllArgValues(OPT_Xcc);
     DebugMapping = ParsedArgs.hasArg(OPT_debug_mapping);
     DisableFailOnError = ParsedArgs.hasArg(OPT_disable_fail_on_error);
 
@@ -2457,6 +2459,11 @@ public:
     InitInvoke.getLangOptions().EnableObjCInterop =
         InitInvoke.getLangOptions().Target.isOSDarwin();
     InitInvoke.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+
+    // Pass -Xcc arguments to the Clang importer
+    for (const auto &arg : ClangImporterArgs) {
+      InitInvoke.getClangImporterOptions().ExtraArgs.push_back(arg);
+    }
 
     if (!SwiftVersion.empty()) {
       using version::Version;

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -53,6 +53,9 @@
     },
     {
        "name": "internal-import-bridging-header"
+    },
+    {
+       "name": "api-digester-Xcc"
     }
   ]
 }

--- a/test/api-digester/Inputs/XccTest/XccTest.h
+++ b/test/api-digester/Inputs/XccTest/XccTest.h
@@ -1,0 +1,9 @@
+@import ObjectiveC;
+
+#ifdef MY_MACRO
+@interface Hidden : NSObject
+@end
+#endif
+
+@interface Exposed : NSObject
+@end

--- a/test/api-digester/Inputs/XccTest/module.modulemap
+++ b/test/api-digester/Inputs/XccTest/module.modulemap
@@ -1,0 +1,4 @@
+module XccTest {
+  header "XccTest.h"
+  export *
+}

--- a/test/api-digester/Xcc-preprocessor-define.swift
+++ b/test/api-digester/Xcc-preprocessor-define.swift
@@ -1,0 +1,13 @@
+// REQUIRES: VENDOR=apple
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t.module-cache)
+
+// RUN: %api-digester -dump-sdk -module XccTest -o %t.with-define.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/XccTest -Xcc -DMY_MACRO
+// RUN: %api-digester -dump-sdk -module XccTest -o %t.without-define.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/XccTest
+
+// RUN: grep -q "Hidden" %t.with-define.json
+// RUN: grep -q "Exposed" %t.with-define.json
+
+// RUN: not grep -q "Hidden" %t.without-define.json
+// RUN: grep -q "Exposed" %t.without-define.json


### PR DESCRIPTION
- **Explanation**:
 Allow clients of swift-api-digester to configure the clang importer using -Xcc options
- **Scope**:
Only affects invocations which pass -Xcc, which used to be rejected. Only affects the API digester
- **Issues**:
https://github.com/swiftlang/swift/issues/82394
- **Original PRs**:
https://github.com/swiftlang/swift/pull/85988
- **Risk**:
  Low. Change is inactive when the flag isn't passed
- **Testing**:
 Added lit test exercising new functionality
- **Reviewers**:
  @nkcsgexi 