### PR TITLE
Fix Android build by copying missing Clang headers (lifetimebound.h, ptrcheck.h) from host toolchain to NDK

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -493,6 +493,10 @@ macro(configure_sdk_unix name architectures)
     endif()
   endforeach()
 
+  if("${prefix}" STREQUAL "ANDROID")
+    swift_android_copy_clang_headers()
+  endif()
+
   # Add this to the list of known SDKs.
   list(APPEND SWIFT_CONFIGURED_SDKS "${prefix}")
 


### PR DESCRIPTION
## Description

closes: #86237


This pull request fixes the Android build failure caused by missing Clang headers (`lifetimebound.h` and `ptrcheck.h`) in the Android NDK toolchain. These headers are required for Swift 6's strict memory checking and automatic `Span` conversion when interacting with C code.

### Current Behavior

When building Swift code for Android that imports C modules with memory safety annotations, the compilation fails with:

```shell
error: 'lifetimebound.h' file not found
error: 'ptrcheck.h' file not found
```

This occurs because the Android NDK's Clang toolchain is missing Swift-specific safety headers that are present in the host Swift toolchain.

### The Fix

Added `swift_android_copy_clang_headers()` function in `SwiftAndroidSupport.cmake` that:
- Detects the Android NDK version and locates the Clang resource directory
- Finds the Swift host toolchain's Clang headers
- Automatically copies `lifetimebound.h` and `ptrcheck.h` to the Android NDK if they don't already exist
- Handles both NDK v26+ (lib/clang) and older versions (lib64/clang)
- Provides clear feedback via STATUS/WARNING messages

The function is called during Android SDK configuration in `SwiftConfigureSDK.cmake`, ensuring headers are available before any builds commence.
