### PR TITLE
[6.3] SILGen: Fix edge case where we didn't erase opaque result type in constructor

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1502,7 +1502,7 @@ public:
     SILType loweredResultTy;
     auto selfMetaTy = selfValue.getType().getAs<AnyMetatypeType>();
     if (selfMetaTy) {
-      loweredResultTy = SILType::getPrimitiveObjectType(
+      loweredResultTy = SGF.getLoweredLoadableType(
         CanMetatypeType::get(resultTy, selfMetaTy->getRepresentation()));
     } else {
       loweredResultTy = SGF.getLoweredLoadableType(resultTy);

--- a/test/SILGen/opaque_result_type_constructor.swift
+++ b/test/SILGen/opaque_result_type_constructor.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen %s
+
+// https://github.com/swiftlang/swift/issues/68277
+
+enum E: P {
+    static func m() -> some Any { () }
+}
+
+protocol P {
+    associatedtype A
+    static func m() -> A
+}
+
+struct S<T> {
+    let t: T
+}
+
+extension S where T == E.A {
+    init() {
+        self.init(t: E.m())
+    }
+}

--- a/validation-test/SILGen/SwiftUI/issue-68298.swift
+++ b/validation-test/SILGen/SwiftUI/issue-68298.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx11 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+protocol StaticFactory {
+    associatedtype Result
+
+    func callAsFunction() -> Self.Result
+}
+
+struct ViewFactory: StaticFactory {
+    let systemName: String
+    
+    func callAsFunction() -> some View {
+        Image(systemName: systemName)
+            .frame(width: 20, height: 20)
+    }
+}
+
+extension Button where Label == ViewFactory.Result {
+    init(
+        systemName: String,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            action: action
+        ) {
+            ViewFactory(systemName: systemName)()
+        }
+    }
+}


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86168.

* **Description:** Fix a SILGen or IRGen (depending on asserts on/off) crash when emitting an allocating initializer when the type of `self` contains an opaque result type that can be erased.

* **Origination:** Never worked.

* **Issues:** https://github.com/swiftlang/swift/issues/68298, https://github.com/swiftlang/swift/issues/68277.

* **Reviewed by:** @DougGregor  

* **Risk:** Very low.

