### PR TITLE
Sema: Fix crash when parameterized protocol types define conflicting type witnesses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3266,6 +3266,11 @@ NOTE(associated_type_deduction_default,none,
      "using associated type default %0", (Type))
 NOTE(ambiguous_witnesses_type,none,
      "multiple matching types named %0", (Identifier))
+ERROR(ambiguous_associated_type_from_parameterized_protocols,none,
+     "ambiguous associated type %0 in conformance to %1",
+     (const AssociatedTypeDecl *, const ProtocolDecl *))
+NOTE(associated_type_candidate_from_parameterized_protocol,none,
+     "candidate inferred from parameterized protocol here", ())
 NOTE(protocol_witness_exact_match,none,
      "candidate exactly matches%0", (StringRef))
 NOTE(protocol_witness_non_sendable,none,

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -439,26 +439,31 @@ static bool isAsyncSequenceFailure(AssociatedTypeDecl *assocType) {
   return assocType->getName() == assocType->getASTContext().Id_Failure;
 }
 
-static Type resolveTypeWitnessViaParameterizedProtocol(
-    Type t, AssociatedTypeDecl *assocType) {
+static void resolveTypeWitnessViaParameterizedProtocol(
+    Type t, SourceLoc inheritedLoc, AssociatedTypeDecl *assocType,
+    SmallVectorImpl<std::pair<Type, SourceLoc>>
+        &fromParameterizedProtocolType) {
   if (auto *pct = t->getAs<ProtocolCompositionType>()) {
     for (auto member : pct->getMembers()) {
-      if (auto result = resolveTypeWitnessViaParameterizedProtocol(
-            member, assocType)) {
-        return result;
-      }
+      resolveTypeWitnessViaParameterizedProtocol(
+          member, inheritedLoc, assocType, fromParameterizedProtocolType);
     }
   } else if (auto *ppt = t->getAs<ParameterizedProtocolType>()) {
     auto *proto = ppt->getProtocol();
     unsigned i = 0;
     for (auto *otherAssocType : proto->getPrimaryAssociatedTypes()) {
-      if (otherAssocType->getName() == assocType->getName())
-        return ppt->getArgs()[i];
+      if (otherAssocType->getName() == assocType->getName()) {
+        auto typeWitness = ppt->getArgs()[i];
+        if (!llvm::any_of(fromParameterizedProtocolType,
+                          [&](const std::pair<Type, SourceLoc> &pair) -> bool {
+                            return pair.first->isEqual(typeWitness);
+                          })) {
+          fromParameterizedProtocolType.push_back({typeWitness, inheritedLoc});
+        }
+      }
       ++i;
     }
   }
-
-  return Type();
 }
 
 /// Attempt to resolve a type witness via member name lookup.
@@ -480,17 +485,15 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
 
   // Look for a parameterized protocol type in the conformance context's
   // inheritance clause.
-  bool deducedFromParameterizedProtocolType = false;
+  SmallVector<std::pair<Type, SourceLoc>, 2> fromParameterizedProtocolType;
   auto inherited = (isa<NominalTypeDecl>(dc)
                     ? cast<NominalTypeDecl>(dc)->getInherited()
                     : cast<ExtensionDecl>(dc)->getInherited());
   for (auto index : inherited.getIndices()) {
     if (auto inheritedTy = inherited.getResolvedType(index)) {
-      if (auto typeWitness = resolveTypeWitnessViaParameterizedProtocol(
-            inheritedTy, assocType)) {
-        recordTypeWitness(conformance, assocType, typeWitness, nullptr);
-        deducedFromParameterizedProtocolType = true;
-      }
+      resolveTypeWitnessViaParameterizedProtocol(
+          inheritedTy, inherited.getEntry(index).getLoc(), assocType,
+          fromParameterizedProtocolType);
     }
   }
 
@@ -507,11 +510,6 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
   dc->lookupQualified(dc->getSelfNominalTypeDecl(), assocType->createNameRef(),
                       dc->getSelfNominalTypeDecl()->getLoc(), subOptions,
                       candidates);
-
-  // If there aren't any candidates, we're done.
-  if (candidates.empty()) {
-    return ResolveWitnessResult::Missing;
-  }
 
   // Determine which of the candidates is viable.
   SmallVector<LookupTypeResultEntry, 2> viable;
@@ -598,7 +596,26 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     }
   }
 
-  if (!deducedFromParameterizedProtocolType) {
+  // Diagnose ambiguity when fromParameterizedProtocolType.size() > 1
+  if (fromParameterizedProtocolType.size() > 1) {
+    ctx.addDelayedConformanceDiag(
+        conformance, true,
+        [assocType, fromParameterizedProtocolType](
+            NormalProtocolConformance *conformance) {
+          auto &diags = assocType->getASTContext().Diags;
+          diags.diagnose(
+              conformance->getLoc(),
+              diag::ambiguous_associated_type_from_parameterized_protocols,
+              assocType, conformance->getProtocol());
+          for (const auto &pair : fromParameterizedProtocolType) {
+            diags.diagnose(
+                pair.second,
+                diag::associated_type_candidate_from_parameterized_protocol);
+          }
+        });
+  }
+
+  if (fromParameterizedProtocolType.empty()) {
     // If there are no viable witnesses, and all nonviable candidates came from
     // protocol extensions, treat this as "missing".
     if (viable.empty() &&
@@ -623,14 +640,29 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
   } else {
     // We deduced the type witness from a parameterized protocol type, so just
     // make sure there was nothing else.
-    if (viable.size() == 1 &&
-        isa<TypeAliasDecl>(viable[0].Member) &&
-        viable[0].Member->isSynthesized()) {
-      // We found the type alias synthesized above.
+    if (viable.empty()) {
+      // There was nothing else. Record the type witness, which will
+      // synthesize the type alias.
+      recordTypeWitness(conformance, assocType,
+                        fromParameterizedProtocolType[0].first,
+                        /*typeDecl=*/nullptr);
+      return ResolveWitnessResult::Success;
+    }
+
+    if (viable.size() == 1 && isa<TypeAliasDecl>(viable[0].Member) &&
+        viable[0].Member->getDeclaredInterfaceType()->isEqual(
+            fromParameterizedProtocolType[0].first)) {
+      // We found another type alias with the same underlying type,
+      // which is okay.
+      recordTypeWitness(conformance, assocType,
+                        fromParameterizedProtocolType[0].first,
+                        viable[0].Member);
       return ResolveWitnessResult::Success;
     }
 
     // Otherwise fall through.
+    recordTypeWitness(conformance, assocType,
+                      ErrorType::get(ctx), nullptr);
   }
 
   // If we had multiple viable types, diagnose the ambiguity.

--- a/test/AssociatedTypeInference/type_witness_from_parameterized_protocol.swift
+++ b/test/AssociatedTypeInference/type_witness_from_parameterized_protocol.swift
@@ -36,19 +36,68 @@ struct S3: P & Q<String> {
   func a(_: Int) {}
 }
 
+struct S4: P<Int, String>, Q<String> {
+  func a(_: Int) {}
+}
+
+struct S5: P<Int, String> & Q<String> {
+  func a(_: Int) {}
+}
+
 protocol R {}
 
-struct S4: (P & Q<String>) & R {
+struct S6: (P & Q<String>) & R {
   func a(_: Int) {}
 }
 
 struct Bad: P<Int, Float> { // expected-error {{type 'Bad' does not conform to protocol 'P'}}
   typealias A = String
   // expected-note@-1 {{possibly intended match}}
-  // expected-note@-2 {{found this candidate}}
 }
 
-let x = Bad.A.self // expected-error {{ambiguous use of 'A'}}
+struct Bad2: P<Int, Float>, Q<String> {
+// expected-error@-1 {{type 'Bad2' does not conform to protocol 'P'}}
+// expected-error@-2 {{type 'Bad2' does not conform to protocol 'Q'}}
+// expected-error@-3 {{ambiguous associated type 'B' in conformance to 'P'}}
+// expected-error@-4 {{ambiguous associated type 'B' in conformance to 'Q'}}
+// expected-note@-5 4{{candidate inferred from parameterized protocol here}}
+}
+
+struct Bad3: P<Int, Float> & Q<String> {
+// expected-error@-1 {{type 'Bad3' does not conform to protocol 'P'}}
+// expected-error@-2 {{type 'Bad3' does not conform to protocol 'Q'}}
+// expected-error@-3 {{ambiguous associated type 'B' in conformance to 'P'}}
+// expected-error@-4 {{ambiguous associated type 'B' in conformance to 'Q'}}
+// expected-note@-5 4{{candidate inferred from parameterized protocol here}}
+}
+
+protocol W<B> {
+  associatedtype B
+}
+
+protocol W2<B> {
+  associatedtype B
+}
+
+protocol W3<B> {
+  associatedtype B
+}
+
+struct Bad4: P<Int, String>, Q<String>, W<Float>, W2<Float>, W3<String> {
+// expected-error@-1 {{type 'Bad4' does not conform to protocol 'P'}}
+// expected-error@-2 {{type 'Bad4' does not conform to protocol 'Q'}}
+// expected-error@-3 {{type 'Bad4' does not conform to protocol 'W'}}
+// expected-error@-4 {{type 'Bad4' does not conform to protocol 'W2'}}
+// expected-error@-5 {{type 'Bad4' does not conform to protocol 'W3'}}
+// expected-error@-6 {{ambiguous associated type 'B' in conformance to 'P'}}
+// expected-error@-7 {{ambiguous associated type 'B' in conformance to 'Q'}}
+// expected-error@-8 {{ambiguous associated type 'B' in conformance to 'W'}}
+// expected-error@-9 {{ambiguous associated type 'B' in conformance to 'W2'}}
+// expected-error@-10 {{ambiguous associated type 'B' in conformance to 'W3'}}
+// expected-note@-11 10{{candidate inferred from parameterized protocol here}}
+}
+
+let x = Bad.A.self
 g(x)
 
 struct Circle: Q<Circle.A> {}

--- a/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
+++ b/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
@@ -58,3 +58,14 @@ public protocol R<E>: ~Copyable & ~Escapable {
 // CHECK: public typealias E = Swift.Int
 public struct N: R<Int> & B<Float64> & ~Copyable  {
 }
+
+public protocol P1<AT> {
+  associatedtype AT
+}
+
+public protocol P2<AT> {
+   associatedtype AT
+}
+
+// CHECK-COUNT-1: public typealias AT = Swift.Int
+public struct S1: P1<Int>, P2<Int> {}


### PR DESCRIPTION
Fixes a compiler crash when a type conforms to multiple parameterized protocol types that define conflicting type witnesses for the same associated type. Fixes synthesis of duplicate typealiases when multiple parameterized protocols provided the same type witness.