### PR TITLE
[stdlib] Use case-sensitive alphabetical order for sources in CMakeLists.txt

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -539,6 +539,10 @@ public:
   }
 
   void forwardDeclare(const EnumDecl *ED) {
+    // Optional and Never don't need to be forward-declared.
+    if (ED->isOptionalDecl() || ED->getASTContext().getNeverDecl() == ED)
+      return;
+
     assert(ED->isCCompatibleEnum() || ED->hasClangNode());
     
     forwardDeclare(ED, [&]{

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -28,7 +28,7 @@ split_embedded_sources(
   OUT_LIST_NORMAL SWIFTLIB_SOURCES
 
   ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
-  EMBEDDED _InlineArray.swift
+  EMBEDDED ASCII.swift
   EMBEDDED Algorithm.swift
   EMBEDDED AnyHashable.swift
   EMBEDDED Array.swift
@@ -39,7 +39,6 @@ split_embedded_sources(
   EMBEDDED ArrayShared.swift
   EMBEDDED ArraySlice.swift
   EMBEDDED ArrayType.swift
-  EMBEDDED ASCII.swift
   EMBEDDED Assert.swift
   EMBEDDED AssertCommon.swift
   EMBEDDED Availability.swift
@@ -51,6 +50,8 @@ split_embedded_sources(
     NORMAL BridgingBuffer.swift
   EMBEDDED Builtin.swift
   EMBEDDED BuiltinMath.swift
+  EMBEDDED CString.swift
+  EMBEDDED CTypes.swift
   EMBEDDED Character.swift
   EMBEDDED CharacterProperties.swift
   EMBEDDED ClosedRange.swift
@@ -66,8 +67,6 @@ split_embedded_sources(
   EMBEDDED ContiguousArray.swift
   EMBEDDED ContiguousArrayBuffer.swift
   EMBEDDED ContiguouslyStored.swift
-  EMBEDDED CString.swift
-  EMBEDDED CTypes.swift
     NORMAL DebuggerSupport.swift
   EMBEDDED Dictionary.swift
   EMBEDDED DictionaryBridging.swift
@@ -91,10 +90,10 @@ split_embedded_sources(
   EMBEDDED Flatten.swift
   EMBEDDED FloatingPoint.swift
   EMBEDDED FloatingPointRandom.swift
+  EMBEDDED HashTable.swift
   EMBEDDED Hashable.swift
   EMBEDDED Hasher.swift
     NORMAL Hashing.swift
-  EMBEDDED HashTable.swift
   EMBEDDED Identifiable.swift
   EMBEDDED Indices.swift
   EMBEDDED InlineArray.swift
@@ -119,14 +118,14 @@ split_embedded_sources(
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift
+  EMBEDDED NFC.swift
+  EMBEDDED NFD.swift
   EMBEDDED NativeDictionary.swift
   EMBEDDED NativeSet.swift
     NORMAL NewtypeWrapper.swift
-  EMBEDDED NFC.swift
-  EMBEDDED NFD.swift
   EMBEDDED ObjectIdentifier.swift
-  EMBEDDED Optional.swift
   EMBEDDED OptionSet.swift
+  EMBEDDED Optional.swift
   EMBEDDED OutputStream.swift
     NORMAL PlaygroundDisplay.swift
   EMBEDDED Pointer.swift
@@ -135,6 +134,7 @@ split_embedded_sources(
     NORMAL Prespecialize.swift
     NORMAL Print.swift
   EMBEDDED PtrAuth.swift
+    NORMAL REPL.swift
   EMBEDDED Random.swift
   EMBEDDED RandomAccessCollection.swift
   EMBEDDED Range.swift
@@ -143,7 +143,6 @@ split_embedded_sources(
   EMBEDDED RangeSetRanges.swift
     NORMAL ReflectionMirror.swift
   EMBEDDED Repeat.swift
-    NORMAL REPL.swift
   EMBEDDED Result.swift
   EMBEDDED Reverse.swift
   EMBEDDED Runtime.swift
@@ -201,35 +200,18 @@ split_embedded_sources(
   EMBEDDED StringStorageBridge.swift
   EMBEDDED StringSwitch.swift
   EMBEDDED StringTesting.swift
-  EMBEDDED StringUnicodeScalarView.swift
   EMBEDDED StringUTF16View.swift
   EMBEDDED StringUTF8Validation.swift
   EMBEDDED StringUTF8View.swift
+  EMBEDDED StringUnicodeScalarView.swift
   EMBEDDED StringWordBreaking.swift
   EMBEDDED Substring.swift
-  EMBEDDED SwiftifyImport.swift
   EMBEDDED SwiftNativeNSArray.swift
+  EMBEDDED SwiftifyImport.swift
   EMBEDDED TemporaryAllocation.swift
     NORMAL ThreadLocalStorage.swift
   EMBEDDED UInt128.swift
   EMBEDDED UIntBuffer.swift
-  EMBEDDED UnavailableStringAPIs.swift
-  EMBEDDED UnfoldSequence.swift
-  EMBEDDED Unicode.swift
-  EMBEDDED UnicodeBreakProperty.swift
-  EMBEDDED UnicodeData.swift
-  EMBEDDED UnicodeEncoding.swift
-  EMBEDDED UnicodeHelpers.swift
-  EMBEDDED UnicodeParser.swift
-  EMBEDDED UnicodeScalar.swift
-  EMBEDDED UnicodeScalarProperties.swift
-  EMBEDDED UnicodeSPI.swift
-  EMBEDDED Unmanaged.swift
-  EMBEDDED UnmanagedOpaqueString.swift
-  EMBEDDED UnmanagedString.swift
-  EMBEDDED UnsafeBufferPointerSlice.swift
-  EMBEDDED UnsafePointer.swift
-  EMBEDDED UnsafeRawPointer.swift
   EMBEDDED UTF16.swift
   EMBEDDED UTF32.swift
   EMBEDDED UTF8.swift
@@ -241,10 +223,28 @@ split_embedded_sources(
   EMBEDDED UTF8SpanInternalHelpers.swift
   EMBEDDED UTF8SpanIterators.swift
   EMBEDDED UTFEncoding.swift
+  EMBEDDED UnavailableStringAPIs.swift
+  EMBEDDED UnfoldSequence.swift
+  EMBEDDED Unicode.swift
+  EMBEDDED UnicodeBreakProperty.swift
+  EMBEDDED UnicodeData.swift
+  EMBEDDED UnicodeEncoding.swift
+  EMBEDDED UnicodeHelpers.swift
+  EMBEDDED UnicodeParser.swift
+  EMBEDDED UnicodeSPI.swift
+  EMBEDDED UnicodeScalar.swift
+  EMBEDDED UnicodeScalarProperties.swift
+  EMBEDDED Unmanaged.swift
+  EMBEDDED UnmanagedOpaqueString.swift
+  EMBEDDED UnmanagedString.swift
+  EMBEDDED UnsafeBufferPointerSlice.swift
+  EMBEDDED UnsafePointer.swift
+  EMBEDDED UnsafeRawPointer.swift
   EMBEDDED ValidUTF8Buffer.swift
     NORMAL VarArgs.swift
   EMBEDDED WriteBackMutableSlice.swift
   EMBEDDED Zip.swift
+  EMBEDDED _InlineArray.swift
     NORMAL "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
   )
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -27,7 +27,6 @@ split_embedded_sources(
   OUT_LIST_EMBEDDED SWIFTLIB_EMBEDDED_SOURCES
   OUT_LIST_NORMAL SWIFTLIB_SOURCES
 
-  ### "ESSENTIAL" SOURCES
   ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
   EMBEDDED _InlineArray.swift
   EMBEDDED Algorithm.swift
@@ -43,6 +42,7 @@ split_embedded_sources(
   EMBEDDED ASCII.swift
   EMBEDDED Assert.swift
   EMBEDDED AssertCommon.swift
+  EMBEDDED Availability.swift
   EMBEDDED BidirectionalCollection.swift
   EMBEDDED Bitset.swift
   EMBEDDED Bool.swift
@@ -58,6 +58,9 @@ split_embedded_sources(
     NORMAL Codable.swift
   EMBEDDED Collection.swift
   EMBEDDED CollectionAlgorithms.swift
+  EMBEDDED CollectionDifference.swift
+  EMBEDDED CollectionOfOne.swift
+    NORMAL CommandLine.swift
   EMBEDDED Comparable.swift
   EMBEDDED CompilerProtocols.swift
   EMBEDDED ContiguousArray.swift
@@ -72,9 +75,12 @@ split_embedded_sources(
   EMBEDDED DictionaryCasting.swift
   EMBEDDED DictionaryStorage.swift
   EMBEDDED DictionaryVariant.swift
+  EMBEDDED Diffing.swift
   EMBEDDED DiscontiguousSlice.swift
   EMBEDDED DropWhile.swift
     NORMAL Dump.swift
+  EMBEDDED Duration.swift
+  EMBEDDED DurationProtocol.swift
   EMBEDDED EmptyCollection.swift
   EMBEDDED EnumeratedSequence.swift
   EMBEDDED Equatable.swift
@@ -84,6 +90,7 @@ split_embedded_sources(
   EMBEDDED FlatMap.swift
   EMBEDDED Flatten.swift
   EMBEDDED FloatingPoint.swift
+  EMBEDDED FloatingPointRandom.swift
   EMBEDDED Hashable.swift
   EMBEDDED Hasher.swift
     NORMAL Hashing.swift
@@ -92,6 +99,8 @@ split_embedded_sources(
   EMBEDDED Indices.swift
   EMBEDDED InlineArray.swift
   EMBEDDED InputStream.swift
+  EMBEDDED Instant.swift
+  EMBEDDED Int128.swift
   EMBEDDED IntegerParsing.swift
   EMBEDDED Integers.swift
   EMBEDDED Join.swift
@@ -106,6 +115,7 @@ split_embedded_sources(
   EMBEDDED Map.swift
   EMBEDDED MemoryLayout.swift
   EMBEDDED MigrationSupport.swift
+  EMBEDDED Mirror.swift
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift
@@ -118,6 +128,7 @@ split_embedded_sources(
   EMBEDDED Optional.swift
   EMBEDDED OptionSet.swift
   EMBEDDED OutputStream.swift
+    NORMAL PlaygroundDisplay.swift
   EMBEDDED Pointer.swift
   EMBEDDED Policy.swift
   EMBEDDED PrefixWhile.swift
@@ -152,6 +163,7 @@ split_embedded_sources(
     NORMAL Shims.swift
   EMBEDDED SipHash.swift
   EMBEDDED Slice.swift
+  EMBEDDED SliceBuffer.swift
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
   EMBEDDED Span/MutableRawSpan.swift
@@ -160,6 +172,7 @@ split_embedded_sources(
   EMBEDDED Span/OutputSpan.swift
   EMBEDDED Span/RawSpan.swift
   EMBEDDED Span/Span.swift
+  EMBEDDED StaticBigInt.swift
   EMBEDDED StaticPrint.swift
   EMBEDDED StaticString.swift
   EMBEDDED Stride.swift
@@ -194,11 +207,14 @@ split_embedded_sources(
   EMBEDDED StringUTF8View.swift
   EMBEDDED StringWordBreaking.swift
   EMBEDDED Substring.swift
+  EMBEDDED SwiftifyImport.swift
   EMBEDDED SwiftNativeNSArray.swift
   EMBEDDED TemporaryAllocation.swift
     NORMAL ThreadLocalStorage.swift
+  EMBEDDED UInt128.swift
   EMBEDDED UIntBuffer.swift
   EMBEDDED UnavailableStringAPIs.swift
+  EMBEDDED UnfoldSequence.swift
   EMBEDDED Unicode.swift
   EMBEDDED UnicodeBreakProperty.swift
   EMBEDDED UnicodeData.swift
@@ -211,6 +227,7 @@ split_embedded_sources(
   EMBEDDED Unmanaged.swift
   EMBEDDED UnmanagedOpaqueString.swift
   EMBEDDED UnmanagedString.swift
+  EMBEDDED UnsafeBufferPointerSlice.swift
   EMBEDDED UnsafePointer.swift
   EMBEDDED UnsafeRawPointer.swift
   EMBEDDED UTF16.swift
@@ -225,29 +242,8 @@ split_embedded_sources(
   EMBEDDED UTF8SpanIterators.swift
   EMBEDDED UTFEncoding.swift
   EMBEDDED ValidUTF8Buffer.swift
-  EMBEDDED WriteBackMutableSlice.swift
-
-    ### "NON-ESSENTIAL" SOURCES, LAYERED ON TOP OF THE "ESSENTIAL" ONES
-    ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
-  EMBEDDED Availability.swift
-  EMBEDDED CollectionDifference.swift
-  EMBEDDED CollectionOfOne.swift
-  EMBEDDED Diffing.swift
-  EMBEDDED Duration.swift
-  EMBEDDED DurationProtocol.swift
-  EMBEDDED FloatingPointRandom.swift
-  EMBEDDED Instant.swift
-  EMBEDDED Int128.swift
-  EMBEDDED Mirror.swift
-    NORMAL PlaygroundDisplay.swift
-  EMBEDDED SwiftifyImport.swift
-    NORMAL CommandLine.swift
-  EMBEDDED SliceBuffer.swift
-  EMBEDDED StaticBigInt.swift
-  EMBEDDED UInt128.swift
-  EMBEDDED UnfoldSequence.swift
-  EMBEDDED UnsafeBufferPointerSlice.swift
     NORMAL VarArgs.swift
+  EMBEDDED WriteBackMutableSlice.swift
   EMBEDDED Zip.swift
     NORMAL "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
   )

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -29,13 +29,14 @@ split_embedded_sources(
 
   ### "ESSENTIAL" SOURCES
   ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
-  # Some files can't be sorted alphabetically, see notes in the list below.
+  EMBEDDED _InlineArray.swift
   EMBEDDED Algorithm.swift
+  EMBEDDED AnyHashable.swift
+  EMBEDDED Array.swift
   EMBEDDED ArrayBody.swift
   EMBEDDED ArrayBuffer.swift
   EMBEDDED ArrayBufferProtocol.swift
   EMBEDDED ArrayCast.swift
-  EMBEDDED Array.swift
   EMBEDDED ArrayShared.swift
   EMBEDDED ArraySlice.swift
   EMBEDDED ArrayType.swift
@@ -51,17 +52,17 @@ split_embedded_sources(
   EMBEDDED Builtin.swift
   EMBEDDED BuiltinMath.swift
   EMBEDDED Character.swift
+  EMBEDDED CharacterProperties.swift
+  EMBEDDED ClosedRange.swift
     NORMAL CocoaArray.swift
     NORMAL Codable.swift
   EMBEDDED Collection.swift
   EMBEDDED CollectionAlgorithms.swift
   EMBEDDED Comparable.swift
   EMBEDDED CompilerProtocols.swift
-  EMBEDDED Sendable.swift
   EMBEDDED ContiguousArray.swift
-  EMBEDDED ContiguouslyStored.swift
-  EMBEDDED ClosedRange.swift
   EMBEDDED ContiguousArrayBuffer.swift
+  EMBEDDED ContiguouslyStored.swift
   EMBEDDED CString.swift
   EMBEDDED CTypes.swift
     NORMAL DebuggerSupport.swift
@@ -84,17 +85,12 @@ split_embedded_sources(
   EMBEDDED Flatten.swift
   EMBEDDED FloatingPoint.swift
   EMBEDDED Hashable.swift
-  # WORKAROUND: This file name is not sorted alphabetically in the list because
-  # if we do so, the compiler crashes.
-  EMBEDDED AnyHashable.swift
-  # END WORKAROUND
   EMBEDDED Hasher.swift
     NORMAL Hashing.swift
   EMBEDDED HashTable.swift
   EMBEDDED Identifiable.swift
   EMBEDDED Indices.swift
   EMBEDDED InlineArray.swift
-  EMBEDDED _InlineArray.swift
   EMBEDDED InputStream.swift
   EMBEDDED IntegerParsing.swift
   EMBEDDED Integers.swift
@@ -109,7 +105,7 @@ split_embedded_sources(
   EMBEDDED ManagedBuffer.swift
   EMBEDDED Map.swift
   EMBEDDED MemoryLayout.swift
-  EMBEDDED UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
+  EMBEDDED MigrationSupport.swift
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift
@@ -141,7 +137,7 @@ split_embedded_sources(
   EMBEDDED Reverse.swift
   EMBEDDED Runtime.swift
     NORMAL RuntimeFunctionCounters.swift
-  EMBEDDED SipHash.swift
+  EMBEDDED Sendable.swift
   EMBEDDED Sequence.swift
   EMBEDDED SequenceAlgorithms.swift
   EMBEDDED Set.swift
@@ -154,6 +150,7 @@ split_embedded_sources(
   EMBEDDED SetVariant.swift
   EMBEDDED ShadowProtocols.swift
     NORMAL Shims.swift
+  EMBEDDED SipHash.swift
   EMBEDDED Slice.swift
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
@@ -163,10 +160,9 @@ split_embedded_sources(
   EMBEDDED Span/OutputSpan.swift
   EMBEDDED Span/RawSpan.swift
   EMBEDDED Span/Span.swift
-  EMBEDDED StaticString.swift
   EMBEDDED StaticPrint.swift
+  EMBEDDED StaticString.swift
   EMBEDDED Stride.swift
-  EMBEDDED StringHashable.swift  # ORDER DEPENDENCY: Must precede String.swift
   EMBEDDED String.swift
   EMBEDDED StringBreadcrumbs.swift
   EMBEDDED StringBridge.swift
@@ -174,17 +170,19 @@ split_embedded_sources(
   EMBEDDED StringComparable.swift
   EMBEDDED StringComparison.swift
   EMBEDDED StringCreate.swift
+  EMBEDDED StringGraphemeBreaking.swift
   EMBEDDED StringGuts.swift
-  EMBEDDED StringGutsSlice.swift
   EMBEDDED StringGutsRangeReplaceable.swift
-  EMBEDDED StringObject.swift
-  EMBEDDED StringProtocol.swift
+  EMBEDDED StringGutsSlice.swift
+  EMBEDDED StringHashable.swift
   EMBEDDED StringIndex.swift
   EMBEDDED StringIndexConversions.swift
   EMBEDDED StringIndexValidation.swift
   EMBEDDED StringInterpolation.swift
   EMBEDDED StringLegacy.swift
   EMBEDDED StringNormalization.swift
+  EMBEDDED StringObject.swift
+  EMBEDDED StringProtocol.swift
   EMBEDDED StringRangeReplaceableCollection.swift
   EMBEDDED StringStorage.swift
   EMBEDDED StringStorageBridge.swift
@@ -192,8 +190,8 @@ split_embedded_sources(
   EMBEDDED StringTesting.swift
   EMBEDDED StringUnicodeScalarView.swift
   EMBEDDED StringUTF16View.swift
-  EMBEDDED StringUTF8View.swift
   EMBEDDED StringUTF8Validation.swift
+  EMBEDDED StringUTF8View.swift
   EMBEDDED StringWordBreaking.swift
   EMBEDDED Substring.swift
   EMBEDDED SwiftNativeNSArray.swift
@@ -201,20 +199,22 @@ split_embedded_sources(
     NORMAL ThreadLocalStorage.swift
   EMBEDDED UIntBuffer.swift
   EMBEDDED UnavailableStringAPIs.swift
+  EMBEDDED Unicode.swift
+  EMBEDDED UnicodeBreakProperty.swift
   EMBEDDED UnicodeData.swift
   EMBEDDED UnicodeEncoding.swift
-  EMBEDDED UnicodeBreakProperty.swift
   EMBEDDED UnicodeHelpers.swift
   EMBEDDED UnicodeParser.swift
+  EMBEDDED UnicodeScalar.swift
   EMBEDDED UnicodeScalarProperties.swift
-  EMBEDDED CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
   EMBEDDED UnicodeSPI.swift
   EMBEDDED Unmanaged.swift
   EMBEDDED UnmanagedOpaqueString.swift
   EMBEDDED UnmanagedString.swift
   EMBEDDED UnsafePointer.swift
   EMBEDDED UnsafeRawPointer.swift
-  EMBEDDED UTFEncoding.swift
+  EMBEDDED UTF16.swift
+  EMBEDDED UTF32.swift
   EMBEDDED UTF8.swift
   EMBEDDED UTF8EncodingError.swift
   EMBEDDED UTF8Span.swift
@@ -223,13 +223,9 @@ split_embedded_sources(
   EMBEDDED UTF8SpanFundamentals.swift
   EMBEDDED UTF8SpanInternalHelpers.swift
   EMBEDDED UTF8SpanIterators.swift
-  EMBEDDED UTF16.swift
-  EMBEDDED UTF32.swift
-  EMBEDDED Unicode.swift # ORDER DEPENDENCY: must follow new unicode support
-  EMBEDDED StringGraphemeBreaking.swift # ORDER DEPENDENCY: Must follow UTF16.swift
+  EMBEDDED UTFEncoding.swift
   EMBEDDED ValidUTF8Buffer.swift
   EMBEDDED WriteBackMutableSlice.swift
-  EMBEDDED MigrationSupport.swift
 
     ### "NON-ESSENTIAL" SOURCES, LAYERED ON TOP OF THE "ESSENTIAL" ONES
     ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -260,7 +260,7 @@ extension Unicode.UTF16 {
   }
 }
 
-extension Unicode.UTF16: Unicode.Encoding {
+extension Unicode.UTF16: _UnicodeEncoding {
   public typealias CodeUnit = UInt16
   public typealias EncodedScalar = _UIntBuffer<UInt16>
 

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -58,7 +58,7 @@ public enum UnicodeDecodingResult: Equatable, Sendable {
 /// UTF-8, UTF-16, and UTF-32 encoding schemes as the `UTF8`, `UTF16`, and
 /// `UTF32` types, respectively. Use the `Unicode.Scalar` type to work with
 /// decoded Unicode scalar values.
-public protocol UnicodeCodec: Unicode.Encoding {
+public protocol UnicodeCodec: _UnicodeEncoding {
 
   /// Creates an instance of the codec.
   init()

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -258,8 +258,8 @@ func resyncParserB11() {}
 // rdar://21346928
 func optStr() -> String? { return nil }
 let x = (optStr() ?? "autoclosure").#^TOP_LEVEL_AUTOCLOSURE_1?check=AUTOCLOSURE_STRING^#
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal/IsSystem: unicodeScalars[#String.UnicodeScalarView#]
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal/IsSystem: utf16[#String.UTF16View#]
+// AUTOCLOSURE_STRING-DAG: Decl[InstanceVar]/CurrNominal/IsSystem: unicodeScalars[#String.UnicodeScalarView#]
+// AUTOCLOSURE_STRING-DAG: Decl[InstanceVar]/CurrNominal/IsSystem: utf16[#String.UTF16View#]
 
 func resyncParserB12() {}
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1617,8 +1617,8 @@ func testThrows006() {
 
 // rdar://21346928
 // Just sample some String API to soundness check.
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}unicodeScalars[#String.UnicodeScalarView#]
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}utf16[#String.UTF16View#]
+// AUTOCLOSURE_STRING-DAG: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}unicodeScalars[#String.UnicodeScalarView#]
+// AUTOCLOSURE_STRING-DAG: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}utf16[#String.UTF16View#]
 func testWithAutoClosure1(_ x: String?) {
   (x ?? "autoclosure").#^AUTOCLOSURE1?check=AUTOCLOSURE_STRING^#
 }


### PR DESCRIPTION
The CMakeLists.txt for the standard library mostly sorted the source files in alphabetical order, but documented a few cases where compiler bugs prevented them from being fully alphabetical. Most of those compiler bugs have been fixed by now, so switch over to alphabetical order. This both matches intent and matches what SwiftPM does. This also gets rid of the now-unused separation between "essential" and "non-essential" standard library sources.

Note that there is one remaining compiler issue that involves protocol conformance resolution where the protocol is named via a typealias. For now I've worked around the issue in the standard library sources by manually looking through the typealias.