### PR TITLE
[6.3] 🍒 Call nonatomic_retain instead of retain

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -646,7 +646,7 @@ void *swift::swift_nonatomic_unknownObjectRetain(void *object) {
 void swift::swift_nonatomic_unknownObjectRelease(void *object) {
   if (isObjCTaggedPointerOrNull(object)) return;
   if (objectUsesNativeSwiftReferenceCounting(object))
-    return swift_release(static_cast<HeapObject *>(object));
+    return swift_nonatomic_release(static_cast<HeapObject *>(object));
   return objc_release(static_cast<id>(object));
 }
 


### PR DESCRIPTION
This is a cherry pick of b4dedb2d83f65594d0c41fac4ed69925a0287e89

- **Explanation**:
  Fixes a copy paste mistake where we call the atomic version in a non-atomic context.
- **Scope**:
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  --> No breakage at all, assuming no misuse of the original function that has this issue/bug in compiler that this bug would have hidden.
- **Original PRs**:
  <!--
  Links to mainline branch pull requests in which the changes originated.
  --> #85880
- **Risk**:
  <!--
  The (specific) risk to the release for taking the changes.
  --> Only risk even theoretically would be if the original function was misused in the first place.
- **Testing**:
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  --> Passed all tests across all platforms.
- **Reviewers**:
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  --> @mikeash 
