### PR TITLE
Fix runtime crash due to miscompile when using result builder via synthesized initializer in non-generic struct

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -578,6 +578,20 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       (void)eltEnd;
       value = std::move(*elti);
       ++elti;
+
+      // If the stored property has an attached result builder and its
+      // type is not a function type, the argument is a noescape closure
+      // that needs to be called.
+      if (field->getResultBuilderType()) {
+        if (!field->getValueInterfaceType()
+                 ->lookThroughAllOptionalTypes()
+                 ->is<AnyFunctionType>()) {
+          auto resultTy = cast<FunctionType>(value.getType()).getResult();
+          value = SGF.emitMonomorphicApply(
+              Loc, std::move(value).getAsSingleValue(SGF, Loc), {}, resultTy,
+              resultTy, ApplyOptions(), std::nullopt, std::nullopt);
+        }
+      }
     } else {
       // Otherwise, use its initializer.
       // TODO: This doesn't correctly take into account destructuring

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -420,6 +420,22 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
 
   auto subs = getSubstitutionsForPropertyInitializer(decl, decl);
 
+  /// If the stored property has an attached result builder and its
+  /// type is not a function type, the argument is a noescape closure
+  /// that needs to be called.
+  auto emitResultBuilderCallIfNeeded = [&](VarDecl *field, RValue &&arg) -> RValue {
+    if (field->getResultBuilderType()) {
+      if (!field->getValueInterfaceType()
+              ->lookThroughAllOptionalTypes()->is<AnyFunctionType>()) {
+        auto resultTy = cast<FunctionType>(arg.getType()).getResult();
+        arg = SGF.emitMonomorphicApply(
+            Loc, std::move(arg).getAsSingleValue(SGF, Loc), {}, resultTy,
+            resultTy, ApplyOptions(), std::nullopt, std::nullopt);
+      }
+    }
+    return std::move(arg);
+  };
+
   // If we have an indirect return slot, initialize it in-place.
   if (resultSlot) {
     auto elti = elements.begin(), eltEnd = elements.end();
@@ -490,19 +506,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
         FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
 
         RValue arg = std::move(*elti);
-
-        // If the stored property has an attached result builder and its
-        // type is not a function type, the argument is a noescape closure
-        // that needs to be called.
-        if (field->getResultBuilderType()) {
-          if (!field->getValueInterfaceType()
-                  ->lookThroughAllOptionalTypes()->is<AnyFunctionType>()) {
-            auto resultTy = cast<FunctionType>(arg.getType()).getResult();
-            arg = SGF.emitMonomorphicApply(
-                Loc, std::move(arg).getAsSingleValue(SGF, Loc), {}, resultTy,
-                resultTy, ApplyOptions(), std::nullopt, std::nullopt);
-          }
-        }
+        arg = emitResultBuilderCallIfNeeded(field, std::move(arg));
 
         maybeEmitPropertyWrapperInitFromValue(SGF, Loc, field, subs,
                                               std::move(arg))
@@ -577,21 +581,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       assert(elti != eltEnd && "number of args does not match number of fields");
       (void)eltEnd;
       value = std::move(*elti);
+      value = emitResultBuilderCallIfNeeded(field, std::move(value));
       ++elti;
-
-      // If the stored property has an attached result builder and its
-      // type is not a function type, the argument is a noescape closure
-      // that needs to be called.
-      if (field->getResultBuilderType()) {
-        if (!field->getValueInterfaceType()
-                 ->lookThroughAllOptionalTypes()
-                 ->is<AnyFunctionType>()) {
-          auto resultTy = cast<FunctionType>(value.getType()).getResult();
-          value = SGF.emitMonomorphicApply(
-              Loc, std::move(value).getAsSingleValue(SGF, Loc), {}, resultTy,
-              resultTy, ApplyOptions(), std::nullopt, std::nullopt);
-        }
-      }
     } else {
       // Otherwise, use its initializer.
       // TODO: This doesn't correctly take into account destructuring

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -869,6 +869,24 @@ let ts1 = MyTupleStruct {
 // CHECK: MyTupleStruct<(Int, String, Optional<String>), (Double, String)>(first: (Function), second: (3.14159, "blah"))
 print(ts1)
 
+// CHECK: testStoredProperties
+struct MyTupleStruct2 {
+  @ArrayBuilder<String> let first: () -> [String]
+  @ArrayBuilder<String> let second: [String]
+}
+
+print("testStoredProperties")
+let ts2 = MyTupleStruct2 {
+  "foo"
+  "bar"
+} second: {
+  "baaz"
+  "quux"
+}
+
+// CHECK: MyTupleStruct2(first: (Function), second: ["baaz", "quux"])
+print(ts2)
+
 // Make sure that `weakV` is `Test?` and not `Test??`
 func test_weak_optionality_stays_the_same() {
   class Test {


### PR DESCRIPTION
This PR fixes https://github.com/swiftlang/swift/issues/86205.

In this sample code, the synthesized memberwise initializer does not properly initialize `value.array`, causing a runtime crash when it is later accessed.

```swift
@resultBuilder
struct StringArrayBuilder {
  static func buildBlock(_ elements: String...) -> [String] {
    elements
  }
}

struct MyValue {
  @StringArrayBuilder let array: [String]
}

let value = MyValue(array: {
  "foo"
  "bar"
})

print("Value?")
print(value.array.count) // Crashes because value.array is uninitialized
```

The result-builder specific logic in `emitImplicitValueConstructor` was missing in the `if (resultSlot) {`'s `else` codepath. In this case generic structs (so, all SwiftUI / `@ViewBuilder` use cases) used the first code path, and non-generic structs use the `else` codepath.