### PR TITLE
[stdlib] Add missing unsafe modifier in StaticPrint

### DIFF
--- a/stdlib/public/core/StaticPrint.swift
+++ b/stdlib/public/core/StaticPrint.swift
@@ -747,7 +747,7 @@ extension ConstantVPrintFArguments {
   @_optimize(none)
   internal mutating func append(_ value: @escaping () -> UnsafeRawPointer) {
     argumentClosures.append({ continuation in
-      continuation(value()._cVarArgEncoding)
+      unsafe continuation(value()._cVarArgEncoding)
     })
   }
 }


### PR DESCRIPTION
Resolves a build failure here: https://ci.swift.org/view/Apple%20Silicon%20(main)/job/oss-swift-pr-test-macos-arm64/1465/