### PR TITLE
[6.3] [Serialization] Ensure semantic attributes are serialized

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4168,7 +4168,7 @@ public:
       writeABIOnlyCounterpart(abiRole.getCounterpartUnchecked());
 
     // Emit attributes (if any).
-    for (auto Attr : D->getAttrs())
+    for (auto Attr : D->getSemanticAttrs())
       writeDeclAttribute(D, Attr);
 
     if (auto *value = dyn_cast<ValueDecl>(D))

--- a/test/Concurrency/nonisolated_nonsending_lazy_typecheck.swift
+++ b/test/Concurrency/nonisolated_nonsending_lazy_typecheck.swift
@@ -1,0 +1,40 @@
+// %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+// Test both with and without '-experimental-lazy-typecheck'
+// RUN: %swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-lazy-typecheck -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
+// RUN: %swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
+
+// RUN: %swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
+// RUN: %swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
+
+//--- Lib.swift
+
+public final class IndexStoreDownloadManager2: Sendable {
+  public func withIndexStore(
+    body: (String) async throws -> Void
+  ) async throws {
+  }
+}
+
+//--- Test.swift
+
+import Lib
+
+private func `import`(
+  indexStoreDownloadManager: IndexStoreDownloadManager2,
+) async throws {
+  import2(
+    indexStoreProvider: { runWithIndexStore in
+      // Make sure we don't error here since `withIndexStore` is nonisolated(nonsending)
+      try await indexStoreDownloadManager.withIndexStore(body: runWithIndexStore)
+    }
+  )
+}
+
+func import2(
+  indexStoreProvider: (_ runWithIndexStore: (_ indexStore: String) async throws -> Void) async throws -> Void,
+) {
+}


### PR DESCRIPTION
*6.3 cherry-pick of #86304*

- Explanation: Fixes an issue where serialized modules would be missing attributes for e.g actor isolation when using `-experimental-lazy-typecheck`
- Scope: Affects serialization
- Issue: rdar://162100120
- Risk: Low, this should only really affect `-experimental-lazy-typecheck` since `getSemanticAttrs()` just returns `getAttrs()` after kicking some semantic requests, and those requests should be kicked by the type-checker prior to serialization without lazy type-checking. Additionally, this aligns the behavior with what we do for interface generation.
- Testing: Added tests to test suite
- Reviewer: Alexis Laferrière