### PR TITLE
[6.3 cherry-pick] SE-0492: Closures, static funcs, @convention(c)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -832,6 +832,8 @@ ERROR(const_unsupported_type_expr,none,
       "type expressions not supported in a constant expression", ())
 ERROR(const_unsupported_closure,none,
       "closures not supported in a constant expression", ())
+ERROR(const_unsupported_closure_with_captures,none,
+      "closures with captures not supported in a constant expression", ())
 ERROR(const_unsupported_keypath,none,
       "keypaths not supported in a constant expression", ())
 ERROR(const_opaque_decl_ref,none,

--- a/lib/Sema/LegalConstExprVerifier.cpp
+++ b/lib/Sema/LegalConstExprVerifier.cpp
@@ -241,7 +241,8 @@ checkSupportedWithSectionAttribute(const Expr *expr,
               functionConvExpr->getType()->getAs<AnyFunctionType>()) {
         if (targetFnTy->getExtInfo().getRepresentation() ==
             FunctionTypeRepresentation::CFunctionPointer) {
-          expressionsToCheck.push_back(functionConvExpr->getSubExpr());
+          // Do not check the inner expression -- if it converts to
+          // CFunctionPointer successfully, then it's constant foldable.
           continue;
         }
       }

--- a/test/ConstValues/SectionIR.swift
+++ b/test/ConstValues/SectionIR.swift
@@ -28,6 +28,17 @@ func bar(x: Int) -> String { return "test" }
 @section("mysection") let funcRef1 = foo // ok
 @section("mysection") let funcRef2 = bar // ok
 
+// closures
+@section("mysection") let closure1 = { }
+@section("mysection") let closure2 = { return 42 }
+@section("mysection") let closure3 = { (x: Int) in return x + 1 }
+@section("mysection") let closure4: () -> Void = { }
+@section("mysection") let closure5: (Int) -> Int = { x in x * 2 }
+@section("mysection") let closure6: @convention(c) (Int) -> Int = { x in x * 2 }
+struct W {
+  @section("mysection") static let closure7: @convention(c) (Int) -> Int = { x in x * 2 }
+}
+
 // metatypes - TODO
 //@section("mysection") let metatype1 = Int.self
 
@@ -56,6 +67,15 @@ func bar(x: Int) -> String { return "test" }
 // CHECK: @"$s9SectionIR12boolLiteral2Sbvp" = {{.*}}constant %TSb zeroinitializer, section "mysection"
 // CHECK: @"$s9SectionIR8funcRef1Siycvp" = {{.*}}constant %swift.function { ptr @"$s9SectionIR3fooSiyF{{.*}}", ptr null }, section "mysection"
 // CHECK: @"$s9SectionIR8funcRef2ySSSicvp" = {{.*}}constant %swift.function { ptr @"$s9SectionIR3bar1xSSSi_tF{{.*}}", ptr null }, section "mysection"
+
+// CHECK: @"$s9SectionIR8closure1yycvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
+// CHECK: @"$s9SectionIR8closure2Siycvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
+// CHECK: @"$s9SectionIR8closure3yS2icvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
+// CHECK: @"$s9SectionIR8closure4yycvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
+// CHECK: @"$s9SectionIR8closure5yS2icvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
+// CHECK: @"$s9SectionIR8closure6yS2iXCvp" = {{.*}}constant ptr @"$s9SectionIR8closure6yS2iXCvpfiS2icfU_To", section "mysection"
+// CHECK: @"$s9SectionIR1WV8closure7yS2iXCvpZ" = {{.*}}constant ptr @"$s9SectionIR1WV8closure7yS2iXCvpZfiS2icfU_To", section "mysection"
+
 // CHECK: @"$s9SectionIR6tuple1Si_S2iSdSbtvp" = {{.*}}constant <{ %TSi, %TSi, %TSi, {{.*}} }> <{ %TSi <{ {{i64|i32}} 1 }>, %TSi <{ {{i64|i32}} 2 }>, %TSi <{ {{i64|i32}} 3 }>, {{.*}} }>, section "mysection"
 // CHECK: @"$s9SectionIR6tuple2Si_SfSbtvp" = {{.*}}constant <{ %TSi, %TSf, %TSb }> <{ %TSi <{ {{i64|i32}} 42 }>, %TSf <{ float 0x40091EB860000000 }>, %TSb zeroinitializer }>, section "mysection"
 // CHECK: @"$s9SectionIR6tuple3Siyc_SSSictvp" = {{.*}}constant <{ %swift.function, %swift.function }> <{ %swift.function { ptr @"$s9SectionIR3fooSiyF{{.*}}", ptr null }, %swift.function { ptr @"$s9SectionIR3bar1xSSSi_tF{{.*}}", ptr null } }>, section "mysection"

--- a/test/ConstValues/SectionSyntactic.swift
+++ b/test/ConstValues/SectionSyntactic.swift
@@ -43,11 +43,23 @@
 func foo() -> Int { return 42 }
 func bar(x: Int) -> String { return "test" }
 
-// function references
+// global function references
 @section("mysection") let funcRef1 = foo // ok
 @section("mysection") let funcRef2 = bar // ok
 @section("mysection") let funcRef3: ()->Int = foo // ok
 @section("mysection") let funcRef4: @convention(c) ()->Int = foo // ok
+
+struct Q {
+  func memberFunc() {}
+  static func staticFunc() {}
+  func genericFunc<T>(t: T) {}
+  static func staticGenericFunc<T>(t: T) {}
+}
+
+// non-global function references
+@section("mysection") let staticFuncRef1 = Q.staticFunc // ok
+extension Q { @section("mysection") static let staticFuncRef2 = staticFunc } // ok
+@section("mysection") let staticFuncRef3 = Bool.random // ok
 
 // invalid function references (should be rejected)
 @section("mysection") let invalidFuncRef1 = foo()
@@ -55,6 +67,16 @@ func bar(x: Int) -> String { return "test" }
 @section("mysection") let invalidFuncRef2 = Bool.self.random
 // expected-error@-1{{not supported in a constant expression}}
 @section("mysection") let invalidFuncRef3 = (Bool.self as Bool.Type).random
+// expected-error@-1{{not supported in a constant expression}}
+@section("mysection") let invalidFuncRef4 = Q.memberFunc
+// expected-error@-1{{not supported in a constant expression}}
+extension Q { @section("mysection") static let invalidFuncRef5 = memberFunc }
+// expected-error@-1{{not supported in a constant expression}}
+extension Q { @section("mysection") static let invalidFuncRef6: (Int)->() = genericFunc(Q()) }
+// expected-error@-1{{not supported in a constant expression}}
+extension Q { @section("mysection") static let invalidFuncRef7: (Q) -> (Int) -> () = genericFunc }
+// expected-error@-1{{not supported in a constant expression}}
+extension Q { @section("mysection") static let invalidFuncRef8: (Int)->() = staticGenericFunc }
 // expected-error@-1{{not supported in a constant expression}}
 
 // generic function references (should be rejected)

--- a/test/ConstValues/SectionSyntactic.swift
+++ b/test/ConstValues/SectionSyntactic.swift
@@ -93,6 +93,14 @@ extension Q { @section("mysection") static let invalidFuncRef8: (Int)->() = stat
 struct W {
   @section("mysection") static let closure7: @convention(c) (Int) -> Int = { x in x * 2 } // ok
 }
+func g() {
+    @Sendable func f() { }
+    @Sendable func h() async { }
+    enum E {
+        @section("mysection") static let record: @convention(c) () -> () = { f() } // ok
+        @section("mysection") static let record2: @convention(c) () -> () = { _ = h } // ok
+    }
+}
 
 let capturedVar = 10
 class TestClass {}


### PR DESCRIPTION
6.3 cherry-pick of SE-0492 implementation that missed the branch point:
- https://github.com/swiftlang/swift/pull/85530
- https://github.com/swiftlang/swift/pull/85423
- https://github.com/swiftlang/swift/pull/86088

- **Explanation**: Remaining implementation of SE-0492.
- **Scope**: Implementation's scope/impact limited to users of `@section`.
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift/pull/85530, https://github.com/swiftlang/swift/pull/85423, https://github.com/swiftlang/swift/pull/86088
- **Risk**: Low, affects users of `@section` only.
- **Testing**: Lit tests.
- **Reviewers**: @DougGregor 