### PR TITLE
[stdlib] mark `Span.mutableBytes` as unsafe

### DIFF
--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -192,7 +192,7 @@ internal func _Float16ToASCII(
   // We need a MutableRawSpan in order to use wide store/load operations
   // TODO: Tune this value down to the actual minimum for Float16
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle various input cases:
   let binaryExponent: Int
@@ -488,7 +488,7 @@ internal func _Float32ToASCII(
   // TODO: Tune this limit down to the actual minimum we need here
   // TODO: `assert` that the buffer is filled with 0x30 bytes (in debug builds)
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle the special cases, decompose the input
 
@@ -734,7 +734,7 @@ internal func _Float64ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   //
   // Step 1: Handle the special cases, decompose the input
@@ -1239,7 +1239,7 @@ internal func _Float80ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle special cases, decompose the input
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1396,7 +1396,7 @@ internal func _BinaryIntegerToASCII<T: BinaryInteger>(
   let radix = radix.magnitude
 
   // We need a `MutableRawSpan` to use wide store/load operations.
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
   var offset = buffer.byteCount
 
   if value == (0 as T.Magnitude) {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -268,8 +268,13 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   /// Construct a MutableRawSpan over the memory represented by this span
   ///
+  /// Mutating `self` through this property is unsafe because
+  /// it is possible to mutate a byte so as to produce an invalid
+  /// bit pattern in the corresponding instance of `Element`.
+  ///
   /// - Returns: a MutableRawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
+  @unsafe
   public var mutableBytes: MutableRawSpan {
     @lifetime(&self)
     mutating get {


### PR DESCRIPTION
Fix the mistake of not marking this accessor with `@unsafe`. If a `Span<Element>` has an `Element` type with invalid representations, then mutating a single byte through its `.mutableBytes` accessor could lead to logic errors or even undefined behaviour.

The fix is to mark the accessor with `@unsafe`. Note that it was proposed with the `@unsafe` annotation.

This change does not impede future evolution, because we can define another `.mutableBytes` accessor without an `@unsafe` annotation and with a refined generic signature (such as `where Element: FixedWithInteger & BitwiseCopyable`,) and in a specialized context the more specific safe accessor will be correctly picked up.

Addresses rdar://167661807