### PR TITLE
6.3: Concurrency: improve withTaskPriorityEscal... docs and adopt noniso(nonsend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@
   // priority: high!
   await withTaskPriorityEscalationHandler {
   await work()
-  } onPriorityEscalated: { newPriority in // may not be triggered if ->high escalation happened before handler was installed
+  } onPriorityEscalated: { oldPriority, newPriority in // may not be triggered if ->high escalation happened before handler was installed
   // do something
   }
   ```

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -106,8 +106,28 @@ extension UnsafeCurrentTask {
 ///              and the second argument is the new escalated priority.
 /// - Returns: the value returned by `operation`
 /// - Throws: when the `operation` throws an error
+@export(implementation)
 @available(SwiftStdlib 6.2, *)
-public func withTaskPriorityEscalationHandler<T, E>(
+public nonisolated(nonsending) func withTaskPriorityEscalationHandler<T, E>(
+  operation: nonisolated(nonsending)  () async throws(E) -> T,
+  onPriorityEscalated handler: @Sendable (TaskPriority, TaskPriority) -> Void
+) async throws(E) -> T {
+  return try await __withTaskPriorityEscalationHandler0(
+    operation: operation,
+    onPriorityEscalated: {
+      handler(TaskPriority(rawValue: $0), TaskPriority(rawValue: $1))
+    })
+}
+
+@available(SwiftStdlib 6.2, *)
+@abi(
+  func withTaskPriorityEscalationHandler<T, E>(
+    operation: () async throws(E) -> T,
+    onPriorityEscalated handler: @Sendable (TaskPriority, TaskPriority) -> Void,
+    isolation: isolated (any Actor)?
+  ) async throws(E) -> T
+)
+public func _isolatedParameter_withTaskPriorityEscalationHandler<T, E>(
   operation: () async throws(E) -> T,
   onPriorityEscalated handler: @Sendable (TaskPriority, TaskPriority) -> Void,
   isolation: isolated (any Actor)? = #isolation
@@ -122,10 +142,9 @@ public func withTaskPriorityEscalationHandler<T, E>(
 // Method necessary in order to avoid the handler0 to be destroyed too eagerly.
 @available(SwiftStdlib 6.2, *)
 @_alwaysEmitIntoClient
-func __withTaskPriorityEscalationHandler0<T, E>(
-  operation: () async throws(E) -> T,
-  onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void,
-  isolation: isolated (any Actor)? = #isolation
+nonisolated(nonsending) func __withTaskPriorityEscalationHandler0<T, E>(
+  operation: nonisolated(nonsending) () async throws(E) -> T,
+  onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void
 ) async throws(E) -> T {
 #if $BuiltinConcurrencyStackNesting
   let record =

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -101,7 +101,9 @@ extension UnsafeCurrentTask {
 /// - Parameters:
 ///   - operation: the operation during which to listen for priority escalation
 ///   - handler: handler to invoke, concurrently to `operation`,
-///              when priority escalation happens
+///              when priority escalation happens.
+///              The first argument is the old priority (before escalation),
+///              and the second argument is the new escalated priority.
 /// - Returns: the value returned by `operation`
 /// - Throws: when the `operation` throws an error
 @available(SwiftStdlib 6.2, *)
@@ -143,7 +145,7 @@ func __withTaskPriorityEscalationHandler0<T, E>(
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_addPriorityEscalationHandler")
 func _taskAddPriorityEscalationHandler(
-  handler: (UInt8, UInt8) -> Void
+  handler: (/* oldPriority: */UInt8, /* newPriority: */UInt8) -> Void
 ) -> UnsafeRawPointer /*EscalationNotificationStatusRecord*/
 
 @usableFromInline


### PR DESCRIPTION
(wrong branch name, but right contents... I blame first day after holidays 😅)

**Description**: Updates docs and moves the withTaskPriorityEscalationHandler API to nonisolated(nonsending) which all "with" methods should do in concurrency lib.
**Scope/Impact**: The withTaskPriorityEscalationHandler method only
**Risk:** 
- source compat impact - removal of the defaulted isolated: parameter
- ABI compatibility is maintained

**Testing**: CI testing
**Reviewed by**: 

**Original PR:** https://github.com/swiftlang/swift/pull/86282
**Radar:** rdar://158140059