### PR TITLE
[SE-0508] Support array expression trailing closures

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1387,16 +1387,12 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
     if (Tok.is(tok::l_brace) && isValidTrailingClosure(isExprBasic, *this)) {
       // FIXME: if Result has a trailing closure, break out.
 
+      // Stop after most types of literals, which may never have trailing closures.
+      // Array and dictionary literals support trailing closures since this can mean
+      // `[Element].init { }` or `[Key: Value].init { }`.
       const auto *callee = Result.get();
-      if (isa<LiteralExpr>(callee) || isa<CollectionExpr>(callee) ||
-          isa<TupleExpr>(callee)) {
-        // Trailing closures are allowed after array and dictionary types,
-        // since this can mean `[Element].init { }` or `[Key: Value].init { }`.
-        bool allowTrailingClosureAfterCollectionLiteral =
-            (isa<ArrayExpr>(callee) || isa<DictionaryExpr>(callee));
-
-        if (!allowTrailingClosureAfterCollectionLiteral)
-          break;
+      if (isa<LiteralExpr>(callee) || isa<TupleExpr>(callee)) {
+        break;
       }
 
       SmallVector<Argument, 2> trailingClosures;

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -537,6 +537,13 @@ extension Dictionary {
   }
 }
 
+extension Dictionary {
+  func callAsFunction(_ closure: (Self) -> Void) -> Self {
+    closure(self)
+    return self
+  }
+}
+
 func testTrailingClosureCollectionInits() {
   _ = [String] { "foo" }
   _ = [String].init { "foo" }
@@ -569,12 +576,28 @@ func testTrailingClosureCollectionInits() {
     (key: "bar", value: 43)
   }
 
+  // Array doesn't has a `callAsFunction` defined in this file.
   _ = [1] { return [1] } // expected-error {{cannot call value of non-function type '[Int]'}}
-  _ = [1: 1] { return [1: 1] } // expected-error {{cannot call value of non-function type '[Int : Int]'}}
 
   _ = [1] // expected-error {{cannot call value of non-function type '[Int]'}}
   { return [1] }
+  
+  var didSetAfterArrayLiteral = [42] {
+    didSet {
+      print(didSetAfterArrayLiteral)
+    }
+  }
 
-  _ = [1: 1] // expected-error {{cannot call value of non-function type '[Int : Int]'}}
-  { return [1: 1] }
+  didSetAfterArrayLiteral[0] += 1
+  
+  // Dictionary does has a `callAsFunction` defined in this file.
+  let dictionaryCallAsFunction = [41: 0] { print($0) }
+
+  var didSetAfterDictionaryLiteral = [42: 0] {
+    didSet {
+      print(didSetAfterDictionaryLiteral)
+    }
+  }
+
+  didSetAfterDictionaryLiteral[42] = 1
 }

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -56,8 +56,7 @@ func notLiterals() {
   // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
   // expected-error@-2 {{closure expression is unused}} expected-note@-2 {{did you mean to use a 'do' statement?}} {{15-15=do }}
   _ = [42] {}
-  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
-  // expected-error@-2 {{closure expression is unused}} expected-note@-2 {{did you mean to use a 'do' statement?}} {{12-12=do }}
+  // expected-error@-1 {{cannot call value of non-function type '[Int]'}}
   _ = (6765, 10946, 17711) {}
   // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
   // expected-error@-2 {{closure expression is unused}} expected-note@-2 {{did you mean to use a 'do' statement?}} {{28-28=do }}
@@ -523,4 +522,59 @@ do {
     let _ = defaulted { return () }
     // expected-error@-1:23 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}}{{24-24= _ in}}
   }
+}
+
+extension Array {
+  init(_ makeElement: () -> Element) {
+    self = [makeElement()]
+  }
+}
+
+extension Dictionary {
+  init?(_ makeElement: () -> (key: Key, value: Value)?) {
+    guard let (key, value) = makeElement() else { return nil }
+    self = [key: value]
+  }
+}
+
+func testTrailingClosureCollectionInits() {
+  _ = [String] { "foo" }
+  _ = [String].init { "foo" }
+  
+  _ = [String: Int] { (key: "foo", value: 42) }
+  _ = [String: Int].init { (key: "foo", value: 42) }
+  
+  _ = [String]
+  { "foo" }
+  
+  var foo = "foo"
+  _ = [foo] // expected-error {{cannot call value of non-function type '[String]'}}
+  { "bar" }
+  
+  if let bar = [String: Int] { (key: "foo", value: 42) } { // expected-warning {{trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning}}
+    print(bar)
+  }
+  
+  if let bar = [String: Int]({ (key: "foo", value: 42) }) {
+    print(bar)
+  }
+  
+  var myArray: Array? = [100]
+  _ = if let myArray: [Int] { "foo" } else { "var" }
+  
+  let myDict = ["foo": 42]
+  _ = if myDict == ["foo": 42] {
+    (key: "foo", value: 42)
+  } else {
+    (key: "bar", value: 43)
+  }
+
+  _ = [1] { return [1] } // expected-error {{cannot call value of non-function type '[Int]'}}
+  _ = [1: 1] { return [1: 1] } // expected-error {{cannot call value of non-function type '[Int : Int]'}}
+
+  _ = [1] // expected-error {{cannot call value of non-function type '[Int]'}}
+  { return [1] }
+
+  _ = [1: 1] // expected-error {{cannot call value of non-function type '[Int : Int]'}}
+  { return [1: 1] }
 }


### PR DESCRIPTION
This PR implements [SE-0508: Array expression trailing closures](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0508-array-expression-trailing-closures.md).

Corresponding Swift Syntax PR: https://github.com/swiftlang/swift-syntax/pull/3223

-----

This PR enables use of trailing closure syntax following array and dictionary literals:

```swift
let value = [String] {
  "a"
}

let value = [String: Int] {
  (key: "a", value: 42)
}
```