### PR TITLE
🍒 [windows] fix build.ps1 sccache expansion on ARM64

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1221,6 +1221,7 @@ function Get-Dependencies {
       param
       (
           [string]$SourceName,
+          [string]$BinaryCache,
           [string]$DestinationName
       )
       $Source = Join-Path -Path $BinaryCache -ChildPath $SourceName
@@ -1367,12 +1368,14 @@ function Get-Dependencies {
 
     if ($EnableCaching) {
       $SCCache = Get-SCCache
-      $FileExtension = [System.IO.Path]::GetExtension($SCCache.URL)
-      DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion.$FileExtension" $SCCache.SHA256
-      if ($FileExtension -eq "tar.gz") {
-        Expand-TapeArchive sccache-$SCCacheVersion.$FileExtension $BinaryCache sccache-$SCCacheVersion
+      $FileExtension = if ($SCCache.URL -match '/[^/]+(\..+)$') { $Matches[1] } else {
+          throw "Invalid sccache URL"
+      }
+      DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion$FileExtension" $SCCache.SHA256
+      if ($FileExtension -eq ".tar.gz") {
+        Expand-TapeArchive "sccache-$SCCacheVersion$FileExtension" $BinaryCache "sccache-$SCCacheVersion"
       } else {
-        Expand-ZipFile sccache-$SCCacheVersion.$FileExtension $BinaryCache sccache-$SCCacheVersion
+        Expand-ZipFile "sccache-$SCCacheVersion$FileExtension" $BinaryCache "sccache-$SCCacheVersion"
       }
       Write-Success "sccache $SCCacheVersion"
     }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1368,7 +1368,7 @@ function Get-Dependencies {
 
     if ($EnableCaching) {
       $SCCache = Get-SCCache
-      $FileExtension = if ($SCCache.URL -match '/[^/]+(\..+)$') { $Matches[1] } else {
+      $FileExtension = if ($SCCache.URL -match '\.(?:tar\.gz|zip)$') { $Matches[0] } else {
           throw "Invalid sccache URL"
       }
       DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion$FileExtension" $SCCache.SHA256


### PR DESCRIPTION
- **Explanation**:
Building on ARM64 with `-EnableCaching` currently fails because the `[System.IO.Path]::GetExtension` returns `.gz` instead of `.tar.gz`. This patch replaces the file extension extraction logic with a more robust regular expression.
- **Scope**:
This change impacts the Swift toolchain build script on Windows on ARM64 when using sccache.
- **Issues**:

- **Original PRs**:
	- https://github.com/swiftlang/swift/pull/86109
	- https://github.com/swiftlang/swift/pull/86142
- **Risk**:
Low, this update does not impact CI, only when building at desk on ARM64 with caching enabled.
- **Testing**:
Built at desk on an ARM64 Windows VM.
- **Reviewers**:
  - @compnerd 

