### PR TITLE
Don’t print module selectors in more cases + Disable preserve-types when using module selectors

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6139,11 +6139,15 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
 
   bool isMemberOfGenericParameter(TypeBase *T) {
     Type parent = nullptr;
-    if (auto alias = dyn_cast<TypeAliasType>(T))
+    if (auto alias = dyn_cast<TypeAliasType>(T))    // don't desugar
       parent = alias->getParent();
     else if (auto generic = T->getAs<AnyGenericType>())
       parent = generic->getParent();
-    return parent && parent->isTypeParameter();
+    else if (T->is<DependentMemberType>())
+      // Parent is always a generic parameter.
+      return true;
+    return parent && (parent->is<SubstitutableType>() ||
+                        isMemberOfGenericParameter(parent.getPointer()));
   }
 
   bool shouldPrintModuleSelector(TypeBase *T) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -576,6 +576,13 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     // Any heuristics we might add would go here.
     Opts.UseModuleSelectors = false;
   }
+
+  if (Opts.PreserveTypesAsWritten && Opts.UseModuleSelectors) {
+    Opts.PreserveTypesAsWritten = false;
+    diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
+                   "-module-interface-preserve-types-as-written",
+                   "-enable-module-selectors-in-module-interface");
+  }
 }
 
 /// Checks if an arg is generally allowed to be included

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -125,13 +125,47 @@ public protocol Proto {
   // CHECK-DISABLED-SAME: TestCase.Struct<Swift.Int>
   typealias TypeAlias = Struct<Int>
 
+  // CHECK: typealias ID =
+  // CHECK-SAME: Self.AssocType.ID
+  typealias ID = AssocType.ID
+
   // CHECK: func requirement() -> Self.AssocType.ID
   func requirement() -> AssocType.ID
 
   // CHECK: func requirement2() ->
-  // CHECK-ENABLED: Self.TypeAlias.TestCase::Nested
-  // CHECK-DISABLED: Self.TypeAlias.Nested
+  // CHECK-SAME: Self.TypeAlias.Nested
   func requirement2() -> TypeAlias.Nested
 
   // CHECK: }
 }
+
+@available(SwiftStdlib 5.1, *)
+extension Proto {
+  public typealias Text = String
+}
+
+// Test cases from rdar://166180424
+
+// CHECK-LABEL: func fn3<T>(_ t: T) ->
+// CHECK-SAME: T.TypeAlias.Nested
+@available(SwiftStdlib 5.1, *)
+public func fn3<T: Proto>(_ t: T) -> T.TypeAlias.Nested { fatalError() }
+
+// CHECK-LABEL: struct ProtoSet
+@available(SwiftStdlib 5.1, *)
+public struct ProtoSet<T: Proto> {
+  // CHECK: let ids:
+  // CHECK-ENABLED-SAME: Swift::Set<T.ID>
+  // CHECK-DISABLED-SAME: Swift.Set<T.ID>
+  public let ids: Set<T.ID>
+
+  // CHECK: let texts:
+  // CHECK-ENABLED-SAME: Swift::Set<T.Text>
+  // CHECK-DISABLED-SAME: Swift.Set<T.Text>
+  public let texts: Set<T.Text>
+
+  // CHECK: let singleText:
+  // CHECK-SAME: T.Text
+  public let singleText: T.Text
+}
+

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -2,27 +2,45 @@
 
 // Test with -enable-module-selectors-in-module-interface
 // RUN: %empty-directory(%t/enabled)
-// RUN: %target-swift-emit-module-interface(%t/enabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface
+// RUN: %target-swift-emit-module-interface(%t/enabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface 2>%t/enabled/stderr.txt
 // RUN: %FileCheck --input-file %t/enabled/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-ENABLED
+// RUN: %FileCheck --input-file %t/enabled/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/enabled/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
 
 // Test with -disable-module-selectors-in-module-interface
 // RUN: %empty-directory(%t/disabled)
-// RUN: %target-swift-emit-module-interface(%t/disabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -disable-module-selectors-in-module-interface
+// RUN: %target-swift-emit-module-interface(%t/disabled/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -disable-module-selectors-in-module-interface 2>%t/disabled/stderr.txt
 // RUN: %FileCheck --input-file %t/disabled/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %FileCheck --input-file %t/disabled/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/disabled/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
 
 // Test default behavior
 // RUN: %empty-directory(%t/default)
-// RUN: %target-swift-emit-module-interface(%t/default/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+// RUN: %target-swift-emit-module-interface(%t/default/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase 2>%t/default/stderr.txt
 // RUN: %FileCheck --input-file %t/default/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %FileCheck --input-file %t/default/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/default/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
 
 // Test with -enable-module-selectors-in-module-interface and blocklist
 // RUN: %empty-directory(%t/blocked)
-// RUN: %target-swift-emit-module-interface(%t/blocked/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface -blocklist-file %S/Inputs/module_selector/blocklist.yml
+// RUN: %target-swift-emit-module-interface(%t/blocked/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -enable-module-selectors-in-module-interface -blocklist-file %S/Inputs/module_selector/blocklist.yml 2>%t/blocked/stderr.txt
 // RUN: %FileCheck --input-file %t/blocked/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED
+// RUN: %FileCheck --input-file %t/blocked/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/blocked/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// Test with -module-interface-preserve-types-as-written and -disable-module-selectors-in-module-interface
+// RUN: %empty-directory(%t/disabled-preserve)
+// RUN: %target-swift-emit-module-interface(%t/disabled-preserve/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -module-interface-preserve-types-as-written -disable-module-selectors-in-module-interface 2>%t/disabled-preserve/stderr.txt
+// RUN: %FileCheck --input-file %t/disabled-preserve/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-PRESERVE
+// RUN: %FileCheck --input-file %t/disabled-preserve/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
+// RUN: %target-swift-typecheck-module-from-interface(%t/disabled-preserve/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
+
+// Test with -module-interface-preserve-types-as-written and -enable-module-selectors-in-module-interface
+// RUN: %empty-directory(%t/enabled-preserve)
+// RUN: %target-swift-emit-module-interface(%t/enabled-preserve/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase -module-interface-preserve-types-as-written -enable-module-selectors-in-module-interface 2>%t/enabled-preserve/stderr.txt
+// RUN: %FileCheck --input-file %t/enabled-preserve/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-ENABLED
+// RUN: %FileCheck --input-file %t/enabled-preserve/stderr.txt %s --check-prefix DIAG-PRESERVE-OVERRIDDEN
+// RUN: %target-swift-typecheck-module-from-interface(%t/enabled-preserve/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
 
 // CHECK: import enums_using_attributes
 import enums_using_attributes
@@ -30,15 +48,19 @@ import enums_using_attributes
 // CHECK-LABEL: public struct Struct<T> :
 // CHECK-ENABLED-SAME: Swift::Hashable where T : Swift::Hashable {
 // CHECK-DISABLED-SAME: Swift.Hashable where T : Swift.Hashable {
+// CHECK-PRESERVE-SAME: Hashable where T : Swift.Hashable {
+// Preserve quirk: Hashable qualified in constraint?
 public struct Struct<T: Hashable>: Hashable {
   // CHECK: public let integer:
   // CHECK-ENABLED-SAME: Swift::Int
   // CHECK-DISABLED-SAME: Swift.Int
+  // CHECK-PRESERVE-SAME: Int
   public let integer: Int = 42
 
   // CHECK: public let enumeration:
   // CHECK-ENABLED-SAME: enums_using_attributes::CFEnumWithAttr
   // CHECK-DISABLED-SAME: enums_using_attributes.CFEnumWithAttr
+  // CHECK-PRESERVE-SAME: CFEnumWithAttr
   public let enumeration: CFEnumWithAttr = CFEnumWithAttr.first
 
   // CHECK: public let t: T?
@@ -47,31 +69,37 @@ public struct Struct<T: Hashable>: Hashable {
   // CHECK: public static func ==
   // CHECK-ENABLED-SAME: (a: TestCase::Struct<T>, b: TestCase::Struct<T>) -> Swift::Bool
   // CHECK-DISABLED-SAME: (a: TestCase.Struct<T>, b: TestCase.Struct<T>) -> Swift.Bool
+  // CHECK-PRESERVE-SAME: (a: TestCase.Struct<T>, b: TestCase.Struct<T>) -> Swift.Bool
 
   // CHECK: public func hash
   // CHECK-ENABLED-SAME: (into hasher: inout Swift::Hasher)
   // CHECK-DISABLED-SAME: (into hasher: inout Swift.Hasher)
+  // CHECK-PRESERVE-SAME: (into hasher: inout Swift.Hasher)
 
   // CHECK: public var hashValue:
   // CHECK-ENABLED-SAME: Swift::Int {
   // CHECK-DISABLED-SAME: Swift.Int {
+  // CHECK-PRESERVE-SAME: Swift.Int {
 
   // CHECK: }
 }
 
 // CHECK-ENABLED: extension TestCase::Struct {
 // CHECK-DISABLED: extension TestCase.Struct {
+// CHECK-PRESERVE: extension Struct {
 extension Struct {
   // CHECK-LABEL: public enum Nested {
   public enum Nested {
     // CHECK: case integer
     // CHECK-ENABLED-SAME: (Swift::Int)
     // CHECK-DISABLED-SAME: (Swift.Int)
+    // CHECK-PRESERVE-SAME: (Int)
     case integer(Int)
 
     // CHECK: case enumeration
     // CHECK-ENABLED-SAME: (enums_using_attributes::CFEnumWithAttr)
     // CHECK-DISABLED-SAME: (enums_using_attributes.CFEnumWithAttr)
+    // CHECK-PRESERVE-SAME: (CFEnumWithAttr)
     case enumeration(CFEnumWithAttr)
 
     // CHECK: case t(T)
@@ -80,6 +108,7 @@ extension Struct {
     // CHECK: case `struct`
     // CHECK-ENABLED-SAME: (TestCase::Struct<T>)
     // CHECK-DISABLED-SAME: (TestCase.Struct<T>)
+    // CHECK-PRESERVE-SAME: (Struct)
     case `struct`(Struct)
 
     // CHECK: }
@@ -90,6 +119,8 @@ extension Struct {
 
 // CHECK-ENABLED: extension Swift::Int {
 // CHECK-DISABLED: extension Swift.Int {
+// CHECK-PRESERVE: extension Int {
+// Preserve quirk: Int has no module selector?
 extension Swift::Int {
   // CHECK-LABEL: public enum RetroactiveNested {
   public enum RetroactiveNested {}
@@ -97,6 +128,7 @@ extension Swift::Int {
 
 // CHECK-ENABLED: extension Swift::Int.TestCase::RetroactiveNested {
 // CHECK-DISABLED: extension Swift.Int.RetroactiveNested {
+// CHECK-PRESERVE: extension Int.RetroactiveNested {
 extension Int.RetroactiveNested {
   public func anchor() {}
 }
@@ -104,11 +136,14 @@ extension Int.RetroactiveNested {
 // CHECK-LABEL: public func fn<T>
 // CHECK-ENABLED-SAME: (_: TestCase::Struct<T>, _: TestCase::Struct<T>.TestCase::Nested)
 // CHECK-DISABLED-SAME: (_: TestCase.Struct<T>, _:  TestCase.Struct<T>.Nested)
+// CHECK-PRESERVE-SAME: (_: Struct<T>, _:  Struct<T>.Nested)
 public func fn<T: Hashable>(_: Struct<T>, _: Struct<T>.Nested) {}
 
 // CHECK-LABEL: public func fn2<T>
 // CHECK-ENABLED-SAME: (_: T) where T : Swift::Identifiable, T.ID == TestCase::Struct<Swift::Int>
 // CHECK-DISABLED-SAME: (_: T) where T : Swift.Identifiable, T.ID == TestCase.Struct<Swift.Int>
+// CHECK-PRESERVE-SAME: (_: T) where T : Swift.Identifiable, T.ID == TestCase.Struct<Swift.Int>
+// Preserve quirk: Still qualified in constraints?
 @available(SwiftStdlib 5.1, *)
 public func fn2<T: Identifiable>(_: T) where T.ID == Struct<Int> {}
 
@@ -118,22 +153,31 @@ public protocol Proto {
   // CHECK: associatedtype AssocType :
   // CHECK-ENABLED-SAME: Swift::Identifiable
   // CHECK-DISABLED-SAME: Swift.Identifiable
+  // CHECK-PRESERVE-SAME: Identifiable
   associatedtype AssocType: Identifiable
 
   // CHECK: typealias TypeAlias =
   // CHECK-ENABLED-SAME: TestCase::Struct<Swift::Int>
   // CHECK-DISABLED-SAME: TestCase.Struct<Swift.Int>
+  // CHECK-PRESERVE-SAME: Struct<Int>
   typealias TypeAlias = Struct<Int>
 
   // CHECK: typealias ID =
-  // CHECK-SAME: Self.AssocType.ID
+  // CHECK-ENABLED-SAME: Self.AssocType.ID
+  // CHECK-DISABLED-SAME: Self.AssocType.ID
+  // CHECK-PRESERVE-SAME: AssocType.ID
   typealias ID = AssocType.ID
 
-  // CHECK: func requirement() -> Self.AssocType.ID
+  // CHECK: func requirement() ->
+  // CHECK-ENABLED-SAME: Self.AssocType.ID
+  // CHECK-DISABLED-SAME: Self.AssocType.ID
+  // CHECK-PRESERVE-SAME: AssocType.ID
   func requirement() -> AssocType.ID
 
   // CHECK: func requirement2() ->
-  // CHECK-SAME: Self.TypeAlias.Nested
+  // CHECK-ENABLED-SAME: Self.TypeAlias.Nested
+  // CHECK-DISABLED-SAME: Self.TypeAlias.Nested
+  // CHECK-PRESERVE-SAME: TypeAlias.Nested
   func requirement2() -> TypeAlias.Nested
 
   // CHECK: }
@@ -157,11 +201,13 @@ public struct ProtoSet<T: Proto> {
   // CHECK: let ids:
   // CHECK-ENABLED-SAME: Swift::Set<T.ID>
   // CHECK-DISABLED-SAME: Swift.Set<T.ID>
+  // CHECK-PRESERVE-SAME: Set<T.ID>
   public let ids: Set<T.ID>
 
   // CHECK: let texts:
   // CHECK-ENABLED-SAME: Swift::Set<T.Text>
   // CHECK-DISABLED-SAME: Swift.Set<T.Text>
+  // CHECK-PRESERVE-SAME: Set<T.Text>
   public let texts: Set<T.Text>
 
   // CHECK: let singleText:
@@ -169,3 +215,5 @@ public struct ProtoSet<T: Proto> {
   public let singleText: T.Text
 }
 
+// DIAG-PRESERVE-OVERRIDDEN: warning: ignoring -module-interface-preserve-types-as-written (overridden by -enable-module-selectors-in-module-interface)
+// DIAG-PRESERVE-NOT-OVERRIDDEN-NOT: warning: ignoring -module-interface-preserve-types-as-written (overridden by -enable-module-selectors-in-module-interface)


### PR DESCRIPTION
There were a number of cases where Swift would emit module selectors into module interface files that it was subsequently unable to parse because the compiler at least temporarily represented them as dependent member types. Modify the carve-out so that if *any* of a type’s parents are generic parameters or archetypes, we don’t print a module selector on it.

Fixes rdar://166180424.

The old `-module-interface-preserve-types-as-written` workaround flag prevents module selectors from being printed into module interfaces even when they have been explicitly requested. Disable it and emit a warning when it’s used in combination with `-enable-module-selectors-in-module-interface`.

Fixes rdar://166237384.

(These have been rolled into a single PR because the test changes intersect.)