### PR TITLE
[Embedded Swift] Enable String._deconstructUTF8 for Embedded Swift

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -1115,14 +1115,13 @@ extension _StringObject {
   @_alwaysEmitIntoClient
   @inlinable
   @inline(__always)
-  @_unavailableInEmbedded
-  internal var owner: AnyObject? {
+  internal var owner: _ConvertedObject? {
     guard self.isMortal else { return nil }
     #if !$Embedded
     let unmanaged = unsafe Unmanaged<AnyObject>.fromOpaque(largeAddress)
     return unsafe unmanaged.takeUnretainedValue()
     #else
-    fatalError("unreachable in embedded Swift")
+    return unsafe unsafeBitCast(largeAddress, to: _ConvertedObject.self)
     #endif
   }
 }

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -60,13 +60,12 @@ extension String {
   public // @testable
   func _classify() -> _StringRepresentation { return _guts._classify() }
 
-#if !$Embedded
   @_alwaysEmitIntoClient
   public // @testable
   func _deconstructUTF8<ToPointer: _Pointer>(
     scratch: UnsafeMutableRawBufferPointer?
   ) -> (
-    owner: AnyObject?,
+    owner: _ConvertedObject?,
     ToPointer,
     length: Int,
     usesScratch: Bool,
@@ -74,7 +73,6 @@ extension String {
   ) {
     unsafe _guts._deconstructUTF8(scratch: scratch)
   }
-#endif
 }
 
 extension _StringGuts {
@@ -115,8 +113,6 @@ extension _StringGuts {
     fatalError()
   }
 
-#if !$Embedded
-
 /*
 
  Deconstruct the string into contiguous UTF-8, allocating memory if necessary
@@ -145,7 +141,7 @@ extension _StringGuts {
   func _deconstructUTF8<ToPointer: _Pointer>(
     scratch: UnsafeMutableRawBufferPointer?
   ) -> (
-    owner: AnyObject?,
+    owner: _ConvertedObject?,
     ToPointer,
     length: Int,
     usesScratch: Bool,
@@ -191,18 +187,15 @@ extension _StringGuts {
   @inline(never) // slow path
   internal
   func _allocateForDeconstruct() -> (
-    owner: AnyObject,
+    owner: _ConvertedObject,
     UnsafeRawPointer,
     length: Int
   ) {
     let utf8 = Array(String(self).utf8) + [0]
-    let (owner, ptr): (AnyObject?, UnsafeRawPointer) =
+    let (owner, ptr): (_ConvertedObject?, UnsafeRawPointer) =
       unsafe _convertConstArrayToPointerArgument(utf8)
 
     // Array's owner cannot be nil, even though it is declared optional...
     return unsafe (owner: owner!, ptr, length: utf8.count - 1)
   }
-
-#endif
-
 }

--- a/test/embedded/string-deconstruction.swift
+++ b/test/embedded/string-deconstruction.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip -Xlinker %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+enum ExpectedDeconstruction {
+  case scratchIfAvailable
+  case interiorPointer
+  case extraAllocation
+}
+
+func expectDeconstruct(
+  _ str: String,
+  _ expectDeconstruct: ExpectedDeconstruction,
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+) {
+  let expectBytes = Array(str.utf8)
+
+  _ = Array<UInt8>(unsafeUninitializedCapacity: 16) {
+    buffer, initializedCount in
+    // Deconstruct with a provided scratch space
+
+    // WS == with scratch, N == nil
+    let scratch = UnsafeMutableRawBufferPointer(buffer)
+    let (ownerWS, ptrWS, lengthWS, usedScratchWS, allocatedMemoryWS)
+      : (_ConvertedObject?, UnsafePointer<UInt8>, Int, Bool, Bool)
+      = str._deconstructUTF8(scratch: scratch)
+    let (ownerN, ptrN, lengthN, usedScratchN, allocatedMemoryN)
+      : (_ConvertedObject?, UnsafePointer<UInt8>, Int, Bool, Bool)
+      = str._deconstructUTF8(scratch: nil)
+
+    let rawBytesWS = UnsafeRawBufferPointer(start: ptrWS, count: lengthWS)
+    let rawBytesN = UnsafeRawBufferPointer(start: ptrN, count: lengthN)
+
+    precondition(expectBytes.elementsEqual(rawBytesWS))
+    precondition(rawBytesWS.elementsEqual(rawBytesN))
+
+    switch expectDeconstruct {
+    case .scratchIfAvailable:
+      precondition(ownerWS == nil)
+      precondition(ownerN != nil)
+
+      precondition(UnsafeRawPointer(scratch.baseAddress) == rawBytesWS.baseAddress)
+      precondition(UnsafeRawPointer(scratch.baseAddress) != rawBytesN.baseAddress)
+
+      precondition(lengthWS < scratch.count)
+      precondition(lengthN < scratch.count)
+
+      precondition(usedScratchWS)
+      precondition(!usedScratchN)
+
+      precondition(!allocatedMemoryWS)
+      precondition(allocatedMemoryN)
+
+      case .interiorPointer:
+      // TODO: owner == (immortal ? nil : StringObject.largeAddress)
+      precondition(str.isContiguousUTF8)
+      var copy = str
+      copy.withUTF8 {
+        precondition($0.baseAddress == ptrWS)
+        precondition($0.baseAddress == ptrN)
+        precondition($0.count == lengthWS)
+        precondition($0.count == lengthN)
+      }
+
+      precondition(!usedScratchWS)
+      precondition(!usedScratchN)
+      precondition(!allocatedMemoryWS)
+      precondition(!allocatedMemoryN)
+    case .extraAllocation:
+      precondition(!str.isContiguousUTF8)
+      precondition(ownerWS != nil)
+      precondition(ownerN != nil)
+      precondition(!usedScratchWS)
+      precondition(!usedScratchN)
+      precondition(allocatedMemoryWS)
+      precondition(allocatedMemoryN)
+    }
+  }
+}
+
+@inline(never)
+func id<T>(_ a: T) -> T { a }
+
+func testDeconstruct() {
+  let smallASCII = "abcd"
+
+#if _pointerBitWidth(_32) && os(watchOS)
+  let smallUTF8 = "ジッパ"
+#elseif _pointerBitWidth(_32)
+  let smallUTF8 = "ジッ"
+#else
+  let smallUTF8 = "ジッパー"
+#endif
+
+  let large = "the quick fox jumped over the lazy brown dog"
+
+  var largeMortal = large
+  largeMortal.append(id("🧟‍♀️"))
+  largeMortal.append(id(largeMortal.last!))
+
+  expectDeconstruct(smallASCII, .scratchIfAvailable)
+  expectDeconstruct(smallUTF8, .scratchIfAvailable)
+  expectDeconstruct(large, .interiorPointer)
+  expectDeconstruct(largeMortal, .interiorPointer)
+}
+
+@main
+struct Main {
+  static func main() {
+    testDeconstruct()
+
+    // CHECK: Success!
+    print("Success!")
+  }
+}


### PR DESCRIPTION
Some support libraries depend on String._deconstructUTF8, and it's just as relevant in Embedded Swift as it is in normal Swift.

This introduces the public typealias `_ConvertedObject` to paper over the AnyObject/NativeObject difference between normal and Embedded Swift for these underscored APIs.

Fixes rdar://166250256.