### PR TITLE
Disable these tests on older macOS versions

### DIFF
--- a/test/stdlib/ParseFloat32.swift
+++ b/test/stdlib/ParseFloat32.swift
@@ -7,6 +7,9 @@
 // Needed to verify the legacy ABI
 // REQUIRES: swift_feature_Extern
 
+// Swift earlier than 5.3 fails many of these tests
+// UNSUPPORTED: use_os_stdlib
+
 import StdlibUnittest
 
 let tests = TestSuite("FloatingPointParsing")

--- a/test/stdlib/ParseFloat64.swift
+++ b/test/stdlib/ParseFloat64.swift
@@ -8,6 +8,9 @@
 // Needed to declare the ABI entry point
 // REQUIRES: swift_feature_Extern
 
+// These tests exercise known bugs in older Swift stdlib
+// UNSUPPORTED: use_os_stdlib
+
 import StdlibUnittest
 
 let tests = TestSuite("FloatingPointParsing")


### PR DESCRIPTION
These tests exercise known bugs in older Swift versions, and as such are expected to fail when run on old versions of macOS with bundled Swift stdlib.

Resolves: rdar://166985147