### PR TITLE
[SILGen]: strengthen assertions when creating InitExistentialRef

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2174,10 +2174,7 @@ public:
                            CanType FormalConcreteType, SILValue Concrete,
                            ArrayRef<ProtocolConformanceRef> Conformances,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    ASSERT(isa<ClassType>(FormalConcreteType) ||
-           isa<BoundGenericClassType>(FormalConcreteType) ||
-           isa<ArchetypeType>(FormalConcreteType) ||
-           isa<DynamicSelfType>(FormalConcreteType));
+    ASSERT(FormalConcreteType->isBridgeableObjectType());
     return insert(InitExistentialRefInst::create(
         getSILDebugLocation(Loc), ExistentialType, FormalConcreteType, Concrete,
         Conformances, &getFunction(), forwardingOwnershipKind));

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2174,6 +2174,10 @@ public:
                            CanType FormalConcreteType, SILValue Concrete,
                            ArrayRef<ProtocolConformanceRef> Conformances,
                            ValueOwnershipKind forwardingOwnershipKind) {
+    ASSERT(isa<ClassType>(FormalConcreteType) ||
+           isa<BoundGenericClassType>(FormalConcreteType) ||
+           isa<ArchetypeType>(FormalConcreteType) ||
+           isa<DynamicSelfType>(FormalConcreteType));
     return insert(InitExistentialRefInst::create(
         getSILDebugLocation(Loc), ExistentialType, FormalConcreteType, Concrete,
         Conformances, &getFunction(), forwardingOwnershipKind));

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -816,7 +816,6 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     assert(existentialTL.isLoadable());
 
     ManagedValue sub = F(SGFContext());
-    assert(concreteFormalType->isBridgeableObjectType());
     return B.createInitExistentialRef(loc, existentialTL.getLoweredType(),
                                       concreteFormalType, sub, conformances);
   }
@@ -853,10 +852,9 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     // If the concrete value is a pseudogeneric archetype, first erase it to
     // its upper bound.
     auto anyObjectTy = getASTContext().getAnyObjectType();
-    auto eraseToAnyObject =
-    [&, concreteFormalType, F](SGFContext C) -> ManagedValue {
+    auto eraseToAnyObject = [&, concreteFormalType,
+                             F](SGFContext C) -> ManagedValue {
       auto concreteValue = F(SGFContext());
-      assert(concreteFormalType->isBridgeableObjectType());
       return B.createInitExistentialRef(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
           concreteValue, conformances);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1121,7 +1121,6 @@ namespace {
                 base.getType().getObjectType(),
                 SGF.getASTContext().AllocateCopy(conformances));
       } else {
-        assert(getSubstFormalType()->isBridgeableObjectType());
         ref = SGF.B.createInitExistentialRef(
                 loc,
                 base.getType().getObjectType(),

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -128,4 +128,17 @@ class EraseDynamicSelf {
     let _: Any = instance
     return instance
   }
+
+// CHECK-LABEL: sil hidden [ossa] @$s19existential_erasure16EraseDynamicSelfC23eraseToClassExistentialyXlyF : $@convention(method) (@guaranteed EraseDynamicSelf) -> @owned AnyObject
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $EraseDynamicSelf):
+// CHECK:  debug_value [[ARG]] : $EraseDynamicSelf, let, name "self", argno 1
+// CHECK:  [[METATYPE:%.*]] = metatype $@thick @dynamic_self EraseDynamicSelf.Type
+// CHECK:  [[UPCAST:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self EraseDynamicSelf.Type to $@thick EraseDynamicSelf.Type
+// CHECK:  [[METHOD:%.*]] = class_method [[UPCAST]] : $@thick EraseDynamicSelf.Type, #EraseDynamicSelf.factory
+// CHECK:  [[INSTANCE:%.*]] = apply [[METHOD]]([[UPCAST]]) : $@convention(method) (@thick EraseDynamicSelf.Type) -> @owned EraseDynamicSelf
+// CHECK:  [[EXISTENTIAL:%.*]] = init_existential_ref [[INSTANCE]] : $EraseDynamicSelf : $@dynamic_self EraseDynamicSelf, $AnyObject
+// CHECK:  return [[EXISTENTIAL]] : $AnyObject
+  func eraseToClassExistential() -> AnyObject {
+    return Self.factory()
+  }
 }

--- a/test/SILGen/isolated_any_issue-77365.swift
+++ b/test/SILGen/isolated_any_issue-77365.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen %s -swift-version 6 -sil-verify-none
+
+// REQUIRES: concurrency
+// REQUIRES: no_asserts
+
+// XFAIL: *
+
+// FIXME: This sort of pattern should be diagnosed as an error in Sema if possible.
+// For now, we expect an ASSERT in SILGen to prevent miscompiling.
+
+// https://github.com/swiftlang/swift/issues/77365
+
+actor A {
+  func f() {
+    let _: @isolated(any) () -> Void = { [unowned self] in
+        self.preconditionIsolated()
+    }
+  }
+
+  func g() {
+    Task {
+        [unowned self] in
+        self.preconditionIsolated()
+    }
+  }
+}

--- a/test/SILGen/isolated_any_issue-77365.swift
+++ b/test/SILGen/isolated_any_issue-77365.swift
@@ -1,14 +1,13 @@
-// RUN: %target-swift-emit-silgen %s -swift-version 6 -sil-verify-none
+// RUN: not --crash %target-swift-emit-silgen %s -swift-version 5 -sil-verify-none 2>&1 | %FileCheck %s
+// RUN: not --crash %target-swift-emit-silgen %s -swift-version 6 -sil-verify-none 2>&1 | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: no_asserts
 
-// XFAIL: *
-
+// https://github.com/swiftlang/swift/issues/77365
 // FIXME: This sort of pattern should be diagnosed as an error in Sema if possible.
 // For now, we expect an ASSERT in SILGen to prevent miscompiling.
 
-// https://github.com/swiftlang/swift/issues/77365
+// CHECK: Assertion failed: {{.*}} function createInitExistentialRef
 
 actor A {
   func f() {


### PR DESCRIPTION
There is currently a miscompilation that can occur when emitting the erased isolation existential codegen if the isolated capture is unowned. To patch this, sink the `isBridgeableObjectType` assertion into the SILBuilder logic that creates the instruction, and upgrade it to an `ASSERT` to prevent silently miscompiling in release compilers.

[Discussion](https://forums.swift.org/t/lets-debug-over-release-of-actors-involving-unowned-self-captures/83897)
