### PR TITLE
🍒 [windows] extract normalized toolchain name

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -572,7 +572,7 @@ if (-not $PinnedBuild) {
 
 $PinnedToolchain = [IO.Path]::GetFileNameWithoutExtension($PinnedBuild)
 # Use a shorter name in paths to avoid going over the path length limit.
-$NormalizedToolchainName = $PinnedToolchain -replace 'swift-(.+?)-a-windows10.*', '$1'
+$ToolchainVersionIdentifier = $PinnedToolchain -replace 'swift-(.+?)-windows10.*', '$1'
 
 if ($EnableCAS -and ($UseHostToolchain -or ($PinnedVersion -ne "0.0.0"))) {
   throw "CAS currently requires using a main-branch pinned toolchain."
@@ -1392,7 +1392,7 @@ function Get-Dependencies {
 
     # TODO(compnerd) stamp/validate that we need to re-extract
     New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
-    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $NormalizedToolchainName
+    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $ToolchainVersionIdentifier
     Write-Success "Swift Toolchain $PinnedVersion"
 
     if ($Android) {
@@ -1446,7 +1446,7 @@ function Get-Dependencies {
 }
 
 function Get-PinnedToolchainToolsDir() {
-  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$NormalizedToolchainName", "LocalApp", "Programs", "Swift", "Toolchains")
+  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$ToolchainVersionIdentifier", "LocalApp", "Programs", "Swift", "Toolchains")
 
   # NOTE: Add a workaround for the main snapshots that inadvertently used the
   # wrong version when they were built. This allows use of the nightly snapshot
@@ -1471,13 +1471,13 @@ function Get-PinnedToolchainToolsDir() {
 }
 
 function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifier = $OS.ToString()) {
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $NormalizedToolchainName,
+  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
     "LocalApp", "Programs", "Swift", "Platforms", (Get-PinnedToolchainVersion),
     "$($OS.ToString()).platform", "Developer", "SDKs", "$Identifier.sdk")
 }
 
 function Get-PinnedToolchainRuntime() {
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $NormalizedToolchainName,
+  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
     "LocalApp", "Programs", "Swift", "Runtimes", (Get-PinnedToolchainVersion),
     "usr", "bin")
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -571,6 +571,8 @@ if (-not $PinnedBuild) {
 }
 
 $PinnedToolchain = [IO.Path]::GetFileNameWithoutExtension($PinnedBuild)
+# Use a shorter name in paths to avoid going over the path length limit.
+$NormalizedToolchainName = $PinnedToolchain -replace 'swift-(.+?)-a-windows10.*', '$1'
 
 if ($EnableCAS -and ($UseHostToolchain -or ($PinnedVersion -ne "0.0.0"))) {
   throw "CAS currently requires using a main-branch pinned toolchain."
@@ -1390,7 +1392,7 @@ function Get-Dependencies {
 
     # TODO(compnerd) stamp/validate that we need to re-extract
     New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
-    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $PinnedToolchain.TrimStart("swift-").TrimEnd("-arm64").TrimEnd("-a-windows10")
+    Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $NormalizedToolchainName
     Write-Success "Swift Toolchain $PinnedVersion"
 
     if ($Android) {
@@ -1444,9 +1446,7 @@ function Get-Dependencies {
 }
 
 function Get-PinnedToolchainToolsDir() {
-  $ToolchainName = $PinnedToolchain.TrimStart("swift-").TrimEnd("-a-windows10")
-
-  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$ToolchainName", "LocalApp", "Programs", "Swift", "Toolchains")
+  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$NormalizedToolchainName", "LocalApp", "Programs", "Swift", "Toolchains")
 
   # NOTE: Add a workaround for the main snapshots that inadvertently used the
   # wrong version when they were built. This allows use of the nightly snapshot
@@ -1471,17 +1471,13 @@ function Get-PinnedToolchainToolsDir() {
 }
 
 function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifier = $OS.ToString()) {
-  $ToolchainName = $PinnedToolchain.TrimStart("swift-").TrimEnd("-a-windows10")
-
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainName,
+  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $NormalizedToolchainName,
     "LocalApp", "Programs", "Swift", "Platforms", (Get-PinnedToolchainVersion),
     "$($OS.ToString()).platform", "Developer", "SDKs", "$Identifier.sdk")
 }
 
 function Get-PinnedToolchainRuntime() {
-  $ToolchainName = $PinnedToolchain.TrimStart("swift-").TrimEnd("-a-windows10")
-
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainName,
+  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $NormalizedToolchainName,
     "LocalApp", "Programs", "Swift", "Runtimes", (Get-PinnedToolchainVersion),
     "usr", "bin")
 }


### PR DESCRIPTION
- **Explanation**:
The path of the ARM64 bootstrap toolchain is invalid once extracted. This patch switches to using a regular expression to normalize the name of the toolchain.
- **Scope**:
This change impacts the Swift toolchain build script on Windows on ARM64 when using sccache.
- **Issues**:

- **Original PRs**:
	- https://github.com/swiftlang/swift/pull/85493
- **Risk**:
Low, this update does not impact CI, only when building at desk on ARM64 with caching enabled.
- **Testing**:
Built at desk on an ARM64 Windows VM.
- **Reviewers**:
  - @compnerd 
  - @speednoisemovement 

