### PR TITLE
[stdlib] Fix documentation typo in TaskPrivate.h

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -63,7 +63,7 @@ class ActiveTaskStatus;
 /// done on behalf of a child task.
 void *_swift_task_alloc_specific(AsyncTask *task, size_t size);
 
-/// dellocate task-local memory on behalf of a specific task,
+/// deallocate task-local memory on behalf of a specific task,
 /// not necessarily the current one.  Generally this should only be
 /// done on behalf of a child task.
 void _swift_task_dealloc_specific(AsyncTask *task, void *ptr);


### PR DESCRIPTION
Hi, I fixed a documentation typo in `TaskPrivate.h`.

- `dellocate` → `deallocate`

Please check out the changes. Thanks!