### PR TITLE
LargeTypesReg2Mem: Avoid building an explosion schema just to count the number of registers for very large types

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -66,7 +66,8 @@ protected:
                 SpecialTypeInfoKind stik = SpecialTypeInfoKind::Fixed)
       : TypeInfo(type, align, pod, bt, copy, alwaysFixedSize, isABIAccessible, stik),
         SpareBits(std::move(spareBits)) {
-    assert(SpareBits.size() == size.getValueInBits());
+    // SpareBits implementation is limited to 32bits.
+    assert(SpareBits.size() == (size.getValueInBits() & 0xFFFFFFFF));
     assert(isFixedSize());
     Bits.FixedTypeInfo.Size = size.getValue();
     assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3512,9 +3512,15 @@ class LargeLoadableHeuristic {
 
   llvm::DenseMap<SILType, Properties> largeTypeProperties;
 
+  /// Cutoff used to determine when to deem a type as large solely on the number
+  /// of registers.
   static const unsigned NumRegistersVeryLargeType = 16;
+  /// Cutoff when we start considering other properties to determine when we
+  /// deem a type as large.
   static const unsigned NumRegistersLargeType = 8;
-  static const unsigned numUsesThreshold = 8;
+  /// Cutoff when we start to deem a type as large based on the number of uses
+  /// (requires the number or registers to be at least 8).
+  static const unsigned NumUsesThreshold = 8;
 
   bool UseAggressiveHeuristic;
 
@@ -3792,7 +3798,7 @@ bool LargeLoadableHeuristic::isLargeLoadableType(SILType ty) {
   if (regs >= NumRegistersVeryLargeType)
     return true;
 
-  if (entry.numUses() > numUsesThreshold)
+  if (entry.numUses() > NumUsesThreshold)
    return true;
 
   if (entry.hasStore())

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -404,6 +404,7 @@ namespace {
           && (!fixedSize.has_value()
               || *fixedSize > BuiltinFixedArrayType::MaximumLoadableSize)) {
         props.setAddressOnly();
+        props.setVeryLargeType();
       }
       return props;
     }


### PR DESCRIPTION


Computing the explosion schema for large types can be expensive.

E.g the following example would spend multiple seconds to compute the explosion scheme for the array type. It is not worth adding the complexity to have a special case explosion schema that handles types like that since exploding a value like that is going to be detrimental.

```
struct Test {
  private var values: [0xfffffff of [UInt32]] =
  InlineArray(repeating: [])
}
```

rdar://165202495