### PR TITLE
[Runtime] Add parentheses to clarify alignment computations.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -395,7 +395,7 @@ BoxPair swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
   if (!swift_isUniquelyReferenced_nonNull_native(box)) {
     auto refAndObjectAddr = BoxPair(swift_allocBox(type));
     // Compute the address of the old object.
-    auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
+    auto headerOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
     auto *oldObjectAddr = reinterpret_cast<OpaqueValue *>(
         reinterpret_cast<char *>(box) + headerOffset);
     // Copy the data.
@@ -405,7 +405,7 @@ BoxPair swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
     swift_release(box);
     return refAndObjectAddr;
   } else {
-    auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
+    auto headerOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
     auto *objectAddr = reinterpret_cast<OpaqueValue *>(
         reinterpret_cast<char *>(box) + headerOffset);
     return BoxPair{box, objectAddr};


### PR DESCRIPTION
Although this is not wrong, it is clearer with parentheses.