### PR TITLE
[6.3] SIL: Fix the ownership verifier for guaranteed phi arguments

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -483,6 +483,8 @@ bool swift::visitGuaranteedForwardingPhisForSSAValue(
   // Transitively, collect GuaranteedForwarding uses.
   for (unsigned i = 0; i < guaranteedForwardingOps.size(); i++) {
     for (auto val : guaranteedForwardingOps[i]->getUser()->getResults()) {
+      if (val->getOwnershipKind() == OwnershipKind::None)
+        continue;
       for (auto *valUse : val->getUses()) {
         if (valUse->getOperandOwnership() ==
             OperandOwnership::GuaranteedForwarding) {

--- a/test/SIL/OwnershipVerifier/guaranteed_phis.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_phis.sil
@@ -15,6 +15,12 @@ struct Wrapper2 {
   var val2: Klass
 }
 
+struct KlassAndInt {
+  let c: Klass
+  let i: Int
+}
+
+
 sil @use_superklass : $@convention(thin) (@guaranteed SuperKlass) -> ()
 sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 
@@ -359,3 +365,20 @@ bb3(%14 : @reborrow $Klass, %15 : @reborrow $Klass):
   %20 = tuple ()
   return %20
 }
+
+sil [ossa] @dont_follow_trivial_field_to_phi : $@convention(thin) (@owned KlassAndInt, @guaranteed Klass) -> () {
+bb0(%0 : @owned $KlassAndInt, %1 : @guaranteed $Klass):
+  %2 = begin_borrow %0
+  %3 = struct_extract %2 , #KlassAndInt.i
+  end_borrow %2
+  destroy_value %0
+  %6 = struct $KlassAndInt (%1, %3)
+  br bb2(%6)
+
+bb2(%8 : @guaranteed $KlassAndInt):
+  %9 = borrowed %8 from (%1)
+  %10 = apply undef(%9) : $@convention(thin) (@guaranteed KlassAndInt) -> ()
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
* **Explanation**:  Fixes a false ownership verifier error. The verifier reported a false error in case an unowned (trivial) value was used in a guaranteed phi argument outside the liverange of a borrow scope.
* **Risk**: Low. It's a simple change which relaxes the computation of liveranges for verification.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://167003182
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86176
