### PR TITLE
SimplifyDestroyValue: don't re-create a `destroy_value [dead_end]` as a non-dead-end `destroy_value`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
@@ -51,6 +51,11 @@ extension DestroyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
       return
     }
 
+    if isDeadEnd {
+      // Dead-end destroys are no-ops, anyway. Don't try to move them away from an `unreachable` instruction.
+      return
+    }
+
     let destroyedInst: Instruction
     switch destroyedValue {
     case is StructInst,

--- a/test/SILOptimizer/simplify_destroy_value.sil
+++ b/test/SILOptimizer/simplify_destroy_value.sil
@@ -421,6 +421,25 @@ bb3(%4 : @owned $C):
   return %10
 }
 
+// CHECK-LABEL: sil [ossa] @dont_hoist_dead_end :
+// CHECK:       bb3([[PHI:%.*]] : @owned $C):
+// CHECK-NEXT:    destroy_value [dead_end] [[PHI]]
+// CHECK:       } // end sil function 'dont_hoist_dead_end'
+sil [ossa] @dont_hoist_dead_end : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0)
+
+bb2:
+  br bb3(%0)
+
+bb3(%4 : @owned $C):
+  destroy_value [dead_end] %4
+  unreachable
+}
+
 // CHECK-LABEL: sil [ossa] @dont_hoist_destroy_in_different_block :
 // CHECK-NOT:     destroy_value
 // CHECK:       bb4:


### PR DESCRIPTION
This can cause several problems, e.g. false performance errors or even mis-compiles. Instead, just ignore dead-end destroys as we don't want to "move" them away from `unreachable` instructions, anyway.

rdar://167553623
