### PR TITLE
[cxx-interop] Fix missing implicit cast in synthesized code

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3649,12 +3649,13 @@ SwiftDeclSynthesizer::addRefCountOperations(
               const_cast<clang::CXXMethodDecl *>(calledMethod),
               clang::AS_public),
           /*HadMultipleCandidates=*/false, calledMethod->getNameInfo(),
-          methodType, clang::VK_PRValue, clang::OK_Ordinary);
-      auto memberCall = clang::CXXMemberCallExpr::Create(
-          clangCtx, memberExpr, {}, clangCtx.VoidTy, clang::VK_PRValue, loc,
-          clang::FPOptionsOverride());
+          clangCtx.BoundMemberTy, clang::VK_PRValue, clang::OK_Ordinary);
+      auto memberCall =
+          clangSema.BuildCallExpr(nullptr, memberExpr, clang::SourceLocation(),
+                                  {}, clang::SourceLocation());
+      ASSERT(memberCall.isUsable());
       method->setBody(clang::CompoundStmt::Create(
-          clangCtx, {memberCall}, clang::FPOptionsOverride(), loc, loc));
+          clangCtx, {memberCall.get()}, clang::FPOptionsOverride(), loc, loc));
     } else {
       clang::Expr *fnExpr = clang::DeclRefExpr::Create(
           clangCtx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(),

--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -22,20 +22,20 @@ private:
 
   int _refCount;
 
-  friend void retainSharedFRT(SharedFRT *_Nonnull);
+public:
+  void retainSharedFRT() {
+    ++_refCount;
+    logMsg("retain");
+  }
+
   friend void releaseSharedFRT(SharedFRT *_Nonnull);
-} SWIFT_SHARED_REFERENCE(retainSharedFRT, releaseSharedFRT);
+} SWIFT_SHARED_REFERENCE(.retainSharedFRT, releaseSharedFRT);
 
 class MyToken {
 public:
   MyToken() = default;
   MyToken(MyToken const &) {}
 };
-
-inline void retainSharedFRT(SharedFRT *_Nonnull x) {
-  ++x->_refCount;
-  x->logMsg("retain");
-}
 
 inline void releaseSharedFRT(SharedFRT *_Nonnull x) {
   --x->_refCount;


### PR DESCRIPTION
Follow up for #86124. I forgot to update on of the branches to use Sema to build the call expression, so the implicit casts responsible for the offset adjustments did not get inserted. Updated the tests to make sure both branches are covered.
