### PR TITLE
[cxx-interop] Fix SafeInteropWrappers crash with namespaced std::span functions

### DIFF
--- a/test/Interop/Cxx/swiftify-import/std-span-in-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/std-span-in-namespace.swift
@@ -1,0 +1,58 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: std_span
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/test.swift -emit-module -o %t/test.swiftmodule -Xcc -std=c++20
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/test.swift -emit-sil -Xcc -std=c++20 | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module StdSpanNamespace {
+    header "span.hpp"
+    requires cplusplus
+    export *
+}
+
+//--- Inputs/span.hpp
+#pragma once
+
+#include <span>
+#include <lifetimebound.h>
+
+using SpanFloat = std::span<const float>;
+using MutableSpanFloat = std::span<float>;
+
+namespace foo {
+
+void takeSpan(SpanFloat buffer __noescape);
+void takeMutableSpan(MutableSpanFloat buffer __noescape);
+
+}
+
+//--- Inputs/span.cpp
+#include "span.hpp"
+
+namespace foo {
+
+void takeSpan(SpanFloat buffer __noescape) {
+  return;
+}
+
+void takeMutableSpan(MutableSpanFloat buffer __noescape) {
+  return;
+}
+
+}
+
+//--- test.swift
+import StdSpanNamespace
+
+public func testBuffer(buffer: Span<Float>) {
+  // CHECK: function_ref @{{.*}}foo{{.*}}takeSpan
+  foo.takeSpan(buffer)
+}
+
+public func testBuffer2(buffer: inout MutableSpan<Float>) {
+  // CHECK: function_ref @{{.*}}foo{{.*}}takeMutableSpan
+  foo.takeMutableSpan(&buffer)
+}


### PR DESCRIPTION
Resolves #86269

The Swift compiler was crashing when SafeInteropWrappers generated wrappers for C++ functions that were both in a namespace and used std::span parameters.

Root cause: The SIL linker's deserializeAndPushToWorklist assertion required functions with shared visibility to either have a body or a foreign body. SafeInteropWrappers-generated functions have shared linkage (from @_alwaysEmitIntoClient) but aren't Clang-generated, so hasForeignBody() returns false.

Solution: Relax the assertion to allow @_alwaysEmitIntoClient functions to have shared linkage without a foreign body, as these are designed to be emitted in the client module.

Testing: Added regression test for std::span in C++ namespaces.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
