### PR TITLE
SILGen: Fix edge case where we didn't erase opaque result type in constructor

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1502,7 +1502,7 @@ public:
     SILType loweredResultTy;
     auto selfMetaTy = selfValue.getType().getAs<AnyMetatypeType>();
     if (selfMetaTy) {
-      loweredResultTy = SILType::getPrimitiveObjectType(
+      loweredResultTy = SGF.getLoweredLoadableType(
         CanMetatypeType::get(resultTy, selfMetaTy->getRepresentation()));
     } else {
       loweredResultTy = SGF.getLoweredLoadableType(resultTy);

--- a/test/SILGen/opaque_result_type_constructor.swift
+++ b/test/SILGen/opaque_result_type_constructor.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen %s
+
+// https://github.com/swiftlang/swift/issues/68277
+
+enum E: P {
+    static func m() -> some Any { () }
+}
+
+protocol P {
+    associatedtype A
+    static func m() -> A
+}
+
+struct S<T> {
+    let t: T
+}
+
+extension S where T == E.A {
+    init() {
+        self.init(t: E.m())
+    }
+}

--- a/validation-test/SILGen/SwiftUI/issue-68298.swift
+++ b/validation-test/SILGen/SwiftUI/issue-68298.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx11 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+protocol StaticFactory {
+    associatedtype Result
+
+    func callAsFunction() -> Self.Result
+}
+
+struct ViewFactory: StaticFactory {
+    let systemName: String
+    
+    func callAsFunction() -> some View {
+        Image(systemName: systemName)
+            .frame(width: 20, height: 20)
+    }
+}
+
+extension Button where Label == ViewFactory.Result {
+    init(
+        systemName: String,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            action: action
+        ) {
+            ViewFactory(systemName: systemName)()
+        }
+    }
+}

--- a/validation-test/compiler_crashers_fixed/issue-52841.swift
+++ b/validation-test/compiler_crashers_fixed/issue-52841.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-ir -g %s
+
+protocol Foo {
+  associatedtype ErrorType: Error
+}
+
+extension Array: Error where Element: Error {}
+
+class Bar<A: Foo> {
+  func doSomething(with result: Result<Any, [A.ErrorType]>) {}
+}

--- a/validation-test/compiler_crashers_fixed/issue-66572.swift
+++ b/validation-test/compiler_crashers_fixed/issue-66572.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public final class TypedNode {
+    public var property: String?
+    
+    public func withProperty(_ generator: (Self) -> String) -> Self {
+        self.property = generator(self)
+        return self
+    }
+}
+
+let tree = TypedNode().withProperty { "\($0)" }

--- a/validation-test/compiler_crashers_fixed/issue-66590.swift
+++ b/validation-test/compiler_crashers_fixed/issue-66590.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct A<X> {}
+extension A<A<Int>.B> {
+  struct B {}
+}


### PR DESCRIPTION
- Fixes https://github.com/swiftlang/swift/issues/68298.
- Fixes https://github.com/swiftlang/swift/issues/68277.

Also while we're here, add some regression tests for a few crashers that have since been fixed.