### PR TITLE
[CSBindings] PotentialBindings: Track only direct conformances, defaults and fallbacks

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2099,6 +2099,12 @@ void PotentialBindings::infer(ConstraintSystem &CS,
 
   case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
+    // Conformances are applicable only to the types they are
+    // placed on. They could be transferred to supertypes
+    // but that happens separately.
+    if (!isDirectRequirement(CS, TypeVar, constraint))
+      break;
+
     if (constraint->getSecondType()->is<ProtocolType>())
       Protocols.push_back(constraint);
     break;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1084,15 +1084,15 @@ void BindingSet::coalesceIntegerAndFloatLiteralRequirements() {
 void PotentialBindings::inferFromLiteral(ConstraintSystem &CS,
                                          TypeVariableType *TypeVar,
                                          Constraint *constraint) {
+  ASSERT(isDirectRequirement(CS, TypeVar, constraint));
+
   auto *protocol = constraint->getProtocol();
 
   for (const auto &literal : Literals) {
     if (literal.getProtocol() == protocol)
       return;
   }
-
-  bool isDirect = isDirectRequirement(CS, TypeVar, constraint);
-
+  
   Type defaultType;
   // `ExpressibleByNilLiteral` doesn't have a default type.
   if (!protocol->isSpecificProtocol(
@@ -1100,7 +1100,7 @@ void PotentialBindings::inferFromLiteral(ConstraintSystem &CS,
     defaultType = TypeChecker::getDefaultType(protocol, CS.DC);
   }
 
-  Literals.emplace_back(protocol, constraint, defaultType, isDirect);
+  Literals.emplace_back(protocol, constraint, defaultType, /*isDirect=*/true);
 }
 
 bool BindingSet::operator==(const BindingSet &other) {
@@ -2119,9 +2119,16 @@ void PotentialBindings::infer(ConstraintSystem &CS,
     // Constraints from which we can't do anything.
     break;
 
-  case ConstraintKind::LiteralConformsTo:
+  case ConstraintKind::LiteralConformsTo: {
+    // Literal conformances are applicable only to the types they
+    // are placed on. They could be transferred to supertypes
+    // but that happens separately.
+    if (!isDirectRequirement(CS, TypeVar, constraint))
+      break;
+
     inferFromLiteral(CS, TypeVar, constraint);
     break;
+  }
 
   case ConstraintKind::Defaultable:
   case ConstraintKind::FallbackType:

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2138,6 +2138,12 @@ void PotentialBindings::infer(ConstraintSystem &CS,
 
   case ConstraintKind::Defaultable:
   case ConstraintKind::FallbackType:
+    // Defaults and fallbacks are applicable only to the types
+    // they are associated with. Defaults could be transferred
+    // to supertypes but that happens separately.
+    if (!isDirectRequirement(CS, TypeVar, constraint))
+      break;
+
     Defaults.push_back(constraint);
     break;
 


### PR DESCRIPTION
When a type variable is bound its constraints are introduced to all
of the type variables referenced by the new fixed type. That includes
conformances and default/fallback constraints as well, but referenced
variables shouldn't track them, because they apply only to the variable 
they are associated with and its supertypes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
