### PR TITLE
Fix import of newtype'd types whenever Objective-C interoperability is disabled

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -122,7 +122,7 @@ split_embedded_sources(
   EMBEDDED NFD.swift
   EMBEDDED NativeDictionary.swift
   EMBEDDED NativeSet.swift
-    NORMAL NewtypeWrapper.swift
+  EMBEDDED NewtypeWrapper.swift
   EMBEDDED ObjectIdentifier.swift
   EMBEDDED OptionSet.swift
   EMBEDDED Optional.swift

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !$Embedded
 /// An implementation detail used to implement support importing
 /// (Objective-)C entities marked with the swift_newtype Clang
 /// attribute.
 public protocol _SwiftNewtypeWrapper
 : RawRepresentable, _HasCustomAnyHashableRepresentation { }
+#else
+/// An implementation detail used to implement support importing
+/// (Objective-)C entities marked with the swift_newtype Clang
+/// attribute.
+public protocol _SwiftNewtypeWrapper
+: RawRepresentable { }
+#endif
 
 extension _SwiftNewtypeWrapper where Self: Hashable, Self.RawValue: Hashable {
   /// The hash value.
@@ -39,6 +47,7 @@ extension _SwiftNewtypeWrapper where Self: Hashable, Self.RawValue: Hashable {
   }
 }
 
+#if !$Embedded
 extension _SwiftNewtypeWrapper {
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
     return nil
@@ -97,6 +106,7 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
     return false
   }
 }
+#endif
 
 #if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue: _ObjectiveCBridgeable {

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -106,9 +106,7 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
     return false
   }
 }
-#endif
 
-#if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue: _ObjectiveCBridgeable {
   // Note: This is the only default typealias for _ObjectiveCType, because
   // constrained extensions aren't allowed to define types in different ways.

--- a/test/ClangImporter/Inputs/custom-modules/SimpleSwiftNewtypes.h
+++ b/test/ClangImporter/Inputs/custom-modules/SimpleSwiftNewtypes.h
@@ -1,0 +1,1 @@
+typedef float Radians __attribute((swift_newtype(struct)));

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -98,6 +98,10 @@ module MissingHeader {
   header "this-header-does-not-exist.h"
 }
 
+module SimpleSwiftNewtypes {
+  header "SimpleSwiftNewtypes.h"
+}
+
 module MoreSwiftNewtypes {
   header "MoreSwiftNewtypes.h"
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,18 +1,9 @@
-// RUN: %empty-directory(%t)
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -primary-file %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %S/Inputs/MoreSwiftNewtypes_conformances.swift -primary-file %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
 import Foundation
-import MoreSwiftNewtypes
 
 func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
-// expected-note@-1 {{where 'T' = 'WrappedRef'}}
-// expected-note@-2 {{where 'T' = 'WrappedValue'}}
 func acceptComparable<T: Comparable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
@@ -31,12 +22,4 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFil
 
   _ = z as NSString
 #endif
-}
-
-
-func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
-  acceptEquatable(wrappedRef)
-  acceptEquatable(wrappedValue)
-  acceptHashable(wrappedRef) // expected-error {{global function 'acceptHashable' requires that 'WrappedRef' conform to 'Hashable'}}
-  acceptHashable(wrappedValue) // expected-error {{global function 'acceptHashable' requires that 'WrappedValue' conform to 'Hashable'}}
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,25 +1,19 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
-import Foundation
+import SimpleSwiftNewtypes
 
 func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
 func acceptComparable<T: Comparable>(_: T) {}
-// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
+// expected-note@-1{{where 'T' = 'Radians'}}
 
-func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
+func testNewTypeWrapper(x: Radians, y: Radians, z: Float) {
   acceptEquatable(x)
   acceptHashable(x)
-  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'Radians' conform to 'Comparable'}}
   // expected-note@-1 {{did you mean to use '.rawValue'?}} {{19-19=.rawValue}}
 
   _ = x == y
   _ = x != y
   _ = x.hashValue
-
-#if _runtime(_ObjC)
-  _ = x as NSString
-
-  _ = z as NSString
-#endif
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -6,8 +6,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
 
-// REQUIRES: objc_interop
-
 import Foundation
 import MoreSwiftNewtypes
 
@@ -27,9 +25,12 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFil
   _ = x == y
   _ = x != y
   _ = x.hashValue
+
+#if _runtime(_ObjC)
   _ = x as NSString
 
   _ = z as NSString
+#endif
 }
 
 

--- a/test/ClangImporter/newtype_conformance_objc.swift
+++ b/test/ClangImporter/newtype_conformance_objc.swift
@@ -15,6 +15,23 @@ func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'WrappedRef'}}
 // expected-note@-2 {{where 'T' = 'WrappedValue'}}
+func acceptComparable<T: Comparable>(_: T) {}
+// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
+
+func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
+  acceptEquatable(x)
+  acceptHashable(x)
+  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  // expected-note@-1 {{did you mean to use '.rawValue'?}} {{19-19=.rawValue}}
+
+  _ = x == y
+  _ = x != y
+  _ = x.hashValue
+
+  _ = x as NSString
+
+  _ = z as NSString
+}
 
 func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
   acceptEquatable(wrappedRef)

--- a/test/ClangImporter/newtype_conformance_objc.swift
+++ b/test/ClangImporter/newtype_conformance_objc.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -primary-file %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %S/Inputs/MoreSwiftNewtypes_conformances.swift -primary-file %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+
+// REQUIRES: objc_interop
+
+import Foundation
+import MoreSwiftNewtypes
+
+func acceptEquatable<T: Equatable>(_: T) {}
+func acceptHashable<T: Hashable>(_: T) {}
+// expected-note@-1 {{where 'T' = 'WrappedRef'}}
+// expected-note@-2 {{where 'T' = 'WrappedValue'}}
+
+func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
+  acceptEquatable(wrappedRef)
+  acceptEquatable(wrappedValue)
+  acceptHashable(wrappedRef) // expected-error {{global function 'acceptHashable' requires that 'WrappedRef' conform to 'Hashable'}}
+  acceptHashable(wrappedValue) // expected-error {{global function 'acceptHashable' requires that 'WrappedValue' conform to 'Hashable'}}
+}

--- a/test/embedded/Inputs/StructAsOptionSet.apinotes
+++ b/test/embedded/Inputs/StructAsOptionSet.apinotes
@@ -1,0 +1,14 @@
+---
+Name: StructAsOptionSet
+Typedefs:
+- Name: WGPUBufferUsage
+  SwiftConformsTo: Swift.OptionSet
+  SwiftWrapper: struct
+Globals:
+- Name: WGPUBufferUsage_None
+  SwiftName: WGPUBufferUsage.none
+- Name: WGPUBufferUsage_MapRead
+  SwiftName: WGPUBufferUsage.mapRead
+- Name: WGPUBufferUsage_MapWrite
+  SwiftName: WGPUBufferUsage.mapWrite
+

--- a/test/embedded/Inputs/module.modulemap
+++ b/test/embedded/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module StructAsOptionSet {
+  header "struct-as-option-set.h"
+}

--- a/test/embedded/Inputs/struct-as-option-set.h
+++ b/test/embedded/Inputs/struct-as-option-set.h
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+typedef uint32_t WGPUBufferUsage;
+static const WGPUBufferUsage WGPUBufferUsage_None = 0x0000000000000000;
+static const WGPUBufferUsage WGPUBufferUsage_MapRead = 0x0000000000000001;
+static const WGPUBufferUsage WGPUBufferUsage_MapWrite = 0x0000000000000002;

--- a/test/embedded/newtype.swift
+++ b/test/embedded/newtype.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/ -enable-experimental-feature Embedded
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
+import StructAsOptionSet
+
+func takeOptionSet<T: OptionSet & Hashable & _SwiftNewtypeWrapper>(_: T) { }
+
+func useStructAsOptionSet() {
+  let usage: WGPUBufferUsage = [.mapRead, .mapWrite]
+  takeOptionSet(usage)
+}


### PR DESCRIPTION
Several aspects of the standard library's support for newtype'd imports are disabled when Objective-C interoperability support is  disabled, even though they shouldn't be. This affects both Embedded Swift (in which the newtype wrapper protocol was completely compiled out) and non-Apple platforms like Windows (in which `_ObjectiveCBridgeable` support was partially compiled out), leading to inconsistent behavior across platforms.

Eliminate the unnecessary deviation among platforms, fixing rdar://167569022 & rdar://167570178