### PR TITLE
[6.3][Caching][DependencyScan] Fix main module header chaining

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1728,8 +1728,9 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   auto FS = ScanASTContext.SourceMgr.getFileSystem();
 
   auto chainBridgingHeader = [&](StringRef moduleName, StringRef headerPath,
-                                 StringRef binaryModulePath) -> llvm::Error {
-    if (useImportHeader) {
+                                 StringRef binaryModulePath,
+                                 bool useHeader) -> llvm::Error {
+    if (useHeader) {
       if (auto buffer = FS->getBufferForFile(headerPath)) {
         outOS << "#include \"" << headerPath << "\"\n";
         return llvm::Error::success();
@@ -1770,9 +1771,9 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
       if (binaryMod->headerImport.empty())
         continue;
 
-      if (auto E =
-              chainBridgingHeader(moduleID.ModuleName, binaryMod->headerImport,
-                                  binaryMod->compiledModulePath))
+      if (auto E = chainBridgingHeader(
+              moduleID.ModuleName, binaryMod->headerImport,
+              binaryMod->compiledModulePath, useImportHeader))
         return E;
     }
   }
@@ -1802,7 +1803,8 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
     if (mainModule->textualModuleDetails.bridgingHeaderFile) {
       if (auto E = chainBridgingHeader(
               rootModuleID.ModuleName,
-              *mainModule->textualModuleDetails.bridgingHeaderFile, ""))
+              *mainModule->textualModuleDetails.bridgingHeaderFile, "",
+              /*useHeader=*/true))
         return E;
     }
 

--- a/test/CAS/bridging-header-prefix-map.swift
+++ b/test/CAS/bridging-header-prefix-map.swift
@@ -57,7 +57,7 @@
 // RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
 // RUN:   -scanner-output-dir %t/header-1 -I %t
 
-// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies\
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies \
 // RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -o %t/deps-3.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
@@ -79,6 +79,18 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps-4.json bridgingHeader:Test includeTree > %t/includeTree-4.casid
 // RUN: diff %t/includeTree-3.casid %t/includeTree-4.casid
 
+/// Scan prefix mapped main bridging header.
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-5.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-prefix-map-paths %t/header-1 /^header \
+// RUN:   -scanner-output-dir %t/header-1 -I %t -import-objc-header %t/header-3/User.h 2>&1 | %FileCheck %s --check-prefix=SUCCESS --allow-empty
+
+// SUCCESS-NOT: error:
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps-5.json
+// DEPS: "bridgingHeader"
 
 
 //--- test.swift
@@ -97,3 +109,5 @@ void b(void);
 #include "Foo.h"
 //--- header-2/Foo.h
 void b(void);
+//--- header-3/User.h
+void user(void);


### PR DESCRIPTION
- **Explanation**: Fix a programming mistake when chaining bridging header for the main module. Main module never has the binary module, thus it always need to chain the bridging header content directly without falling back to embedded binary module. Previously, the scanner was wrongly error out because it failed to locate the binary module for main module.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Affect builds using caching build + scanner prefix mapping + bridging header
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://167707148
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/86363
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Limited scope and the change is small and clear.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit test.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
