### PR TITLE
[IDE] Reference appendInterpolation calls in string interpolation

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -361,8 +361,10 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       return Action::Continue(E);
     }
 
-    // Skip implicit constructor references - they're handled via CtorRefs.
-    if (DRE->isImplicit() && isa<ConstructorDecl>(DRE->getDecl()))
+    // Skip implicit DeclRefExprs that will be handled via CtorRefs in
+    // passReference. This matches the location check in passReference.
+    if (DRE->isImplicit() && !CtorRefs.empty() &&
+        CtorRefs.back()->getFn()->getLoc() == DRE->getLoc())
       return Action::Continue(E);
   }
 

--- a/test/Index/index_string_interpolation.swift
+++ b/test/Index/index_string_interpolation.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -swift-version 5 -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+// Test that appendInterpolation methods are referenced from string interpolation
+// (https://github.com/swiftlang/swift/issues/56189)
+
+extension DefaultStringInterpolation {
+  // CHECK: [[@LINE+1]]:17 | instance-method(internal)/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR:.*]] | Def
+  mutating func appendInterpolation(value: Int) {}
+}
+
+func testStringInterpolation() {
+  // CHECK: [[@LINE+1]]:11 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call
+  print("\(value: 1)")
+
+  // CHECK: [[@LINE+1]]:18 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call
+  print("value: \(value: 42)")
+}

--- a/test/Index/index_string_interpolation.swift
+++ b/test/Index/index_string_interpolation.swift
@@ -9,9 +9,9 @@ extension DefaultStringInterpolation {
 }
 
 func testStringInterpolation() {
-  // CHECK: [[@LINE+1]]:11 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call
+  // CHECK: [[@LINE+1]]:11 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call,Impl
   print("\(value: 1)")
 
-  // CHECK: [[@LINE+1]]:18 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call
+  // CHECK: [[@LINE+1]]:18 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call,Impl
   print("value: \(value: 42)")
 }


### PR DESCRIPTION
Fix missing references to `appendInterpolation` functions called implicitly in string interpolations.

Fixes #56189