### PR TITLE
Optimize `_SmallString.init?(_:appending:)` (with different approaches)

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -335,21 +335,105 @@ extension _SmallString {
 
   @usableFromInline // @testable
   internal init?(_ base: _SmallString, appending other: _SmallString) {
-    let totalCount = base.count + other.count
+    let otherCount = other.count
+
+    if otherCount == 0 {
+      // Fast path: nothing to append
+      self = base
+      return
+    }
+
+    let baseCount = base.count
+    let totalCount = baseCount + otherCount
     guard totalCount <= _SmallString.capacity else { return nil }
 
-    // TODO(SIMD): The below can be replaced with just be a couple vector ops
+    let baseClean = base.zeroTerminatedRawCodeUnits
+    var resultLeading = baseClean.0
+    var resultTrailing = baseClean.1
+    let (otherLeading, otherTrailing) = other.zeroTerminatedRawCodeUnits
 
-    var result = base
-    var writeIdx = base.count
-    for readIdx in 0..<other.count {
-      result[writeIdx] = other[readIdx]
-      writeIdx &+= 1
+    // Use direct bit manipulation instead of byte-by-byte copying.
+    // This is more efficient than SIMD for such small data sizes (max 15 bytes).
+
+    if baseCount < 8 {
+      if baseCount + otherCount <= 8 {
+        // Everything fits in leading word
+        let shiftAmount = UInt64(baseCount) &* 8
+        let otherMask = (UInt64(1) &<< (UInt64(otherCount) &* 8)) &- 1
+        let otherBits = otherLeading & otherMask
+#if _endian(big)
+        let insertShift = UInt64(8 - baseCount - otherCount) &* 8
+        resultLeading |= otherBits &<< insertShift
+#else
+        resultLeading |= otherBits &<< shiftAmount
+#endif
+      } else {
+        // Spans both words
+        let leadingBytes = 8 - baseCount
+        let trailingBytes = otherCount - leadingBytes
+
+        // Copy leading portion
+        let shiftAmount = UInt64(baseCount) &* 8
+        let leadingMask = (UInt64(1) &<< (UInt64(leadingBytes) &* 8)) &- 1
+        let leadingBits = otherLeading & leadingMask
+#if _endian(big)
+        resultLeading |= leadingBits &<< (UInt64(8 - baseCount - leadingBytes) &* 8)
+#else
+        resultLeading |= leadingBits &<< shiftAmount
+#endif
+
+        // Copy trailing portion
+        let trailingMask = (UInt64(1) &<< (UInt64(trailingBytes) &* 8)) &- 1
+#if _endian(big)
+        if leadingBytes < 8 {
+          let otherShift = UInt64(8 - leadingBytes) &* 8
+          let trailingBits = (otherLeading &>> otherShift) | (otherTrailing &<< (UInt64(leadingBytes) &* 8))
+          resultTrailing = trailingBits & trailingMask
+        } else {
+          resultTrailing = otherTrailing & trailingMask
+        }
+#else
+        if leadingBytes < 8 {
+          let otherShift = UInt64(leadingBytes) &* 8
+          let trailingBits = (otherLeading &>> otherShift) | (otherTrailing &<< (UInt64(8 - leadingBytes) &* 8))
+          resultTrailing = trailingBits & trailingMask
+        } else {
+          resultTrailing = otherTrailing & trailingMask
+        }
+#endif
+      }
+    } else {
+      // Base uses trailing word, append to trailing
+      let trailingIndex = baseCount - 8
+      let shiftAmount = UInt64(trailingIndex) &* 8
+      let availableBytes = 8 - trailingIndex
+
+      if otherCount <= availableBytes {
+        // Fits in trailing word
+        let otherMask = (UInt64(1) &<< (UInt64(otherCount) &* 8)) &- 1
+        let otherBits = otherLeading & otherMask
+#if _endian(big)
+        let insertShift = UInt64(availableBytes - otherCount) &* 8
+        resultTrailing |= otherBits &<< insertShift
+#else
+        resultTrailing |= otherBits &<< shiftAmount
+#endif
+      } else {
+        // This case shouldn't happen as totalCount > capacity would be caught above
+        // But for safety, fall back to original implementation
+        var result = base
+        var writeIdx = base.count
+        for readIdx in 0..<other.count {
+          result[writeIdx] = other[readIdx]
+          writeIdx &+= 1
+        }
+        let (leading, trailing) = result.zeroTerminatedRawCodeUnits
+        self.init(leading: leading, trailing: trailing, count: totalCount)
+        return
+      }
     }
-    _internalInvariant(writeIdx == totalCount)
 
-    let (leading, trailing) = result.zeroTerminatedRawCodeUnits
-    self.init(leading: leading, trailing: trailing, count: totalCount)
+    self.init(leading: resultLeading, trailing: resultTrailing, count: totalCount)
   }
 }
 

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -335,105 +335,23 @@ extension _SmallString {
 
   @usableFromInline // @testable
   internal init?(_ base: _SmallString, appending other: _SmallString) {
-    let otherCount = other.count
-
-    if otherCount == 0 {
-      // Fast path: nothing to append
-      self = base
-      return
-    }
-
-    let baseCount = base.count
-    let totalCount = baseCount + otherCount
+    let totalCount = base.count + other.count
     guard totalCount <= _SmallString.capacity else { return nil }
 
-    let baseClean = base.zeroTerminatedRawCodeUnits
-    var resultLeading = baseClean.0
-    var resultTrailing = baseClean.1
-    let (otherLeading, otherTrailing) = other.zeroTerminatedRawCodeUnits
-
-    // Use direct bit manipulation instead of byte-by-byte copying.
-    // This is more efficient than SIMD for such small data sizes (max 15 bytes).
-
-    if baseCount < 8 {
-      if baseCount + otherCount <= 8 {
-        // Everything fits in leading word
-        let shiftAmount = UInt64(baseCount) &* 8
-        let otherMask = (UInt64(1) &<< (UInt64(otherCount) &* 8)) &- 1
-        let otherBits = otherLeading & otherMask
-#if _endian(big)
-        let insertShift = UInt64(8 - baseCount - otherCount) &* 8
-        resultLeading |= otherBits &<< insertShift
-#else
-        resultLeading |= otherBits &<< shiftAmount
-#endif
-      } else {
-        // Spans both words
-        let leadingBytes = 8 - baseCount
-        let trailingBytes = otherCount - leadingBytes
-
-        // Copy leading portion
-        let shiftAmount = UInt64(baseCount) &* 8
-        let leadingMask = (UInt64(1) &<< (UInt64(leadingBytes) &* 8)) &- 1
-        let leadingBits = otherLeading & leadingMask
-#if _endian(big)
-        resultLeading |= leadingBits &<< (UInt64(8 - baseCount - leadingBytes) &* 8)
-#else
-        resultLeading |= leadingBits &<< shiftAmount
-#endif
-
-        // Copy trailing portion
-        let trailingMask = (UInt64(1) &<< (UInt64(trailingBytes) &* 8)) &- 1
-#if _endian(big)
-        if leadingBytes < 8 {
-          let otherShift = UInt64(8 - leadingBytes) &* 8
-          let trailingBits = (otherLeading &>> otherShift) | (otherTrailing &<< (UInt64(leadingBytes) &* 8))
-          resultTrailing = trailingBits & trailingMask
-        } else {
-          resultTrailing = otherTrailing & trailingMask
-        }
-#else
-        if leadingBytes < 8 {
-          let otherShift = UInt64(leadingBytes) &* 8
-          let trailingBits = (otherLeading &>> otherShift) | (otherTrailing &<< (UInt64(8 - leadingBytes) &* 8))
-          resultTrailing = trailingBits & trailingMask
-        } else {
-          resultTrailing = otherTrailing & trailingMask
-        }
-#endif
-      }
-    } else {
-      // Base uses trailing word, append to trailing
-      let trailingIndex = baseCount - 8
-      let shiftAmount = UInt64(trailingIndex) &* 8
-      let availableBytes = 8 - trailingIndex
-
-      if otherCount <= availableBytes {
-        // Fits in trailing word
-        let otherMask = (UInt64(1) &<< (UInt64(otherCount) &* 8)) &- 1
-        let otherBits = otherLeading & otherMask
-#if _endian(big)
-        let insertShift = UInt64(availableBytes - otherCount) &* 8
-        resultTrailing |= otherBits &<< insertShift
-#else
-        resultTrailing |= otherBits &<< shiftAmount
-#endif
-      } else {
-        // This case shouldn't happen as totalCount > capacity would be caught above
-        // But for safety, fall back to original implementation
-        var result = base
-        var writeIdx = base.count
-        for readIdx in 0..<other.count {
-          result[writeIdx] = other[readIdx]
-          writeIdx &+= 1
-        }
-        let (leading, trailing) = result.zeroTerminatedRawCodeUnits
-        self.init(leading: leading, trailing: trailing, count: totalCount)
-        return
-      }
+    func convert(_ s: _SmallString) -> _UInt128 {
+      let bits = s.zeroTerminatedRawCodeUnits
+      return .init(_low: bits.0.littleEndian, _high: bits.1.littleEndian)
     }
 
-    self.init(leading: resultLeading, trailing: resultTrailing, count: totalCount)
+    var resultInt = convert(other)
+    resultInt &*= (1 << (8 &* base.count))
+    resultInt &+= convert(base)
+
+    self.init(
+      leading: resultInt._low.littleEndian,
+      trailing: resultInt._high.littleEndian,
+      count: totalCount
+    )
   }
 }
 

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -335,7 +335,18 @@ extension _SmallString {
 
   @usableFromInline // @testable
   internal init?(_ base: _SmallString, appending other: _SmallString) {
-    let totalCount = base.count + other.count
+    let otherCount = other.count
+    let baseCount = base.count
+
+    if otherCount == 0 {
+      self = base
+      return
+    } else if baseCount == 0 {
+      self = other
+      return
+    }
+
+    let totalCount = baseCount + otherCount
     guard totalCount <= _SmallString.capacity else { return nil }
 
     func convert(_ s: _SmallString) -> _UInt128 {

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -338,21 +338,18 @@ extension _SmallString {
     let totalCount = base.count + other.count
     guard totalCount <= _SmallString.capacity else { return nil }
 
-    var ss: _InlineArray = [base._storage, (0,0)]
-    var span = ss.mutableSpan
-    var bytes = span.mutableBytes
+    func convert(_ s: _SmallString) -> _UInt128 {
+      let bits = s.zeroTerminatedRawCodeUnits
+      return .init(_low: bits.0.littleEndian, _high: bits.1.littleEndian)
+    }
 
-    unsafe bytes.storeBytes(
-        of: other._storage,
-        toUncheckedByteOffset: base.count,
-        as: _SmallString.RawBitPattern.self
+    let resultInt = (convert(other) << (8 &* base.count)) &+ convert(base)
+
+    self.init(
+      leading: resultInt._low.littleEndian,
+      trailing: resultInt._high.littleEndian,
+      count: totalCount
     )
-
-    let bitPattern = unsafe bytes
-                       .unsafeLoad(as: _SmallString.self)
-                       .zeroTerminatedRawCodeUnits
-
-    self.init(leading: bitPattern.0, trailing: bitPattern.1, count: totalCount)
   }
 }
 


### PR DESCRIPTION
Continuing some optimization work started in https://github.com/swiftlang/swift/pull/82301, benchmarking a different approach.