### PR TITLE
[6.2] [Test] Mark issue-78598.swift as executable test

### DIFF
--- a/test/Interpreter/issue-78598.swift
+++ b/test/Interpreter/issue-78598.swift
@@ -2,6 +2,11 @@
 
 // https://github.com/swiftlang/swift/issues/78598
 
+// REQUIRES: executable_test
+
+// This test needs a Swift 5.9 runtime or newer.
+// UNSUPPORTED: back_deployment_runtime
+
 var counter = 0
 
 final class Entry<Results> {


### PR DESCRIPTION
Explanation:  Fix failing testcase issue-78598.swift on 6.2
Scope: Marks issue-78598.swift as an executable test, and unsupported on back_deployment_runtime
Issues: rdar://167640515
Original PRs: https://github.com/swiftlang/swift/pull/85443  
Risk: Low. Only impacts test case

