### PR TITLE
Avoid loading serialized extensions for nominals in SourceFile

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1723,6 +1723,13 @@ bool MemoryBufferSerializedModuleLoader::unregisterMemoryBuffer(
 
 void SerializedModuleLoaderBase::loadExtensions(NominalTypeDecl *nominal,
                                                 unsigned previousGeneration) {
+  // Nominals in parsed SourceFiles can't have extensions provided by imported
+  // serialized modules. This is necessary to avoid triggering semantic requests
+  // from extension binding since looking up extensions may need to compute the
+  // mangled name.
+  if (nominal->getParentSourceFile())
+    return;
+
   for (auto &modulePair : LoadedModuleFiles) {
     if (modulePair.second <= previousGeneration)
       continue;

--- a/test/decl/ext/extension_binding_multi.swift
+++ b/test/decl/ext/extension_binding_multi.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -primary-file %S/../Inputs/empty.swift %s -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %S/../../Inputs/empty.swift %s -verify
 
 struct A: Collection {
   struct Index: Comparable {}

--- a/test/decl/ext/extension_binding_multiple_nested.swift
+++ b/test/decl/ext/extension_binding_multiple_nested.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift
+
+// Make sure we can produce a valid interface
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Lib
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Lib
+
+// https://github.com/swiftlang/swift/issues/86285
+public enum A {}
+
+extension A {
+  public struct B<T: A.P> {}
+}
+extension A.B {
+  public struct Set {}
+}
+extension A.B.Set {
+  public struct D {}
+}
+extension A.B.Set.D {
+  public struct E {}
+}
+extension A {
+  public protocol P {}
+}
+
+public enum B {}
+
+extension B {
+  public struct Set<T: A.P> {}
+}
+extension B.Set {
+  public struct X {}
+}
+extension B.Set.X {
+  public struct E {}
+}
+extension B {
+  public protocol P {}
+}

--- a/validation-test/IDE/crashers_fixed/GenericSignatureImpl-getSuperclassBound-7d168e.swift
+++ b/validation-test/IDE/crashers_fixed/GenericSignatureImpl-getSuperclassBound-7d168e.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","signature":"swift::GenericSignatureImpl::getSuperclassBound(swift::Type) const"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 protocol a {
   associatedtype b: Error
 }

--- a/validation-test/compiler_crashers_fixed/ASTMangler-appendExistentialLayout-e5dc06.swift
+++ b/validation-test/compiler_crashers_fixed/ASTMangler-appendExistentialLayout-e5dc06.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::Mangle::ASTMangler::appendExistentialLayout(swift::ExistentialLayout const&, swift::GenericSignature, swift::ValueDecl const*)","stackOverflow":true}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   typealias b = Int
 }

--- a/validation-test/compiler_crashers_fixed/ASTMangler-appendExtension-f1419d.swift
+++ b/validation-test/compiler_crashers_fixed/ASTMangler-appendExtension-f1419d.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::Mangle::ASTMangler::appendExtension(swift::ExtensionDecl const*, swift::Mangle::ASTMangler::BaseEntitySignature&, llvm::StringRef)","stackOverflow":true}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 extension Collection where Self : a {
   struct Index protocol a

--- a/validation-test/compiler_crashers_fixed/RequirementMachine-lookupNestedType-18f909.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementMachine-lookupNestedType-18f909.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"25bd9966","signature":"swift::rewriting::RequirementMachine::lookupNestedType(swift::Type, swift::Identifier) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b: Error
 }


### PR DESCRIPTION
Looking up serialized extensions for a nested nominal type requires computing its mangled name, which may kick semantic requests. Ensure we don't do this for nominals in parsed SourceFiles such that we don't end up kicking this during extension binding.

Resolves #86285