### PR TITLE
[SILVerifier]: fix crash on null generic signature

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7810,10 +7810,12 @@ public:
         auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
         auto *distributedProtocol =
             ctx.getProtocol(KnownProtocolKind::DistributedActor);
-        require(argType->canBeIsolatedTo() ||
-                    genericSig->requiresProtocol(argType, actorProtocol) ||
-                    genericSig->requiresProtocol(argType, distributedProtocol),
-                "Only any actor types can be isolated");
+        require(
+            argType->canBeIsolatedTo() ||
+                (genericSig &&
+                 (genericSig->requiresProtocol(argType, actorProtocol) ||
+                  genericSig->requiresProtocol(argType, distributedProtocol))),
+            "Only any actor types can be isolated");
         require(!foundIsolatedParameter, "Two isolated parameters");
         foundIsolatedParameter = true;
       }


### PR DESCRIPTION
was looking into https://github.com/swiftlang/swift/issues/77447 and the null signature was resulting in misleading verifier output. after the change, the verifier error looks more like:

```
SIL verification failed: Only any actor types can be isolated: argType->canBeIsolatedTo() || (genericSig && (genericSig->requiresProtocol(argType, actorProtocol) || genericSig->requiresProtocol(argType, distributedProtocol)))
In function:
// closure #1 in A.f()
// Isolation: actor_instance. name: 'self'
sil private [ossa] @$s4main1AC1fyyFyycfU_ : $@convention(thin) (@sil_isolated @guaranteed @sil_unowned A) -> () {
// %0 "self"                                      // users: %2, %1
bb0(%0 : @closureCapture @guaranteed $@sil_unowned A):
  debug_value %0, let, name "self", argno 1       // id: %1
  %2 = strong_copy_unowned_value %0               // users: %4, %3
  ignored_use %2                                  // id: %3
  destroy_value %2                                // id: %4
  %5 = tuple ()                                   // user: %6
  return %5                                       // id: %6
} // end sil function '$s4main1AC1fyyFyycfU_'

Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
...
```