### PR TITLE
[Runtime][Backtracing][Linux] Read and write from `ptr`, not `buf`.

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -94,7 +94,7 @@ ssize_t safe_read(int fd, void *buf, size_t len) {
   while (ptr < end) {
     ssize_t ret;
     do {
-      ret = read(fd, buf, len);
+      ret = read(fd, ptr, len);
     } while (ret <= 0 && errno == EINTR);
     if (ret <= 0)
       return ret;
@@ -114,7 +114,7 @@ ssize_t safe_write(int fd, const void *buf, size_t len) {
   while (ptr < end) {
     ssize_t ret;
     do {
-      ret = write(fd, buf, len);
+      ret = write(fd, ptr, len);
     } while (ret <= 0 && errno == EINTR);
     if (ret <= 0)
       return ret;


### PR DESCRIPTION
This causes both functions to repeatedly read/write the same bytes from the beginning of the buffer instead of advancing through it.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
