### PR TITLE
reverted generic arguments strip

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3085,6 +3085,11 @@ ERROR(witness_not_as_sendable,none,
 NOTE(less_sendable_reqt_here,none,
      "expected sendability to match requirement here",
      ())
+ERROR(ambiguous_witnesses_wrong_type,none,
+      "conflicting type witnesses for associated type %0: %1 vs %2",
+      (DeclName, Type, Type))
+NOTE(ambiguous_witness_note_protocol,none,
+     "witness %1 inferred from protocol %0", (Identifier, Type))
 WARNING(witness_not_accessible_strict_check,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "

--- a/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
+++ b/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-module-interface(%t/Fancy.swiftinterface) %s -module-name Library
+// RUN: %target-swift-emit-module-interface(%t/Fancy.swiftinterface) %s -module-name Library -DINTERFACE_GEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/Fancy.swiftinterface) -module-name Library
 // RUN: %FileCheck %s < %t/Fancy.swiftinterface
 
@@ -58,3 +58,18 @@ public protocol R<E>: ~Copyable & ~Escapable {
 // CHECK: public typealias E = Swift.Int
 public struct N: R<Int> & B<Float64> & ~Copyable  {
 }
+
+public protocol P1<AT> { // expected-note {{witness 'Int' inferred from protocol 'P1'}}
+  associatedtype AT
+}
+
+public protocol P2<AT> {
+  associatedtype AT
+}
+
+// CHECK-COUNT-1: public typealias AT = Swift.Int
+public struct S1: P1<Int>, P2<Int> {}
+
+#if !INTERFACE_GEN
+public struct S2: P1<Int>, P2<String> {} // expected-error {{conflicting type witnesses for associated type 'AT': 'Int' vs 'String'}}
+#endif


### PR DESCRIPTION
When a type conforms to multiple parameterized protocols with
same-named associated types (e.g., `struct S: P<Int>, Q<Int>`),
the compiler was synthesizing duplicate typealias declarations,
causing module interface verification to fail.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
