### PR TITLE
[cxx-interop] Support inherited protected destructors and copy/move constructors

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8456,6 +8456,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
         // ~Copyable, the type should also be ~Copyable.
         for (auto field : cxxRecordDecl->fields())
           maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
+        for (auto base : cxxRecordDecl->bases())
+          maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
       }
     }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -91,6 +91,7 @@
 #include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -5370,7 +5371,7 @@ template <typename Kind>
 static bool checkConditionalParams(
     const clang::RecordDecl *recordDecl, ClangImporter::Implementation *impl,
     llvm::ArrayRef<int> STLParams, std::set<StringRef> &conditionalParams,
-    llvm::function_ref<void(const clang::Type *)> maybePushToStack) {
+    llvm::function_ref<void(const clang::Type *, bool)> maybePushToStack) {
   bool foundErrors = false;
   auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
   SmallVector<std::pair<unsigned, StringRef>, 4> argumentsToCheck;
@@ -5407,7 +5408,10 @@ static bool checkConditionalParams(
           foundErrors = true;
         } else {
           maybePushToStack(
-              nonPackArg.getAsType()->getUnqualifiedDesugaredType());
+              nonPackArg.getAsType()->getUnqualifiedDesugaredType(),
+              /*isBase=*/false); // None of the STL template parameters (for the
+                                 // classes enumerated in STLConditionalParams)
+                                 // are used as base classes.
         }
       }
     }
@@ -5489,7 +5493,7 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
   // Keep track of Types we've seen to avoid cycles
   llvm::SmallDenseSet<const clang::Type *, 4> seen;
 
-  auto maybePushToStack = [&](const clang::Type *type) {
+  auto maybePushToStack = [&](const clang::Type *type, bool unused=false) {
     auto desugared = type->getUnqualifiedDesugaredType();
     if (seen.insert(desugared).second)
       stack.push_back(desugared);
@@ -8242,37 +8246,51 @@ bool importer::isViewType(const clang::CXXRecordDecl *decl) {
 const clang::CXXConstructorDecl *
 importer::findCopyConstructor(const clang::CXXRecordDecl *decl) {
   for (auto ctor : decl->ctors()) {
-    if (ctor->isCopyConstructor() &&
-        // FIXME: Support default arguments (https://github.com/swiftlang/swift/issues/86260)
-        ctor->getNumParams() == 1 && ctor->getAccess() == clang::AS_public &&
-        !ctor->isDeleted() && !ctor->isIneligibleOrNotSelected())
+    if (ctor->isCopyConstructor() && !ctor->isDeleted() &&
+        !ctor->isIneligibleOrNotSelected() &&
+        // FIXME: Support default arguments
+        // (https://github.com/swiftlang/swift/issues/86260)
+        ctor->getNumParams() == 1)
       return ctor;
   }
   return nullptr;
 }
 
-static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {
+static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl,
+                                  bool inherited) {
   if (decl->hasSimpleMoveConstructor())
     return true;
 
-  return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
+  return llvm::any_of(decl->ctors(), [&](clang::CXXConstructorDecl *ctor) {
+    // protected constructors are reachable from derived classes, so we only
+    // consider it inaccessible if this move constructor isn't inherited.
+    auto ctorAccessible =
+        ctor->getAccess() == clang::AS_public ||
+        (inherited && ctor->getAccess() == clang::AS_protected);
+
     return ctor->isMoveConstructor() && !ctor->isDeleted() &&
            !ctor->isIneligibleOrNotSelected() &&
-           // FIXME: Support default arguments (https://github.com/swiftlang/swift/issues/86260)
-           ctor->getNumParams() == 1 &&
-           ctor->getAccess() == clang::AS_public;
+           // FIXME: Support default arguments
+           // (https://github.com/swiftlang/swift/issues/86260)
+           ctor->getNumParams() == 1 && ctorAccessible;
   });
 }
 
-static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl) {
+static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl,
+                                     bool inherited) {
   if (decl->hasSimpleDestructor())
     return true;
 
-  if (auto dtor = decl->getDestructor()) {
+  if (auto *dtor = decl->getDestructor()) {
     if (dtor->isDeleted() || dtor->isIneligibleOrNotSelected() ||
-        dtor->getAccess() != clang::AS_public) {
+        dtor->getAccess() == clang::AS_private)
       return false;
-    }
+
+    // protected destructors are reachable from derived classes, so we only
+    // consider it inaccessible if this destructor isn't inherited.
+    if (!inherited && dtor->getAccess() == clang::AS_protected)
+      return false;
+
     return true;
   }
   return false;
@@ -8383,18 +8401,20 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   const auto *type = desc.type->getUnqualifiedDesugaredType();
   auto *importerImpl = desc.importerImpl;
 
-  bool hasUnknown = false;
-  llvm::SmallVector<const clang::RecordDecl *, 4> stack;
-  // Keep track of Decls we've seen to avoid cycles
-  llvm::SmallDenseSet<const clang::RecordDecl *, 4> seen;
+  using DeclToCheck = llvm::PointerIntPair<const clang::RecordDecl *, 1, bool>;
 
-  auto maybePushToStack = [&](const clang::Type *type) {
+  // DFS to visit bases (bool is true) and fields (bool is false)
+  llvm::SmallVector<DeclToCheck, 4> stack;
+  // Keep track of Decls we've seen to avoid cycles
+  llvm::SmallDenseSet<DeclToCheck, 4> seen;
+
+  auto maybePushToStack = [&](const clang::Type *type, bool isBase) {
     auto recordType = type->getAs<clang::RecordType>();
     if (!recordType)
       return;
 
     auto recordDecl = recordType->getDecl();
-    if (seen.insert(recordDecl).second) {
+    if (seen.insert({recordDecl, isBase}).second) {
       // When a reference type is copied, the pointer’s value is copied rather
       // than the object’s storage. This means reference types can be imported
       // as copyable to Swift, even when they are non-copyable in C++.
@@ -8408,13 +8428,16 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
             recordDecl->getName() == "_Optional_construct_base")
           return;
       }
-      stack.push_back(recordDecl);
+      stack.push_back({recordDecl, isBase});
     }
   };
 
-  maybePushToStack(type);
+  maybePushToStack(type, false);
+
+  bool hasUnknown = false;
+
   while (!stack.empty()) {
-    const clang::RecordDecl *recordDecl = stack.back();
+    auto [recordDecl, isBase] = stack.back();
     stack.pop_back();
     bool isExplicitlyNonCopyable = hasNonCopyableAttr(recordDecl);
     if (!isExplicitlyNonCopyable) {
@@ -8441,31 +8464,46 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       continue;
     }
 
-    bool isCopyable = !isExplicitlyNonCopyable;
-    if (!isExplicitlyNonCopyable) {
-      auto copyCtor = findCopyConstructor(cxxRecordDecl);
-      isCopyable = copyCtor || 
-                   cxxRecordDecl->hasSimpleCopyConstructor() ||
-                   cxxRecordDecl->needsImplicitCopyConstructor();
-      if ((copyCtor && copyCtor->isDefaulted()) ||
-          cxxRecordDecl->hasSimpleCopyConstructor() ||
-          cxxRecordDecl->needsImplicitCopyConstructor()) {
+    bool isCopyable;
+    if (isExplicitlyNonCopyable) {
+      isCopyable = false;
+    } else {
+      bool hasDefaultedOrImplicitCopyCtor; // i.e., requires member-wise copy
+
+      if (auto *copyCtor = findCopyConstructor(cxxRecordDecl)) {
+        // Found a copy constructor, but only consider it viable if it can be
+        // accessed publicly. If cxxRecordDecl is a base class, it suffices to
+        // be protected, and does not need to be public.
+        isCopyable =
+            copyCtor->getAccess() == clang::AS_public ||
+            (isBase && copyCtor->getAccess() == clang::AS_protected);
+
+        hasDefaultedOrImplicitCopyCtor = isCopyable && copyCtor->isDefaulted();
+      } else {
+        // Even if the copy constructor cannot be found, it might be implicit
+        isCopyable = hasDefaultedOrImplicitCopyCtor =
+            cxxRecordDecl->needsImplicitCopyConstructor() ||
+            cxxRecordDecl->hasSimpleCopyConstructor();
+      }
+
+      if (hasDefaultedOrImplicitCopyCtor) {
         // If the copy constructor is implicit/defaulted, we ask Clang to
         // generate its definition. The implicitly-defined copy constructor
         // performs full member-wise copy. Thus, if any member of this type is
         // ~Copyable, the type should also be ~Copyable.
         for (auto field : cxxRecordDecl->fields())
-          maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
+          maybePushToStack(field->getType()->getUnqualifiedDesugaredType(),
+                           /*isBase=*/false);
         for (auto base : cxxRecordDecl->bases())
-          maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
+          maybePushToStack(base.getType()->getUnqualifiedDesugaredType(),
+                           /*isBase=*/true);
       }
     }
 
-    bool isMovable = hasMoveTypeOperations(cxxRecordDecl);
+    bool isMovable = hasMoveTypeOperations(cxxRecordDecl, isBase);
+    bool isDestructible = hasDestroyTypeOperations(cxxRecordDecl, isBase);
 
-    if (!hasDestroyTypeOperations(cxxRecordDecl) ||
-        (!isCopyable && !isMovable)) {
-
+    if (!isDestructible || (!isCopyable && !isMovable)) {
       if (hasConstructorWithUnsupportedDefaultArgs(cxxRecordDecl) &&
           importerImpl)
         importerImpl->addImportDiagnostic(

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -39,6 +39,7 @@
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/Mangle.h"
 #include "clang/AST/RecordLayout.h"
+#include "clang/Basic/Specifiers.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 #include "clang/Sema/Sema.h"
@@ -553,7 +554,10 @@ namespace {
       const auto *cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(ClangDecl);
       if (!cxxRecordDecl)
         return nullptr;
-      return importer::findCopyConstructor(cxxRecordDecl);
+      if (auto *cctor = importer::findCopyConstructor(cxxRecordDecl);
+          cctor && cctor->getAccess() == clang::AS_public)
+        return cctor;
+      return nullptr;
     }
 
     const clang::CXXConstructorDecl *findMoveConstructor() const {

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -53,3 +53,8 @@ module CircularInheritance {
   header "circular-inheritance.h"
   requires cplusplus
 }
+
+module ProtectedSpecialMember {
+  header "protected-special-member.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/Inputs/protected-special-member.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/protected-special-member.h
@@ -1,0 +1,128 @@
+#pragma once
+#include <iostream>
+#include <vector>
+
+// NOTE: expected notes are suppressed due to -suppress-notes.
+
+// suppressed-note@+1 {{record 'ProtectedDtor' is not automatically available}}
+struct ProtectedDtor {
+  int fromBase = 111;
+protected:
+  ~ProtectedDtor() { std::cout << "~ProtectedDtor(fromBase = " << fromBase << ")\n"; }
+};
+
+struct InheritsProtectedDtor : ProtectedDtor {
+  int inDerived = 222;
+};
+
+struct PrivatelyInheritsProtectedDtor : private ProtectedDtor {
+  int inDerived = 222;
+  void setFromBase(int v) { fromBase = v; }
+};
+
+// suppressed-note@+1 {{record 'ProtectedDtorField' is not automatically available}}
+struct ProtectedDtorField {
+  int inDerived = 222;
+  ProtectedDtor pd{};
+};
+
+// suppressed-note@+1 {{record 'ProtectedDtorBaseAndField' is not automatically available}}
+struct ProtectedDtorBaseAndField : ProtectedDtor {
+  int inDerived = 222;
+  ProtectedDtor pd{};
+};
+
+// Note that ProtectedCopy is not imported because it does not define a move
+// constructor, which means it is neither copyable nor move-only.
+// suppressed-note@+1 {{record 'ProtectedCopy' is not automatically available}}
+struct ProtectedCopy {
+  int fromBase = 111;
+  ProtectedCopy() = default;
+protected:
+  // NOTE: the copy has an incremented fromBase, so we can check at runtime that
+  // the correct custom copy operation took place
+  ProtectedCopy(const ProtectedCopy &c) : fromBase{c.fromBase + 1} {}
+};
+
+struct InheritsProtectedCopy : ProtectedCopy {
+  int getFromBase(void) const { return fromBase; }
+  void setFromBase(int x) { fromBase = x; }
+};
+
+struct PrivatelyInheritsProtectedCopy : private ProtectedCopy {
+  int getFromBase(void) const { return fromBase; }
+  void setFromBase(int x) { fromBase = x; }
+};
+
+struct PrivatelyInheritsPrivatelyInheritsProtectedCopy : private PrivatelyInheritsProtectedCopy {};
+
+// suppressed-note@+1 {{record 'ProtectedCopyField' is not automatically available}}
+struct ProtectedCopyField {
+  ProtectedCopy pc;
+};
+
+// suppressed-note@+1 {{record 'ProtectedCopyBaseAndField' is not automatically available}}
+struct ProtectedCopyBaseAndField : ProtectedCopy {
+  ProtectedCopy pc;
+};
+
+using VecOfProtectedCopy = std::vector<ProtectedCopy>;
+using VecOfInheritsProtectedCopy = std::vector<InheritsProtectedCopy>;
+
+// suppressed-note@+1 {{record 'FieldVecOfProtectedCopy ' is not automatically available}}
+struct FieldVecOfProtectedCopy { std::vector<ProtectedCopy> v; };
+struct FieldVecOfInheritsProtectedCopy {
+  std::vector<InheritsProtectedCopy> v;
+  FieldVecOfInheritsProtectedCopy(int x, int y, int z) : v{} {
+    v.emplace_back(InheritsProtectedCopy{});
+    v.emplace_back(InheritsProtectedCopy{});
+    v.emplace_back(InheritsProtectedCopy{});
+    v[0].setFromBase(x);
+    v[1].setFromBase(y);
+    v[2].setFromBase(z);
+  }
+  int get(unsigned idx) const { return v[idx].getFromBase(); }
+};
+
+// suppressed-note@+1 {{record 'ProtectedMove' is not automatically available}}
+struct ProtectedMove {
+  int fromBase = 111;
+  ProtectedMove() = default;
+protected:
+  ProtectedMove(ProtectedMove &&) = default;
+};
+
+struct InheritsProtectedMove : ProtectedMove {
+  int getFromBase(void) const { return fromBase; }
+  void setFromBase(int x) { fromBase = x; }
+};
+
+using VecOfProtectedMove = std::vector<ProtectedMove>;
+using VecOfInheritsProtectedMove = std::vector<InheritsProtectedMove>;
+
+// suppressed-note@+1 {{record 'FieldVecOfProtectedMove ' is not automatically available}}
+struct FieldVecOfProtectedMove { std::vector<ProtectedMove> v; };
+struct FieldVecOfInheritsProtectedMove { std::vector<InheritsProtectedMove> v; };
+
+struct ProtectedCopyWithMove {
+  int fromBase = 111;
+  ProtectedCopyWithMove() = default;
+  ProtectedCopyWithMove(ProtectedCopyWithMove &&) = default;
+protected:
+  // NOTE: the copy has an incremented fromBase, so we can check at runtime that
+  // the correct custom copy operation took place
+  ProtectedCopyWithMove(const ProtectedCopyWithMove &o) : fromBase{o.fromBase + 1} {}
+};
+
+struct InheritsProtectedCopyWithMove : ProtectedCopyWithMove {
+  int getFromBase(void) const { return fromBase; }
+  void setFromBase(int x) { fromBase = x; }
+};
+
+struct ProtectedCopyWithMoveField {
+  ProtectedCopyWithMove pcm;
+};
+
+struct ProtectedCopyWithMoveBaseAndField : ProtectedCopyWithMove {
+  ProtectedCopyWithMove pcm;
+};

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
@@ -1,0 +1,107 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default) | %FileCheck %s
+//
+// REQUIRES: executable_test
+//
+// REQUIRES: OS=macosx
+// Fails on Linux:   https://github.com/swiftlang/swift/issues/86426
+// Fails on Windows：https://github.com/swiftlang/swift/issues/67288
+
+import StdlibUnittest
+import ProtectedSpecialMember
+
+var ProtectedSpecialMemberTestSuite = TestSuite("Protected Special Members")
+
+ProtectedSpecialMemberTestSuite.test("class that inherits protected destructor") {
+  var d = InheritsProtectedDtor()
+  d.inDerived = 123
+  expectEqual(123, d.inDerived)
+
+  // FIXME: accessing fromBase should be fine, but doesn't work because we rely on
+  // importing the base class to access its members.
+  // d.fromBase = 456
+  // expectEqual(456, d.fromBase)
+
+  // Make sure inherited protected destructor is called:
+  // CHECK: ~ProtectedDtor(fromBase = 111)
+}
+
+ProtectedSpecialMemberTestSuite.test("class that privately inherits protected destructor") {
+  var d = PrivatelyInheritsProtectedDtor()
+  d.inDerived = 123
+  expectEqual(123, d.inDerived)
+
+  d.setFromBase(456)
+
+  // Make sure inherited protected destructor is called:
+  // CHECK: ~ProtectedDtor(fromBase = 456)
+}
+
+ProtectedSpecialMemberTestSuite.test("class that inherits protected copy constructor") {
+  let c1 = InheritsProtectedCopy()
+  let c2 = c1
+  expectEqual(111, c1.getFromBase())
+  expectEqual(112, c2.getFromBase())
+
+  var c3 = InheritsProtectedCopy()
+  c3.setFromBase(66)
+  let c4 = c3
+  expectEqual(66, c3.getFromBase())
+  expectEqual(67, c4.getFromBase())
+}
+
+ProtectedSpecialMemberTestSuite.test("classes that privately inherit protected copy constructor") {
+  let c1 = PrivatelyInheritsProtectedCopy()
+  let c2 = c1
+  expectEqual(111, c1.getFromBase())
+  expectEqual(112, c2.getFromBase())
+
+  var c3 = PrivatelyInheritsProtectedCopy()
+  c3.setFromBase(66)
+  let c4 = c3
+  expectEqual(66, c3.getFromBase())
+  expectEqual(67, c4.getFromBase())
+
+  let p = PrivatelyInheritsPrivatelyInheritsProtectedCopy()
+  let _ = p
+}
+
+ProtectedSpecialMemberTestSuite.test("class that contains vector of class that inherited copy ctor") {
+  let v1 = FieldVecOfInheritsProtectedCopy(101, 201, 301)
+  expectEqual(101, v1.get(0))
+  expectEqual(201, v1.get(1))
+  expectEqual(301, v1.get(2))
+
+  let v2 = v1 // Invokes copy ctor of std::vector<InheritsProtectedCopy>,
+              // which invokes copy ctor of InheritsProtectedCopy elements,
+              // thus incrementing each value
+
+  expectEqual(102, v2.get(0))
+  expectEqual(202, v2.get(1))
+  expectEqual(302, v2.get(2))
+}
+
+ProtectedSpecialMemberTestSuite.test("class that inherits protected move constructor") {
+  var m1 = InheritsProtectedMove()
+  expectEqual(111, m1.getFromBase())
+  m1.setFromBase(112)
+  let m2 = m1
+  expectEqual(112, m2.getFromBase())
+}
+
+ProtectedSpecialMemberTestSuite.test("class with public move and protected copy") {
+  var cm1 = ProtectedCopyWithMove()
+  expectEqual(111, cm1.fromBase)
+  cm1.fromBase = 112
+  let cm2 = cm1
+  expectEqual(112, cm2.fromBase)
+}
+
+ProtectedSpecialMemberTestSuite.test("class that inherits public move and protected copy") {
+  var c3 = InheritsProtectedCopyWithMove()
+  c3.setFromBase(66)
+  let c4 = c3
+  expectEqual(66, c3.getFromBase())
+  expectEqual(67, c4.getFromBase())
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ProtectedSpecialMember -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+// CHECK-NOT: ProtectedDtor
+// CHECK-NOT: ProtectedDtorField
+// CHECK-NOT: ProtectedCopy
+// CHECK-NOT: ProtectedMove
+
+// CHECK:      struct InheritsProtectedDtor {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var inDerived: Int32
+// CHECK-NEXT: }
+
+// CHECK:      struct PrivatelyInheritsProtectedDtor {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   mutating func setFromBase(_ v: Int32)
+// CHECK-NEXT:   var inDerived: Int32
+// CHECK-NEXT: }
+
+// CHECK:      struct InheritsProtectedCopy {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func getFromBase() -> Int32
+// CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT: }
+
+// CHECK:      struct PrivatelyInheritsProtectedCopy {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func getFromBase() -> Int32
+// CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT: }
+
+// CHECK:      struct PrivatelyInheritsPrivatelyInheritsProtectedCopy {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+// CHECK:      struct InheritsProtectedMove {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func getFromBase() -> Int32
+// CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT: }
+
+// CHECK:      struct ProtectedCopyWithMove {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var fromBase: Int32
+// CHECK-NEXT: }
+
+// CHECK:      struct InheritsProtectedCopyWithMove {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func getFromBase() -> Int32
+// CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT:   var fromBase: Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-typechecker.swift
@@ -1,0 +1,78 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default \
+// RUN:     -verify-additional-file %S/Inputs/protected-special-member.h \
+// RUN:     -suppress-notes -verify-ignore-unrelated
+//
+// UNSUPPORTED: OS=windows-msvc
+// Fails on Windows due to https://github.com/swiftlang/swift/issues/67288
+
+import ProtectedSpecialMember
+
+let pd = ProtectedDtor() // expected-error {{cannot find 'ProtectedDtor' in scope}}
+
+let ipd = InheritsProtectedDtor()
+let _ = ipd.inDerived
+// FIXME: accessing fromBase should be fine, but doesn't work because we rely on
+// importing the base class to access its members, but ProtectedDtor is not
+// importable because it has a protected destructor.
+let _ = ipd.fromBase // expected-error {{value of type 'InheritsProtectedDtor' has no member 'fromBase'}}
+
+let pipd = PrivatelyInheritsProtectedDtor()
+let _ = pipd.inDerived
+
+let pdf = ProtectedDtorField() // expected-error {{cannot find 'ProtectedDtorField' in scope}}
+
+let pdbf = ProtectedDtorBaseAndField() // expected-error {{cannot find 'ProtectedDtorBaseAndField' in scope}}
+
+func copy<T: Copyable>(_ _: T) {}
+
+let pc = ProtectedCopy() // expected-error {{cannot find 'ProtectedCopy' in scope}}
+
+let ipc = InheritsProtectedCopy()
+copy(ipc)
+
+let pipc = PrivatelyInheritsProtectedCopy()
+copy(pipc)
+
+let pipipc = PrivatelyInheritsPrivatelyInheritsProtectedCopy()
+copy(pipipc)
+
+let pcf = ProtectedCopyField() // expected-error {{cannot find 'ProtectedCopyField' in scope}}
+
+let pcfb = ProtectedCopyBaseAndField() // expected-error {{cannot find 'ProtectedCopyBaseAndField' in scope}}
+
+let vpc = VecOfProtectedCopy() // expected-error {{cannot find 'VecOfProtectedCopy' in scope}}
+
+let vipc = VecOfInheritsProtectedCopy()
+copy(vipc)
+
+let fvpc = FieldVecOfProtectedCopy() // expected-error {{cannot find 'FieldVecOfProtectedCopy' in scope}}
+
+let fvipc = FieldVecOfInheritsProtectedCopy(1, 2, 3)
+copy(fvipc)
+
+let pm = ProtectedMove() // expected-error {{cannot find 'ProtectedMove' in scope}}
+
+let ipm = InheritsProtectedMove()
+copy(ipm) // expected-error {{conform to 'Copyable'}}
+
+let vpm = VecOfProtectedMove() // expected-error {{cannot find 'VecOfProtectedMove' in scope}}
+
+let vipm = VecOfInheritsProtectedMove()
+copy(vipm) // expected-error {{conform to 'Copyable'}}
+
+let fvpm = FieldVecOfProtectedMove() // expected-error {{cannot find 'FieldVecOfProtectedMove' in scope}}
+
+let fvipm = FieldVecOfInheritsProtectedMove()
+copy(fvipm) // expected-error {{conform to 'Copyable'}}
+
+let pcwm  = ProtectedCopyWithMove()
+copy(pcwm) // expected-error {{conform to 'Copyable'}}
+
+let ipcwm = InheritsProtectedCopyWithMove()
+copy(ipcwm)
+
+let pcmf = ProtectedCopyWithMoveField()
+copy(pcmf) // expected-error {{conform to 'Copyable'}}
+
+let pcmbf = ProtectedCopyWithMoveBaseAndField()
+copy(pcmbf) // expected-error {{conform to 'Copyable'}}

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -293,12 +293,10 @@ func copyableDisposablePOD(p: DisposablePOD) {
 
 func couldCreateCycleOfCxxValueSemanticsRequests() {
   let d1 = DerivesFromMe()
-  // FIXME expected error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
-  takeCopyable(d1)
+  takeCopyable(d1) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
 
   let d2 = DerivesFromMeToo()
-  // FIXME expected error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
-  takeCopyable(d2)
+  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
 
   let d3 = FieldDependsOnMe()
   takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -105,3 +105,9 @@ module StdExpected {
   requires cplusplus
   export *
 }
+
+module StdEnableSharedFromThis {
+  header "std-enable-shared-from-this.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-enable-shared-from-this.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-enable-shared-from-this.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <memory>
+
+struct SharableFromThis : std::enable_shared_from_this<SharableFromThis> {
+  int field = 42;
+};
+
+struct Foo {};
+using MalformedFoo = std::enable_shared_from_this<Foo>;
+using MalformedInt = std::enable_shared_from_this<int>;

--- a/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this-typechecker.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default
+
+import StdEnableSharedFromThis
+
+func s(_ _: SharableFromThis) {}
+func f(_ _: MalformedFoo) {} // expected-error {{cannot find type 'MalformedFoo' in scope}}
+func i(_ _: MalformedInt) {} // expected-error {{cannot find type 'MalformedInt' in scope}}

--- a/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this.swift
+++ b/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this.swift
@@ -1,0 +1,14 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdEnableSharedFromThis
+
+var StdESFT = TestSuite("StdEnableSharedFromThis")
+
+StdESFT.test("User type that inherits from std::enable_shared_from_this") {
+  let s = SharableFromThis()
+  expectEqual(s.field, 42)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -35,4 +35,4 @@ takeCopyable(hasVector)
 
 let baseHasVector = BaseHasVector()
 takeCopyable(baseHasVector)
-// FIXME expected error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'
+// CHECK: error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'


### PR DESCRIPTION
C++ classes can have protected destructors, copy constructors, and move
constructors. This pattern prevents that class from being directly
constructed, copied, or moved directly, but permits those operations on
types that inherit from it.

Those protected special members are inaccessible in the base class, but
are indirectly accessible in the derived class, so they shouldn't
prevent that derived class from being imported in Swift.

Such members were previously causing the derived class to be
incorrectly considered as having unknown copyability.

Note that, at the time of this patch, Swift cannot (directly) access any
members inherited from the base class with the protected special member,
because doing so relies on that base class being imported on its own
(which it can't without a public dtor/copy ctor/move ctor).

rdar://167555864