### PR TITLE
runtime: silence a warning on clang

### DIFF
--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -86,7 +86,12 @@ private:
   uint32_t numAllocatedSlabs:31;
 
   /// The configuration object.
-  [[no_unique_address]] SlabAllocatorConfiguration configuration;
+#if defined(_MSC_VER)
+  [[msvc::no_unique_address]]
+#elif defined(__clang__)
+  [[clang::no_unique_address]]
+#endif
+  SlabAllocatorConfiguration configuration;
 
   /// The minimal alignment of allocated memory.
   static constexpr size_t alignment = MaximumAlignment;


### PR DESCRIPTION
`[[no_unique_address]]` is a C++20 feature and we currently use C++17. Guard this with `__clang__` and use the clang namespaced attribute which is available. Additionally, since this feature is supported by MSVC as well as an extension in earlier versions, use the MSVC scoped attribute on MSVC.