### PR TITLE
[6.3] stdlib: Fix OpenBSD typo in preprocessor in `Concurrency/Clock.cpp`

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -240,7 +240,7 @@ void swift_sleep(
     delay = deadline - now;
   }
 #elif defined(__linux__) || defined(__APPLE__) || defined(__wasi__) \
-  || defined(__OpenBSD) || defined(__FreeBSD__)
+  || defined(__OpenBSD__) || defined(__FreeBSD__)
   struct timespec ts;
   ts.tv_sec = seconds;
   ts.tv_nsec = nanoseconds;


### PR DESCRIPTION
Explanation:
Fixes a typo causing OpenBSD
Scope: No breakage at all, assuming no misuse of the original function that has this issue/bug in compiler that this bug would have hidden.
Original PRs: https://github.com/swiftlang/swift/pull/85885
Risk: Small risk if the new code happened to have quirks on OpenBSD, but that does not seem to be the case.
Testing: Passed all tests across all platforms.
Reviewers: @MaxDesiatov 