### PR TITLE
[windows] fix sccache regex

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1370,7 +1370,7 @@ function Get-Dependencies {
 
     if ($EnableCaching) {
       $SCCache = Get-SCCache
-      $FileExtension = if ($SCCache.URL -match '/[^/]+(\..+)$') { $Matches[1] } else {
+      $FileExtension = if ($SCCache.URL -match '\.(?:tar\.\w+|zip)$') { $Matches[0] } else {
           throw "Invalid sccache URL"
       }
       DownloadAndVerify $SCCache.URL "$BinaryCache\sccache-$SCCacheVersion$FileExtension" $SCCache.SHA256


### PR DESCRIPTION
This patch fixes the regular expression used to determine the extension of the sccache archive.

This is a follow up to https://github.com/swiftlang/swift/pull/86109.