### PR TITLE
[rbi] Add a special diagnostic for when emitting error for a non-Sendable mutable box escaping from one concurrency domaint to another.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1056,6 +1056,8 @@ NOTE(regionbasedisolation_named_value_used_after_explicit_sending, none,
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
       "%select{%1 |}0%2 is captured by a %3 closure. %3 uses in closure may race against later %4 uses",
       (bool, StringRef, Identifier, StringRef, StringRef))
+NOTE(regionbasedisolation_named_isolated_closure_yields_race_mutable, none,
+     "%0 closure captures reference to mutable %1 which remains modifiable by %select{%3 code|code in the current task}2", (StringRef, Identifier, bool, StringRef))
 
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1098,7 +1098,7 @@ NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_
      "closure captures %0 which is accessible to code in the current task",
      (DeclName))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_boxed_value_task_isolated, none,
-     "closure captures reference to mutable %kind0 which is accessible to code in the current task",
+     "closure captures reference to mutable %kind0 which remains modifiable by code in the current task",
      (const ValueDecl *))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region, none,
      "closure captures %1 which is accessible to %0 code",

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1794,7 +1794,7 @@ extension MyActor {
 func nonSendableAllocBoxConsumingParameter(x: consuming SendableKlass) async throws {
   try await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-note {{closure captures reference to mutable parameter 'x' which is accessible to code in the current task}}
+      useValue(x) // expected-note {{closure captures reference to mutable parameter 'x' which remains modifiable by code in the current task}}
     }
 
     try await group.waitForAll()
@@ -1807,7 +1807,7 @@ func nonSendableAllocBoxConsumingVar() async throws {
 
   try await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-note {{closure captures reference to mutable var 'x' which is accessible to code in the current task}}
+      useValue(x) // expected-note {{closure captures reference to mutable var 'x' which remains modifiable by code in the current task}}
     }
 
     try await group.waitForAll()
@@ -1865,7 +1865,7 @@ func testFunctionIsNotEmpty(input: SendableKlass) async throws {
   var result: [SendableKlass] = []
   try await withThrowingTaskGroup(of: Void.self) { taskGroup in // expected-warning {{no calls to throwing functions occur within 'try' expression}}
     taskGroup.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      result.append(input) // expected-note {{closure captures reference to mutable var 'result' which is accessible to code in the current task}}
+      result.append(input) // expected-note {{closure captures reference to mutable var 'result' which remains modifiable by code in the current task}}
     }
   }
 }

--- a/test/Concurrency/transfernonsendable_closure_captures.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures.swift
@@ -50,7 +50,7 @@ func testMutableCopyableSendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -142,7 +142,7 @@ func testMutableNoncopyableSendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -191,7 +191,7 @@ func testNoncopyableNonsendableStructWithNonescapingMainActorAsync() {
   let x = NoncopyableStructNonsendable()
   let _ = {
     nonescapingAsyncUse { @MainActor in
-      useValue(x)  // expected-error {{sending 'x' risks causing data races}}
+      useValue(x) // expected-error {{sending 'x' risks causing data races}}
       // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -382,7 +382,7 @@ func testCopyableSendableClassWithEscapingMainActorAsyncWeakCapture() {
   let _ = { [weak x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -393,7 +393,7 @@ func testMutableCopyableSendableClassWithEscapingMainActorAsyncWeakCapture() {
   let _ = { [weak x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -424,7 +424,7 @@ func testCopyableSendableClassWithNonescapingMainActorAsyncWeakCapture() {
   let _ = { [weak x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -435,7 +435,7 @@ func testMutableCopyableSendableClassWithNonescapingMainActorAsyncWeakCapture() 
   let _ = { [weak x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -556,7 +556,7 @@ func testGenericSendableWithEscapingMainActorAsync<T : ~Copyable>(_ value: consu
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }
@@ -569,7 +569,7 @@ func testMutableGenericSendableWithEscapingMainActorAsync<T : ~Copyable>(
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
     }
   }
 }


### PR DESCRIPTION
I am doing general work in this area to fix a larger bug. As I brought up tests
for the new larger bug, I noticed some small improvements that I could make at
the same time. In this case, I am porting a diagnostic that already exists for
sending to closures to have a similar form for isolated closures.

The diagnostic occurs when we error on escaping a non-Sendable box that contains
a Sendable var. We would emit an error saying that 'x' (the Sendable value) is
isolated in some way and that is why we are emitting an error. This is of course
incorrect since we are erroring due to the mutable box that contains the
sendable type being mutatable from multiple isolation domains. To see this in
action, we used to emit the following diagnostic in this case:

```swift
func testMutableNoncopyableSendableStructWithEscapingMainActorAsync() {
  var x = NoncopyableStructSendable()
  x = NoncopyableStructSendable()
  let _ = {
    escapingAsyncUse { @MainActor in
      useValue(x) // expected-error {{sending 'x' risks causing data races}}
      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses     in closure may race against later nonisolated uses}}
    }
  }
}
```

After this change, we emit the following diagnostic which emphasizes the
mutability of 'x' and how it is referenceable from multiple concurrency domains.

```
test.swift:48:7: error: sending 'x' risks causing data races [#SendingRisksDataRace]
46 |   let _ = {
47 |     escapingAsyncUse { @MainActor in
48 |       useValue(x)
   |       |- error: sending 'x' risks causing data races [#SendingRisksDataRace]
   |       `- note: main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task
59 |     }
```

rdar://166417084

----

I also included an additional change that normalizes the sending closure version of this diagnostic to use the same verbiage.
