### PR TITLE
[windows] add Syft support when building on ARM64

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -164,7 +164,7 @@ param
 
   # SBoM Support
   [switch] $IncludeSBoM = $false,
-  [string] $SyftVersion = "1.29.1",
+  [string] $SyftVersion = "1.40.0",
 
   # Dependencies
   [ValidatePattern('^\d+(\.\d+)*$')]
@@ -520,6 +520,18 @@ $KnownSyft = @{
       SHA256 = "3C67CD9AF40CDCC7FFCE041C8349B4A77F33810184820C05DF23440C8E0AA1D7"
       Path = [IO.Path]::Combine("$BinaryCache\syft-1.29.1", "syft.exe")
     }
+  };
+  "1.40.0" = @{
+    AMD64 = @{
+      URL = "https://github.com/anchore/syft/releases/download/v1.40.0/syft_1.40.0_windows_amd64.zip"
+      SHA256 = "3F4021EC098B4BCBAF19BBA7028CF7704FEF12936970778CEC3C6D669B740E6D"
+      Path = [IO.Path]::Combine("$BinaryCache\syft-1.40.0", "syft.exe")
+    };
+    ARM64 = @{
+      URL = "https://github.com/anchore/syft/releases/download/v1.40.0/syft_1.40.0_windows_arm64.zip"
+      SHA256 = "CE7129DBCC39809542C9BC5032B179131DFEE72C68C5B3741E3270A3D9ED46E4"
+      Path = [IO.Path]::Combine("$BinaryCache\syft-1.40.0", "syft.exe")
+    };
   }
 }
 


### PR DESCRIPTION
This patch adds Syft support when building on ARM64 by bumping the Syft version to `1.40.0`.

This is needed when building on ARM64 with `build-windows-toolchain.bat`, which sets the `IncludeSBoM` flag.