### PR TITLE
Strict enforcement of conditionally Escapable dependencies

### DIFF
--- a/include/swift/AST/ConformanceLookup.h
+++ b/include/swift/AST/ConformanceLookup.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_CONFORMANCELOOKUP_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include <optional>
 
 namespace swift {
@@ -92,6 +93,29 @@ ProtocolConformanceRef lookupExistentialConformance(Type type,
 llvm::ArrayRef<ProtocolConformanceRef>
 collectExistentialConformances(CanType fromType, CanType existential,
                                bool allowMissing = false);
+
+/// Find all types in conformance 'type: proto' that must not conform to 'proto'
+/// to prevent 'type' from conforming. If 'type' has no conformance, then it is
+/// the only type returned.
+///
+/// \param requiredInterfaceTypes is initially empty and upon returning contains all types
+/// required to prevent conformance. It remains empty if 'type' unconditionally
+/// conforms to 'proto'.
+///
+/// \returns 'false' only if requirements cannot be visited, for example because
+/// of an error type.
+///
+/// Example:
+///
+///     (normal_conformance type="Wrapper<T, U>" protocol="Escapable"
+///        (requirement "T" conforms_to "Escapable")
+///        (requirement "U" conforms_to "Escapable"))
+///
+///     requiredInterfaceTypes: (T, U)
+///
+bool collectRequiredTypesForInverseConformance(
+  Type type, ProtocolDecl *proto,
+  llvm::SmallVectorImpl<Type> &requiredInterfaceTypes);
 
 }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8475,9 +8475,7 @@ ERROR(lifetime_dependence_function_type, none,
 ERROR(lifetime_dependence_immortal_alone, none,
       "cannot specify any other dependence source along with immortal", ())
 ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
-      "cannot copy the lifetime of an Escapable type, use "
-      "'@_lifetime(%0%1)' instead",
-      (StringRef, StringRef))
+      "cannot copy the lifetime of an Escapable type", ())
 ERROR(lifetime_dependence_parsed_borrow_with_ownership, none,
       "invalid use of %0 dependence with %1 ownership",
       (StringRef, StringRef))
@@ -8496,6 +8494,11 @@ ERROR(lifetime_parameter_requires_inout, none,
       "lifetime-dependent parameter '%0' must be 'inout'", (StringRef))
 ERROR(lifetime_target_requires_nonescapable, none,
       "invalid lifetime dependence on an Escapable %0", (StringRef))
+ERROR(lifetime_escapable_source_requires_escapable, none,
+     "cannot copy lifetime dependency from parameter '%0' because its type %1 is potentially Escapable when the result type %2 is non-Escapable",
+      (StringRef, Type, Type))
+NOTE(lifetime_escapable_source_requires_escapable_note, none,
+     "use '@_lifetime(%0%1)' instead", (StringRef, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Requirements

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -195,6 +195,10 @@ public:
       SmallVectorImpl<ProtocolConformanceRef> *isolatedConformances = nullptr
   ) const;
 
+  bool collectRequiredTypesForInvertibleProtocol(
+    SmallVectorImpl<Requirement> &subReqs, ProtocolDecl *proto,
+    SmallVectorImpl<Type> &requiredInterfaceTypes) const;
+
   /// Determines if this substituted requirement can ever be satisfied,
   /// possibly with additional substitutions.
   ///
@@ -248,6 +252,10 @@ checkRequirementsWithoutContext(ArrayRef<Requirement> requirements);
 CheckRequirementsResult checkRequirements(ArrayRef<Requirement> requirements,
                                           TypeSubstitutionFn substitutions,
                                           SubstOptions options = std::nullopt);
+
+bool collectRequiredTypesForInvertibleProtocol(
+  ArrayRef<Requirement> requirements, ProtocolDecl *proto,
+  SmallVectorImpl<Type> &requiredInterfaceTypes);
 
 /// A requirement as written in source, together with a source location. See
 /// ProtocolDecl::getStructuralRequirements().

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -872,6 +872,20 @@ swift::checkConformanceWithoutContext(Type type, ProtocolDecl *proto,
   return lookupResult;
 }
 
+bool swift::collectRequiredTypesForInverseConformance(
+  Type type, ProtocolDecl *proto,
+  SmallVectorImpl<Type> &requiredInterfaceTypes) {
+
+  assert(requiredInterfaceTypes.empty());
+
+  Requirement req(RequirementKind::Conformance, type,
+                  proto->getDeclaredInterfaceType());
+  bool success =
+    collectRequiredTypesForInvertibleProtocol({req}, proto,
+                                              requiredInterfaceTypes);
+  return success;
+}
+
 ///
 /// Sendable checking utility
 ///

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -34,3 +34,5 @@ struct NEG<T : ~Escapable> : ~Escapable {
     self.t = t
   }
 }
+
+extension NEG: Escapable where T: Escapable {}

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -210,17 +210,7 @@ public struct OuterNE: ~Escapable {
     set { inner1 = newValue }
   }
 
-  public struct InnerNE: ~Escapable {
-    @_lifetime(copy owner)
-    init<Owner: ~Escapable & ~Copyable>(
-      owner: borrowing Owner
-    ) {}
-  }
-
-  @_lifetime(copy owner)
-  init<Owner: ~Copyable & ~Escapable>(owner: borrowing Owner) {
-    self.inner1 = InnerNE(owner: owner)
-  }
+  public struct InnerNE: ~Escapable {}
 
   // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method) (@guaranteed OuterNE.InnerNE, @lifetime(copy 0) @inout OuterNE) -> () {
   @_lifetime(self: copy value)

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -8,7 +8,7 @@
 public struct Span<Element> : ~Escapable {
   private var baseAddress: UnsafeRawPointer
   public let count: Int
-  @_lifetime(copy owner)
+  @_lifetime(borrow owner)
   public init<Owner: ~Copyable & ~Escapable>(
       baseAddress: UnsafeRawPointer,
       count: Int,

--- a/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
+++ b/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
@@ -14,6 +14,8 @@ struct Butt<T: ~Escapable>: ~Escapable {
 	}
 }
 
+extension Butt: Escapable where T: Escapable {}
+
 struct Tubb<T>: ~Escapable {
 	var x: T
 

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1840,6 +1840,8 @@ struct NE<T> : ~Escapable where T : ~Escapable {
   init(_ t: borrowing T)
 }
 
+extension NE: Escapable where T: Escapable {}
+
 // CHECK-NOT: sil [serialized] [signature_optimized_thunk] [heuristic_always_inline] @neinit :
 sil [noinline] @neinit : $@convention(method) <T where T : ~Escapable> (@in_guaranteed T, @thin NE<T>.Type) -> @lifetime(copy 0) @owned NE<T> {
 bb0(%0 : @noImplicitCopy $*T, %1 : $@thin NE<T>.Type):

--- a/test/SILOptimizer/functionsigopts_crash.swift
+++ b/test/SILOptimizer/functionsigopts_crash.swift
@@ -62,6 +62,8 @@ struct NE<T : ~Escapable> : ~Escapable {
   init(_ t: borrowing T) {}
 }
 
+extension NE: Escapable where T: Escapable {}
+
 @_lifetime(copy t)
 func getNE<T : ~Escapable>(_ t: borrowing T) -> NE<T> {
   return NE(t)

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -60,6 +60,8 @@ extension NEOptional where Wrapped: ~Escapable {
   public init(_ some: consuming Wrapped) { self = .some(some) }
 }
 
+extension NEOptional: Escapable where Wrapped: Escapable {}
+
 func takeClosure(_: () -> ()) {}
 
 // No mark_dependence is needed for a inherited scope.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
@@ -52,7 +52,7 @@ struct NCInt: ~Copyable {
 struct NEInt: ~Escapable {
   let value: Builtin.Int64
 
-  @_lifetime(copy o)
+  @_lifetime(borrow o)
   init<O: ~Copyable & ~Escapable>(v: Builtin.Int64, o: borrowing O) {
     self.value = v
   }

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -82,6 +82,8 @@ struct TestCoroAccessorOfCoroAccessor<T : ~Escapable> : ~Copyable & ~Escapable {
   }
 }
 
+extension TestCoroAccessorOfCoroAccessor: Escapable where T: Escapable {}
+
 @usableFromInline
 internal func unsafeBitCast<T: ~Escapable & ~Copyable, U>(
    _ x: consuming T, to type: U.Type

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -182,3 +182,73 @@ func getGeneric<T : ~Escapable>(_outValue: inout T, _ inValue: T)  {
   _outValue = inValue
 }
 
+// =============================================================================
+// Requires Escapable Rule - depenencies on conditionally Escapable parameters
+// =============================================================================
+
+@_lifetime(copy t) // expected-error{{cannot copy lifetime dependency from parameter 't' because its type 'T' is potentially Escapable when the result type 'U' is non-Escapable}}
+                   // expected-note@-1{{use '@_lifetime(borrow t)' instead}}
+func unrelatedTypeParameter<T: ~Escapable, U: ~Escapable>(t: T, u: U) -> U { u }
+
+@_lifetime(copy t) // OK
+func sameTypeParameter<T: ~Escapable>(t: T) -> T { t }
+
+struct NE1<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE1: Escapable where T: Escapable {}
+
+@_lifetime(copy ne) // OK
+func conditionalNESource<T: ~Escapable>(ne: NE1<T>) -> T {
+  ne.t
+}
+
+@_lifetime(copy t) // OK
+func conditionalNEDest<T: ~Escapable>(t: T) -> NE1<T> {
+  NE1(t: t)
+}
+
+struct NE2<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE2: Escapable where T: Escapable {}
+
+@_lifetime(copy ne) // OK
+func conditionalNESourceDest<T: ~Escapable>(ne: NE1<T>) -> NE2<T> {
+  NE2(t: ne.t)
+}
+
+@_lifetime(copy ne) // OK
+func conditionalNENestedSource<T: ~Escapable>(ne: NE1<NE1<T>>) -> NE2<T> {
+  NE2(t: ne.t.t)
+}
+
+@_lifetime(copy ne) // OK
+func specializedNESource(ne: NE1<NE>) -> NE { ne.t }
+
+@_lifetime(copy ne) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                    // expected-note@-1{{use '@_lifetime(borrow ne)' instead}}
+func specializedESource(ne: NE1<Int>) -> NE { NE() }
+
+@_lifetime(copy ne) // OK
+func specializedNEDest(ne: NE) -> NE1<NE> { NE1(t: ne) }
+
+@_lifetime(copy ne) // expected-error{{invalid lifetime dependence on an Escapable result}}
+func specializedEDest(ne: NE) -> NE1<Int> { NE1(t: 3) }
+
+@_lifetime(copy ne) // OK
+func specializedNESourceDest(ne: NE1<NE>) -> NE2<NE> {
+  NE2<NE>(t: ne.t)
+}
+
+@_lifetime(copy ne) // OK
+func optionalUnwrap(ne: NE?) -> NE { ne! }
+
+@_lifetime(copy ne) // OK
+func optionalWrap(ne: NE) -> NE? { ne }
+
+@_lifetime(copy a) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                   // expected-note@-1{{use '@_lifetime(borrow a)' instead}}
+func optionalEscapableUnwrap(a: Int?) -> NE { NE() }

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -104,17 +104,20 @@ func inoutLifetimeDependence(_ ne: inout NE) -> NE {
   ne
 }
 
-@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+// expected-note@-1{{use '@_lifetime(&k)' instead}}
 func dependOnEscapable(_ k: inout Klass) -> NE {
   NE()
 }
 
-@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+// expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 func dependOnEscapable(_ k: borrowing Klass) -> NE { 
   NE()
 }
 
-@_lifetime(copy k) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                   // expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 func dependOnEscapable(_ k: consuming Klass) -> NE { 
   NE()
 }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -233,7 +233,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   func noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -246,7 +247,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   mutating func mutating_noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -257,7 +259,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   func oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -269,7 +272,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   mutating func mutating_oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -283,7 +287,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self) // OK
   func noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self) // OK
@@ -295,7 +300,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -307,7 +313,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self)
   func oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -319,7 +326,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self)
   mutating func mutating_oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -27,52 +27,70 @@ struct MutNE: ~Copyable & ~Escapable {}
 // Same-type default rule
 // =============================================================================
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam(ne: NE) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeConsumingParam(ne: consuming NE) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeBorrowingParam(ne: borrowing NE) -> NE { ne }
 
 func sameTypeInoutParam(ne: inout NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
+/* DEFAULT: @_lifetime(copy ne, copy ne2) */
 func sameTypeParam_sameTypeParam(ne1: NE, ne2: NE) -> NE { ne1 }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam_otherTypeParam(ne: NE, c: C) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam_sameTypeInoutParam(ne: NE, mutNE: inout NE) -> NE { ne }
 
 struct NonEscapable<T>: ~Escapable {
   @_lifetime(immortal)
   init() {}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init(ne: Self) {}
 
   init(c: C) {} // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an initializer}}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init(ne: Self, c: C) {}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init<U>(ne: Self, u: U) {}
 
+  /* DEFAULT: @_lifetime(copy neNominal) */
   init<U>(neNominal: NonEscapable<T>, u: U) {}
 
   init<U>(other: NonEscapable<U>) {} // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow other)' or '@_lifetime(copy other)'}}
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_noParam() -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   consuming func sameTypeConsumingSelf_noParam() -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   borrowing func sameTypeBorrowingSelf_noParam() -> Self { self }
 
   mutating func sameTypeMutatingSelf() -> Self { self } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
 
+  /* DEFAULT: @_lifetime(copy self, copy ne) */
   func sameTypeSelf_sameTypeParam(ne: Self) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_otherTypeParam(c: C) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_sameTypeInoutParam(mutNE: inout Self) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameArchetypeSelf<U>(u: U) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameNominalTypeSelf_genericParam<U>(u: U) -> NonEscapable<T> { self }
 
   func otherNominalTypeSelf_genericParam<U>(u: U) -> NonEscapable<U> { NonEscapable<U>() } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
@@ -90,6 +108,7 @@ protocol NonEscapableProtocol: ~Escapable {
 
   init(neProtocol: any NonEscapableProtocol, c: C) // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameArchetypeSelf() -> Self
 
   mutating func sameArchetypeMutatingSelf() -> Self // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
@@ -101,6 +120,7 @@ extension NonEscapableProtocol where Self: ~Escapable {
   }
 }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameGenericTypeParam<T: ~Escapable>(ne: T) -> T {
   ne
 }
@@ -145,6 +165,64 @@ extension AssociatedQ where Q == QQ {
     QQ.U.create()
   }
 }
+
+// =============================================================================
+// Same type default rule for conditionally Escapable parameters
+// =============================================================================
+
+/* DEFAULT: @_lifetime(copy t) */
+func unconditionalNESource<T: ~Escapable>(ne: NE, t: T) -> T {
+  t
+}
+
+struct NE1<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE1: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNESource<T: ~Escapable>(ne: NE1<T>) -> T {
+  ne.t
+}
+
+/* DEFAULT: @_lifetime(copy t) */
+func conditionalNEDest<T: ~Escapable>(t: T) -> NE1<T> {
+  NE1(t: t)
+}
+
+struct NE2<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE2: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNESourceDest<T: ~Escapable>(ne: NE1<T>) -> NE2<T> {
+  NE2(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNENestedSource<T: ~Escapable>(ne: NE1<NE1<T>>) -> NE2<T> {
+  NE2(t: ne.t.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNESource(ne: NE1<NE>) -> NE { ne.t }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNEDest(ne: NE) -> NE1<NE> { NE1(t: ne) }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNESourceDest(ne: NE1<NE>) -> NE2<NE> {
+  NE2<NE>(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func optionalUnwrap(ne: NE?) -> NE { ne! }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func optionalWrap(ne: NE) -> NE? { ne }
 
 // =============================================================================
 // Single parameter default rule for functions

--- a/test/Sema/lifetime_depend_infer_defaults.swift
+++ b/test/Sema/lifetime_depend_infer_defaults.swift
@@ -161,6 +161,74 @@ extension AssociatedQ where Q == QQ {
 }
 
 // =============================================================================
+// Same type default rule for conditionally Escapable parameters
+// =============================================================================
+
+/* DEFAULT: @_lifetime(copy t) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults21unconditionalNESource2ne1txAA2NEV_xtRi0_zlF : $@convention(thin) <T where T : ~Escapable> (@guaranteed NE, @in_guaranteed T) -> @lifetime(copy 1) @out T {
+func unconditionalNESource<T: ~Escapable>(ne: NE, t: T) -> T {
+  t
+}
+
+struct NE1<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE1: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults19conditionalNESource2nexAA3NE1VyxG_tRi0_zlF : $@convention(thin) <T where T : ~Escapable> (@in_guaranteed NE1<T>) -> @lifetime(copy 0) @out T
+func conditionalNESource<T: ~Escapable>(ne: NE1<T>) -> T {
+  ne.t
+}
+
+/* DEFAULT: @_lifetime(copy t) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults17conditionalNEDest1tAA3NE1VyxGx_tRi0_zlF : $@convention(thin) <T where T : ~Escapable> (@in_guaranteed T) -> @lifetime(copy 0) @out NE1<T>
+func conditionalNEDest<T: ~Escapable>(t: T) -> NE1<T> {
+  NE1(t: t)
+}
+
+struct NE2<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE2: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults23conditionalNESourceDest2neAA3NE2VyxGAA3NE1VyxG_tRi0_zlF : $@convention(thin) <T where T : ~Escapable> (@in_guaranteed NE1<T>) -> @lifetime(copy 0) @out NE2<T> {
+func conditionalNESourceDest<T: ~Escapable>(ne: NE1<T>) -> NE2<T> {
+  NE2(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults25conditionalNENestedSource2neAA3NE2VyxGAA3NE1VyAHyxGG_tRi0_zlF : $@convention(thin) <T where T : ~Escapable> (@in_guaranteed NE1<NE1<T>>) -> @lifetime(copy 0) @out NE2<T> {
+func conditionalNENestedSource<T: ~Escapable>(ne: NE1<NE1<T>>) -> NE2<T> {
+  NE2(t: ne.t.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults19specializedNESource2neAA2NEVAA3NE1VyAEG_tF : $@convention(thin) (@guaranteed NE1<NE>) -> @lifetime(copy 0) @owned NE
+func specializedNESource(ne: NE1<NE>) -> NE { ne.t }
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults17specializedNEDest2neAA3NE1VyAA2NEVGAG_tF : $@convention(thin) (@guaranteed NE) -> @lifetime(copy 0) @owned NE1<NE> {
+func specializedNEDest(ne: NE) -> NE1<NE> { NE1(t: ne) }
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults23specializedNESourceDest2neAA3NE2VyAA2NEVGAA3NE1VyAGG_tF : $@convention(thin) (@guaranteed NE1<NE>) -> @lifetime(copy 0) @owned NE2<NE> {
+func specializedNESourceDest(ne: NE1<NE>) -> NE2<NE> {
+  NE2<NE>(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults14optionalUnwrap2neAA2NEVAESg_tF : $@convention(thin) (@guaranteed Optional<NE>) -> @lifetime(copy 0) @owned NE {
+func optionalUnwrap(ne: NE?) -> NE { ne! }
+
+/* DEFAULT: @_lifetime(copy ne) */
+// CHECK: sil hidden [ossa] @$s30lifetime_depend_infer_defaults12optionalWrap2neAA2NEVSgAE_tF : $@convention(thin) (@guaranteed NE) -> @lifetime(copy 0) @owned Optional<NE> {
+func optionalWrap(ne: NE) -> NE? { ne }
+
+// =============================================================================
 // Single parameter default rule for functions
 // =============================================================================
 


### PR DESCRIPTION
- **Document new @_lifetime restrictions and defaults**
  

- **Strict enforcement of conditionally Escapable dependencies**
  Example:
  
      @_lifetime(copy t)
      func foo<T: ~Escapable, U: ~Escapable>(t: T) -> U
  
      // error: cannot copy lifetime depenency from parameter 't'
      // because its type 'T' is potentially Escapable when the
      // result type 'U' is non-Escapable
      //
      // note: use '@_lifetime(borrow t)' instead
  

- **Updates tests for conditionally ~Escapable enforcement**
  