### PR TITLE
[cxx-interop] Move a test to `long_test` category

### DIFF
--- a/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: OS=macosx
 
+// This test is slow, because it triggers Clang module build for the C++ stdlib and Foundation.
+// REQUIRES: long_test
+
 import Foundation
 import MyCxxModule
 


### PR DESCRIPTION
This marks `bridge-cxx-types-to-objcxx.swift` as a slow running test, to prevent it from taking too much time off the smoke test CI run.
