### PR TITLE
[docs] Fix usage example in CppInteroperabilityManifesto.md

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperability/CppInteroperabilityManifesto.md
@@ -464,7 +464,7 @@ func printInt(_ value: Int)
 
 func caller() {
   let x = 42
-  printInt(y) // OK
+  printInt(x) // OK
 }
 ```
 


### PR DESCRIPTION
Update usage example in CppInteroperabilityManifesto.md to print variable 'x' instead of 'y'.