### PR TITLE
[cxx-interop] Diagnose bases with wrong escapability

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -378,9 +378,9 @@ NOTE(ptr_to_nonescapable,none,
      "pointer to non-escapable type %0 cannot be imported",
      (const clang::Type*))
 
-NOTE(nonescapable_field_of_escapable, none,
-     "escapable record %0 cannot have non-escapable field '%1'",
-     (const clang::NamedDecl *, StringRef))
+NOTE(nonescapable_member_of_escapable, none,
+     "escapable record %1 cannot have non-escapable %select{field|base}0 '%2'",
+     (bool, const clang::NamedDecl *, StringRef))
 
 NOTE(refcounted_ptr_missing_torawpointer, none,
      "SWIFT_REFCOUNTED_PTR on %0 is missing required "

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2392,6 +2392,16 @@ namespace {
                                  MoveOnlyAttr(/*Implicit=*/true));
       }
 
+      bool isNonEscapable = false;
+      if (evaluateOrDefault(
+              Impl.SwiftContext.evaluator,
+              ClangTypeEscapability({decl->getTypeForDecl(), &Impl}),
+              CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
+        result->addAttribute(new (Impl.SwiftContext)
+                                 NonEscapableAttr(/*Implicit=*/true));
+        isNonEscapable = true;
+      }
+
       // FIXME: Figure out what to do with superclasses in C++. One possible
       // solution would be to turn them into members and add conversion
       // functions.
@@ -2401,18 +2411,25 @@ namespace {
             if (auto *baseRecordDecl = base.getType()->getAsCXXRecordDecl()) {
               Impl.importDecl(baseRecordDecl, getVersion());
             }
+
+            if (!isNonEscapable) {
+              if (evaluateOrDefault(Impl.SwiftContext.evaluator,
+                                    ClangTypeEscapability(
+                                        {base.getType().getTypePtr(), &Impl}),
+                                    CxxEscapability::Unknown) ==
+                  CxxEscapability::NonEscapable) {
+                Impl.addImportDiagnostic(
+                    decl,
+                    Diagnostic(diag::nonescapable_member_of_escapable, true,
+                               decl,
+                               Impl.SwiftContext.AllocateCopy(
+                                   base.getType().getAsString())),
+                    base.getBeginLoc());
+                return nullptr;
+              }
+            }
           }
         }
-      }
-
-      bool isNonEscapable = false;
-      if (evaluateOrDefault(
-              Impl.SwiftContext.evaluator,
-              ClangTypeEscapability({decl->getTypeForDecl(), &Impl}),
-              CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
-        result->addAttribute(new (Impl.SwiftContext)
-                                 NonEscapableAttr(/*Implicit=*/true));
-        isNonEscapable = true;
       }
 
       // Import each of the members.
@@ -2527,8 +2544,8 @@ namespace {
                 CxxEscapability::NonEscapable) {
               Impl.addImportDiagnostic(
                   decl,
-                  Diagnostic(diag::nonescapable_field_of_escapable, decl,
-                             nd->getName()),
+                  Diagnostic(diag::nonescapable_member_of_escapable, false,
+                             decl, nd->getName()),
                   decl->getLocation());
               return nullptr;
             }

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -167,6 +167,10 @@ struct SWIFT_ESCAPABLE Invalid {
     View v;
 };
 
+// expected-note@+1 {{escapable record 'Invalid2' cannot have non-escapable base 'View'}}
+struct SWIFT_ESCAPABLE Invalid2 : View {
+};
+
 struct SWIFT_NONESCAPABLE NonEscapable {};
 
 using NonEscapableOptional = std::optional<NonEscapable>;
@@ -297,6 +301,9 @@ import CxxStdlib
 
 // expected-error@+1 {{cannot find type 'Invalid' in scope}}
 public func importInvalid(_ x: Invalid) {}
+
+// expected-error@+1 {{cannot find type 'Invalid2' in scope}}
+public func importInvalid(_ x: Invalid2) {}
 
 // expected-LIFETIMES-error@+3 {{a function with a ~Escapable result needs a parameter to depend on}}
 // expected-LIFETIMES-note@+2 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}


### PR DESCRIPTION
Escapable types cannot have non-escapable base classes. This PR adds a diagnostic to prevent this from happening.
