### PR TITLE
SILGen: Fix a crash when emitting @convention(c) function pointer from a closure in some cases [6.3]

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1839,9 +1839,11 @@ static ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
   } else if (isAnyClosureExpr(semanticExpr)) {
     if (auto init = C.getAsConversion()) {
       auto conv = init->getConversion();
-      auto origParamType = conv.getBridgingOriginalInputType();
-      if (origParamType.isClangType())
-        destFnType = origParamType.getClangType();
+      if (conv.isBridging()) {
+        auto origParamType = conv.getBridgingOriginalInputType();
+        if (origParamType.isClangType())
+          destFnType = origParamType.getClangType();
+      }
     }
     (void)emitAnyClosureExpr(
         SGF, semanticExpr, [&](AbstractClosureExpr *closure) {

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -108,3 +108,11 @@ class Selfless {
     // expected-error@-1 {{a C function pointer cannot be formed from a closure that captures dynamic Self type}}
   }
 }
+
+enum E {
+    case x(@convention(c) (Float, Bool) -> UnsafeRawPointer?)
+}
+
+func non_trivial_conversion() -> E {
+  return E.x { x, y in nil }
+}


### PR DESCRIPTION
6.3 cherry-pick of https://github.com/swiftlang/swift/pull/86415.

* **Description:** Fix a crash when emitting @convention(c) function pointer from a closure in some cases.

* **Origination:** New regression in 6.3 from https://github.com/swiftlang/swift/commit/f26749245b95927b4d9f8b19c37330be48e3862d.

* **Risk:** Very low, worst case we continue to crash in a new way, but when the condition being checked here didn't hold, we would definitely crash.

* **Tested:** Added a test

* **Reviewed by:** @xazax-hun

* **Issue:** https://github.com/swiftlang/swift/issues/86414