### PR TITLE
[Test] Disable objc_getClass.NotPresent on macOS 10.15.

### DIFF
--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -246,7 +246,9 @@ testSuite.test("ResilientNSObject")
   expectEqual(ResilientSubclassOfConcreteNSObject().subvalue.i, 7)
 }
 
-testSuite.test("NotPresent") {
+testSuite.test("NotPresent")
+  .skip(.osxMinorRange(10, 0...15, reason: "test crashes, runtime fix not available on old OSes"))
+  .code {
   // This class does not exist.
   expectNil(NSClassFromString("main.ThisClassDoesNotExist"));
 
@@ -256,25 +258,20 @@ testSuite.test("NotPresent") {
   // Swift.Int is not a class type.
   expectNil(NSClassFromString("Si"))
 
-  if #available(StdlibDeploymentTarget 5.3, *) {
-    // Mangled names with byte sequences that look like symbolic references
-    // should not be demangled. Use indirect references to test. Direct
-    // references often resolve to readable memory, and then the data there
-    // often looks like a descriptor with an unknown kind and the lookup code
-    // then fails gracefully. With an indirect reference, the indirected pointer
-    // is typically garbage and dereferencing it will crash.
-    expectNil(NSClassFromString("\u{2}badnews"));
-    expectNil(NSClassFromString("$s\u{2}badnews"));
-    expectNil(NSClassFromString("_T\u{2}badnews"));
-  }
-
-  if #available(StdlibDeploymentTarget 5.3, *) {
-    // Correct mangled names with additional text afterwards should not resolve.
-    expectNil(NSClassFromString("_TtC4main20MangledSwiftSubclass_"))
-    expectNil(NSClassFromString("_TtC4main22MangledSwiftSuperclassXYZ"))
-    expectNil(NSClassFromString("_TtC4main19MangledObjCSubclass123"))
-    expectNil(NSClassFromString("_TtC4main21MangledObjCSuperclasswhee"))
-  }
+  // Mangled names with byte sequences that look like symbolic references
+  // should not be demangled. Use indirect references to test. Direct
+  // references often resolve to readable memory, and then the data there
+  // often looks like a descriptor with an unknown kind and the lookup code
+  // then fails gracefully. With an indirect reference, the indirected pointer
+  // is typically garbage and dereferencing it will crash.
+  expectNil(NSClassFromString("\u{2}badnews"));
+  expectNil(NSClassFromString("$s\u{2}badnews"));
+  expectNil(NSClassFromString("_T\u{2}badnews"));
+  // Correct mangled names with additional text afterwards should not resolve.
+  expectNil(NSClassFromString("_TtC4main20MangledSwiftSubclass_"))
+  expectNil(NSClassFromString("_TtC4main22MangledSwiftSuperclassXYZ"))
+  expectNil(NSClassFromString("_TtC4main19MangledObjCSubclass123"))
+  expectNil(NSClassFromString("_TtC4main21MangledObjCSuperclasswhee"))
 }
 
 runAllTests()


### PR DESCRIPTION
The test is crashing there, and it's testing runtime behavior that's not going to change on 10.15 at this point.

rdar://162832379