### PR TITLE
[6.3][ABIChecker] Remove -iframework from swift-api-digester

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2099,10 +2099,6 @@ def BI : JoinedOrSeparate<["-"], "BI">,
 def BI_EQ : Joined<["-"], "BI=">, Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   Alias<BI>;
 
-def iframework : JoinedOrSeparate<["-"], "iframework">,
-  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
-  HelpText<"add a directory to the clang importer system framework search path">;
-
 def baseline_path : JoinedOrSeparate<["-"], "baseline-path">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
   HelpText<"The path to the Json file that we should use as the baseline">;

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -38,7 +38,6 @@
 #include "swift/Option/Options.h"
 #include "swift/Parse/ParseVersion.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
@@ -2365,7 +2364,6 @@ public:
     Triple = ParsedArgs.getLastArgValue(OPT_target).str();
     SwiftVersion = ParsedArgs.getLastArgValue(OPT_swift_version).str();
     SystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_Fsystem);
-    llvm::append_range(SystemFrameworkPaths, ParsedArgs.getAllArgValues(OPT_iframework));
     BaselineFrameworkPaths = ParsedArgs.getAllArgValues(OPT_BF);
     FrameworkPaths = ParsedArgs.getAllArgValues(OPT_F);
     SystemModuleImportPaths = ParsedArgs.getAllArgValues(OPT_Isystem);


### PR DESCRIPTION
- **Explanation**: SwiftBuild stopped using `-iframework` in favor of `-Fsystem` in 6.3. The defunct argument should be removed so that no one gets confused which argument is correct.
- **Scope**: It's unknown if there are any uses of `swift-api-digester` outside of SwiftBuild. If there are, they will need to update their argument name. SwiftBuild and Xcode will be unaffected (as they've already updated their arguments).
- **Issues**:
- **Original PRs**: https://github.com/swiftlang/swift/pull/85470
- **Risk**: Low risk, there are probably few uses of `swift-api-digester` outside of SwiftBuild, and the fix is trivial even if there are.
- **Testing**: Verified that `-iframework` is no longer an available argument, and that `-Fsystem` is passed through via lit testing.
- **Reviewers**: [Xi Ge](https://github.com/nkcsgexi)