### PR TITLE
LifetimeDependence: Minimise use of AbstractFunctionDecl interface

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -206,24 +206,6 @@ void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
   }
 }
 
-static ValueOwnership getLoweredOwnership(ParamDecl *param,
-                                          AbstractFunctionDecl *afd) {
-  if (isa<ConstructorDecl>(afd)) {
-    return ValueOwnership::Owned;
-  }
-  if (auto *ad = dyn_cast<AccessorDecl>(afd)) {
-    if (ad->getAccessorKind() == AccessorKind::Set) {
-      return param->isSelfParameter() ? ValueOwnership::InOut
-                                      : ValueOwnership::Owned;
-    }
-    if (isYieldingMutableAccessor(ad->getAccessorKind())) {
-      assert(param->isSelfParameter());
-      return ValueOwnership::InOut;
-    }
-  }
-  return ValueOwnership::Shared;
-}
-
 static bool isBitwiseCopyable(Type type, ASTContext &ctx) {
   auto *bitwiseCopyableProtocol =
       ctx.getProtocol(KnownProtocolKind::BitwiseCopyable);
@@ -420,11 +402,17 @@ public:
 /// implements the lifetime inferrence rules.
 class LifetimeDependenceChecker {
   using TargetDeps = LifetimeDependenceBuilder::TargetDeps;
+  using Param = AnyFunctionType::Param;
 
-  AbstractFunctionDecl *afd;
+  SmallVector<LifetimeEntry *, 2> lifetimeEntries;
+  SmallVector<Param, 4> parameters;
+  SmallVector<SourceLoc, 4> paramLocs;
 
-  DeclContext *dc;
+  DeclContext *functionDC;
   ASTContext &ctx;
+
+  // The result or yield type of the function being checked.
+  Type resultTy;
 
   SourceLoc returnLoc;
 
@@ -436,6 +424,19 @@ class LifetimeDependenceChecker {
   unsigned resultIndex = ~0;
 
   LifetimeDependenceBuilder depBuilder;
+
+  bool const isImplicit;
+  bool const isInit;
+  bool const hasUnsafeNonEscapableResult;
+
+  // A function type parameter corresponding to the implicit self declaration of
+  // the function, if it has one. Otherwise, std::nullopt.
+  std::optional<Param> implicitSelfParam;
+  // The location of the implicit self parameter, if it exists.
+  SourceLoc implicitSelfParamLoc;
+  // The decl context's self interface type, mapped into the environment, if
+  // there is a self parameter.
+  Type selfTypeInContext;
 
   // True if lifetime diganostics have already been performed. Avoids redundant
   // diagnostics, and allows bypassing diagnostics for special cases.
@@ -452,17 +453,64 @@ public:
     return paramList ? paramList->size() + 1 : 1;
   }
 
+private:
+  void collectLifetimeEntries(DeclAttributes const &attrs) {
+    for (auto attr : attrs.getAttributes<LifetimeAttr>()) {
+      lifetimeEntries.push_back(attr->getLifetimeEntry());
+    }
+  }
+
+  void collectParameterInfo(ParameterList const *params) {
+    for (auto *param : *params) {
+      parameters.push_back(param->toFunctionParam());
+      paramLocs.push_back(param->getLoc());
+    }
+  }
+
 public:
   LifetimeDependenceChecker(AbstractFunctionDecl *afd)
-      : afd(afd), dc(afd->getDeclContext()), ctx(dc->getASTContext()),
+      : functionDC(afd), ctx(afd->getDeclContext()->getASTContext()),
         resultIndex(getResultIndex(afd)),
-        depBuilder(/*sourceIndexCap*/ resultIndex) {
+        depBuilder(/*sourceIndexCap*/ resultIndex),
+        isImplicit(afd->isImplicit()), isInit(isa<ConstructorDecl>(afd)),
+        hasUnsafeNonEscapableResult(
+            afd->getAttrs().hasAttribute<UnsafeNonEscapableResultAttr>()) {
+    collectLifetimeEntries(afd->getAttrs());
+    collectParameterInfo(afd->getParameters());
+    if (auto *decl = afd->getImplicitSelfDecl()) {
+      implicitSelfParam = decl->toFunctionParam();
+      implicitSelfParamLoc = decl->getLoc();
+      // The implicit self parameter is at index parameters.size(). Adding it to
+      // the locations array allows us to get the location of any parameter
+      // given its index.
+      paramLocs.push_back(implicitSelfParamLoc);
+      auto *dc = afd->getDeclContext();
+      selfTypeInContext = afd->mapTypeIntoEnvironment(dc->getSelfInterfaceType());
+    }
+
+    if (auto *accessor = dyn_cast<AccessorDecl>(functionDC);
+        accessor && accessor->isCoroutine()) {
+
+      auto yieldTyInContext = accessor->mapTypeIntoEnvironment(
+          accessor->getStorage()->getValueInterfaceType());
+      this->resultTy = yieldTyInContext;
+
+    } else {
+      Type resultType;
+      if (auto fn = dyn_cast<FuncDecl>(afd)) {
+        resultType = fn->getResultInterfaceType();
+      } else {
+        auto ctor = cast<ConstructorDecl>(afd);
+        resultType = ctor->getResultInterfaceType();
+      }
+      this->resultTy = afd->mapTypeIntoEnvironment(resultType);
+    }
 
     auto resultTypeRepr = afd->getResultTypeRepr();
     returnLoc = resultTypeRepr ? resultTypeRepr->getLoc() : afd->getLoc();
 
     if (afd->hasImplicitSelfDecl()) {
-      selfIndex = afd->getParameters()->size();
+      selfIndex = parameters.size();
     }
   }
 
@@ -472,9 +520,10 @@ public:
   }
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> checkFuncDecl() {
-    assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
+    assert(isa<FuncDecl>(functionDC) || isa<ConstructorDecl>(functionDC));
     assert(depBuilder.empty());
 
+    auto *afd = cast<AbstractFunctionDecl>(functionDC);
     // Handle Builtins first because, even though Builtins require
     // LifetimeDependence, we don't force the experimental feature
     // to be enabled when importing the Builtin module.
@@ -504,14 +553,14 @@ public:
       return currentDependencies();
     }
 
-    if (afd->getAttrs().hasAttribute<LifetimeAttr>()) {
+    if (!lifetimeEntries.empty()) {
       initializeAttributeDeps();
       if (performedDiagnostics)
         return std::nullopt;
     }
     // Methods or functions with @_unsafeNonescapableResult do not require
     // lifetime annotation and do not infer any lifetime dependency.
-    if (afd->getAttrs().hasAttribute<UnsafeNonEscapableResultAttr>()) {
+    if (hasUnsafeNonEscapableResult) {
       return currentDependencies();
     }
 
@@ -576,18 +625,6 @@ protected:
     return ctx.Diags.diagnose(Loc, ID, std::move(Args)...);
   }
 
-  // Issue a diagnostic for an @_lifetime attribute. This does not set
-  // 'performedDiagnostics', so other lifetime diagnosics are raised as if the
-  // attribute was not present.
-  template<typename ...ArgTypes>
-  InFlightDiagnostic
-  diagnoseAttr(const Decl *decl, Diag<ArgTypes...> id,
-               typename detail::PassArgument<ArgTypes>::type... args) {
-    return ctx.Diags.diagnose(decl, Diagnostic(id, std::move(args)...));
-  }
-
-  bool isInit() const { return isa<ConstructorDecl>(afd); }
-
   // For initializers, the implicit self parameter is ignored and instead shows
   // up as the result type.
   //
@@ -598,16 +635,16 @@ protected:
   // the extra formal self parameter, a dependency targeting the formal result
   // index would incorrectly target the SIL metatype parameter.
   bool hasImplicitSelfParam() const {
-    return !isInit() && afd->hasImplicitSelfDecl();
+    return !isInit && implicitSelfParam.has_value();
   }
 
   // In SIL, implicit initializers and accessors become explicit.
   bool isImplicitOrSIL() const {
-    if (afd->isImplicit()) {
+    if (isImplicit) {
       return true;
     }
     // TODO: remove this check once SIL prints @lifetime.
-    if (auto *sf = afd->getParentSourceFile()) {
+    if (auto *sf = functionDC->getParentSourceFile()) {
       // The AST printer makes implicit initializers explicit, but does not
       // print the @lifetime annotations. Until that is fixed, avoid
       // diagnosing this as an error.
@@ -621,7 +658,7 @@ protected:
   bool isInterfaceFile() const {
     // TODO: remove this check once all compilers that are rev-locked to the
     // stdlib print the 'copy' dependence kind in the interface (Aug '25)
-    if (auto *sf = afd->getDeclContext()->getParentSourceFile()) {
+    if (auto *sf = functionDC->getParentSourceFile()) {
       if (sf->Kind == SourceFileKind::Interface) {
         return true;
       }
@@ -640,22 +677,22 @@ protected:
   // ==========================================================================
 
   std::string diagnosticQualifier() const {
-    if (afd->isImplicit()) {
-      if (isInit()) {
+    if (isImplicit) {
+      if (isInit) {
         return "an implicit initializer";
       }
-      if (auto *ad = dyn_cast<AccessorDecl>(afd)) {
+      if (auto *ad = dyn_cast<AccessorDecl>(functionDC)) {
         std::string qualifier = "the '";
         qualifier += accessorKindName(ad->getAccessorKind());
         qualifier += "' accessor";
         return qualifier;
       }
     }
-    if (afd->hasImplicitSelfDecl()) {
-      if (isInit()) {
+    if (implicitSelfParam.has_value()) {
+      if (isInit) {
         return "an initializer";
       }
-      if (afd->getImplicitSelfDecl()->isInOut()) {
+      if (implicitSelfParam->isInOut()) {
         return "a mutating method";
       }
       return "a method";
@@ -667,7 +704,7 @@ protected:
   // needs one. Always runs before the checker completes if no other diagnostics
   // were issued.
   void diagnoseMissingResultDependencies(DiagID diagID) {
-    if (!isDiagnosedNonEscapable(getResultOrYield())) {
+    if (!isDiagnosedNonEscapable(resultTy)) {
       return;
     }
     if (!depBuilder.hasTargetDeps(resultIndex)) {
@@ -684,39 +721,38 @@ protected:
     if (!hasImplicitSelfParam()) {
       return;
     }
-    auto *selfDecl = afd->getImplicitSelfDecl();
-    if (!selfDecl->isInOut()) {
+    if (!implicitSelfParam->isInOut()) {
       return;
     }
-    if (!isDiagnosedNonEscapable(dc->getSelfTypeInContext())) {
+    if (!isDiagnosedNonEscapable(selfTypeInContext)) {
       return;
     }
     if (!depBuilder.hasTargetDeps(selfIndex)) {
-      ctx.Diags.diagnose(selfDecl->getLoc(), diagID,
+      ctx.Diags.diagnose(implicitSelfParamLoc, diagID,
                          {StringRef(diagnosticQualifier())});
     }
   }
   
   void diagnoseMissingInoutDependencies(DiagID diagID) {
     unsigned paramIndex = 0;
-    for (auto *param : *afd->getParameters()) {
+    for (auto &param : parameters) {
       SWIFT_DEFER { paramIndex++; };
-      if (!param->isInOut()) {
+      if (!param.isInOut()) {
         continue;
       }
       if (!isDiagnosedNonEscapable(
-            afd->mapTypeIntoEnvironment(param->getInterfaceType()))) {
+              functionDC->mapTypeIntoEnvironment(param.getPlainType()))) {
         continue;
       }
       if (!depBuilder.hasTargetDeps(paramIndex)) {
-        ctx.Diags.diagnose(param->getLoc(), diagID,
-                           {StringRef(diagnosticQualifier()),
-                            param->getName().str()});
+        ctx.Diags.diagnose(
+            paramLocs[paramIndex], diagID,
+            {StringRef(diagnosticQualifier()), param.getInternalLabel().str()});
         if (diagID == diag::lifetime_dependence_cannot_infer_inout.ID) {
           ctx.Diags.diagnose(
-            param->getLoc(),
-            diag::lifetime_dependence_cannot_infer_inout_suggest,
-            param->getName().str());
+              paramLocs[paramIndex],
+              diag::lifetime_dependence_cannot_infer_inout_suggest,
+              param.getInternalLabel().str());
         }
       }
     }
@@ -724,17 +760,11 @@ protected:
 
   // Attribute parsing helper.
   bool isCompatibleWithOwnership(ParsedLifetimeDependenceKind kind,
-                                 ParamDecl *param,
+                                 Type paramType, ValueOwnership loweredOwnership,
                                  bool isInterfaceFile = false) const {
     if (kind == ParsedLifetimeDependenceKind::Inherit) {
       return true;
     }
-
-    auto paramType = param->getTypeInContext();
-    auto ownership = param->getValueOwnership();
-    auto loweredOwnership = ownership != ValueOwnership::Default
-                                ? ownership
-                                : getLoweredOwnership(param, afd);
 
     if (kind == ParsedLifetimeDependenceKind::Borrow) {
       // An owned/consumed BitwiseCopyable value can be effectively borrowed
@@ -755,16 +785,13 @@ protected:
 
   // Inferrence helper.
   bool isCompatibleWithOwnership(LifetimeDependenceKind kind,
-                                 ParamDecl *param) const {
+                                 Param const &param) const {
     if (kind == LifetimeDependenceKind::Inherit) {
       return true;
     }
 
-    auto paramType = param->getTypeInContext();
-    auto ownership = param->getValueOwnership();
-    auto loweredOwnership = ownership != ValueOwnership::Default
-                                ? ownership
-                                : getLoweredOwnership(param, afd);
+    auto paramType = functionDC->mapTypeIntoEnvironment(param.getPlainType());
+    auto loweredOwnership = getLoweredOwnership(param);
     // Lifetime dependence always propagates through temporary BitwiseCopyable
     // values, even if the dependence is scoped.
     if (isBitwiseCopyable(paramType, ctx)) {
@@ -775,38 +802,17 @@ protected:
            loweredOwnership == ValueOwnership::InOut;
   }
 
-  Type getResultOrYield() const {
-    if (auto *accessor = dyn_cast<AccessorDecl>(afd)) {
-      if (accessor->isCoroutine()) {
-        auto yieldTyInContext = accessor->mapTypeIntoEnvironment(
-          accessor->getStorage()->getValueInterfaceType());
-        return yieldTyInContext;
-      }
-    }
-    Type resultType;
-    if (auto fn = dyn_cast<FuncDecl>(afd)) {
-      resultType = fn->getResultInterfaceType();
-    } else {
-      auto ctor = cast<ConstructorDecl>(afd);
-      resultType = ctor->getResultInterfaceType();
-    }
-    return afd->mapTypeIntoEnvironment(resultType);
-  }
-
   // ==========================================================================
   // MARK: @_lifetime attribute semantics
   // ==========================================================================
 
   std::optional<LifetimeDependenceKind>
   getDependenceKindFromDescriptor(LifetimeDescriptor descriptor,
-                                  ParamDecl *paramDecl) {
-    auto loc = descriptor.getLoc();
-    auto type = paramDecl->getTypeInContext();
-    auto parsedLifetimeKind = descriptor.getParsedLifetimeDependenceKind();
-    auto ownership = paramDecl->getValueOwnership();
-    auto loweredOwnership = ownership != ValueOwnership::Default
-                                ? ownership
-                                : getLoweredOwnership(paramDecl, afd);
+                                  Param const &param) {
+    auto const loc = descriptor.getLoc();
+    auto const type = functionDC->mapTypeIntoEnvironment(param.getPlainType());
+    auto const parsedLifetimeKind = descriptor.getParsedLifetimeDependenceKind();
+    auto const loweredOwnership = getLoweredOwnership(param);
 
     switch (parsedLifetimeKind) {
     case ParsedLifetimeDependenceKind::Default: {
@@ -833,7 +839,7 @@ protected:
     case ParsedLifetimeDependenceKind::Inout: {
       // @lifetime(borrow x) is valid only for borrowing parameters.
       // @lifetime(&x) is valid only for inout parameters.
-      if (isCompatibleWithOwnership(parsedLifetimeKind, paramDecl,
+      if (isCompatibleWithOwnership(parsedLifetimeKind, type, loweredOwnership,
                                     isInterfaceFile())) {
         return LifetimeDependenceKind::Scope;
       }
@@ -880,38 +886,33 @@ protected:
     }
   }
 
-  // Finds the ParamDecl* and its index from a LifetimeDescriptor
-  std::optional<std::pair<ParamDecl *, unsigned>>
-  getParamDeclFromDescriptor(LifetimeDescriptor descriptor) {
+  // Finds the Param* and its index from a LifetimeDescriptor
+  std::optional<std::pair<Param const *, unsigned>>
+  getParamFromDescriptor(LifetimeDescriptor descriptor) {
     switch (descriptor.getDescriptorKind()) {
     case LifetimeDescriptor::DescriptorKind::Named: {
-      unsigned paramIndex = 0;
-      ParamDecl *candidateParam = nullptr;
-      for (auto *param : *afd->getParameters()) {
-        if (param->getParameterName() == descriptor.getName()) {
-          candidateParam = param;
-          break;
-        }
-        paramIndex++;
-      }
-      if (!candidateParam) {
+      auto const candidate = llvm::find_if(
+          parameters, [name = descriptor.getName()](auto const &param) {
+            return param.getInternalLabel() == name;
+          });
+
+      if (parameters.end() == candidate) {
         diagnose(descriptor.getLoc(),
                  diag::lifetime_dependence_invalid_param_name,
                  descriptor.getName());
         return std::nullopt;
       }
-      return std::make_pair(candidateParam, paramIndex);
+      return std::make_pair(candidate, candidate - parameters.begin());
     }
     case LifetimeDescriptor::DescriptorKind::Ordered: {
       auto paramIndex = descriptor.getIndex();
-      if (paramIndex >= afd->getParameters()->size()) {
+      if (paramIndex >= parameters.size()) {
         diagnose(descriptor.getLoc(),
                  diag::lifetime_dependence_invalid_param_index,
                  paramIndex);
         return std::nullopt;
       }
-      auto candidateParam = afd->getParameters()->get(paramIndex);
-      return std::make_pair(candidateParam, paramIndex);
+      return std::make_pair(&parameters[paramIndex], paramIndex);
     }
     case LifetimeDescriptor::DescriptorKind::Self: {
       if (!hasImplicitSelfParam()) {
@@ -919,53 +920,49 @@ protected:
                  diag::lifetime_dependence_invalid_self_in_static);
         return std::nullopt;
       }
-      if (isa<ConstructorDecl>(afd)) {
+      if (isInit) {
         diagnose(descriptor.getLoc(),
                  diag::lifetime_dependence_invalid_self_in_init);
         return std::nullopt;
       }
-      auto *selfDecl = afd->getImplicitSelfDecl();
-      return std::make_pair(selfDecl, afd->getParameters()->size());
+      return std::make_pair(&implicitSelfParam.value(), selfIndex);
     }
     }
   }
 
   // Initialize 'depBuilder' based on the function's @_lifetime attributes.
   void initializeAttributeDeps() {
-    auto lifetimeAttrs = afd->getAttrs().getAttributes<LifetimeAttr>();
-    for (auto attr : lifetimeAttrs) {
-      LifetimeEntry *entry = attr->getLifetimeEntry();
+    for (LifetimeEntry *entry : lifetimeEntries) {
       auto targetDescriptor = entry->getTargetDescriptor();
       unsigned targetIndex;
       if (targetDescriptor.has_value()) {
-        auto targetDeclAndIndex = getParamDeclFromDescriptor(*targetDescriptor);
-        if (!targetDeclAndIndex.has_value()) {
+        auto targetParamAndIndex = getParamFromDescriptor(*targetDescriptor);
+        if (!targetParamAndIndex.has_value()) {
           return;
         }
         // TODO: support dependencies on non-inout parameters.
-        if (!targetDeclAndIndex->first->isInOut()) {
-          diagnoseAttr(targetDeclAndIndex->first,
-                       diag::lifetime_parameter_requires_inout,
-                       targetDescriptor->getString());
+        auto *parameter = targetParamAndIndex->first;
+        targetIndex = targetParamAndIndex->second;
+        if (!parameter->isInOut()) {
+          ctx.Diags.diagnose(paramLocs[targetIndex],
+                             diag::lifetime_parameter_requires_inout,
+                             targetDescriptor->getString());
         }
-        if (isDiagnosedEscapable(
-                targetDeclAndIndex->first->getTypeInContext())) {
+        if (isDiagnosedEscapable(functionDC->mapTypeIntoEnvironment(
+                targetParamAndIndex->first->getPlainType()))) {
           diagnose(targetDescriptor->getLoc(),
                    diag::lifetime_target_requires_nonescapable, "target");
         }
-        targetIndex = targetDeclAndIndex->second;
       } else {
-        if (isDiagnosedEscapable(getResultOrYield())) {
+        if (isDiagnosedEscapable(resultTy)) {
           diagnose(entry->getLoc(), diag::lifetime_target_requires_nonescapable,
                    "result");
         }
-        targetIndex = afd->hasImplicitSelfDecl()
-                          ? afd->getParameters()->size() + 1
-                          : afd->getParameters()->size();
+        targetIndex = resultIndex;
       }
       TargetDeps *deps = depBuilder.createAnnotatedTargetDeps(targetIndex);
       if (deps == nullptr) {
-        diagnose(attr->getLocation(),
+        diagnose(entry->getLoc(),
                  diag::lifetime_dependence_duplicate_target);
         return;
       }
@@ -975,6 +972,30 @@ protected:
     }
   }
 
+  // Get the value ownership of param if it is non-default. Otherwise, compute
+  // the lowered value ownership. The supplied Param must be a member of
+  // parameters or implicitSelfParam.value().
+  ValueOwnership getLoweredOwnership(Param const &param) const {
+    auto const ownership = param.getValueOwnership();
+    if (ownership != ValueOwnership::Default)
+      return ownership;
+    if (isa<ConstructorDecl>(functionDC)) {
+      return ValueOwnership::Owned;
+    }
+    if (auto *ad = dyn_cast<AccessorDecl>(functionDC)) {
+      auto const isSelfParameter =
+          implicitSelfParam.has_value() && &param == &implicitSelfParam.value();
+      if (ad->getAccessorKind() == AccessorKind::Set) {
+        return isSelfParameter ? ValueOwnership::InOut : ValueOwnership::Owned;
+      }
+      if (isYieldingMutableAccessor(ad->getAccessorKind())) {
+        assert(isSelfParameter);
+        return ValueOwnership::InOut;
+      }
+    }
+    return ValueOwnership::Shared;
+  }
+
   // Initialize TargetDeps based on the function's @_lifetime attributes.
   void initializeDescriptorDeps(unsigned targetIndex,
                                 TargetDeps &deps,
@@ -982,47 +1003,49 @@ protected:
     if (source.isImmortal()) {
       // Record the immortal dependency even if it is invalid to suppress other diagnostics.
       deps.isImmortal = true;
-      auto immortalParam = std::find_if(
-          afd->getParameters()->begin(), afd->getParameters()->end(),
-          [](ParamDecl *param) {
-            return param->getName().nonempty()
-                   && strcmp(param->getName().get(), "immortal") == 0;
-          });
-      if (immortalParam != afd->getParameters()->end()) {
-        diagnoseAttr(*immortalParam,
-                     diag::lifetime_dependence_immortal_conflict_name);
+      auto immortalParam = llvm::find_if(parameters, [](Param const &param) {
+        return param.getInternalLabel().is("immortal");
+      });
+
+      unsigned immortalIndex = immortalParam - parameters.begin();
+      if (immortalParam != parameters.end()) {
+        ctx.Diags.diagnose(paramLocs[immortalIndex],
+                           diag::lifetime_dependence_immortal_conflict_name);
         return;
       }
       if (deps.inheritIndices.any() || deps.scopeIndices.any()) {
-        diagnoseAttr(*immortalParam, diag::lifetime_dependence_immortal_alone);
+        ctx.Diags.diagnose(paramLocs[immortalIndex],
+                           diag::lifetime_dependence_immortal_alone);
       }
       return;
     }
 
-    auto paramDeclAndIndex = getParamDeclFromDescriptor(source);
-    if (!paramDeclAndIndex.has_value()) {
+    auto paramAndIndex = getParamFromDescriptor(source);
+    if (!paramAndIndex.has_value()) {
       return;
     }
-    auto *param = paramDeclAndIndex->first;
-    unsigned sourceIndex = paramDeclAndIndex->second;
-    auto lifetimeKind = getDependenceKindFromDescriptor(source, param);
+    auto *param = paramAndIndex->first;
+    unsigned sourceIndex = paramAndIndex->second;
+    auto lifetimeKind =
+        getDependenceKindFromDescriptor(source, *param);
     if (!lifetimeKind.has_value()) {
       return;
     }
-    if (lifetimeKind == LifetimeDependenceKind::Scope && param->isInOut()
-        && sourceIndex == targetIndex) {
+    if (lifetimeKind == LifetimeDependenceKind::Scope &&
+        param->isInOut() && sourceIndex == targetIndex) {
       diagnose(source.getLoc(),
                diag::lifetime_dependence_cannot_use_parsed_borrow_inout);
       ctx.Diags.diagnose(source.getLoc(),
                          diag::lifetime_dependence_cannot_infer_inout_suggest,
-                         param->getName().str());
+                         param->getInternalLabel().str());
 
       return;
     }
     addDescriptorIndices(deps, source, sourceIndex, *lifetimeKind);
   }
 
-  void addDescriptorIndices(TargetDeps &deps, LifetimeDescriptor descriptor,
+  void addDescriptorIndices(LifetimeDependenceBuilder::TargetDeps &deps,
+                            LifetimeDescriptor descriptor,
                             unsigned paramIndexToSet,
                             LifetimeDependenceKind lifetimeKind) {
     if (deps.isImmortal) {
@@ -1050,9 +1073,8 @@ protected:
   // Infer the kind of dependence that makes sense for reading or writing a
   // stored property (for getters or initializers).
   std::optional<LifetimeDependenceKind>
-  inferLifetimeDependenceKind(ParamDecl *param) {
-    Type paramType = param->getTypeInContext();
-    ValueOwnership ownership = param->getValueOwnership();
+  inferLifetimeDependenceKind(Param const &param) {
+    Type paramType = functionDC->mapTypeIntoEnvironment(param.getPlainType());
     if (!paramType->isEscapable()) {
       return LifetimeDependenceKind::Inherit;
     }
@@ -1061,9 +1083,7 @@ protected:
     if (isBitwiseCopyable(paramType, ctx)) {
       return LifetimeDependenceKind::Scope;
     }
-    auto loweredOwnership = ownership != ValueOwnership::Default
-                                ? ownership
-                                : getLoweredOwnership(param, afd);
+    auto loweredOwnership = getLoweredOwnership(param);
     // It is impossible to depend on a consumed Escapable value (unless it is
     // BitwiseCopyable as checked above).
     if (loweredOwnership == ValueOwnership::Owned) {
@@ -1076,17 +1096,17 @@ protected:
   // 'performedDiagnostics' indicates whether any specific diagnostics were
   // issued.
   void inferOrDiagnose() {
-    if (auto accessor = dyn_cast<AccessorDecl>(afd)) {
+    if (auto accessor = dyn_cast<AccessorDecl>(functionDC)) {
       inferAccessor(accessor);
       // Aside from the special cases handled above, accessors are considered
       // regular methods...
     }
 
     // Infer non-Escapable results.
-    if (isDiagnosedNonEscapable(getResultOrYield())) {
+    if (isDiagnosedNonEscapable(resultTy)) {
       inferNonEscapableResultOnSameTypeParam();
 
-      if (isInit() && isImplicitOrSIL()) {
+      if (isInit && isImplicitOrSIL()) {
         inferImplicitInit();
       } else if (hasImplicitSelfParam()) {
         // Methods that return a non-Escapable value - single parameter
@@ -1111,7 +1131,7 @@ protected:
   // type.
   void inferNonEscapableResultOnSameTypeParam() {
     // The function declaration's substituted result type.
-    CanType resultTy = getResultOrYield()->getCanonicalType();
+    CanType canResultTy = resultTy->getCanonicalType();
 
     TargetDeps *targetDeps = depBuilder.getInferredTargetDeps(resultIndex);
     if (!targetDeps)
@@ -1119,27 +1139,26 @@ protected:
 
     // Ignore mutating self. An 'inout' modifier effectively makes the parameter
     // a different type for lifetime inference.
-    if (hasImplicitSelfParam() && !afd->getImplicitSelfDecl()->isInOut()) {
-      Type selfTy = afd->mapTypeIntoEnvironment(dc->getSelfInterfaceType());
-      if (selfTy->getCanonicalType() == resultTy) {
+    if (hasImplicitSelfParam() && !implicitSelfParam->isInOut()) {
+      if (selfTypeInContext->getCanonicalType() == canResultTy) {
         targetDeps->inheritIndices.set(selfIndex);
       }
     }
 
     unsigned paramIndex = 0;
-    for (auto *param : *afd->getParameters()) {
+    for (auto const &param : parameters) {
       SWIFT_DEFER { paramIndex++; };
 
       // Ignore 'inout' parameters. An 'inout' modifier effectively makes the
       // parameter a different type for lifetime inference. An 'inout' parameter
       // defaults to being the source and target of a self-dependency, as
       // covered by the 'inout' rule.
-      if (param->isInOut())
+      if (param.isInOut())
         continue;
 
-      CanType paramTy = afd->mapTypeIntoEnvironment(
-        param->getInterfaceType())->getCanonicalType();
-      if (paramTy != resultTy)
+      CanType paramTy = functionDC->mapTypeIntoEnvironment(param.getPlainType())
+                            ->getCanonicalType();
+      if (paramTy != canResultTy)
         continue;
 
       targetDeps->inheritIndices.set(paramIndex);
@@ -1155,7 +1174,7 @@ protected:
       // global accessors have no 'self'.
       return;
     }
-    bool nonEscapableSelf = isDiagnosedNonEscapable(dc->getSelfTypeInContext());
+    bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
     if (nonEscapableSelf && accessor->getImplicitSelfDecl()->isInOut()) {
       // First, infer the dependency of the inout non-Escapable 'self'. This may
       // result in two inferred dependencies for accessors (one targetting
@@ -1192,9 +1211,9 @@ protected:
       break;
     case AccessorKind::Set: {
       const unsigned newValIdx = 0;
-      auto *param = afd->getParameters()->get(newValIdx);
+      auto const &param = parameters[newValIdx];
       Type paramTypeInContext =
-        afd->mapTypeIntoEnvironment(param->getInterfaceType());
+          functionDC->mapTypeIntoEnvironment(param.getPlainType());
       if (paramTypeInContext->hasError()) {
         return;
       }
@@ -1232,7 +1251,7 @@ protected:
   // error.
   std::optional<LifetimeDependenceKind>
   getImplicitAccessorResultDependence(AccessorDecl *accessor) {
-    if (!isDiagnosedNonEscapable(getResultOrYield()))
+    if (!isDiagnosedNonEscapable(resultTy))
       return std::nullopt;
 
     std::optional<AccessorKind> wrappedAccessorKind = std::nullopt;
@@ -1274,7 +1293,7 @@ protected:
     }
     // Either a Get or Modify without any wrapped accessor. Handle these like a
     // read of the stored property.
-    return inferLifetimeDependenceKind(accessor->getImplicitSelfDecl());
+    return inferLifetimeDependenceKind(*implicitSelfParam);
   }
 
   // Infer implicit initialization. A non-Escapable initializer parameter can
@@ -1285,7 +1304,7 @@ protected:
   // that are unrelated to lifetime. Avoid inferring any dependency on Escapable
   // parameters unless it is the (unambiguously borrowed) sole parameter.
   void inferImplicitInit() {
-    if (afd->getParameters()->size() == 0) {
+    if (parameters.size() == 0) {
       // Empty ~Escapable types can be implicitly initialized without any
       // dependencies. In SIL, implicit initializers become explicit. Set
       // performedDiagnostics here to bypass normal dependence checking without
@@ -1301,10 +1320,10 @@ protected:
       return; // same-type inferrence applied; don't issue diagnostics.
 
     unsigned paramIndex = 0;
-    for (auto *param : *afd->getParameters()) {
+    for (auto const &param : parameters) {
       SWIFT_DEFER { paramIndex++; };
       Type paramTypeInContext =
-        afd->mapTypeIntoEnvironment(param->getInterfaceType());
+          functionDC->mapTypeIntoEnvironment(param.getPlainType());
       if (paramTypeInContext->hasError()) {
         return;
       }
@@ -1314,8 +1333,8 @@ protected:
         resultDeps->addIfNew(paramIndex, LifetimeDependenceKind::Inherit);
         continue;
       }
-      if (afd->getParameters()->size() > 1 && !useLazyInference()) {
-        diagnose(param->getLoc(),
+      if (parameters.size() > 1 && !useLazyInference()) {
+        diagnose(paramLocs[paramIndex],
                  diag::lifetime_dependence_cannot_infer_implicit_init);
         return;
       }
@@ -1324,7 +1343,7 @@ protected:
       if (!kind) {
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_scope_ownership,
-                 param->getParameterName().str(), diagnosticQualifier());
+                 param.getInternalLabel().str(), diagnosticQualifier());
       }
       resultDeps->addIfNew(paramIndex, LifetimeDependenceKind::Scope);
     }
@@ -1341,26 +1360,25 @@ protected:
     if (!resultDeps->empty())
       return; // same-type inferrence applied; don't issue diagnostics.
 
-    bool nonEscapableSelf = isDiagnosedNonEscapable(dc->getSelfTypeInContext());
+    bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
     // Do not infer the result's dependence when the method is mutating and
     // 'self' is non-Escapable. Independently, a missing dependence on inout
     // 'self' will be diagnosed. Since an explicit annotation will be needed for
     // 'self', we also require the method's result to have an explicit
     // annotation.
-    if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
+    if (nonEscapableSelf && implicitSelfParam->isInOut()) {
       return;
     }
     // Methods with parameters only apply to lazy inference. This does not
     // include accessors because a subscript's index is assumed not to be the
     // source of the result's dependency.
-    if (!isa<AccessorDecl>(afd) && !useLazyInference()
-        && afd->getParameters()->size() > 0) {
+    if (!isa<AccessorDecl>(functionDC) && !useLazyInference() &&
+        parameters.size() > 0) {
       return;
     }
     if (!useLazyInference() && !isImplicitOrSIL()) {
       // Require explicit @_lifetime(borrow self) for UnsafePointer-like self.
-      if (!nonEscapableSelf
-          && isBitwiseCopyable(dc->getSelfTypeInContext(), ctx)) {
+      if (!nonEscapableSelf && isBitwiseCopyable(selfTypeInContext, ctx)) {
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_bitwisecopyable,
                  diagnosticQualifier(), "self");
@@ -1375,7 +1393,7 @@ protected:
     }
     // Infer based on ownership if possible for either explicit accessors or
     // methods as long as they pass preceding ambiguity checks.
-    auto kind = inferLifetimeDependenceKind(afd->getImplicitSelfDecl());
+    auto kind = inferLifetimeDependenceKind(*implicitSelfParam);
     if (!kind) {
       // Special diagnostic for an attempt to depend on a consuming parameter.
       diagnose(returnLoc,
@@ -1412,7 +1430,7 @@ protected:
 
     // Strict inference only handles a single escapable parameter,
     // which is an unambiguous borrow dependence.
-    if (afd->getParameters()->size() == 0) {
+    if (parameters.size() == 0) {
       diagnose(returnLoc,
                diag::lifetime_dependence_cannot_infer_return_no_param,
                diagnosticQualifier());
@@ -1420,27 +1438,27 @@ protected:
                diag::lifetime_dependence_cannot_infer_return_immortal);
       return;
     }
-    if (afd->getParameters()->size() > 1) {
+    if (parameters.size() > 1) {
       // The usual diagnostic check is sufficient.
       return;
     }
     // Do not infer non-escapable dependence kind -- it is ambiguous.
-    auto *param = afd->getParameters()->get(0);
+    auto const &param = parameters[0];
     Type paramTypeInContext =
-      afd->mapTypeIntoEnvironment(param->getInterfaceType());
+        functionDC->mapTypeIntoEnvironment(param.getPlainType());
     if (paramTypeInContext->hasError()) {
       return;
     }
     if (!paramTypeInContext->isEscapable()) {
       diagnose(returnLoc, diag::lifetime_dependence_cannot_infer_kind,
-               diagnosticQualifier(), param->getParameterName().str());
+               diagnosticQualifier(), param.getInternalLabel().str());
       return;
     }
     auto kind = LifetimeDependenceKind::Scope;
     if (!isCompatibleWithOwnership(kind, param)) {
       diagnose(returnLoc,
                diag::lifetime_dependence_cannot_infer_scope_ownership,
-               param->getParameterName().str(), diagnosticQualifier());
+               param.getInternalLabel().str(), diagnosticQualifier());
       return;
     }
     resultDeps->addIfNew(/*paramIndex*/ 0, kind);
@@ -1456,14 +1474,14 @@ protected:
     std::optional<unsigned> candidateParamIndex;
     std::optional<LifetimeDependenceKind> candidateLifetimeKind;
     unsigned paramIndex = 0;
-    for (auto *param : *afd->getParameters()) {
+    for (auto const &param : parameters) {
       SWIFT_DEFER { paramIndex++; };
       Type paramTypeInContext =
-        afd->mapTypeIntoEnvironment(param->getInterfaceType());
+          functionDC->mapTypeIntoEnvironment(param.getPlainType());
       if (paramTypeInContext->hasError()) {
         return;
       }
-      auto paramOwnership = param->getValueOwnership();
+      auto paramOwnership = param.getValueOwnership();
       if (paramTypeInContext->isEscapable()) {
         if (isBitwiseCopyable(paramTypeInContext, ctx)) {
           continue;
@@ -1500,12 +1518,11 @@ protected:
     if (!hasImplicitSelfParam())
       return;
 
-    if (!isDiagnosedNonEscapable(dc->getSelfTypeInContext()))
+    if (!isDiagnosedNonEscapable(selfTypeInContext))
       return;
 
-    assert(!isInit() && "class initializers have Escapable self");
-    auto *selfDecl = afd->getImplicitSelfDecl();
-    if (!selfDecl->isInOut())
+    assert(!isInit && "class initializers have Escapable self");
+    if (!implicitSelfParam->isInOut())
       return;
 
     // Assume that a mutating method does not depend on its parameters.
@@ -1543,13 +1560,13 @@ protected:
   // Do not issue any diagnostics. This inference is triggered even when the
   // feature is disabled!
   void inferInoutParams() {
-    for (unsigned paramIndex : range(afd->getParameters()->size())) {
-      auto *param = afd->getParameters()->get(paramIndex);
+    for (unsigned paramIndex : range(parameters.size())) {
+      auto const &param = parameters[paramIndex];
       if (!isDiagnosedNonEscapable(
-              afd->mapTypeIntoEnvironment(param->getInterfaceType()))) {
+              functionDC->mapTypeIntoEnvironment(param.getPlainType()))) {
         continue;
       }
-      if (!param->isInOut())
+      if (!param.isInOut())
         continue;
 
       depBuilder.inferInoutDependency(paramIndex);
@@ -1557,22 +1574,25 @@ protected:
   }
 
   void inferUnambiguousInoutParams() {
-    if (afd->getParameters()->size() != 1) {
+    if (parameters.size() != 1) {
       return;
     }
     const unsigned paramIndex = 0;
-    auto *param = afd->getParameters()->get(paramIndex);
-    if (!param->isInOut()) {
+    auto const &param = parameters[paramIndex];
+    if (!param.isInOut()) {
       return;
     }
     if (!isDiagnosedNonEscapable(
-          afd->mapTypeIntoEnvironment(param->getInterfaceType()))) {
+            functionDC->mapTypeIntoEnvironment(param.getPlainType()))) {
       return;
     }
     depBuilder.inferInoutDependency(paramIndex);
   }
 
   void inferBuiltin() {
+    assert(isa<AbstractFunctionDecl>(functionDC));
+    auto *afd = cast<AbstractFunctionDecl>(functionDC);
+
     // Normal inout parameter inference works for most generic Builtins.
     inferUnambiguousInoutParams();
 

--- a/validation-test/compiler_crashers_fixed/TypeBase-getContextSubstitutions-622ea0.swift
+++ b/validation-test/compiler_crashers_fixed/TypeBase-getContextSubstitutions-622ea0.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*)","signatureAssert":"Assertion failed: (0 && \"Bad base type\"), function getContextSubstitutions"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a< b {
   @propertyWrapper struct e {
     var wrappedValue

--- a/validation-test/compiler_crashers_fixed/getLoc-84d2d3.swift
+++ b/validation-test/compiler_crashers_fixed/getLoc-84d2d3.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::getLoc(swift::ASTNode)","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a {
   wrappedValue : b var projectedValue init(projectedValue c) {
     func d(@a Int) d


### PR DESCRIPTION
This provides a basis for extending LifetimeDependence to work with closures and function types (see #85414).

As much information as possible is extracted from the AbstractFunctionDecl in the constructor, so most of the business logic of the pass can be reused.

Parameters are converted to `AnyFunctionType::Param` because `AnyFunctionType::Param` is used for function type parameters and `ParamDecl` can be converted to it but not vice versa.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
