### PR TITLE
tests: disable SILOptimizer/exclusivity_violation.swift for back-deployment

### DIFF
--- a/test/SILOptimizer/exclusivity_violation.swift
+++ b/test/SILOptimizer/exclusivity_violation.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: executable_test
 
+// For some reason we don't get exclusivity violations on older OSes
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 
 


### PR DESCRIPTION
rdar://165958396
