### PR TITLE
[6.3 cherry-pick] [Test] Add .ptrauth patterns to test/ConstValues/SectionIR.swift

### DIFF
--- a/test/ConstValues/SectionIR.swift
+++ b/test/ConstValues/SectionIR.swift
@@ -73,8 +73,8 @@ struct W {
 // CHECK: @"$s9SectionIR8closure3yS2icvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
 // CHECK: @"$s9SectionIR8closure4yycvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
 // CHECK: @"$s9SectionIR8closure5yS2icvp" = {{.*}}constant %swift.function { {{.*}} }, section "mysection"
-// CHECK: @"$s9SectionIR8closure6yS2iXCvp" = {{.*}}constant ptr @"$s9SectionIR8closure6yS2iXCvpfiS2icfU_To", section "mysection"
-// CHECK: @"$s9SectionIR1WV8closure7yS2iXCvpZ" = {{.*}}constant ptr @"$s9SectionIR1WV8closure7yS2iXCvpZfiS2icfU_To", section "mysection"
+// CHECK: @"$s9SectionIR8closure6yS2iXCvp" = {{.*}}constant ptr @"$s9SectionIR8closure6yS2iXCvpfiS2icfU_To{{(.ptrauth)?}}", section "mysection"
+// CHECK: @"$s9SectionIR1WV8closure7yS2iXCvpZ" = {{.*}}constant ptr @"$s9SectionIR1WV8closure7yS2iXCvpZfiS2icfU_To{{(.ptrauth)?}}", section "mysection"
 
 // CHECK: @"$s9SectionIR6tuple1Si_S2iSdSbtvp" = {{.*}}constant <{ %TSi, %TSi, %TSi, {{.*}} }> <{ %TSi <{ {{i64|i32}} 1 }>, %TSi <{ {{i64|i32}} 2 }>, %TSi <{ {{i64|i32}} 3 }>, {{.*}} }>, section "mysection"
 // CHECK: @"$s9SectionIR6tuple2Si_SfSbtvp" = {{.*}}constant <{ %TSi, %TSf, %TSb }> <{ %TSi <{ {{i64|i32}} 42 }>, %TSf <{ float 0x40091EB860000000 }>, %TSb zeroinitializer }>, section "mysection"


### PR DESCRIPTION
Test-only cherry-pick of: https://github.com/swiftlang/swift/pull/85661. This resolves a CI bot failure at <https://ci.swift.org/view/Swift%206.3/job/oss-swift-6.3_tools-RA_stdlib-DA_test-device-non_executable/>.

- **Explanation**: Fix IR checking expectations in a lit test related to `@section`.
- **Scope**: Test-only fix.
- **Issues**: rdar://164947665
- **Original PRs**: https://github.com/swiftlang/swift/pull/85661
- **Risk**: Low, test-only fix.
- **Testing**: lit tests
- **Reviewers**: N/A
