### PR TITLE
[cxx-interop] Synthesize subscript without requiring ClangNode

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1899,10 +1899,19 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
   DeclName name(ctx, DeclBaseName::createSubscript(), bodyParams);
   auto dc = getterImpl->getDeclContext();
 
-  SubscriptDecl *subscript = SubscriptDecl::createImported(
-      ctx, name, getterImpl->getLoc(), bodyParams, getterImpl->getLoc(),
-      elementTy, dc, getterImpl->getGenericParams(),
-      getterImpl->getClangNode());
+  SubscriptDecl *subscript;
+  if (auto ClangN = getterImpl->getClangNode()) {
+    subscript = SubscriptDecl::createImported(
+        ctx, name, getterImpl->getLoc(), bodyParams, getterImpl->getLoc(),
+        elementTy, dc, getterImpl->getGenericParams(), ClangN);
+  } else {
+    // getterImpl may lack an associated ClangNode if it is synthesized,
+    // e.g., if it is a cloned from a base class member due to inheritance.
+    subscript = SubscriptDecl::create(
+        ctx, name, SourceLoc(), StaticSpellingKind::None, getterImpl->getLoc(),
+        bodyParams, getterImpl->getLoc(), elementTy, dc,
+        getterImpl->getGenericParams());
+  }
   subscript->copyFormalAccessFrom(getterImpl);
 
   bool useAddress = rawElementTy->getAnyPointerElementType() &&

--- a/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
@@ -68,7 +68,7 @@ struct OperatorBase {
   operator bool() const { return true; }
   int operator*() const { return 456; }
   OperatorBase operator!() const { return *this; }
-  // int operator[](const int x) const { return x; } // FIXME: see below
+  int operator[](const int x) const { return x; }
 };
 
 struct OperatorBasePrivateInheritance : private OperatorBase {
@@ -76,7 +76,7 @@ public:
   using OperatorBase::operator bool;
   using OperatorBase::operator*;
   using OperatorBase::operator!;
-  // using OperatorBase::operator[];  // FIXME: using operator[] is broken
+  using OperatorBase::operator[];
 };
 
 #endif // !_USING_BASE_MEMBERS_H

--- a/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
@@ -60,7 +60,7 @@ UsingBaseTestSuite.test("OperatorBasePrivateInheritance") {
   // expectTrue(Bool(fromCxx: p))
   // expectTrue(Bool(fromCxx: !p))
   expectEqual(456, p.pointee)
-  // expectEqual(789, p[789])   // FIXME: operator[] is currently broken
+  expectEqual(789, p[789])
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -70,6 +70,7 @@
 
 // CHECK:      public struct OperatorBasePrivateInheritance : CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   public subscript(x: Int32) -> Int32 { get }
 // CHECK-NEXT:   public var pointee: Int32 { get }
 // CHECK-NEXT:   public func __convertToBool() -> Bool
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
@@ -77,4 +78,6 @@
 // CHECK-NEXT:   prefix public static func ! (lhs: OperatorBasePrivateInheritance) -> OperatorBase
 // CHECK-NEXT:   @available(*, unavailable, message: "use ! instead")
 // CHECK-NEXT:   public func __operatorExclaim() -> OperatorBase
+// CHECK-NEXT:   @available(*, unavailable, message: "use subscript")
+// CHECK-NEXT:   public func __operatorSubscriptConst(_ x: Int32) -> Int32
 // CHECK-NEXT: }


### PR DESCRIPTION
This scenario happens when a derived class inherits operator[] from a base class. The derived class's operator[] is a synthesized shim, which (currently) does not have a ClangNode associated with it.

This prevents an assertion failure in SubscriptDecl::createImported().

rdar://167701851

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
