### PR TITLE
Reserve the total expected capacity, not the delta

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -65,18 +65,17 @@ public struct _FDInputStream {
   }
 
   public mutating func read() {
-    var space = _buffer.count - _offset
-    if space < 128 {
-      let capacity = _buffer.count + (128 - space)
-      _buffer.reserveCapacity(capacity)
-      for _ in _buffer.count..<capacity {
-        _buffer.append(0)
-      }
-      space = 128
+    let minFree = 128
+    var bufferFree = _buffer.count - _offset
+    if bufferFree < minFree {
+      let toAdd = minFree - bufferFree
+      _buffer.reserveCapacity(_buffer.count + toAdd)
+      _buffer.append(contentsOf: repeatElement(0, count: toAdd))
+      bufferFree = minFree
     }
     let read: Int = _buffer.withUnsafeMutableBufferPointer { buffer in
       var read: DWORD = 0
-      ReadFile(handle, buffer.baseAddress! + _offset, DWORD(space), &read, nil)
+      ReadFile(handle, buffer.baseAddress! + _offset, DWORD(bufferFree), &read, nil)
       return Int(read)
     }
     if read == 0 {
@@ -125,11 +124,10 @@ public struct _FDInputStream {
     let minFree = 128
     var bufferFree = _buffer.count - _bufferUsed
     if bufferFree < minFree {
-      _buffer.reserveCapacity(minFree - bufferFree)
-      while bufferFree < minFree {
-        _buffer.append(0)
-        bufferFree += 1
-      }
+      let toAdd = minFree - bufferFree
+      _buffer.reserveCapacity(_buffer.count + toAdd)
+      _buffer.append(contentsOf: repeatElement(0, count: toAdd))
+      bufferFree = minFree
     }
     let fd = self.fd
     let readResult: Int = _buffer.withUnsafeMutableBufferPointer {

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -69,7 +69,6 @@ public struct _FDInputStream {
     var bufferFree = _buffer.count - _offset
     if bufferFree < minFree {
       let toAdd = minFree - bufferFree
-      _buffer.reserveCapacity(_buffer.count + toAdd)
       _buffer.append(contentsOf: repeatElement(0, count: toAdd))
       bufferFree = minFree
     }
@@ -125,7 +124,6 @@ public struct _FDInputStream {
     var bufferFree = _buffer.count - _bufferUsed
     if bufferFree < minFree {
       let toAdd = minFree - bufferFree
-      _buffer.reserveCapacity(_buffer.count + toAdd)
       _buffer.append(contentsOf: repeatElement(0, count: toAdd))
       bufferFree = minFree
     }


### PR DESCRIPTION
We were reserving the delta, but that is wrong and would lead to unneeded allocations.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
