### PR TITLE
Remove extraneous ) in backtrace

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -1498,7 +1498,7 @@ Generate a backtrace for the parent process.
     writeln("")
     writeln("\(theme.register("eflags")) \(hexFlags)  \(status)")
     writeln("")
-    writeln("\(theme.register("es")): \(es) \(theme.register("cs")): \(cs) \(theme.register("ss")): \(ss) \(theme.register("ds")): \(ds) \(theme.register("fs")): \(fs)) \(theme.register("gs")): \(gs)")
+    writeln("\(theme.register("es")): \(es) \(theme.register("cs")): \(cs) \(theme.register("ss")): \(ss) \(theme.register("ds")): \(ds) \(theme.register("fs")): \(fs) \(theme.register("gs")): \(gs)")
   }
 
   static func showRegisters(_ context: ARM64Context) {


### PR DESCRIPTION
The backtrace for 32-bit x86 systems included a spurious `)` in its output.
