### PR TITLE
Revert "[DependencyScan] Correct setup clang VFS for dependency scanning

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -30,9 +30,10 @@
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Mutex.h"
-#include "llvm/Support/StringSaver.h"
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -1035,12 +1036,6 @@ using BridgeClangDependencyCallback = llvm::function_ref<ModuleDependencyInfo(
 /// A carrier of state shared among possibly multiple invocations of the
 /// dependency scanner.
 class SwiftDependencyScanningService {
-  /// BumpPtrAllocator for data matching the life-time of ScanningService.
-  llvm::BumpPtrAllocator Alloc;
-
-  /// StringSaver for data matching the life-time of ScanningService.
-  llvm::StringSaver Saver;
-
   /// The CASOption created the Scanning Service if used.
   std::optional<clang::CASOptions> CASOpts;
 
@@ -1061,8 +1056,6 @@ public:
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
-
-  llvm::StringSaver &getStringSaver() { return Saver; }
 
 private:
   /// Enforce clients not being allowed to query this cache directly, it must be

--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -21,6 +21,7 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/StringSaver.h"
 
 namespace swift {
 namespace dependencies {
@@ -145,6 +146,8 @@ private:
 
   /// Shared state mutual-exclusivity lock
   llvm::sys::SmartMutex<true> DependencyScanningToolStateLock;
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver;
 };
 
 swiftscan_diagnostic_set_t *mapCollectedDiagnosticsForOutput(

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -514,8 +514,7 @@ void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
   }
 }
 
-SwiftDependencyScanningService::SwiftDependencyScanningService()
-    : Alloc(), Saver(Alloc) {
+SwiftDependencyScanningService::SwiftDependencyScanningService() {
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       clang::tooling::dependencies::ScanningOutputFormat::FullTree,

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -202,7 +202,8 @@ ClangImporter::createClangArgs(const ClangImporterOptions &ClangImporterOpts,
 }
 
 static SmallVector<std::pair<std::string, std::string>, 2>
-getLibcFileMapping(const ASTContext &ctx, StringRef modulemapFileName,
+getLibcFileMapping(const ClangInvocationFileMappingContext &ctx,
+                   StringRef modulemapFileName,
                    std::optional<ArrayRef<StringRef>> maybeHeaderFileNames,
                    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs,
                    bool suppressDiagnostic) {
@@ -269,7 +270,8 @@ getLibcFileMapping(const ASTContext &ctx, StringRef modulemapFileName,
 }
 
 static void getLibStdCxxFileMapping(
-    ClangInvocationFileMapping &fileMapping, const ASTContext &ctx,
+    ClangInvocationFileMapping &fileMapping,
+    const ClangInvocationFileMappingContext &ctx,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs,
     bool suppressDiagnostic) {
   assert(ctx.LangOpts.EnableCXXInterop &&
@@ -448,26 +450,26 @@ static void getLibStdCxxFileMapping(
     includeHeaderInModuleMap(additionalFile);
   os << contents.substr(headerInjectionPoint);
 
-  fileMapping.overridenFiles.emplace_back(llvm::MemoryBuffer::getMemBufferCopy(
-      additionalHeaderDirectives, injectedModuleMapPath));
+  fileMapping.overridenFiles.push_back(
+      {std::string(injectedModuleMapPath), std::move(os.str())});
 }
 
 namespace {
-std::string GetPlatformAuxiliaryFile(StringRef Platform, StringRef File,
-                                     llvm::vfs::FileSystem &VFS,
-                                     const SearchPathOptions &Options) {
+std::string
+GetPlatformAuxiliaryFile(StringRef Platform, StringRef File,
+                         const SearchPathOptions &Options) {
   StringRef SDKPath = Options.getSDKPath();
   if (!SDKPath.empty()) {
     llvm::SmallString<261> path{SDKPath};
     llvm::sys::path::append(path, "usr", "share", File);
-    if (VFS.exists(path))
+    if (llvm::sys::fs::exists(path))
       return path.str().str();
   }
 
   if (!Options.RuntimeResourcePath.empty()) {
     llvm::SmallString<261> path{Options.RuntimeResourcePath};
     llvm::sys::path::append(path, Platform, File);
-    if (VFS.exists(path))
+    if (llvm::sys::fs::exists(path))
       return path.str().str();
   }
 
@@ -475,7 +477,8 @@ std::string GetPlatformAuxiliaryFile(StringRef Platform, StringRef File,
 }
 
 void GetWindowsFileMappings(
-    ClangInvocationFileMapping &fileMapping, const ASTContext &Context,
+    ClangInvocationFileMapping &fileMapping,
+    const ClangInvocationFileMappingContext &Context,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &driverVFS,
     bool &requiresBuiltinHeadersInSystemModules) {
   const llvm::Triple &Triple = Context.LangOpts.Target;
@@ -511,7 +514,7 @@ void GetWindowsFileMappings(
     llvm::sys::path::append(WinSDKInjection, "module.modulemap");
 
     AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "winsdk_um.modulemap",
-                                             VFS, SearchPathOpts);
+                                             SearchPathOpts);
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
                                                AuxiliaryFile);
@@ -520,7 +523,7 @@ void GetWindowsFileMappings(
     llvm::sys::path::remove_filename(WinSDKInjection);
     llvm::sys::path::append(WinSDKInjection, "shared", "module.modulemap");
     AuxiliaryFile = GetPlatformAuxiliaryFile(
-        "windows", "winsdk_shared.modulemap", VFS, SearchPathOpts);
+        "windows", "winsdk_shared.modulemap", SearchPathOpts);
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
                                                AuxiliaryFile);
@@ -537,8 +540,8 @@ void GetWindowsFileMappings(
     llvm::sys::path::append(UCRTInjection, "Include", UCRTSDK.Version, "ucrt");
     llvm::sys::path::append(UCRTInjection, "module.modulemap");
 
-    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "ucrt.modulemap", VFS,
-                                             SearchPathOpts);
+    AuxiliaryFile =
+        GetPlatformAuxiliaryFile("windows", "ucrt.modulemap", SearchPathOpts);
     if (!AuxiliaryFile.empty()) {
       // The ucrt module map has the C standard library headers all together.
       // That leads to module cycles with the clang _Builtin_ modules. e.g.
@@ -575,16 +578,18 @@ void GetWindowsFileMappings(
     llvm::sys::path::append(VCToolsInjection, "include");
 
     llvm::sys::path::append(VCToolsInjection, "module.modulemap");
-    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "vcruntime.modulemap",
-                                             VFS, SearchPathOpts);
+    AuxiliaryFile =
+        GetPlatformAuxiliaryFile("windows", "vcruntime.modulemap",
+                                 SearchPathOpts);
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(VCToolsInjection),
                                                AuxiliaryFile);
 
     llvm::sys::path::remove_filename(VCToolsInjection);
     llvm::sys::path::append(VCToolsInjection, "vcruntime.apinotes");
-    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "vcruntime.apinotes",
-                                             VFS, SearchPathOpts);
+    AuxiliaryFile =
+        GetPlatformAuxiliaryFile("windows", "vcruntime.apinotes",
+                                 SearchPathOpts);
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(VCToolsInjection),
                                                AuxiliaryFile);
@@ -605,17 +610,23 @@ void GetWindowsFileMappings(
     for (const char * const header : kInjectedHeaders) {
       llvm::sys::path::remove_filename(VCToolsInjection);
       llvm::sys::path::append(VCToolsInjection, header);
-      if (!VFS.exists(VCToolsInjection))
-        fileMapping.overridenFiles.emplace_back(
-            llvm::MemoryBuffer::getMemBufferCopy("", VCToolsInjection));
+      if (!llvm::sys::fs::exists(VCToolsInjection))
+        fileMapping.overridenFiles.emplace_back(std::string{VCToolsInjection},
+                                                "");
     }
   }
 }
 } // namespace
 
+ClangInvocationFileMappingContext::ClangInvocationFileMappingContext(
+    const swift::ASTContext &Ctx)
+  : ClangInvocationFileMappingContext(Ctx.LangOpts, Ctx.SearchPathOpts,
+        Ctx.ClangImporterOpts, Ctx.CASOpts, Ctx.Diags) {}
+
 ClangInvocationFileMapping swift::getClangInvocationFileMapping(
-    const ASTContext &ctx, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
-    bool suppressDiagnostic) {
+  const ClangInvocationFileMappingContext &ctx,
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+  bool suppressDiagnostic) {
   ClangInvocationFileMapping result;
   if (!vfs)
     vfs = llvm::vfs::getRealFileSystem();
@@ -682,22 +693,51 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
 
   GetWindowsFileMappings(result, ctx, vfs,
                          result.requiresBuiltinHeadersInSystemModules);
+  return result;
+}
 
-  // push the redirect files into a YAML vfs overlay file.
-  if (!result.redirectedFiles.empty()) {
-    // Create a vfs overlay map for all redirects.
-    llvm::vfs::YAMLVFSWriter vfsWriter;
-    vfsWriter.setUseExternalNames(true);
-    for (const auto &mapping : result.redirectedFiles)
-      vfsWriter.addFileMapping(mapping.first, mapping.second);
+ClangInvocationFileMapping swift::applyClangInvocationMapping(
+    const ClangInvocationFileMappingContext &ctx,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseVFS,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &fileSystem,
+    bool suppressDiagnostics) {
+  if (ctx.CASOpts.HasImmutableFileSystem)
+    return ClangInvocationFileMapping();
 
-    std::string vfsYAML;
-    llvm::raw_string_ostream os(vfsYAML);
-    vfsWriter.write(os);
+  ClangInvocationFileMapping fileMapping =
+    getClangInvocationFileMapping(ctx, baseVFS, suppressDiagnostics);
 
-    result.overridenFiles.emplace_back(llvm::MemoryBuffer::getMemBufferCopy(
-        vfsYAML, ClangImporter::getClangSystemOverlayFile(ctx.SearchPathOpts)));
+  auto importerOpts = ctx.ClangImporterOpts;
+  // Wrap Swift's FS to allow Clang to override the working directory
+  fileSystem = llvm::vfs::RedirectingFileSystem::create(
+      fileMapping.redirectedFiles, true, *fileSystem);
+  if (importerOpts.DumpClangDiagnostics) {
+    llvm::errs() << "clang importer redirected file mappings:\n";
+    for (const auto &mapping : fileMapping.redirectedFiles) {
+      llvm::errs() << "   mapping real file '" << mapping.second
+                   << "' to virtual file '" << mapping.first << "'\n";
+    }
+    llvm::errs() << "\n";
   }
 
-  return result;
+  if (!fileMapping.overridenFiles.empty()) {
+    llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
+        new llvm::vfs::InMemoryFileSystem();
+    for (const auto &file : fileMapping.overridenFiles) {
+      if (importerOpts.DumpClangDiagnostics) {
+        llvm::errs() << "clang importer overriding file '" << file.first
+                     << "' with the following contents:\n";
+        llvm::errs() << file.second << "\n";
+      }
+      // Note MemoryBuffer is guaranteeed to be null-terminated.
+      overridenVFS->addFile(file.first, 0,
+                            llvm::MemoryBuffer::getMemBufferCopy(file.second));
+    }
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlayVFS =
+        new llvm::vfs::OverlayFileSystem(fileSystem);
+    fileSystem = overlayVFS;
+    overlayVFS->pushOverlay(overridenVFS);
+  }
+
+  return fileMapping;
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -491,13 +491,10 @@ public:
 
   const Version CurrentVersion;
 
-  constexpr static const char *const moduleImportBufferName =
-      "<swift-imported-modules>";
-  constexpr static const char *const bridgingHeaderBufferName =
-      "<bridging-header-import>";
-  /// The name of system vfsoverlay.
-  constexpr static const char *const clangSystemVFSOverlayName =
-      "<clang-system-vfs-overlay>";
+  constexpr static const char * const moduleImportBufferName =
+    "<swift-imported-modules>";
+  constexpr static const char * const bridgingHeaderBufferName =
+    "<bridging-header-import>";
 
 private:
   DiagnosticWalker Walker;
@@ -2020,7 +2017,6 @@ void getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 void addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
                                   ASTContext &ctx,
                                   bool requiresBuiltinHeadersInSystemModules,
-                                  bool needSystemVFSOverlay,
                                   bool ignoreClangTarget);
 
 /// Finds a particular kind of nominal by looking through typealiases.

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -267,7 +267,8 @@ static swiftscan_import_set_t generateHollowDiagnosticOutputImportSet(
 }
 
 DependencyScanningTool::DependencyScanningTool()
-    : ScanningService(std::make_unique<SwiftDependencyScanningService>()) {}
+    : ScanningService(std::make_unique<SwiftDependencyScanningService>()),
+      Alloc(), Saver(Alloc) {}
 
 llvm::ErrorOr<swiftscan_dependency_graph_t>
 DependencyScanningTool::getDependencies(ArrayRef<const char *> Command,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -195,16 +195,15 @@ static std::vector<std::string> inputSpecificClangScannerCommand(
 
 static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 getClangScanningFS(std::shared_ptr<llvm::cas::ObjectStore> cas,
-                   ASTContext &ctx, llvm::StringSaver &saver) {
-  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  // Dependency scanner needs to create its own file system per worker.
-  auto fs = ClangImporter::computeClangImporterFileSystem(
-      ctx, importer->getClangFileMapping(),
-      llvm::vfs::createPhysicalFileSystem(), true, &saver);
+                   ASTContext &ctx) {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFileSystem =
+      llvm::vfs::createPhysicalFileSystem();
+  ClangInvocationFileMapping fileMapping =
+    applyClangInvocationMapping(ctx, nullptr, baseFileSystem, false);
 
   if (cas)
-    return llvm::cas::createCASProvidingFileSystem(cas, fs);
-  return fs;
+    return llvm::cas::createCASProvidingFileSystem(cas, baseFileSystem);
+  return baseFileSystem;
 }
 
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
@@ -218,10 +217,8 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     llvm::PrefixMapper *Mapper)
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
-      clangScanningTool(
-          *globalScanningService.ClangScanningService,
-          getClangScanningFS(CAS, ScanASTContext,
-                             globalScanningService.getStringSaver())),
+      clangScanningTool(*globalScanningService.ClangScanningService,
+                        getClangScanningFS(CAS, ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter) {
   // Instantiate a worker-specific diagnostic engine and copy over
@@ -2100,16 +2097,10 @@ ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
   invocation.getMutCASOpts() = clang::CASOptions();
   invocation.getMutFrontendOpts().CASIncludeTreeID.clear();
 
+  // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
+  // from clang scanner and pass to swift.
   if (!ScanASTContext.CASOpts.EnableCaching) {
     auto &overlayFiles = invocation.getMutHeaderSearchOpts().VFSOverlayFiles;
-
-    // clang system overlay file is a virtual file that is not an actual file.
-    auto clangSystemOverlayFile =
-        ClangImporter::getClangSystemOverlayFile(ScanASTContext.SearchPathOpts);
-    llvm::erase(overlayFiles, clangSystemOverlayFile);
-
-    // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
-    // from clang scanner and pass to swift.
     for (auto overlay : overlayFiles) {
       swiftArgs.push_back("-vfsoverlay");
       swiftArgs.push_back(overlay);

--- a/test/ClangImporter/print-module-map-paths.swift
+++ b/test/ClangImporter/print-module-map-paths.swift
@@ -28,13 +28,11 @@
 // RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/sdk/usr/lib/swift/android
 // RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID-CXX %s
 
-// CHECK-macosx-CXX-NOT: clang importer redirected file mappings:
-
 // CHECK-LINUX: clang importer redirected file mappings:
 // CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}glibc.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
 // CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}SwiftGlibc.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftGlibc.h'
 
-// CHECK-linux-gnu-CXX: clang importer redirected file mappings:
+// CHECK-CXX: clang importer redirected file mappings:
 // CHECK-linux-gnu-CXX: mapping real file '{{.*}}/resources/linux/libstdcxx.h' to virtual file '{{.*}}/usr/include/c++/{{.*}}/libstdcxx.h'
 // CHECK-linux-gnu-CXX: clang importer overriding file '{{.*}}/usr/include/c++/{{.*}}/module.modulemap' with the following contents:
 // CHECK-linux-gnu-CXX-NEXT: --- libstdcxx.modulemap ---
@@ -49,5 +47,3 @@
 // CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftBionic.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftBionic.h'
 
 // CHECK-ANDROID-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources{{/|\\}}android{{/|\\}}libcxxshim.modulemap'
-
-// CHECK-CXX: clang importer cc1 args:

--- a/test/ScanDependencies/scanner_api_working_dir.swift
+++ b/test/ScanDependencies/scanner_api_working_dir.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -module-name A -o %t/include/A.swiftmodule -swift-version 5 \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -emit-module-interface-path %t/include/A.swiftinterface -enable-library-evolution -I %t/internal -enable-testing \
-// RUN:   %t/A.swift -I %t/include
+// RUN:   %t/A.swift
 
 // RUN: %swift-scan-test -action scan_dependency -cwd %t -- %target-swift-frontend -emit-module -module-name Test \
 // RUN:   -swift-version 5 -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -13,7 +13,7 @@
 // CHECK: "mainModuleName": "Test"
 
 // RUN: cd %t
-// RUN: %swift-scan-test -action scan_dependency -threads 10  -- %target-swift-frontend -emit-module -module-name Test \
+// RUN: %swift-scan-test -action scan_dependency -- %target-swift-frontend -emit-module -module-name Test \
 // RUN:   -swift-version 5 -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -I include %t/test.swift | %FileCheck %s
 
@@ -21,11 +21,4 @@
 import A
 
 //--- A.swift
-import B
 public func a() {}
-
-//--- include/module.modulemap
-module B { header "B.h" export *}
-
-//--- include/B.h
-void b(void);

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -213,7 +213,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     vfs.devtoolSet("9").libstdCxxModulemap("\n");
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 2);
-    ASSERT_TRUE(paths.overridenFiles.size() == 1);
+    ASSERT_TRUE(paths.overridenFiles.empty());
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
@@ -229,14 +229,14 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     vfs.devtoolSet("9").cxxStdlibHeader("string_view").libstdCxxModulemap();
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 1);
-    ASSERT_TRUE(paths.overridenFiles.size() == 2);
+    ASSERT_TRUE(paths.overridenFiles.size() == 1);
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
               "/usr/lib/swift/linux/libstdcxx.h");
-    EXPECT_EQ(paths.overridenFiles[0]->getBufferIdentifier(),
+    EXPECT_EQ(paths.overridenFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
-    EXPECT_NE(paths.overridenFiles[0]->getBuffer().find(
+    EXPECT_NE(paths.overridenFiles[0].second.find(
                   "header \"string_view\"\n  /// additional headers."),
               StringRef::npos);
   }
@@ -255,15 +255,15 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
         .libstdCxxModulemap();
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 1);
-    ASSERT_TRUE(paths.overridenFiles.size() == 2);
+    ASSERT_TRUE(paths.overridenFiles.size() == 1);
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
               "/usr/lib/swift/linux/libstdcxx.h");
-    EXPECT_EQ(paths.overridenFiles[0]->getBufferIdentifier(),
+    EXPECT_EQ(paths.overridenFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
     EXPECT_NE(
-        paths.overridenFiles[0]->getBuffer().find(
+        paths.overridenFiles[0].second.find(
             "header \"codecvt\"\n  header \"any\"\n  header \"charconv\"\n  "
             "header \"filesystem\"\n  header \"memory_resource\"\n  header "
             "\"optional\"\n  header \"string_view\"\n  header \"variant\"\n  "


### PR DESCRIPTION
This reverts commit e0e69f7ac06282310f4516e6123d3471a333eebe. This causes flaky tests ScanDependencies/scanner_api_working_dir.swift.

rdar://167742034

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
