### PR TITLE
6.3: Fix swift_coroFrameAlloc crash for 32-bit target platforms

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -150,7 +150,7 @@ func alignedAlloc(size: Int, alignment: Int) -> UnsafeMutableRawPointer? {
 }
 
 @c
-public func swift_coroFrameAlloc(_ size: Int, _ type: UInt) -> UnsafeMutableRawPointer? {
+public func swift_coroFrameAlloc(_ size: Int, _ type: UInt64) -> UnsafeMutableRawPointer? {
   return unsafe alignedAlloc(
     size: size,
     alignment: _swift_MinAllocationAlignment)

--- a/test/embedded/coro_frame_alloc_abi.swift
+++ b/test/embedded/coro_frame_alloc_abi.swift
@@ -7,6 +7,9 @@
 // RUN: %target-swift-frontend -c -emit-module -o %t/Lib.o %t/Lib.swift -enable-experimental-feature Embedded -parse-as-library -disable-objc-interop -wmo -O
 // RUN: %target-swift-frontend -I %t -c -o %t/Client.o %t/Client.swift -enable-experimental-feature Embedded -parse-as-library -disable-objc-interop -wmo -O
 
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
 //--- Lib.swift
 
 public struct S {

--- a/test/embedded/coro_frame_alloc_abi.swift
+++ b/test/embedded/coro_frame_alloc_abi.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// This test used to fail on 32 bit platforms. It would crash on the second
+// swift-frontend invocation.
+
+// RUN: %target-swift-frontend -c -emit-module -o %t/Lib.o %t/Lib.swift -enable-experimental-feature Embedded -parse-as-library -disable-objc-interop -wmo -O
+// RUN: %target-swift-frontend -I %t -c -o %t/Client.o %t/Client.swift -enable-experimental-feature Embedded -parse-as-library -disable-objc-interop -wmo -O
+
+//--- Lib.swift
+
+public struct S {
+    public var a, b, c, d: Float
+    public init(a: Float, b: Float, c: Float, d: Float) {
+        self.a = a; self.b = b; self.c = c; self.d = d
+    }
+}
+
+public var setFn: ((OpaquePointer, S) -> Void)? = nil
+public var getFn: ((OpaquePointer) -> S)? = nil
+
+open class C {
+    public var ptr: OpaquePointer
+    public init() { ptr = OpaquePointer(bitPattern: 1)! }
+    public var value: S? {
+        get { getFn.unsafelyUnwrapped(ptr) }
+        set {
+            if let newValue { setFn.unsafelyUnwrapped(ptr, newValue) }
+        }
+    }
+}
+
+//--- Client.swift
+
+import Lib
+
+final class D: C {
+    override init() {
+        super.init()
+        value = S(a: 0, b: 0, c: 0, d: 0)
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/86291

**Explanation**: The type of `malloc_type_id_t` is a 64-bit integer (`unsigned long long`).
**Scope**: limited to Embedded Swift.
**Risk**: low due to limited scope and added automated test.
**Testing**: new test case added.
**Issue**: https://github.com/swiftlang/swift/issues/86069, https://github.com/swiftlang/swift/issues/84427, rdar://161075055, rdar://166566352
**Reviewer**: @aschwaighofer @DougGregor 
