### PR TITLE
Make `@c` user-accessible and work around compilers that cannot handle it

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -370,7 +370,7 @@ SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
 
 DECL_ATTR(c, CDecl,
   OnFunc | OnAccessor | OnEnum,
-  LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  LongAttribute | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   63)
 DECL_ATTR_ALIAS(_cdecl, CDecl)
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -411,6 +411,9 @@ public:
   /// Suppress printing of ~Sendable in inheritance and requirement lists.
   bool SuppressTildeSendable = false;
 
+  /// Suppress printing of @c in favor of @_cdecl.
+  bool SuppressCAttribute = false;
+
   /// Whether to print the \c{/*not inherited*/} comment on factory initializers.
   bool PrintFactoryInitializerComment = true;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -279,6 +279,10 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(NonexhaustiveAttribute, 487, "Nonexhaustive Enums"
 LANGUAGE_FEATURE(ModuleSelector, 491, "Module selectors (`Module::name` syntax)")
 LANGUAGE_FEATURE(BuiltinConcurrencyStackNesting, 0, "Concurrency Stack Nesting Builtins")
 
+// TEMPORARY: Never use this, because it is only meant to allow us to model
+// suppression of @c in Swift interfaces as a temporary measure.
+SUPPRESSIBLE_LANGUAGE_FEATURE(CAttribute, 495, "@c attribute")
+
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3318,6 +3318,13 @@ static void suppressingFeatureTildeSendable(PrintOptions &options,
   action();
 }
 
+static void
+suppressingFeatureCAttribute(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<bool> scope(options.SuppressCAttribute, true);
+  action();
+}
+
 namespace {
 struct ExcludeAttrRAII {
   std::vector<AnyAttrKind> &ExcludeAttrList;
@@ -3413,6 +3420,14 @@ static void printCompatibilityCheckIf(ASTPrinter &printer, bool isElseIf,
     } else {
       first = false;
     }
+
+    // Special case: CAttribute feature prints has a hasAttribute(c) check. We
+    // might want to generalize this notion if we keep having to do it.
+    if (Feature(feature) == Feature::CAttribute) {
+      printer << "hasAttribute(c)";
+      continue;
+    }
+
     printer << "$" << Feature(feature).getName();
   }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1270,9 +1270,12 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DeclAttrKind::CDecl: {
     auto Attr = cast<CDeclAttr>(this);
-    if (Attr->Underscored)
-      Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
-    else {
+    if (Attr->Underscored || Options.SuppressCAttribute) {
+      auto name = cast<CDeclAttr>(this)->Name;
+      if (name.empty() && isa<ValueDecl>(D))
+        name = cast<ValueDecl>(D)->getBaseIdentifier().str();
+      Printer << "@_cdecl(\"" << name << "\")";
+    } else {
       Printer << "@c";
       if (!Attr->Name.empty())
         Printer << "(" << cast<CDeclAttr>(this)->Name << ")";

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -149,6 +149,16 @@ UNINTERESTING_FEATURE(CheckImplementationOnly)
 UNINTERESTING_FEATURE(CheckImplementationOnlyStrict)
 UNINTERESTING_FEATURE(EnforceSPIOperatorGroup)
 
+static bool usesFeatureCAttribute(Decl *decl) {
+  for (auto attr : decl->getAttrs()) {
+    if (auto cdeclAttr = dyn_cast<CDeclAttr>(attr))
+      if (!cdeclAttr->Underscored)
+        return true;
+  }
+
+  return false;
+}
+
 static bool findLifetimeAttr(Decl *decl, bool findUnderscored) {
   auto hasLifetimeAttr = [&](Decl *decl) {
     if (!decl->getAttrs().hasAttribute<LifetimeAttr>()) {

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -111,6 +111,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       nonobjc[#Func Attribute#]; name=nonobjc{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       inlinable[#Func Attribute#]; name=inlinable{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       warn_unqualified_access[#Func Attribute#]; name=warn_unqualified_access{{$}}
+// KEYWORD2-NEXT:             Keyword/None:                       c[#Func Attribute#]; name=c
 // KEYWORD2-NEXT:             Keyword/None:                       usableFromInline[#Func Attribute#]; name=usableFromInline
 // KEYWORD2-NEXT:             Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // KEYWORD2-NEXT:             Keyword/None:                       differentiable[#Func Attribute#]; name=differentiable
@@ -161,6 +162,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicCallable[#Enum Attribute#]; name=dynamicCallable
 // KEYWORD4-NEXT:             Keyword/None:                       main[#Enum Attribute#]; name=main
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicMemberLookup[#Enum Attribute#]; name=dynamicMemberLookup
+// KEYWORD4-NEXT:             Keyword/None:                       c[#Enum Attribute#]; name=c
 // KEYWORD4-NEXT:             Keyword/None:                       usableFromInline[#Enum Attribute#]; name=usableFromInline
 // KEYWORD4-NEXT:             Keyword/None:                       frozen[#Enum Attribute#]; name=frozen
 // KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper

--- a/test/ModuleInterface/cdecl-swiftinterface.swift
+++ b/test/ModuleInterface/cdecl-swiftinterface.swift
@@ -39,9 +39,13 @@ public func objcImplFunc() { }
 /// Print other @c functions.
 @c
 public func bareCDecl() {}
-// CHECK: @c
+// CHECK: #if compiler(>=5.3) && hasAttribute(c)
+// CHECK-NEXT: @c
 // CHECK-NEXT: public func bareCDecl
-
+// CHECK-NEXT: #else
+// CHECK-NEXT: @_cdecl("bareCDecl")
+// CHECK-NEXT: public func bareCDecl
+// CHECK-NEXT: #endif
 @c(c_name)
 public func namedCDecl() {}
 // CHECK: @c(c_name)

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -4,6 +4,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s \
 // RUN:    -disable-objc-interop
 
+#if hasAttribute(c)
+// good
+#else
+#error("missing the attribute we're using???")
+#endif
+
 @c(cdecl_foo) func foo(x: Int) -> Int { return x }
 
 @c(not an identifier) func invalidName() {}


### PR DESCRIPTION
Make `@c` a user-accessible attribute, so that one can check for it with `#if hasAttribute(c)` and it will show up in code completion after the `@`.

Use the `hasAttribute(c)` check in module interface printing so that older compilers can process newer .swiftinterfaces that make use of `@c`. Older compilers will see `@_cdecl` instead, which should be close enough for now despite the slight ABI differences.

Fixes rdar://167554912 & rdar://167546897.