### PR TITLE
[6.2] Fix _SwiftNewtypeWrapper when not using the Objective-C runtime

### DIFF
--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -98,7 +98,6 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
   }
 }
 
-#if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue: _ObjectiveCBridgeable {
   // Note: This is the only default typealias for _ObjectiveCType, because
   // constrained extensions aren't allowed to define types in different ways.
@@ -173,5 +172,3 @@ extension _SwiftNewtypeWrapper where Self.RawValue: AnyObject {
     return Self(rawValue: source!)!
   }
 }
-#endif
-

--- a/test/ClangImporter/Inputs/custom-modules/SimpleSwiftNewtypes.h
+++ b/test/ClangImporter/Inputs/custom-modules/SimpleSwiftNewtypes.h
@@ -1,0 +1,1 @@
+typedef float Radians __attribute((swift_newtype(struct)));

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -93,6 +93,10 @@ module MissingHeader {
   header "this-header-does-not-exist.h"
 }
 
+module SimpleSwiftNewtypes {
+  header "SimpleSwiftNewtypes.h"
+}
+
 module MoreSwiftNewtypes {
   header "MoreSwiftNewtypes.h"
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,18 +1,9 @@
-// RUN: %empty-directory(%t)
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -primary-file %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %S/Inputs/MoreSwiftNewtypes_conformances.swift -primary-file %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
 import Foundation
-import MoreSwiftNewtypes
 
 func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
-// expected-note@-1 {{where 'T' = 'WrappedRef'}}
-// expected-note@-2 {{where 'T' = 'WrappedValue'}}
 func acceptComparable<T: Comparable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
@@ -31,12 +22,4 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFil
 
   _ = z as NSString
 #endif
-}
-
-
-func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
-  acceptEquatable(wrappedRef)
-  acceptEquatable(wrappedValue)
-  acceptHashable(wrappedRef) // expected-error {{global function 'acceptHashable' requires that 'WrappedRef' conform to 'Hashable'}}
-  acceptHashable(wrappedValue) // expected-error {{global function 'acceptHashable' requires that 'WrappedValue' conform to 'Hashable'}}
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,25 +1,19 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
-import Foundation
+import SimpleSwiftNewtypes
 
 func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
 func acceptComparable<T: Comparable>(_: T) {}
-// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
+// expected-note@-1{{where 'T' = 'Radians'}}
 
-func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
+func testNewTypeWrapper(x: Radians, y: Radians, z: Float) {
   acceptEquatable(x)
   acceptHashable(x)
-  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'Radians' conform to 'Comparable'}}
   // expected-note@-1 {{did you mean to use '.rawValue'?}} {{19-19=.rawValue}}
 
   _ = x == y
   _ = x != y
   _ = x.hashValue
-
-#if _runtime(_ObjC)
-  _ = x as NSString
-
-  _ = z as NSString
-#endif
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -6,8 +6,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
 
-// REQUIRES: objc_interop
-
 import Foundation
 import MoreSwiftNewtypes
 
@@ -27,9 +25,12 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFil
   _ = x == y
   _ = x != y
   _ = x.hashValue
+
+#if _runtime(_ObjC)
   _ = x as NSString
 
   _ = z as NSString
+#endif
 }
 
 

--- a/test/ClangImporter/newtype_conformance_objc.swift
+++ b/test/ClangImporter/newtype_conformance_objc.swift
@@ -15,6 +15,23 @@ func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'WrappedRef'}}
 // expected-note@-2 {{where 'T' = 'WrappedValue'}}
+func acceptComparable<T: Comparable>(_: T) {}
+// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
+
+func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
+  acceptEquatable(x)
+  acceptHashable(x)
+  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  // expected-note@-1 {{did you mean to use '.rawValue'?}} {{19-19=.rawValue}}
+
+  _ = x == y
+  _ = x != y
+  _ = x.hashValue
+
+  _ = x as NSString
+
+  _ = z as NSString
+}
 
 func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
   acceptEquatable(wrappedRef)

--- a/test/ClangImporter/newtype_conformance_objc.swift
+++ b/test/ClangImporter/newtype_conformance_objc.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -primary-file %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %S/Inputs/MoreSwiftNewtypes_conformances.swift -primary-file %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+
+// REQUIRES: objc_interop
+
+import Foundation
+import MoreSwiftNewtypes
+
+func acceptEquatable<T: Equatable>(_: T) {}
+func acceptHashable<T: Hashable>(_: T) {}
+// expected-note@-1 {{where 'T' = 'WrappedRef'}}
+// expected-note@-2 {{where 'T' = 'WrappedValue'}}
+
+func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
+  acceptEquatable(wrappedRef)
+  acceptEquatable(wrappedValue)
+  acceptHashable(wrappedRef) // expected-error {{global function 'acceptHashable' requires that 'WrappedRef' conform to 'Hashable'}}
+  acceptHashable(wrappedValue) // expected-error {{global function 'acceptHashable' requires that 'WrappedValue' conform to 'Hashable'}}
+}


### PR DESCRIPTION
- **Explanation**: The standard library's support for newtype'd imports is disabled when Objective-C interoperability support is disabled, even though it shouldn't be. This affects use of newtype on Windows and Linux, leading to inconsistent behavior across platforms.
- **Scope**: Limited to the standard library's support for newtype'd imports (`_SwiftNewtypeWrapper`).
- **Issues**: rdar://167570178
- **Original PRs**: https://github.com/swiftlang/swift/pull/86301 (limited to the second commit; we're not bringing in the Embedded Swift parts of that PR for 6.2)
- **Risk**: Low. This code has been enabled on Apple platforms since its introduction. This brings consistent behavior across platforms.
- **Testing**: Normal CI suffices; enabled an existing test for non-Apple platforms.
- **Reviewers**:
