### PR TITLE
ASTMangler: Fix mangling of sugared (nested) ProtocolCompositionTypes [6.3]

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -807,7 +807,8 @@ protected:
   void appendLifetimeDependence(LifetimeDependenceInfo info);
 
   void gatherExistentialRequirements(SmallVectorImpl<Requirement> &reqs,
-                                     ParameterizedProtocolType *PPT) const;
+                                     SmallVectorImpl<InverseRequirement> &inverses,
+                                     Type base) const;
 
   /// Extracts a list of inverse requirements from a PCT serving as the
   /// constraint type of an existential.

--- a/test/DebugInfo/sugared-composition-with-inverses.swift
+++ b/test/DebugInfo/sugared-composition-with-inverses.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-ir -g %s | %FileCheck %s
+
+public protocol P: ~Copyable {}
+
+public typealias PP = P
+
+// Make sure this doesn't crash:
+public func withProto(_ e: borrowing any PP & ~Copyable) {}
+
+// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$s4main1P_pRi_s_XPD", size: {{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "$s4main1P_pRi_s_XPD")


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86266

* **Description:** Canonical ProtocolCompositionTypes never nest; we flatten the structure when computing a canonical type. However, in DWARF mangling, we might encounter ProtocolCompositionTypes that contain other ProtocolCompositionTypes, via TypeAliasType sugar. Make sure to visit this nested structure instead of just ignoring it.

* **Issue:** Fixes https://github.com/swiftlang/swift/issues/86207.

* **Reviewed by:** @kavon 

* **Risk:** Low, behavior should be unchanged for ABI mangling purposes (because canonical ProtocolCompositionTypes don't nest), so worst case I got it wrong and debug info gets messed up.