### PR TITLE
[cxx-interop] Enable a test on Windows

### DIFF
--- a/test/Interop/Cxx/class/mirror.swift
+++ b/test/Interop/Cxx/class/mirror.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -I %S/Inputs)
 
 // REQUIRES: executable_test
-// Metadata for foreign reference types is not supported on Windows.
-// UNSUPPORTED: OS=windows-msvc
 
 import StdlibUnittest
 import Mirror


### PR DESCRIPTION
Swift now supports metadata for foreign reference types on Windows.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
