### PR TITLE
[stdlib] Fix documentation typo in DebugDescription macro

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -57,7 +57,7 @@ import SwiftShims
 ///
 /// The description implementation has the following requirements:
 ///
-/// * The body of the description implementation must a single string
+/// * The body of the description implementation must be a single string
 ///   expression. String concatenation is not supported, use string interpolation
 ///   instead.
 /// * String interpolation can reference stored properties only, functions calls


### PR DESCRIPTION
Hi. I fixed a typo in the documentation for the DebugDescription macro in `stdlib > public > core > DebuggerSupport.swift`.

`must a single string` → `must be a single string`

Please check out the changes. Thanks!