### PR TITLE
Sema: Fix accidental mutation of DenseMap in ConstraintSystem::selectDisjunction() [6.3]

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1945,10 +1945,11 @@ ConstraintSystem::selectDisjunction() {
         if (auto preference = isPreferable(*this, first, second))
           return preference.value();
 
-        auto &[firstScore, firstFavoredChoices, isFirstSpeculative] =
-            favorings[first];
-        auto &[secondScore, secondFavoredChoices, isSecondSpeculative] =
-            favorings[second];
+        const auto &firstFavorings = favorings[first];
+        const auto &secondFavorings = favorings[second];
+
+        auto firstScore = firstFavorings.Score;
+        auto secondScore = secondFavorings.Score;
 
         bool isFirstOperator = isOperatorDisjunction(first);
         bool isSecondOperator = isOperatorDisjunction(second);
@@ -1968,10 +1969,10 @@ ConstraintSystem::selectDisjunction() {
         // when nothing concrete is known about them, let's reset the score
         // and compare purely based on number of choices.
         if (isFirstOperator != isSecondOperator) {
-          if (isFirstOperator && isFirstSpeculative)
+          if (isFirstOperator && firstFavorings.IsSpeculative)
             firstScore = 0;
 
-          if (isSecondOperator && isSecondSpeculative)
+          if (isSecondOperator && secondFavorings.IsSpeculative)
             secondScore = 0;
         }
 
@@ -1997,17 +1998,17 @@ ConstraintSystem::selectDisjunction() {
           // because it would fail and prune the other overload if parameter
           // type (aka contextual type) is `Int`.
           if (isFirstOperator && isSecondOperator &&
-              isFirstSpeculative != isSecondSpeculative)
-            return isSecondSpeculative;
+              firstFavorings.IsSpeculative != secondFavorings.IsSpeculative)
+            return secondFavorings.IsSpeculative;
         }
 
         // Use favored choices only if disjunction score is higher
         // than zero. This means that we can maintain favoring
         // choices without impacting selection decisions.
         unsigned numFirstFavored =
-            firstScore.value_or(0) ? firstFavoredChoices.size() : 0;
+            firstScore.value_or(0) ? firstFavorings.FavoredChoices.size() : 0;
         unsigned numSecondFavored =
-            secondScore.value_or(0) ? secondFavoredChoices.size() : 0;
+            secondScore.value_or(0) ? secondFavorings.FavoredChoices.size() : 0;
 
         if (numFirstFavored == numSecondFavored) {
           if (firstActive != secondActive)


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86352.

* **Description:** Fix accidental modification of a DenseMap inside the selectDisjunction() algorithm. The accesses of the values from the DenseMap were unintentionally declared as references, when they should be values, because the assignments were not meant to be written back to the DenseMap.

* **Origination:** The new logic was part of the solver-perf optimizations and did not ship in a release yet.

* **Tested:** I do not have a test case to exercise the formerly-incorrect behavior. I only found the problem while debugging some changes to the algorithm where I intentionally performed the selection pass twice, and I noticed the result was not deterministic.

* **Risk:** Disjunction selection order can affect both performance, and -- unfortunately -- the actual solution produced by the solver. There is some remote risk this incorrect behavior was load-bearing in some cases, but this is why I want to land it in 6.3, since we don't want users to rely on it going forward.

* **Reviewed by:** @xedin
