### PR TITLE
[6.3] SILGen: Fix assert when emitting re-abstraction thunk in edge case involving opaque return type

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3426,7 +3426,9 @@ CanSILFunctionType swift::buildSILFunctionThunkType(
 
   if (!capturedEnvs.empty() ||
       expectedType->hasPrimaryArchetype() ||
-      sourceType->hasPrimaryArchetype()) {
+      sourceType->hasPrimaryArchetype() ||
+      (inputSubstType && inputSubstType->hasPrimaryArchetype()) ||
+      (outputSubstType && outputSubstType->hasPrimaryArchetype())) {
     // Get the existing generic signature.
     baseGenericSig = fn->getLoweredFunctionType()
         ->getInvocationGenericSignature();

--- a/test/SILGen/opaque_result_type_thunk.swift
+++ b/test/SILGen/opaque_result_type_thunk.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s
+
+// https://github.com/swiftlang/swift/issues/86118
+
+// The AST type of the thunk depends on the generic signature, but the
+// lowered type does not, because we can see the opaque return type's
+// underlying type from the expansion point, and it does not involve
+// type parameters. Make sure this does not cause us to assert.
+
+public struct G<T> {
+  public static func f(_: Any, _: Any) -> some Any {
+    return 123
+  }
+}
+
+public func g<T>(_: T) {
+  let fn: (Any, Any) -> _ = G<T>.f
+  let fn2: (Int, Int) -> _ = fn
+}


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86131

* **Description:** If we can see the underlying type of an opaque return type, and this underlying type does not depend on the opaque return type's generic signature, then we can end up in a situation where the lowered type of a re-abstraction thunk is not generic, but the formal type is. This would trigger an assertion failure. Check both the lowered type and formal type for type parameters to cope with this.

* **Issue:**  Fixes https://github.com/swiftlang/swift/issues/86118.

* **Risk:** Extremely low, because dropping the generic signature here is an optimization, so making it more conservative should generally be safe.

* **Reviewed by:** @jckarter 