### PR TITLE
[Concurrency] NonisolatedNonsendingByDefault: Turn inferred `nonisola…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6513,6 +6513,20 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       }
     }
 
+    // When `NonisolatedNonsendingByDefault` feature is enabled and the value is
+    // asynchronous `nonisolated` always means `nonisolated(nonsending)`.
+    if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&
+        inferred.isNonisolated() && value->isAsync()) {
+      // Either current module or async variant of an ObjC API.
+      if (value->getModuleContext() == ctx.MainModule ||
+          (value->hasClangNode() &&
+           !isa<ProtocolDecl>(value->getDeclContext()))) {
+        inferred =
+            ActorIsolation::forCallerIsolationInheriting().withPreconcurrency(
+                inferred.preconcurrency());
+      }
+    }
+
     // Add an implicit attribute to capture the actor isolation that was
     // inferred, so that (e.g.) it will be printed and serialized.
     switch (inferred) {
@@ -6724,13 +6738,6 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       if (shouldSelfIsolationOverrideDefault(
               ctx, value->getDeclContext(), selfTypeIsolation.isolation)) {
         auto isolation = selfTypeIsolation.isolation;
-
-        if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&
-            value->isAsync() && value->getModuleContext() == ctx.MainModule &&
-            isolation.isNonisolated()) {
-          isolation = ActorIsolation::forCallerIsolationInheriting();
-        }
-
         return {inferredIsolation(isolation, onlyGlobal),
                 selfTypeIsolation.source};
       }

--- a/test/Concurrency/attr_execution/nonisolated_nonsending_by_default_and_objc_nonisolated.swift
+++ b/test/Concurrency/attr_execution/nonisolated_nonsending_by_default_and_objc_nonisolated.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -swift-version 5 \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -enable-upcoming-feature NonisolatedNonsendingByDefault \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+//--- Test.h
+#define SWIFT_NONISOLATED __attribute__((__swift_attr__("nonisolated")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+SWIFT_NONISOLATED
+@interface Doc : NSObject
+- (void)saveWithCompletionHandler:(void (^ __nullable)(BOOL success))completionHandler;
+@end
+
+SWIFT_NONISOLATED
+@interface Doc(Reset)
+- (void)resetWithCompletionHandler:(void (^ __nullable)(BOOL success))completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+
+final class Test {
+  let doc = Doc()
+  
+  func test() async {
+    _ = await doc.save() // Ok
+    _ = await doc.reset() // Ok
+  }
+}


### PR DESCRIPTION
…ted` into `nonisolated(nonsending)`

Inferred `nonisolated` from the context i.e. an extension should mark the member as `@concurrent` instead it should behave as `nonisolated(nonsending)` when `NonisolatedNonsendingByDefault` is enabled.

Resolves: rdar://157789572

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
