### PR TITLE
[6.3] MemoryLifetimeVerifier: fix verification of `init_enum_data_addr`

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -749,11 +749,14 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
         requireNoStoreBorrowLocation(IEAI->getOperand(), &I);
         break;
       }
-      case SILInstructionKind::InitExistentialAddrInst:
-      case SILInstructionKind::InitEnumDataAddrInst: {
+      case SILInstructionKind::InitExistentialAddrInst: {
         SILValue addr = I.getOperand(0);
         requireBitsClear(bits & nonTrivialLocations, addr, &I);
         requireNoStoreBorrowLocation(addr, &I);
+        break;
+      }
+      case SILInstructionKind::InitEnumDataAddrInst: {
+        requireNoStoreBorrowLocation(I.getOperand(0), &I);
         break;
       }
       case SILInstructionKind::OpenExistentialAddrInst:

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -458,6 +458,16 @@ bb3:
   return %r : $()
 }
 
+sil [ossa] @test_init_enum2 : $@convention(thin) (@inout Optional<T>, @in T) -> () {
+bb0(%0 : $*Optional<T>, %1 : $*T):
+  %11 = init_enum_data_addr %0, #Optional.some!enumelt
+  destroy_addr %0
+  copy_addr [take] %1 to [init] %11
+  inject_enum_addr %0, #Optional.some!enumelt
+  %121 = tuple ()
+  return %121
+}
+
 sil [ossa] @test_store_to_enum : $@convention(thin) (@owned T) -> () {
 bb0(%0 : @owned $T):
   %1 = alloc_stack $Optional<T>


### PR DESCRIPTION
* **Explanation**:  Fixes a false memory-lifetime verification error. The `init_enum_data_addr` SIL instruction is a pure address projection instruction, similar to `struct_element_addr`. It doesn't matter if the underlying memory is initialized or not at the point of this instruction. Therefore, the verifier should not check if memory is initialized at the point of `init_enum_data_addr`.
* **Risk**: Very low. It's a simple change which removes a verifier condition.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://166962673
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86229
