### PR TITLE
[6.3][cxx-interop] Fix miscompilation for inferred shared references

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -216,8 +216,12 @@ public:
                                           DeclContext *newContext,
                                           ClangInheritanceInfo inheritance) = 0;
 
-  /// Returnes the original method if \param decl is a clone from a base class
+  /// Returns the original method if \param decl is a clone from a base class
   virtual ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) = 0;
+
+  /// Returns true if we synthesize this member for every type so no need to
+  /// clone it for the derived classes.
+  virtual bool isMemberSynthesizedPerType(const ValueDecl *decl) = 0;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -640,6 +640,7 @@ public:
                                   ClangInheritanceInfo inheritance) override;
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) override;
+  bool isMemberSynthesizedPerType(const ValueDecl *decl) override;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -500,7 +500,7 @@ struct CustomRefCountingOperationResult {
 
   CustomRefCountingOperationResultKind kind;
   ValueDecl *operation;
-  std::string name;
+  StringRef name;
 };
 
 class CustomRefCountingOperation

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6575,6 +6575,7 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
       auto namedMember = dyn_cast<ValueDecl>(member);
       if (!namedMember || !namedMember->hasName() ||
           namedMember->getName().getBaseName() != name ||
+          clangModuleLoader->isMemberSynthesizedPerType(namedMember) ||
           clangModuleLoader->getOriginalForClonedMember(namedMember))
         continue;
 
@@ -7984,6 +7985,16 @@ ValueDecl *ClangImporter::Implementation::getOriginalForClonedMember(
   return nullptr;
 }
 
+bool ClangImporter::Implementation::isMemberSynthesizedPerType(
+    const ValueDecl *decl) {
+  return membersSynthesizedPerType.contains(decl);
+}
+
+void ClangImporter::Implementation::markMemberSynthesizedPerType(
+    const ValueDecl *decl) {
+  membersSynthesizedPerType.insert(decl);
+}
+
 size_t ClangImporter::Implementation::getImportedBaseMemberDeclArity(
     const ValueDecl *valueDecl) {
   if (auto *func = dyn_cast<FuncDecl>(valueDecl)) {
@@ -8002,6 +8013,10 @@ ClangImporter::importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
 
 ValueDecl *ClangImporter::getOriginalForClonedMember(const ValueDecl *decl) {
   return Impl.getOriginalForClonedMember(decl);
+}
+
+bool ClangImporter::isMemberSynthesizedPerType(const ValueDecl *decl) {
+  return Impl.isMemberSynthesizedPerType(decl);
 }
 
 void ClangImporter::diagnoseTopLevelValue(const DeclName &name) {
@@ -8157,12 +8172,15 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
   auto clangDecl = decl->getClangDecl();
   llvm::SmallVector<ValueDecl *, 1> results;
 
-  if (name.starts_with(".")) {
+  if (name.consume_front(".")) {
     // Look for a member of decl instead of a global.
-    StringRef memberName = name.drop_front(1);
-    if (memberName.empty())
+    if (name.empty())
       return {};
-    auto declName = DeclName(ctx.getIdentifier(memberName));
+    auto declName = DeclName(ctx.getIdentifier(name));
+    auto swiftLookupResults = decl->lookupDirect(declName);
+    if (!swiftLookupResults.empty())
+      return SmallVector<ValueDecl *, 1>(swiftLookupResults.begin(),
+                                         swiftLookupResults.end());
     auto allResults = evaluateOrDefault(
         ctx.evaluator, ClangRecordMemberLookup({decl, declName}), {});
     return SmallVector<ValueDecl *, 1>(allResults.begin(), allResults.end());
@@ -8193,9 +8211,9 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
   return results;
 }
 
-static const clang::RecordDecl *
-getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
-                   ClangImporter::Implementation *importerImpl) {
+const clang::RecordDecl *
+importer::getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
+                             ClangImporter::Implementation *importerImpl) {
   auto refParentDecls = getRefParentDecls(decl, ctx, importerImpl);
   if (refParentDecls.empty())
     return nullptr;
@@ -8208,11 +8226,11 @@ getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
     assert(refParentDecl && "refParentDecl is null inside getRefParentOrDiag");
     for (const auto *attr : refParentDecl->getAttrs()) {
       if (const auto swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr)) {
-        const auto &attribute = swiftAttr->getAttribute();
-        if (attribute.starts_with(retainPrefix))
-          uniqueRetainDecls.insert(attribute.drop_front(retainPrefix.size()));
-        else if (attribute.starts_with(releasePrefix))
-          uniqueReleaseDecls.insert(attribute.drop_front(releasePrefix.size()));
+        auto attribute = swiftAttr->getAttribute();
+        if (attribute.consume_front(retainPrefix))
+          uniqueRetainDecls.insert(attribute);
+        else if (attribute.consume_front(releasePrefix))
+          uniqueReleaseDecls.insert(attribute);
       }
     }
   }
@@ -8765,19 +8783,12 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     Evaluator &evaluator, CustomRefCountingOperationDescriptor desc) const {
   auto swiftDecl = desc.decl;
   auto operation = desc.kind;
-  auto &ctx = swiftDecl->getASTContext();
 
-  std::string operationStr = operation == CustomRefCountingOperationKind::retain
-                                 ? "retain:"
-                                 : "release:";
+  StringRef operationStr = operation == CustomRefCountingOperationKind::retain
+                               ? "retain:"
+                               : "release:";
 
   auto decl = cast<clang::RecordDecl>(swiftDecl->getClangDecl());
-
-  if (!hasImportAsRefAttr(decl)) {
-    if (auto parentRefDecl = getRefParentOrDiag(decl, ctx, nullptr))
-      decl = parentRefDecl;
-  }
-
   if (!decl->hasAttrs())
     return {CustomRefCountingOperationResult::noAttribute, nullptr, ""};
 
@@ -8796,10 +8807,8 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
   if (retainReleaseAttrs.size() > 1)
     return {CustomRefCountingOperationResult::tooManyAttributes, nullptr, ""};
 
-  auto name = retainReleaseAttrs.front()
-                  ->getAttribute()
-                  .drop_front(StringRef(operationStr).size())
-                  .str();
+  auto name = retainReleaseAttrs.front()->getAttribute().drop_front(
+      operationStr.size());
 
   if (name == "immortal")
     return {CustomRefCountingOperationResult::immortal, nullptr, name};

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2127,6 +2127,39 @@ namespace {
       return;
     }
 
+    std::pair<CustomRefCountingOperationResult,
+              CustomRefCountingOperationResult>
+    addRefCountOperationsIfRequired(ClassDecl *nominal,
+                                    clang::RecordDecl *clangType) {
+      auto &context = Impl.SwiftContext;
+      auto nonInheritedRefCountingOperations = [&] {
+        auto retainResult = evaluateOrDefault(
+            context.evaluator,
+            CustomRefCountingOperation(
+                {nominal, CustomRefCountingOperationKind::retain}),
+            {});
+        auto releaseResult = evaluateOrDefault(
+            context.evaluator,
+            CustomRefCountingOperation(
+                {nominal, CustomRefCountingOperationKind::release}),
+            {});
+        return std::make_pair(retainResult, releaseResult);
+      };
+      auto clangDecl = dyn_cast<clang::CXXRecordDecl>(clangType);
+      if (!clangDecl)
+        return nonInheritedRefCountingOperations();
+      auto baseClangDecl = dyn_cast_or_null<clang::CXXRecordDecl>(
+          getRefParentOrDiag(clangDecl, context, nullptr));
+      if (!baseClangDecl || baseClangDecl == clangDecl)
+        return nonInheritedRefCountingOperations();
+
+      auto baseSwiftDecl = cast<ClassDecl>(
+          Impl.importDecl(baseClangDecl, getActiveSwiftVersion()));
+
+      return synthesizer.addRefCountOperations(nominal, clangDecl,
+                                               baseSwiftDecl, baseClangDecl);
+    }
+
     Decl *VisitRecordDecl(const clang::RecordDecl *decl) {
       // Track whether this record contains fields we can't reference in Swift
       // as stored properties.
@@ -2715,7 +2748,11 @@ namespace {
       }
 
       if (auto classDecl = dyn_cast<ClassDecl>(result)) {
-        validateForeignReferenceType(decl, classDecl);
+        auto operations = addRefCountOperationsIfRequired(
+            classDecl, const_cast<clang::RecordDecl *>(decl));
+
+        validateForeignReferenceType(decl, classDecl, operations.first,
+                                     operations.second);
 
         auto availability = Impl.SwiftContext.getSwift58Availability();
         if (!availability.isAlwaysAvailable()) {
@@ -2778,8 +2815,10 @@ namespace {
       }
     }
 
-    void validateForeignReferenceType(const clang::RecordDecl *decl,
-                                      ClassDecl *classDecl) {
+    void validateForeignReferenceType(
+        const clang::RecordDecl *decl, ClassDecl *classDecl,
+        CustomRefCountingOperationResult retainOperation,
+        CustomRefCountingOperationResult releaseOperation) {
 
       enum class RetainReleaseOperationKind {
         notAfunction,
@@ -2862,11 +2901,6 @@ namespace {
         return RetainReleaseOperationKind::valid;
       };
 
-      auto retainOperation = evaluateOrDefault(
-          Impl.SwiftContext.evaluator,
-          CustomRefCountingOperation(
-              {classDecl, CustomRefCountingOperationKind::retain}),
-          {});
       if (retainOperation.kind ==
           CustomRefCountingOperationResult::noAttribute) {
         HeaderLoc loc(decl->getLocation());
@@ -2933,11 +2967,6 @@ namespace {
                CustomRefCountingOperationResult::immortal);
       }
 
-      auto releaseOperation = evaluateOrDefault(
-          Impl.SwiftContext.evaluator,
-          CustomRefCountingOperation(
-              {classDecl, CustomRefCountingOperationKind::release}),
-          {});
       if (releaseOperation.kind ==
           CustomRefCountingOperationResult::noAttribute) {
         HeaderLoc loc(decl->getLocation());

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -48,6 +48,7 @@
 #include "clang/Serialization/ModuleFileExtension.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallBitVector.h"
@@ -706,6 +707,7 @@ private:
 
   // Map all cloned methods back to the original member
   llvm::DenseMap<ValueDecl *, ValueDecl *> clonedMembers;
+  llvm::DenseSet<const ValueDecl *> membersSynthesizedPerType;
 
   // Keep track of methods that are unavailale in each class.
   // We need this set because these methods will be imported lazily. We don't
@@ -724,6 +726,8 @@ public:
                                   ClangInheritanceInfo inheritance);
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl);
+  bool isMemberSynthesizedPerType(const ValueDecl *decl);
+  void markMemberSynthesizedPerType(const ValueDecl *decl);
 
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
 
@@ -2233,6 +2237,11 @@ getImplicitObjectParamAnnotation(const clang::FunctionDecl *FD) {
   }
   return nullptr;
 }
+
+/// Find a unique base class that is annotated as SHARED_REFERENCE if any.
+const clang::RecordDecl *
+getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
+                   ClangImporter::Implementation *importerImpl);
 
 } // end namespace importer
 } // end namespace swift

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -27,6 +27,7 @@
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/Mangle.h"
 #include "clang/Sema/DelayedDiagnostic.h"
+#include "clang/Sema/Sema.h"
 
 using namespace swift;
 using namespace importer;
@@ -3151,6 +3152,138 @@ void SwiftDeclSynthesizer::addExplicitDeinitIfRequired(
       synthesizeDeinitBodyForCustomDestroy, destroyFunc);
 
   nominal->addMember(destructor);
+}
+
+static void cloneReferenceAttributes(const clang::CXXRecordDecl *from,
+                                     clang::CXXRecordDecl *to,
+                                     clang::ASTContext &ctx) {
+  if (!from->hasAttr<clang::SwiftAttrAttr>())
+    return;
+  for (auto attr : from->getAttrs()) {
+    if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+      if (swiftAttr->getAttribute().starts_with("release:"))
+        to->addAttr(
+            clang::SwiftAttrAttr::Create(ctx, swiftAttr->getAttribute()));
+      else if (swiftAttr->getAttribute().starts_with("retain:"))
+        to->addAttr(
+            clang::SwiftAttrAttr::Create(ctx, swiftAttr->getAttribute()));
+    }
+  }
+}
+
+std::pair<CustomRefCountingOperationResult, CustomRefCountingOperationResult>
+SwiftDeclSynthesizer::addRefCountOperations(
+    ClassDecl *decl, clang::CXXRecordDecl *clangDecl, const ClassDecl *baseDecl,
+    const clang::CXXRecordDecl *baseClangDecl) {
+  auto &context = ImporterImpl.SwiftContext;
+  auto &clangCtx = ImporterImpl.getClangASTContext();
+  auto retainResult =
+      evaluateOrDefault(context.evaluator,
+                        CustomRefCountingOperation(
+                            {baseDecl, CustomRefCountingOperationKind::retain}),
+                        {});
+  auto releaseResult = evaluateOrDefault(
+      context.evaluator,
+      CustomRefCountingOperation(
+          {baseDecl, CustomRefCountingOperationKind::release}),
+      {});
+  if (retainResult.kind == CustomRefCountingOperationResult::immortal ||
+      releaseResult.kind == CustomRefCountingOperationResult::immortal) {
+    cloneReferenceAttributes(baseClangDecl, clangDecl, clangCtx);
+    return std::make_pair(retainResult, releaseResult);
+  }
+  if (!retainResult.operation || !releaseResult.operation)
+    return std::make_pair(retainResult, releaseResult);
+  auto retainClangFn =
+      cast<clang::FunctionDecl>(retainResult.operation->getClangDecl());
+  auto releaseClangFn =
+      cast<clang::FunctionDecl>(releaseResult.operation->getClangDecl());
+
+  // Synthesize forwarding function.
+  auto &clangSema = ImporterImpl.getClangSema();
+
+  clang::QualType methodType = clangCtx.getFunctionType(
+      clangCtx.VoidTy, {}, clang::FunctionProtoType::ExtProtoInfo{});
+
+  auto generateLifetimeOperation =
+      [&](const clang::FunctionDecl *fd) -> const clang::CXXMethodDecl * {
+    auto loc = fd->getLocation();
+    auto &ident = clangCtx.Idents.get("__synthesized_lifetimeAccessor_" +
+                                      fd->getNameAsString());
+    clang::DeclarationName methodName(&ident);
+    auto method = clang::CXXMethodDecl::Create(
+        clangCtx, clangDecl, fd->getSourceRange().getBegin(),
+        clang::DeclarationNameInfo(methodName, clang::SourceLocation()),
+        methodType, clangCtx.getTrivialTypeSourceInfo(methodType),
+        clang::SC_None,
+        /*usesFPIntrin=*/false, /*isInline=*/true,
+        clang::ConstexprSpecKind::Unspecified, fd->getSourceRange().getEnd());
+    method->setImplicit();
+    method->setImplicitlyInline();
+    method->setAccess(clang::AccessSpecifier::AS_public);
+    method->addAttr(clang::NoDebugAttr::CreateImplicit(clangCtx));
+
+    clang::Expr *argExpr =
+        clang::CXXThisExpr::Create(clangCtx, clang::SourceLocation(),
+                                   method->getThisType(), /*IsImplicit=*/false);
+
+    if (auto calledMethod = dyn_cast<clang::CXXMethodDecl>(fd)) {
+      if (calledMethod->isStatic())
+        return nullptr;
+      auto memberExpr = clangSema.BuildMemberExpr(
+          argExpr, /*isArrow=*/true, loc, clang::NestedNameSpecifierLoc(),
+          clang::SourceLocation(),
+          const_cast<clang::CXXMethodDecl *>(calledMethod),
+          clang::DeclAccessPair::make(
+              const_cast<clang::CXXMethodDecl *>(calledMethod),
+              clang::AS_public),
+          /*HadMultipleCandidates=*/false, calledMethod->getNameInfo(),
+          methodType, clang::VK_PRValue, clang::OK_Ordinary);
+      auto memberCall = clang::CXXMemberCallExpr::Create(
+          clangCtx, memberExpr, {}, clangCtx.VoidTy, clang::VK_PRValue, loc,
+          clang::FPOptionsOverride());
+      method->setBody(clang::CompoundStmt::Create(
+          clangCtx, {memberCall}, clang::FPOptionsOverride(), loc, loc));
+    } else {
+      clang::Expr *fnExpr = clang::DeclRefExpr::Create(
+          clangCtx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(),
+          const_cast<clang::FunctionDecl *>(fd),
+          /*RefersToEnclosingVariableOrCapture=*/false, loc, fd->getType(),
+          clang::VK_LValue);
+      auto call =
+          clangSema.BuildCallExpr(nullptr, fnExpr, clang::SourceLocation(),
+                                  {argExpr}, clang::SourceLocation());
+      method->setBody(clang::CompoundStmt::Create(
+          clangCtx, {call.get()}, clang::FPOptionsOverride(), loc, loc));
+    }
+    return method;
+  };
+
+  auto synthesizedRetain = generateLifetimeOperation(retainClangFn);
+  auto synthesizedRelease = generateLifetimeOperation(releaseClangFn);
+  if (!synthesizedRetain || !synthesizedRelease)
+    return std::make_pair(retainResult, releaseResult);
+
+  // Add attributes to class.
+  clangDecl->addAttr(clang::SwiftAttrAttr::Create(
+      clangCtx,
+      context.AllocateCopy("retain:." + synthesizedRetain->getNameAsString())));
+  clangDecl->addAttr(clang::SwiftAttrAttr::Create(
+      clangCtx, context.AllocateCopy("release:." +
+                                     synthesizedRelease->getNameAsString())));
+
+  // Update the Swift type
+  auto importRefCountOp = [&](const clang::CXXMethodDecl *op) {
+    auto importedOp =
+        cast<ValueDecl>(context.getClangModuleLoader()->importDeclDirectly(op));
+    ImporterImpl.markMemberSynthesizedPerType(importedOp);
+    decl->addMember(importedOp);
+    decl->addMemberToLookupTable(importedOp);
+  };
+  importRefCountOp(synthesizedRetain);
+  importRefCountOp(synthesizedRelease);
+
+  return std::make_pair(retainResult, releaseResult);
 }
 
 FuncDecl *SwiftDeclSynthesizer::makeAvailabilityDomainPredicate(

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3238,12 +3238,13 @@ SwiftDeclSynthesizer::addRefCountOperations(
               const_cast<clang::CXXMethodDecl *>(calledMethod),
               clang::AS_public),
           /*HadMultipleCandidates=*/false, calledMethod->getNameInfo(),
-          methodType, clang::VK_PRValue, clang::OK_Ordinary);
-      auto memberCall = clang::CXXMemberCallExpr::Create(
-          clangCtx, memberExpr, {}, clangCtx.VoidTy, clang::VK_PRValue, loc,
-          clang::FPOptionsOverride());
+          clangCtx.BoundMemberTy, clang::VK_PRValue, clang::OK_Ordinary);
+      auto memberCall =
+          clangSema.BuildCallExpr(nullptr, memberExpr, clang::SourceLocation(),
+                                  {}, clang::SourceLocation());
+      ASSERT(memberCall.isUsable());
       method->setBody(clang::CompoundStmt::Create(
-          clangCtx, {memberCall}, clang::FPOptionsOverride(), loc, loc));
+          clangCtx, {memberCall.get()}, clang::FPOptionsOverride(), loc, loc));
     } else {
       clang::Expr *fnExpr = clang::DeclRefExpr::Create(
           clangCtx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(),

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -15,6 +15,8 @@
 
 #include "ImporterImpl.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
+#include "clang/AST/DeclCXX.h"
 
 namespace swift {
 
@@ -347,6 +349,14 @@ public:
   /// that calls that destroy operation.
   void addExplicitDeinitIfRequired(
       NominalTypeDecl *nominal, const clang::RecordDecl *clangType);
+
+  /// When a base class is marked as SHARED_REFERENCE, synthesize a call to
+  /// the ref counting operations. This call does the derived to base conversion
+  /// that is responsible for all the offset adjustments on the pointer.
+  std::pair<CustomRefCountingOperationResult, CustomRefCountingOperationResult>
+  addRefCountOperations(ClassDecl *decl, clang::CXXRecordDecl *clangDecl,
+                        const ClassDecl *baseDecl,
+                        const clang::CXXRecordDecl *baseClangDecl);
 
   /// Synthesize a Swift function that calls the Clang runtime predicate
   /// function for the availability domain represented by `var`.

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -109,8 +109,8 @@ __attribute__((swift_attr("release:immortal"))) ImmortalRefType {};
 ImmortalRefType *returnImmortalRefType() { return new ImmortalRefType(); };
 
 struct DerivedFromImmortalRefType : ImmortalRefType {};
-DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() { // expected-note {{annotate 'returnDerivedFromImmortalRefType()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED}}
-    return new DerivedFromImmortalRefType();
+DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() {
+  return new DerivedFromImmortalRefType();
 };
 
 } // namespace ImmortalRefereceExample

--- a/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/lifetime-operation-methods.h
@@ -112,8 +112,8 @@ struct StaticRetainRelease {
 } SWIFT_SHARED_REFERENCE(.staticRetain, .staticRelease);
 
 struct DerivedStaticRetainRelease : StaticRetainRelease {
-// expected-error@-1 {{cannot find retain function '.staticRetain' for reference type 'DerivedStaticRetainRelease'}}
-// expected-error@-2 {{cannot find release function '.staticRelease' for reference type 'DerivedStaticRetainRelease'}}
+// expected-error@-1 {{specified release function '.staticRelease' is a static function; expected an instance function}}
+// expected-error@-2 {{specified retain function '.staticRetain' is a static function; expected an instance function}}
   int secondValue = 1;
   DerivedStaticRetainRelease(int value, int secondValue)
       : StaticRetainRelease(value), secondValue(secondValue) {}

--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -22,20 +22,20 @@ private:
 
   int _refCount;
 
-  friend void retainSharedFRT(SharedFRT *_Nonnull);
+public:
+  void retainSharedFRT() {
+    ++_refCount;
+    logMsg("retain");
+  }
+
   friend void releaseSharedFRT(SharedFRT *_Nonnull);
-} SWIFT_SHARED_REFERENCE(retainSharedFRT, releaseSharedFRT);
+} SWIFT_SHARED_REFERENCE(.retainSharedFRT, releaseSharedFRT);
 
 class MyToken {
 public:
   MyToken() = default;
   MyToken(MyToken const &) {}
 };
-
-inline void retainSharedFRT(SharedFRT *_Nonnull x) {
-  ++x->_refCount;
-  x->logMsg("retain");
-}
 
 inline void releaseSharedFRT(SharedFRT *_Nonnull x) {
   --x->_refCount;

--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -85,3 +85,10 @@ private:
   explicit Payload(int value) : m_value(value) {}
   int m_value;
 };
+
+struct FirstBase {
+  int a, b, c;
+  virtual ~FirstBase() {}
+};
+
+struct DerivedFRT : FirstBase, SharedFRT {};

--- a/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import LoggingFrts
+
+func go() {
+    let frt = DerivedFRT()
+    let copy = frt
+}
+
+go()
+
+// CHECK: RefCount: 1, message: Ctor
+// CHECK: RefCount: 2, message: retain
+// CHECK: RefCount: 1, message: release
+// CHECK: RefCount: 0, message: release
+// CHECK: RefCount: 0, message: Dtor

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -6,7 +6,7 @@
 import Inheritance
 
 let _ = ImmortalRefereceExample.returnImmortalRefType()
-let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType() // expected-warning {{cannot infer ownership of foreign reference value returned by 'returnDerivedFromImmortalRefType()'}}
+let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType()
 
 let _ = ExplicitAnnotationHasPrecedence1.returnValueType()
 let _ = ExplicitAnnotationHasPrecedence1.returnRefType() // expected-warning {{cannot infer ownership of foreign reference value returned by 'returnRefType()'}}


### PR DESCRIPTION
Explanation: When the reference count operation is defined for a base class and that base class is not at offset 0 we need to do offset adjustments before calling the refcount operations. We did not do that. This PR adds clang stubs that will do correct codegen for the derived to base conversions to avoid the miscompilation. This is a similar strategy what we do for inherited member functions.
Issues: rdar://166227787
Original PRs: #86124, #86184
Risk: Medium, there is a change in how we handle shared reference annotations when only a base class is annotated but this is a case that was already buggy in many cases. On the other hand, synthesizing new/more code always have a slight risk of generating code that would not compile.
Testing: Added a compiler test.
Reviewers: @egorzhdan @j-hui