### PR TITLE
[Serialization] Return a nullptr instead of crashing

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3113,7 +3113,8 @@ ModuleDecl *ModuleFile::getModule(ImportPath::Module name,
       name.front().Item == getContext().getRealModuleName(parentName)) {
     if (!UnderlyingModule && allowLoading) {
       auto importer = getContext().getClangModuleLoader();
-      assert(importer && "no way to import shadowed module");
+      if (!importer)
+        return nullptr;
       UnderlyingModule =
           importer->loadModule(SourceLoc(), name.getTopLevelPath());
     }


### PR DESCRIPTION
We got LLDB crash logs where `importer` is dereferenced. In the same crash log the parent frame correctly checks for nullptr, so this would fix the immediate crash. In LLDB it is not guaranteed that a ClangImporter is installed at all times.

rdar://166224928
(cherry picked from commit 9f59903ea3f43f5b4bddbc1abbb316af4297aa6f)

- **Explanation**: Avoid a crash in LLDB.
- **Scope**: Module imports in LLDB
- **Issues**: rdar://166224928
- **Original PRs**: https://github.com/swiftlang/swift/pull/86153
- **Risk**: None. Would have crashed otherwise.
- **Testing**: N/A
- **Reviewers**: @xymus 