### PR TITLE
Fix Mem2Reg of multiple store_borrow to a lexical stack location

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1186,9 +1186,9 @@ SILInstruction *StackAllocationPromoter::promoteAllocationInBlock(
       if (sbi->getDest() != asi) {
         continue;
       }
-      assert(!deinitializationPoints[blockPromotingWithin]);
-      deinitializationPoints[blockPromotingWithin] = inst;
       if (!runningVals.has_value()) {
+        assert(!deinitializationPoints[blockPromotingWithin]);
+        deinitializationPoints[blockPromotingWithin] = inst;
         continue;
       }
       if (!runningVals->value.isGuaranteed()) {

--- a/test/SILOptimizer/mem2reg_lifetime_borrows.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_borrows.sil
@@ -561,3 +561,21 @@ bb6:
   %17 = tuple ()
   return %17 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @multiple_storeborrow_lexical :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_storeborrow_lexical'
+sil [ossa] @multiple_storeborrow_lexical : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  br bb1
+
+bb1:
+  %sb1 = store_borrow %0 to %1 : $*Klass
+  end_borrow %sb1 : $*Klass
+  %sb2 = store_borrow %0 to %1 : $*Klass
+  end_borrow %sb2 : $*Klass
+  dealloc_stack  %1 : $*Klass
+  %6 = tuple ()
+  return %6 : $()
+}


### PR DESCRIPTION
`deinitializationPoints` are populated in mem2reg for instructions considered as "deinitialization" - `load [take]`, `destroy_addr` and `end_borrow` when an earlier store to the same stack allocation is not found in the block.

For `end_borrow` of `store_borrow`, we were populating them without checking if there wasn't any earlier store. This PR fixes it. 

rdar://166959368