### PR TITLE
[Index] Relate ObjC optional protocol methods to protocol requirement

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/SourceLoc.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include <memory>
 #include <tuple>
 
@@ -347,6 +348,12 @@ namespace swift {
   SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
                                     CustomAttr *attr, bool passParentContext,
                                     MacroRole role, StringRef discriminator);
+
+  /// Find the Objective-C protocol requirements that the given declaration
+  /// satisfies, including requirements from inherited conformances.
+  llvm::TinyPtrVector<ValueDecl *>
+  findWitnessedObjCRequirements(const ValueDecl *witness,
+                                bool anySingleRequirement);
 }
 
 #endif

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1479,6 +1479,15 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
       if (witness.Member == D)
         addRelation(Info, (SymbolRoleSet) SymbolRole::RelationOverrideOf, witness.Requirement);
     }
+
+    // For ObjC methods, also check if this satisfies an optional protocol
+    // requirement from an inherited conformance.
+    if (auto VD = dyn_cast<ValueDecl>(D)) {
+      for (auto Req : findWitnessedObjCRequirements(VD, /*anySingleRequirement=*/false)) {
+        addRelation(Info, (SymbolRoleSet) SymbolRole::RelationOverrideOf, Req);
+      }
+    }
+
     if (auto ParentVD = dyn_cast<ValueDecl>(Parent)) {
       SymbolRoleSet RelationsToParent = (SymbolRoleSet)SymbolRole::RelationChildOf;
       if (Info.symInfo.SubKind == SymbolSubKind::AccessorGetter ||

--- a/test/Index/objc_conformances.swift
+++ b/test/Index/objc_conformances.swift
@@ -15,3 +15,12 @@ class C : P {
   // CHECK: RelOver | instance-method/Swift | g() | c:@M@swift_ide_test@objc(pl)P(im)g
   // CHECK: RelChild | class/Swift | C | s:14swift_ide_test1CC
 }
+
+// Make sure optional protocol methods in subclasses get RelOver to the
+// protocol requirement. (https://github.com/swiftlang/swift/issues/56327)
+class D : C {
+  func f() {}
+  // CHECK: [[@LINE-1]]:8 | instance-method(internal)/Swift | f() | s:14swift_ide_test1DC1fyyF | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK: RelOver | instance-method/Swift | f() | c:@M@swift_ide_test@objc(pl)P(im)f
+  // CHECK: RelChild | class/Swift | D | s:14swift_ide_test1DC
+}


### PR DESCRIPTION
When a class implements an optional ObjC protocol method, the indexer was not creating a RelationOverrideOf relation to the protocol requirement. Use findWitnessedObjCRequirements to find and index these optional requirements.

Fixes #56327