### PR TITLE
[6.3] Runtime: Fix error message concatenation using null pointer

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -333,7 +333,7 @@ reportOnCrash(uint32_t flags, const char *message)
     current = nullptr;
 
     if (previous)
-      swift_asprintf(&current, "%s%s", current, message);
+      swift_asprintf(&current, "%s%s", previous, message);
     else
 #if defined(_WIN32)
       current = ::_strdup(message);


### PR DESCRIPTION
Explanation:
Error message would have always printed (null) instead of the correct variable
Original PRs: https://github.com/swiftlang/swift/pull/86224
Risk: Cannot forsee any.
Testing: Passed all tests across all platforms.
Reviewers: @compnerd