### PR TITLE
[6.3] PrintAsClang: Remove `typedef` from `@objc` enum forward declarations 

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -211,9 +211,9 @@ CLANG_MACRO_BODY("SWIFT_ENUM_FWD_DECL", \
     "# if (defined(__cplusplus) && __cplusplus >= 201103L) || " \
     "     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || " \
     "     __has_feature(objc_fixed_enum)\n" \
-    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) enum _name : _type _name;\n" \
+    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) enum _name : _type;\n" \
     "# else\n" \
-    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) _type _name;\n" \
+    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) typedef _type _name;\n" \
     "# endif")
 
 CLANG_MACRO("SWIFT_UNAVAILABLE", , "__attribute__((unavailable))")

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -543,7 +543,7 @@ public:
     
     forwardDeclare(ED, [&]{
       // Forward declare in a way to be compatible with older C standards.
-      os << "typedef SWIFT_ENUM_FWD_DECL(";
+      os << "SWIFT_ENUM_FWD_DECL(";
       printer.print(ED->getRawType());
       os << ", " << getNameForObjC(ED) << ")\n";
     });

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -585,7 +585,7 @@ static void writePostImportPrologue(raw_ostream &os, ModuleDecl &M) {
         "#endif\n\n";
 }
 
-static void writeObjCEpilogue(raw_ostream &os) {
+static void writeBlockEpilogue(raw_ostream &os) {
   // Pop out of `external_source_symbol` attribute
   // before emitting the C++ section as the C++ section
   // might include other files in it.
@@ -627,7 +627,9 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
                  clangHeaderSearchInfo, exposedModuleHeaderNames,
                  /*useCxxImport=*/false, /*useNonModularIncludes*/true);
 
+    writePostImportPrologue(os, *M);
     emitExternC(os, [&] { os << "\n" << cModuleContents.str(); });
+    writeBlockEpilogue(os);
     moduleContentsScratch.clear();
   }
 
@@ -643,7 +645,7 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
   });
   writePostImportPrologue(os, *M);
   emitObjCConditional(os, [&] { os << "\n" << objcModuleContents.str(); });
-  writeObjCEpilogue(os);
+  writeBlockEpilogue(os);
 
   // C++ content
   emitCxxConditional(os, [&] {

--- a/test/PrintAsObjC/cdecl-enum-reference.swift
+++ b/test/PrintAsObjC/cdecl-enum-reference.swift
@@ -29,7 +29,7 @@ import CoreLib
 
 @c(CFunc)
 public func CFunc(e: CEnum) {}
-// CHECK: typedef SWIFT_ENUM_FWD_DECL(int, CEnum)
+// CHECK: SWIFT_ENUM_FWD_DECL(int, CEnum)
 // CHECK: SWIFT_EXTERN void CFunc(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT;
 
 //--- Client.c

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -12,6 +12,7 @@
 // RUN: %FileCheck -check-prefix=NEGATIVE %s -input-file %t/enums.WMO.h
 // RUN: %check-in-clang %t/enums.WMO.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.WMO.h -include ctypes.h -include CoreFoundation.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.WMO.h -include ctypes.h -include CoreFoundation.h -std=c99
 
 // Ensure that providing the output header path via the supplementary output
 // file map also works.
@@ -26,12 +27,12 @@ import Foundation
 
 // NEGATIVE-NOT: NSMalformedEnumMissingTypedef :
 // NEGATIVE-NOT: enum EnumNamed
-// CHECK-LABEL: typedef SWIFT_ENUM_FWD_DECL(NSInteger, FooComments)
-// CHECK-LABEL: typedef SWIFT_ENUM_FWD_DECL(int16_t, NegativeValues)
-// CHECK-LABEL: typedef SWIFT_ENUM_FWD_DECL(NSInteger, ObjcEnumNamed)
+// CHECK-LABEL: SWIFT_ENUM_FWD_DECL(NSInteger, FooComments)
+// CHECK-LABEL: SWIFT_ENUM_FWD_DECL(int16_t, NegativeValues)
+// CHECK-LABEL: SWIFT_ENUM_FWD_DECL(NSInteger, ObjcEnumNamed)
 
-// CHECK-SUPPLEMENTAL: typedef SWIFT_ENUM_FWD_DECL(int16_t, NegativeValues)
-// CHECK-SUPPLEMENTAL: typedef SWIFT_ENUM_FWD_DECL(NSInteger, ObjcEnumNamed)
+// CHECK-SUPPLEMENTAL: SWIFT_ENUM_FWD_DECL(int16_t, NegativeValues)
+// CHECK-SUPPLEMENTAL: SWIFT_ENUM_FWD_DECL(NSInteger, ObjcEnumNamed)
 
 // CHECK-LABEL: @interface AnEnumMethod
 // CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo SWIFT_WARN_UNUSED_RESULT;


### PR DESCRIPTION
The compiler emitted an extra `typedef` on enum forward declarations that could cause warnings in the generated compatibility header in Objective-C + C-pre-11 mode: `warning: redefinition of typedef 'MyEnum' is a C11 feature`. Limit emitting that `typedef` only for C dialects without support for an enum raw type should avoid this issue and properly support `@c` decls and other language modes.

- Scope: Compatibility headers with enums.
- Risk: Low, reverts to the 6.2 behavior.
- Testing: Extended existing lit test to cover older C dialect.
- Cherry-pick of #86333
- Reviewed by @Xazax-hun 
- Resolves rdar://164505307