### PR TITLE
[Test][Darwin] Add CanonicalName and SupportedTargets to all applicable SDKSettings

### DIFF
--- a/test/CAS/path_remap.swift
+++ b/test/CAS/path_remap.swift
@@ -83,4 +83,8 @@ version: 1
 modules:
   - name: _B_A
 //--- sdk/SDKSettings.json
-{}
+{"Version":"26.1", "CanonicalName": "macosx26.1", "MaximumDeploymentTarget": "26.1.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": "\/System\/macOSSupport"},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
@@ -1,30 +1,36 @@
 {
   "Version":"10.15.4",
-  "CanonicalName": "macosx10.15.4",
+  "CanonicalName": "macosx10.15",
+  "SupportedTargets": {
+      "macosx": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "macosx",
+          "LLVMTargetTripleEnvironment": ""
+      },
+      "iosmac": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "ios",
+          "LLVMTargetTripleEnvironment": "macabi"
+      }
+  },
   "VersionMap" : {
       "macOS_iOSMac" : {
-          "10.14.4" : "12.4",
-          "10.14.3" : "12.3",
-          "10.14.2" : "12.2",
-          "10.14.1" : "12.1",
-          "10.15" : "13.0",
-          "10.14" : "12.0",
-          "10.14.5" : "12.5",
+          "10.15" : "13.1",
           "10.15.1" : "13.2",
+          "10.15.2" : "13.3",
+          "10.15.3" : "13.3.1",
           "10.15.4" : "13.4"
       },
       "iOSMac_macOS" : {
-          "13.0" : "10.15",
-          "12.3" : "10.14.3",
-          "12.0" : "10.14",
-          "12.4" : "10.14.4",
-          "12.1" : "10.14.1",
-          "12.5" : "10.14.5",
-          "12.2" : "10.14.2",
+          "13.1" : "10.15",
           "13.2" : "10.15.1",
+          "13.3" : "10.15.2",
+          "13.3.1" : "10.15.3",
           "13.4" : "10.15.4"
       }
   },
-  "DefaultDeploymentTarget" : "11.0",
-  "MaximumDeploymentTarget" : "11.0.99"
+  "DefaultDeploymentTarget" : "10.15",
+  "MaximumDeploymentTarget" : "10.15.99"
 }

--- a/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -1,6 +1,20 @@
 {
   "Version":"10.15",
   "CanonicalName": "macosx10.15",
+  "SupportedTargets": {
+      "macosx": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "macosx",
+          "LLVMTargetTripleEnvironment": ""
+      },
+      "iosmac": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "ios",
+          "LLVMTargetTripleEnvironment": "macabi"
+      }
+  },
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.15" : "13.1",

--- a/test/Inputs/MockPlatformRemapSDKConfig/SDKSettings.json
+++ b/test/Inputs/MockPlatformRemapSDKConfig/SDKSettings.json
@@ -1,6 +1,15 @@
 {
   "DisplayName": "visionOS 1.1",
   "Version": "1.1",
+  "SupportedTargets": {
+    "xros": {
+      "Archs": ["arm64e","arm64"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "xros",
+      "LLVMTargetTripleEnvironment": "",
+      "SystemPrefix": ""
+    }
+  },
   "VersionMap": {
     "xrOS_iOS": {
       "1.0": "17.1",


### PR DESCRIPTION
clang will start looking at CanonicalName and SupportedTargets soon, and error if those aren't as expected in the shipping SDKs. Pre-emptively add those to the test SDKSettings.

rdar://166277280