### PR TITLE
Android: re-enable C++ Interop test that was failing for armv7 alone after #84340, but is now passing again after #85996

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
-// XFAIL: OS=linux-androideabi
 
 import StdVector
 import StdVectorNoCPlusPlusRequirement


### PR DESCRIPTION
Really fixes CI issue #84597, as can be seen on [the latest Android CI run](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/148/console).