### PR TITLE
[Swiftify] don't attach macro when module does not import stdlib

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1137,10 +1137,6 @@ namespace swift {
     /// ones to apply.
     bool LoadVersionIndependentAPINotes = false;
 
-    /// Whether the importer should skip SafeInteropWrappers, even though the
-    /// feature is enabled.
-    bool DisableSafeInteropWrappers = false;
-
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.
     llvm::hash_code getPCHHashComponents() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2216,8 +2216,6 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
 
   Opts.LoadVersionIndependentAPINotes |= Args.hasArg(OPT_version_independent_apinotes);
 
-  Opts.DisableSafeInteropWrappers |= FrontendOpts.ParseStdlib;
-
   if (FrontendOpts.DisableImplicitModules)
     Opts.DisableImplicitClangModules = true;
 

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -1,0 +1,32 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Prevent target SDK decl of memcmp (which may or may not have __sized_by annotations)
+// from being picked up as the canonical decl.
+// RUN: %empty-directory(%t/sdk)
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -sdk %t/sdk \
+// RUN:   -Xcc -Werror %t/test.swift -import-objc-header %t/test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions
+
+// Check that ClangImporter does not try to apply _SwiftifyImport to functions in SwiftShims,
+// as it does not import the standard library types.
+
+//--- test.swift
+public func callMemCmp1(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
+  // expected-error@+2{{missing argument for parameter #3 in call}}
+  // expected-error@+1 2{{cannot convert value of type 'UnsafeMutableRawBufferPointer' to expected argument type 'UnsafeRawPointer'}}
+  let _ = unsafe memcmp(p1, p2)
+}
+
+public func callMemCmp2(_ p1: UnsafeMutableRawPointer, _ p2: UnsafeMutableRawPointer) {
+  let _ = unsafe memcmp(p1, p2, 13)
+}
+
+//--- test.h
+#include <stddef.h>
+#define __sized_by(x) __attribute__((__sized_by__(x)))
+
+// expected-note@+1{{'memcmp' declared here}}
+int memcmp(const void * _Nullable __sized_by(n) s1, const void * _Nullable __sized_by(n) s2, size_t n);

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -7,8 +7,8 @@
 // from being picked up as the canonical decl.
 // RUN: %empty-directory(%t/sdk)
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -sdk %t/sdk \
-// RUN:   -Xcc -Werror %t/test.swift -import-objc-header %t/test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -sdk %t/sdk \
+// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions
 
 // Check that ClangImporter does not try to apply _SwiftifyImport to functions in SwiftShims,
 // as it does not import the standard library types.


### PR DESCRIPTION
This prevents stuff like memcmp from SwiftShims from being imported with @_SwiftifyImport, which would then result in name lookup errors as it does not import the Swift standard library module. This makes the previous approach to disable safe interop when compiling with -parse-stdlib redundant.

rdar://165856959