### PR TITLE
[ConstraintSystem] Fix crash when diagnosing missing args in KeyPath application

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5286,7 +5286,11 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   // foo(bar) // `() -> Void` vs. `(Int) -> Void`
   // ```
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    auto info = *(getFunctionArgApplyInfo(locator));
+    auto info_ptr = getFunctionArgApplyInfo(locator);
+    if (!info_ptr)
+      return false;
+
+    auto info = *info_ptr;
 
     auto *argExpr = info.getArgExpr();
     emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5286,16 +5286,13 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   // foo(bar) // `() -> Void` vs. `(Int) -> Void`
   // ```
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    // FIX: Added safety check
-    if (auto info = getFunctionArgApplyInfo(locator)) {
-      auto *argExpr = info->getArgExpr();
-      emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,
-                     info->getArgType(), info->getParamType());
-      // TODO: It would be great so somehow point out which arguments are missing.
-      return true;
-    }
+    auto info = *(getFunctionArgApplyInfo(locator));
 
-    return false;
+    auto *argExpr = info.getArgExpr();
+    emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,
+                     info.getArgType(), info.getParamType());
+    // TODO: It would be great so somehow point out which arguments are missing.
+    return true;
   }
 
   // Function type has fewer arguments than expected by context:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4246,7 +4246,9 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   } else {
     // If we didn't resolve an overload for the callee, we should be dealing
     // with a call of an arbitrary function expr.
-    auto *call = castToExpr<CallExpr>(anchor);
+    auto *call = getAsExpr<CallExpr>(anchor);
+    if (!call)
+      return std::nullopt;
     rawFnType = getType(call->getFn());
 
     // If callee couldn't be resolved due to expression

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -760,35 +760,6 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
                             getOverloadFor);
   }
 
-  {
-    auto iter = path.rbegin();
-    if (locator->findLast<LocatorPathElt::KeyPathComponent>(iter)) {
-      auto componentElt = iter->castTo<LocatorPathElt::KeyPathComponent>();
-      auto *kpExpr = castToExpr<KeyPathExpr>(anchor);
-      auto component = kpExpr->getComponents()[componentElt.getIndex()];
-
-      using ComponentKind = KeyPathExpr::Component::Kind;
-      if (component.getKind() == ComponentKind::Apply ||
-          component.getKind() == ComponentKind::UnresolvedApply) {
-        // The callee is the previous component in the list.
-        // We must specifically target index - 1 to distinguish this call from others
-        // and avoid "recordArgumentList" collisions.
-        if (componentElt.getIndex() > 0) {
-          unsigned prevIndex = componentElt.getIndex() - 1;
-
-          // Drop the current component (the Apply)
-          auto prefix = path.drop_back(iter - path.rbegin() + 1);
-
-          // Build the new path: Prefix + KeyPathComponent(prevIndex)
-          SmallVector<LocatorPathElt, 4> newPathVec(prefix.begin(), prefix.end());
-          newPathVec.push_back(LocatorPathElt::KeyPathComponent(prevIndex));
-
-          return getConstraintLocator(anchor, newPathVec);
-        }
-          }
-    }
-  }
-
   // If we have a locator that starts with a key path component element, we
   // may have a callee given by a property, subscript, initializer, or method
   // component.
@@ -813,7 +784,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       break;
     case ComponentKind::UnresolvedApply:
     case ComponentKind::Apply:
-      return getConstraintLocator(anchor, *componentElt);
+      return getConstraintLocator(anchor, LocatorPathElt::KeyPathComponent(componentElt->getIndex() - 1));
     case ComponentKind::Invalid:
     case ComponentKind::OptionalForce:
     case ComponentKind::OptionalChain:
@@ -4267,6 +4238,7 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   std::optional<OverloadChoice> choice;
   Type rawFnType;
   auto *calleeLocator = getCalleeLocator(argLocator);
+
   if (auto overload = getOverloadChoiceIfAvailable(calleeLocator)) {
     // If we have resolved an overload for the callee, then use that to get the
     // function type and callee.
@@ -4275,24 +4247,27 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   } else {
     // If we didn't resolve an overload for the callee, we should be dealing
     // with a call of an arbitrary function expr.
-    auto *call = castToExpr<CallExpr>(anchor);
-    rawFnType = getType(call->getFn());
+    if (auto *call = getAsExpr<CallExpr>(anchor)) {
+      rawFnType = getType(call->getFn());
 
-    // If callee couldn't be resolved due to expression
-    // issues e.g. it's a reference to an invalid member
-    // let's just return here.
-    if (simplifyType(rawFnType)->is<ErrorType>())
-      return std::nullopt;
-
-    // A tuple construction is spelled in the AST as a function call, but
-    // is really more like a tuple conversion.
-    if (auto metaTy = simplifyType(rawFnType)->getAs<MetatypeType>()) {
-      if (metaTy->getInstanceType()->is<TupleType>())
+      // If callee couldn't be resolved due to expression
+      // issues e.g. it's a reference to an invalid member
+      // let's just return here.
+      if (simplifyType(rawFnType)->is<ErrorType>())
         return std::nullopt;
-    }
 
-    assert(!shouldHaveDirectCalleeOverload(call) &&
-             "Should we have resolved a callee for this?");
+      // A tuple construction is spelled in the AST as a function call, but
+      // is really more like a tuple conversion.
+      if (auto metaTy = simplifyType(rawFnType)->getAs<MetatypeType>()) {
+        if (metaTy->getInstanceType()->is<TupleType>())
+          return std::nullopt;
+      }
+
+      assert(!shouldHaveDirectCalleeOverload(call) &&
+               "Should we have resolved a callee for this?");
+    } else {
+      return std::nullopt;
+    }
   }
 
   // Try to resolve the function type by loading lvalues and looking through

--- a/test/Constraints/issue-85942.swift
+++ b/test/Constraints/issue-85942.swift
@@ -7,6 +7,6 @@
 func f(buttonsStr: [Substring]) {
     // expected-error@+3 {{unexpected code '(separator: ",").compactMap(Int.init)' in function call}}
     // expected-error@+2 {{key path cannot refer to instance method 'compactMap'}}
-    // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Substring.Element>) throws -> Int?' (aka '(ArraySlice<Character>) throws -> Optional<Int>')}}
+    // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Character>) throws -> Int?'}}
     let _: [[Int]] = buttonsStr.map(\.split(separator: ",").compactMap(Int.init))
 }

--- a/test/Constraints/issue-85942.swift
+++ b/test/Constraints/issue-85942.swift
@@ -1,12 +1,12 @@
+// expected-error@1 {{new Swift parser generated errors for code that C++ parser accepted}}
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@1 {{new Swift parser generated errors for code that C++ parser accepted}}
 // https://github.com/swiftlang/swift/issues/85942
 // Verify that we do not crash when a KeyPath is used in a map with missing arguments.
 
 func f(buttonsStr: [Substring]) {
     // expected-error@+3 {{unexpected code '(separator: ",").compactMap(Int.init)' in function call}}
-    // expected-error@+2 {{missing arguments for parameters 'maxSplits', 'omittingEmptySubsequences' in call}}
-    // expected-error@+1 {{key path cannot refer to instance method 'compactMap'}}
+    // expected-error@+2 {{key path cannot refer to instance method 'compactMap'}}
+    // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Character>) throws -> Int?'}}
     let _: [[Int]] = buttonsStr.map(\.split(separator: ",").compactMap(Int.init))
 }

--- a/test/Constraints/issue-85942.swift
+++ b/test/Constraints/issue-85942.swift
@@ -1,11 +1,9 @@
-// expected-error@1 {{new Swift parser generated errors for code that C++ parser accepted}}
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-experimental-parser-round-trip
 
 // https://github.com/swiftlang/swift/issues/85942
 // Verify that we do not crash when a KeyPath is used in a map with missing arguments.
 
 func f(buttonsStr: [Substring]) {
-    // expected-error@+3 {{unexpected code '(separator: ",").compactMap(Int.init)' in function call}}
     // expected-error@+2 {{key path cannot refer to instance method 'compactMap'}}
     // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Character>) throws -> Int?'}}
     let _: [[Int]] = buttonsStr.map(\.split(separator: ",").compactMap(Int.init))

--- a/test/Constraints/issue-85942.swift
+++ b/test/Constraints/issue-85942.swift
@@ -7,6 +7,6 @@
 func f(buttonsStr: [Substring]) {
     // expected-error@+3 {{unexpected code '(separator: ",").compactMap(Int.init)' in function call}}
     // expected-error@+2 {{key path cannot refer to instance method 'compactMap'}}
-    // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Character>) throws -> Int?'}}
+    // expected-error@+1 {{cannot convert value of type '() -> Int' to expected argument type '(ArraySlice<Substring.Element>) throws -> Int?' (aka '(ArraySlice<Character>) throws -> Optional<Int>')}}
     let _: [[Int]] = buttonsStr.map(\.split(separator: ",").compactMap(Int.init))
 }

--- a/test/Constraints/issue-85942.swift
+++ b/test/Constraints/issue-85942.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+// expected-error@1 {{new Swift parser generated errors for code that C++ parser accepted}}
+// https://github.com/swiftlang/swift/issues/85942
+// Verify that we do not crash when a KeyPath is used in a map with missing arguments.
+
+func f(buttonsStr: [Substring]) {
+    // expected-error@+3 {{unexpected code '(separator: ",").compactMap(Int.init)' in function call}}
+    // expected-error@+2 {{missing arguments for parameters 'maxSplits', 'omittingEmptySubsequences' in call}}
+    // expected-error@+1 {{key path cannot refer to instance method 'compactMap'}}
+    let _: [[Int]] = buttonsStr.map(\.split(separator: ",").compactMap(Int.init))
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -839,8 +839,8 @@ func test_keypath_with_method_refs() {
     init(val value: Int = 2024) { year = value }
     
     var add: (Int, Int) -> Int { return { $0 + $1 } }
-    func add(this: Int) -> Int { this + this}
-    func add(that: Int) -> Int { that + that }
+    func add(this: Int) -> Int { this + this} // expected-note 2 {{candidate has partially matching parameter list (this: Int)}}
+    func add(that: Int) -> Int { that + that } // expected-note 2 {{candidate has partially matching parameter list (that: Int)}}
     static func subtract(_ val: Int) -> Int { return millenium - val }
     nonisolated func nonisolatedNextYear() -> Int { return year + 1 }
     consuming func consume() { print(year) }
@@ -862,10 +862,10 @@ func test_keypath_with_method_refs() {
   }
 
   let _: KeyPath<S, (Int, Int) -> Int> = \.add
-  let _: KeyPath<S, (Int, Int) -> Int> = \.add()
+  let _: KeyPath<S, (Int, Int) -> Int> = \.add() // expected-error {{no exact matches in call to instance method 'add'}}
   // expected-error@-1 {{cannot assign value of type 'KeyPath<S, Int>' to type 'KeyPath<S, (Int, Int) -> Int>'}}
   // expected-note@-2 {{arguments to generic parameter 'Value' ('Int' and '(Int, Int) -> Int') are expected to be equal}}
-  let _: KeyPath<S, Int> = \.add() // expected-error {{failed to produce diagnostic for expression}}
+  let _: KeyPath<S, Int> = \.add() // expected-error {{no exact matches in call to instance method 'add'}}
   let _: KeyPath<S, (Int) -> Int> = \.add(this:)
   let _: KeyPath<S, Int> = \.add(that: 1)
   let _: KeyPath<S, (Int) -> Int> = \.subtract // expected-error {{static member 'subtract' cannot be used on instance of type 'S'}}


### PR DESCRIPTION
This patch fixes a compiler crash (Signal 11) where `getFunctionArgApplyInfo` blindly cast an expression to `CallExpr` without verification, and `CSDiagnostics` subsequently dereferenced a null result.

This occurred specifically when using a KeyPath expression (e.g. inside `.map`) that had argument labels missing. The diagnostic logic triggered on the KeyPath node, which is not a `CallExpr`, causing an assertion failure in debug builds and a segfault in release builds.

Resolves: #85942