### PR TITLE
[6.3] Make @c attribute user-accessible

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -370,7 +370,7 @@ SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
 
 DECL_ATTR(c, CDecl,
   OnFunc | OnAccessor | OnEnum,
-  LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  LongAttribute | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   63)
 DECL_ATTR_ALIAS(_cdecl, CDecl)
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -111,6 +111,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       nonobjc[#Func Attribute#]; name=nonobjc{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       inlinable[#Func Attribute#]; name=inlinable{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       warn_unqualified_access[#Func Attribute#]; name=warn_unqualified_access{{$}}
+// KEYWORD2-NEXT:             Keyword/None:                       c[#Func Attribute#]; name=c
 // KEYWORD2-NEXT:             Keyword/None:                       usableFromInline[#Func Attribute#]; name=usableFromInline
 // KEYWORD2-NEXT:             Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // KEYWORD2-NEXT:             Keyword/None:                       differentiable[#Func Attribute#]; name=differentiable
@@ -160,6 +161,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicCallable[#Enum Attribute#]; name=dynamicCallable
 // KEYWORD4-NEXT:             Keyword/None:                       main[#Enum Attribute#]; name=main
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicMemberLookup[#Enum Attribute#]; name=dynamicMemberLookup
+// KEYWORD4-NEXT:             Keyword/None:                       c[#Enum Attribute#]; name=c
 // KEYWORD4-NEXT:             Keyword/None:                       usableFromInline[#Enum Attribute#]; name=usableFromInline
 // KEYWORD4-NEXT:             Keyword/None:                       frozen[#Enum Attribute#]; name=frozen
 // KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -4,6 +4,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s \
 // RUN:    -disable-objc-interop
 
+#if hasAttribute(c)
+// good
+#else
+#error("missing the attribute we're using???")
+#endif
+
 @c(cdecl_foo) func foo(x: Int) -> Int { return x }
 
 @c(not an identifier) func invalidName() {}


### PR DESCRIPTION
- **Explanation**: Mark the `@c` attribute introduced by [SE-0495](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0495-cdecl.md) as "user accessible" so that `#if hasAttribute(c)` will evaluate true and it `@c` will show up in code completion.
- **Scope**: Extremely narrow; this is a flag in the attribute definition that we forgot to remove when the feature was approved.
- **Issues**:  rdar://167554912
- **Original PRs**: https://github.com/swiftlang/swift/pull/86293
- **Risk**: Extremely low. 
- **Testing**: Normal CI with new tests.
- **Reviewers**: @artemcm 
