### PR TITLE
[cxx-interop] Add conditional escapability to standard smart pointers

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5366,7 +5366,9 @@ TinyPtrVector<ValueDecl *> CXXNamespaceMemberLookup::evaluate(
   return result;
 }
 
-static const llvm::StringMap<std::vector<int>> STLConditionalParams{
+// These conditional "conformances" are used for both escapability and
+// copiability.
+static const llvm::StringMap<SmallVector<int>> STLConditionalParams{
     {"basic_string", {0}},
     {"vector", {0}},
     {"array", {0}},
@@ -5396,10 +5398,17 @@ static const llvm::StringMap<std::vector<int>> STLConditionalParams{
     {"unordered_multimap", {0, 1}},
 };
 
+static const llvm::StringMap<SmallVector<int>> STLConditionalEscapabilityParams{
+    {"unique_ptr", {0}},
+    {"shared_ptr", {0}},
+    {"weak_ptr", {0}},
+    {"auto_ptr", {0}},
+};
+
 template <typename Kind>
 static bool checkConditionalParams(
     const clang::RecordDecl *recordDecl, ClangImporter::Implementation *impl,
-    const std::vector<int> &STLParams, std::set<StringRef> &conditionalParams,
+    llvm::ArrayRef<int> STLParams, std::set<StringRef> &conditionalParams,
     llvm::function_ref<void(const clang::Type *)> maybePushToStack) {
   bool foundErrors = false;
   auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
@@ -5535,13 +5544,13 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         return CxxEscapability::NonEscapable;
       if (hasEscapableAttr(recordDecl))
         continue;
-      auto injectedStlAnnotation =
-          recordDecl->isInStdNamespace()
-              ? STLConditionalParams.find(recordDecl->getName())
-              : STLConditionalParams.end();
-      auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
-                           ? injectedStlAnnotation->second
-                           : std::vector<int>();
+      SmallVector<int> STLParams;
+      if (recordDecl->isInStdNamespace()) {
+        STLParams = STLConditionalParams.lookup(recordDecl->getName());
+        if (STLParams.empty())
+          STLParams =
+              STLConditionalEscapabilityParams.lookup(recordDecl->getName());
+      }
       auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
 
       if (!STLParams.empty() || !conditionalParams.empty()) {
@@ -8591,13 +8600,9 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     stack.pop_back();
     bool isExplicitlyNonCopyable = hasNonCopyableAttr(recordDecl);
     if (!isExplicitlyNonCopyable) {
-      auto injectedStlAnnotation =
-          recordDecl->isInStdNamespace()
-              ? STLConditionalParams.find(recordDecl->getName())
-              : STLConditionalParams.end();
-      auto STLParams = injectedStlAnnotation != STLConditionalParams.end()
-                           ? injectedStlAnnotation->second
-                           : std::vector<int>();
+      SmallVector<int> STLParams;
+      if (recordDecl->isInStdNamespace())
+        STLParams = STLConditionalParams.lookup(recordDecl->getName());
       auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
 
       if (!STLParams.empty() || !conditionalParams.empty()) {

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-//
+
 // RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
 // RUN:   -I %swift_src_root%{fs-sep}lib%{fs-sep}ClangImporter%{fs-sep}SwiftBridging -I %t%{fs-sep}Inputs \
 // RUN:   -cxx-interoperability-mode=default \
@@ -8,14 +8,14 @@
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
 // RUN:   -verify-additional-prefix LIFETIMES- \
 // RUN:   -enable-experimental-feature LifetimeDependence
-//
+
 // RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
 // RUN:   -I %swift_src_root%{fs-sep}lib%{fs-sep}ClangImporter%{fs-sep}SwiftBridging -I %t%{fs-sep}Inputs \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -verify-ignore-unrelated \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
 // RUN:   -verify-additional-prefix NO-LIFETIMES-
-//
+
 // REQUIRES: swift_feature_LifetimeDependence
 
 //--- Inputs/module.modulemap
@@ -319,7 +319,7 @@ public func noAnnotations() -> View {
     k2()
     k3()
     l1()
-    l2();
+    l2()
     return View()
 }
 

--- a/test/Interop/Cxx/class/nonescapable-smartptr-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-smartptr-errors.swift
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
+// RUN:   -I %swift_src_root%{fs-sep}lib%{fs-sep}ClangImporter%{fs-sep}SwiftBridging -I %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -verify-ignore-unrelated \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
+// RUN:   -verify-additional-prefix LIFETIMES- \
+// RUN:   -enable-experimental-feature LifetimeDependence
+
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
+// RUN:   -I %swift_src_root%{fs-sep}lib%{fs-sep}ClangImporter%{fs-sep}SwiftBridging -I %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -verify-ignore-unrelated \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}nonescapable.h \
+// RUN:   -verify-additional-prefix NO-LIFETIMES-
+
+// REQUIRES: swift_feature_LifetimeDependence
+
+// FIXME: On windows the following error is produced:
+//     cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter,
+//     specify '@_lifetime(borrow _Right)' or '@_lifetime(copy _Right)'
+//     optional(_Ty2&& _Right) noexcept(is_nothrow_constructible_v<_Ty, _Ty2>) // strengthened
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Inputs/module.modulemap
+module Test {
+    header "nonescapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/nonescapable.h
+#include "swift/bridging"
+#include <memory>
+
+struct SWIFT_NONESCAPABLE View {
+    View() : member(nullptr) {}
+    View(const int *p [[clang::lifetimebound]]) : member(p) {}
+    View(const View&) = default;
+private:
+    const int *member;
+};
+
+// expected-LIFETIMES-error@+2 {{a function with a ~Escapable result needs a parameter to depend on}}
+// expected-LIFETIMES-note@+1 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+std::unique_ptr<View> o1();
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+// expected-LIFETIMES-error@+2 {{a function with a ~Escapable result needs a parameter to depend on}}
+// expected-LIFETIMES-note@+1 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+std::shared_ptr<View> o2();
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+
+//--- test.swift
+import Test
+import CxxStdlib
+
+// expected-LIFETIMES-error@+3 {{a function with a ~Escapable result needs a parameter to depend on}}
+// expected-LIFETIMES-note@+2 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+// expected-NO-LIFETIMES-error@+1 {{a function cannot return a ~Escapable result}}
+public func noAnnotations() -> View {
+    o1()
+    o2()
+    return View()
+}


### PR DESCRIPTION
The smart pointers in the standard library should be conditionally escapable based on the escapability of the pointee type. They, however, should not be conditionally copyable. This patch adds the missing conditional conformance for these types.
