### PR TITLE
SIL Verifier: workaround a MoveOnlyChecker pass bug

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Verifier.swift
@@ -190,7 +190,7 @@ extension BeginAccessInst : VerifiableInstruction {
       return
     }
 
-    if address.type.isMoveOnly && enforcement == .static {
+    if enforcement == .static {
       // This is a workaround for a bug in the move-only checker: rdar://151841926.
       // The move-only checker sometimes inserts destroy_addr within read-only static access scopes.
       // TODO: remove this once the bug is fixed.

--- a/test/SIL/verifier-fail-access-scope.sil
+++ b/test/SIL/verifier-fail-access-scope.sil
@@ -9,7 +9,7 @@ import Swift
 
 sil [ossa] @write_in_read_only_scope : $@convention(thin) (@inout Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
-  %2 = begin_access [read] [static] %0
+  %2 = begin_access [read] [dynamic] %0
   store %1 to [trivial] %0
   end_access %2
   %5 = tuple()

--- a/test/SILOptimizer/moveonly_checker_access_scope.swift
+++ b/test/SILOptimizer/moveonly_checker_access_scope.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend  %s -emit-sil -o /dev/null
+
+// Check that the compiler doesn't crash.
+
+struct S {
+  var i: Int64
+
+  consuming func testit() -> S {
+    self.i = Int64.init(Double.init(self.i))
+    return self
+  }
+}


### PR DESCRIPTION
The MoveOnlyChecker is inserting a `destroy_addr` in a read-only access scope, which is illegal. Relax the verification of read-only access scope by only looking at dynamic scopes.

Fixes a verifier crash.
https://github.com/swiftlang/swift/issues/86147
rdar://166896665
