### PR TITLE
[cxx-interop] Add swift safety annotations to the bridging header

### DIFF
--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -299,6 +299,17 @@
 #define SWIFT_PRIVATE_FILEID(_fileID) \
   __attribute__((swift_attr("private_fileid:" _fileID)))
 
+/// A type or function annotated with SWIFT_UNSAFE will be imported as an unsafe
+/// declaration into Swift. Using these declarations will trigger a warning in
+/// strictly memory safe Swift. The 'unsafe' keyword can be used to suppress
+/// these warnings.
+#define SWIFT_UNSAFE __attribute__((swift_attr("unsafe")))
+
+/// A type or function annotated with SWIFT_SAFE safely encapsulates some
+/// unsafe behavior. Such declarations will be considered safe even if they have
+/// unsafe constituents.
+#define SWIFT_SAFE __attribute__((swift_attr("safe")))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -322,6 +333,8 @@
 #define SWIFT_RETURNS_RETAINED
 #define SWIFT_RETURNS_UNRETAINED
 #define SWIFT_PRIVATE_FILEID(_fileID)
+#define SWIFT_UNSAFE
+#define SWIFT_SAFE
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -109,6 +109,30 @@ struct IsUnsafe { int *p; };
 struct HasUnsafe : TTake2<PassThru<HasUnsafe>, IsUnsafe> {};
 using AlsoUnsafe = PassThru<HasUnsafe>;
 
+struct SWIFT_UNSAFE ExplicitlyUnsafeStruct {};
+struct HasUnsafeMember {
+  HasUnsafeMember();
+  ExplicitlyUnsafeStruct member;
+};
+
+struct HasUnsafeBase : ExplicitlyUnsafeStruct {
+  HasUnsafeBase();
+};
+
+struct SWIFT_SAFE WrapsUnsafeMember {
+  WrapsUnsafeMember();
+  ExplicitlyUnsafeStruct member;
+};
+
+struct SWIFT_SAFE WrapsUnsafeBase : ExplicitlyUnsafeStruct {
+  WrapsUnsafeBase();
+};
+
+struct SWIFT_SAFE WrapsUnannotatedMember {
+  WrapsUnannotatedMember();
+  Unannotated member;
+};
+
 //--- test.swift
 
 import Test
@@ -228,4 +252,21 @@ func useTTakeUnsafeTuple(x: HasUnsafe) {
 func useTTakeUnsafeTuple(x: AlsoUnsafe) {
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   _ = x // expected-note{{reference to parameter 'x' involves unsafe type}}
+}
+
+func explicitlyUnsafeTypes(a: ExplicitlyUnsafeStruct, 
+                           b: HasUnsafeMember,
+                           c: HasUnsafeBase,
+                           d: WrapsUnsafeMember,
+                           e: WrapsUnsafeBase,
+                           f: WrapsUnannotatedMember) {
+ // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+ _ = a // expected-note{{reference to parameter 'a' involves unsafe type}} 
+ // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+ _ = b // expected-note{{reference to parameter 'b' involves unsafe type}}
+ // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+ _ = c // expected-note{{reference to parameter 'c' involves unsafe type}}
+ _ = d
+ _ = e
+ _ = f
 }


### PR DESCRIPTION
Also add some tests to demonstrate that SWIFT_SAFE annotation can suppress escapability related unsafety. However, there is still some work to do, because currently, if we can infer that a type like an aggregate is escapable, we will ignore the explicit SWIFT_UNSAFE on its constituents. This should be addressed in a follow-up PR.