### PR TITLE
Sema: Enable exportability checks in non-library-evolution mode as warnings by default

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -364,6 +364,12 @@ namespace swift {
     /// emitted as a warning, but a note will still be emitted as a note.
     InFlightDiagnostic &limitBehavior(DiagnosticBehavior limit);
 
+    /// Prevent the diagnostic from behaving more severely than \p limit or the
+    /// previously set limit. Use to compose conditions to downgrade a
+    /// diagnostic in succession.
+    InFlightDiagnostic
+    &limitBehaviorIfMorePermissive(DiagnosticBehavior limit);
+
     /// Conditionally prevent the diagnostic from behaving more severely than \p
     /// limit. If the condition is false, no limit is imposed.
     InFlightDiagnostic &limitBehaviorIf(bool shouldLimit,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1272,8 +1272,9 @@ ERROR(module_not_compiled_with_library_evolution,none,
       (Identifier, Identifier))
 GROUPED_WARNING(implementation_only_requires_library_evolution,
         ImplementationOnlyDeprecated,none,
-        "using '@_implementationOnly' without enabling library evolution "
-        "for %0 may lead to instability during execution",
+        "safely use '@_implementationOnly' without library evolution "
+        "by setting '-enable-experimental-feature CheckImplementationOnly' "
+        "for %0",
         (Identifier))
 GROUPED_WARNING(implementation_only_deprecated,
         ImplementationOnlyDeprecated,none,

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -104,19 +104,15 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
   // Special case for dtors and enum elements: inherit from container
   if (D->getKind() == DeclKind::Destructor ||
       D->getKind() == DeclKind::EnumElement) {
-    if (D->hasInterfaceType() && D->isInvalid()) {
-      return AccessLevel::Private;
-    } else {
-      auto container = dyn_cast<NominalTypeDecl>(DC);
-      if (D->getKind() == DeclKind::Destructor && !container) {
-        // A destructor in an extension means @_objcImplementation. An
-        // @_objcImplementation class's deinit is only called by the ObjC thunk,
-        // if at all, so it is nonpublic.
-        return AccessLevel::Internal;
-      }
-
-      return std::max(container->getFormalAccess(), AccessLevel::Internal);
+    auto container = dyn_cast<NominalTypeDecl>(DC);
+    if (D->getKind() == DeclKind::Destructor && !container) {
+      // A destructor in an extension means @_objcImplementation. An
+      // @_objcImplementation class's deinit is only called by the ObjC thunk,
+      // if at all, so it is nonpublic.
+      return AccessLevel::Internal;
     }
+
+    return std::max(container->getFormalAccess(), AccessLevel::Internal);
   }
 
   switch (DC->getContextKind()) {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -1062,5 +1062,5 @@ ExportedLevel swift::isExported(const ExtensionDecl *ED) {
   for (const Decl *D : ED->getMembers())
     membersExported = std::max(membersExported, isExported(D));
 
-  return membersExported;
+  return std::min(exported, membersExported);
 }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -1014,8 +1014,6 @@ ExportedLevel swift::isExported(const ValueDecl *VD) {
 
   // Is this a type exposed by default in a non-resilient module?
   if (isa<NominalTypeDecl>(VD) &&
-      VD->getASTContext().LangOpts.hasFeature(
-          Feature::CheckImplementationOnly) &&
       VD->getDeclContext()->getParentModule()->getResilienceStrategy() !=
           ResilienceStrategy::Resilient &&
       !VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -479,7 +479,7 @@ private:
     if (decl->isSPI())
       return true;
 
-    return isExported(decl) == ExportedLevel::None;
+    return isExported(decl) != ExportedLevel::Exported;
   }
 
   /// Returns the source range which should be refined by declaration. This

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2808,8 +2808,7 @@ ExportedLevel VarDecl::isLayoutExposedToClients() const {
     return ExportedLevel::None;
 
   auto M = getDeclContext()->getParentModule();
-  if (getASTContext().LangOpts.hasFeature(Feature::CheckImplementationOnly) &&
-      M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
+  if (M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
     // Non-resilient module expose layouts by default.
     return ExportedLevel::ImplicitlyExported;
   } else {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -459,6 +459,13 @@ InFlightDiagnostic::limitBehavior(DiagnosticBehavior limit) {
 }
 
 InFlightDiagnostic &
+InFlightDiagnostic::limitBehaviorIfMorePermissive(DiagnosticBehavior limit) {
+  auto prev = getDiag().getBehaviorLimit();
+  getDiag().setBehaviorLimit(prev.merge(limit));
+  return *this;
+}
+
+InFlightDiagnostic &
 InFlightDiagnostic::limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
                                                    unsigned majorVersion) {
   if (!Engine->languageVersion.isVersionAtLeast(majorVersion)) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -929,8 +929,8 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
                              diag::implementation_only_deprecated);
         inFlight.fixItReplace(import.implementationOnlyRange, "internal");
       }
-    } else if ( // Non-resilient client
-        !shouldSuppressNonResilientImplementationOnlyImportDiagnostic(
+    } else if (!ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly) &&
+               !shouldSuppressNonResilientImplementationOnlyImportDiagnostic(
             targetName.str(), importerName.str())) {
       ctx.Diags.diagnose(import.importLoc,
                          diag::implementation_only_requires_library_evolution,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -252,7 +252,13 @@ static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
   switch (*reason) {
   case ExportabilityReason::ExtensionWithPublicMembers:
   case ExportabilityReason::ExtensionWithConditionalConformances:
-    return true;
+    // Allow public members in extensions of implicitly exported types.
+    // Extensions cannot define stored variables avoiding the memory layout
+    // concerns and we don't print swiftinterfaces in non-library-evolution
+    // mode.
+    // We should be able to always allow this if it's correctly guarded
+    // at generating module interfaces and generated headers.
+    return where.getExportedLevel() == ExportedLevel::Exported;
   case ExportabilityReason::Inheritance:
   case ExportabilityReason::ImplicitlyPublicInheritance:
     return isa<ProtocolDecl>(D);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2169,8 +2169,6 @@ swift::getDisallowedOriginKind(const Decl *decl,
 
   // Implementation-only memory layouts for non-library-evolution mode.
   if (isa<NominalTypeDecl>(decl) &&
-      Context.LangOpts.hasFeature(
-          Feature::CheckImplementationOnly) &&
       decl->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     return DisallowedOriginKind::ImplementationOnlyMemoryLayout;
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -202,9 +202,10 @@ public:
   /// because it is the function body context of an inlinable function.
   bool mustOnlyReferenceExportedDecls() const;
 
-  /// If true, the context reference a dependency of \p originKind  without
-  /// restriction.
-  bool canReferenceOrigin(DisallowedOriginKind originKind) const;
+  /// Level of restriction to references from the context to an \p originKind.
+  /// This check is shared by different diagnostics.
+  DiagnosticBehavior
+  behaviorForReferenceToOrigin(DisallowedOriginKind originKind) const;
 
   /// Get the ExportabilityReason for diagnostics. If this is 'None', there
   /// are no restrictions on referencing unexported declarations.

--- a/test/Index/enum_case_with_invalid_associated_type.swift
+++ b/test/Index/enum_case_with_invalid_associated_type.swift
@@ -1,7 +1,7 @@
 enum MyEnum {
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
   case test(artifactID: String, hostTriple: Triple)
-// CHECK: enumerator(less_than_private)/Swift | test(artifactID:hostTriple:)
+// CHECK: enumerator(internal)/Swift | test(artifactID:hostTriple:)
 // CHECK: param/Swift | artifactID
 // CHECK: param/Swift | hostTriple
 }

--- a/test/Sema/access-level-and-implementation-only-import-embedded.swift
+++ b/test/Sema/access-level-and-implementation-only-import-embedded.swift
@@ -18,7 +18,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly internal import directs
-// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+// expected-warning @-1 {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 // expected-note @-2 11 {{struct 'StructFromDirect' imported as 'internal' from 'directs' here}}
 // expected-note @-3 6 {{initializer 'init()' imported as 'internal' from 'directs' here}}
 import indirects

--- a/test/Sema/access-level-and-implementation-only-import-embedded.swift
+++ b/test/Sema/access-level-and-implementation-only-import-embedded.swift
@@ -174,9 +174,9 @@ public struct ExposedLayoutPublic {
   // expected-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
   // expected-note @-2 {{struct 'StructFromDirect' is imported by this file as 'internal' from 'directs'}}
 
-  private var privateField: StructFromDirect
+  private var privateField: StructFromDirect // expected-warning {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 }
 
 private struct ExposedLayoutPrivate {
-  private var privateField: StructFromDirect
+  private var privateField: StructFromDirect // expected-warning {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 }

--- a/test/Sema/access-level-import-classic-exportability.swift
+++ b/test/Sema/access-level-import-classic-exportability.swift
@@ -1,13 +1,33 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 
-/// Build the libraries.
+/// Non-library-evolution.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
+// RUN:   -package-name pkg
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
+
+/// Check diagnostics.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name pkg -swift-version 5 \
+// RUN:   -verify -verify-ignore-unrelated
+
+/// CheckImplementationOnly doesn't change the results.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name pkg -swift-version 5 \
+// RUN:   -enable-experimental-feature CheckImplementationOnly \
+// RUN:   -verify -verify-ignore-unrelated
+
+
+/// Library-evolution.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
 // RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
 // RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -enable-library-evolution -package-name pkg
 // RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t \
 // RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t \
@@ -15,16 +35,18 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name TestPackage -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify -verify-ignore-unrelated
-
-/// Check diagnostics with library-evolution.
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name TestPackage -swift-version 5 \
+// RUN:   -package-name pkg -swift-version 5 \
 // RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify -verify-ignore-unrelated
+// RUN:   -verify -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_AccessLevelOnImport
+/// CheckImplementationOnly doesn't change the results.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name pkg -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature CheckImplementationOnly \
+// RUN:   -verify -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_CheckImplementationOnly
 
 //--- PublicLib.swift
 public struct PublicImportType {
@@ -40,6 +62,8 @@ public struct PackageImportType {
 public struct InternalImportType {
     public init() {}
 }
+
+package struct InternalImportPackageType {}
 
 //--- FileprivateLib.swift
 public struct FileprivateImportType {
@@ -140,6 +164,9 @@ fileprivate protocol InternalConstrainedExtensionProtoInFileprivate {}
 extension Array: InternalConstrainedExtensionProtoInFileprivate where Element == InternalImportType {}
 extension InternalImportType {
     fileprivate func fileprivateMethod() {}
+}
+extension InternalImportPackageType { // No error
+    public func foo() {}
 }
 
 private protocol InternalConstrainedExtensionProtoInPrivate {}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -38,6 +38,7 @@
 // RUN: %target-swift-frontend -emit-module -verify -verify-ignore-unrelated %s -I %t \
 // RUN:   -swift-version 5 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded \
+// RUN:   -verify-additional-prefix embedded- \
 // RUN:   -verify-additional-prefix not-opt-in-
 
 /// Opt-in diags
@@ -46,6 +47,7 @@
 // RUN:   -enable-experimental-feature Embedded \
 // RUN:   -verify-additional-prefix opt-in- \
 // RUN:   -verify-additional-prefix embedded-opt-in- \
+// RUN:   -verify-additional-prefix embedded- \
 // RUN:   -enable-experimental-feature CheckImplementationOnly
 
 /// Same diags with CheckImplementationOnlyStrict
@@ -54,6 +56,7 @@
 // RUN:   -enable-experimental-feature Embedded \
 // RUN:   -verify-additional-prefix opt-in- \
 // RUN:   -verify-additional-prefix embedded-opt-in- \
+// RUN:   -verify-additional-prefix embedded- \
 // RUN:   -enable-experimental-feature CheckImplementationOnlyStrict
 
 // REQUIRES: swift_feature_Embedded
@@ -100,14 +103,14 @@ private class HiddenClass {
 // expected-note @-1 2 {{class 'HiddenClass' is not '@usableFromInline' or public}}
 // expected-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-note @-3 3 {{type declared here}}
-// expected-opt-in-note @-4 7 {{class declared here}}
+// expected-note @-4 7 {{class declared here}}
 }
 
 @_implementationOnly
 private struct HiddenLayout {
 // expected-note @-1 2 {{struct 'HiddenLayout' is not '@usableFromInline' or public}}
 // expected-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
-// expected-opt-in-note @-3 9 {{struct declared here}}
+// expected-note @-3 9 {{struct declared here}}
 // expected-note @-4 4 {{type declared here}}
 }
 
@@ -126,7 +129,7 @@ private enum ExposedEnumPrivate {
 
 @_implementationOnly
 private enum HiddenEnum {
-// expected-opt-in-note @-1 6 {{enum declared here}}
+// expected-note @-1 6 {{enum declared here}}
 // expected-note @-2 2 {{enum 'HiddenEnum' is not '@usableFromInline' or public}}
 // expected-note @-3 2 {{type declared here}}
   case A
@@ -150,7 +153,7 @@ private protocol ExposedProtocolPrivate {
 @_implementationOnly
 private protocol HiddenProtocol {
 // expected-note @-1 {{protocol 'HiddenProtocol' is not '@usableFromInline' or public}}
-// expected-opt-in-note @-2 9 {{protocol declared here}}
+// expected-note @-2 9 {{protocol declared here}}
 // expected-note @-3 4 {{type declared here}}
 }
 
@@ -200,46 +203,46 @@ public func implicitlyInlinablePublic() {
   let _: ExposedLayoutPublic = ExposedLayoutPublic()
   let _: ExposedLayoutPrivate = ExposedLayoutPrivate()
   let _: HiddenLayout = HiddenLayout()
-  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   let _: ExposedClassPublic = ExposedClassPublic()
   let _: ExposedClassPrivate = ExposedClassPrivate()
   let _: HiddenClass = HiddenClass()
-  // expected-embedded-opt-in-error @-1 2 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   let _: ExposedEnumPublic = ExposedEnumPublic.A
   let _: ExposedEnumPrivate = ExposedEnumPrivate.A
   let _: HiddenEnum = HiddenEnum.A
-  // expected-embedded-opt-in-error @-1 2 {{enum 'HiddenEnum' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{enum 'HiddenEnum' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenEnum' is marked '@_implementationOnly'}}
 
   let _: ExposedProtocolPublic
   let _: ExposedProtocolInternal
   let _: ExposedProtocolPrivate
   let _: HiddenProtocol
-  // expected-embedded-opt-in-error @-1 {{protocol 'HiddenProtocol' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{protocol 'HiddenProtocol' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
 private func implicitlyInlinablePrivate() {
   let _: ExposedLayoutPublic = ExposedLayoutPublic()
   let _: ExposedLayoutPrivate = ExposedLayoutPrivate()
   let _: HiddenLayout = HiddenLayout()
-  // expected-embedded-opt-in-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   let _: ExposedClassPublic = ExposedClassPublic()
   let _: ExposedClassPrivate = ExposedClassPrivate()
   let _: HiddenClass = HiddenClass()
-  // expected-embedded-opt-in-error @-1 2 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   let _: ExposedEnumPublic = ExposedEnumPublic.A
   let _: ExposedEnumPrivate = ExposedEnumPrivate.A
   let _: HiddenEnum = HiddenEnum.A
-  // expected-embedded-opt-in-error @-1 2 {{enum 'HiddenEnum' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 2 {{enum 'HiddenEnum' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenEnum' is marked '@_implementationOnly'}}
 
   let _: ExposedProtocolPublic
   let _: ExposedProtocolInternal
   let _: ExposedProtocolPrivate
   let _: HiddenProtocol
-  // expected-embedded-opt-in-error @-1 {{protocol 'HiddenProtocol' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{protocol 'HiddenProtocol' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
 @export(interface)
@@ -300,7 +303,7 @@ public struct ExposedLayoutFrozenUser: ProtocolFromDirect {
   private var b: ExposedLayoutPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private var ca: ExposedClassPublic
@@ -309,14 +312,14 @@ public struct ExposedLayoutFrozenUser: ProtocolFromDirect {
   private var cc: ExposedClassPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var cd: HiddenClass
-  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenClass' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenEnum' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private var pp: ProtocolFromDirect
@@ -328,13 +331,13 @@ public struct ExposedLayoutFrozenUser: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
-  // expected-embedded-opt-in-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   @_spi(S) public var s: SPIStruct
   // expected-error @-1 {{stored property 's' cannot be declared '@_spi' in a '@frozen' struct}}
@@ -349,111 +352,117 @@ public struct ExposedLayoutPublicUser: ProtocolFromDirect {
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var pp: ProtocolFromDirect
   // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
-  // expected-embedded-opt-in-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   @_spi(S) public var s: SPIStruct
 }
 
 internal struct ExposedLayoutInternalUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
-  // expected-embedded-opt-in-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   @_spi(S) public var s: SPIStruct
 }
 
 private struct ExposedLayoutPrivateUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var ca: ExposedClassPublic
   private var cb: ExposedClassInternal
   private var cc: ExposedClassPrivate
   private var cd: HiddenClass
-  // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use class 'HiddenClass' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {}
-  // expected-embedded-opt-in-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
-  // expected-embedded-opt-in-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+  // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
   @_spi(S) public var s: SPIStruct
 }
@@ -501,65 +510,70 @@ public enum PublicEnumUser: ProtocolFromDirect {
     case c(ExposedLayoutInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case d(ExposedLayoutPrivate) // expected-error {{enum case in a public enum uses a private type}}
     case b(HiddenLayout) // expected-error {{enum case in a public enum uses a private type}}
-    // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in an associated value of a public or '@usableFromInline' enum; 'HiddenLayout' is marked '@_implementationOnly'}}
+    // expected-error @-1 {{cannot use struct 'HiddenLayout' in an associated value of a public or '@usableFromInline' enum; 'HiddenLayout' is marked '@_implementationOnly'}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case cd(ExposedClassPrivate) // expected-error {{enum case in a public enum uses a private type}}
     case cb(HiddenClass) // expected-error {{enum case in a public enum uses a private type}}
-    // expected-opt-in-error @-1 {{cannot use class 'HiddenClass' in an associated value of a public or '@usableFromInline' enum; 'HiddenClass' is marked '@_implementationOnly'}}
+    // expected-error @-1 {{cannot use class 'HiddenClass' in an associated value of a public or '@usableFromInline' enum; 'HiddenClass' is marked '@_implementationOnly'}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal) // expected-error {{enum case in a public enum uses an internal type}}
     case h(ExposedProtocolPrivate) // expected-error {{enum case in a public enum uses a private type}}
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of a public or '@usableFromInline' enum; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-error {{cannot use protocol 'HiddenProtocol' in an associated value of a public or '@usableFromInline' enum; 'HiddenProtocol' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in a public enum uses a private type}}
 }
 
 internal enum InternalEnumUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
     case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+    // expected-not-opt-in-warning @-1 {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    case b(HiddenLayout) // expected-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    case cb(HiddenClass) // expected-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate) // expected-error {{enum case in an internal enum uses a private type}}
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
     // expected-error @-1 {{enum case in an internal enum uses a private type}}
 }
 
 private enum PrivateEnumUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
     case a(StructFromDirect) // expected-opt-in-error {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+    // expected-not-opt-in-warning @-1 {{cannot use struct 'StructFromDirect' in an associated value of an enum not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
     case e(ExposedLayoutPublic)
     case c(ExposedLayoutInternal)
     case d(ExposedLayoutPrivate)
-    case b(HiddenLayout) // expected-opt-in-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+    case b(HiddenLayout) // expected-error {{cannot use struct 'HiddenLayout' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
     case ce(ExposedClassPublic)
     case cc(ExposedClassInternal)
     case cd(ExposedClassPrivate)
-    case cb(HiddenClass) // expected-opt-in-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
+    case cb(HiddenClass) // expected-error {{cannot use class 'HiddenClass' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenClass' is marked '@_implementationOnly'}}
 
     case f(ExposedProtocolPublic)
     case g(ExposedProtocolInternal)
     case h(ExposedProtocolPrivate)
-    case i(HiddenProtocol) // expected-opt-in-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+    case i(HiddenProtocol) // expected-error {{cannot use protocol 'HiddenProtocol' in an associated value of an enum not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
 internal enum InternalEnumWithRawType : RawTypeFromDirect { // expected-opt-in-error {{cannot use struct 'RawTypeFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-1 {{cannot use struct 'RawTypeFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
   typealias RawValue = RawTypeFromDirect
   case a
 }
@@ -632,22 +646,23 @@ open class OpenClassUser: ProtocolFromDirect {
 
   private var privateField: StructFromDirect
   // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
@@ -670,14 +685,14 @@ public class FixedClassUser: ProtocolFromDirect {
   private var b: ExposedLayoutPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var c: HiddenLayout
-  // expected-opt-in-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenLayout' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var f: HiddenEnum
-  // expected-opt-in-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenEnum' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   private var g: ExposedProtocolPublic
@@ -686,7 +701,7 @@ public class FixedClassUser: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   // expected-error @-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
   private var j: HiddenProtocol
-  // expected-opt-in-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
   @export(interface)
@@ -695,6 +710,7 @@ public class FixedClassUser: ProtocolFromDirect {
 
 internal class InternalClassUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   public init() { fatalError() }
 
@@ -715,11 +731,12 @@ internal class InternalClassUser: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
 
-  private func privateFunc(h: HiddenLayout) {} // expected-embedded-opt-in-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 private class PrivateClassUser: ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' in a conformance on a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 
   public init() { fatalError() }
 
@@ -740,7 +757,7 @@ private class PrivateClassUser: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
 
-  private func privateFunc(h: HiddenLayout) {} // expected-embedded-opt-in-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+  private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 @_implementationOnly
@@ -781,10 +798,12 @@ public protocol PublicProtocol : ProtocolFromDirect {
 
 internal protocol InternalProtocol : ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' here; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' here; 'directs' has been imported as implementation-only}}
 }
 
 private protocol PrivateProtocol : ProtocolFromDirect {
 // expected-opt-in-error @-1 {{cannot use protocol 'ProtocolFromDirect' here; 'directs' has been imported as implementation-only}}
+// expected-not-opt-in-warning @-2 {{cannot use protocol 'ProtocolFromDirect' here; 'directs' has been imported as implementation-only}}
 }
 
 #if UseImplementationOnly

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -65,7 +65,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly import directs
-// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+// expected-not-opt-in-warning @-1 {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 import indirects
 
 /// Referenced types

--- a/test/Sema/implementation-only-import-conformances-non-library-evolution.swift
+++ b/test/Sema/implementation-only-import-conformances-non-library-evolution.swift
@@ -1,0 +1,116 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift \
+// RUN:  -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t \
+// RUN:  -swift-version 5
+
+/// Warnings by default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %t \
+// RUN:  -swift-version 6 -verify-additional-prefix not-opt-in-
+
+/// Opt-in errors
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %t \
+// RUN:  -swift-version 6 -verify-additional-prefix opt-in- \
+// RUN:  -enable-experimental-feature CheckImplementationOnly
+
+// REQUIRES: swift_feature_CheckImplementationOnly
+
+import NormalLibrary
+@_implementationOnly import BADLibrary // expected-not-opt-in-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+
+/// No diagnostics on functions in non-embedded mode.
+
+internal typealias NormalProtoAssoc<T: NormalProto> = T.Assoc
+internal func testConformanceInTypealias(_: NormalProtoAssoc<NormalStruct>) {}
+
+internal struct NormalProtoAssocHolder<T: NormalProto> {
+  public var value: T.Assoc
+}
+internal func testConformanceInBoundGeneric(_: NormalProtoAssocHolder<NormalStruct>) {}
+
+internal struct OuterGenericHolder<T> {
+  internal struct Nested where T : NormalProto {
+    public var value: T.Assoc
+  }
+}
+internal func testConformanceInNestedNonGeneric(_: OuterGenericHolder<NormalStruct>.Nested) {}
+
+internal class SubclassOfNormalClass: NormalClass {}
+
+internal func testInheritedConformance(_: NormalProtoAssocHolder<SubclassOfNormalClass>) {}
+internal func testSpecializedConformance(_: NormalProtoAssocHolder<GenericStruct<Int>>) {}
+
+extension Array where Element == NormalProtoAssocHolder<NormalStruct> { // Should we error here?
+  internal func testConstrainedExtensionUsingBadConformance() {}
+}
+
+public struct ConditionalGenericStruct<T> {}
+extension ConditionalGenericStruct: NormalProto where T: NormalProto {
+  public typealias Assoc = Int
+}
+internal func testConditionalGeneric(_: NormalProtoAssocHolder<ConditionalGenericStruct<NormalStruct>>) {}
+
+public protocol PublicAssociatedTypeProto {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+@usableFromInline protocol UFIAssociatedTypeProto {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+protocol InternalAssociatedTypeProto {
+  associatedtype Assoc: NormalProto
+  func takesAssoc(_: Assoc)
+}
+
+public struct PublicInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension PublicInferredAssociatedTypeImpl: PublicAssociatedTypeProto {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-1 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension PublicInferredAssociatedTypeImpl: UFIAssociatedTypeProto {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-1 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension PublicInferredAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay
+
+@usableFromInline struct UFIInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension UFIInferredAssociatedTypeImpl: PublicAssociatedTypeProto {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-1 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension UFIInferredAssociatedTypeImpl: UFIAssociatedTypeProto {} // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-1 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension UFIInferredAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay
+
+struct InternalInferredAssociatedTypeImpl {
+  public func takesAssoc(_: NormalStruct) {}
+}
+extension InternalInferredAssociatedTypeImpl: PublicAssociatedTypeProto {}
+// expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+extension InternalInferredAssociatedTypeImpl: UFIAssociatedTypeProto {}
+// expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note @-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension InternalInferredAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay
+
+internal struct PublicExplicitAssociatedTypeImpl {
+  internal typealias Assoc = NormalStruct
+  internal func takesAssoc(_: NormalStruct) {}
+}
+extension PublicExplicitAssociatedTypeImpl: PublicAssociatedTypeProto {}
+// expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension PublicExplicitAssociatedTypeImpl: UFIAssociatedTypeProto {}
+// expected-not-opt-in-warning @-1 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-opt-in-error @-2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+// expected-note@-3 {{in associated type 'Self.Assoc' (inferred as 'NormalStruct')}}
+
+extension PublicExplicitAssociatedTypeImpl: InternalAssociatedTypeProto {} // okay

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -212,9 +212,9 @@ public func legalAccessToIndirect(arg: StructFromIndirect = StructFromIndirect()
 public struct ExposedLayoutPublic {
   public var publicField: StructFromDirect // expected-error {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
 
-  private var privateField: StructFromDirect // FIXME should error
+  private var privateField: StructFromDirect // expected-warning {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 }
 
 private struct ExposedLayoutPrivate {
-  private var privateField: StructFromDirect // FIXME should error
+  private var privateField: StructFromDirect // expected-warning {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
 }

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -19,7 +19,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 
 @_implementationOnly import directs
-// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+// expected-warning @-1 {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 @_spi(S) @_spiOnly import indirects
 
 internal func localInternalFunc() {} // expected-note {{global function 'localInternalFunc()' is not '@usableFromInline' or public}}

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -41,12 +41,12 @@ module ClangModuleB {
 //--- empty.swift
 
 //--- client-non-resilient.swift
-@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
-@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+@_implementationOnly import SwiftModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import SwiftModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 import SwiftModuleB
 
-@_implementationOnly import ClangModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
-@_implementationOnly import ClangModuleA.Submodule // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+@_implementationOnly import ClangModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
+@_implementationOnly import ClangModuleA.Submodule // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 import ClangModuleB
 
 //--- client-resilient.swift
@@ -59,7 +59,7 @@ import SwiftModuleB
 import ClangModuleB
 
 //--- Crypto.swift
-@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Crypto' may lead to instability during execution}}
+@_implementationOnly import SwiftModuleA // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'Crypto'}}
 import SwiftModuleB
 @_implementationOnly import CCryptoBoringSSL
 import ClangModuleB

--- a/test/Sema/restricted-import-embedded-inlinable-conformances.swift
+++ b/test/Sema/restricted-import-embedded-inlinable-conformances.swift
@@ -24,7 +24,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 
 #if IOI
-@_implementationOnly import BADLibrary // expected-ioi-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+@_implementationOnly import BADLibrary // expected-ioi-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}
 #else
 internal import BADLibrary // expected-access-level-note 35 {{imported as 'internal' from 'BADLibrary' here}}
 #endif

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -74,4 +74,4 @@ import func français.phoûx
 import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}
 
 @_exported @_implementationOnly import empty // expected-error {{module 'empty' cannot be both exported and implementation-only}} {{12-33=}}
-// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+// expected-warning @-1 {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}

--- a/test/embedded/linkage/implementation_only_hiding.swift
+++ b/test/embedded/linkage/implementation_only_hiding.swift
@@ -35,8 +35,8 @@
 // REQUIRES: swift_feature_Embedded
 
 //--- Library.swift
-@_implementationOnly import CDependency // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Library' may lead to instability during execution}}
-@_implementationOnly import SwiftDependency // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Library' may lead to instability during execution}}
+@_implementationOnly import CDependency // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'Library'}}
+@_implementationOnly import SwiftDependency // expected-warning {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'Library'}}
 
 @export(interface)
 public func test() {


### PR DESCRIPTION
Always check references to `@_implementationOnly` imports even without library-evolution enabled but downgrade errors to warnings by default. Clients should enable them as errors by adopting `-enable-experimental-feature CheckImplementationOnly`.

Use the existing warning on the `@_implementationsOnly` imports from modules without library-evolution to invite existing users to adopt `CheckImplementationOnly`. Adopting that feature will also silence the warning on the import.

rdar://167805228

---

Note, I looked into using `-Werror` over `CheckImplementationOnly` but this use case doesn't apply very well since this is an existing diagnostic targeting many different exportability source to reference combinations that's already an error by default. If we really want to we could do so by accessing the `-Werror` flags directly, with the implied added complexity.