### PR TITLE
[Backtracing] `target.pid` should be `pid`

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
@@ -410,7 +410,7 @@ class Target {
     print("""
             From another shell, please run
 
-            lldb --attach-pid \(target.pid) -o c
+            lldb --attach-pid \(pid) -o c
             """)
     body()
     #endif


### PR DESCRIPTION
This code is never actually compiled, but if we somehow did attempt to build it, it would not work.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
