### PR TITLE
[6.3] Sema: Fix a case where we form a bogus curry thunk

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1047,8 +1047,7 @@ namespace {
         // "T.init(...)" -- pretend it has two argument lists like
         // a real '.' call.
         if (isa<ConstructorDecl>(member) &&
-            isa<CallExpr>(prev) &&
-            isa<TypeExpr>(cast<CallExpr>(prev)->getFn())) {
+            isa<CallExpr>(prev)) {
           assert(maxArgCount == 2);
           return 2;
         }

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -57,3 +57,21 @@ func castExpr(x: Any) {
     // CHECK: [[@LINE+1]]:15 | struct/Swift | S1 | [[S1_USR]] | Ref
     _ = x as? S1
 }
+
+// Test that initializers are indexed when called through Self.NestedType
+
+// CHECK: [[@LINE+1]]:7 | class(internal)/Swift | Container | [[Container_USR:.*]] | Def
+class Container {
+    // CHECK: [[@LINE+1]]:11 | class(internal)/Swift | NestedType | [[NestedType_USR:.*]] | Def
+    class NestedType {
+        // CHECK: [[@LINE+1]]:9 | constructor(internal)/Swift | init(value:) | [[NestedType_init_USR:.*]] | Def
+        init(value: Int) {}
+    }
+
+    func someFunc() {
+        // CHECK: [[@LINE+3]]:13 | class/Swift | Container | [[Container_USR]] | Ref
+        // CHECK: [[@LINE+2]]:18 | class/Swift | NestedType | [[NestedType_USR]] | Ref
+        // CHECK: [[@LINE+1]]:18 | constructor/Swift | init(value:) | [[NestedType_init_USR]] | Ref,Call
+        _ = Self.NestedType(value: 1)
+    }
+}

--- a/test/SILGen/bogus_curry_thunk.swift
+++ b/test/SILGen/bogus_curry_thunk.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+class Container {
+  class NestedType {}
+
+  func someFunc1() {
+    // This constructor call should not require a curry thunk.
+    _ = Container.NestedType()
+  }
+
+  func someFunc2() {
+    // This constructor call should not require a curry thunk.
+    _ = Self.NestedType()
+  }
+
+  func someFunc3() {
+    let m = Container.self
+
+    // This constructor call should not require a curry thunk.
+    _ = m.NestedType()
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17bogus_curry_thunk9ContainerC9someFunc1yyF : $@convention(method) (@guaranteed Container) -> () {
+// CHECK: bb0(%0 : @guaranteed $Container):
+// CHECK:   [[META2:%.*]] = metatype $@thick Container.NestedType.Type
+// CHECK:   [[FN:%.*]] = function_ref @$s17bogus_curry_thunk9ContainerC10NestedTypeCAEycfC : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]([[META2]]) : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   ignored_use [[RESULT]]
+// CHECK:   destroy_value [[RESULT]]
+// CHECK:   [[TUPLE:%.*]] = tuple ()
+// CHECK:   return [[TUPLE]]
+// CHECK: }
+
+
+// CHECK-LABEL: sil hidden [ossa] @$s17bogus_curry_thunk9ContainerC9someFunc2yyF : $@convention(method) (@guaranteed Container) -> () {
+// CHECK: bb0(%0 : @guaranteed $Container):
+// CHECK:   [[META2:%.*]] = metatype $@thick Container.NestedType.Type
+// CHECK:   [[FN:%.*]] = function_ref @$s17bogus_curry_thunk9ContainerC10NestedTypeCAEycfC : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]([[META2]]) : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   ignored_use [[RESULT]]
+// CHECK:   destroy_value [[RESULT]]
+// CHECK:   [[TUPLE:%.*]] = tuple ()
+// CHECK:   return [[TUPLE]]
+// CHECK: }
+
+
+// CHECK-LABEL: sil hidden [ossa] @$s17bogus_curry_thunk9ContainerC9someFunc3yyF : $@convention(method) (@guaranteed Container) -> () {
+// CHECK: bb0(%0 : @guaranteed $Container):
+// CHECK:   [[META:%.*]] = metatype $@thick Container.Type
+// CHECK:   [[META2:%.*]] = metatype $@thick Container.NestedType.Type
+// CHECK:   [[FN:%.*]] = function_ref @$s17bogus_curry_thunk9ContainerC10NestedTypeCAEycfC : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]([[META2]]) : $@convention(method) (@thick Container.NestedType.Type) -> @owned Container.NestedType
+// CHECK:   ignored_use [[RESULT]]
+// CHECK:   destroy_value [[RESULT]]
+// CHECK:   [[TUPLE:%.*]] = tuple ()
+// CHECK:   return [[TUPLE]]
+// CHECK: }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -381,3 +381,16 @@ protocol P {
   func foo() -> Self<Int>
   // expected-error@-1 {{cannot specialize non-generic type 'Self'}}
 }
+
+// https://github.com/peripheryapp/periphery/issues/676
+
+class Container {
+  class NestedType {
+    init(value: Int) {}
+  }
+
+  func someFunc() {
+    let _ = [Container.NestedType]()  // ok
+    let _ = [Self.NestedType]()  // ok
+  }
+}


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86146.

* **Description:** Sometimes the type checker would transform a constructor call `Foo.Bar()` into an immediately-applied curry thunk. While semantically equivalent, this apparently confused indexing. It is also less efficient, either resulting in runtime overhead or creating more work for the optimizer in the best case.

* **Origination:** Probably this has been broken for a long time.

* **Reviewed by:** @xedin 

* **Risk:** Low, unless the unnecessary autoclosure was load-bearing in some way.