### PR TITLE
Add support to show objc selector

### DIFF
--- a/test/SourceKit/ObjCSelector/basic.swift
+++ b/test/SourceKit/ObjCSelector/basic.swift
@@ -1,0 +1,26 @@
+// REQUIRES: objc_interop
+
+import Foundation
+
+class MyClass: NSObject {
+    @objc func simpleMethod() {
+        print("simple")
+    }
+
+    @objc func methodWithParameters(param1: Int, param2: String) {
+        print("params")
+    }
+
+    @objc(customSelector:with:)
+    func methodWithCustomSelector(foo: Int, bar: String) {
+        print("custom")
+    }
+}
+
+// RUN: %sourcekitd-test -req=objc-selector -pos=6:16 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-SIMPLE
+// RUN: %sourcekitd-test -req=objc-selector -pos=10:16 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-PARAMS
+// RUN: %sourcekitd-test -req=objc-selector -pos=15:10 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-CUSTOM
+
+// CHECK-SIMPLE: simpleMethod
+// CHECK-PARAMS: methodWithParametersWithParam1:param2:
+// CHECK-CUSTOM: customSelector:with:

--- a/test/SourceKit/ObjCSelector/basic.swift
+++ b/test/SourceKit/ObjCSelector/basic.swift
@@ -21,6 +21,11 @@ class MyClass: NSObject {
 // RUN: %sourcekitd-test -req=objc-selector -pos=10:16 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-PARAMS
 // RUN: %sourcekitd-test -req=objc-selector -pos=15:10 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-CUSTOM
 
+// The offset is snapped to the start of the token, so a position in the middle of the name resolves as well. This is
+// what editors send, since they pass the user's cursor position.
+// RUN: %sourcekitd-test -req=objc-selector -pos=6:20 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-SIMPLE
+// RUN: %sourcekitd-test -req=objc-selector -pos=15:14 %s -- -target %target-triple -sdk %sdk %s | %FileCheck %s -check-prefix=CHECK-CUSTOM
+
 // CHECK-SIMPLE: simpleMethod
 // CHECK-PARAMS: methodWithParametersWithParam1:param2:
 // CHECK-CUSTOM: customSelector:with:

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1256,6 +1256,13 @@ public:
                                    SourceKitCancellationToken CancellationToken,
                                    CategorizedEditsReceiver Receiver) = 0;
 
+  virtual void getObjCSelector(StringRef PrimaryFilePath,
+                               StringRef InputBufferName,
+                               unsigned Offset,
+                               ArrayRef<const char *> Args,
+                               SourceKitCancellationToken CancellationToken,
+                               std::function<void(const RequestResult<std::string> &)> Receiver) = 0;
+
   virtual void collectExpressionTypes(
       StringRef PrimaryFilePath, StringRef InputBufferName,
       ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedProtocols,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -735,6 +735,13 @@ public:
                            SourceKitCancellationToken CancellationToken,
                            CategorizedEditsReceiver Receiver) override;
 
+  void getObjCSelector(StringRef PrimaryFilePath,
+                       StringRef InputBufferName,
+                       unsigned Offset,
+                       ArrayRef<const char *> Args,
+                       SourceKitCancellationToken CancellationToken,
+                       std::function<void(const RequestResult<std::string> &)> Receiver) override;
+
   void getDocInfo(llvm::MemoryBuffer *InputBuf,
                   StringRef ModuleName,
                   ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2889,6 +2889,87 @@ void SwiftLangSupport::semanticRefactoring(
                                    llvm::vfs::createPhysicalFileSystem());
 }
 
+void SwiftLangSupport::getObjCSelector(
+    StringRef PrimaryFilePath, StringRef InputBufferName,
+    unsigned Offset, ArrayRef<const char *> Args,
+    SourceKitCancellationToken CancellationToken,
+    std::function<void(const RequestResult<std::string> &)> Receiver) {
+  std::string Error;
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
+  if (!Invok) {
+    LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
+    Receiver(RequestResult<std::string>::fromError(Error));
+    return;
+  }
+
+  class ObjCSelectorConsumer : public SwiftASTConsumer {
+    std::string InputBufferName;
+    unsigned Offset;
+    std::function<void(const RequestResult<std::string> &)> Receiver;
+
+  public:
+    ObjCSelectorConsumer(StringRef InputBufferName, unsigned Offset,
+                         std::function<void(const RequestResult<std::string> &)> Receiver)
+        : InputBufferName(InputBufferName.str()), Offset(Offset),
+          Receiver(std::move(Receiver)) {}
+
+    void handlePrimaryAST(ASTUnitRef AstUnit) override {
+      auto &CompIns = AstUnit->getCompilerInstance();
+      auto &SM = CompIns.getSourceMgr();
+
+      SourceFile *SF = retrieveInputFile(InputBufferName, CompIns);
+      if (!SF) {
+        Receiver(RequestResult<std::string>::fromError("Unable to find input file"));
+        return;
+      }
+
+      unsigned BufferID = SF->getBufferID();
+      SourceLoc Loc = SM.getLocForOffset(BufferID, Offset);
+
+      auto CursorInfo = evaluateOrDefault(
+          SF->getASTContext().evaluator,
+          CursorInfoRequest{CursorInfoOwner(SF, Loc)},
+          new ResolvedCursorInfo());
+
+      if (!CursorInfo || CursorInfo->isInvalid()) {
+        Receiver(RequestResult<std::string>::fromError("Invalid cursor position"));
+        return;
+      }
+
+      if (auto *ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(CursorInfo.get())) {
+        if (auto *VD = ValueRefInfo->getValueD()) {
+          if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
+            if (AFD->isObjC()) {
+              auto selector = AFD->getObjCSelector();
+              SmallString<64> scratch;
+              std::string selectorString = selector.getString(scratch).str();
+              Receiver(RequestResult<std::string>::fromResult(selectorString));
+              return;
+            }
+          }
+        }
+      }
+
+      Receiver(RequestResult<std::string>::fromError(
+          "Cursor is not on an Objective-C method"));
+    }
+
+    void cancelled() override {
+      Receiver(RequestResult<std::string>::cancelled());
+    }
+
+    void failed(StringRef Error) override {
+      Receiver(RequestResult<std::string>::fromError(Error));
+    }
+  };
+
+  auto Consumer = std::make_shared<ObjCSelectorConsumer>(InputBufferName, Offset, Receiver);
+  getASTManager()->processASTAsync(Invok, std::move(Consumer), nullptr,
+                                   CancellationToken,
+                                   llvm::vfs::getRealFileSystem());
+}
+
 void SwiftLangSupport::collectExpressionTypes(
     StringRef PrimaryFilePath, StringRef InputBufferName,
     ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedProtocols,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2925,7 +2925,9 @@ void SwiftLangSupport::getObjCSelector(
       }
 
       unsigned BufferID = SF->getBufferID();
-      SourceLoc Loc = SM.getLocForOffset(BufferID, Offset);
+      // Snap the offset to the start of the token so that a cursor anywhere
+      // inside an identifier resolves, not just on its first character.
+      SourceLoc Loc = Lexer::getLocForStartOfToken(SM, BufferID, Offset);
 
       auto CursorInfo = evaluateOrDefault(
           SF->getASTContext().evaluator,

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -156,6 +156,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("syntactic-expandmacro", SourceKitRequest::SyntacticMacroExpansion)
         .Case("index-to-store", SourceKitRequest::IndexToStore)
         .Case("polyglot-ast", SourceKitRequest::PolyglotAST)
+        .Case("objc-selector", SourceKitRequest::ObjCSelector)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/Refactoring/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
@@ -208,6 +209,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- dependency-updated\n"
                      << "- syntactic-expandmacro\n"
                      << "- index-to-store\n"
+                     << "- objc-selector\n"
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
 #include "swift/Refactoring/RefactoringKinds.def"
                         "\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -74,6 +74,7 @@ enum class SourceKitRequest {
   SyntacticMacroExpansion,
   IndexToStore,
   PolyglotAST,
+  ObjCSelector,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/Refactoring/RefactoringKinds.def"
 };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1241,6 +1241,11 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::PolyglotAST:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestPolyglotAST);
     break;
+
+  case SourceKitRequest::ObjCSelector:
+    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestGetObjCSelector);
+    sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
+    break;
   }
 
   if (!Opts.SourceFile.empty()) {
@@ -1668,6 +1673,13 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
             sourcekitd_variant_dictionary_get_string(Info, KeyFilePath);
         if (value)
           llvm::outs() << value << '\n';
+        break;
+      }
+      case SourceKitRequest::ObjCSelector: {
+        const char *Text = sourcekitd_variant_dictionary_get_string(Info, KeyText);
+        if (Text) {
+          llvm::outs() << Text << "\n";
+        }
         break;
       }
     }

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1801,6 +1801,51 @@ handleRequestSemanticRefactoring(const RequestDict &Req,
 }
 
 static void
+handleRequestGetObjCSelector(const RequestDict &Req,
+                             SourceKitCancellationToken CancellationToken,
+                             ResponseReceiver Rec) {
+  if (checkVFSNotSupported(Req, Rec))
+    return;
+
+  handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
+    std::optional<StringRef> PrimaryFilePath =
+        getPrimaryFilePathForRequestOrEmitError(Req, Rec);
+    if (!PrimaryFilePath)
+      return;
+
+    StringRef InputBufferName = getInputBufferNameForRequest(Req, Rec);
+
+    SmallVector<const char *, 8> Args;
+    if (getCompilerArgumentsForRequestOrEmitError(Req, Args, Rec))
+      return;
+
+    int64_t Offset = 0;
+    if (Req.getInt64(KeyOffset, Offset, /*isOptional=*/false)) {
+      return Rec(createErrorRequestInvalid("'key.offset' is required"));
+    }
+
+    LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
+
+    return Lang.getObjCSelector(
+        *PrimaryFilePath, InputBufferName, Offset, Args,
+        CancellationToken,
+        [Rec](const RequestResult<std::string> &Result) {
+          if (Result.isCancelled()) {
+            return Rec(createErrorRequestCancelled());
+          }
+          if (Result.isError()) {
+            return Rec(createErrorRequestFailed(Result.getError()));
+          }
+
+          ResponseBuilder RespBuilder;
+          auto Dict = RespBuilder.getDictionary();
+          Dict.set(KeyText, Result.value());
+          Rec(RespBuilder.createResponse());
+        });
+  });
+}
+
+static void
 handleRequestCollectExpressionType(const RequestDict &Req,
                                    SourceKitCancellationToken CancellationToken,
                                    ResponseReceiver Rec) {
@@ -2311,6 +2356,7 @@ void handleRequestImpl(sourcekitd_object_t ReqObj,
   HANDLE_REQUEST(RequestCursorInfo, handleRequestCursorInfo)
   HANDLE_REQUEST(RequestRangeInfo, handleRequestRangeInfo)
   HANDLE_REQUEST(RequestSemanticRefactoring, handleRequestSemanticRefactoring)
+  HANDLE_REQUEST(RequestGetObjCSelector, handleRequestGetObjCSelector)
 
   HANDLE_REQUEST(RequestCollectExpressionType,
                  handleRequestCollectExpressionType)

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -292,6 +292,7 @@ UID_REQUESTS = [
     REQUEST('FindLocalRenameRanges',
             'source.request.find-local-rename-ranges'),
     REQUEST('SemanticRefactoring', 'source.request.semantic.refactoring'),
+    REQUEST('GetObjCSelector', 'source.request.objc.selector'),
     REQUEST('EnableCompileNotifications',
             'source.request.enable-compile-notifications'),
     REQUEST('TestNotification', 'source.request.test_notification'),


### PR DESCRIPTION
Adds a `source.request.objc.selector` sourcekitd request that returns the Objective-C selector of the declaration at a given offset, and fails if that declaration isn't exposed to Objective-C. It is a plain request, not a refactoring action.

The offset is snapped to the start of the token, so a cursor anywhere inside the name resolves.

Used by https://github.com/swiftlang/sourcekit-lsp/pull/2399.

https://github.com/user-attachments/assets/467cec3f-d0cb-4e64-91f1-adfc7879d33f
