### PR TITLE
[Lexer] Close comment on //*/ instead of opening a nested one

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -452,6 +452,8 @@ static bool skipToEndOfSlashStarComment(const char *&CurPtr,
     case '/':
       // Check for a '/*'
       if (*CurPtr == '*') {
+        if (CurPtr[1] == '/')
+          continue;
         ++CurPtr;
         ++Depth;
       }

--- a/test/Parse/slash_star_comment.swift
+++ b/test/Parse/slash_star_comment.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/44163
+
+/*
+//*/
+print("wat")
+
+/*/ comment /*/
+print("ok")


### PR DESCRIPTION
  Resolves https://github.com/swiftlang/swift/issues/44163.
