### PR TITLE
Remove `REQUIRES: shell` from tests

### DIFF
--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -21,7 +21,6 @@
 // RUN: %target-typecheck-verify-swift "${COMPILER_ARGS[@]}" \
 // RUN:   -enable-experimental-feature ParserASTGen
 
-// REQUIRES: shell
 // REQUIRES: swift_feature_ParserASTGen
 
 @available(swift 4)

--- a/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
@@ -7,10 +7,6 @@
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -18,10 +18,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=Simplification -emit-ir %s | %FileCheck %s --check-prefix=IRGEN --check-prefix %target-cpu
 // NOTE: `%target-cpu`-specific FileCheck lines exist because lowered function types in LLVM IR differ between architectures.
 
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
@@ -16,10 +16,6 @@
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiable_function_inst.sil
@@ -17,10 +17,6 @@
 
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK-IRGEN
 
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
-
 // Would need to update for arm64e.
 // UNSUPPORTED: CPU=arm64e
 

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -17,10 +17,6 @@
 
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=IRGEN %s
 
-// `shell` is required only to run `sed` as a
-// https://github.com/apple/swift/issues/54526 workaround.
-// REQUIRES: shell
-
 sil_stage raw
 
 import Builtin

--- a/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
+++ b/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
@@ -3,7 +3,6 @@
 // preserving response files) instead of trying to spawn the process with the
 // expansion, which may exceed `ARG_MAX`.
 
-// REQUIRES: shell
 // RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.resp
 // RUN: cp %S/Inputs/print-args.sh %swift-bin-dir/legacy-driver-propagates-response-file.sh
 // RUN: env SWIFT_OVERLOAD_DRIVER=legacy-driver-propagates-response-file.sh %swiftc_driver_plain -disallow-use-new-driver %s @%t.resp | %FileCheck %s

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -1,5 +1,3 @@
-// Must be able to run xcrun-return-self.sh
-// REQUIRES: shell
 // REQUIRES: rdar65281056
 // FIXME: When this is turned on, please move the test from linker-library-with-space.swift
 // to this file and remove that file.

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,4 +1,3 @@
-// REQUIRES: shell
 // Check that 'swift' and 'swift repl' invoke the REPL.
 
 // RUN: rm -rf %t.dir

--- a/test/Index/Store/index_compress.swift
+++ b/test/Index/Store/index_compress.swift
@@ -1,5 +1,3 @@
-// REQUIRES: shell
-
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -index-store-path %t/idx -index-store-compress -o %t.o -typecheck %s
 // RUN: c-index-test core -print-record %t/idx | %FileCheck %s

--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -29,9 +29,6 @@
 // REQUIRES: foundation
 // XFAIL: CPU=arm64e
 
-// Because of the use of 'sed' in this test.
-// REQUIRES: shell
-
 import Darwin
 import Foundation
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -8,7 +8,6 @@ func foo() {
 }
 
 // Checks that, due to default check delay, a modification will be ignored and fast completion will still activate.
-// REQUIRES: shell
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -5,8 +5,6 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -7,8 +7,6 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
@@ -5,7 +5,6 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
 // REQUIRES: rdar74150023
 
 // RUN: %empty-directory(%t/Frameworks)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -5,8 +5,6 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -17,7 +17,6 @@ func foo(val: MyStruct) {
 // BEGIN DUMMY.swift
 
 // Checks that editing and saving the current file doesn't affect dependency checking.
-// REQUIRES: shell
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Frameworks)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -7,8 +7,6 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -2,8 +2,6 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -2,8 +2,6 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -129,7 +129,7 @@ struct HasNestedType {
   struct Inner {}
 }
 
-// REQUIRES: swift_swift_parser, executable_test, shell, asserts
+// REQUIRES: swift_swift_parser, executable_test, asserts
 // REQUIRES: swift_feature_PreambleMacros
 
 // RUN: %empty-directory(%t)

--- a/test/SourceKit/Misc/match-module-cache-with-compiler.swift
+++ b/test/SourceKit/Misc/match-module-cache-with-compiler.swift
@@ -1,8 +1,6 @@
 // This test ensures a certain set of arguments allows both compiler and sourcekitd invocations to share the same module cache.
 // NOTE: Do not change this test without a review from @akyrtzi
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t)
 
 // RUN: COMPILER_ARGS=( \

--- a/test/SourceKit/Misc/no-driver-outputs.swift
+++ b/test/SourceKit/Misc/no-driver-outputs.swift
@@ -1,5 +1,3 @@
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t)
 // RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=syntax-map %s 
 // RUN: ls %t/ | count 0

--- a/test/TypeRoundTrip/round-trip.swift
+++ b/test/TypeRoundTrip/round-trip.swift
@@ -11,7 +11,6 @@
 // RUN: %target-run %t/round-trip | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: shell
 // REQUIRES: remote_mirror
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: %empty-directory(%t)
 RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run sh -c 'echo ":${FOO}:" ":${BAR}:"' | %FileCheck %s
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v sh -c 'echo ":${FOO}:" ":${BAR}:"' 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s

--- a/test/remote-run/exit-code.test-sh
+++ b/test/remote-run/exit-code.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: export SWIFT_BACKTRACE=
 RUN: not %debug-remote-run false >%t.txt 2>%t.errs.txt

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: %debug-remote-run echo hello | %FileCheck %s
 RUN: %debug-remote-run -v echo hello 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s

--- a/test/remote-run/stderr.test-sh
+++ b/test/remote-run/stderr.test-sh
@@ -1,5 +1,4 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: %debug-remote-run sh -c "echo hello; echo goodbye >&2" > %t.stdout.txt 2> %t.stderr.txt
 RUN: %FileCheck -check-prefix CHECK-STDOUT %s < %t.stdout.txt

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -23,7 +23,6 @@
 // RUN: %target-run %t/Mirror
 
 // REQUIRES: executable_test
-// REQUIRES: shell
 // REQUIRES: reflection
 
 // rdar://96439408

--- a/test/stdlib/MirrorWithPacks.swift
+++ b/test/stdlib/MirrorWithPacks.swift
@@ -16,7 +16,6 @@
 // RUN: %target-run %t/Mirror
 
 // REQUIRES: executable_test
-// REQUIRES: shell
 // REQUIRES: reflection
 
 // rdar://96439408

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -22,7 +22,6 @@
 // RUN: %target-run %t/Mirror
 
 // REQUIRES: executable_test
-// REQUIRES: shell
 // REQUIRES: reflection
 // REQUIRES: swift_feature_ImmutableWeakCaptures
 

--- a/validation-test/Driver/many-inputs.swift
+++ b/validation-test/Driver/many-inputs.swift
@@ -1,4 +1,3 @@
-// REQUIRES: shell
 // RUN: %empty-directory(%t)
 
 // This limit was chosen because multi-threaded compilation broke here on OS X


### PR DESCRIPTION
In anticipation of the llvm change 9553f11, remove uses of REQUIRES: shell, as this lit feature is no longer available.