### PR TITLE
[ConstraintSystem] Implement lazy transitive supertype inference

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -130,6 +130,10 @@ struct PotentialBinding {
 
   Constraint *getSource() const { return cast<Constraint *>(BindingSource); }
 
+  PotentialBinding withKind(AllowedBindingKind kind) const {
+    return {BindingType, kind, BindingSource, Originator};
+  }
+
   PotentialBinding withType(Type type) const {
     return {type, Kind, BindingSource, Originator};
   }
@@ -144,6 +148,10 @@ struct PotentialBinding {
   }
 
   bool isTransitive() const { return bool(Originator); }
+
+  bool isTransitiveSupertype() const {
+    return Kind == AllowedBindingKind::Supertypes && isTransitive();
+  }
 
   /// Determine whether this binding could be a viable candidate
   /// to be "joined" with some other binding. It has to be at least

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -149,10 +149,6 @@ struct PotentialBinding {
 
   bool isTransitive() const { return bool(Originator); }
 
-  bool isTransitiveSupertype() const {
-    return Kind == AllowedBindingKind::Supertypes && isTransitive();
-  }
-
   /// Determine whether this binding could be a viable candidate
   /// to be "joined" with some other binding. It has to be at least
   /// a non-default r-value supertype binding with no type variables.
@@ -324,7 +320,9 @@ struct PotentialBindings {
   /// \param literal The constraint to process.
   /// \param isDirect Determines whether this is a direct requirement of the
   /// current type variable or constraint has been transitively inferred.
-  void inferFromLiteral(Constraint *literal, TypeVariableType *transitiveFrom);
+  ///
+  /// \returns true if new literal was added to the set and false otherwise.
+  bool inferFromLiteral(Constraint *literal, TypeVariableType *transitiveFrom);
 
   /// Attempt to infer a new binding and other useful information
   /// (i.e. whether bindings should be delayed) from the given

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -317,7 +317,7 @@ struct PotentialBindings {
   /// relational constraint.
   std::optional<PotentialBinding> inferFromRelational(Constraint *constraint);
 
-  void infer(Constraint *constraint);
+  std::optional<PotentialBinding> infer(Constraint *constraint);
 
   /// Retract all bindings and other information related to a given
   /// constraint from this binding set.

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -96,8 +96,6 @@ GRAPH_NODE_CHANGE(AddedConstraint)
 GRAPH_NODE_CHANGE(RemovedConstraint)
 GRAPH_NODE_CHANGE(AddedConstraintToInference)
 GRAPH_NODE_CHANGE(RetractedConstraintFromInference)
-GRAPH_NODE_CHANGE(AddedLiteral)
-GRAPH_NODE_CHANGE(RetractedLiteral)
 
 COMMON_BINDING_INFORMATION_ADDITION(DelayedBy, DelayedBy)
 COMMON_BINDING_INFORMATION_RETRACTION(DelayedBy, DelayedBy)
@@ -145,8 +143,10 @@ CHANGE(RecordedKeyPath)
 CHANGE(RetiredConstraint)
 CHANGE(AddedBinding)
 CHANGE(RetractedBinding)
+CHANGE(AddedLiteral)
+CHANGE(RetractedLiteral)
 
-LAST_CHANGE(RetractedBinding)
+LAST_CHANGE(RetractedLiteral)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -150,6 +150,12 @@ public:
         TypeVariableType *Originator;
       } Binding;
 
+      struct {
+        TypeVariableType *TypeVar;
+        Constraint *Constraint;
+        TypeVariableType *TransitiveFrom;
+      } Literal;
+
       ConstraintFix *TheFix;
       ConstraintLocator *TheLocator;
       PackExpansionType *TheExpansion;
@@ -265,6 +271,19 @@ public:
     /// bindings.
     static Change RetractedBinding(TypeVariableType *typeVar,
                                    inference::PotentialBinding binding);
+
+    /// Create a change that added a literal conformance requirement to the
+    /// type variable's potential bindings. This could be caused by direct
+    /// or transitive inference.
+    static Change AddedLiteral(TypeVariableType *typeVar,
+                               Constraint *constraint,
+                               TypeVariableType *transitiveFrom);
+
+    /// Create a change that removed a literal conformance requirement from
+    /// the type variable's potential bindings.
+    static Change RetractedLiteral(TypeVariableType *typeVar,
+                                   Constraint *constraint,
+                                   TypeVariableType *transitiveFrom);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -177,6 +177,15 @@ private:
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
   /// }
 
+  /// If the given constraint represents a subtype/supertype relationship
+  /// between this type variable and some other one, let's note that in the
+  /// node.
+  ///
+  /// \param constraint The constraint that is either added or removed.
+  /// \param retraction Indicates whether the given constraint is being
+  /// removed from the graph.
+  void updateTypeVariableAssociations(Constraint *constraint, bool retraction);
+
   /// The constraint graph this node belongs to.
   ConstraintGraph &CG;
 
@@ -206,6 +215,13 @@ private:
   /// The set of type variables that occur within the fixed binding of
   /// this type variable.
   llvm::SmallSetVector<TypeVariableType *, 2> References;
+
+  /// The set of type variables that are connected to this type variable
+  /// via a Subtype constraint where this type variable appears on the right.
+  llvm::SmallSetVector<TypeVariableType *, 2> SupertypeOf;
+  /// The set of type variables that are connected to this type variable
+  /// via a Subtype constraint where this type variable appears on the left.
+  llvm::SmallSetVector<TypeVariableType *, 2> SubtypeOf;
 
   /// All of the type variables in the same equivalence class as this
   /// representative type variable.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -166,19 +166,25 @@ private:
   /// Remove the potential transitive bindings matching the given source
   /// constraint from the current node and all of its subtypes or supertypes
   /// depending on the given `direction`.
-  void retractTransitiveBindingsFrom(Constraint *constraint,
-                                     ChainDirection direction);
+  void retractAllTransitiveBindingsFrom(Constraint *constraint,
+                                        ChainDirection direction);
 
   /// Remove the potential transitive bindings matching the given
   /// originator type variable from the current node and all of its
   /// subtypes or supertypes depending on the given `direction`.
-  void retractTransitiveBindingsFrom(
+  void retractAllTransitiveBindingsFrom(
       llvm::SmallPtrSetImpl<TypeVariableType *> &typeVars,
       ChainDirection direction);
 
   /// Remove the potential transitive bindings matching the given predicate
+  /// from the current node.
+  void retractTrasitiveBindings(
+      llvm::function_ref<bool(const inference::PotentialBinding &binding)>
+          matching);
+
+  /// Remove the potential transitive bindings matching the given predicate
   /// from the current node and all of its supertypes.
-  void retractTransitiveBindings(
+  void retractAllTransitiveBindings(
       llvm::function_ref<bool(const inference::PotentialBinding &binding)>
           matching,
       ChainDirection direction);
@@ -200,9 +206,10 @@ private:
 
   /// Record the potential binding that was transitively inferred from
   /// one of the chain members and propagate it up or down depending on
-  /// the `direction` parameter.
-  void introduceTransitive(inference::PotentialBinding binding,
-                           ChainDirection direction);
+  /// the `propagateTo` parameter.
+  void
+  introduceTransitive(inference::PotentialBinding binding,
+                      std::optional<ChainDirection> propagateTo = std::nullopt);
 
   /// Notify all of the type variables that have this one (or any member of
   /// its equivalence class) referenced in their fixed type.
@@ -221,19 +228,19 @@ private:
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
 
 public: // public to enable unit tests.
-  /// Notify all of the type variables that are in a direct subtype relationship
+  /// Notify all of the type variables that are in a subtype relationship
   /// with this one.
   ///
   /// For example, consider $T1 <: $T2 <: $T3, if current type variable is
-  /// $T3 this method would notify _only_ $T2.
-  void notifyDirectSubtypes(
+  /// $T3 this method would notify $T2 and $T3.
+  void notifySubtypes(
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
 
   /// Notify all of the type variables that are in a supertype relationship
   /// with this one.
   /// For example, consider $T1 <: $T2 <: $T3, if current type variable is
-  /// $T1 this method would notify _only_ $T2.
-  void notifyDirectSupertypes(
+  /// $T1 this method would notify $T2 and $T3.
+  void notifySupertypes(
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
   /// }
 

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -158,6 +158,22 @@ private:
   /// to a type variable.
   void retractFromInference();
 
+  /// Remove the potential transitive bindings matching the given source
+  /// constraint from the current node and all of its supertypes.
+  void retractTransitiveBindingsFrom(Constraint *constraint);
+
+  /// Remove the potential transitive bindings matching the given
+  /// originator type variable from the current node and all of its
+  /// supertypes.
+  void retractTransitiveBindingsFrom(
+      llvm::SmallPtrSetImpl<TypeVariableType *> &typeVars);
+
+  /// Remove the potential transitive bindings matching the given predicate
+  /// from the current node and all of its supertypes.
+  void retractTransitiveBindings(
+      llvm::function_ref<bool(const inference::PotentialBinding &binding)>
+          matching);
+
   /// Attempt to infer bindings from the constraint. The inferred bindings
   /// would have to be removed once the constraint gets retracted from the
   /// graph.
@@ -172,6 +188,10 @@ private:
   /// a conformance lookup), so inference has to be delayed until its clear that
   /// type variable has been bound to a valid type and solver can make progress.
   void introduceToInference(Type fixedType);
+
+  /// Add the potential binding that was transitively inferred from
+  /// one the current node's subtypes and propagate it up the supertype chain.
+  void introduceTransitiveSupertype(inference::PotentialBinding binding);
 
   /// Notify all of the type variables that have this one (or any member of
   /// its equivalence class) referenced in their fixed type.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -89,6 +89,14 @@ public:
     return Potential;
   }
 
+  ArrayRef<TypeVariableType *> supertypeOf() const {
+    return SupertypeOf.getArrayRef();
+  }
+
+  ArrayRef<TypeVariableType *> subtypeOf() const {
+    return SubtypeOf.getArrayRef();
+  }
+
   void initBindingSet();
 
   inference::BindingSet &getBindingSet() {
@@ -104,13 +112,13 @@ public:
     Set.reset();
   }
 
-private:
   /// Determines whether the type variable associated with this node
   /// is a representative of an equivalence class.
   ///
   /// Note: The smallest equivalence class is of just one variable - itself.
   bool forRepresentativeVar() const;
 
+private:
   /// Retrieve all of the type variables in the same equivalence class
   /// as this type variable.
   ArrayRef<TypeVariableType *> getEquivalenceClassUnsafe() const;
@@ -180,8 +188,25 @@ private:
   /// Notify all of the type variables referenced by this one about a change.
   void notifyReferencedVars(
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
+
+public: // public to enable unit tests.
+  /// Notify all of the type variables that are in a direct subtype relationship
+  /// with this one.
+  ///
+  /// For example, consider $T1 <: $T2 <: $T3, if current type variable is
+  /// $T3 this method would notify _only_ $T2.
+  void notifyDirectSubtypes(
+      llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
+
+  /// Notify all of the type variables that are in a supertype relationship
+  /// with this one.
+  /// For example, consider $T1 <: $T2 <: $T3, if current type variable is
+  /// $T1 this method would notify _only_ $T2.
+  void notifyDirectSupertypes(
+      llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
   /// }
 
+private:
   /// If the given constraint represents a subtype/supertype relationship
   /// between this type variable and some other one, let's note that in the
   /// node.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -341,7 +341,7 @@ public:
   ///
   /// This records graph changes that must be undone after the merge has
   /// been undone.
-  void mergeNodesPre(TypeVariableType *typeVar2);
+  void mergeNodesPre(TypeVariableType *repr, TypeVariableType *member);
 
   /// Merge the two nodes for the two given type variables.
   ///

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -453,6 +453,9 @@ public:
       OrphanedConstraints.push_back(orphaned);
   }
 
+  /// Check whether transitive binding feature is enabled for this graph.
+  bool supportsTransitiveInference() const;
+
   /// Print the graph.
   void print(ArrayRef<TypeVariableType *> typeVars, llvm::raw_ostream &out);
   void dump(llvm::raw_ostream &out);

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -150,6 +150,11 @@ private:
   /// to a type variable.
   void retractFromInference();
 
+  /// Attempt to infer bindings from the constraint. The inferred bindings
+  /// would have to be removed once the constraint gets retracted from the
+  /// graph.
+  void introduceToInference(Constraint *constraint);
+
   /// Perform graph updates that must be undone before we bind a fixed type
   /// to a type variable.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2050,7 +2050,7 @@ public:
   llvm::DenseMap<ConstraintLocator *, ProtocolDecl *>
       SynthesizedConformances;
 
-private:
+public:
   /// Describes the current solver state.
   struct SolverState {
     SolverState(ConstraintSystem &cs,
@@ -2135,6 +2135,7 @@ private:
     SmallVector<Constraint *, 4> activeConstraints;
   };
 
+private:
   class CacheExprTypes : public ASTWalker {
     Expr *RootExpr;
     ConstraintSystem &CS;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1560,6 +1560,10 @@ enum class ConstraintSystemFlags {
 
   /// Disable macro expansions.
   DisableMacroExpansions = 0x40,
+
+  /// When set, bindings from subtypes are going to be propagated
+  /// up to their supertypes as they become available.
+  EnableTransitiveInference = 0x80,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1229,12 +1229,14 @@ bool BindingSet::operator<(const BindingSet &other) {
   // for "subtype" type variable to attempt more bindings later.
   // This is required because algorithm can't currently infer
   // bindings for subtype transitively through superclass ones.
-  if (!(std::get<0>(xScore) && std::get<0>(yScore))) {
-    if (Info.isSubtypeOf(other.getTypeVariable()))
-      return false;
+  if (!CS.Options.contains(ConstraintSystemFlags::EnableTransitiveInference)) {
+    if (!(std::get<0>(xScore) && std::get<0>(yScore))) {
+      if (Info.isSubtypeOf(other.getTypeVariable()))
+        return false;
 
-    if (other.Info.isSubtypeOf(getTypeVariable()))
-      return true;
+      if (other.Info.isSubtypeOf(getTypeVariable()))
+        return true;
+    }
   }
 
   // As a last resort, let's check if the bindings are

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2133,11 +2133,12 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
 /// Retrieve the set of potential type bindings for the given
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.
-void PotentialBindings::infer(Constraint *constraint) {
+std::optional<PotentialBinding>
+PotentialBindings::infer(Constraint *constraint) {
   ASSERT(TypeVar);
 
   if (!Constraints.insert(constraint))
-    return;
+    return std::nullopt;
 
   // Record the change, if there are active scopes.
   if (CS.solverState)
@@ -2162,7 +2163,7 @@ void PotentialBindings::infer(Constraint *constraint) {
       break;
 
     addPotentialBinding(*binding);
-    break;
+    return binding;
   }
   case ConstraintKind::KeyPathApplication: {
     // If this variable is in the application projected result type, delay
@@ -2326,6 +2327,8 @@ void PotentialBindings::infer(Constraint *constraint) {
     break;
   }
   }
+
+  return std::nullopt;
 }
 
 void PotentialBindings::retract(Constraint *constraint) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1128,6 +1128,10 @@ void ConstraintGraph::incrementConstraintsPerContractionCounter() {
   }
 }
 
+bool ConstraintGraph::supportsTransitiveInference() const {
+  return CS.Options.contains(ConstraintSystemFlags::EnableTransitiveInference);
+}
+
 #pragma mark Debugging output
 
 void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -398,13 +398,13 @@ void ConstraintGraphNode::retractFromInference() {
   // Notify all of the type variables that reference this one.
   //
   // Since this type variable is going to be replaced with a fixed type
-  // all of the concrete types that reference it are going to change,
-  // which means that all of the not-yet-attempted bindings should
-  // change as well.
-  return notifyReferencingVars(
-      [](ConstraintGraphNode &node, Constraint *constraint) {
-        node.getPotentialBindings().retract(constraint);
-      });
+  // or a representative all of the concrete types that reference it
+  // are going to change, which means that all of the not-yet-attempted
+  // bindings should change as well.
+  notifyReferencingVars([](ConstraintGraphNode &node,
+                              Constraint *constraint) {
+    node.getPotentialBindings().retract(constraint);
+  });
 }
 
 void ConstraintGraphNode::retractTransitiveBindingsFrom(
@@ -592,12 +592,7 @@ void ConstraintGraph::mergeNodesPre(TypeVariableType *typeVar2) {
   auto &nonRepNode = (*this)[typeVar2];
 
   for (auto *newMember : nonRepNode.getEquivalenceClassUnsafe()) {
-    auto &node = (*this)[newMember];
-
-    node.notifyReferencingVars(
-        [&](ConstraintGraphNode &node, Constraint *constraint) {
-          node.getPotentialBindings().retract(constraint);
-        });
+    (*this)[newMember].retractFromInference();
   }
 }
 

--- a/lib/Sema/TypeVariableType.cpp
+++ b/lib/Sema/TypeVariableType.cpp
@@ -231,7 +231,7 @@ void ConstraintSystem::mergeEquivalenceClasses(TypeVariableType *typeVar1,
   if (typeVar1->getImpl().getID() > typeVar2->getImpl().getID())
     std::swap(typeVar1, typeVar2);
 
-  CG.mergeNodesPre(typeVar2);
+  CG.mergeNodesPre(typeVar1, typeVar2);
   typeVar1->getImpl().mergeEquivalenceClasses(typeVar2, getTrail());
   CG.mergeNodes(typeVar1, typeVar2);
 

--- a/unittests/Sema/CMakeLists.txt
+++ b/unittests/Sema/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_unittest(swiftSemaTests
   SemaFixture.cpp
   BindingInferenceTests.cpp
   ConstraintGenerationTests.cpp
+  ConstraintGraphTests.cpp
   ConstraintSimplificationTests.cpp
   ConstraintSystemDumpTests.cpp
   UnresolvedMemberLookupTests.cpp

--- a/unittests/Sema/ConstraintGraphTests.cpp
+++ b/unittests/Sema/ConstraintGraphTests.cpp
@@ -1,0 +1,168 @@
+//===--- ConstraintGraphTests.cpp -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SemaFixture.h"
+#include "swift/Sema/ConstraintSystem.h"
+
+using namespace swift;
+using namespace swift::unittest;
+using namespace swift::constraints;
+using namespace swift::constraints::inference;
+
+static void collectSupertypes(const ConstraintGraphNode &node,
+                              SmallVectorImpl<TypeVariableType *> &supertypes) {
+  node.notifyDirectSupertypes([&](ConstraintGraphNode &supertype) {
+    supertypes.push_back(supertype.getTypeVariable());
+    collectSupertypes(supertype, supertypes);
+  });
+}
+
+static void collectSubtypes(const ConstraintGraphNode &node,
+                            SmallVectorImpl<TypeVariableType *> &subtypes) {
+  node.notifyDirectSubtypes([&](ConstraintGraphNode &subtype) {
+    subtypes.push_back(subtype.getTypeVariable());
+    collectSubtypes(subtype, subtypes);
+  });
+}
+
+static void checkSupertypes(const ConstraintGraphNode &node,
+                            ArrayRef<TypeVariableType *> expected) {
+  SmallVector<TypeVariableType *> supertypes;
+  collectSupertypes(node, supertypes);
+  ASSERT_EQ(ArrayRef(supertypes), expected);
+}
+
+static void checkSubtypes(const ConstraintGraphNode &node,
+                          ArrayRef<TypeVariableType *> expected) {
+  SmallVector<TypeVariableType *> subtypes;
+  collectSubtypes(node, subtypes);
+  ASSERT_EQ(ArrayRef(subtypes), expected);
+}
+
+TEST_F(SemaTest, TestSubtypeSypertypeChains) {
+  ConstraintSystem cs(DC, std::nullopt);
+  auto &cg = cs.getConstraintGraph();
+
+  auto intTy = getStdlibType("Int");
+
+  auto *loc = cs.getConstraintLocator({});
+
+  ConstraintSystem::SolverState state(cs, FreeTypeVariableBinding::Disallow);
+
+  {
+    ConstraintSystem::SolverScope scope(cs);
+
+    auto *T0 = cs.createTypeVariable(loc, /*options=*/0);
+    auto *T1 = cs.createTypeVariable(loc, /*options=*/0);
+    auto *T2 = cs.createTypeVariable(loc, /*options=*/0);
+    auto *T3 = cs.createTypeVariable(loc, /*options=*/0);
+    auto *T4 = cs.createTypeVariable(loc, /*options=*/0);
+
+    // $T2 <: $T3
+    cs.addConstraint(ConstraintKind::Subtype, T2, T3, loc);
+
+    {
+      ConstraintSystem::SolverScope subtypeThroughEqMember(cs);
+
+      // $T0 == $T1 == $T2 ($T0 is now a representative).
+      cs.addConstraint(ConstraintKind::Equal, T1, T2, loc);
+      cs.addConstraint(ConstraintKind::Equal, T0, T1, loc);
+
+      // $T0 <: T4
+      cs.addConstraint(ConstraintKind::Subtype, T0, T4, loc);
+
+      // Check that $T0 (and every member of its equivalence class) is a
+      // subtype of $T3 now traversing from both sides.
+
+      for (auto *typeVar : {T0, T1, T2})
+        checkSupertypes(cg[typeVar], ArrayRef({T4, T3}));
+
+      for (auto *typeVar : {T3, T4})
+        checkSubtypes(cg[typeVar], T0);
+
+      // Check that assigning a fixed type does break the chain.
+
+      // $T1 (aka $T0) := Int
+      {
+        ConstraintSystem::SolverScope scope(cs);
+
+        cs.addConstraint(ConstraintKind::Equal, intTy, T1, loc);
+
+        for (auto *typeVar : {T0, T1, T2})
+          checkSupertypes(cg[typeVar], {});
+
+        for (auto *typeVar : {T3, T4})
+          checkSubtypes(cg[typeVar], {});
+      }
+
+      // $T3 and $T4 := Int
+      {
+        ConstraintSystem::SolverScope scope(cs);
+
+        cs.addConstraint(ConstraintKind::Equal, intTy, T3, loc);
+
+        for (auto *typeVar : {T0, T1, T2})
+          checkSupertypes(cg[typeVar], T4);
+
+        checkSubtypes(cg[T3], {});
+        checkSubtypes(cg[T4], T0);
+
+        cs.addConstraint(ConstraintKind::Equal, intTy, T4, loc);
+
+        for (auto *typeVar : {T0, T1, T2})
+          checkSupertypes(cg[typeVar], {});
+
+        for (auto *typeVar : {T3, T4})
+          checkSubtypes(cg[typeVar], {});
+      }
+
+      // $T2 := Int, $T3, $T4 := Int
+      {
+        ConstraintSystem::SolverScope scope(cs);
+
+        for (auto *typeVar : {T2, T3, T4})
+          cs.addConstraint(ConstraintKind::Equal, typeVar, intTy, loc);
+
+        for (auto *typeVar : {T0, T1, T2})
+          checkSupertypes(cg[typeVar], {});
+
+        for (auto *typeVar : {T3, T4})
+          checkSubtypes(cg[typeVar], {});
+      }
+
+      // Retracing assignments brings everything back.
+
+      for (auto *typeVar : {T0, T1, T2})
+        checkSupertypes(cg[typeVar], ArrayRef({T4, T3}));
+
+      for (auto *typeVar : {T3, T4})
+        checkSubtypes(cg[typeVar], T0);
+    }
+
+    // $T2 := $T3
+    {
+      ConstraintSystem::SolverScope bindT2T3(cs);
+
+      cs.addConstraint(ConstraintKind::Equal, T2, T3, loc);
+
+      checkSubtypes(cg[T3], {});
+      checkSupertypes(cg[T2], {});
+    }
+
+    // Check that retracting equivalences updates the chains.
+
+    for (auto *typeVar : {T0, T1})
+      checkSupertypes(cg[typeVar], {});
+
+    checkSupertypes(cg[T2], T3);
+  }
+}


### PR DESCRIPTION
The functionally is hidden behind a constraint system flag - `EnableTransitiveInference` at the moment
and can only be enabled for unit tests.

The constraint graph now tracks subtype/supertype chains established by introduction of `Subtype`.
When new exact/supertype binding for a type variable becomes available, it gets propagated up
the chain to all of the current supertypes of this type variable. Such "transitive" bindings get retracted
when a type variable gets bound or originator constraint gets retracted.

This is a replacement for the logic that currently lives in `determineBestBindings` and isn't currently in
100% correct because it relies on the type variable ordering (i.e. it's wrong when a type variable with
a higher ID is a subtype of a type variable is a lower ID).


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
