### PR TITLE
[ParseVersion] Fix parseVersionString passing Diags as skipQuote, which shifted version component SourceRanges by 1 and mislocated diagnostics

### DIFF
--- a/lib/Parse/ParseVersion.cpp
+++ b/lib/Parse/ParseVersion.cpp
@@ -192,7 +192,7 @@ VersionParser::parseVersionString(StringRef VersionString, SourceLoc Loc,
     return std::nullopt;
   }
 
-  splitVersionComponents(SplitComponents, VersionString, Loc, Diags);
+  splitVersionComponents(SplitComponents, VersionString, Loc, false);
 
   uint64_t ComponentNumber;
   bool isValidVersion = true;


### PR DESCRIPTION
- **Explanation**:
  Fix `VersionParser::parseVersionString` to stop passing `DiagnosticEngine*` as the `skipQuote` argument to `splitVersionComponents`. The implicit pointer-to-bool conversion was effectively making `skipQuote` true, advancing `Loc` by one character and shifting version component `SourceRange`s, which can misplace diagnostics and contribute to cascading errors.

- **Scope**:
  Diagnostic-only change. Does not alter version parsing semantics, only the computed source locations for diagnostics emitted from this path. Unlikely to break existing code; may require updating tests that assert exact caret ranges.

- **Issues**:
  N/A

- **Original PRs**:
  N/A

- **Risk**:
  Low. Main risk is test expectation churn around diagnostic ranges; runtime behavior and accepted syntax should be unchanged.

- **Testing**:
  Not tested yet.

- **Reviewers**:
  N/A