### PR TITLE
 Set up the AST-affecting ClangImporter CodeGenOpts options early

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -200,7 +200,9 @@ public:
   /// \returns a new Clang module importer, or null (with a diagnostic) if
   /// an error occurred.
   static std::unique_ptr<ClangImporter>
-  create(ASTContext &ctx, std::string swiftPCHHash = "",
+  create(ASTContext &ctx,
+         const IRGenOptions *IRGenOpts = nullptr,
+         std::string swiftPCHHash = "",
          DependencyTracker *tracker = nullptr,
          DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
          bool ignoreFileMapping = false);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1312,7 +1312,8 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
 }
 
 std::unique_ptr<ClangImporter> ClangImporter::create(
-    ASTContext &ctx, std::string swiftPCHHash, DependencyTracker *tracker,
+    ASTContext &ctx, const IRGenOptions *IRGenOpts, std::string swiftPCHHash,
+    DependencyTracker *tracker,
     DWARFImporterDelegate *dwarfImporterDelegate, bool ignoreFileMapping) {
   std::unique_ptr<ClangImporter> importer{
       new ClangImporter(ctx, tracker, dwarfImporterDelegate)};
@@ -1444,6 +1445,48 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
   } else {
     // Set using the existing invocation.
     importer->Impl.configureOptionsForCodeGen(clangDiags);
+  }
+
+  if (IRGenOpts) {
+    // We need to set the AST-affecting CodeGenOpts here early so that
+    // the clang module cache hash will be consistent throughout. Also
+    // prefer to set the AST-benign ones here unless they are computed
+    // after this point or may var per inputs.
+    auto &CGO = importer->getCodeGenOpts();
+    CGO.OptimizationLevel = IRGenOpts->shouldOptimize() ? 3 : 0;
+    CGO.DebugTypeExtRefs = !IRGenOpts->DisableClangModuleSkeletonCUs;
+    switch (IRGenOpts->DebugInfoLevel) {
+    case IRGenDebugInfoLevel::None:
+      CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::NoDebugInfo);
+      break;
+    case IRGenDebugInfoLevel::LineTables:
+      CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
+      break;
+    case IRGenDebugInfoLevel::ASTTypes:
+    case IRGenDebugInfoLevel::DwarfTypes:
+      CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::FullDebugInfo);
+      break;
+    }
+    switch (IRGenOpts->DebugInfoFormat) {
+    case IRGenDebugInfoFormat::None:
+      break;
+    case IRGenDebugInfoFormat::DWARF:
+      CGO.DebugCompilationDir = IRGenOpts->DebugCompilationDir;
+      CGO.DwarfVersion = IRGenOpts->DWARFVersion;
+      break;
+    case IRGenDebugInfoFormat::CodeView:
+      CGO.EmitCodeView = true;
+      CGO.DebugCompilationDir = IRGenOpts->DebugCompilationDir;
+      break;
+    }
+    if (!IRGenOpts->TrapFuncName.empty()) {
+      CGO.TrapFuncName = IRGenOpts->TrapFuncName;
+    }
+    // We don't need to perform coverage mapping for any Clang decls we've
+    // synthesized, as they have no user-written code. This is also needed to
+    // avoid a Clang crash when attempting to emit coverage for decls without
+    // source locations (rdar://100172217).
+    CGO.CoverageMapping = false;
   }
 
   // Create the associated action.

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -198,8 +198,9 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
 
-  ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, "",
-                                               nullptr, nullptr,
+  IRGenOptions IRGenOpts;
+  ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, &IRGenOpts,
+                                               "", nullptr, nullptr,
                                                true),
                          true);
   ModuleDecl *M =

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -872,7 +872,8 @@ bool CompilerInstance::setUpModuleLoaders() {
   // Otherwise, we just keep it around as our interface to Clang's ABI
   // knowledge.
   std::unique_ptr<ClangImporter> clangImporter =
-    ClangImporter::create(*Context, Invocation.getPCHHash(),
+    ClangImporter::create(*Context, &Invocation.getIRGenOptions(),
+                          Invocation.getPCHHash(),
                           getDependencyTracker());
   if (!clangImporter) {
     Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -108,50 +108,20 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
 
   auto &CGTI = Importer->getTargetInfo();
   auto &CGO = Importer->getCodeGenOpts();
-  CGO.OptimizationLevel = Opts.shouldOptimize() ? 3 : 0;
 
-  CGO.DebugTypeExtRefs = !Opts.DisableClangModuleSkeletonCUs;
+  // Here we set the AST-benign CodeGenOpts options only. Set the
+  // AST-affecting ones early in ClangImporter::create.
   CGO.DiscardValueNames = !Opts.shouldProvideValueNames();
-  switch (Opts.DebugInfoLevel) {
-  case IRGenDebugInfoLevel::None:
-    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::NoDebugInfo);
-    break;
-  case IRGenDebugInfoLevel::LineTables:
-    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
-    break;
-  case IRGenDebugInfoLevel::ASTTypes:
-  case IRGenDebugInfoLevel::DwarfTypes:
-    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::FullDebugInfo);
-    break;
-  }
   switch (Opts.DebugInfoFormat) {
   case IRGenDebugInfoFormat::None:
     break;
   case IRGenDebugInfoFormat::DWARF:
-    CGO.DebugCompilationDir = Opts.DebugCompilationDir;
-    CGO.DwarfVersion = Opts.DWARFVersion;
-    CGO.DwarfDebugFlags =
-        Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop,
-                           Context.LangOpts.hasFeature(Feature::Embedded));
-    break;
   case IRGenDebugInfoFormat::CodeView:
-    CGO.EmitCodeView = true;
-    CGO.DebugCompilationDir = Opts.DebugCompilationDir;
-    // This actually contains the debug flags for codeview.
     CGO.DwarfDebugFlags =
         Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop,
                            Context.LangOpts.hasFeature(Feature::Embedded));
     break;
   }
-  if (!Opts.TrapFuncName.empty()) {
-    CGO.TrapFuncName = Opts.TrapFuncName;
-  }
-
-  // We don't need to perform coverage mapping for any Clang decls we've
-  // synthesized, as they have no user-written code. This is also needed to
-  // avoid a Clang crash when attempting to emit coverage for decls without
-  // source locations (rdar://100172217).
-  CGO.CoverageMapping = false;
 
   auto &VFS = Importer->getClangInstance().getVirtualFileSystem();
   auto &HSI = Importer->getClangPreprocessor()

--- a/test/DebugInfo/BridgingHeaderPCH-Type.swift
+++ b/test/DebugInfo/BridgingHeaderPCH-Type.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend \
-// RUN:   -emit-pch %S/Inputs/BridgingHeader.h -o %t.pch
+// RUN:   -emit-pch %S/Inputs/BridgingHeader.h -o %t.pch -g
 // RUN: %target-swift-frontend \
 // RUN:   -import-objc-header %t.pch -emit-ir -g %s -o - | %FileCheck %s
 

--- a/test/DebugInfo/BridgingHeaderPCH.swift
+++ b/test/DebugInfo/BridgingHeaderPCH.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend \
-// RUN:   -emit-pch %S/Inputs/InlineBridgingHeader.h -o %t.pch 
+// RUN:   -emit-pch %S/Inputs/InlineBridgingHeader.h -o %t.pch -g
 // RUN: %target-swift-frontend \
 // RUN:   -import-objc-header %t.pch -emit-ir -g %s -o - | %FileCheck %s
 

--- a/test/Interop/Cxx/modules/module-cache-hash.swift
+++ b/test/Interop/Cxx/modules/module-cache-hash.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -c -emit-module-path %t/Foo.swiftmodule -g -cxx-interoperability-mode=default %t/Test.swift -module-cache-path %t/clang-module-cache
+
+//--- Test.swift
+// Empty


### PR DESCRIPTION
This is to keep clang module cache hashes consistent throughout the
build and avoid inconsistent hash errors due to the CodeGenOpts
changing at the IRGen phase in the middle of a build.

https://github.com/swiftlang/swift/issues/86116