### PR TITLE
AST: Prefer associated types over protocol type aliases

### DIFF
--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -39,34 +39,38 @@ enum NLOptions : unsigned {
   /// Remove overridden declarations from the set of results.
   NL_RemoveOverridden = 1 << 2,
 
+  /// Remove associated type declarations from the set of results. This is used
+  /// by conformance checking for resolving type witnesses.
+  NL_RemoveAssociatedTypes = 1 << 3,
+
   /// Don't check access when doing lookup into a type.
   ///
   /// When performing lookup into a module, this option only applies to
   /// declarations in the same module the lookup is coming from.
-  NL_IgnoreAccessControl = 1 << 3,
+  NL_IgnoreAccessControl = 1 << 4,
 
   /// This lookup should only return type declarations.
-  NL_OnlyTypes = 1 << 4,
+  NL_OnlyTypes = 1 << 5,
 
   /// Include synonyms declared with @_implements()
-  NL_IncludeAttributeImplements = 1 << 5,
+  NL_IncludeAttributeImplements = 1 << 6,
 
   // Include @usableFromInline and @inlinable
-  NL_IncludeUsableFromInline = 1 << 6,
+  NL_IncludeUsableFromInline = 1 << 7,
 
   /// Exclude names introduced by macro expansions in the top-level module.
-  NL_ExcludeMacroExpansions = 1 << 7,
+  NL_ExcludeMacroExpansions = 1 << 8,
 
   /// This lookup should only return macro declarations.
-  NL_OnlyMacros = 1 << 8,
+  NL_OnlyMacros = 1 << 9,
 
   /// Include members that would otherwise be filtered out because they come
   /// from a module that has not been imported.
-  NL_IgnoreMissingImports = 1 << 9,
+  NL_IgnoreMissingImports = 1 << 10,
 
   /// If @abi attributes are present, return the decls representing the ABI,
   /// not the API.
-  NL_ABIProviding = 1 << 10,
+  NL_ABIProviding = 1 << 11,
 
   /// The default set of options used for qualified name lookup.
   ///

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -200,9 +200,6 @@ public:
       IndexOfFirstOuterResult++;
       assert(IndexOfFirstOuterResult == Results.size() &&
              "found an outer result before an inner one");
-    } else {
-      assert(IndexOfFirstOuterResult > 0 &&
-             "found outer results without an inner one");
     }
   }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -527,11 +527,27 @@ static void recordShadowedDeclsAfterTypeMatch(
           }
         }
 
+        auto *firstProto = firstDecl->getDeclContext()->getSelfProtocolDecl();
+        auto *secondProto = secondDecl->getDeclContext()->getSelfProtocolDecl();
+
         // If one declaration is in a protocol or extension thereof and the
         // other is not, prefer the one that is not.
-        if ((bool)firstDecl->getDeclContext()->getSelfProtocolDecl() !=
-              (bool)secondDecl->getDeclContext()->getSelfProtocolDecl()) {
-          if (firstDecl->getDeclContext()->getSelfProtocolDecl()) {
+        if ((bool)firstProto != (bool)secondProto) {
+          if (firstProto) {
+            shadowed.insert(firstDecl);
+            break;
+          } else {
+            shadowed.insert(secondDecl);
+            continue;
+          }
+        }
+
+        // If one declaration is an associated type and the other is a type alias
+        // in a protocol or protocol extension, prefer the associated type.
+        if ((bool)firstProto && (bool)secondProto &&
+            (isa<AssociatedTypeDecl>(firstDecl) !=
+             isa<AssociatedTypeDecl>(secondDecl))) {
+          if (isa<AssociatedTypeDecl>(secondDecl)) {
             shadowed.insert(firstDecl);
             break;
           } else {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2518,6 +2518,16 @@ bool namelookup::isInABIAttr(SourceFile *sourceFile, SourceLoc loc) {
 void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
                                       Identifier moduleSelector,
                                       SmallVectorImpl<ValueDecl *> &decls) {
+  // If we're supposed to remove associated type declarations, do so now.
+  if (options & NL_RemoveAssociatedTypes) {
+    decls.erase(
+      std::remove_if(decls.begin(), decls.end(),
+                     [&](ValueDecl *decl) {
+                       return isa<AssociatedTypeDecl>(decl);
+                     }),
+      decls.end());
+  }
+
   // If we're supposed to remove overridden declarations, do so now.
   if (options & NL_RemoveOverridden)
     removeOverriddenDecls(decls);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -140,7 +140,6 @@ namespace {
 
       auto addResult = [&](ValueDecl *result) {
         if (Known.insert({{result, baseDC}, false}).second) {
-          // HERE, need to look up base decl
           Result.add(LookupResultEntry(baseDC, baseDecl, result), isOuter);
           if (isOuter)
             FoundOuterDecls.push_back(result);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1856,23 +1856,6 @@ resolveUnqualifiedIdentTypeRepr(const TypeResolution &resolution,
     didIgnoreMissingImports = true;
   }
 
-  // If we're doing structural resolution and one of the results is an
-  // associated type, ignore any other results found from the same
-  // DeclContext; they are going to be protocol typealiases, possibly
-  // from constrained extensions, and trying to compute their type in
-  // resolveTypeInContext() might hit request cycles since structural
-  // resolution is performed while computing the requirement signature
-  // of the protocol.
-  DeclContext *assocTypeDC = nullptr;
-  if (resolution.getStage() == TypeResolutionStage::Structural) {
-    for (const auto &entry : globals) {
-      if (isa<AssociatedTypeDecl>(entry.getValueDecl())) {
-        assocTypeDC = entry.getDeclContext();
-        break;
-      }
-    }
-  }
-
   // Process the names we found.
   Type current;
   TypeDecl *currentDecl = nullptr;
@@ -1881,11 +1864,6 @@ resolveUnqualifiedIdentTypeRepr(const TypeResolution &resolution,
   for (const auto &entry : globals) {
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
-
-    // See the comment above.
-    if (assocTypeDC != nullptr &&
-        foundDC == assocTypeDC && !isa<AssociatedTypeDecl>(typeDecl))
-      continue;
 
     // Compute the type of the found declaration when referenced from this
     // location.

--- a/test/decl/typealias/on_constrained_protocol.swift
+++ b/test/decl/typealias/on_constrained_protocol.swift
@@ -45,11 +45,26 @@ func useDoubleOverloadedSameTypealias() -> DoubleOverloadedSameTypealias.Content
 // https://github.com/apple/swift/issues/50805
 
 protocol MarkerProtocol {}
+
 protocol ProtocolWithAssoctype {
-  associatedtype MyAssocType // expected-note {{found this candidate}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Self.MyAssocType'}} (from useAssocTypeOutsideExtension)
+  associatedtype MyAssocType
 }
+
 extension ProtocolWithAssoctype where Self: MarkerProtocol {
-  typealias MyAssocType = Int // expected-note {{found this candidate}} (from useAssocTypeInExtension) expected-note {{found candidate with type 'Int'}} (from useAssocTypeOutsideExtension)
-  func useAssocTypeInExtension() -> MyAssocType {} // expected-error {{'MyAssocType' is ambiguous for type lookup in this context}}
+  typealias MyAssocType = Int
+
+  func useAssocTypeInExtension(_ a: Self.MyAssocType) -> MyAssocType {
+    return a
+  }
+
+  func useAssocMetatypeInExtensionUnqualified() -> MyAssocType.Type {
+    return MyAssocType.self
+  }
+
+  func useAssocMetatypeInExtensionQualified() -> Self.MyAssocType.Type {
+    return Self.MyAssocType.self
+  }
 }
-func useAssocTypeOutsideExtension() -> ProtocolWithAssoctype.MyAssocType {} // expected-error {{ambiguous type name 'MyAssocType' in 'ProtocolWithAssoctype'}}
+
+func useAssocTypeOutsideExtension() -> ProtocolWithAssoctype.MyAssocType {}
+// expected-error@-1 {{cannot access associated type 'MyAssocType' from 'ProtocolWithAssoctype'; use a concrete type or generic parameter base instead}}

--- a/validation-test/compiler_crashers_fixed/LookupResultBuilder-add-a7ee60.swift
+++ b/validation-test/compiler_crashers_fixed/LookupResultBuilder-add-a7ee60.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::DeclContext*, swift::ValueDecl*, swift::Type, bool)::'lambda'(swift::ValueDecl*)::operator()(swift::ValueDecl*) const","signatureAssert":"Assertion failed: (IndexOfFirstOuterResult > 0 && \"found outer results without an inner one\"), function add"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a{b} protocol c : a protocol d : c extension d {
   struct e : d {
     f {


### PR DESCRIPTION
Fix a regression from https://github.com/swiftlang/swift/pull/85938 by formalizing a load-bearing behavior of the old hack.

Fixes rdar://167550301.