### PR TITLE
[Frontend][Darwin] Use the system prefix from SDK when constructing the default search paths

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -272,6 +272,7 @@ class ASTContext final {
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SerializationOptions &serializationOpts, SourceManager &SourceMgr,
       DiagnosticEngine &Diags,
+      std::optional<clang::DarwinSDKInfo> &DarwinSDKInfo,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
 
 public:
@@ -298,6 +299,7 @@ public:
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SerializationOptions &serializationOpts, SourceManager &SourceMgr,
       DiagnosticEngine &Diags,
+      std::optional<clang::DarwinSDKInfo> &DarwinSDKInfo,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
   ~ASTContext();
 
@@ -1028,12 +1030,6 @@ public:
 
   /// Availability macros parsed from the command line arguments.
   const AvailabilityMacroMap &getAvailabilityMacroMap() const;
-
-  /// Test support utility for loading a platform remap file
-  /// in case an SDK is not specified to the compilation.
-  const clang::DarwinSDKInfo::RelatedTargetVersionMapping *
-  getAuxiliaryDarwinPlatformRemapInfo(
-      clang::DarwinSDKInfo::OSEnvPair Kind) const;
 
   //===--------------------------------------------------------------------===//
   // Diagnostics Helper functions

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -24,6 +24,9 @@
 WARNING(warning_no_such_sdk,none,
         "no such SDK: '%0'", (StringRef))
 
+WARNING(warning_darwin_sdk_invalid_settings, none,
+        "SDK settings were ignored as 'SDKSettings.json' could not be parsed", ())
+
 ERROR(error_no_frontend_args, none,
       "no arguments provided to '-frontend'", ())
 

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -524,10 +524,6 @@ public:
   /// A file containing a list of protocols whose conformances require const value extraction.
   std::string ConstGatherProtocolListFilePath;
 
-  /// Path to the file that defines platform mapping for availability
-  /// version inheritance.
-  std::optional<std::string> PlatformAvailabilityInheritanceMapPath;
-
   /// Cross import module information. Map from module name to the list of cross
   /// import overlay files that associate with that module.
   using CrossImportMap = llvm::StringMap<std::vector<std::string>>;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -43,6 +43,7 @@
 #include "swift/Serialization/Validation.h"
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "clang/Basic/FileManager.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetVector.h"
@@ -95,6 +96,7 @@ class CompilerInvocation {
   FrontendOptions FrontendOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
   SearchPathOptions SearchPathOpts;
   DiagnosticOptions DiagnosticOpts;
   MigratorOptions MigratorOpts;
@@ -247,8 +249,6 @@ public:
 
   void setRuntimeResourcePath(StringRef Path);
 
-  void setPlatformAvailabilityInheritanceMapPath(StringRef Path);
-
   /// Compute the default prebuilt module cache path for a given resource path
   /// and SDK version. This function is also used by LLDB.
   static std::string
@@ -322,6 +322,11 @@ public:
   symbolgraphgen::SymbolGraphOptions &getSymbolGraphOptions() { return SymbolGraphOpts; }
   const symbolgraphgen::SymbolGraphOptions &getSymbolGraphOptions() const {
     return SymbolGraphOpts;
+  }
+
+  std::optional<clang::DarwinSDKInfo> &getSDKInfo() { return SDKInfo; }
+  const std::optional<clang::DarwinSDKInfo> &getSDKInfo() const {
+    return SDKInfo;
   }
 
   SearchPathOptions &getSearchPathOptions() { return SearchPathOpts; }

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1584,10 +1584,6 @@ def scanner_debug_write_output: Flag<["-"], "scanner-debug-write-output">,
   HelpText<"Write generated output from scanner for debugging purpose">,
   Flags<[HelpHidden]>;
 
-def platform_availability_inheritance_map_path
-  : Separate<["-"], "platform-availability-inheritance-map-path">, MetaVarName<"<path>">,
-    HelpText<"Path of the platform inheritance platform map">;
-
 def enable_address_dependencies : Flag<["-"], "enable-address-dependencies">,
   HelpText<"Enable enforcement of lifetime dependencies on addressable values.">;
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -445,10 +445,9 @@ static const clang::DarwinSDKInfo::RelatedTargetVersionMapping *
 getFallbackVersionMapping(const ASTContext &Ctx,
                           clang::DarwinSDKInfo::OSEnvPair Kind) {
   auto *SDKInfo = Ctx.getDarwinSDKInfo();
-  if (SDKInfo)
-    return SDKInfo->getVersionMapping(Kind);
-
-  return Ctx.getAuxiliaryDarwinPlatformRemapInfo(Kind);
+  if (!SDKInfo)
+    return nullptr;
+  return SDKInfo->getVersionMapping(Kind);
 }
 
 static std::optional<clang::VersionTuple>

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -240,7 +240,8 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       workerCompilerInvocation->getSymbolGraphOptions(),
                       workerCompilerInvocation->getCASOptions(),
                       workerCompilerInvocation->getSerializationOptions(),
-                      ScanASTContext.SourceMgr, *workerDiagnosticEngine));
+                      ScanASTContext.SourceMgr, *workerDiagnosticEngine,
+                      workerCompilerInvocation->getSDKInfo()));
 
   scanningASTDelegate = std::make_unique<InterfaceSubContextDelegateImpl>(
       workerASTContext->SourceMgr, workerDiagnosticEngine.get(),

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -27,6 +27,7 @@
 #include "swift/SIL/TypeLowering.h"
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Bitstream/BitstreamReader.h"
@@ -189,12 +190,13 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
   SerializationOptions SerializationOpts;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
   LangOpts.Target = Invocation.getTargetTriple();
   LangOpts.EnableObjCInterop = Invocation.enableObjCInterop();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
       SymbolGraphOpts, CASOpts, SerializationOpts, SrcMgr, Instance.getDiags(),
-      llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
+      SDKInfo, llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
 

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -19,6 +19,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Bridging/ASTGen.h"
 #include "swift/Subsystems.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 
@@ -82,9 +83,10 @@ struct LibParseExecutor {
     symbolgraphgen::SymbolGraphOptions symbolOpts;
     CASOptions casOpts;
     SerializationOptions serializationOpts;
+    std::optional<clang::DarwinSDKInfo> SDKInfo;
     std::unique_ptr<ASTContext> ctx(ASTContext::get(
         langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
-        casOpts, serializationOpts, SM, diagEngine));
+        casOpts, serializationOpts, SM, diagEngine, SDKInfo));
     auto &eval = ctx->evaluator;
     registerParseRequestFunctions(eval);
     registerTypeCheckerRequestFunctions(eval);
@@ -154,13 +156,14 @@ struct ASTGenExecutor {
     CASOptions casOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
     SerializationOptions serializationOpts;
+    std::optional<clang::DarwinSDKInfo> SDKInfo;
 
     // Enable ASTGen.
     langOpts.enableFeature(Feature::ParserASTGen);
 
     std::unique_ptr<ASTContext> ctx(ASTContext::get(
         langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
-        casOpts, serializationOpts, SM, diagEngine));
+        casOpts, serializationOpts, SM, diagEngine, SDKInfo));
     auto &eval = ctx->evaluator;
     registerParseRequestFunctions(eval);
     registerTypeCheckerRequestFunctions(eval);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -198,9 +198,37 @@ void CompilerInvocation::setDefaultInProcessPluginServerPathIfNecessary() {
   SearchPathOpts.InProcessPluginServerPath = serverLibPath.str();
 }
 
-static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
-                                      const FrontendOptions &FrontendOpts,
-                                      const LangOptions &LangOpts) {
+static std::optional<clang::DarwinSDKInfo>
+parseSDKSettings(llvm::vfs::FileSystem &VFS, const LangOptions &LangOpts,
+                 const SearchPathOptions &SearchPathOpts,
+                 DiagnosticEngine &Diags) {
+  if (!LangOpts.Target.isOSDarwin() || SearchPathOpts.getSDKPath().empty())
+    return std::nullopt;
+  auto SDKInfoOrErr =
+      clang::parseDarwinSDKInfo(VFS, SearchPathOpts.getSDKPath());
+  if (!SDKInfoOrErr) {
+    llvm::consumeError(SDKInfoOrErr.takeError());
+    Diags.diagnose(SourceLoc(), diag::warning_darwin_sdk_invalid_settings);
+    return std::nullopt;
+  }
+  return *SDKInfoOrErr;
+}
+
+static void appendPlatformIncludePrefix(
+    SmallString<128> &Path, const llvm::Triple &Triple,
+    const std::optional<clang::DarwinSDKInfo> &SDKInfo) {
+  if (SDKInfo) {
+    const StringRef PlatformIncludePrefix = SDKInfo->getPlatformPrefix(Triple);
+    if (!PlatformIncludePrefix.empty())
+      llvm::sys::path::append(Path, PlatformIncludePrefix);
+  }
+}
+
+static void
+updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
+                          const FrontendOptions &FrontendOpts,
+                          const LangOptions &LangOpts,
+                          const std::optional<clang::DarwinSDKInfo> &SDKInfo) {
   const llvm::Triple &Triple = LangOpts.Target;
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
@@ -272,6 +300,7 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
     }
 
     LibPath = SearchPathOpts.getSDKPath();
+    appendPlatformIncludePrefix(LibPath, Triple, SDKInfo);
     llvm::sys::path::append(LibPath, "usr", "lib", swiftDir);
     if (!Triple.isOSDarwin()) {
       // Use the non-architecture suffixed form with directory-layout
@@ -290,9 +319,9 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   SearchPathOpts.setRuntimeLibraryImportPaths(RuntimeLibraryImportPaths);
 }
 
-static void
-updateImplicitFrameworkSearchPaths(SearchPathOptions &SearchPathOpts,
-                                   const LangOptions &LangOpts) {
+static void updateImplicitFrameworkSearchPaths(
+    SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
+    const std::optional<clang::DarwinSDKInfo> &SDKInfo) {
   if (SearchPathOpts.SkipAllImplicitImportPaths) {
     SearchPathOpts.setImplicitFrameworkSearchPaths({});
     return;
@@ -303,6 +332,7 @@ updateImplicitFrameworkSearchPaths(SearchPathOptions &SearchPathOpts,
     if (!SearchPathOpts.SkipSDKImportPaths &&
         !SearchPathOpts.getSDKPath().empty()) {
       SmallString<128> SDKPath(SearchPathOpts.getSDKPath());
+      appendPlatformIncludePrefix(SDKPath, LangOpts.Target, SDKInfo);
 
       SmallString<128> systemFrameworksScratch(SDKPath);
       llvm::sys::path::append(systemFrameworksScratch, "System", "Library",
@@ -428,11 +458,7 @@ void CompilerInvocation::computeCXXStdlibOptions() {
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
   SearchPathOpts.RuntimeResourcePath = Path.str();
-  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts);
-}
-
-void CompilerInvocation::setPlatformAvailabilityInheritanceMapPath(StringRef Path) {
-  SearchPathOpts.PlatformAvailabilityInheritanceMapPath = Path.str();
+  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
 }
 
 void CompilerInvocation::setTargetTriple(StringRef Triple) {
@@ -441,14 +467,14 @@ void CompilerInvocation::setTargetTriple(StringRef Triple) {
 
 void CompilerInvocation::setTargetTriple(const llvm::Triple &Triple) {
   LangOpts.setTarget(Triple);
-  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts);
-  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts);
+  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
+  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts, SDKInfo);
 }
 
 void CompilerInvocation::setSDKPath(const std::string &Path) {
   SearchPathOpts.setSDKPath(Path);
-  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts);
-  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts);
+  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
+  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts, SDKInfo);
 }
 
 bool CompilerInvocation::setModuleAliasMap(std::vector<std::string> args,
@@ -2547,9 +2573,6 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(OPT_const_gather_protocols_file))
     Opts.ConstGatherProtocolListFilePath = A->getValue();
 
-  if (const Arg *A = Args.getLastArg(OPT_platform_availability_inheritance_map_path))
-    Opts.PlatformAvailabilityInheritanceMapPath = A->getValue();
-
   for (auto A : Args.getAllArgValues(options::OPT_serialized_path_obfuscate)) {
     auto SplitMap = StringRef(A).split('=');
     Opts.DeserializedPathRecoverer.addMapping(SplitMap.first, SplitMap.second);
@@ -4294,9 +4317,12 @@ bool CompilerInvocation::parseArgs(
                         SearchPathOpts.RuntimeResourcePath, ParsedArgs, Diags)) {
     return true;
   }
+  
+  SDKInfo = parseSDKSettings(*llvm::vfs::getRealFileSystem(), LangOpts,
+                             SearchPathOpts, Diags);
 
-  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts);
-  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts);
+  updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
+  updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts, SDKInfo);
   setDefaultPrebuiltCacheIfNecessary();
   setDefaultBlocklistsIfNecessary();
   setDefaultInProcessPluginServerPathIfNecessary();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -338,7 +338,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
       Invocation.getSILOptions(), Invocation.getSearchPathOptions(),
       Invocation.getClangImporterOptions(), Invocation.getSymbolGraphOptions(),
       Invocation.getCASOptions(), Invocation.getSerializationOptions(),
-      SourceMgr, Diagnostics, OutputBackend));
+      SourceMgr, Diagnostics, Invocation.getSDKInfo(), OutputBackend));
   if (!Invocation.getFrontendOptions().ModuleAliasMap.empty())
     Context->setModuleAliases(Invocation.getFrontendOptions().ModuleAliasMap);
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1715,12 +1715,6 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.setSDKPath(SearchPathOpts.getSDKPath().str());
   }
 
-  if (SearchPathOpts.PlatformAvailabilityInheritanceMapPath) {
-    GenericArgs.push_back("-platform-availability-inheritance-map-path");
-    GenericArgs.push_back(ArgSaver.save(*SearchPathOpts.PlatformAvailabilityInheritanceMapPath));
-    genericSubInvocation.setPlatformAvailabilityInheritanceMapPath(*SearchPathOpts.PlatformAvailabilityInheritanceMapPath);
-  }
-
   // Inherit the plugin search opts but do not inherit the arguments.
   genericSubInvocation.getSearchPathOptions().PluginSearchOpts =
       SearchPathOpts.PluginSearchOpts;

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -32,6 +32,7 @@
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -129,11 +130,14 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   CASOptions casOpts = ctx.CASOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts = ctx.SymbolGraphOpts;
   SerializationOptions serializationOpts = ctx.SerializationOpts;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
+  if (auto *ctxSDKInfo = ctx.getDarwinSDKInfo())
+    SDKInfo = *ctxSDKInfo;
 
   DiagnosticEngine tmpDiags(tmpSM);
-  auto &tmpCtx =
-      *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
-                       symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags);
+  auto &tmpCtx = *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
+                                  clangOpts, symbolOpts, casOpts,
+                                  serializationOpts, tmpSM, tmpDiags, SDKInfo);
   registerParseRequestFunctions(tmpCtx.evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx.evaluator);
 

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -36,6 +36,7 @@
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -268,9 +269,12 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
   CASOptions casOpts;
   SerializationOptions serializationOpts =
       CachedCI->getASTContext().SerializationOpts;
-  std::unique_ptr<ASTContext> tmpCtx(
-      ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
-                      symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags));
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
+  if (auto *contextSDKInfo = CachedCI->getASTContext().getDarwinSDKInfo())
+    SDKInfo = *contextSDKInfo;
+  std::unique_ptr<ASTContext> tmpCtx(ASTContext::get(
+      langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
+      casOpts, serializationOpts, tmpSM, tmpDiags, SDKInfo));
   tmpCtx->CancellationFlag = CancellationFlag;
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -67,7 +67,7 @@ bool SyntacticMacroExpansionInstance::setup(
       invocation.getSILOptions(), invocation.getSearchPathOptions(),
       invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
       invocation.getCASOptions(), invocation.getSerializationOptions(),
-      SourceMgr, Diags));
+      SourceMgr, Diags, invocation.getSDKInfo()));
   registerParseRequestFunctions(Ctx->evaluator);
   registerTypeCheckerRequestFunctions(Ctx->evaluator);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -31,6 +31,7 @@
 #include "swift/Parse/ParseSILSupport.h"
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Compiler.h"
@@ -1192,6 +1193,7 @@ struct ParserUnit::Implementation {
   CASOptions CASOpts;
   SerializationOptions SerializationOpts;
   DiagnosticEngine Diags;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
   ASTContext &Ctx;
   SourceManager &SM;
   unsigned BufferID;
@@ -1204,7 +1206,7 @@ struct ParserUnit::Implementation {
         SILOpts(SILOptions()), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                              clangImporterOpts, symbolGraphOpts, CASOpts,
-                             SerializationOpts, SM, Diags)),
+                             SerializationOpts, SM, Diags, SDKInfo)),
         SM(SM), BufferID(BufferID) {
     registerParseRequestFunctions(Ctx.evaluator);
 

--- a/test/Frontend/Inputs/MacOSX26.1.sdk/SDKSettings.json
+++ b/test/Frontend/Inputs/MacOSX26.1.sdk/SDKSettings.json
@@ -1,0 +1,5 @@
+{"Version":"26.1", "CanonicalName": "macosx26.1", "MaximumDeploymentTarget": "26.1.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": "\/System\/macOSSupport"},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/test/Frontend/default-search-paths.swift
+++ b/test/Frontend/default-search-paths.swift
@@ -11,6 +11,17 @@
 // APPLE-NEXT: [1] SOURCE_DIR/test/Inputs/clang-importer-sdk/usr/lib/swift
 // APPLE-NEXT: (End of search path lists.)
 
+// Apple paths with a system prefix.
+// RUN: %swift_frontend_plain -target arm64-apple-macos15.4 -sdk %S/Inputs/MacOSX26.1.sdk -parse-stdlib -parse %s -Rmodule-loading 2>&1 | %FileCheck --sanitize SDKROOT=%S/Inputs/MacOSX26.1.sdk -check-prefix=SYSTEMPREFIX %s
+// SYSTEMPREFIX: Implicit framework search paths:
+// SYSTEMPREFIX-NEXT: [0] SDKROOT/System/macOSSupport/System/Library/Frameworks
+// SYSTEMPREFIX-NEXT: [1] SDKROOT/System/macOSSupport/System/Library/SubFrameworks
+// SYSTEMPREFIX-NEXT: [2] SDKROOT/System/macOSSupport/Library/Frameworks
+// SYSTEMPREFIX-NEXT: Runtime library import search paths:
+// SYSTEMPREFIX-NEXT: [0] BUILD_DIR/lib/swift/macosx
+// SYSTEMPREFIX-NEXT: [1] SDKROOT/System/macOSSupport/usr/lib/swift
+// SYSTEMPREFIX-NEXT: (End of search path lists.)
+
 // Non-Apple platforms don't have any implicit framework search paths.
 // RUN: %swift_frontend_plain -target x86_64-unknown-linux-android %clang-importer-sdk-nosource -parse-stdlib -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=ANDROID %s
 // ANDROID: Implicit framework search paths:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1609,23 +1609,15 @@ if run_vendor == 'apple':
     if run_os == 'maccatalyst':
         maccatalyst_extra_frameworks = "-F {}/System/iOSSupport/System/Library/Frameworks".format(config.variant_sdk)
 
-    swift_frontend_platform_remap_config = ""
-    swiftc_platform_remap_config = ""
-    if run_os == 'xros':
-        swift_frontend_platform_remap_config = "-platform-availability-inheritance-map-path %s" % platform_remap_mock_sdk_config
-        swiftc_platform_remap_config = "-Xfrontend -platform-availability-inheritance-map-path -Xfrontend %s" % platform_remap_mock_sdk_config
-
     config.target_swift_frontend = (
-        "%s %s -sdk %r %s %s %s %s" %
+        "%s %s -sdk %r %s %s %s" %
         (config.swift_frontend, target_options, config.variant_sdk, maccatalyst_extra_frameworks,
-         config.swift_test_options, config.swift_frontend_test_options,
-         swift_frontend_platform_remap_config))
+         config.swift_test_options, config.swift_frontend_test_options))
     config.target_swift_frontend_plain = "%s %s" % (config.swift_frontend, target_options)
     subst_target_swift_frontend_mock_sdk = (
-        "%s %s -sdk %r %s %s %s" %
+        "%s %s -sdk %r %s %s" %
         (config.swift_frontend, target_options_for_mock_sdk, config.variant_sdk,
-         config.swift_test_options, config.swift_frontend_test_options,
-         swift_frontend_platform_remap_config))
+         config.swift_test_options, config.swift_frontend_test_options))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -1662,8 +1654,8 @@ if run_vendor == 'apple':
         ("%s %s -toolchain-stdlib-rpath %s " +
          # This ensures LC_LOAD_DYLIB rewrite will succeed in %target-codesign (rdar://7885126):
          "-Xlinker -headerpad_max_install_names " +
-         "-Xlinker -rpath -Xlinker /usr/lib/swift %s %s ")%
-        (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options, swiftc_platform_remap_config))
+         "-Xlinker -rpath -Xlinker /usr/lib/swift %s ")%
+        (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options))
     config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_clang = (
         "%s %s %s" %

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -38,7 +38,7 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals,
     : TestContextBase(target),
       Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                            ClangImporterOpts, SymbolGraphOpts, CASOpts,
-                           SerializationOpts, SourceMgr, Diags)) {
+                           SerializationOpts, SourceMgr, Diags, SDKInfo)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -18,6 +18,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/TargetParser/Host.h"
 
 namespace swift {
@@ -39,6 +40,7 @@ public:
   SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
 
   TestContextBase(llvm::Triple target) : Diags(SourceMgr) {
     LangOpts.Target = target;

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -8,6 +8,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -83,9 +84,10 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::SerializationOptions serializationOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
   std::unique_ptr<ASTContext> context(ASTContext::get(
       langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags, SDKInfo));
   auto importer = ClangImporter::create(*context);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");
@@ -199,6 +201,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   ClangImporterOptions options;
   CASOptions casOpts;
   SerializationOptions serializationOpts;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
   options.clangPath = "/usr/bin/clang";
   options.ExtraArgs.push_back(
       (llvm::Twine("--gcc-toolchain=") + "/opt/rh/devtoolset-9/root/usr")
@@ -206,7 +209,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   options.ExtraArgs.push_back("--gcc-toolchain");
   std::unique_ptr<ASTContext> context(ASTContext::get(
       langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags, SDKInfo));
 
   {
     LibStdCxxInjectionVFS vfs;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -18,6 +18,7 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
@@ -105,9 +106,10 @@ protected:
     SILOptions silOpts;
     CASOptions casOpts;
     SerializationOptions serializationOpts;
+    std::optional<clang::DarwinSDKInfo> SDKInfo;
     auto ctx = ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts,
                                clangImpOpts, symbolGraphOpts, casOpts,
-                               serializationOpts, sourceMgr, diags);
+                               serializationOpts, sourceMgr, diags, SDKInfo);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -29,9 +29,10 @@ using namespace swift::unittest;
 using namespace swift::constraints::inference;
 
 SemaTest::SemaTest()
-    : Context(*ASTContext::get(
-          LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
-          SymbolGraphOpts, CASOpts, SerializationOpts, SourceMgr, Diags)) {
+    : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts,
+                               SearchPathOpts, ClangImporterOpts,
+                               SymbolGraphOpts, CASOpts, SerializationOpts,
+                               SourceMgr, Diags, SDKInfo)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TargetParser/Host.h"
@@ -46,6 +47,7 @@ public:
   SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
+  std::optional<clang::DarwinSDKInfo> SDKInfo;
 
   SemaTestBase() : Diags(SourceMgr) {
     LangOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());


### PR DESCRIPTION
Some Darwin platforms like DriverKit use a system prefix on all of their search paths. Even though DriverKit isn't supported, add support to get the system prefix from SDKSettings when constructing the default search paths.

This requires the DarwinSDKInfo to be gotten earlier in CompilerInvocation, pass that down to ASTContext through CompilerInstance.

-platform-availability-inheritance-map-path is no longer needed to support visionOS in tests, remove that and its supporting code that gets an alternative DarwinSDKInfo.

rdar://166277280