### PR TITLE
[Caching][DependencyScan] Fix main module header chaining

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1843,8 +1843,9 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   auto FS = ScanASTContext.SourceMgr.getFileSystem();
 
   auto chainBridgingHeader = [&](StringRef moduleName, StringRef headerPath,
-                                 StringRef binaryModulePath) -> llvm::Error {
-    if (useImportHeader) {
+                                 StringRef binaryModulePath,
+                                 bool useHeader) -> llvm::Error {
+    if (useHeader) {
       if (auto buffer = FS->getBufferForFile(headerPath)) {
         outOS << "#include \"" << headerPath << "\"\n";
         return llvm::Error::success();
@@ -1885,9 +1886,9 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
       if (binaryMod->headerImport.empty())
         continue;
 
-      if (auto E =
-              chainBridgingHeader(moduleID.ModuleName, binaryMod->headerImport,
-                                  binaryMod->compiledModulePath))
+      if (auto E = chainBridgingHeader(
+              moduleID.ModuleName, binaryMod->headerImport,
+              binaryMod->compiledModulePath, useImportHeader))
         return E;
     }
   }
@@ -1917,7 +1918,8 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
     if (mainModule->textualModuleDetails.bridgingHeaderFile) {
       if (auto E = chainBridgingHeader(
               rootModuleID.ModuleName,
-              *mainModule->textualModuleDetails.bridgingHeaderFile, ""))
+              *mainModule->textualModuleDetails.bridgingHeaderFile, "",
+              /*useHeader=*/true))
         return E;
     }
 

--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -43,14 +43,14 @@
 // RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd /^tmp/test.swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 
-// RUN: %target-swift-frontend-plain -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
 // RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
 // RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
 // RUN:   -scanner-output-dir %t/header-1 -I %t
 
-// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies\
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies \
 // RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
@@ -72,6 +72,18 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-4.json bridgingHeader:Test includeTree > %t/includeTree-4.casid
 // RUN: diff %t/includeTree-3.casid %t/includeTree-4.casid
 
+/// Scan prefix mapped main bridging header.
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-5.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
+// RUN:   -scanner-output-dir %t/header-1 -I %t -import-objc-header %t/header-3/User.h 2>&1 | %FileCheck %s --check-prefix=SUCCESS --allow-empty
+
+// SUCCESS-NOT: failed to load bridging header
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps-5.json
+// DEPS: "bridgingHeader"
 
 
 //--- test.swift
@@ -90,3 +102,5 @@ void b(void);
 #include "Foo.h"
 //--- header-2/Foo.h
 void b(void);
+//--- header-3/User.h
+void user(void);


### PR DESCRIPTION
Fix a programming mistake when chaining bridging header for the main module. Main module never has the binary module, thus it always need to chain the bridging header content directly without falling back to embedded binary module. Previously, the scanner was wrongly error out because it failed to locate the binary module for main module.

rdar://167707148

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
