### PR TITLE
[6.3] LoopInvariantCodeMotion: don't hoist `load [take]`

### DIFF
--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -2207,3 +2207,27 @@ bb3:
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @dont_hoist_load_take :
+// CHECK:       bb1:
+// CHECK-NEXT:    load [take]
+// CHECK-LABEL: } // end sil function 'dont_hoist_load_take'
+sil [ossa] @dont_hoist_load_take : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = alloc_stack [dynamic_lifetime] $String
+  store %0 to [init] %1
+  br bb1
+
+bb1:
+  %4 = load [take] %1
+  destroy_value %4
+  cond_br undef, bb3, bb2
+
+bb2:
+  br bb1
+
+bb3:
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9
+}
+


### PR DESCRIPTION
* **Explanation**:  Fixes a SIL verifier crash. Usually a `load [take]` instruction is not hoisted out of a loop anyway, because there must be another instruction in the loop which re-initializes the loaded memory location. However, this is not necessarily true for `alloc_stack` locations with dynamic lifetime, e.g. a pack-loop which is specialized for a single pack element (at runtime the loop is only executed once).
* **Risk**: Low. It's a simple change which makes the optimization more conservative 
* **Testing**: Tested by a lit test.
* **Issue**: rdar://167504916
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86283
