### PR TITLE
[Sema]: relax overly restrictive function conversion sendable checks

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2830,12 +2830,14 @@ namespace {
             }
 
             case FunctionTypeIsolation::Kind::NonIsolated: {
-              // nonisolated synchronous <-> @concurrent
-              if (fromFnType->isAsync() != toFnType->isAsync()) {
-                diagnoseNonSendableParametersAndResult(
-                    toFnType,
-                    version::Version::getFutureMajorLanguageVersion());
-              }
+              // At this point we know that `fromFnType` is `@Sendable` because
+              // otherwise we should have returned early to defer to RBI.
+              ASSERT(fromFnType->isSendable() && "Expected @Sendable function");
+
+              // Since neither the source nor result of the conversion involves
+              // actor isolation (inherited or otherwise), converting from sync
+              // -> async or dropping @Sendable are okay because the original
+              // function was safe to call anywhere.
               break;
             }
             }

--- a/test/Concurrency/attr_execution/conversions.swift
+++ b/test/Concurrency/attr_execution/conversions.swift
@@ -161,4 +161,12 @@ func testNonSendableDiagnostics(
   // expected-error@-1 {{cannot convert value actor-isolated to 'MainActor' to specified type actor-isolated to 'MyActor'}}
   let _: @MyActor () async -> NonSendable = globalActor2
   // expected-error@-1 {{cannot convert value actor-isolated to 'MainActor' to specified type actor-isolated to 'MyActor'}}
+
+  // https://github.com/swiftlang/swift/issues/86203
+  do {
+    let _: @Sendable (NonSendable) async -> Void = nonIsolated1 // sync -> async
+    let _: (NonSendable) async -> Void = nonIsolated2           // drop @Sendable
+    let _: @Sendable () async -> NonSendable = nonIsolated3     // sync -> async
+    let _: @concurrent () async -> NonSendable = nonIsolated3   // drop @Sendable
+  }
 }


### PR DESCRIPTION
Removed the parameter & result Sendable checking from nonisolated to nonisolated function conversions in which the source of the conversion is also Sendable.

resolves: https://github.com/swiftlang/swift/issues/86203
