### PR TITLE
isScalar needs to reject invalid ASCII

### DIFF
--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -30,7 +30,7 @@ extension Unicode.ASCII: Unicode.Encoding {
   @inline(__always)
   @inlinable
   public static func _isScalar(_ x: CodeUnit) -> Bool {
-    return true
+    return isASCII(x)
   }
 
   @inline(__always)

--- a/test/stdlib/Unicode.swift
+++ b/test/stdlib/Unicode.swift
@@ -110,4 +110,12 @@ UnicodeAPIs.test("UTF-8 and UTF-16 queries") {
   }
 }
 
+
+UnicodeAPIs.test("ASCII._isScalar") {
+  expectTrue(ASCII._isScalar(0))
+  expectTrue(ASCII._isScalar(0x7F))
+  expectFalse(ASCII._isScalar(0x80))
+  expectFalse(ASCII._isScalar(0xFF))
+}
+
 runAllTests()


### PR DESCRIPTION
0x80 - 0xFF are invalid ascii, and thus, need to not return true always.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
