### PR TITLE
Sema: Extend exportability checking for non-library-evolution to more reasons

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3858,7 +3858,9 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
       "in a conformance on a type not marked '@_implementationOnly'|" \
       "in an '@available' attribute here|" \
       "in a property declaration marked public or in a '@frozen' or '@usableFromInline' context|" \
-      "in a property declaration member of a type not marked '@_implementationOnly'}"
+      "in a property declaration member of a type not marked '@_implementationOnly'|" \
+      "in an associated value of a public or '@usableFromInline' enum|" \
+      "in an associated value of an enum not marked '@_implementationOnly'}"
 
 ERROR(decl_from_hidden_module,none,
       "cannot use %kind0 %" EXPORTABILITY_REASON_SELECT "1; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3958,9 +3958,6 @@ ERROR(implementation_only_override_import_without_attr,none,
       "override of %kindonly0 imported as implementation-only must be declared "
       "'@_implementationOnly'",
       (const ValueDecl *))
-ERROR(implementation_only_on_types_feature,none,
-      "'@_implementationOnly' on a type requires "
-      "'-enable-experimental-feature CheckImplementationOnly'", ())
 
 ERROR(import_attr_conflict,none,
       "%0 inconsistently imported with %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3855,6 +3855,7 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
       "in an extension with public or '@usableFromInline' members|" \
       "in an extension with conditional conformances|" \
       "in a public or '@usableFromInline' conformance|" \
+      "in a conformance on a type not marked '@_implementationOnly'|" \
       "in an '@available' attribute here|" \
       "in a property declaration marked public or in a '@frozen' or '@usableFromInline' context|" \
       "in a property declaration member of a type not marked '@_implementationOnly'}"

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -1047,20 +1047,22 @@ bool swift::hasConformancesToPublicProtocols(const ExtensionDecl *ED) {
 
 ExportedLevel swift::isExported(const ExtensionDecl *ED) {
   // An extension can only be exported if it extends an exported type.
+  ExportedLevel exported = ExportedLevel::None;
   if (auto *NTD = ED->getExtendedNominal()) {
-    if (isExported(NTD) == ExportedLevel::None)
-      return ExportedLevel::None;
+    exported = isExported(NTD);
+    if (exported == ExportedLevel::None)
+      return exported;
   }
 
   // If the extension declares a conformance to a public protocol then the
   // extension is exported.
   if (hasConformancesToPublicProtocols(ED))
-    return ExportedLevel::Exported;
+    return exported;
 
   // If there are any exported members then the extension is exported.
-  ExportedLevel exported = ExportedLevel::None;
+  ExportedLevel membersExported = ExportedLevel::None;
   for (const Decl *D : ED->getMembers())
-    exported = std::max(exported, isExported(D));
+    membersExported = std::max(membersExported, isExported(D));
 
-  return exported;
+  return membersExported;
 }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -263,6 +263,8 @@ static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
   case ExportabilityReason::PropertyWrapper:
   case ExportabilityReason::PublicVarDecl:
   case ExportabilityReason::ImplicitlyPublicVarDecl:
+  case ExportabilityReason::AssociatedValue:
+  case ExportabilityReason::ImplicitlyPublicAssociatedValue:
     return false;
   }
 }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -248,6 +248,7 @@ static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
   case ExportabilityReason::ExtensionWithConditionalConformances:
     return true;
   case ExportabilityReason::Inheritance:
+  case ExportabilityReason::ImplicitlyPublicInheritance:
     return isa<ProtocolDecl>(D);
   case ExportabilityReason::AvailableAttribute:
     // If the context is an extension and that extension has an explicit

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2493,9 +2493,13 @@ public:
       flags |= DeclAvailabilityFlag::
           AllowPotentiallyUnavailableAtOrBelowDeploymentTarget;
 
+    ExportabilityReason reason =
+      Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?
+        ExportabilityReason::ImplicitlyPublicInheritance :
+        ExportabilityReason::Inheritance;
     for (TypeLoc inherited : nominal->getInherited().getEntries()) {
       checkType(inherited.getType(), inherited.getTypeRepr(), nominal,
-                ExportabilityReason::Inheritance,
+                reason,
                 flags | DeclAvailabilityFlag::DisableUnsafeChecking);
     }
   }
@@ -2597,9 +2601,13 @@ public:
     // must be exported.
     DeclAvailabilityFlags flags = DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
     flags |= DeclAvailabilityFlag::DisableUnsafeChecking;
+    ExportabilityReason inheritanceReason =
+      Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?
+        ExportabilityReason::ImplicitlyPublicInheritance :
+        ExportabilityReason::Inheritance;
     for (TypeLoc inherited : ED->getInherited().getEntries()) {
       checkType(inherited.getType(), inherited.getTypeRepr(), ED,
-                ExportabilityReason::Inheritance, flags);
+                inheritanceReason, flags);
     }
 
     auto wasWhere = Where;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2563,8 +2563,12 @@ public:
   void visitEnumElementDecl(EnumElementDecl *EED) {
     if (!EED->hasAssociatedValues())
       return;
+    ExportabilityReason reason =
+      Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?
+        ExportabilityReason::ImplicitlyPublicAssociatedValue :
+        ExportabilityReason::AssociatedValue;
     for (auto &P : *EED->getParameterList())
-      checkType(P->getInterfaceType(), P->getTypeRepr(), EED);
+      checkType(P->getInterfaceType(), P->getTypeRepr(), EED, reason);
   }
 
   void visitMacroDecl(MacroDecl *MD) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5058,12 +5058,6 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
 
   // @_implementationOnly on types only applies to non-public types.
   if (isa<NominalTypeDecl>(D)) {
-    if (!Ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly) &&
-        !Ctx.LangOpts.hasFeature(Feature::CheckImplementationOnlyStrict)) {
-      diagnoseAndRemoveAttr(attr, diag::implementation_only_on_types_feature);
-      return;
-    }
-
     auto access =
         VD->getFormalAccessScope(/*useDC=*/nullptr,
                                  /*treatUsableFromInlineAsPublic=*/true);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -244,10 +244,9 @@ bool ExportContext::canReferenceOrigin(DisallowedOriginKind originKind) const {
   // than the library-evolution ones. Implicitly always emit into client code
   // in embedded mode and implicitly exported layouts in non-library-evolution
   // mode can reference SPIs and non-public dependencies.
-  auto reason = getExportabilityReason();
   if (getFragileFunctionKind().kind ==
         FragileFunctionKind::EmbeddedAlwaysEmitIntoClient ||
-      (reason && *reason == ExportabilityReason::ImplicitlyPublicVarDecl)) {
+      getExportedLevel() == ExportedLevel::ImplicitlyExported) {
     switch (originKind) {
     case DisallowedOriginKind::None:
     case DisallowedOriginKind::NonPublicImport:

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -82,6 +82,7 @@ enum class ExportabilityReason : unsigned {
   ExtensionWithPublicMembers,
   ExtensionWithConditionalConformances,
   Inheritance,
+  ImplicitlyPublicInheritance,
   AvailableAttribute,
   PublicVarDecl,
   ImplicitlyPublicVarDecl,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -86,6 +86,8 @@ enum class ExportabilityReason : unsigned {
   AvailableAttribute,
   PublicVarDecl,
   ImplicitlyPublicVarDecl,
+  AssociatedValue,
+  ImplicitlyPublicAssociatedValue,
 };
 
 /// A description of the restrictions on what declarations can be referenced

--- a/test/SPI/spi_enum_element.swift
+++ b/test/SPI/spi_enum_element.swift
@@ -36,7 +36,7 @@ public struct PublicStruct {}
 
 public enum PublicEnumWithPayloads {
   case publicCasePublicPayload(_ s: PublicStruct)
-  case publicCaseSPIPayload(_ s: SPIStruct) // expected-error {{cannot use struct 'SPIStruct' here; it is SPI}}
+  case publicCaseSPIPayload(_ s: SPIStruct) // expected-error {{cannot use struct 'SPIStruct' in an associated value of a public or '@usableFromInline' enum; it is SPI}}
   @_spi(S) case spiCasePublicPayload(_ s: PublicStruct)
   @_spi(S) case spiCaseSPIPayload(_ s: SPIStruct)
 }

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -495,68 +495,68 @@ public struct PublicHiddenStruct {}
 
 public enum PublicEnumUser: ProtocolFromDirect {
 // expected-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
-    case a(StructFromDirect) // expected-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+    case a(StructFromDirect) // expected-error {{cannot use struct 'StructFromDirect' in an associated value of a public or '@usableFromInline' enum; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case d(ExposedLayoutPrivate) // expected-error {{enum case in a public enum uses a private type}}
     case b(HiddenLayout) // expected-error {{enum case in a public enum uses a private type}}
-    // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' here; 'HiddenLayout' is marked '@_implementationOnly'}}
+    // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in an associated value of a public or '@usableFromInline' enum; 'HiddenLayout' is marked '@_implementationOnly'}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case cd(ExposedClassPrivate) // expected-error {{enum case in a public enum uses a private type}}
     case cb(HiddenClass) // expected-error {{enum case in a public enum uses a private type}}
-    // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' here; 'HiddenClass' is marked '@_implementationOnly'}}
+    // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in an associated value of a public or '@usableFromInline' enum; 'HiddenClass' is marked '@_implementationOnly'}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case h(ExposedProtocolPrivate) // expected-error {{enum case in a public enum uses a private type}}
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' here; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of a public or '@usableFromInline' enum; 'HiddenProtocol' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in a public enum uses a private type}}
 }
 
 internal enum InternalEnumUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
-    case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+    case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' here; 'HiddenLayout' is marked '@_implementationOnly'}}
+    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' here; 'HiddenClass' is marked '@_implementationOnly'}}
+    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' here; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 }
 
 private enum PrivateEnumUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
-    case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
+    case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate)
-    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' here; 'HiddenLayout' is marked '@_implementationOnly'}}
+    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate)
-    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' here; 'HiddenClass' is marked '@_implementationOnly'}}
+    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate)
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' here; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
 internal enum InternalEnumWithRawType : RawTypeFromDirect { // expected-opt-in-error {{cannot use struct 'RawTypeFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -385,7 +385,7 @@ public struct ExposedLayoutPublicUser: ProtocolFromDirect {
 }
 
 internal struct ExposedLayoutInternalUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
@@ -422,7 +422,7 @@ internal struct ExposedLayoutInternalUser: ProtocolFromDirect {
 }
 
 private struct ExposedLayoutPrivateUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
@@ -517,7 +517,7 @@ public enum PublicEnumUser: ProtocolFromDirect {
 }
 
 internal enum InternalEnumUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
     case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
@@ -540,7 +540,7 @@ internal enum InternalEnumUser: ProtocolFromDirect {
 }
 
 private enum PrivateEnumUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
     case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' here; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
@@ -559,7 +559,7 @@ private enum PrivateEnumUser: ProtocolFromDirect {
     case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' here; 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
-internal enum InternalEnumWithRawType : RawTypeFromDirect { // expected-opt-in-error {{cannot use struct 'RawTypeFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+internal enum InternalEnumWithRawType : RawTypeFromDirect { // expected-opt-in-error {{cannot use struct 'RawTypeFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
   typealias RawValue = RawTypeFromDirect
   case a
 }
@@ -694,7 +694,7 @@ public class FixedClassUser: ProtocolFromDirect {
 }
 
 internal class InternalClassUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   public init() { fatalError() }
 
@@ -719,7 +719,7 @@ internal class InternalClassUser: ProtocolFromDirect {
 }
 
 private class PrivateClassUser: ProtocolFromDirect {
-// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   public init() { fatalError() }
 

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -30,8 +30,8 @@ public struct TestGenericParamsWithOuter<T> {
 }
 
 public enum TestCase {
-  case x(BadStruct) // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
-  case y(Int, BadStruct) // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  case x(BadStruct) // expected-error {{cannot use struct 'BadStruct' in an associated value of a public or '@usableFromInline' enum; 'BADLibrary' has been imported as implementation-only}}
+  case y(Int, BadStruct) // expected-error {{cannot use struct 'BadStruct' in an associated value of a public or '@usableFromInline' enum; 'BADLibrary' has been imported as implementation-only}}
 }
 
 public func testGenericParams<T: BadProto>(_: T) {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}

--- a/test/Sema/spi-in-decls.swift
+++ b/test/Sema/spi-in-decls.swift
@@ -61,8 +61,8 @@ public struct TestGenericParams<T: BadProto> {} // expected-error {{cannot use p
 public struct TestGenericParamsWhereClause<T> where T: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; it is SPI}}
 
 public enum TestCase {
-  case x(BadStruct) // expected-error {{cannot use struct 'BadStruct' here; it is SPI}}
-  case y(Int, BadStruct) // expected-error {{cannot use struct 'BadStruct' here; it is SPI}}
+  case x(BadStruct) // expected-error {{cannot use struct 'BadStruct' in an associated value of a public or '@usableFromInline' enum; it is SPI}}
+  case y(Int, BadStruct) // expected-error {{cannot use struct 'BadStruct' in an associated value of a public or '@usableFromInline' enum; it is SPI}}
 }
 
 public func testGenericParams<T: BadProto>(_: T) {} // expected-error {{cannot use protocol 'BadProto' here; it is SPI}}

--- a/test/attr/attr_implementation_only_on_types_feature_required.swift
+++ b/test/attr/attr_implementation_only_on_types_feature_required.swift
@@ -1,4 +1,0 @@
-// RUN: %target-typecheck-verify-swift %s
-
-@_implementationOnly struct MyStruct {}
-// expected-error@-1{{'@_implementationOnly' on a type requires '-enable-experimental-feature CheckImplementationOnly'}}


### PR DESCRIPTION
Extend exportability checking in non-library-evolution mode to handle more reasons (the classification of why references are restricted) to prepare for enabling this check as warning by default. Notably add a custom diagnostics for the use of restricted references in enum associated values and in a conformance in a non-implementation-only types.

Allow the use of `@_implementationOnly` on types without enabling the experimental feature. This is to prepare removing the feature flag.