### PR TITLE
Shrink obscenely large SmallVectors

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2008,7 +2008,7 @@ SwiftDeclCollector::SwiftDeclCollector(SDKContext &Ctx,
   }
   assert(!Modules.empty());
   for (auto M: Modules) {
-    llvm::SmallVector<Decl*, 512> Decls;
+    llvm::SmallVector<Decl*> Decls;
     swift::getTopLevelDeclsForDisplay(M, Decls);
     for (auto D : Decls) {
       if (Ctx.shouldIgnore(D))

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -388,7 +388,7 @@ SourceFileParsingResult parseSourceFileViaASTGen(SourceFile &SF) {
           langOpts.WarnOnEditorPlaceholder);
 
   // Generate AST nodes.
-  SmallVector<ASTNode, 128> items;
+  SmallVector<ASTNode, 8> items;
   swift_ASTGen_buildTopLevelASTNodes(
       &Diags, exportedSourceFile, declContext, attachedDecl, Ctx,
       static_cast<SmallVectorImpl<ASTNode> *>(&items),
@@ -431,7 +431,7 @@ SourceFileParsingResult parseSourceFile(SourceFile &SF) {
 
   // If the buffer is generated source information, we might have more
   // context that we need to set up for parsing.
-  SmallVector<ASTNode, 128> items;
+  SmallVector<ASTNode, 8> items;
   if (auto generatedInfo = ctx.SourceMgr.getGeneratedSourceInfo(bufferID)) {
     if (generatedInfo->declContext)
       parser.CurDeclContext = generatedInfo->declContext;

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -81,7 +81,7 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, void> {
   llvm::DenseSet<ProtocolConformance *> VisitedConformances;
 
   /// Worklist of SILFunctions we are processing.
-  llvm::SmallVector<SILFunction *, 128> Worklist;
+  llvm::SmallVector<SILFunction *, 32> Worklist;
 
   llvm::SmallVector<SILFunction *, 32> toVerify;
 

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1625,7 +1625,7 @@ namespace {
 class CapturePromotionPass : public SILModuleTransform {
   /// The entry point to the transformation.
   void run() override {
-    SmallVector<SILFunction *, 128> worklist;
+    SmallVector<SILFunction *, 8> worklist;
     for (auto &f : *getModule()) {
       if (f.wasDeserializedCanonical() || !f.hasOwnership())
         continue;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -622,7 +622,7 @@ bool LifetimeChecker::isBlockIsReachableFromEntry(const SILBasicBlock *BB) {
   // Lazily compute reachability, so we only have to do it in the case of an
   // error.
   if (BlocksReachableFromEntry.empty()) {
-    SmallVector<const SILBasicBlock*, 128> Worklist;
+    SmallVector<const SILBasicBlock*, 8> Worklist;
     Worklist.push_back(&BB->getParent()->front());
     BlocksReachableFromEntry.insert(Worklist.back());
     

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -1099,7 +1099,7 @@ static bool removeUnreachableBlocks(SILFunction &F, SILModule &M,
     return false;
 
   BasicBlockSet Reachable(&F);
-  SmallVector<SILBasicBlock*, 128> Worklist;
+  SmallVector<SILBasicBlock*, 8> Worklist;
   Worklist.push_back(&F.front());
   Reachable.insert(&F.front());
   unsigned numReachableBlocks = 1;

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -77,7 +77,7 @@ static llvm::cl::opt<bool> EnableSILCombineCanonicalize(
 /// instructions are dead or constant).
 void SILCombiner::addReachableCodeToWorklist(SILBasicBlock *BB) {
   BasicBlockWorklist Worklist(BB);
-  llvm::SmallVector<SILInstruction *, 128> InstrsForSILCombineWorklist;
+  llvm::SmallVector<SILInstruction *, 16> InstrsForSILCombineWorklist;
 
   while (SILBasicBlock *BB = Worklist.pop()) {
     for (SILBasicBlock::iterator BBI = BB->begin(), E = BB->end(); BBI != E; ) {

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -176,7 +176,7 @@ int symbolgraphgen::emitSymbolGraphForModule(
       !WildcardExportClangModules.empty() || !ExportedClangModules.empty())
     importCollector.importFilter = std::move(importFilter);
 
-  SmallVector<Decl *, 64> ModuleDecls;
+  SmallVector<Decl *> ModuleDecls;
   swift::getTopLevelDeclsForDisplay(
       M, ModuleDecls, [&importCollector](ModuleDecl *M, SmallVectorImpl<Decl *> &results) {
         M->getDisplayDeclsRecursivelyAndImports(results, importCollector);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3140,7 +3140,7 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
     }
     {
       GroupNamesPrinter Printer(llvm::outs());
-      llvm::SmallVector<Decl*, 256> Results;
+      llvm::SmallVector<Decl*> Results;
       swift::getTopLevelDeclsForDisplay(M, Results);
       for (auto R : Results) {
         Printer.addDecl(R);


### PR DESCRIPTION
There's no reason to ever have a triple-digit size for a SmallVector, because the cost of processing the elements is going to dwarf the cost of the heap allocation, and most of these were in cold code paths anyway.

There are some remaining triple-digit SmallVectors where the element type is `char`. I left those alone, but they're probably unnecessary too.