### PR TITLE
[cxx-interop] Add API Notes for std::unique_ptr

### DIFF
--- a/stdlib/public/Cxx/std/std.apinotes
+++ b/stdlib/public/Cxx/std/std.apinotes
@@ -33,4 +33,5 @@ Namespaces:
       SwiftSafety: safe
     - Name: empty
       SwiftSafety: safe
- 
+  - Name: unique_ptr
+    SwiftCopyable: false

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 struct NonCopyable {
@@ -92,6 +93,15 @@ inline std::unique_ptr<CountCopies> getCopyCountedUniquePtr() { return std::make
 struct HasUniqueIntVector {
   HasUniqueIntVector() = default;
   std::vector<std::unique_ptr<int>> x;
+};
+
+struct HasUnorderedMap {
+  HasUnorderedMap() = default;
+  HasUnorderedMap(const HasUnorderedMap &) = default;
+  HasUnorderedMap(HasUnorderedMap &&) = default;
+  std::unordered_map<int,
+                     std::vector<std::unique_ptr<int>>>
+      field;
 };
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr-typechecker.swift
@@ -14,3 +14,6 @@ takeCopyable(vecUniquePtr)
 let uniqueIntVec = HasUniqueIntVector()
 takeCopyable(uniqueIntVec)
 // CHECK: error: global function 'takeCopyable' requires that 'HasUniqueIntVector' conform to 'Copyable'
+
+let unorderedMap = HasUnorderedMap()
+_ = unorderedMap.field


### PR DESCRIPTION
Sometimes we call the `CxxValueSemantics` request before we have the definition of `std::unique_ptr`, which makes the compiler erroneously import it as copyable. This PR adds API Notes for `std::unique_ptr` to make sure we always import it as non-copyable.

These changes are dependent on https://github.com/llvm/llvm-project/pull/173386, because we currently import API Notes twice for class template specializations, ending up with duplicate `~Copyable` attributes, which is an error.

rdar://166179307
