### PR TITLE
IRGen: Fix yet another typed throws crash [6.3]

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6689,7 +6689,7 @@ void irgen::emitAsyncReturn(
 void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,
                             SILType funcResultTypeInContext,
                             CanSILFunctionType fnType, Explosion &result,
-                            Explosion &error) {
+                            Explosion &error, SILType funcErrorTypeInContext) {
   assert((fnType->hasErrorResult() && !error.empty()) ||
          (!fnType->hasErrorResult() && error.empty()));
 
@@ -6705,8 +6705,7 @@ void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,
   if (fnType->hasErrorResult() && !conv.hasIndirectSILResults() &&
       !conv.hasIndirectSILErrorResults() && !nativeSchema.requiresIndirect() &&
       conv.isTypedError()) {
-    auto errorType = conv.getSILErrorType(IGM.getMaximalTypeExpansionContext());
-    auto &errorTI = IGM.getTypeInfo(errorType);
+    auto &errorTI = IGM.getTypeInfo(funcErrorTypeInContext);
     auto &nativeError = errorTI.nativeReturnValueSchema(IGM);
     if (!nativeError.shouldReturnTypedErrorIndirectly()) {
       assert(!error.empty() && "Direct error return must have error value");

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -276,7 +276,8 @@ namespace irgen {
   void emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &layout,
                        SILType funcResultTypeInContext,
                        CanSILFunctionType fnType, Explosion &result,
-                       Explosion &error);
+                       Explosion &error,
+                       SILType funcErrorTypeInContext);
   void emitYieldOnceCoroutineResult(IRGenFunction &IGF, Explosion &result,
                                     SILType funcResultType, SILType returnResultType);
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -698,7 +698,7 @@ void DistributedAccessor::emitReturn(llvm::Value *errorValue) {
   error.add(errorValue);
 
   emitAsyncReturn(IGF, AsyncLayout, getResultType(), AccessorType, voidResult,
-                  error);
+                  error, getErrorType());
 }
 
 void DistributedAccessor::emit() {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1084,7 +1084,10 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     auto resultType = callee.getOrigFunctionType()->getDirectFormalResultsType(
         IGM.getSILModule(), IGM.getMaximalTypeExpansionContext());
     subIGF.emitScalarReturn(resultType, resultType, result,
-                            true /*isSwiftCCReturn*/, false);
+                            /*isSwiftCCReturn=*/true,
+                            /*isOutlined=*/false,
+                            /*mayPeepholeLoad=*/false,
+                            /*errorType=*/SILType());
   }
   
   return fwd;

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -539,10 +539,13 @@ void IRGenThunk::emit() {
   } else {
     if (isAsync) {
       Explosion error;
-      if (errorValue)
+      SILType directErrorType;
+      if (errorValue) {
         error.add(errorValue);
+        directErrorType = conv.getSILErrorType(expansionContext);
+      }
       emitAsyncReturn(IGF, *asyncLayout, directResultType, origTy, result,
-                      error);
+                      error, directErrorType);
       return;
     }
   }
@@ -562,7 +565,9 @@ void IRGenThunk::emit() {
   resultTy = resultTy.subst(IGF.getSILModule(), subMap);
   IGF.emitScalarReturn(resultTy, resultTy, result,
                        /*swiftCCReturn=*/false,
-                       /*isOutlined=*/false);
+                       /*isOutlined=*/false,
+                       /*mayPeepholeLoad=*/false,
+                       /*errorType=*/SILType());
 }
 
 void IRGenModule::emitDispatchThunk(SILDeclRef declRef) {

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -103,7 +103,9 @@ public:
 
   friend class Scope;
 
-  Address createErrorResultSlot(SILType errorType, bool isAsync, bool setSwiftErrorFlag = true, bool isTypedError = false);
+  Address createErrorResultSlot(SILType errorType, bool isAsync,
+                                bool setSwiftErrorFlag = true,
+                                bool isTypedError = false);
 
   //--- Function prologue and epilogue
   //-------------------------------------------
@@ -111,8 +113,8 @@ public:
   Explosion collectParameters();
   void emitScalarReturn(SILType returnResultType, SILType funcResultType,
                         Explosion &scalars, bool isSwiftCCReturn,
-                        bool isOutlined, bool mayPeepholeLoad = false,
-                        SILType errorType = {});
+                        bool isOutlined, bool mayPeepholeLoad,
+                        SILType errorType);
   void emitScalarReturn(llvm::Type *resultTy, Explosion &scalars);
   
   void emitBBForReturn();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4535,6 +4535,13 @@ static void emitReturnInst(IRGenSILFunction &IGF,
   auto funcResultType = IGF.CurSILFn->mapTypeIntoEnvironment(
       conv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext()));
 
+  SILType funcErrorType;
+  if (fnType->hasErrorResult() && conv.isTypedError() &&
+      !conv.hasIndirectSILResults() && !conv.hasIndirectSILErrorResults()) {
+    funcErrorType = IGF.CurSILFn->mapTypeIntoEnvironment(
+        conv.getSILErrorType(IGF.IGM.getMaximalTypeExpansionContext()));
+  }
+
   if (IGF.isAsync()) {
     // If we're generating an async function, store the result into the buffer.
     auto asyncLayout = getAsyncContextLayout(IGF);
@@ -4543,20 +4550,15 @@ static void emitReturnInst(IRGenSILFunction &IGF,
       error.add(getNullErrorValue());
     }
 
-    emitAsyncReturn(IGF, asyncLayout, funcResultType, fnType, result, error);
+    emitAsyncReturn(IGF, asyncLayout, funcResultType,
+                    fnType, result, error, funcErrorType);
   } else {
     auto funcLang = IGF.CurSILFn->getLoweredFunctionType()->getLanguage();
     auto swiftCCReturn = funcLang == SILFunctionLanguage::Swift;
     assert(swiftCCReturn ||
            funcLang == SILFunctionLanguage::C && "Need to handle all cases");
-    SILType errorType;
-    if (fnType->hasErrorResult() && conv.isTypedError() &&
-        !conv.hasIndirectSILResults() && !conv.hasIndirectSILErrorResults()) {
-      errorType = IGF.CurSILFn->mapTypeIntoEnvironment(
-          conv.getSILErrorType(IGF.IGM.getMaximalTypeExpansionContext()));
-    }
-    IGF.emitScalarReturn(resultTy, funcResultType, result, swiftCCReturn, false,
-                         mayPeepholeLoad, errorType);
+    IGF.emitScalarReturn(resultTy, funcResultType, result, swiftCCReturn,
+                         /*isOutlined=*/false, mayPeepholeLoad, funcErrorType);
   }
 }
 
@@ -4673,15 +4675,14 @@ void IRGenSILFunction::visitThrowInst(swift::ThrowInst *i) {
     auto layout = getAsyncContextLayout(*this);
     auto funcResultType = CurSILFn->mapTypeIntoEnvironment(
         conv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
+    SILType funcErrorType;
 
     if (conv.isTypedError()) {
-      auto silErrorTy = CurSILFn->mapTypeIntoEnvironment(
+      funcErrorType = CurSILFn->mapTypeIntoEnvironment(
           conv.getSILErrorType(IGM.getMaximalTypeExpansionContext()));
-      auto &errorTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(silErrorTy));
+      auto &errorTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(funcErrorType));
 
-      auto silResultTy = CurSILFn->mapTypeIntoEnvironment(
-          conv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
-      auto &resultTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(silResultTy));
+      auto &resultTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(funcResultType));
       auto &resultSchema = resultTI.nativeReturnValueSchema(IGM);
       auto &errorSchema = errorTI.nativeReturnValueSchema(IGM);
 
@@ -4696,7 +4697,7 @@ void IRGenSILFunction::visitThrowInst(swift::ThrowInst *i) {
         Explosion nativeAgg;
         auto combined =
             combineResultAndTypedErrorType(IGM, resultSchema, errorSchema);
-        buildDirectError(*this, combined, errorSchema, silErrorTy, exn,
+        buildDirectError(*this, combined, errorSchema, funcErrorType, exn,
                          /*forAsync*/ true, nativeAgg);
         assert(exn.empty() && "Unclaimed typed error results");
 
@@ -4720,7 +4721,8 @@ void IRGenSILFunction::visitThrowInst(swift::ThrowInst *i) {
 
     Explosion empty;
     emitAsyncReturn(*this, layout, funcResultType,
-                    i->getFunction()->getLoweredFunctionType(), empty, exn);
+                    i->getFunction()->getLoweredFunctionType(), empty,
+                    exn, funcErrorType);
   }
 }
 
@@ -4749,6 +4751,8 @@ void IRGenSILFunction::visitThrowAddrInst(swift::ThrowAddrInst *i) {
     auto layout = getAsyncContextLayout(*this);
     auto funcResultType = CurSILFn->mapTypeIntoEnvironment(
         conv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
+    auto funcErrorType = CurSILFn->mapTypeIntoEnvironment(
+        conv.getSILErrorType(IGM.getMaximalTypeExpansionContext()));
 
     llvm::Constant *flag = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
     flag = llvm::ConstantExpr::getIntToPtr(flag, IGM.Int8PtrTy);
@@ -4758,7 +4762,8 @@ void IRGenSILFunction::visitThrowAddrInst(swift::ThrowAddrInst *i) {
 
     Explosion empty;
     emitAsyncReturn(*this, layout, funcResultType,
-                    i->getFunction()->getLoweredFunctionType(), empty, exn);
+                    i->getFunction()->getLoweredFunctionType(), empty,
+                    exn, funcErrorType);
   }
 }
 

--- a/test/IRGen/typed_throws_generic.swift
+++ b/test/IRGen/typed_throws_generic.swift
@@ -1,9 +1,10 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-irgen
+// RUN: %target-swift-frontend -primary-file %s -emit-irgen -enable-library-evolution
 
 // https://github.com/swiftlang/swift/issues/80020
 //
 // We used to assert if you had a loadable return type that contained
-// a generic parameter.
+// a generic parameter, and typed throws.
 
 public enum MyError: Error {
   case error
@@ -11,10 +12,60 @@ public enum MyError: Error {
 
 public struct G<T> {}  // Note: G<T> is loadable
 
-public func f<T>(t: T) throws(MyError) -> G<T> {
-  return G<T>()
+public func loadableReturnType<T>(_ b: Bool, _ t: T) throws(MyError) -> G<T> {
+   if b {
+    throw MyError.error
+  } else {
+    return G<T>()
+  }
 }
 
-public func g<U>(u: U?) throws(MyError) -> G<U?> {
-  return try f(t: u)
+public func loadableReturnType2<U>(_ b: Bool, _ u: U?) throws(MyError) -> G<U?> {
+  if b {
+    throw MyError.error
+  } else {
+    return try loadableReturnType(b, u)
+  }
+}
+
+// https://github.com/swiftlang/swift/issues/74289
+public struct LoadableGenericError<E>: Error {
+  struct Nested: Error {}
+}
+
+func throwsLoadableGeneric1<E>(_ b: Bool, _: E) throws(LoadableGenericError<E>) {
+  if b {
+    throw LoadableGenericError<E>()
+  }
+}
+
+func throwsLoadableGeneric2<E>(_ b: Bool, _: E) throws(LoadableGenericError<E>.Nested) {
+  if b {
+    throw LoadableGenericError<E>.Nested()
+  }
+}
+
+// https://github.com/swiftlang/swift/issues/86347
+func asyncThrowsLoadableGeneric1<E>(_ b: Bool, _: E) async throws(LoadableGenericError<E>) {
+  if b {
+    throw LoadableGenericError<E>()
+  }
+}
+
+func asyncThrowsLoadableGeneric2<E>(_ b: Bool, _: E) async throws(LoadableGenericError<E>.Nested) {
+  if b {
+    throw LoadableGenericError<E>.Nested()
+  }
+}
+
+// Make sure we do the right thing in dispatch thunks, too
+
+public class ClassTest {
+  public func throwsLoadableGeneric1<E>(_ b: Bool, _: E) throws(LoadableGenericError<E>) {}
+  public func asyncThrowsLoadableGeneric<E>(_ b: Bool, _: E) async throws(LoadableGenericError<E>) {}
+}
+
+public protocol ProtocolTest {
+  func throwsLoadableGeneric<E>(_ b: Bool, _: E) throws(LoadableGenericError<E>)
+  func asyncThrowsLoadableGeneric<E>(_ b: Bool, _: E) async throws(LoadableGenericError<E>)
 }

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -389,8 +389,17 @@ extension ReducedError where T == MyError {
 }
 
 // https://github.com/swiftlang/swift/issues/74289
-struct LoadableGeneric<E>: Error {}
+struct LoadableGenericError<E>: Error {}
 
-func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {
-  throw LoadableGeneric<E>()
+func throwsLoadableGeneric<E>(_ b: Bool, _: E) throws(LoadableGenericError<E>) {
+  if b {
+    throw LoadableGenericError<E>()
+  }
+}
+
+// https://github.com/swiftlang/swift/issues/86347
+func asyncThrowsLoadableGeneric<E>(_ b: Bool, _: E) async throws(LoadableGenericError<E>) {
+  if b {
+    throw LoadableGenericError<E>()
+  }
 }


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86387.

* **Description:** Fix a crash if an async function throws a loadable generic type.

* **Origination:** Never worked.

* **Issue:** https://github.com/swiftlang/swift/issues/86347.

* **Risk:** Low, I had to do some plumbing to pass the right type down, like we already do for the result type, because there is no enough information inside `emitAsyncReturn()` to handle a generic type, but the change is pretty mechanical.

* **Reviewed by:** @rjmccall