### PR TITLE
Introduce a SwiftPM package to build the Embedded Swift Standard Library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,256 @@
+// swift-tools-version: 6.3
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This package manifest is used only for Embedded Swift. Clients need to
+// provide a number of specialized build settings to make it work at all.
+//
+//===----------------------------------------------------------------------===//
+
+import CompilerPluginSupport
+import Foundation
+import PackageDescription
+
+// Common Swift settings for the Standard Library and its various supporting
+// libraries. This was extracted from CMakeLists.txt and likely contains some
+// stale settings.
+let basicSwiftSettings: [SwiftSetting] = try! [
+  .enableExperimentalFeature("NoncopyableGenerics2"),
+  .enableExperimentalFeature("SE427NoInferenceOnExtension"),
+  .enableExperimentalFeature("NonescapableTypes"),
+  .enableExperimentalFeature("Lifetimes"),
+  .enableExperimentalFeature("LifetimeDependence"),
+  .enableExperimentalFeature("InoutLifetimeDependence"),
+  .enableExperimentalFeature("LifetimeDependenceMutableAccessors"),
+  .enableExperimentalFeature("BorrowAndMutateAccessors"),
+  .enableExperimentalFeature("Reparenting"),
+  .enableExperimentalFeature("Embedded"),
+  .swiftLanguageMode(.v5),
+  .strictMemorySafety(),
+  .unsafeFlags([
+      "-Xfrontend", "-emit-empty-object-file",
+      "-nostdimport", "-nostdlibimport",
+    ])
+] + availabilityMacros.map { macro in
+  .unsafeFlags([
+      "-Xfrontend", "-define-availability", "-Xfrontend", "\(macro)"
+  ])
+}
+
+let package = Package(
+  name: "SwiftStandardLibrary",
+  platforms: [
+    .macOS(.v15),
+    .iOS(.v13),
+    .tvOS(.v13),
+    .watchOS(.v6),
+    .macCatalyst(.v13)
+  ],
+  products: [
+    .library(
+      name: "Swift",
+      targets: ["Swift"]
+    ),
+
+    .library(
+      name: "_Builtin_float",
+      targets: ["_Builtin_float"]
+    ),
+
+    .library(
+      name: "_Volatile",
+      targets: ["_Volatile"]
+    ),
+
+    .library(
+      name: "Synchronization",
+      targets: ["Synchronization"]
+    ),
+  ],
+  traits: [
+    /// The UnicodeDataTables trait is used to link in the library containing
+    /// the Unicode data tables.
+    .trait(name: "UnicodeDataTables"),
+  ],
+  targets: [
+    // Swift standard library
+    .target(
+      name: "Swift",
+      dependencies: [
+        .target(
+          name: "SwiftUnicodeDataTables",
+          condition: .when(traits: ["UnicodeDataTables"])
+        ),
+      ],
+      path: "stdlib/public/core",
+      exclude: [
+        // Not relevant to the SwiftPM build.
+        "GroupInfo.json",
+        "PreviousModuleInstallName.json",
+
+        // This is hidden for some platforms in the CMake.
+        // TODO: Figure out whether we can get this enabled everywhere,
+        // using #ifs in the sources if necessary.
+        "ObjectIdentifier+DebugDescription.swift",
+        
+        // TODO: This file is unused and should probably be removed.
+        "EitherSequence.swift",
+
+        // Ignore the CMake build system.
+        "CMakeLists.txt",
+
+        // Standard library files that aren't included in the Embedded
+        // build. These are marked as "NORMAL" in CMakeLists.txt
+        "BridgeObjectiveC.swift",
+        "BridgingBuffer.swift",
+        "CocoaArray.swift",
+        "Codable.swift",
+        "CommandLine.swift",
+        "DebuggerSupport.swift",
+        "Dump.swift",
+        "Hashing.swift",
+        "LegacyABI.swift",
+        "Macros.swift",
+        "Mirrors.swift",
+        "PlaygroundDisplay.swift",
+        "Prespecialize.swift",
+        "Print.swift",
+        "REPL.swift",
+        "ReflectionMirror.swift",
+        "RuntimeFunctionCounters.swift",
+        "SetAnyHashableExtensions.swift",
+        "SetBridging.swift",
+        "Shims.swift",
+        "ThreadLocalStorage.swift",
+        "VarArgs.swift",
+        "AtomicInt.swift.gyb",
+      ],
+      swiftSettings: basicSwiftSettings + [
+        .enableExperimentalFeature("Extern"),
+        .enableExperimentalFeature("AddressableTypes"),
+        .enableExperimentalFeature("AddressableParameters"),
+        .unsafeFlags(["-parse-stdlib"]),
+      ],
+      plugins: ["GYBPlugin"],
+    ),
+
+    // Unicode tables for operations that require them. Clients are expected
+    // to use this by defining the UnicodeDataTables trait.
+    .target(
+      name: "SwiftUnicodeDataTables",
+      path: "stdlib/public/stubs/Unicode",
+      sources: [
+        "UnicodeData.cpp",
+        "UnicodeGrapheme.cpp",
+        "UnicodeNormalization.cpp",
+        "UnicodeScalarProps.cpp",
+        "UnicodeWord.cpp",
+      ],
+      publicHeadersPath: "",
+      cSettings: [
+        .headerSearchPath("../../../../stdlib/public/SwiftShims"),
+        .define("SWIFT_STDLIB_ENABLE_UNICODE_DATA"),
+      ],
+    ),
+
+    .target(
+      name: "_Builtin_float",
+      dependencies: ["Swift"],
+      path: "stdlib/public/ClangOverlays",
+      exclude: [
+        // Ignore the CMake build system.
+        "CMakeLists.txt",
+
+        "linker-support/magic-symbols-for-install-name.c",
+      ],
+      swiftSettings: basicSwiftSettings,
+      plugins: ["GYBPlugin"],
+    ),
+
+    .target(
+      name: "_Volatile",
+      dependencies: ["Swift"],
+      path: "stdlib/public/Volatile",
+      exclude: [
+        "CMakeLists.txt",
+      ],
+      swiftSettings: basicSwiftSettings + [
+        .unsafeFlags(["-parse-stdlib"]),
+      ],
+    ),
+
+    .target(
+      name: "Synchronization",
+      dependencies: ["Swift"],
+      path: "stdlib/public/Synchronization",
+      exclude: [
+        // Ignore the CMake build system.
+        "CMakeLists.txt",
+
+        // TODO: This exclusion list means that Mutex support is completely
+        // disabled.
+        "Mutex/Mutex.swift",
+        "Mutex/DarwinImpl.swift",
+        "Mutex/FreeBSDImpl.swift",
+        "Mutex/LinuxImpl.swift",
+        "Mutex/OpenBSDImpl.swift",
+        "Mutex/SpinLoopHint.swift",
+        "Mutex/WasmImpl.swift",
+        "Mutex/WindowsImpl.swift",
+      ],
+      swiftSettings: basicSwiftSettings + [
+        .enableExperimentalFeature("BuiltinModule"),
+        .enableExperimentalFeature("RawLayout"),
+        .enableExperimentalFeature("StaticExclusiveOnly"),
+      ],
+      plugins: ["GYBPlugin"],
+    ),
+
+    // Plugin for expanding .swift.gyb files into .swift files.
+    .plugin(
+      name: "GYBPlugin",
+      capability: .buildTool(),
+    ),
+  ]
+)
+
+// utils/availability-macros.def processing logic, used to figure out
+// availability macro definitions.
+var availabilityMacros: [String] {
+  get throws {
+    let allLines = try String(contentsOfFile: Context.packageDirectory + "/utils/availability-macros.def", encoding: .utf8)
+      .split(separator: "\n")
+     let foundMacros = allLines.compactMap { (line) -> String? in
+      if line.contains("#") { return nil }
+
+      guard let colonIndex = line.firstIndex(of: ":") else {
+        return nil
+      }
+
+      // Under embedded swift, all stdlib APIs should be available always.
+      // Replace all availability macros with very very old OS version.      
+      return String(line[..<colonIndex]) + ":macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0"
+    }
+
+    // Create "StdlibDeploymentTarget" counterparts for "SwiftStdlib"
+    // availability macros.
+    return foundMacros + foundMacros.compactMap { macro in
+      guard macro.contains("SwiftStdlib") else {
+        return nil
+      }
+
+      let afterPrefix = macro.index(macro.startIndex, offsetBy: "SwiftStdlib".count)
+      return "StdlibDeploymentTarget" + String(macro[afterPrefix...])
+    }
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,17 @@ import CompilerPluginSupport
 import Foundation
 import PackageDescription
 
+let availabilitySettings: [SwiftSetting] = try!
+  availabilityMacros.map { macro in
+    .unsafeFlags([
+        "-Xfrontend", "-define-availability", "-Xfrontend", "\(macro)"
+    ])
+  }
+
 // Common Swift settings for the Standard Library and its various supporting
 // libraries. This was extracted from CMakeLists.txt and likely contains some
 // stale settings.
-let basicSwiftSettings: [SwiftSetting] = try! [
+let basicSwiftSettings: [SwiftSetting] = [
   .enableExperimentalFeature("NoncopyableGenerics2"),
   .enableExperimentalFeature("SE427NoInferenceOnExtension"),
   .enableExperimentalFeature("NonescapableTypes"),
@@ -41,14 +48,10 @@ let basicSwiftSettings: [SwiftSetting] = try! [
       "-Xfrontend", "-emit-empty-object-file",
       "-nostdimport", "-nostdlibimport",
     ])
-] + availabilityMacros.map { macro in
-  .unsafeFlags([
-      "-Xfrontend", "-define-availability", "-Xfrontend", "\(macro)"
-  ])
-}
+] + availabilitySettings
 
 let package = Package(
-  name: "SwiftStandardLibrary",
+  name: "swift-standard-library",
   platforms: [
     .macOS(.v15),
     .iOS(.v13),
@@ -76,6 +79,11 @@ let package = Package(
       name: "Synchronization",
       targets: ["Synchronization"]
     ),
+
+    .library(
+      name: "_Concurrency",
+      targets: ["_Concurrency"]
+    ),
   ],
   traits: [
     /// The UnicodeDataTables trait is used to link in the library containing
@@ -83,10 +91,17 @@ let package = Package(
     .trait(name: "UnicodeDataTables"),
   ],
   targets: [
+    .target(
+      name: "SwiftShims",
+      path: "stdlib/public/SwiftShims/swift/shims",
+      publicHeadersPath: "."
+    ),
+
     // Swift standard library
     .target(
       name: "Swift",
       dependencies: [
+        "SwiftShims",
         .target(
           name: "SwiftUnicodeDataTables",
           condition: .when(traits: ["UnicodeDataTables"])
@@ -216,21 +231,175 @@ let package = Package(
       plugins: ["GYBPlugin"],
     ),
 
+    .target(
+      name: "_ConcurrencyCpp",
+      path: "stdlib/public/Concurrency",
+      sources: [
+        "Actor.cpp",
+        "AsyncLet.cpp",
+        "Clock.cpp",
+        "ConcurrencyHooks.cpp",
+        "GlobalExecutor.cpp",
+        "EmbeddedSupport.cpp",
+        "Error.cpp",
+        "ExecutorBridge.cpp",
+        "ExecutorChecks.cpp",
+        "Task.cpp",
+        "TaskAlloc.cpp",
+        "TaskStatus.cpp",
+        "TaskGroup.cpp",
+        "TaskLocal.cpp",
+        "ThreadingError.cpp",
+        "TracingSignpost.cpp",
+        "AsyncStream.cpp",
+      ],
+      publicHeadersPath: ".",
+      cSettings: [
+        .headerSearchPath("../../../include/"),
+        .headerSearchPath("../../../stdlib/public/SwiftShims"),
+        .headerSearchPath("../../../stdlib/public/DummyHeaders"),
+        .headerSearchPath("../../../stdlib/include"),
+        .define("SWIFT_TARGET_LIBRARY_NAME", to: "swift_Concurrency"),
+        .define("SWIFT_CONCURRENCY_EMBEDDED", to: "1"),
+        .define("SWIFT_RUNTIME_EMBEDDED", to: "1"),
+      ],
+      plugins: ["GYBPlugin"],
+    ),
+
+    .target(
+      name: "ConcurrencyShims",
+      path: "stdlib/public/Concurrency/InternalShims",
+      publicHeadersPath: "."
+    ),
+
+    .target(
+      name: "_Concurrency",
+      dependencies: ["ConcurrencyShims", "Swift", "Synchronization", "_ConcurrencyCpp"],
+      path: "stdlib/public/Concurrency",
+      sources: [
+        "Actor.swift",
+        "AsyncLet.swift",
+        "CheckedContinuation.swift",
+        "Errors.swift",
+        "Executor.swift",
+        "ExecutorBridge.swift",
+        "ExecutorAssertions.swift",
+        "AsyncCompactMapSequence.swift",
+        "AsyncDropFirstSequence.swift",
+        "AsyncDropWhileSequence.swift",
+        "AsyncFilterSequence.swift",
+        "AsyncFlatMapSequence.swift",
+        "AsyncIteratorProtocol.swift",
+        "AsyncMapSequence.swift",
+        "AsyncPrefixSequence.swift",
+        "AsyncPrefixWhileSequence.swift",
+        "AsyncSequence.swift",
+        "AsyncThrowingCompactMapSequence.swift",
+        "AsyncThrowingDropWhileSequence.swift",
+        "AsyncThrowingFilterSequence.swift",
+        "AsyncThrowingFlatMapSequence.swift",
+        "AsyncThrowingMapSequence.swift",
+        "AsyncThrowingPrefixWhileSequence.swift",
+        "PartialAsyncTask.swift",
+        "GlobalActor.swift",
+        "GlobalConcurrentExecutor.swift",
+        "MainActor.swift",
+        "PriorityQueue.swift",
+        "SourceCompatibilityShims.swift",
+        "Task.swift",
+        "Task+PriorityEscalation.swift",
+        "Task+TaskExecutor.swift",
+        "TaskCancellation.swift",
+        "TaskGroup.swift",
+        "DiscardingTaskGroup.swift",
+        "TaskLocal.swift",
+        "TaskSleep.swift",
+        "AsyncStreamBuffer.swift",
+        "AsyncStream.swift",
+        "AsyncThrowingStream.swift",
+        "Deque/_DequeBuffer.swift",
+        "Deque/_DequeBufferHeader.swift",
+        "Deque/_DequeSlot.swift",
+        "Deque/_UnsafeWrappedBuffer.swift",
+        "Deque/Compatibility.swift",
+        "Deque/Deque+Storage.swift",
+        "Deque/Deque+UnsafeHandle.swift",
+        "Deque/Deque.swift",
+        "Deque/Deque+Codable.swift",
+        "Deque/Deque+Collection.swift",
+        "Deque/Deque+CustomDebugStringConvertible.swift",
+        "Deque/Deque+CustomReflectable.swift",
+        "Deque/Deque+CustomStringConvertible.swift",
+        "Deque/Deque+Equatable.swift",
+        "Deque/Deque+ExpressibleByArrayLiteral.swift",
+        "Deque/Deque+Extras.swift",
+        "Deque/Deque+Hashable.swift",
+        "Deque/Deque+Testing.swift",
+        "Deque/UnsafeMutableBufferPointer+Utilities.swift",
+        "Clock.swift",
+        "ContinuousClock.swift",
+        "SuspendingClock.swift",
+        "TaskSleepDuration.swift",
+        "UnimplementedExecutor.swift",
+        "CooperativeExecutor.swift",
+        "PlatformExecutorCooperative.swift",
+        "PlatformExecutorDarwin.swift",
+        "PlatformExecutorLinux.swift",
+        "PlatformExecutorWindows.swift",
+        "PlatformExecutorOpenBSD.swift",
+        "PlatformExecutorFreeBSD.swift",
+      ],
+      swiftSettings: basicSwiftSettings + [
+        .enableExperimentalFeature("BuiltinModule"),
+        .unsafeFlags(["-parse-stdlib"]),
+        .define("SWIFT_CONCURRENCY_EMBEDDED"),
+        .unsafeFlags(["-runtime-compatibility-version", "none"]),
+      ],
+      plugins: ["GYBPlugin"],
+    ),
+
     // Plugin for expanding .swift.gyb files into .swift files.
     .plugin(
       name: "GYBPlugin",
       capability: .buildTool(),
     ),
-  ]
+  ],
+  cxxLanguageStandard: .gnucxx17
 )
 
 // utils/availability-macros.def processing logic, used to figure out
 // availability macro definitions.
 var availabilityMacros: [String] {
   get throws {
-    let allLines = try String(contentsOfFile: Context.packageDirectory + "/utils/availability-macros.def", encoding: .utf8)
+    // Due to https://github.com/swiftlang/swift-package-manager/issues/5610,
+    // we're unable to use packageDirectory, so hardcode the string.
+    #if false
+    let allLines = try String(contentsOfFile: Context.packageDirectory + "utils/availability-macros.def", encoding: .utf8)
       .split(separator: "\n")
-     let foundMacros = allLines.compactMap { (line) -> String? in
+    #else
+    let allLines = """
+      SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+      SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
+      SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0
+      SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4
+      SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
+      SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
+      SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
+      SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
+      SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
+      SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
+      SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
+      SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
+      SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
+      SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
+      SwiftStdlib 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0
+      SwiftStdlib 6.3:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4
+      SwiftStdlib 6.4:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+      SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0
+      SwiftCompatibilitySpan 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionBacktracing 6.2: macOS 26.0
+      """.split(separator: "\n")
+    #endif
+    let foundMacros = allLines.compactMap { (line) -> String? in
       if line.contains("#") { return nil }
 
       guard let colonIndex = line.firstIndex(of: ":") else {
@@ -239,18 +408,18 @@ var availabilityMacros: [String] {
 
       // Under embedded swift, all stdlib APIs should be available always.
       // Replace all availability macros with very very old OS version.      
-      return String(line[..<colonIndex]) + ":macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0"
+//      return String(line[..<colonIndex]) + ":macOS 10.14, iOS 12.0, watchOS 7.0, tvOS 12.0, visionOS 1.0"
+      return String(line[..<colonIndex]) + ":*"
     }
 
     // Create "StdlibDeploymentTarget" counterparts for "SwiftStdlib"
     // availability macros.
     return foundMacros + foundMacros.compactMap { macro in
-      guard macro.contains("SwiftStdlib") else {
+      if !macro.contains("SwiftStdlib") {
         return nil
       }
 
-      let afterPrefix = macro.index(macro.startIndex, offsetBy: "SwiftStdlib".count)
-      return "StdlibDeploymentTarget" + String(macro[afterPrefix...])
+      return macro.replacingOccurrences(of: "SwiftStdlib", with: "StdlibDeploymentTarget")
     }
   }
 }

--- a/Plugins/GYBPlugin/GYBPlugin.swift
+++ b/Plugins/GYBPlugin/GYBPlugin.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Plugin that expands *.swift.gyb files using the Gyb tool that is part of
+// the Swift repository.
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import PackagePlugin
+
+@main
+struct GYBPlugin: BuildToolPlugin {
+  func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+    guard let sourceModule = target.sourceModule else { return [] }
+
+    let gybFiles = sourceModule.sourceFiles(withSuffix: ".gyb").map {
+      $0.url.path
+    }
+
+    if gybFiles.isEmpty {
+      return []
+    }
+
+    // TODO: Find 'python' in a more robust manner, or switch to a Swift-only
+    // implementation of gyb.
+    let python = FileManager.default.fileExists(atPath: "/usr/local/bin/python")
+      ? URL(filePath: "/usr/local/bin/python")!
+      : URL(filePath: "/usr/bin/python")!
+    let gybPath = URL(filePath: "utils/gyb")!.path
+    
+    // Set pointer size passed to GYB.
+    // TODO: Can we get this from the target description somehow?
+    let pointerSize: Int
+    if let pointerSizeEnv = ProcessInfo.processInfo.environment["SWIFT_POINTER_SIZE"] {
+      pointerSize = Int(pointerSizeEnv)!
+    } else {
+      pointerSize = 8
+    }
+
+    return gybFiles.map { gybFilePath in
+      let swiftFileURL = URL(filePath: context.pluginWorkDirectoryURL.path)
+        .appending(path: "\(pointerSize)")
+        .appending(path: URL(filePath: gybFilePath).lastPathComponent)
+        .deletingPathExtension()
+      return .buildCommand(
+        displayName: "GYB \(gybFilePath) in module \(sourceModule.name) for ptr size = \(pointerSize) to \(swiftFileURL.path)",
+        executable: python,
+        arguments: [
+          gybPath, "-DCMAKE_SIZEOF_VOID_P=\(pointerSize)",
+          "-o", swiftFileURL.path,
+          gybFilePath,
+        ],
+        inputFiles: [ URL(filePath: gybFilePath) ],
+        outputFiles: [ swiftFileURL ]
+      )
+    }
+  }
+}

--- a/Plugins/GYBPlugin/GYBPlugin.swift
+++ b/Plugins/GYBPlugin/GYBPlugin.swift
@@ -32,9 +32,9 @@ struct GYBPlugin: BuildToolPlugin {
 
     // TODO: Find 'python' in a more robust manner, or switch to a Swift-only
     // implementation of gyb.
-    let python = FileManager.default.fileExists(atPath: "/usr/local/bin/python")
-      ? URL(filePath: "/usr/local/bin/python")!
-      : URL(filePath: "/usr/bin/python")!
+    let python = FileManager.default.fileExists(atPath: "/usr/local/bin/python3")
+      ? URL(filePath: "/usr/local/bin/python3")!
+      : URL(filePath: "/usr/bin/python3")!
     let gybPath = URL(filePath: "utils/gyb")!.path
     
     // Set pointer size passed to GYB.

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
     linker-support/magic-symbols-for-install-name.c
   )
 
+  # EMBEDDED float.swift.gyb
   set(BUILTIN_FLOAT_GYB_SOURCES
     float.swift.gyb
   )

--- a/stdlib/public/ClangOverlays/dummy.swift
+++ b/stdlib/public/ClangOverlays/dummy.swift
@@ -1,0 +1,2 @@
+// Placeholder file to ensure that SwiftPM detects this target as a
+// Swift target.

--- a/stdlib/public/DummyHeaders/swift/Runtime/CMakeConfig.h
+++ b/stdlib/public/DummyHeaders/swift/Runtime/CMakeConfig.h
@@ -1,0 +1,10 @@
+// This file is processed by CMake.
+// See https://cmake.org/cmake/help/v3.0/command/configure_file.html.
+
+#ifndef SWIFT_RUNTIME_CMAKECONFIG_H
+#define SWIFT_RUNTIME_CMAKECONFIG_H
+
+#define SWIFT_VERSION_MAJOR "6"
+#define SWIFT_VERSION_MINOR "4"
+
+#endif

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SWIFT_SYNCHRONIZATION_SOURCES
   Cell.swift
 )
 
+# EMBEDDED Atomics/AtomicIntegers.swift.gyb
+# EMBEDDED Atomics/AtomicStorage.swift.gyb
 set(SWIFT_SYNCHRONIZATION_GYB_SOURCES
   Atomics/AtomicIntegers.swift.gyb
   Atomics/AtomicStorage.swift.gyb


### PR DESCRIPTION
Create a package that builds the embedded version of the Swift standard library as well as related modules SwiftUnicodeDataTables, _Builtin_float, _Volatile, and Synchronization. It is meant to be used instead of pre-building different versions of these modules into `lib/swift/embedded`, because one can provide any triple supported by the compiler to SwiftPM, and SwiftPM will build the standard library along with everything else in the package, obviating the need for a prebuilt SDK to work with embedded targets.

The package itself is fairly complicated because it is duplicating nontrivial logic from the CMake build system. Custom logic in the package includes:
* A build tool plugin that processes `.swift.gyb` files to produce `.swift` files (`GYBPlugin`)
* A step that parses `utils/availability-macros.def` to produce the right availability-macro arguments for the build.
* Lots of compiler flags for experimental features, disabling implicit module search paths, "parse as standard library" flags, and so on.

The end result is still awkward to use, because one must explicitly set up dependencies on the Swift standard library (+ other libraries) in any target that wants to build this way. It only properly builds in release mode (`-c release`). If this direction is indeed promising, then we can bring this logic into SwiftPM itself, automatically introducing the appropriate package and library dependencies as well as passing the flags to prevent looking into the toolchain for prebuilt modules.

The optional Unicode tables can be linked by enabling the UnicodeDataTables trait.

Aside from the above usability issue, there are a number of remaining problems with this package that will need to be addressed, including:
* Duplication of compiler flags between the CMake and the package is going to cause them to get out-of-sync, causing unfortunate surprises
* Synchronization builds the unavailable stubs, because I did not find a good way to make the source files conditional at the SwiftPM level.
* _Concurrency isn't supported at all, because it requires us to mix Swift and C++ source files in the same target, which SwiftPM doesn't currently support. The same limitation means that we can't support the full Swift Standard Library + runtime, because much of that code is in C++ now.
* The GYB plugin cannot figure out the pointer size, because SwiftPM doesn't seem to have a way to query the target triple or any information about it. One can set the environment variable SWIFT_POINTER_SIZE=<bytes in a pointer> to override the default of 8 bytes.
* The GYB plugin uses some guesswork and hackery to find Python and GYB that needs to be improved.