### PR TITLE
[DependencyScanner] Fix non-deterministic failures

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -30,10 +30,9 @@
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringSet.h"
-#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Mutex.h"
+#include "llvm/Support/StringSaver.h"
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -1036,6 +1035,12 @@ using BridgeClangDependencyCallback = llvm::function_ref<ModuleDependencyInfo(
 /// A carrier of state shared among possibly multiple invocations of the
 /// dependency scanner.
 class SwiftDependencyScanningService {
+  /// BumpPtrAllocator for data matching the life-time of ScanningService.
+  llvm::BumpPtrAllocator Alloc;
+
+  /// StringSaver for data matching the life-time of ScanningService.
+  llvm::StringSaver Saver;
+
   /// The CASOption created the Scanning Service if used.
   std::optional<clang::CASOptions> CASOpts;
 
@@ -1056,6 +1061,9 @@ public:
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
+
+  /// Allocate string inside ScanningService.
+  StringRef save(StringRef str);
 
 private:
   /// Enforce clients not being allowed to query this cache directly, it must be

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -148,6 +148,17 @@ typedef llvm::PointerUnion<const clang::Decl *, const clang::MacroInfo *,
                            const clang::Type *, const clang::Token *>
     ImportDiagnosticTarget;
 
+/// Addition file mapping information for ClangImporter.
+struct ClangInvocationFileMapping {
+  /// Mapping from a file name to an existing file path.
+  SmallVector<std::pair<std::string, std::string>, 2> redirectedFiles;
+
+  /// MemoryBuffer for files to be overriden.
+  SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 2> overridenFiles;
+
+  bool requiresBuiltinHeadersInSystemModules = false;
+};
+
 /// Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
 class ClangImporter final : public ClangModuleLoader {
@@ -166,7 +177,7 @@ public:
 private:
   Implementation &Impl;
 
-  bool requiresBuiltinHeadersInSystemModules = false;
+  ClangInvocationFileMapping clangFileMapping;
 
   ClangImporter(ASTContext &ctx, DependencyTracker *tracker,
                 DWARFImporterDelegate *dwarfImporterDelegate);
@@ -204,6 +215,17 @@ public:
          DependencyTracker *tracker = nullptr,
          DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
          bool ignoreFileMapping = false);
+
+  static std::string getClangSystemOverlayFile(const SearchPathOptions &Opts);
+
+  /// Compute the file system used by the ClangImporter from
+  /// ClangInvocationFileMapping.
+  static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+  computeClangImporterFileSystem(
+      const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
+      bool suppressDiagnostics = false,
+      llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
 
   std::vector<std::string>
   getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget = false);
@@ -536,6 +558,11 @@ public:
   clang::CodeGenOptions &getCodeGenOpts() const;
 
   std::string getClangModuleHash() const;
+
+  /// Get clang file mapping.
+  const ClangInvocationFileMapping &getClangFileMapping() const {
+    return clangFileMapping;
+  }
 
   /// Get clang import creation cc1 args for swift explicit module build.
   std::vector<std::string> getSwiftExplicitModuleDirectCC1Args() const;
@@ -890,36 +917,6 @@ std::optional<ResultConvention>
 getCxxRefConventionWithAttrs(const clang::Decl *decl);
 } // namespace importer
 
-struct ClangInvocationFileMapping {
-  /// Mapping from a file name to an existing file path.
-  SmallVector<std::pair<std::string, std::string>, 2> redirectedFiles;
-
-  /// Mapping from a file name to a string of characters that represents the
-  /// contents of the file.
-  SmallVector<std::pair<std::string, std::string>, 1> overridenFiles;
-
-  bool requiresBuiltinHeadersInSystemModules;
-};
-
-class ClangInvocationFileMappingContext {
-public:
-  const LangOptions &LangOpts;
-  SearchPathOptions &SearchPathOpts;
-  ClangImporterOptions &ClangImporterOpts;
-  const CASOptions &CASOpts;
-  DiagnosticEngine &Diags;
-
-  ClangInvocationFileMappingContext(
-    const LangOptions &LangOpts, SearchPathOptions &SearchPathOpts,
-    ClangImporterOptions &ClangImporterOpts, const CASOptions &CASOpts,
-    DiagnosticEngine &Diags)
-    : LangOpts(LangOpts), SearchPathOpts(SearchPathOpts),
-      ClangImporterOpts(ClangImporterOpts), CASOpts(CASOpts),
-      Diags(Diags) {}
-
-  ClangInvocationFileMappingContext(const swift::ASTContext &Ctx);
-};
-
 /// On Linux, some platform libraries (glibc, libstdc++) are not modularized.
 /// We inject modulemaps for those libraries into their include directories
 /// to allow using them from Swift.
@@ -927,18 +924,9 @@ public:
 /// `suppressDiagnostic` prevents us from emitting warning messages when we
 /// are unable to find headers.
 ClangInvocationFileMapping getClangInvocationFileMapping(
-    const ClangInvocationFileMappingContext &ctx,
+    const ASTContext &ctx,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr,
     bool suppressDiagnostic = false);
-
-/// Apply the given file mapping to the specified 'fileSystem', used
-/// primarily to inject modulemaps on platforms with non-modularized
-/// platform libraries.
-ClangInvocationFileMapping applyClangInvocationMapping(
-    const ClangInvocationFileMappingContext &ctx,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseVFS,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &fileSystem,
-    bool suppressDiagnostics = false);
 
 /// Information used to compute the access level of inherited C++ members.
 class ClangInheritanceInfo {

--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -21,7 +21,6 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/StringSaver.h"
 
 namespace swift {
 namespace dependencies {
@@ -146,8 +145,6 @@ private:
 
   /// Shared state mutual-exclusivity lock
   llvm::sys::SmartMutex<true> DependencyScanningToolStateLock;
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver;
 };
 
 swiftscan_diagnostic_set_t *mapCollectedDiagnosticsForOutput(

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -514,7 +514,8 @@ void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
   }
 }
 
-SwiftDependencyScanningService::SwiftDependencyScanningService() {
+SwiftDependencyScanningService::SwiftDependencyScanningService()
+    : Alloc(), Saver(Alloc) {
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       clang::tooling::dependencies::ScanningOutputFormat::FullTree,
@@ -662,6 +663,11 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
       clang::tooling::dependencies::ScanningOptimizations::All);
 
   return false;
+}
+
+StringRef SwiftDependencyScanningService::save(StringRef str) {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+  return Saver.save(str);
 }
 
 ModuleDependenciesCache::ModuleDependenciesCache(

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -824,10 +824,9 @@ getEmbedBitcodeInvocationArguments(std::vector<std::string> &invocationArgStrs,
   });
 }
 
-void
-importer::addCommonInvocationArguments(
-    std::vector<std::string> &invocationArgStrs,
-    ASTContext &ctx, bool requiresBuiltinHeadersInSystemModules,
+void importer::addCommonInvocationArguments(
+    std::vector<std::string> &invocationArgStrs, ASTContext &ctx,
+    bool requiresBuiltinHeadersInSystemModules, bool needSystemVFSOverlay,
     bool ignoreClangTarget) {
   using ImporterImpl = ClangImporter::Implementation;
   llvm::Triple triple = ctx.LangOpts.Target;
@@ -999,6 +998,12 @@ importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-Xclang");
     invocationArgStrs.push_back("-fbuiltin-headers-in-system-modules");
   }
+
+  if (needSystemVFSOverlay) {
+    invocationArgStrs.push_back("-ivfsoverlay");
+    invocationArgStrs.push_back(
+        ClangImporter::getClangSystemOverlayFile(ctx.SearchPathOpts));
+  }
 }
 
 bool ClangImporter::canReadPCH(StringRef PCHFilename) {
@@ -1147,6 +1152,67 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
   return PCHFilename.value();
 }
 
+std::string
+ClangImporter::getClangSystemOverlayFile(const SearchPathOptions &Opts) {
+  llvm::SmallString<256> overlayPath(Opts.RuntimeResourcePath);
+  llvm::sys::path::append(overlayPath,
+                          Implementation::clangSystemVFSOverlayName);
+  return overlayPath.str().str();
+}
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+ClangImporter::computeClangImporterFileSystem(
+    const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
+    bool suppressDiagnostics,
+    llvm::function_ref<StringRef(StringRef)> allocateString) {
+  // Configure ClangImporter file system. There are two situations:
+  // * If caching is used, thus file system is immutable, the one immutable file
+  //   system is shared between swift frontend and ClangImporter.
+  // * Otherwise, ClangImporter file system is configure from scratch from
+  //   VFS in SourceMgr using ivfsoverlay options.
+  if (ctx.CASOpts.HasImmutableFileSystem)
+    return baseFS;
+
+  // If no file mapping, nothing to update.
+  if (fileMapping.redirectedFiles.empty() && fileMapping.overridenFiles.empty())
+    return baseFS;
+
+  const auto &importerOpts = ctx.ClangImporterOpts;
+  if (!fileMapping.redirectedFiles.empty()) {
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer redirected file mappings:\n";
+      for (const auto &mapping : fileMapping.redirectedFiles) {
+        llvm::errs() << "   mapping real file '" << mapping.second
+                     << "' to virtual file '" << mapping.first << "'\n";
+      }
+      llvm::errs() << "\n";
+    }
+  }
+
+  auto overridenVFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  for (auto &file : fileMapping.overridenFiles) {
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer overriding file '"
+                   << file->getBufferIdentifier()
+                   << "' with the following contents:\n";
+      llvm::errs() << file->getBuffer() << "\n";
+    }
+    // Note MemoryBuffer is guaranteeed to be null-terminated.
+    auto content = file->getMemBufferRef();
+    // If allocateString callback is provided, it means the life-time of the
+    // file buffer needs to be extended by saving into the string saver.
+    if (allocateString)
+      content = llvm::MemoryBufferRef(allocateString(content.getBuffer()), "");
+    overridenVFS->addFileNoOwn(file->getBufferIdentifier(), 0, content);
+  }
+  auto overlayVFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(baseFS);
+  overlayVFS->pushOverlay(std::move(overridenVFS));
+  return overlayVFS;
+}
+
 std::vector<std::string>
 ClangImporter::getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget) {
   assert(!ctx.ClangImporterOpts.DirectClangCC1ModuleBuild &&
@@ -1164,8 +1230,12 @@ ClangImporter::getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget) 
     getEmbedBitcodeInvocationArguments(invocationArgStrs, ctx);
     break;
   }
-  addCommonInvocationArguments(invocationArgStrs, ctx,
-      requiresBuiltinHeadersInSystemModules, ignoreClangTarget);
+  addCommonInvocationArguments(
+      invocationArgStrs, ctx,
+      clangFileMapping.requiresBuiltinHeadersInSystemModules,
+      /*needSystemVFSOverlay=*/!clangFileMapping.redirectedFiles.empty() &&
+          !ctx.CASOpts.HasImmutableFileSystem,
+      ignoreClangTarget);
   return invocationArgStrs;
 }
 
@@ -1230,6 +1300,11 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
       if (ctx.LangOpts.TargetVariant.has_value())
         CI->getTargetOpts().DarwinTargetVariantTriple = ctx.LangOpts.TargetVariant->str();
     }
+
+    if (!clangFileMapping.redirectedFiles.empty() &&
+        !ctx.CASOpts.HasImmutableFileSystem)
+      CI->getHeaderSearchOpts().AddVFSOverlayFile(
+          getClangSystemOverlayFile(ctx.SearchPathOpts));
 
     // Forward the index store path. That information is not passed to scanner
     // and it is cached invariant so we don't want to re-scan if that changed.
@@ -1344,18 +1419,18 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
     }
   }
 
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-      ctx.SourceMgr.getFileSystem();
+  if (!ctx.CASOpts.HasImmutableFileSystem)
+    importer->clangFileMapping = getClangInvocationFileMapping(
+        ctx, ctx.SourceMgr.getFileSystem(), ignoreFileMapping);
 
-  ClangInvocationFileMapping fileMapping =
-    applyClangInvocationMapping(ctx, nullptr, VFS, ignoreFileMapping);
-
-  importer->requiresBuiltinHeadersInSystemModules =
-      fileMapping.requiresBuiltinHeadersInSystemModules;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs =
+      computeClangImporterFileSystem(ctx, importer->clangFileMapping,
+                                     ctx.SourceMgr.getFileSystem(),
+                                     ignoreFileMapping);
 
   // Create a new Clang compiler invocation.
   {
-    if (auto ClangArgs = importer->getClangCC1Arguments(ctx, VFS))
+    if (auto ClangArgs = importer->getClangCC1Arguments(ctx, vfs))
       importer->Impl.ClangArgs = *ClangArgs;
     else
       return nullptr;
@@ -1369,7 +1444,7 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
       llvm::errs() << "'\n";
     }
     importer->Impl.Invocation = createClangInvocation(
-        importer.get(), importerOpts, VFS, importer->Impl.ClangArgs);
+        importer.get(), importerOpts, vfs, importer->Impl.ClangArgs);
     if (!importer->Impl.Invocation)
       return nullptr;
   }
@@ -1420,7 +1495,7 @@ std::unique_ptr<ClangImporter> ClangImporter::create(
   auto actualDiagClient = std::make_unique<ClangDiagnosticConsumer>(
       importer->Impl, instance.getDiagnosticOpts(),
       importerOpts.DumpClangDiagnostics);
-  instance.createVirtualFileSystem(std::move(VFS), actualDiagClient.get());
+  instance.createVirtualFileSystem(std::move(vfs), actualDiagClient.get());
   instance.createFileManager();
   instance.createDiagnostics(actualDiagClient.release());
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -491,10 +491,13 @@ public:
 
   const Version CurrentVersion;
 
-  constexpr static const char * const moduleImportBufferName =
-    "<swift-imported-modules>";
-  constexpr static const char * const bridgingHeaderBufferName =
-    "<bridging-header-import>";
+  constexpr static const char *const moduleImportBufferName =
+      "<swift-imported-modules>";
+  constexpr static const char *const bridgingHeaderBufferName =
+      "<bridging-header-import>";
+  /// The name of system vfsoverlay.
+  constexpr static const char *const clangSystemVFSOverlayName =
+      "<clang-system-vfs-overlay>";
 
 private:
   DiagnosticWalker Walker;
@@ -2017,6 +2020,7 @@ void getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 void addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
                                   ASTContext &ctx,
                                   bool requiresBuiltinHeadersInSystemModules,
+                                  bool needSystemVFSOverlay,
                                   bool ignoreClangTarget);
 
 /// Finds a particular kind of nominal by looking through typealiases.

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -267,8 +267,7 @@ static swiftscan_import_set_t generateHollowDiagnosticOutputImportSet(
 }
 
 DependencyScanningTool::DependencyScanningTool()
-    : ScanningService(std::make_unique<SwiftDependencyScanningService>()),
-      Alloc(), Saver(Alloc) {}
+    : ScanningService(std::make_unique<SwiftDependencyScanningService>()) {}
 
 llvm::ErrorOr<swiftscan_dependency_graph_t>
 DependencyScanningTool::getDependencies(ArrayRef<const char *> Command,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -194,16 +194,19 @@ static std::vector<std::string> inputSpecificClangScannerCommand(
 }
 
 static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-getClangScanningFS(std::shared_ptr<llvm::cas::ObjectStore> cas,
+getClangScanningFS(SwiftDependencyScanningService &service,
+                   std::shared_ptr<llvm::cas::ObjectStore> cas,
                    ASTContext &ctx) {
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFileSystem =
-      llvm::vfs::createPhysicalFileSystem();
-  ClangInvocationFileMapping fileMapping =
-    applyClangInvocationMapping(ctx, nullptr, baseFileSystem, false);
+  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  // Dependency scanner needs to create its own file system per worker.
+  auto fs = ClangImporter::computeClangImporterFileSystem(
+      ctx, importer->getClangFileMapping(),
+      llvm::vfs::createPhysicalFileSystem(), true,
+      [&](StringRef str) { return service.save(str); });
 
   if (cas)
-    return llvm::cas::createCASProvidingFileSystem(cas, baseFileSystem);
-  return baseFileSystem;
+    return llvm::cas::createCASProvidingFileSystem(cas, fs);
+  return fs;
 }
 
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
@@ -217,8 +220,9 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     llvm::PrefixMapper *Mapper)
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
-      clangScanningTool(*globalScanningService.ClangScanningService,
-                        getClangScanningFS(CAS, ScanASTContext)),
+      clangScanningTool(
+          *globalScanningService.ClangScanningService,
+          getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter) {
   // Instantiate a worker-specific diagnostic engine and copy over
@@ -2097,10 +2101,16 @@ ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
   invocation.getMutCASOpts() = clang::CASOptions();
   invocation.getMutFrontendOpts().CASIncludeTreeID.clear();
 
-  // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
-  // from clang scanner and pass to swift.
   if (!ScanASTContext.CASOpts.EnableCaching) {
     auto &overlayFiles = invocation.getMutHeaderSearchOpts().VFSOverlayFiles;
+
+    // clang system overlay file is a virtual file that is not an actual file.
+    auto clangSystemOverlayFile =
+        ClangImporter::getClangSystemOverlayFile(ScanASTContext.SearchPathOpts);
+    llvm::erase(overlayFiles, clangSystemOverlayFile);
+
+    // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
+    // from clang scanner and pass to swift.
     for (auto overlay : overlayFiles) {
       swiftArgs.push_back("-vfsoverlay");
       swiftArgs.push_back(overlay);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -711,25 +711,6 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
         new llvm::vfs::OverlayFileSystem(MemFS);
     OverlayVFS->pushOverlay(SourceMgr.getFileSystem());
     SourceMgr.setFileSystem(std::move(OverlayVFS));
-  } else {
-    // For non-caching -direct-clang-cc1-module-build emit-pcm build,
-    // setup the clang VFS so it can find system modulemap files
-    // (like vcruntime.modulemap) as an input file.
-    if (Invocation.getClangImporterOptions().DirectClangCC1ModuleBuild &&
-        Invocation.getFrontendOptions().RequestedAction ==
-            FrontendOptions::ActionType::EmitPCM) {
-      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-          SourceMgr.getFileSystem();
-      ClangInvocationFileMappingContext Context(
-          Invocation.getLangOptions(), Invocation.getSearchPathOptions(),
-          Invocation.getClangImporterOptions(), Invocation.getCASOptions(),
-          Diagnostics);
-      ClangInvocationFileMapping FileMapping = applyClangInvocationMapping(
-          Context, nullptr, VFS, /*suppressDiagnostic=*/false);
-      if (!FileMapping.redirectedFiles.empty()) {
-        SourceMgr.setFileSystem(std::move(VFS));
-      }
-    }
   }
 
   auto ExpectedOverlay =
@@ -991,10 +972,10 @@ std::string CompilerInstance::getBridgingHeaderPath() const {
 }
 
 bool CompilerInstance::setUpInputs() {
-  // There is no input file when building PCM using Caching.
+  // There is no need to setup input when emit PCM. Let ClangImporter and the
+  // underlying clang CompilerInstance to handle inputs.
   if (Invocation.getFrontendOptions().RequestedAction ==
-          FrontendOptions::ActionType::EmitPCM &&
-      Invocation.getCASOptions().EnableCaching)
+      FrontendOptions::ActionType::EmitPCM)
     return false;
 
   // Adds to InputSourceCodeBufferIDs, so may need to happen before the

--- a/test/ClangImporter/print-module-map-paths.swift
+++ b/test/ClangImporter/print-module-map-paths.swift
@@ -28,11 +28,13 @@
 // RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/sdk/usr/lib/swift/android
 // RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID-CXX %s
 
+// CHECK-macosx-CXX-NOT: clang importer redirected file mappings:
+
 // CHECK-LINUX: clang importer redirected file mappings:
 // CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}glibc.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
 // CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}SwiftGlibc.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftGlibc.h'
 
-// CHECK-CXX: clang importer redirected file mappings:
+// CHECK-linux-gnu-CXX: clang importer redirected file mappings:
 // CHECK-linux-gnu-CXX: mapping real file '{{.*}}/resources/linux/libstdcxx.h' to virtual file '{{.*}}/usr/include/c++/{{.*}}/libstdcxx.h'
 // CHECK-linux-gnu-CXX: clang importer overriding file '{{.*}}/usr/include/c++/{{.*}}/module.modulemap' with the following contents:
 // CHECK-linux-gnu-CXX-NEXT: --- libstdcxx.modulemap ---
@@ -47,3 +49,5 @@
 // CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftBionic.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftBionic.h'
 
 // CHECK-ANDROID-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources{{/|\\}}android{{/|\\}}libcxxshim.modulemap'
+
+// CHECK-CXX: clang importer cc1 args:

--- a/test/ScanDependencies/scanner_api_working_dir.swift
+++ b/test/ScanDependencies/scanner_api_working_dir.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -module-name A -o %t/include/A.swiftmodule -swift-version 5 \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -emit-module-interface-path %t/include/A.swiftinterface -enable-library-evolution -I %t/internal -enable-testing \
-// RUN:   %t/A.swift
+// RUN:   %t/A.swift -I %t/include
 
 // RUN: %swift-scan-test -action scan_dependency -cwd %t -- %target-swift-frontend -emit-module -module-name Test \
 // RUN:   -swift-version 5 -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
@@ -13,7 +13,7 @@
 // CHECK: "mainModuleName": "Test"
 
 // RUN: cd %t
-// RUN: %swift-scan-test -action scan_dependency -- %target-swift-frontend -emit-module -module-name Test \
+// RUN: %swift-scan-test -action scan_dependency -threads 2  -- %target-swift-frontend -emit-module -module-name Test \
 // RUN:   -swift-version 5 -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -I include %t/test.swift | %FileCheck %s
 
@@ -21,4 +21,11 @@
 import A
 
 //--- A.swift
+import B
 public func a() {}
+
+//--- include/module.modulemap
+module B { header "B.h" export *}
+
+//--- include/B.h
+void b(void);

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -213,7 +213,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     vfs.devtoolSet("9").libstdCxxModulemap("\n");
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 2);
-    ASSERT_TRUE(paths.overridenFiles.empty());
+    ASSERT_TRUE(paths.overridenFiles.size() == 1);
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
@@ -229,14 +229,14 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     vfs.devtoolSet("9").cxxStdlibHeader("string_view").libstdCxxModulemap();
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 1);
-    ASSERT_TRUE(paths.overridenFiles.size() == 1);
+    ASSERT_TRUE(paths.overridenFiles.size() == 2);
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
               "/usr/lib/swift/linux/libstdcxx.h");
-    EXPECT_EQ(paths.overridenFiles[0].first,
+    EXPECT_EQ(paths.overridenFiles[0]->getBufferIdentifier(),
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
-    EXPECT_NE(paths.overridenFiles[0].second.find(
+    EXPECT_NE(paths.overridenFiles[0]->getBuffer().find(
                   "header \"string_view\"\n  /// additional headers."),
               StringRef::npos);
   }
@@ -255,15 +255,15 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
         .libstdCxxModulemap();
     auto paths = swift::getClangInvocationFileMapping(*context, vfs.vfs);
     ASSERT_TRUE(paths.redirectedFiles.size() == 1);
-    ASSERT_TRUE(paths.overridenFiles.size() == 1);
+    ASSERT_TRUE(paths.overridenFiles.size() == 2);
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
               "/usr/lib/swift/linux/libstdcxx.h");
-    EXPECT_EQ(paths.overridenFiles[0].first,
+    EXPECT_EQ(paths.overridenFiles[0]->getBufferIdentifier(),
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
     EXPECT_NE(
-        paths.overridenFiles[0].second.find(
+        paths.overridenFiles[0]->getBuffer().find(
             "header \"codecvt\"\n  header \"any\"\n  header \"charconv\"\n  "
             "header \"filesystem\"\n  header \"memory_resource\"\n  header "
             "\"optional\"\n  header \"string_view\"\n  header \"variant\"\n  "


### PR DESCRIPTION
Fix two issues when attempting to testing parallel scanning using `swift-scan-test` tools:
* Make sure the BumpPtrAllocator in ScanningService is thread-safe so there are no race condition when a new slab is allocated.
* Make sure the output of `swift-scan-test` only written from one thread. This prevents some race conditions when writing to the same raw_fd_ostream.

rdar://167760262

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
