### PR TITLE
[cxx-interop] Check for the presence of simple copy constructor

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8296,8 +8296,11 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     bool isCopyable = !isExplicitlyNonCopyable;
     if (!isExplicitlyNonCopyable) {
       auto copyCtor = findCopyConstructor(cxxRecordDecl);
-      isCopyable = copyCtor || cxxRecordDecl->needsImplicitCopyConstructor();
+      isCopyable = copyCtor || 
+                   cxxRecordDecl->hasSimpleCopyConstructor() ||
+                   cxxRecordDecl->needsImplicitCopyConstructor();
       if ((copyCtor && copyCtor->isDefaulted()) ||
+          cxxRecordDecl->hasSimpleCopyConstructor() ||
           cxxRecordDecl->needsImplicitCopyConstructor()) {
         // If the copy constructor is implicit/defaulted, we ask Clang to
         // generate its definition. The implicitly-defined copy constructor


### PR DESCRIPTION
Sometimes, a `CxxRecordDecl` will have an implicitly declared copy constructor that is not found through `findCopyConstructor()`. So, we also explicitly check for the presence of a simple copy constructor. 

Unfortunately, I couldn't come up with a small reproducer for this. 

rdar://167551559