### PR TITLE
[IRGen][NFC]: remove dead code in GenEnum.cpp

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1825,11 +1825,6 @@ namespace {
       return cast<LoadableTypeInfo>(*ElementsWithPayload[0].ti);
     }
 
-    llvm::Value *emitPayloadMetadataForLayout(IRGenFunction &IGF,
-                                     SILType T) const {
-      return IGF.emitTypeMetadataRefForLayout(getPayloadType(IGF.IGM, T));
-    }
-
     /// More efficient value semantics implementations for certain enum layouts.
     enum CopyDestroyStrategy {
       /// No special behavior.


### PR DESCRIPTION
Deletes the seemingly-unused emitPayloadMetadataForLayout method. Git history suggests the last use was removed in ~2017 via https://github.com/swiftlang/swift/pull/12697.