### PR TITLE
[stdlib] Fix _ObjectiveCBridgeable conformance crash for swift_newtype on non-ObjC platform

### DIFF
--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -98,7 +98,6 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
   }
 }
 
-#if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue: _ObjectiveCBridgeable {
   // Note: This is the only default typealias for _ObjectiveCType, because
   // constrained extensions aren't allowed to define types in different ways.
@@ -173,5 +172,3 @@ extension _SwiftNewtypeWrapper where Self.RawValue: AnyObject {
     return Self(rawValue: source!)!
   }
 }
-#endif
-

--- a/test/ClangImporter/Inputs/custom-modules/NewtypeFoundation.h
+++ b/test/ClangImporter/Inputs/custom-modules/NewtypeFoundation.h
@@ -1,0 +1,6 @@
+// Test header for swift_newtype with Foundation types
+
+#include <stdint.h>
+
+// Test swift_newtype with integer types on all platforms
+typedef uint32_t MyUInt32Newtype __attribute__((swift_newtype(struct)));

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -110,6 +110,10 @@ module NewtypeSystem [system] {
   header "NewtypeSystem.h"
 }
 
+module NewtypeFoundation {
+  header "NewtypeFoundation.h"
+}
+
 module ImportAsMember {
   export *
 

--- a/test/ClangImporter/swift_newtype_foundation.swift
+++ b/test/ClangImporter/swift_newtype_foundation.swift
@@ -1,57 +1,41 @@
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
-// Test that swift_newtype works on all platforms when Foundation is imported.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
+// Build the FoundationStub module first
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/FoundationStub.swiftmodule -module-name FoundationStub %t/FoundationStub.swift
 
-// REQUIRES: OS=linux-gnu || OS=windows-msvc
+// Test that swift_newtype works on all platforms when _ObjectiveCBridgeable is available.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %t/main.swift -verify
 
 // This test verifies the fix for https://github.com/swiftlang/swift/issues/71086
-// Previously, importing swift_newtype types with Foundation would crash on non-ObjC
-// platforms because the _ObjectiveCBridgeable extension in NewtypeWrapper.swift was
-// incorrectly guarded by #if _runtime(_ObjC), preventing it from being available on
-// Linux even though _ObjectiveCBridgeable is available via swift-corelibs-foundation.
+// Previously, importing swift_newtype types would crash on non-ObjC platforms
+// because the _ObjectiveCBridgeable extension in NewtypeWrapper.swift was
+// incorrectly guarded by #if _runtime(_ObjC), preventing it from being available
+// on Linux even though _ObjectiveCBridgeable is available via swift-corelibs-foundation.
 
-import NewtypeFoundation
-
-// Stub Foundation types for non-Darwin platforms since the mock SDK doesn't include them
-// Minimal NSObject stub
-class NSObject {
-  init() {}
-
-  func isEqual(_ object: Any?) -> Bool {
-    return false
-  }
-}
+//--- FoundationStub.swift
 
 // Minimal NSNumber stub for testing
-class NSNumber: NSObject {
+public class NSNumber {
   private var _value: UInt64
 
-  init(value: UInt32) {
+  public init(value: UInt32) {
     self._value = UInt64(value)
-    super.init()
   }
 
-  var uint32Value: UInt32 {
+  public var uint32Value: UInt32 {
     return UInt32(truncatingIfNeeded: _value)
-  }
-
-  override func isEqual(_ object: Any?) -> Bool {
-    guard let other = object as? NSNumber else { return false }
-    return self._value == other._value
   }
 }
 
-// UInt32 bridging conformance for non-Darwin platforms
-extension UInt32: _ObjectiveCBridgeable {
+// UInt32 bridging conformance
+extension UInt32: @retroactive _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSNumber {
     return NSNumber(value: self)
   }
 
   public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) {
-    if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
-      fatalError("Unable to bridge \(type(of: x)) to \(self)")
-    }
+    result = x.uint32Value
   }
 
   public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) -> Bool {
@@ -65,15 +49,20 @@ extension UInt32: _ObjectiveCBridgeable {
   }
 }
 
+//--- main.swift
+
+import NewtypeFoundation
+import FoundationStub
+
 // Test that the newtype wrapper conforms to _ObjectiveCBridgeable when the
 // underlying type does
 func acceptObjectiveCBridgeable<T: _ObjectiveCBridgeable>(_ t: T) {}
 
 func testUInt32Newtype(attr: MyUInt32Newtype) {
-  // UInt32 conforms to _ObjectiveCBridgeable on all platforms (via Foundation)
+  // UInt32 conforms to _ObjectiveCBridgeable (via FoundationStub)
   // so MyUInt32Newtype should also conform
   acceptObjectiveCBridgeable(attr)
-  
+
   // Test that we can use the newtype
   let _ = attr.rawValue
   let copy = MyUInt32Newtype(rawValue: 42)
@@ -85,7 +74,7 @@ func testEquatableHashable(a: MyUInt32Newtype, b: MyUInt32Newtype) {
   let _ = a == b
   let _ = a != b
   let _ = a.hashValue
-  
+
   var dict: [MyUInt32Newtype: String] = [:]
   dict[a] = "test"
   let _ = dict[b]
@@ -99,7 +88,7 @@ func testCollections() {
     MyUInt32Newtype(rawValue: 3)
   ]
   let _ = array.count
-  
+
   let set: Set<MyUInt32Newtype> = [
     MyUInt32Newtype(rawValue: 1),
     MyUInt32Newtype(rawValue: 2)
@@ -115,4 +104,3 @@ struct Container: Equatable {
 func testContainerEquatable(a: Container, b: Container) {
   let _ = a == b
 }
-

--- a/test/ClangImporter/swift_newtype_foundation.swift
+++ b/test/ClangImporter/swift_newtype_foundation.swift
@@ -3,14 +3,67 @@
 // Test that swift_newtype works on all platforms when Foundation is imported.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
+// REQUIRES: OS=linux-gnu || OS=windows-msvc
+
 // This test verifies the fix for https://github.com/swiftlang/swift/issues/71086
 // Previously, importing swift_newtype types with Foundation would crash on non-ObjC
 // platforms because the _ObjectiveCBridgeable extension in NewtypeWrapper.swift was
 // incorrectly guarded by #if _runtime(_ObjC), preventing it from being available on
 // Linux even though _ObjectiveCBridgeable is available via swift-corelibs-foundation.
 
-import Foundation
 import NewtypeFoundation
+
+// Stub Foundation types for non-Darwin platforms since the mock SDK doesn't include them
+// Minimal NSObject stub
+class NSObject {
+  init() {}
+
+  func isEqual(_ object: Any?) -> Bool {
+    return false
+  }
+}
+
+// Minimal NSNumber stub for testing
+class NSNumber: NSObject {
+  private var _value: UInt64
+
+  init(value: UInt32) {
+    self._value = UInt64(value)
+    super.init()
+  }
+
+  var uint32Value: UInt32 {
+    return UInt32(truncatingIfNeeded: _value)
+  }
+
+  override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? NSNumber else { return false }
+    return self._value == other._value
+  }
+}
+
+// UInt32 bridging conformance for non-Darwin platforms
+extension UInt32: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber {
+    return NSNumber(value: self)
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) {
+    if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+      fatalError("Unable to bridge \(type(of: x)) to \(self)")
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) -> Bool {
+    result = x.uint32Value
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt32 {
+    guard let src = source else { return 0 }
+    return src.uint32Value
+  }
+}
 
 // Test that the newtype wrapper conforms to _ObjectiveCBridgeable when the
 // underlying type does

--- a/test/ClangImporter/swift_newtype_foundation.swift
+++ b/test/ClangImporter/swift_newtype_foundation.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+
+// Test that swift_newtype works on all platforms when Foundation is imported.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
+
+// This test verifies the fix for https://github.com/swiftlang/swift/issues/71086
+// Previously, importing swift_newtype types with Foundation would crash on non-ObjC
+// platforms because the _ObjectiveCBridgeable extension in NewtypeWrapper.swift was
+// incorrectly guarded by #if _runtime(_ObjC), preventing it from being available on
+// Linux even though _ObjectiveCBridgeable is available via swift-corelibs-foundation.
+
+import Foundation
+import NewtypeFoundation
+
+// Test that the newtype wrapper conforms to _ObjectiveCBridgeable when the
+// underlying type does
+func acceptObjectiveCBridgeable<T: _ObjectiveCBridgeable>(_ t: T) {}
+
+func testUInt32Newtype(attr: MyUInt32Newtype) {
+  // UInt32 conforms to _ObjectiveCBridgeable on all platforms (via Foundation)
+  // so MyUInt32Newtype should also conform
+  acceptObjectiveCBridgeable(attr)
+  
+  // Test that we can use the newtype
+  let _ = attr.rawValue
+  let copy = MyUInt32Newtype(rawValue: 42)
+  let _ = copy
+}
+
+// Test that Equatable and Hashable work
+func testEquatableHashable(a: MyUInt32Newtype, b: MyUInt32Newtype) {
+  let _ = a == b
+  let _ = a != b
+  let _ = a.hashValue
+  
+  var dict: [MyUInt32Newtype: String] = [:]
+  dict[a] = "test"
+  let _ = dict[b]
+}
+
+// Test that the type can be used in collections
+func testCollections() {
+  let array: [MyUInt32Newtype] = [
+    MyUInt32Newtype(rawValue: 1),
+    MyUInt32Newtype(rawValue: 2),
+    MyUInt32Newtype(rawValue: 3)
+  ]
+  let _ = array.count
+  
+  let set: Set<MyUInt32Newtype> = [
+    MyUInt32Newtype(rawValue: 1),
+    MyUInt32Newtype(rawValue: 2)
+  ]
+  let _ = set.count
+}
+
+// Test that the type can be used in a struct with Equatable
+struct Container: Equatable {
+  var value: MyUInt32Newtype
+}
+
+func testContainerEquatable(a: Container, b: Container) {
+  let _ = a == b
+}
+


### PR DESCRIPTION
When importing C types marked with `swift_newtype(struct)` on Linux with Foundation imported, the Swift compiler crashes with a fatal error:

```
Cannot look up associated type for imported conformance:
(struct_type decl="CDemoKit.(file).CAttribute@...")
(associated_type_decl ... "_ObjectiveCType" ...)
```

### Root Cause

The `_SwiftNewtypeWrapper` extension that provides the default `_ObjectiveCType` typealias and bridging methods for types conforming to `_ObjectiveCBridgeable` was incorrectly guarded by `#if _runtime(_ObjC)` in `NewtypeWrapper.swift`. This prevented the extension from being available on non-Apple platforms.

However:
1. The `_ObjectiveCBridgeable` protocol is available on all platforms, not just Apple platforms
2. swift-corelibs-foundation provides `_ObjectiveCBridgeable` conformances for basic types (e.g., `UInt32: _ObjectiveCBridgeable` bridging to `NSNumber`) on Linux
3. The ClangImporter adds `_ObjectiveCBridgeable` conformance to `swift_newtype` structs when the underlying type conforms to the protocol
4. Without the extension, the conformance is incomplete, causing the compiler to crash when trying to resolve the `_ObjectiveCType` associated type

### Solution

Remove the `#if _runtime(_ObjC)` guard around the `_ObjectiveCBridgeable` extension in `NewtypeWrapper.swift`. The bridging mechanism should work on any platform where `_ObjectiveCBridgeable` is available, which includes Linux via swift-corelibs-foundation.

This aligns with the design of `_ObjectiveCBridgeable` as documented: it's not necessarily tied to Objective-C runtime and is equally available to Swift Foundation on non-Apple platforms.

https://github.com/swiftlang/swift/blob/652402e9e83d2e970de5a12c34e419f95d1cb7f3/docs/DynamicCasting.md?plain=1#L102-L103

### Testing

Verified that `swift_newtype` types now compile successfully on Linux when Foundation is imported, and the generated types properly bridge through their underlying types' `_ObjectiveCBridgeable` conformances.

Closes #71086