### PR TITLE
Always suppress swift_(begin|end)Access calls with `-enforce-exclusivity=unchecked`

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3322,6 +3322,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   if (const Arg *A = Args.getLastArg(options::OPT_enforce_exclusivity_EQ)) {
     parseExclusivityEnforcementOptions(A, Opts, Diags);
+  } else if (!Opts.RemoveRuntimeAsserts &&
+             LangOpts.hasFeature(Feature::Embedded)) {
+    // Embedded Swift defaults to -enforce-exclusivity=unchecked for now.
+    Opts.EnforceExclusivityStatic = true;
+    Opts.EnforceExclusivityDynamic = false;
   }
 
   Opts.OSSACompleteLifetimes =

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6905,8 +6905,13 @@ static SILAccessEnforcement getEffectiveEnforcement(IRGenFunction &IGF,
   if (enforcement == SILAccessEnforcement::Dynamic &&
       IGF.IGM.getTypeInfo(access->getSource()->getType())
              .isKnownEmpty(ResilienceExpansion::Maximal)) {
-    enforcement = SILAccessEnforcement::Unsafe;
+    return SILAccessEnforcement::Unsafe;
   }
+
+  // Don't use dynamic enforcement if it has been disabled on the command line.
+  if (enforcement == SILAccessEnforcement::Dynamic &&
+      !IGF.getSILModule().getOptions().EnforceExclusivityDynamic)
+    return SILAccessEnforcement::Unsafe;
 
   return enforcement;
 }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -650,20 +650,6 @@ fileprivate func storeRelaxed(_ atomic: UnsafeMutablePointer<Int>, newValue: Int
   Builtin.atomicstore_monotonic_Word(atomic._rawValue, newValue._builtinWordValue)
 }
 
-/// Exclusivity checking
-
-@c
-public func swift_beginAccess(pointer: UnsafeMutableRawPointer, buffer: UnsafeMutableRawPointer, flags: UInt, pc: UnsafeMutableRawPointer) {
-  // TODO: Add actual exclusivity checking.
-}
-
-@c
-public func swift_endAccess(buffer: UnsafeMutableRawPointer) {
-  // TODO: Add actual exclusivity checking.
-}
-
-
-
 // Once
 
 @c


### PR DESCRIPTION
The exclusivity enforcement command-line flags currently impact the generation of SIL within the current module. However, it does not impact any SIL that was deserialized from another module, which means that `-enforce-exclusivity=unchecked` doesn't actually remove all of the dynamic exclusivity checks.

When dynamic exclusivity is disabled, lower SIL
begin_access/end_access instructions to nothing to ensure that we won't do any dynamic exclusivity checks.

Use this to better model the reality of dynamic exclusivity checking in Embedded Swift, which effectively turned off all dynamic exclusivity checking by having empty stub implementations of swift_(begin|end)Access. Instead, have Embedded Swift default to `-enforce-exclusivity=unchecked`, so that it never emits calls to swift_(begin|end)Access. Remove the stub implementations of swift_(begin|end)Access from the Embedded Swift runtime, since we will no longer generate calls to them by default.

Moving forward, this will allow us to conditionally enable the new implementation of dynamic exclusivity checking by specifying `-enforce-exclusivity=checked` for Embedded Swift builds. We'll stage that in over time to avoid breaking existing Embedded Swift clients.
