### PR TITLE
[Diags] A couple of diagnostic engine fixes

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -292,7 +292,10 @@ namespace swift {
   /// for a transaction.
   struct ActiveDiagnostic {
     Diagnostic Diag;
-    SmallVector<DiagnosticInfo, 2> WrappedDiagnostics;
+
+    // NOTE: The `unique_ptr` here is important since we use a DiagnosticInfo
+    // pointer as the diagnostic argument for `Diag` when wrapping.
+    SmallVector<std::unique_ptr<DiagnosticInfo>, 2> WrappedDiagnostics;
     SmallVector<std::vector<DiagnosticArgument>, 4> WrappedDiagnosticArgs;
 
     ActiveDiagnostic(Diagnostic diag) : Diag(std::move(diag)) {}

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1499,13 +1499,7 @@ namespace swift {
 
     /// Create a new diagnostic queue with a given engine to forward the
     /// diagnostics to.
-    explicit DiagnosticQueue(DiagnosticEngine &engine, bool emitOnDestruction)
-        : UnderlyingEngine(engine), QueueEngine(engine.SourceMgr),
-          EmitOnDestruction(emitOnDestruction) {
-      // Open a transaction to avoid emitting any diagnostics for the temporary
-      // engine.
-      QueueEngine.TransactionCount++;
-    }
+    explicit DiagnosticQueue(DiagnosticEngine &engine, bool emitOnDestruction);
 
     /// Retrieve the engine which may be used to enqueue diagnostics.
     DiagnosticEngine &getDiags() { return QueueEngine; }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -520,12 +520,12 @@ InFlightDiagnostic::wrapIn(const Diagnostic &wrapper) {
   llvm::SaveAndRestore<DiagnosticBehavior> limit(
       Diag.BehaviorLimit, DiagnosticBehavior::Unspecified);
 
-  ActiveDiag.WrappedDiagnostics.push_back(*Engine->diagnosticInfoForDiagnostic(
-      Diag, /* includeDiagnosticName= */ false));
+  ActiveDiag.WrappedDiagnostics.push_back(std::make_unique<DiagnosticInfo>(
+      Engine->diagnosticInfoForDiagnostic(Diag, /*diagName*/ false).value()));
 
   Engine->state.swap(tempState);
 
-  auto &wrapped = ActiveDiag.WrappedDiagnostics.back();
+  auto &wrapped = *ActiveDiag.WrappedDiagnostics.back();
 
   // Copy and update its arg list.
   ActiveDiag.WrappedDiagnosticArgs.emplace_back(wrapped.FormatArgs);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1865,6 +1865,17 @@ void DiagnosticEngine::onTentativeDiagnosticFlush(Diagnostic &diagnostic) {
   }
 }
 
+DiagnosticQueue::DiagnosticQueue(DiagnosticEngine &engine,
+                                 bool emitOnDestruction)
+    : UnderlyingEngine(engine), QueueEngine(engine.SourceMgr),
+      EmitOnDestruction(emitOnDestruction) {
+  // Open a transaction to avoid emitting any diagnostics for the temporary
+  // engine.
+  QueueEngine.TransactionCount++;
+
+  QueueEngine.setLanguageVersion(engine.languageVersion);
+}
+
 void DiagnosticQueue::forEach(
     llvm::function_ref<void(const Diagnostic &)> body) const {
   for (auto &activeDiag : QueueEngine.TentativeDiagnostics)

--- a/test/Concurrency/isolated_parameters_typechecker_errors.swift
+++ b/test/Concurrency/isolated_parameters_typechecker_errors.swift
@@ -228,6 +228,14 @@ struct CheckIsolatedFunctionTypes {
   }
 }
 
+// Make sure we emit the correct diagnostics under a DiagnosticTransaction, e.g
+// in a default expr.
+func checkInDiagnosticTransation(fn: () -> Void = {
+  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  func bar(_ fn: @MainActor @Sendable (isolated A, isolated A) -> Void) {}
+}) {}
+
 @available(SwiftStdlib 5.1, *)
 func checkIsolatedAndGlobalClosures(_ a: A) {
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}


### PR DESCRIPTION
Set the language mode for DiagnosticQueue (no test case since I don't think this is exercised yet), and make sure we form a stable address for the `DiagnosticInfo` pointer we use as an argument for a wrapped diagnostic.