### PR TITLE
Fix conformance-related warnings appearing after PR85757

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -1258,7 +1258,10 @@ let specializeBranchTracingEnums = FunctionTest("autodiff_specialize_branch_trac
   print("Specialized branch tracing enum dict for VJP \(function.name) contains \(specializedBTEDict.count) elements:")
 
   var keys = [Type](specializedBTEDict.keys)
-  keys.sort()
+
+  func compareTypes(lhs: Type, rhs: Type) -> Bool { "\(lhs)" < "\(rhs)" }
+  keys.sort(by: compareTypes)
+
   for (idx, key) in keys.enumerated() {
     print("non-specialized BTE \(idx): \(key.nominal!.description)")
     print("specialized BTE \(idx): \(specializedBTEDict[key]!.nominal!.description)")

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -788,12 +788,6 @@ private extension EnumInst {
   }
 }
 
-extension EnumCase : Equatable {
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
-    return lhs.enumElementDecl == rhs.enumElementDecl
-  }
-}
-
 private extension Function {
   var effectAllowsSpecialization: Bool {
     switch self.effectAttribute {
@@ -1255,13 +1249,6 @@ private func specializeBranchTracingEnumBBArgInVJP(
   let newType = specializedBTEDict[arg.type]!
   return bb.insertPhiArgument(
     atPosition: arg.index, type: newType, ownership: arg.ownership, context)
-}
-
-// Use this to make test output predictable
-extension Type: Comparable {
-  public static func < (lhs: SIL.`Type`, rhs: SIL.`Type`) -> Bool {
-    return "\(lhs)" < "\(rhs)"
-  }
 }
 
 let specializeBranchTracingEnums = FunctionTest("autodiff_specialize_branch_tracing_enums") {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -241,17 +241,13 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
   }
 }
 
-extension Type: Equatable, Hashable, Comparable {
+extension Type: Equatable, Hashable {
   public static func ==(lhs: Type, rhs: Type) -> Bool { 
     lhs.bridged.opaqueValue == rhs.bridged.opaqueValue
   }
 
   public func hash(into hasher: inout Hasher) {
     hasher.combine(bridged.opaqueValue)
-  }
-
-  public static func < (lhs: Type, rhs: Type) -> Bool {
-    return "\(lhs)" < "\(rhs)"
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -241,13 +241,17 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
   }
 }
 
-extension Type: Equatable, Hashable {
+extension Type: Equatable, Hashable, Comparable {
   public static func ==(lhs: Type, rhs: Type) -> Bool { 
     lhs.bridged.opaqueValue == rhs.bridged.opaqueValue
   }
 
   public func hash(into hasher: inout Hasher) {
     hasher.combine(bridged.opaqueValue)
+  }
+
+  public static func < (lhs: Type, rhs: Type) -> Bool {
+    return "\(lhs)" < "\(rhs)"
   }
 }
 
@@ -294,11 +298,15 @@ public struct NominalFieldsArray : RandomAccessCollection, FormattedLikeArray {
   }
 }
 
-public struct EnumCase {
+public struct EnumCase : Equatable {
   public let enumElementDecl : EnumElementDecl
   public let payload: Type?
   public let index: Int
   public var name: StringRef { enumElementDecl.name }
+
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs.enumElementDecl == rhs.enumElementDecl
+  }
 }
 
 public struct EnumCases : CollectionLikeSequence, IteratorProtocol {


### PR DESCRIPTION
The conformances `Type: Comparable` and `EnumCase: Equatable` were previously introduced in #85757 for implementing AutoDiff closure specialization logic. This patch moves the latter directly to the SIL module. The conformance `Type: Comparable` is deleted, and `sort(by:)` is used instead of `sort` to mimic the same behavior in tests. These changes address warnings mentioned in the comment: https://github.com/swiftlang/swift/pull/85757#issuecomment-3681636278
