### PR TITLE
Runtime: Fix error message concatenation using null pointer

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -333,7 +333,7 @@ reportOnCrash(uint32_t flags, const char *message)
     current = nullptr;
 
     if (previous)
-      swift_asprintf(&current, "%s%s", current, message);
+      swift_asprintf(&current, "%s%s", previous, message);
     else
 #if defined(_WIN32)
       current = ::_strdup(message);


### PR DESCRIPTION
Error history is lost because we used current, which is set to nullptr, so it would just print (null)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
