### PR TITLE
[Observations] Prevent duplicate emissions on re-iterating Observations after cancellation

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/Observations.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observations.swift
@@ -133,7 +133,6 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
   // internal funnel method for initialziation
   internal init(emit: Emit) {
     self.emit = emit
-    self.state = _ManagedCriticalState(State())
   }
   
   /// Constructs an asynchronous sequence for a given closure by tracking changes of `@Observable` types.
@@ -167,7 +166,6 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
     // the state ivar serves two purposes:
     // 1) to store a critical region of state of the mutations
     // 2) to idenitify the termination of _this_ sequence
-    var state: _ManagedCriticalState<State>?
     let emit: Emit
     var started = false
     
@@ -251,6 +249,6 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
   }
   
   public func makeAsyncIterator() -> Iterator {
-    Iterator(state: state, emit: emit)
+     Iterator(state: _ManagedCriticalState(State()), emit: emit)
   }
 }


### PR DESCRIPTION
* **Explanation**:
  Fix duplicated emissions when re-iterating `Observations` after cancelling a prior iteration by allocating internal state per iterator (instead of sharing state across iterations).
* **Scope**:
  Stdlib Observation change; alters internal iteration-state lifetime (sequence-scoped → iterator-scoped). No API surface change, but behavior changes for code that (implicitly) relied on cross-iterator state sharing.
* **Issues**:
  Resolves [https://github.com/swiftlang/swift/issues/85683](https://github.com/swiftlang/swift/issues/85683)
* **Original PRs**:
  N/A
* **Risk**:
  Low–medium. Changes internal state sharing semantics between iterators; could affect any undocumented reliance on shared `dirty/continuation` bookkeeping across multiple iterators.
* **Testing**:
  Not tested on any platform.
* **Reviewers**:
  N/A