### PR TITLE
SIL: Fix the ownership verifier for guaranteed phi arguments

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -483,6 +483,8 @@ bool swift::visitGuaranteedForwardingPhisForSSAValue(
   // Transitively, collect GuaranteedForwarding uses.
   for (unsigned i = 0; i < guaranteedForwardingOps.size(); i++) {
     for (auto val : guaranteedForwardingOps[i]->getUser()->getResults()) {
+      if (val->getOwnershipKind() == OwnershipKind::None)
+        continue;
       for (auto *valUse : val->getUses()) {
         if (valUse->getOperandOwnership() ==
             OperandOwnership::GuaranteedForwarding) {

--- a/test/SIL/OwnershipVerifier/guaranteed_phis.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_phis.sil
@@ -18,6 +18,12 @@ struct Wrapper2 {
 struct TStruct {
 }
 
+struct KlassAndInt {
+  let c: Klass
+  let i: Int
+}
+
+
 sil @use_superklass : $@convention(thin) (@guaranteed SuperKlass) -> ()
 sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 
@@ -395,3 +401,20 @@ bb3(%14 : @reborrow $Klass, %15 : @reborrow $Klass):
   %20 = tuple ()
   return %20
 }
+
+sil [ossa] @dont_follow_trivial_field_to_phi : $@convention(thin) (@owned KlassAndInt, @guaranteed Klass) -> () {
+bb0(%0 : @owned $KlassAndInt, %1 : @guaranteed $Klass):
+  %2 = begin_borrow %0
+  %3 = struct_extract %2 , #KlassAndInt.i
+  end_borrow %2
+  destroy_value %0
+  %6 = struct $KlassAndInt (%1, %3)
+  br bb2(%6)
+
+bb2(%8 : @guaranteed $KlassAndInt):
+  %9 = borrowed %8 from (%1)
+  %10 = apply undef(%9) : $@convention(thin) (@guaranteed KlassAndInt) -> ()
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
The verifier reported a false error in case an unowned (trivial) value was used in an guaranteed phi argument outside the liverange of a borrow scope. For example:

```
  %2 = begin_borrow %0
  %3 = struct_extract %2 , #KlassAndInt.int    // %3 is trivial and can outlive the borrow scope
  end_borrow %2
  %6 = struct $KlassAndInt (%someOtherGuaranteedValue, %3)
  br bb2(%6)

bb2(%8 : @guaranteed $KlassAndInt):      // false error reported at the uses of %8
```

Fixes a compiler crash
rdar://167003182