### PR TITLE
use subst directly instead of calling bridgeToSwiftCall.substitutionMap again

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -200,7 +200,7 @@ private func optimizeNonOptionalBridging(_ apply: ApplyInst,
   let subst = bridgeToObjcCall.substitutionMap
   let emptySwiftValue = noneBuilder.createApply(
         function: bridgeToSwiftCall.callee,
-        bridgeToSwiftCall.substitutionMap, arguments: Array(bridgeToSwiftCall.arguments))
+        subst, arguments: Array(bridgeToSwiftCall.arguments))
   // ... and bridge that to ObjectiveC.
   let emptyObjCValue = noneBuilder.createApply(
         function: noneBuilder.createFunctionRef(bridgeToObjcCall.referencedFunction!),


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
