### PR TITLE
[Runtime] return `hashablebasetype` instead of `type` in `ErrorObject.mm`

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -372,7 +372,7 @@ const Metadata *SwiftError::getHashableBaseType() const {
       expectedType, hashableBaseType ? hashableBaseType
                                      : reinterpret_cast<const Metadata *>(1),
       std::memory_order_acq_rel);
-  return type;
+  return hashableBaseType;
 }
 
 const HashableWitnessTable *SwiftError::getHashableConformance() const {


### PR DESCRIPTION
`type` at this point will always be a null pointer, and is clearly not what we want to return.