### PR TITLE
[CSDiagnostics] Produce a tailored diagnostic for key path mutability mismatches

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -690,6 +690,12 @@ public:
 
   bool diagnoseAsNote() override;
 
+  /// If the type of a key path literal is read-only due to setter
+  /// availability constraints but the context requires a writable
+  /// key path, let's produce a tailed availability diagnostic that
+  /// points to the offending setter.
+  bool diagnoseKeyPathLiteralMutabilityMismatch() const;
+
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
 

--- a/test/Availability/availability_accessors.swift
+++ b/test/Availability/availability_accessors.swift
@@ -63,14 +63,14 @@ struct BaseStruct<T> {
   var unavailableSetter: T {
     get { fatalError() }
     @available(*, unavailable)
-    set { fatalError() } // expected-note 33 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 34 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
   }
 
   var unavailableGetterAndSetter: T {
     @available(*, unavailable)
     get { fatalError() } // expected-note 71 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
     @available(*, unavailable)
-    set { fatalError() } // expected-note 33 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 34 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
   }
 
   var deprecatedGetter: T {
@@ -583,12 +583,9 @@ func testKeyPathArguments_Struct() {
 
   takesWritableKeyPath(&x, \.available)
   takesWritableKeyPath(&x, \.unavailableGetter) // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  // FIXME: Ideally we would diagnose the unavailability of the setter instead
-  // of simply indicating that a conversion to WritableKeyPath is not possible
-  // (rdar://157249275)
-  takesWritableKeyPath(&x, \.unavailableSetter) // expected-error {{cannot convert value of type 'KeyPath<BaseStruct<StructValue>, StructValue>' to expected argument type 'WritableKeyPath<BaseStruct<StructValue>, U>'}}
+  takesWritableKeyPath(&x, \.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
   // expected-error@-1 {{generic parameter 'U' could not be inferred}}
-  takesWritableKeyPath(&x, \.unavailableGetterAndSetter) // expected-error {{cannot convert value of type 'KeyPath<BaseStruct<StructValue>, StructValue>' to expected argument type 'WritableKeyPath<BaseStruct<StructValue>, U>'}}
+  takesWritableKeyPath(&x, \.unavailableGetterAndSetter) // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   // expected-error@-1 {{generic parameter 'U' could not be inferred}}
   takesWritableKeyPath(&x, \.deprecatedGetter) // expected-warning {{getter for 'deprecatedGetter' is deprecated: reading not recommended}}
   takesWritableKeyPath(&x, \.deprecatedSetter) // expected-warning {{setter for 'deprecatedSetter' is deprecated: writing not recommended}}

--- a/test/Availability/availability_accessors.swift
+++ b/test/Availability/availability_accessors.swift
@@ -579,14 +579,11 @@ func testKeyPathArguments_Struct() {
   takesSendableKeyPath(x, \.deprecatedSetter)
 
   func takesWritableKeyPath<T, U>(_ t: inout T, _ keyPath: WritableKeyPath<T, U>) -> () { }
-  // expected-note@-1 2 {{in call to function 'takesWritableKeyPath'}}
 
   takesWritableKeyPath(&x, \.available)
   takesWritableKeyPath(&x, \.unavailableGetter) // expected-error {{getter for 'unavailableGetter' is unavailable}}
   takesWritableKeyPath(&x, \.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // expected-error@-1 {{generic parameter 'U' could not be inferred}}
   takesWritableKeyPath(&x, \.unavailableGetterAndSetter) // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // expected-error@-1 {{generic parameter 'U' could not be inferred}}
   takesWritableKeyPath(&x, \.deprecatedGetter) // expected-warning {{getter for 'deprecatedGetter' is deprecated: reading not recommended}}
   takesWritableKeyPath(&x, \.deprecatedSetter) // expected-warning {{setter for 'deprecatedSetter' is deprecated: writing not recommended}}
 

--- a/test/stdlib/KeyPathAppending.swift
+++ b/test/stdlib/KeyPathAppending.swift
@@ -61,7 +61,7 @@ func mismatchedAppends<T, U, V>(readOnlyLeft: KeyPath<T, U>,
   // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = writableRight.appending(path: readOnlyLeft)
-  // expected-error@-1 {{instance method 'appending(path:)' requires that 'KeyPath<U, V>' inherit from 'KeyPath<U, T>'}}
+  // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = writableRight.appending(path: writableLeft)
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<T, U>' to expected argument type 'WritableKeyPath<V, U>'}}
@@ -71,7 +71,7 @@ func mismatchedAppends<T, U, V>(readOnlyLeft: KeyPath<T, U>,
   // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = referenceRight.appending(path: readOnlyLeft)
-  // expected-error@-1 {{instance method 'appending(path:)' requires that 'KeyPath<U, V>' inherit from 'KeyPath<U, T>'}}
+  // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = referenceRight.appending(path: writableLeft)
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<T, U>' to expected argument type 'WritableKeyPath<V, U>'}}


### PR DESCRIPTION
If the type of a key path literal is read-only due to setter
availability constraints but the context requires a writable
key path, let's produce a tailed availability diagnostic that
points to the offending setter.

Also match root/value of a key path even when superclass
check fails to propagate types and avoid extraneous issues
with generic parameter inference when the problem is related
to key path mutability or erasure.

Resolves: rdar://157249275

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
