### PR TITLE
[Sema] 61733 error message improvement

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2432,6 +2432,10 @@ private:
   /// constructions) to the argument lists for the call to that locator.
   llvm::DenseMap<ConstraintLocator *, ArgumentList *> ArgumentLists;
 
+  /// Tracks type variables involved in a ForceOptional fix.
+  /// Used to suppress default generic argument inference for those variables.
+  llvm::SmallPtrSet<TypeVariableType*, 2> ForceOptionalTypeVars;
+
 public:
   /// A map from argument expressions to their applied property wrapper expressions.
   llvm::SmallDenseMap<ASTNode, SmallVector<AppliedPropertyWrapper, 2>, 4>
@@ -5559,6 +5563,11 @@ public:
   /// increase the likelihood that a favored constraint will be successfully
   /// resolved before any others.
   void optimizeConstraints(Expr *e);
+
+  /// Returns true if a ForceOptional fix already exists at the same
+  /// source location as the given anchor. Used to suppress secondary
+  /// diagnostics when unwrapping is the primary issue.
+  bool hasForceOptionalFixAtSameStartLoc(ASTNode anchor) const;
 
   /// Set the current sub-expression (of a multi-statement closure, etc) for
   /// the purposes of diagnosing "reasonable time" errors.

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -449,13 +449,6 @@ RelabelArguments::create(ConstraintSystem &cs,
   return new (mem) RelabelArguments(cs, correctLabels, locator);
 }
 
-static bool isExistentialOrWrappedInOptional(Type type) {
-    if (!type)
-      return false;
-    return type->lookThroughAllOptionalTypes()->isExistentialType();
-}
-
-
 bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
   auto *locator = getLocator();
 
@@ -463,8 +456,11 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
   if (locator) {
     auto *anchor = locator->getAnchor().dyn_cast<Expr *>();
 
+    Type nonConforming = getNonConformingType();
+
     if (anchor &&
-        isExistentialOrWrappedInOptional(getNonConformingType()) &&
+        nonConforming &&
+        nonConforming->lookThroughAllOptionalTypes()->isExistentialType() &&
         getProtocolType()->is<ProtocolType>()) {
 
       bool sawOpenedGeneric = false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8458,7 +8458,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           }
         }
       }
-      continue;
     }
 
     bool suppressDeepEquality = false;

--- a/test/Constraints/issue-61733.swift
+++ b/test/Constraints/issue-61733.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: asserts
+// Issue: https://github.com/swiftlang/swift/issues/61733
+// Verifies SE-0375 fix for (any P)? → (some P) conversion via ForceOptional
+
+
+
+protocol P {}
+struct S: P {}
+
+func takesOptionalP(_: (some P)?) {}
+
+func passOptional(foo: (any P)?) {
+    takesOptionalP(foo)
+    // expected-error @-1 {{value of optional type '(any P)?' must be unwrapped to a value of type 'any P'}}
+    // expected-note @-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note @-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}


### PR DESCRIPTION
### Resolves
[Issue 61733](https://github.com/swiftlang/swift/issues/61733)

### Problem Statement
If you try to pass a value of type (any P)? to an argument of type (some P)?, the compiler tells you that any P cannot conform to P, which is confusing and not actionable. With [SE-0375](https://github.com/apple/swift-evolution/blob/main/proposals/0375-opening-existential-optional.md), existential opening/unboxing is supported with optionals, but only if the argument is not an optional because it's possible that the (any P)? is nil (and thus does not have a dynamic type to bind to some P). With [SE-0375](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0375), the fix is to unwrap the optional or provide a default value. So, the error message should tell you that!

#### Reproducer code

````
protocol P {}

struct S: P {}

func takesOptionalP(_: (some P)?) {}

func passOptional(value: (any P)?) {
  takesOptionalP(value) // error: type 'any P' cannot conform to 'P'

  takesOptionalP(value ?? S()) // okay under SE-0375
  takesOptionalP(value!) // okay under SE-0375
}
````
The constraint system currently applies the MissingConformance fix when solving for the takesOptionalP(value) expression. Instead, it should identify that the wrapped type of the argument matches the parameter type, and apply the ForceOptional fix.

### Cause
During constraint solving for takesOptionalP(value), the constraint system records a viable ForceOptional fix at the call site, but during salvage it still applies MissingConformance, producing a misleading protocol conformance diagnostic.

### Changes
Helper added to ConstraintSystem to detect whether a ForceOptional fix already explains the failure at a given source location. This is used to suppress MissingConformance diagnostics only when a value-level optionality fix is already known to apply.  

Test case was also created.

#### Before
````
$ cat 61733.swift 
protocol P {}
struct S: P {}

func takesOptionalP(_: (some P)?) {}

// Test Case 01
func passOptional(foo: (any P)?) {
    takesOptionalP(foo)
}

$ swiftc 61733.swift 
61733.swift:8:5: error: type 'any P' cannot conform to 'P'
 2 | struct S: P {}
 3 | 
 4 | func takesOptionalP(_: (some P)?) {}
   |      `- note: required by global function 'takesOptionalP' where 'some P' = 'any P'
 5 | 
 6 | // Test Case 01
 7 | func passOptional(foo: (any P)?) {
 8 |     takesOptionalP(foo)
   |     |- error: type 'any P' cannot conform to 'P'
   |     `- note: only concrete types such as structs, enums and classes can conform to protocols
 9 | }
10 | 
````
#### After
````
$ cat 61733.swift 
protocol P {}
struct S: P {}

func takesOptionalP(_: (some P)?) {}

// Test Case 01
func passOptional(foo: (any P)?) {
    takesOptionalP(foo)
}

$ swiftc 61733.swift 
61733.swift:8:20: error: value of optional type '(any P)?' must be unwrapped to a value of type 'any P'
 6 | // Test Case 01
 7 | func passOptional(foo: (any P)?) {
 8 |     takesOptionalP(foo)
   |                    |- error: value of optional type '(any P)?' must be unwrapped to a value of type 'any P'
   |                    |- note: coalesce using '??' to provide a default when the optional value contains 'nil'
   |                    `- note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
 9 | }
10 | 
````
