### PR TITLE
introduce UnderscoreOwned feature

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -610,7 +610,7 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
 
 SIMPLE_DECL_ATTR(_owned, Owned,
   OnVar | OnSubscript,
-  UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove | ForbiddenInABIAttr,
+  NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove | ForbiddenInABIAttr,
   111)
 
 CONTEXTUAL_DECL_ATTR(nonisolated, Nonisolated,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -608,7 +608,10 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
   ConcurrencyOnly | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UnreachableInABIAttr,
   110)
 
-// Unused '111'
+SIMPLE_DECL_ATTR(_owned, Owned,
+  OnVar | OnSubscript,
+  UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove | ForbiddenInABIAttr,
+  111)
 
 CONTEXTUAL_DECL_ATTR(nonisolated, Nonisolated,
   OnFunc | OnConstructor | OnDestructor | OnVar | OnSubscript | OnProtocol | OnExtension | OnClass | OnStruct | OnEnum,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6929,7 +6929,7 @@ ERROR(exclusivity_on_computed_property,none,
       ())
 
 //------------------------------------------------------------------------------
-// MARK: @_borrowed
+// MARK: @_borrowed and @_owned
 //------------------------------------------------------------------------------
 ERROR(borrowed_with_objc_dynamic,none,
       "%kindonly0 cannot be '@_borrowed' if it is '@objc dynamic'",
@@ -6941,6 +6941,12 @@ ERROR(borrowed_on_objc_protocol_requirement,none,
 ERROR(borrowed_with_effect,none,
       "%kindonly0 cannot be '@_borrowed' if it is 'async' or 'throws'",
       (const AccessorDecl *))
+ERROR(borrowed_and_owned,none,
+      "%kindonly0 cannot be '@_borrowed' and '@_owned' at the same time",
+      (const AbstractStorageDecl *))
+ERROR(owned_non_getter,none,
+      "%kindonly0 must define a 'get' to support '@_owned'",
+      (const AbstractStorageDecl *))
 
 //------------------------------------------------------------------------------
 // MARK: dynamic

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -574,6 +574,9 @@ EXPERIMENTAL_FEATURE(EnforceSPIOperatorGroup, true)
 /// Enable source-level warning control with `@warn`
 EXPERIMENTAL_FEATURE(SourceWarningControl, true)
 
+/// Allows a `get` returning a noncopyable type have owned semantics in opaque interfaces.
+EXPERIMENTAL_FEATURE(UnderscoreOwned, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5106,6 +5106,7 @@ public:
   TRIVIAL_ATTR_PRINTER(ObjCNonLazyRealization, objc_non_lazy_realization)
   TRIVIAL_ATTR_PRINTER(Optional, optional)
   TRIVIAL_ATTR_PRINTER(Override, override)
+  TRIVIAL_ATTR_PRINTER(Owned, owned)
   TRIVIAL_ATTR_PRINTER(Postfix, postfix)
   TRIVIAL_ATTR_PRINTER(PreInverseGenerics, pre_inverse_generics)
   TRIVIAL_ATTR_PRINTER(Preconcurrency, preconcurrency)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -131,6 +131,10 @@ UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 UNINTERESTING_FEATURE(EmbeddedExistentials)
 
+static bool usesFeatureUnderscoreOwned(Decl *D) {
+  return D->getAttrs().hasAttribute<OwnedAttr>();
+}
+
 // TODO: Return true for inlinable function bodies with module selectors in them
 UNINTERESTING_FEATURE(ModuleSelector)
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -291,6 +291,7 @@ extension ASTGenVisitor {
         .NSManaged,
         .ObjCMembers,
         .ObjCNonLazyRealization,
+        .Owned,
         .Preconcurrency,
         .PreInverseGenerics,
         .PropertyWrapper,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1615,6 +1615,7 @@ namespace  {
     UNINTERESTING_ATTR(Inline)
     UNINTERESTING_ATTR(Isolated)
     UNINTERESTING_ATTR(Optimize)
+    UNINTERESTING_ATTR(Owned)
     UNINTERESTING_ATTR(Exclusivity)
     UNINTERESTING_ATTR(Nonexhaustive)
     UNINTERESTING_ATTR(NoLocks)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1074,6 +1074,9 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
   if (storage->getAttrs().hasAttribute<BorrowedAttr>())
     return usesBorrowed(DiagKind::BorrowedAttr);
 
+  if (storage->getAttrs().hasAttribute<OwnedAttr>())
+    return OpaqueReadOwnership::Owned;
+
   if (storage->getInnermostDeclContext()->mapTypeIntoEnvironment(
         storage->getValueInterfaceType())->isNoncopyable())
     return usesBorrowed(DiagKind::NoncopyableType);

--- a/test/Interpreter/Inputs/moveonly_resilient_type.swift
+++ b/test/Interpreter/Inputs/moveonly_resilient_type.swift
@@ -60,3 +60,19 @@ public struct ResilientCapturesInDeinit: ~Copyable {
         return nextValue
     }
 }
+
+public struct HasDeinit: ~Copyable {
+  public consuming func consume() {}
+  deinit { print("HasDeinit.deinit") }
+}
+
+public protocol Giver {
+  @_owned var thing: HasDeinit { get }
+}
+
+public struct GiverImpl: Giver {
+  public init() {}
+  @_owned public var thing: HasDeinit {
+    get { return HasDeinit() }
+  }
+}

--- a/test/Interpreter/moveonly_resilient_owned_get.swift
+++ b/test/Interpreter/moveonly_resilient_owned_get.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import moveonly_resilient_type
+
+func concrete(_ g: GiverImpl) {
+  g.thing.consume()
+}
+
+
+public func generic(_ g: some Giver) {
+  g.thing.consume()
+}
+
+func main() {
+  let g = GiverImpl()
+  print("starting") // CHECK: starting
+
+  concrete(g) // CHECK: HasDeinit.deinit
+  concrete(g) // CHECK: HasDeinit.deinit
+  generic(g) // CHECK: HasDeinit.deinit
+  generic(g) // CHECK: HasDeinit.deinit
+
+  print("finished")  // CHECK: finished
+}
+main()

--- a/test/SILGen/Inputs/owned_attr.swift
+++ b/test/SILGen/Inputs/owned_attr.swift
@@ -1,0 +1,16 @@
+public struct Source: ~Copyable, Giver {
+  public init() {}
+
+  @_owned
+  public var mutableSpan: MutableSpan<Int> {
+    @_lifetime(&self)
+    mutating get {
+      MutableSpan()
+    }
+  }
+}
+
+public protocol Giver: ~Copyable {
+  @_owned
+  var mutableSpan: MutableSpan<Int> { mutating get }
+}

--- a/test/SILGen/owned_attr.swift
+++ b/test/SILGen/owned_attr.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/OwnedAttrLib.swiftmodule -emit-module-interface-path %t/OwnedAttrLib.swiftinterface -module-name=OwnedAttrLib %S/Inputs/owned_attr.swift \
+// RUN:     -enable-experimental-feature Lifetimes
+
+// RUN: %target-swift-emit-silgen -module-name X %s -I %t -enable-experimental-feature Lifetimes | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name X %s -I %t -enable-experimental-feature Lifetimes -verify
+
+// RUN: %FileCheck --check-prefix CHECK-INTERFACE %s < %t/OwnedAttrLib.swiftinterface
+
+// REQUIRES: swift_feature_Lifetimes
+
+import OwnedAttrLib
+
+// CHECK-INTERFACE: public struct Source
+// CHECK-INTERFACE: #if compiler(>=5.3) {{.*}}&& $UnderscoreOwned
+// CHECK-INTERFACE: @_owned public var mutableSpan
+
+// CHECK-INTERFACE: public protocol Giver
+// CHECK-INTERFACE: #if compiler(>=5.3) {{.*}}&& $UnderscoreOwned
+// CHECK-INTERFACE: @_owned var mutableSpan{{.*}} { mutating get }
+
+// Verify that when accessing a property of noncopyable type within a resilient struct, where that property
+// has an @_owned getter, we get an owned value.
+
+// CHECK-LABEL: sil hidden [ossa] @$s1X4testyyF : $@convention(thin) () -> ()
+func test() {
+  var source = Source()
+  
+  // CHECK: [[MUTSPAN_BOX:%.*]] = alloc_box {{.*}} var, name "mutSpan"
+  // CHECK: [[MUTSPAN_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[MUTSPAN_BOX]]
+  // CHECK: [[MUTSPAN_ADDR:%.*]] = project_box [[MUTSPAN_BORROW]], 0
+  // CHECK: [[MUTABLE_SPAN_GETTER:%.*]] = function_ref @$s12OwnedAttrLib6SourceV11mutableSpans07MutableF0VySiGvg : $@convention(method) (@inout Source) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  // CHECK: [[MUTSPAN:%.*]] = apply [[MUTABLE_SPAN_GETTER]]
+  // CHECK: store [[MUTSPAN]] to [init] [[MUTSPAN_ADDR]]
+  var mutSpan = source.mutableSpan
+  mutSpan[0] = 1
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s1X5test2yyx12OwnedAttrLib5GiverRzlF
+func test2(_ s: some Giver) {
+  var source = s
+  // CHECK: witness_method $τ_0_0, #Giver.mutableSpan!getter : <Self where Self : OwnedAttrLib.Giver, Self : ~Copyable> (inout Self) -> @lifetime(borrow 0) () -> MutableSpan<Int> : $@convention(witness_method: Giver) <τ_0_0 where τ_0_0 : Giver, τ_0_0 : ~Copyable> (@inout τ_0_0) -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  // CHECK: apply {{.*}} : $@convention(witness_method: Giver) {{.*}} -> @lifetime(borrow address_for_deps 0) @owned MutableSpan<Int>
+  // CHECK-NOT: witness_method
+  var mutSpan = source.mutableSpan
+  mutSpan[0] = 1
+}

--- a/test/attr/attr_borrowed.swift
+++ b/test/attr/attr_borrowed.swift
@@ -38,3 +38,8 @@ public class Holder {
     }
   }
 }
+
+#if hasAttribute(_owned)
+#else
+#error("hasAttribute should be true!")
+#endif

--- a/test/attr/attr_borrowed.swift
+++ b/test/attr/attr_borrowed.swift
@@ -27,4 +27,14 @@ public class Holder {
   @_borrowed var two: String {
     get throws { "" } // expected-error {{getter cannot be '@_borrowed' if it is 'async' or 'throws'}}
   }
+
+  @_borrowed @_owned var three: String { // expected-error {{property cannot be '@_borrowed' and '@_owned' at the same time}}
+    get { "" }
+  }
+  @_owned var four: String { // expected-error {{property must define a 'get' to support '@_owned'}}
+    _read {
+      let x = ""
+      yield x
+    }
+  }
 }


### PR DESCRIPTION
This experimental feature allows you to override the default behavior of a 'get' returning a noncopyable type, so that it returns an owned value rather than a borrow, when that getter is exposed in opaque interfaces like protocol requirements or resilient types.

resolves rdar://157318147
