### PR TITLE
[cxx-interop] Implicitly bridge annotated smart pointers to reference types

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -204,6 +204,10 @@ public:
   /// Imports a clang decl directly, rather than looking up its name.
   virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
 
+  /// Returns a decl that was imported earlier or null if it was not found in
+  /// the cache.
+  virtual Decl *lookupImportedDecl(const clang::NamedDecl *decl) = 0;
+
   /// Clones an imported \param decl from its base class to its derived class
   /// \param newContext where it is inherited. Its access level is determined
   /// with respect to \param inheritance, which signifies whether \param decl

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -397,6 +397,21 @@ NOTE(refcounted_ptr_torawpointer_lookup_ambiguity, none,
      "'_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR %1",
      (StringRef, const clang::NamedDecl *))
 
+NOTE(refcounted_ptr_ctor_wrong_parameter_type, none,
+     "the constructor's parameter to create smart pointer from a raw pointer "
+     "does not match the return type of the raw pointer accessor in %0",
+     (const clang::NamedDecl *))
+
+NOTE(refcounted_ptr_ctor_lookup_failure, none,
+     "cannot find constructor to create smart pointer from a raw pointer to a "
+     "shared reference %0",
+     (const clang::NamedDecl *))
+
+NOTE(refcounted_ptr_ctor_lookup_ambiguity, none,
+     "there are multiple constructors to create smart pointer from a raw "
+     "pointer to a shared reference %0",
+     (const clang::NamedDecl *))
+
 NOTE(refcounted_ptr_torawpointer_not_function, none,
      "%0 specified in '_toRawPointer' parameter of "
      "SWIFT_REFCOUNTED_PTR on %1 is not a function",
@@ -408,6 +423,7 @@ NOTE(
     "SWIFT_REFCOUNTED_PTR on %1 has incorrect signature; expected a function "
     "that takes no arguments and returns a pointer to a foreign reference type",
     (const Decl *, const clang::NamedDecl *))
+
 ERROR(invalid_conditional_attr, none,
       "%0 is invalid because it is only supported in "
       "class templates",

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -19,6 +19,7 @@
 #include "swift/AST/Attr.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/Decl.h"
 #include "clang/AST/Attr.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/Specifiers.h"
@@ -99,6 +100,7 @@ class StructDecl;
 class SwiftLookupTable;
 class TypeDecl;
 class ValueDecl;
+class ConstructorDecl;
 class VisibleDeclConsumer;
 using ModuleDependencyIDSetVector =
     llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
@@ -681,6 +683,10 @@ public:
   /// Imports a clang decl directly, rather than looking up it's name.
   Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
 
+  /// Returns a decl that was imported earlier or null if it was not found in
+  /// the cache.
+  virtual Decl *lookupImportedDecl(const clang::NamedDecl *decl) override;
+
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
                                   ClangInheritanceInfo inheritance) override;
 
@@ -917,6 +923,31 @@ std::optional<T> matchSwiftAttrOnRecordPtr(
 /// \returns Matched `ResultConvention`, or `std::nullopt` if none applies.
 std::optional<ResultConvention>
 getCxxRefConventionWithAttrs(const clang::Decl *decl);
+
+enum class RefCountedPtrError {
+  NotAnnotated,
+  MissingToRawPointer,
+  ToRawPointerLookupFailure,
+  ToRawPointerLookupAmbiguity,
+  ToRawPointerNotFunction,
+  ToRawPointerWrongSignature,
+  CtorLookupAmbiguity,
+  CtorLookupFailure,
+  CtorWrongParamType
+};
+
+struct RefCountedPtrInfo {
+  ConstructorDecl *toSmartPtr;
+};
+
+struct RefCountedPtrRequestResult {
+  std::variant<RefCountedPtrInfo, RefCountedPtrError> result;
+  ValueDecl *toRawPtrFunc = nullptr;
+  StringRef toRawPtrName = "";
+};
+
+RefCountedPtrRequestResult
+getClangRefCountedSmartPointer(NominalTypeDecl *decl);
 } // namespace importer
 
 /// On Linux, some platform libraries (glibc, libstdc++) are not modularized.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -17,12 +17,14 @@
 #define SWIFT_CLANG_IMPORTER_REQUESTS_H
 
 #include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/EvaluatorDependencies.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/Hashing.h"
@@ -659,6 +661,54 @@ private:
   // Evaluation.
   ExplicitSafety evaluate(Evaluator &evaluator,
                           ClangDeclExplicitSafetyDescriptor desc) const;
+};
+
+struct ClangRefCountedSmartPointerDescriptor final {
+  NominalTypeDecl *smartPtr;
+
+  ClangRefCountedSmartPointerDescriptor(NominalTypeDecl *smartPtr)
+      : smartPtr(smartPtr) {}
+
+  friend llvm::hash_code
+  hash_value(const ClangRefCountedSmartPointerDescriptor &desc) {
+    return llvm::hash_combine(desc.smartPtr);
+  }
+
+  friend bool operator==(const ClangRefCountedSmartPointerDescriptor &lhs,
+                         const ClangRefCountedSmartPointerDescriptor &rhs) {
+    return lhs.smartPtr == rhs.smartPtr;
+  }
+
+  friend bool operator!=(const ClangRefCountedSmartPointerDescriptor &lhs,
+                         const ClangRefCountedSmartPointerDescriptor &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    ClangRefCountedSmartPointerDescriptor desc);
+SourceLoc extractNearestSourceLoc(ClangRefCountedSmartPointerDescriptor desc);
+
+/// Determine the safety of the given Clang declaration.
+class ClangRefCountedSmartPointer
+    : public SimpleRequest<ClangRefCountedSmartPointer,
+                           importer::RefCountedPtrRequestResult(
+                               ClangRefCountedSmartPointerDescriptor),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // Source location
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+  bool isCached() const { return true; }
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  importer::RefCountedPtrRequestResult
+  evaluate(Evaluator &evaluator,
+           ClangRefCountedSmartPointerDescriptor desc) const;
 };
 
 #define SWIFT_TYPEID_ZONE ClangImporter

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -51,3 +51,6 @@ SWIFT_REQUEST(ClangImporter, CxxValueSemantics,
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
               ExplicitSafety(ClangDeclExplicitSafetyDescriptor), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, ClangRefCountedSmartPointer,
+              RefCountedPtrRequestResult(ClangRefCountedSmartPointerDescriptor),
+              Cached, NoLocationInfo)

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1199,6 +1199,8 @@ private:
 #endif
 };
 
+clang::CXXRecordDecl *getBridgedSmartPtr(AbstractionPattern pattern);
+
 } // namespace Lowering
 
 CanSILFunctionType getNativeSILFunctionType(

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7833,6 +7833,10 @@ Decl *ClangImporter::importDeclDirectly(const clang::NamedDecl *decl) {
   return Impl.importDecl(decl, Impl.CurrentVersion);
 }
 
+Decl *ClangImporter::lookupImportedDecl(const clang::NamedDecl *decl) {
+  return Impl.lookupImportedDecl(decl);
+}
+
 ValueDecl *ClangImporter::Implementation::importBaseMemberDecl(
     ValueDecl *decl, DeclContext *newContext,
     ClangInheritanceInfo inheritance) {
@@ -8866,6 +8870,94 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
 
 bool ClangDeclExplicitSafety::isCached() const {
   return isa<clang::RecordDecl>(std::get<0>(getStorage()).decl);
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           ClangRefCountedSmartPointerDescriptor desc) {
+  out << "Validating SWIFT_REFCOUNTED_PTR for '";
+  out << desc.smartPtr->getNameStr();
+  out << "'\n";
+}
+
+SourceLoc
+swift::extractNearestSourceLoc(ClangRefCountedSmartPointerDescriptor desc) {
+  return SourceLoc();
+}
+
+RefCountedPtrRequestResult ClangRefCountedSmartPointer::evaluate(
+    Evaluator &evaluator, ClangRefCountedSmartPointerDescriptor desc) const {
+  for (const auto *attr : desc.smartPtr->getAttrs()) {
+    if (const auto *customAttr = dyn_cast<CustomAttr>(attr)) {
+      if (!customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
+              "_refCountedPtr"))
+        continue;
+      StringRef ToRawPtrFuncName;
+      for (auto arg : *customAttr->getArgs()) {
+        if (arg.getLabel().str() == "ToRawPointer") {
+          if (const auto *literal = dyn_cast<StringLiteralExpr>(arg.getExpr()))
+            ToRawPtrFuncName = literal->getValue();
+        }
+      }
+      if (ToRawPtrFuncName.empty())
+        return {RefCountedPtrError::MissingToRawPointer, nullptr};
+
+      auto results = getValueDeclsForName(desc.smartPtr, ToRawPtrFuncName);
+      if (results.empty())
+        return {RefCountedPtrError::ToRawPointerLookupFailure, nullptr,
+                ToRawPtrFuncName};
+
+      if (results.size() > 1)
+        return {RefCountedPtrError::ToRawPointerLookupAmbiguity, nullptr,
+                ToRawPtrFuncName};
+
+      auto toRawPtrFunc = dyn_cast<FuncDecl>(results.front());
+      if (!toRawPtrFunc)
+        return {RefCountedPtrError::ToRawPointerNotFunction, toRawPtrFunc};
+
+      auto pointeeType = toRawPtrFunc->getResultInterfaceType()
+                             ->lookThroughSingleOptionalType();
+      ClassDecl *referenceDecl = pointeeType->getClassOrBoundGenericClass();
+
+      if (toRawPtrFunc->getParameters()->size() != 0 || !referenceDecl)
+        return {RefCountedPtrError::ToRawPointerWrongSignature, toRawPtrFunc};
+
+      auto ctors =
+          desc.smartPtr->lookupDirect(DeclBaseName::createConstructor());
+      // We should have a single constructor taking a foreign reference
+      // types. This is relied on during SILGen to introduce implicit
+      // bridging.
+      ConstructorDecl *selected = nullptr;
+      Type selectedCtorParamType = nullptr;
+      for (auto result : ctors) {
+        auto ctor = cast<ConstructorDecl>(result);
+        if (ctor->getParameters()->size() != 1)
+          continue;
+        Type ctorParamType = ctor->getParameters()->get(0)->getInterfaceType();
+        if (ctorParamType->isForeignReferenceType()) {
+          if (selected != nullptr)
+            return {RefCountedPtrError::CtorLookupAmbiguity, toRawPtrFunc};
+          selected = ctor;
+          selectedCtorParamType = ctorParamType;
+        }
+      }
+      if (!selected)
+        return {RefCountedPtrError::CtorLookupFailure, toRawPtrFunc};
+      if (!selectedCtorParamType->lookThroughSingleOptionalType()->isEqual(
+              pointeeType))
+        return {RefCountedPtrError::CtorWrongParamType, toRawPtrFunc};
+
+      return {RefCountedPtrInfo{selected}, toRawPtrFunc};
+    }
+  }
+  return {RefCountedPtrError::NotAnnotated, nullptr};
+}
+
+RefCountedPtrRequestResult
+importer::getClangRefCountedSmartPointer(NominalTypeDecl *decl) {
+  return evaluateOrDefault(
+      decl->getASTContext().evaluator,
+      ClangRefCountedSmartPointer(ClangRefCountedSmartPointerDescriptor{decl}),
+      RefCountedPtrRequestResult{RefCountedPtrError::NotAnnotated, nullptr});
 }
 
 const clang::TypedefType *ClangImporter::getTypeDefForCXXCFOptionsDefinition(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -32,6 +32,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Identifier.h"
 #include "swift/AST/LifetimeDependence.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
@@ -2110,82 +2111,77 @@ namespace {
 
     bool
     injectBridgingConversionsForRefCountedSmartPtrs(NominalTypeDecl *smartPtr) {
-      for (const auto *attr : smartPtr->getAttrs()) {
-        if (const auto *customAttr = dyn_cast<CustomAttr>(attr)) {
-          if (!customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
-                  "_refCountedPtr"))
-            continue;
-          auto clangDecl = cast<clang::TagDecl>(smartPtr->getClangDecl());
-          StringRef ToRawPtrFuncName;
-          for (auto arg : *customAttr->getArgs()) {
-            if (arg.getLabel().str() == "ToRawPointer") {
-              if (const auto *literal =
-                      dyn_cast<StringLiteralExpr>(arg.getExpr()))
-                ToRawPtrFuncName = literal->getValue();
-            }
-          }
-          if (ToRawPtrFuncName.empty()) {
-            Impl.addImportDiagnostic(
-                clangDecl,
-                Diagnostic(diag::refcounted_ptr_missing_torawpointer,
-                           clangDecl),
-                clangDecl->getLocation());
-            return false;
-          }
-
-          auto results = getValueDeclsForName(smartPtr, ToRawPtrFuncName);
-          if (results.empty()) {
-            Impl.addImportDiagnostic(
-                clangDecl,
-                Diagnostic(
-                    diag::refcounted_ptr_torawpointer_lookup_failure,
-                    Impl.SwiftContext.AllocateCopy(ToRawPtrFuncName.str()),
-                    clangDecl),
-                clangDecl->getLocation());
-            return false;
-          }
-          if (results.size() > 1) {
-            Impl.addImportDiagnostic(
-                clangDecl,
-                Diagnostic(
-                    diag::refcounted_ptr_torawpointer_lookup_ambiguity,
-                    Impl.SwiftContext.AllocateCopy(ToRawPtrFuncName.str()),
-                    clangDecl),
-                clangDecl->getLocation());
-            return false;
-          }
-
-          auto toRawPtrFunc = dyn_cast<FuncDecl>(results.front());
-          if (!toRawPtrFunc) {
-            Impl.addImportDiagnostic(
-                clangDecl,
-                Diagnostic(diag::refcounted_ptr_torawpointer_not_function,
-                           toRawPtrFunc, clangDecl),
-                clangDecl->getLocation());
-            return false;
-          }
-
-          auto pointeeType = toRawPtrFunc->getResultInterfaceType()
-                                 ->lookThroughSingleOptionalType();
-          ClassDecl *referenceDecl = pointeeType->getClassOrBoundGenericClass();
-
-          if (toRawPtrFunc->getParameters()->size() != 0 || !referenceDecl) {
-            Impl.addImportDiagnostic(
-                clangDecl,
-                Diagnostic(diag::refcounted_ptr_torawpointer_wrong_signature,
-                           toRawPtrFunc, clangDecl),
-                clangDecl->getLocation());
-            return false;
-          }
-
-          auto asReferenceDecl =
-              synthesizer.createSmartPtrBridgingProperty(toRawPtrFunc);
-          smartPtr->addMember(asReferenceDecl);
-          smartPtr->addMemberToLookupTable(asReferenceDecl);
-          break;
+      auto clangDecl = cast<clang::TagDecl>(smartPtr->getClangDecl());
+      auto [refCountedSmartPtr, toRawPtrFunc, toRawPtrFuncName] =
+          getClangRefCountedSmartPointer(smartPtr);
+      if (auto error = std::get_if<RefCountedPtrError>(&refCountedSmartPtr)) {
+        switch (*error) {
+        case RefCountedPtrError::MissingToRawPointer:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_missing_torawpointer, clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::ToRawPointerLookupFailure:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_torawpointer_lookup_failure,
+                         Impl.SwiftContext.AllocateCopy(toRawPtrFuncName.str()),
+                         clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::ToRawPointerLookupAmbiguity:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_torawpointer_lookup_ambiguity,
+                         Impl.SwiftContext.AllocateCopy(toRawPtrFuncName.str()),
+                         clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::ToRawPointerNotFunction:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_torawpointer_not_function,
+                         toRawPtrFunc, clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::ToRawPointerWrongSignature:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_torawpointer_wrong_signature,
+                         toRawPtrFunc, clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::CtorLookupAmbiguity:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_ctor_lookup_ambiguity, clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::CtorLookupFailure:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_ctor_lookup_failure, clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::CtorWrongParamType:
+          Impl.addImportDiagnostic(
+              clangDecl,
+              Diagnostic(diag::refcounted_ptr_ctor_wrong_parameter_type,
+                         clangDecl),
+              clangDecl->getLocation());
+          return false;
+        case RefCountedPtrError::NotAnnotated:
+          return true;
         }
+      } else {
+        ASSERT(toRawPtrFunc);
+        auto asReferenceDecl = synthesizer.createSmartPtrBridgingProperty(
+            cast<FuncDecl>(toRawPtrFunc));
+        smartPtr->addMember(asReferenceDecl);
+        smartPtr->addMemberToLookupTable(asReferenceDecl);
+        return true;
       }
-      return true;
     }
 
     std::pair<CustomRefCountingOperationResult,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
@@ -119,6 +120,9 @@ namespace {
 
       /// The source type is any other pointer type.
       OtherPointer,
+
+      /// The source types is annotated with SWIFT_REFCOUNTED_PTR.
+      IntrusivelyRefCountedSmartPtr,
     };
 
     ImportHintKind Kind;
@@ -148,6 +152,7 @@ namespace {
     case ImportHint::Boolean:
     case ImportHint::NSUInteger:
     case ImportHint::Void:
+    case ImportHint::IntrusivelyRefCountedSmartPtr:
       return false;
 
     case ImportHint::Block:
@@ -894,6 +899,7 @@ namespace {
         case ImportHint::CFunctionPointer:
         case ImportHint::OtherPointer:
         case ImportHint::VAList:
+        case ImportHint::IntrusivelyRefCountedSmartPtr:
           return {mappedType, underlying.Hint};
 
         case ImportHint::Boolean:
@@ -1037,6 +1043,14 @@ namespace {
           Impl.importDecl(type->getDecl(), Impl.CurrentVersion));
       if (!decl)
         return nullptr;
+
+      for (const auto *attr : decl->getAttrs())
+        if (const auto *customAttr = dyn_cast<CustomAttr>(attr))
+          if (customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
+                  "_refCountedPtr")) {
+            return ImportResult(decl->getDeclaredInterfaceType(),
+                                ImportHint::IntrusivelyRefCountedSmartPtr);
+          }
 
       return decl->getDeclaredInterfaceType();
     }
@@ -1680,6 +1694,17 @@ static ImportedType adjustTypeForConcreteImport(
       }
     }
 
+    break;
+  case ImportHint::IntrusivelyRefCountedSmartPtr:
+    if (bridging == Bridgeability::Full && canBridgeTypes(importKind)) {
+      auto decl = importedType->castTo<StructType>()->getDecl();
+      auto lookupResult = decl->lookupDirect(
+          DeclName(impl.SwiftContext.getIdentifier("asReference")));
+      ASSERT(lookupResult.size() == 1);
+      auto asReference = cast<VarDecl>(lookupResult.front());
+      importedType = asReference->getInterfaceType();
+      optKind = OTK_None;
+    }
     break;
   }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1179,6 +1179,14 @@ public:
                                   /*UseCanonicalDecl*/ UseCanonicalDecl);
   }
 
+  Decl *lookupImportedDecl(const clang::NamedDecl *decl) {
+    auto Known = importDeclCached(
+        cast<clang::NamedDecl>(decl->getCanonicalDecl()), CurrentVersion, true);
+    if (Known.has_value())
+      return Known.value();
+    return nullptr;
+  }
+
   /// Import the given Clang declaration into Swift.  Use this function
   /// outside of the importer implementation, when importing a decl requested by
   /// Swift code.

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -111,16 +111,59 @@
   __attribute__((swift_attr("release:immortal")))    \
   __attribute__((swift_attr("unsafe")))
 
-/// The annotated `class` or `struct` is a smart pointer to an intrusively
-/// reference counted object. The pointee type is expected to be a Swift shared
-/// reference. The presence of this annotation will introduce conversion
-/// functions between the smart pointer type and Swift's native reference type.
-/// The conversion function is expected to return a +0 raw pointer to a Swift
-/// shared reference type.
+/// This annotation makes smart pointers to intrusively reference counted
+/// objects more ergonomic to use in Swift by:
+///
+/// * introducing explicit conversions between the smart pointer type and
+///   the underlying reference type and
+/// * importing C++ APIs that return the smart pointer type or take it as a
+///   parameter as returning or taking the underlying reference type.
+///
+/// Place this annotation on a smart pointer class or struct. The argument
+/// to the annotation names an accessor function, which can be a file-scope
+/// function or (if prefixed by .) a member function of the smart pointer
+/// class. The return type of the accessor function determines the underlying
+/// reference type of the smart pointer; it must be a pointer to a class or
+/// struct with the SWIFT_SHARED_REFERENCE annotation. Note that
+/// SWIFT_SHARED_REFERENCE requires the underlying reference type
+/// to provide independent retain and release operations; Swift does not
+/// currently support this ergonomic import of smart pointers to objects
+/// that can only be managed through a smart pointer class.
+///
+/// The Swift importer will diagnose a class with this annotation as an
+/// error if it cannot determine an underlying reference type. If the class
+/// is templated, this applies to instantiations of the template, not to the
+/// template pattern. (That is, it is okay to have a templated smart pointer
+/// type as long as the concrete instantiations used in your C++ interface
+/// all have determinable underlying reference types.)
+///
+/// The smart pointer type is required to have a constructor that takes a raw
+/// pointer. This constructor is expected to perform a retain of the object.
+/// (In the +0 / +1 language of Objective-C reference counting, it would be
+/// said to take the object at +0: it does not take responsibility for a retain
+/// performed by its caller.) Generally, this kind of constructor matches with
+/// object models where the object constructor initializes the reference
+/// count to 0.
+///
+/// The argument of this annotation is required to be the name of an
+/// "accessor" method that returns a raw-pointer to the object. This method
+/// is required to return a raw pointer to the object without changing the
+/// reference count.
+///
+/// Swift will define conversion operations using these functions to
+/// convert between the raw pointer and the smart pointer representations.
+///
+/// By default, smart pointer types are assumed to have a valid null state.
+/// Passing a null pointer to the raw-pointer constructor will create a smart
+/// pointer in the null state, and calling the raw-pointer accessor method
+/// on a smart pointer in the null state will return a null pointer. In case the
+/// constructor and the raw-pointer accessor are annotated with _Nonnull, we
+/// assume the smart pointer does not have a null state.
 ///
 ///  ```c++
 ///   template <class T>
 ///   struct SWIFT_REFCOUNTED_PTR(.getPtr) Ptr {
+///     Ptr(T* ptr);
 ///     T *_Nullable getPtr() const { return ptr; }
 ///   };
 ///
@@ -134,6 +177,13 @@
 ///    let y = x.asReference
 ///  }
 ///  ```
+///
+/// Moreover, this annotation introduces implicit bridging for functions taking
+/// or returning smart pointers by value:
+///  ```c++
+///   PtrOfSharedRef foo(PtrOfSharedRef param);
+///  ```
+/// Imported with the signature `func foo(_ param: SharedRef) -> SharedRef`
 #define SWIFT_REFCOUNTED_PTR(_toRawPointer)                                            \
   __attribute__((swift_attr(                                                           \
       "@_refCountedPtr(ToRawPointer: \"" _CXX_INTEROP_STRINGIFY(_toRawPointer) "\")")))

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -18,6 +18,7 @@
 #include "Conversion.h"
 #include "Initialization.h"
 #include "swift/Basic/Assertions.h"
+#include "clang/AST/DeclCXX.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -166,9 +167,10 @@ ManagedValue ArgumentSource::materialize(SILGenFunction &SGF,
                                          AbstractionPattern origFormalType,
                                          SILType destType) && {
   auto substFormalType = getSubstRValueType();
-  assert(!destType || destType.getObjectType() ==
-               SGF.getLoweredType(origFormalType,
-                                  substFormalType).getObjectType());
+  assert(
+      !destType ||
+      destType.getObjectType() ==
+          SGF.getLoweredType(origFormalType, substFormalType).getObjectType());
 
   // Fast path: if the types match exactly, no abstraction difference
   // is possible and we can just materialize as normal.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -25,10 +25,12 @@
 #include "StorageRefResult.h"
 #include "Varargs.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Effects.h"
+#include "swift/AST/Evaluator.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -44,6 +46,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Unicode.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SIL/AbstractionPatternGenerators.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
@@ -3942,6 +3945,30 @@ private:
     });
   }
 
+  static ManagedValue
+  emitNativeToCppBridgedSmartPtr(ArgumentSource &&argSrc,
+                                 const clang::CXXRecordDecl *rd,
+                                 SILType destType, SILGenFunction &SGF) {
+    auto decl = cast<StructDecl>(
+        SGF.getASTContext().getClangModuleLoader()->lookupImportedDecl(rd));
+    auto result = importer::getClangRefCountedSmartPointer(decl);
+
+    // We always have a RefCountedPtrInfo here as this is validated when the
+    // type is imported.
+    ConstructorDecl *selected =
+        std::get<importer::RefCountedPtrInfo>(result.result).toSmartPtr;
+    SILLocation loc = argSrc.getLocation();
+    SILDeclRef c(selected, SILDeclRef::Kind::Allocator, true);
+    SILValue bridgingFn = SGF.emitGlobalFunctionRef(loc, c);
+
+    auto temporary = SGF.emitTemporary(loc, SGF.getTypeLowering(destType));
+    SGF.B.createApply(loc, bridgingFn, {},
+                      {temporary->getAddress(),
+                       std::move(argSrc).getAsSingleValue(SGF).getValue()});
+    temporary->finishInitialization(SGF);
+    return temporary->getManagedAddress();
+  }
+
   void emitIndirect(ArgumentSource &&arg,
                     SILType loweredSubstArgType,
                     AbstractionPattern origParamType,
@@ -3986,8 +4013,15 @@ private:
 
     // Otherwise, simultaneously emit and reabstract.
     } else {
-      result = std::move(arg).materialize(SGF, origParamType,
-                                          SGF.getSILInterfaceType(param));
+      // Try materialize via bridging conversion first.
+      auto substFormalType = arg.getSubstRValueType();
+      auto destType = SGF.getSILInterfaceType(param);
+      if (substFormalType.isForeignReferenceType())
+        if (auto rd = Lowering::getBridgedSmartPtr(origParamType))
+          result =
+              emitNativeToCppBridgedSmartPtr(std::move(arg), rd, destType, SGF);
+      if (!result)
+        result = std::move(arg).materialize(SGF, origParamType, destType);
     }
 
     Args.push_back(result);

--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
@@ -7,8 +7,16 @@ class RefCountedBase {
 public:
   RefCountedBase() : _refCount(1) { printf("created\n"); }
 
+  static RefCountedBase * _Nonnull forSmartPtr() {
+    auto p = new RefCountedBase();
+    p->_refCount = 0;
+    return p;
+  }
+
+  int method() const { return 42; }
+
 protected:
-  virtual ~RefCountedBase() { printf("destroyed"); }
+  virtual ~RefCountedBase() { printf("destroyed\n"); }
 
 private:
 
@@ -18,8 +26,6 @@ private:
   RefCountedBase &operator=(RefCountedBase &&) = delete;
 
   int _refCount;
-
-  int method() const { return 42; }
 
   friend void retainSharedFRT(RefCountedBase *_Nonnull);
   friend void releaseSharedFRT(RefCountedBase *_Nonnull);
@@ -109,6 +115,15 @@ using RefOfBase = Ref<RefCountedBase>;
 using PtrOfBase = Ptr<RefCountedBase>;
 using DerivedRefOfBase = DerivedRef<RefCountedBase>;
 
+inline void bridgedFunction(RefOfBase ptr) {}
+inline void bridgedFunction2(PtrOfBase ptr) {}
+inline RefOfBase bridgedFunction3() {
+  return RefOfBase(RefCountedBase::forSmartPtr());
+}
+inline PtrOfBase bridgedFunction4() {
+  return PtrOfBase(RefCountedBase::forSmartPtr());
+}
+
 namespace errors { // expected-note * {{'errors' declared here}}
 struct __attribute__((
     swift_attr("@_refCountedPtr(Nullability: \"Nullable\")"))) MissingToRawPtr {};
@@ -130,6 +145,26 @@ struct SWIFT_REFCOUNTED_PTR(.getPtr) WrongConversionSignature {
 
 class SWIFT_REFCOUNTED_PTR(.getPtr) PrivateConversionFunction {
   // expected-note@-1 * {{cannot find function '.getPtr' specified in '_toRawPointer' parameter of SWIFT_REFCOUNTED_PTR 'PrivateConversionFunction'}}
+  RefCountedBase *_Nonnull getPtr();
+};
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) NoSuitableCtor {
+  // expected-note@-1 * {{cannot find constructor to create smart pointer from a raw pointer to a shared reference 'NoSuitableCtor'}}
+  RefCountedBase *_Nonnull getPtr();
+};
+
+struct RefCounted : RefCountedBase {};
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) AmbiguousCtors {
+  // expected-note@-1 * {{there are multiple constructors to create smart pointer from a raw pointer to a shared reference 'AmbiguousCtors'}}
+  AmbiguousCtors(RefCountedBase* _Nullable);
+  AmbiguousCtors(RefCounted* _Nullable);
+  RefCountedBase *_Nonnull getPtr();
+};
+
+struct SWIFT_REFCOUNTED_PTR(.getPtr) MismatchingPointerTypes {
+  // expected-note@-1 * {{the constructor's parameter to create smart pointer from a raw pointer does not match the return type of the raw pointer accessor in 'MismatchingPointerTypes'}}
+  MismatchingPointerTypes(RefCounted* _Nullable);
   RefCountedBase *_Nonnull getPtr();
 };
 } // namespace errors

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-errors.swift
@@ -5,5 +5,8 @@ func triggerWarnings(_ a: errors.MissingToRawPtr,               // @expected-err
                      _ b: errors.MissingConversionFunction,     // @expected-error {{'MissingConversionFunction' is not a member type of enum '__ObjC.errors'}}
                      _ c: errors.MultipleConversionFunctions,   // @expected-error {{'MultipleConversionFunctions' is not a member type of enum '__ObjC.errors'}}
                      _ d: errors.WrongConversionSignature,      // @expected-error {{'WrongConversionSignature' is not a member type of enum '__ObjC.errors'}}
-                     _ e: errors.PrivateConversionFunction) {   // @expected-error {{'PrivateConversionFunction' is not a member type of enum '__ObjC.errors'}}
+                     _ e: errors.PrivateConversionFunction,     // @expected-error {{'PrivateConversionFunction' is not a member type of enum '__ObjC.errors'}}
+                     _ f: errors.NoSuitableCtor,                // @expected-error {{'NoSuitableCtor' is not a member type of enum '__ObjC.errors'}}
+                     _ g: errors.AmbiguousCtors,                // @expected-error {{'AmbiguousCtors' is not a member type of enum '__ObjC.errors'}}
+                     _ h: errors.MismatchingPointerTypes) {     // @expected-error {{'MismatchingPointerTypes' is not a member type of enum '__ObjC.errors'}}
 }

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=RefCountedSmartPtrs -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: func bridgedFunction(_ ptr: RefCountedBase)
+// CHECK: func bridgedFunction2(_ ptr: RefCountedBase?)
+// CHECK: func bridgedFunction3() -> RefCountedBase
+// CHECK: func bridgedFunction4() -> RefCountedBase?

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
@@ -5,6 +5,7 @@
 import RefCountedSmartPtrs
 
 func conversions(_ r: RefCountedBase) {
+    print("conversions")
     let ref = RefOfBase(r)
     let ptr = PtrOfBase(r)
     let _ = ref.asReference
@@ -13,7 +14,38 @@ func conversions(_ r: RefCountedBase) {
     let _ = derivedRef.asReference
 }
 
-conversions(RefCountedBase())
+func bridgedFunctions(_ r: RefCountedBase) {
+    print("bridging")
+    bridgedFunction(r)
+    bridgedFunction2(r)
+    let x = bridgedFunction3()
+    print(x.method())
+    let y = bridgedFunction4()
+    print(y!.method())
+}
 
+func takesOptional(_ r: RefCountedBase?) {}
+
+func bridgedFunctionsWithOptionalInjection() {
+    print("bridgingWithInjection")
+    takesOptional(bridgedFunction3())
+}
+
+conversions(RefCountedBase())
+// CHECK: created
+// CHECK: conversions
+// CHECK: destroyed
+bridgedFunctions(RefCountedBase())
+// CHECK: created
+// CHECK: bridging
+// CHECK: created
+// CHECK: 42
+// CHECK: created
+// CHECK: 42
+// CHECK: destroyed
+// CHECK: destroyed
+// CHECK: destroyed
+bridgedFunctionsWithOptionalInjection()
+// CHECK: bridgingWithInjection
 // CHECK: created
 // CHECK: destroyed


### PR DESCRIPTION
This PR introduces implicit bridging from annotated smart pointers to reference counted objects to Swift foreign reference types. The bridging only happens when these smart pointers are passed around by value. The frontend only sees the Swift foreign reference types in the signature and the actual bridging happens during SILGen when we look at the original clang types and note that they differ significantly from the native types.

The bridging of parameters did not quite fit into the existing structure of bridging conversions as smart pointers are non-trivial types passed around as addresses and existing bridging conversions were implemented for types passed directly.

rdar://156521316
