### PR TITLE
ASTMangler: Fix mangling of sugared (nested) ProtocolCompositionTypes

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -45,7 +45,7 @@ enum class DestructorKind {
 /// The mangler for AST declarations.
 class ASTMangler : public Mangler {
 protected:
-  const ASTContext &Context;
+  ASTContext &Context;
   ModuleDecl *Mod = nullptr;
 
   /// Optimize out protocol names if a type only conforms to one protocol.
@@ -194,7 +194,7 @@ public:
   };
 
   /// lldb overrides \p DWARFMangling to 'true'.
-  ASTMangler(const ASTContext &Ctx, bool DWARFMangling = false,
+  ASTMangler(ASTContext &Ctx, bool DWARFMangling = false,
              bool UseAPIMangling = false)
       : Context(Ctx) {
     if (DWARFMangling) {
@@ -209,11 +209,11 @@ public:
 
   /// Create an ASTMangler suitable for mangling a USR for use in semantic
   /// functionality.
-  static ASTMangler forUSR(const ASTContext &Ctx) {
+  static ASTMangler forUSR(ASTContext &Ctx) {
     return ASTMangler(Ctx, /*DWARFMangling*/ true, /*UseAPIMangling*/ true);
   }
 
-  const ASTContext &getASTContext() { return Context; }
+  ASTContext &getASTContext() { return Context; }
 
   void addTypeSubstitution(Type type, GenericSignature sig) {
     type = dropProtocolsFromAssociatedTypes(type, sig);

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -807,7 +807,8 @@ protected:
   void appendLifetimeDependence(LifetimeDependenceInfo info);
 
   void gatherExistentialRequirements(SmallVectorImpl<Requirement> &reqs,
-                                     ParameterizedProtocolType *PPT) const;
+                                     SmallVectorImpl<InverseRequirement> &inverses,
+                                     Type base) const;
 
   /// Extracts a list of inverse requirements from a PCT serving as the
   /// constraint type of an existential.

--- a/include/swift/SILOptimizer/Utils/DifferentiationMangler.h
+++ b/include/swift/SILOptimizer/Utils/DifferentiationMangler.h
@@ -26,7 +26,7 @@ namespace Mangle {
 /// A mangler for generated differentiation functions.
 class DifferentiationMangler : public ASTMangler {
 public:
-  DifferentiationMangler(const ASTContext &Ctx) : ASTMangler(Ctx) {}
+  DifferentiationMangler(ASTContext &Ctx) : ASTMangler(Ctx) {}
   /// Returns the mangled name for a differentiation function of the given kind.
   std::string mangleAutoDiffFunction(StringRef originalName,
                                      Demangle::AutoDiffFunctionKind kind,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -396,10 +396,9 @@ std::string ASTMangler::mangleKeyPathGetterThunkHelper(
 
       // FIXME: This seems wrong. We used to just mangle opened archetypes as
       // their interface type. Let's make that explicit now.
-      sub = sub.transformRec([](Type t) -> std::optional<Type> {
-        if (auto *openedExistential = t->getAs<ExistentialArchetypeType>()) {
-          auto &ctx = openedExistential->getASTContext();
-          return ctx.TheSelfType;
+      sub = sub.transformRec([&](Type t) -> std::optional<Type> {
+        if (t->is<ExistentialArchetypeType>()) {
+          return Context.TheSelfType;
         }
         return std::nullopt;
       });
@@ -432,10 +431,9 @@ std::string ASTMangler::mangleKeyPathSetterThunkHelper(
 
       // FIXME: This seems wrong. We used to just mangle opened archetypes as
       // their interface type. Let's make that explicit now.
-      sub = sub.transformRec([](Type t) -> std::optional<Type> {
-        if (auto *openedExistential = t->getAs<ExistentialArchetypeType>()) {
-          auto &ctx = openedExistential->getASTContext();
-          return ctx.TheSelfType;
+      sub = sub.transformRec([&](Type t) -> std::optional<Type> {
+        if (t->is<ExistentialArchetypeType>()) {
+          return Context.TheSelfType;
         }
         return std::nullopt;
       });
@@ -4812,11 +4810,10 @@ void ASTMangler::appendDistributedThunk(
   // recipient, whichever 'protocol Type'-conforming type it will be.
   NominalTypeDecl *stubActorDecl = nullptr;
   if (auto P = referenceInProtocolContextOrRequirement()) {
-    auto &C = thunk->getASTContext();
     auto M = thunk->getModuleContext();
 
     SmallVector<ValueDecl *, 1> stubClassLookupResults;
-    C.lookupInModule(M, llvm::Twine("$", P->getNameStr()).str(), stubClassLookupResults);
+    Context.lookupInModule(M, llvm::Twine("$", P->getNameStr()).str(), stubClassLookupResults);
 
     assert(stubClassLookupResults.size() <= 1 && "Found multiple distributed stub types!");
     if (stubClassLookupResults.size() > 0) {
@@ -4913,9 +4910,8 @@ void ASTMangler::appendMacroExpansionContext(
       auto innermostNonlocalDC = outermostLocalDC->getParent();
       appendContext(innermostNonlocalDC, nullBase, StringRef());
       Identifier name = macroName;
-      ASTContext &ctx = origDC->getASTContext();
       unsigned discriminator = macroDiscriminator;
-      name = encodeLocalPrecheckedDiscriminator(ctx, name, discriminator);
+      name = encodeLocalPrecheckedDiscriminator(Context, name, discriminator);
       appendIdentifier(name.str());
     } else {
       return appendContext(origDC, nullBase, StringRef());
@@ -5111,10 +5107,9 @@ ASTMangler::appendMacroExpansion(const FreestandingMacroExpansion *expansion) {
 void ASTMangler::appendMacroExpansion(ClosureExpr *attachedTo,
                                       CustomAttr *attr,
                                       MacroDecl *macro) {
-  auto &ctx = attachedTo->getASTContext();
   auto discriminator =
-      ctx.getNextMacroDiscriminator(attachedTo,
-                                    macro->getBaseName());
+      Context.getNextMacroDiscriminator(attachedTo,
+                                        macro->getBaseName());
 
   appendMacroExpansionContext(
       attr->getLocation(),
@@ -5193,7 +5188,8 @@ const DeclContext *DeclOrEnclosingContext::getEnclosingContext() const {
 /// mangle entities within local contexts before they are fully type-checked,
 /// as is needed for macro expansions.
 static std::pair<DeclOrEnclosingContext, std::optional<unsigned>>
-getPrecheckedLocalContextDiscriminator(const Decl *decl, Identifier name) {
+getPrecheckedLocalContextDiscriminator(ASTContext &ctx, const Decl *decl,
+                                       Identifier name) {
   auto outermostLocal = getOutermostLocalContext(decl->getDeclContext());
   if (!outermostLocal) {
     return std::make_pair(
@@ -5211,7 +5207,6 @@ getPrecheckedLocalContextDiscriminator(const Decl *decl, Identifier name) {
 
   DeclContext *enclosingDC = const_cast<DeclContext *>(
       declOrEnclosingContext.getEnclosingContext());
-  ASTContext &ctx = enclosingDC->getASTContext();
   auto discriminator = ctx.getNextMacroDiscriminator(enclosingDC, name);
   return std::make_pair(declOrEnclosingContext, discriminator);
 }
@@ -5230,7 +5225,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
   auto appendDeclWithName = [&](const Decl *decl, Identifier name) {
     // Mangle the context.
     auto precheckedMangleContext =
-        getPrecheckedLocalContextDiscriminator(decl, name);
+        getPrecheckedLocalContextDiscriminator(Context, decl, name);
     if (auto mangleDecl = dyn_cast_or_null<ValueDecl>(
             precheckedMangleContext.first.dyn_cast<const Decl *>())) {
       appendContextOf(mangleDecl, nullBase);
@@ -5246,7 +5241,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
     if (auto discriminator = precheckedMangleContext.second) {
       skipLocalDiscriminator = true;
       name = encodeLocalPrecheckedDiscriminator(
-          decl->getASTContext(), name, *discriminator);
+          Context, name, *discriminator);
     }
 
     if (auto valueDecl = dyn_cast<ValueDecl>(decl))
@@ -5286,7 +5281,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
           out << "Z";
       }
 
-      attachedToName = decl->getASTContext().getIdentifier(name);
+      attachedToName = Context.getIdentifier(name);
     }
 
     appendDeclWithName(storage, attachedToName);
@@ -5295,7 +5290,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
     auto name = valueDecl->getName().getBaseName();
     if (name.isSpecial()) {
       attachedToName =
-          decl->getASTContext().getIdentifier(name.userFacingName());
+          Context.getIdentifier(name.userFacingName());
     } else {
       attachedToName = name.getIdentifier();
     }
@@ -5311,7 +5306,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
   if (auto *macroDecl = attr->getResolvedMacro()) {
     macroName = macroDecl->getName().getBaseName();
   } else {
-    macroName = decl->getASTContext().getIdentifier("__unknown_macro__");
+    macroName = Context.getIdentifier("__unknown_macro__");
   }
 
   // FIXME: attached macro discriminators should take attachedToName into

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -5360,14 +5360,14 @@ void ASTMangler::appendConstrainedExistential(Type base, GenericSignature sig,
   auto layout = base->getExistentialLayout();
   appendExistentialLayout(layout, sig, forDecl);
 
-  assert(!base->is<ProtocolType>() &&
+  ASSERT(!base->is<ProtocolType>() &&
          "plain protocol type constraint has no generalization structure");
 
   SmallVector<Requirement, 4> requirements;
   SmallVector<InverseRequirement, NumInvertibleProtocols> inverses;
   gatherExistentialRequirements(requirements, inverses, base);
 
-  assert(requirements.size() + inverses.size() > 0 &&
+  ASSERT(requirements.size() + inverses.size() > 0 &&
          "Unconstrained existential?");
 
   // Sort the requirements to canonicalize their order.

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -50,7 +50,7 @@ class ClangSyntaxPrinter {
 public:
   enum class LeadingTrivia { None, Comma };
 
-  ClangSyntaxPrinter(const ASTContext &Ctx, raw_ostream &os) : os(os), mangler(Ctx) {}
+  ClangSyntaxPrinter(ASTContext &Ctx, raw_ostream &os) : os(os), mangler(Ctx) {}
 
   /// Print a given identifier. If the identifer conflicts with a keyword, add a
   /// trailing underscore.

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -158,7 +158,7 @@ private:
   }
 
 public:
-  void printTypeName(const ASTContext &Context, raw_ostream &os) const {
+  void printTypeName(ASTContext &Context, raw_ostream &os) const {
     ClangSyntaxPrinter(Context, os).printClangTypeReference(typeDecl);
   }
 
@@ -169,7 +169,7 @@ public:
                         bodyOfReturn);
   }
 
-  void printReturnScaffold(const ASTContext &Context, raw_ostream &os,
+  void printReturnScaffold(ASTContext &Context, raw_ostream &os,
                            llvm::function_ref<void(StringRef)> bodyOfReturn) {
     std::string fullQualifiedType;
     std::string typeName;

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -53,7 +53,7 @@ void ClangValueTypePrinter::printCxxImplClassName(raw_ostream &os,
 }
 
 void ClangValueTypePrinter::printMetadataAccessAsVariable(
-    const ASTContext &Context,
+    ASTContext &Context,
     raw_ostream &os, StringRef metadataFuncName,
     ArrayRef<GenericRequirement> genericRequirements, int indent,
     StringRef varName) {
@@ -66,7 +66,7 @@ void ClangValueTypePrinter::printMetadataAccessAsVariable(
 }
 
 void ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-    const ASTContext &Context,
+    ASTContext &Context,
     raw_ostream &os, StringRef metadataFuncName,
     ArrayRef<GenericRequirement> genericRequirements, int indent,
     StringRef metadataVarName, StringRef vwTableVarName) {

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -81,14 +81,14 @@ public:
                                     const NominalTypeDecl *type);
 
   /// Print a variable that can be used to access type's metadata function
-  static void printMetadataAccessAsVariable(const ASTContext &Context,
+  static void printMetadataAccessAsVariable(ASTContext &Context,
       raw_ostream &os, StringRef metadataFuncName,
       ArrayRef<GenericRequirement> genericRequirements, int indent = 4,
       StringRef varName = "metadata");
 
   /// Print a variable that can be used to access type's metadata function and
   /// value witness table
-  static void printValueWitnessTableAccessAsVariable(const ASTContext &Context,
+  static void printValueWitnessTableAccessAsVariable(ASTContext &Context,
       raw_ostream &os, StringRef metadataFuncName,
       ArrayRef<GenericRequirement> genericRequirements, int indent = 4,
       StringRef metadataVarName = "metadata",
@@ -118,7 +118,7 @@ private:
   raw_ostream &os;
   raw_ostream &cPrologueOS;
   SwiftToClangInteropContext &interopContext;
-  const ASTContext &Context;
+  ASTContext &Context;
 };
 
 } // end namespace swift

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -26,7 +26,7 @@
 
 using namespace swift;
 
-static void printKnownStruct(const ASTContext &astContext,
+static void printKnownStruct(ASTContext &astContext,
     PrimitiveTypeMapping &typeMapping, raw_ostream &os, StringRef name,
     const IRABIDetailsProvider::TypeRecordABIRepresentation &typeRecord) {
   assert(typeRecord.getMembers().size() > 1);
@@ -39,7 +39,7 @@ static void printKnownStruct(const ASTContext &astContext,
   os << "};\n";
 }
 
-static void printKnownTypedef(const ASTContext &astContext,
+static void printKnownTypedef(ASTContext &astContext,
     PrimitiveTypeMapping &typeMapping, raw_ostream &os, StringRef name,
     const IRABIDetailsProvider::TypeRecordABIRepresentation &typeRecord) {
   assert(typeRecord.getMembers().size() == 1);
@@ -49,7 +49,7 @@ static void printKnownTypedef(const ASTContext &astContext,
   os << " " << name << ";\n";
 }
 
-static void printKnownType(const ASTContext &astContext,
+static void printKnownType(ASTContext &astContext,
     PrimitiveTypeMapping &typeMapping, raw_ostream &os, StringRef name,
     const IRABIDetailsProvider::TypeRecordABIRepresentation &typeRecord) {
   if (typeRecord.getMembers().size() == 1)

--- a/lib/PrintAsClang/SwiftToClangInteropContext.h
+++ b/lib/PrintAsClang/SwiftToClangInteropContext.h
@@ -41,7 +41,7 @@ public:
   ~SwiftToClangInteropContext();
 
   IRABIDetailsProvider &getIrABIDetails();
-  const ASTContext &getASTContext() { return mod.getASTContext(); }
+  ASTContext &getASTContext() { return mod.getASTContext(); }
 
   // Runs the given function if we haven't emitted some context-specific stub
   // for the given concrete stub name.

--- a/test/DebugInfo/sugared-composition-with-inverses.swift
+++ b/test/DebugInfo/sugared-composition-with-inverses.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-ir -g %s | %FileCheck %s
+
+public protocol P: ~Copyable {}
+
+public typealias PP = P
+
+// Make sure this doesn't crash:
+public func withProto(_ e: borrowing any PP & ~Copyable) {}
+
+// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$s4main1P_pRi_s_XPD", size: {{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "$s4main1P_pRi_s_XPD")


### PR DESCRIPTION
Canonical ProtocolCompositionTypes never nest; we flatten the structure when computing a canonical type.

However, in DWARF mangling, we might encounter ProtocolCompositionTypes that contain other ProtocolCompositionTypes, via TypeAliasType sugar.

Make sure to visit this nested structure instead of just ignoring it.

- Fixes https://github.com/swiftlang/swift/issues/86207.