### PR TITLE
SILGen: Fix a crash when emitting @convention(c) function pointer from a closure in some cases

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1844,9 +1844,11 @@ static ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
   } else if (isAnyClosureExpr(semanticExpr)) {
     if (auto init = C.getAsConversion()) {
       auto conv = init->getConversion();
-      auto origParamType = conv.getBridgingOriginalInputType();
-      if (origParamType.isClangType())
-        destFnType = origParamType.getClangType();
+      if (conv.isBridging()) {
+        auto origParamType = conv.getBridgingOriginalInputType();
+        if (origParamType.isClangType())
+          destFnType = origParamType.getClangType();
+      }
     }
     (void)emitAnyClosureExpr(
         SGF, semanticExpr, [&](AbstractClosureExpr *closure) {

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -108,3 +108,11 @@ class Selfless {
     // expected-error@-1 {{a C function pointer cannot be formed from a closure that captures dynamic Self type}}
   }
 }
+
+enum E {
+    case x(@convention(c) (Float, Bool) -> UnsafeRawPointer?)
+}
+
+func non_trivial_conversion() -> E {
+  return E.x { x, y in nil }
+}


### PR DESCRIPTION
This fixes a regression from f26749245b95927b4d9f8b19c37330be48e3862d.

We need to check the conversion's kind before we call getBridgingOriginalInputType(), otherwise we will assert or crash.

- Fixes https://github.com/swiftlang/swift/issues/86414.