### PR TITLE
[Sema] Use `getFormalAccessScope` in MemberwiseInitMaxAccessLevel

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -437,13 +437,13 @@ MemberwiseInitMaxAccessLevel::evaluate(Evaluator &evaluator,
                               /*minAccess*/ AccessLevel::Private, props);
 
   // The memberwise initializer is only ever internal at most, and is limited
-  // by the access of the enclosing decl. A 'private' decl or a decl in a local
-  // context is implicitly 'fileprivate'.
-  auto nominalAccess = nominal->getFormalAccess();
-  if (nominal->getLocalContext() || nominalAccess == AccessLevel::Private)
-    nominalAccess = AccessLevel::FilePrivate;
-
-  auto maxAccess = std::min(nominalAccess, AccessLevel::Internal);
+  // by the access of the enclosing nominal. The only case that matters here is
+  // if the nominal is private or fileprivate, the memberwise initializer is
+  // effectively at most fileprivate in both cases.
+  auto nominalAccess = nominal->getFormalAccessScope();
+  auto maxAccess = nominalAccess.isPrivate() || nominalAccess.isFileScope()
+                       ? AccessLevel::FilePrivate
+                       : AccessLevel::Internal;
   if (props.empty())
     return maxAccess;
 

--- a/test/decl/memberwise_init_compat.swift
+++ b/test/decl/memberwise_init_compat.swift
@@ -7,9 +7,6 @@
 // REQUIRES: swift_feature_ExcludePrivateFromMemberwiseInit
 // REQUIRES: swift7
 
-// This file uses alphabetic prefixes on its declarations because swift-ide-test
-// sorts decls in a module before printing them.
-
 // - CHECK matches before, during, and after adoption of the feature
 // - CHECK-COMPAT matches before and during the feature
 // - CHECK-NEW matches during and after the feature
@@ -295,6 +292,32 @@ func locals() {
 
 #if FORCE
   func forceEmission() { _ = Self.init(x:y:) }
+#endif
+  }
+}
+
+// CHECK-LABEL: private enum TestNested {
+private enum TestNested {
+  // CHECK-LABEL: struct A {
+  struct A {
+    fileprivate var x: Int?
+    var y: Int
+    // CHECK: fileprivate init(x: Int? = nil, y: Int)
+
+#if FORCE
+    func forceEmission() { _ = Self.init(x:y:) }
+#endif
+  }
+
+  // CHECK-LABEL: struct B {
+  struct B {
+    private var x: Int?
+    var y: Int
+    // CHECK-COMPAT: private init(x: Int? = nil, y: Int)
+    // CHECK-NEW: internal init(y: Int)
+
+#if FORCE
+    func forceEmission() { _ = Self.init(x:y:) }
 #endif
   }
 }

--- a/test/decl/memberwise_init_compat_diag.swift
+++ b/test/decl/memberwise_init_compat_diag.swift
@@ -133,3 +133,31 @@ struct I { // expected-error {{cannot synthesize memberwise initializer}}
   }
   var d: Int
 }
+
+protocol P {
+  init(x: Int?, y: Int)
+}
+
+private struct TestNested {
+  struct S: P {
+    fileprivate var x: Int?
+    var y: Int
+  }
+}
+
+func testLocal() {
+  struct A: P {
+    fileprivate var x: Int?
+    var y: Int
+  }
+  struct B {
+    // expected-warning@-1 {{synthesized memberwise initializer no longer includes 'x'; uses of it will be an error in a future Swift language mode}}
+    // expected-note@-2 {{insert an explicit implementation of the memberwise initializer}} {{159:5-5=private init(x: Int? = nil, y: Int) {\nself.x = x\nself.y = y\n\}\n}}
+    private var x: Int?
+    var y: Int
+
+    func foo() {
+      _ = B(x: 0, y: 0) // expected-note {{memberwise initializer used here}}
+    }
+  }
+}


### PR DESCRIPTION
This ensures we handle nested types correctly for `ExcludePrivateFromMemberwiseInit`.