### PR TITLE
[CS] Narrow the cases where we add dynamic member after applicable fn

### DIFF
--- a/test/Constraints/opened_existentials_dynamic_member.swift
+++ b/test/Constraints/opened_existentials_dynamic_member.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+func takesP(_ x: some P) {}
+
+struct Value {
+  let prop: any P
+}
+
+@dynamicMemberLookup
+struct ValueWithDynamicMember {
+  let prop: any P
+
+  subscript<U>(dynamicMember keyPath: KeyPath<Int, U>) -> U {
+    fatalError()
+  }
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  subscript<U>(dynamicMember keyPath: KeyPath<T, U>) -> U {
+    fatalError()
+  }
+}
+
+func test(_ a: Lens<Value>, _ b: Lens<ValueWithDynamicMember>) {
+  takesP(a.prop)
+  takesP(b.prop)
+}


### PR DESCRIPTION
Only delay adding the member constraint if we both have a subscript lookup and the base has `@dynamicMemberLookup`. This narrows the fix made in #86011 and ensures we have access to the applicable function constraint for such recursive cases, but otherwise allows us to potentially simplify the constraint in CSGen, which is currently load-bearing for existential opening.

rdar://167495745