### PR TITLE
Stricter access control enforcement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3101,7 +3101,13 @@ ERROR(witness_not_as_sendable,none,
 NOTE(less_sendable_reqt_here,none,
      "expected sendability to match requirement here",
      ())
-WARNING(witness_not_accessible_strict_check,none,
+WARNING(witness_not_accessible_strict_check_warn,none,
+      "%select{initializer %1|method %1|%select{|setter for }2property %1"
+      "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
+      "type because it matches a requirement in protocol %5",
+      (RequirementKind, const ValueDecl *, bool, AccessLevel, AccessLevel,
+       const ProtocolDecl *))
+ERROR(witness_not_accessible_strict_check,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
       "type because it matches a requirement in protocol %5",

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -90,10 +90,14 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
         auto storage = accessor->getStorage();
         if (accessor->getFormalAccess() < storage->getFormalAccess()) {
           auto diagID = diag::resilience_decl_unavailable;
-          Context.Diags
-              .diagnose(loc, diagID, D, accessor->getFormalAccess(),
-                        fragileKind.getSelector())
-              .limitBehavior(DiagnosticBehavior::Warning);
+          if (Context.LangOpts.hasFeature(Feature::StrictAccessControl))
+            Context.Diags.diagnose(loc, diagID, D, accessor->getFormalAccess(),
+                                   fragileKind.getSelector());
+          else
+            Context.Diags
+                .diagnose(loc, diagID, D, accessor->getFormalAccess(),
+                          fragileKind.getSelector())
+                .limitBehavior(DiagnosticBehavior::Warning);
           Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
         }
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4453,8 +4453,13 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         auto diagKind = protoForcesAccess
                           ? diag::witness_not_accessible_proto
                           : diag::witness_not_accessible_type;
-        if (check.getKind() == CheckKind::AccessStrict)
-          diagKind = diag::witness_not_accessible_strict_check;
+        if (check.getKind() == CheckKind::AccessStrict) {
+          if (witness->getASTContext().LangOpts.hasFeature(
+                  Feature::StrictAccessControl))
+            diagKind = diag::witness_not_accessible_strict_check;
+          else
+            diagKind = diag::witness_not_accessible_strict_check_warn;
+        }
         bool isSetter = check.isForSetterAccess();
 
         auto &diags = DC->getASTContext().Diags;

--- a/test/attr/attr_inlinable_strict.swift
+++ b/test/attr/attr_inlinable_strict.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift -enable-library-evolution -enable-upcoming-feature StrictAccessControl
+
+// REQUIRES: swift_feature_StrictAccessControl
+
+public struct HasUsableFromInlinePrivateSetProperty {
+  @usableFromInline private(set) var bytes: UnsafeMutableRawPointer // expected-note 2 {{setter for property 'bytes' is not '@usableFromInline' or public}}
+  public init() {
+      self.bytes = UnsafeMutableRawPointer.allocate(byteCount: 1024, alignment: 8)
+  }
+  @usableFromInline
+  func modifyPointer(_ ptr: inout UnsafeMutableRawPointer) {
+    ptr = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+  }
+  @usableFromInline
+  func readPointer(_ ptr: UnsafeMutableRawPointer) {
+    _ = ptr
+  }
+  // writes should trigger diagnostic
+  @inlinable
+  public mutating func writeDirect() {
+      self.bytes = UnsafeMutableRawPointer.allocate(byteCount: 2048, alignment: 8) // expected-error {{setter for property 'bytes' is private and cannot be referenced from an '@inlinable' function}}
+  }
+  @inlinable
+  public mutating func writeFunc() {
+    modifyPointer(&self.bytes) // expected-error {{setter for property 'bytes' is private and cannot be referenced from an '@inlinable' function}}
+  }
+  // reads should be ok
+  @inlinable
+  public func usesBytes() -> UnsafeMutableRawPointer {
+    _ = self.bytes
+  }
+  @inlinable
+  public func readsViaLoad() -> Int {
+    return self.bytes.load(as: Int.self)
+  }
+  @inlinable
+  public func readsViaFunc() {
+    readPointer(self.bytes)  // OK
+  }
+}

--- a/test/decl/protocol/conforms/access_corner_case_strict.swift
+++ b/test/decl/protocol/conforms/access_corner_case_strict.swift
@@ -1,0 +1,131 @@
+// RUN: %target-typecheck-verify-swift -package-name myPkg -enable-upcoming-feature StrictAccessControl
+
+// REQUIRES: swift_feature_StrictAccessControl
+
+// Protocol requirement is witnessed from a member of a
+// less-visible extension
+public protocol P {
+  func publicRequirement()
+}
+
+package protocol Pkg: P {
+  func packageRequirement()
+}
+
+protocol Q : P {
+  func internalRequirement()
+}
+
+fileprivate protocol R : Q {
+  func fileprivateRequirement()
+}
+
+private protocol S : R {
+  func privateRequirement()
+  func privateRequirementCannotWork()
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'}}
+}
+
+extension S {
+  public func publicRequirement() {} // expected-note {{mark the instance method as 'public' to satisfy the requirement}}
+  internal func internalRequirement() {} // expected-note {{mark the instance method as 'internal' to satisfy the requirement}}
+  fileprivate func fileprivateRequirement() {}
+  fileprivate func privateRequirement() {}
+
+  // Cannot witness requirement in another protocol!
+  private func privateRequirementCannotWork() {}
+}
+
+public struct T : S {}
+// expected-error@-1 {{type 'T' does not conform to protocol 'S'}}
+// expected-note@-2 {{add stubs for conformance}}
+// expected-error@-3 {{method 'internalRequirement()' must be as accessible as its enclosing type because it matches a requirement in protocol 'Q'}}
+// expected-error@-4 {{method 'publicRequirement()' must be as accessible as its enclosing type because it matches a requirement in protocol 'P'}}
+
+protocol Qpkg : Pkg {
+  func internalRequirement()
+}
+
+fileprivate protocol Rpkg : Qpkg {
+  func fileprivateRequirement()
+}
+private protocol Spkg : Rpkg {
+  func privateRequirement()
+  func privateRequirementCannotWork()
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'}}
+}
+
+extension Spkg {
+  public func publicRequirement() {} // expected-note {{mark the instance method as 'public' to satisfy the requirement}}
+  package func packageRequirement() {} // expected-note {{mark the instance method as 'package' to satisfy the requirement}}
+  internal func internalRequirement() {} // expected-note {{mark the instance method as 'internal' to satisfy the requirement}}
+  fileprivate func fileprivateRequirement() {}
+  fileprivate func privateRequirement() {}
+
+  // Cannot witness requirement in another protocol!
+  private func privateRequirementCannotWork() {}
+}
+
+public struct Tpkg : Spkg {}
+// expected-error@-1 {{type 'Tpkg' does not conform to protocol 'Spkg'}}
+// expected-note@-2 {{add stubs for conformance}}
+// expected-error@-3 {{method 'internalRequirement()' must be as accessible as its enclosing type because it matches a requirement in protocol 'Qpkg'}}
+// expected-error@-4 {{method 'packageRequirement()' must be as accessible as its enclosing type because it matches a requirement in protocol 'Pkg'}}
+// expected-error@-5 {{method 'publicRequirement()' must be as accessible as its enclosing type because it matches a requirement in protocol 'P'}}
+
+// This is also OK
+@usableFromInline
+internal protocol U : P {}
+
+extension U {
+  public func publicRequirement() {}
+}
+
+public struct SS : U {}
+
+@usableFromInline
+package protocol Upkg : P {}
+
+extension Upkg {
+  public func publicRequirement() {}
+}
+
+public struct SSpkg : Upkg {}
+
+
+// Currently this is banned
+public protocol P2 {
+  func publicRequirement()
+}
+
+protocol Q2 : P2 {}
+
+extension Q2 {
+  // note: not public
+  func publicRequirement() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
+}
+
+public struct T2 : Q2 {} // expected-error {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}
+
+package protocol Q2pkg : P2 {}
+
+extension Q2pkg {
+  // note: not public
+  func publicRequirement() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
+}
+
+public struct T2pkg : Q2pkg {} // expected-error {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}
+
+public struct Foo {
+  public init(value: Int) {}
+}
+public protocol PublicProtocol {
+  init?(integer: Int)
+}
+protocol InternalProtocol: PublicProtocol {}
+extension InternalProtocol {
+  public init(integer: Int) {} // expected-note {{mark the initializer as 'public' to satisfy the requirement}}
+}
+extension Foo: PublicProtocol, InternalProtocol {} // expected-error {{initializer 'init(integer:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProtocol'}}


### PR DESCRIPTION
Emit an errors instead of warnings access control violations that should be fixed in the future when StrictAccessControl upcoming feature is enabled

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
