### PR TITLE
[SE-0474] use new "yielding borrow" terminology in SIL printing

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -394,16 +394,10 @@ void SILDeclRef::print(raw_ostream &OS) const {
       OS << "!init";
       break;
     case AccessorKind::YieldingBorrow:
-// TODO: Change the SIL printing to use the standard
-// terminology instead of the interim terms.
-// Note: SIL parsing already accepts both
-//      OS << "!yielding_borrow"
-      OS << "!read2";
+      OS << "!yielding_borrow";
       break;
     case AccessorKind::YieldingMutate:
-// TODO: Switch to standard terminology
-//      OS << "!yielding_mutate"
-      OS << "!modify2";
+      OS << "!yielding_mutate";
       break;
     case AccessorKind::Borrow:
       OS << "!borrow";

--- a/test/SIL/Parser/default_override.sil
+++ b/test/SIL/Parser/default_override.sil
@@ -18,27 +18,27 @@ open class B {
 }
 
 sil @B_i_read : $@yield_once @convention(method) (@guaranteed B) -> @yields Int
-sil @B_i_read2 : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields Int
+sil @B_i_yielding_borrow : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields Int
 sil @B_i_set : $@convention(method) (Int, @guaranteed B) -> ()
 sil @B_i_modify : $@yield_once @convention(method) (@guaranteed B) -> @yields @inout Int
-sil @B_i_modify2 : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields @inout Int
+sil @B_i_yielding_mutate : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields @inout Int
 
 sil_vtable B {
   #B.i!read: (B) -> () -> () : @B_i_read
-  #B.i!read2: (B) -> () -> () : @B_i_read2
+  #B.i!yielding_borrow: (B) -> () -> () : @B_i_yielding_borrow
   #B.i!setter: (B) -> (Int) -> () : @B_i_set
   #B.i!modify: (B) -> () -> () : @B_i_modify
-  #B.i!modify2: (B) -> () -> () : @B_i_modify2
+  #B.i!yielding_mutate: (B) -> () -> () : @B_i_yielding_mutate
 }
 
-sil @B_i_read2_default_override : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields Int
-sil @B_i_modify2_default_override : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields @inout Int
+sil @B_i_yielding_borrow_default_override : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields Int
+sil @B_i_yielding_mutate_default_override : $@yield_once_2 @convention(method) (@guaranteed B) -> @yields @inout Int
 
 // CHECK-LABEL: sil_default_override_table B {
-// CHECK-NEXT:    #B.i!read2: #B.i!read: (B) -> () -> () : @B_i_read2_default_override
-// CHECK-NEXT:    #B.i!modify2: #B.i!modify: (B) -> () -> () : @B_i_modify2_default_override
+// CHECK-NEXT:    #B.i!yielding_borrow: #B.i!read: (B) -> () -> () : @B_i_yielding_borrow_default_override
+// CHECK-NEXT:    #B.i!yielding_mutate: #B.i!modify: (B) -> () -> () : @B_i_yielding_mutate_default_override
 // CHECK-NEXT:  }
 sil_default_override_table B {
-  #B.i!read2: #B.i!read: (B) -> () -> () : @B_i_read2_default_override
-  #B.i!modify2: #B.i!modify: (B) -> () -> () : @B_i_modify2_default_override
+  #B.i!yielding_borrow: #B.i!read: (B) -> () -> () : @B_i_yielding_borrow_default_override
+  #B.i!yielding_mutate: #B.i!modify: (B) -> () -> () : @B_i_yielding_mutate_default_override
 }

--- a/test/SIL/Parser/default_override_legacy_syntax.sil
+++ b/test/SIL/Parser/default_override_legacy_syntax.sil
@@ -1,9 +1,12 @@
-// sil (this file) -> sib -> sib -> sil | FileCheck
+// RUN: %target-sil-opt %s \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature CoroutineAccessors \
+// RUN: | %FileCheck %s
 
-// RUN: %empty-directory(%t)
-// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name default_override -enable-library-evolution -enable-experimental-feature CoroutineAccessors
-// RUN: %target-sil-opt %t/tmp.sib -emit-sib -o %t/tmp.2.sib -module-name default_override -enable-library-evolution -enable-experimental-feature CoroutineAccessors
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name default_override -emit-sorted-sil -enable-library-evolution -enable-experimental-feature CoroutineAccessors | %FileCheck %s
+// Note:  This is the same as default_override.sil, except that the
+// input uses the transitional `read2` and `modify2` terminology to
+// ensure those continue to be parsed.  These yielding accessors will
+// still get printed as `yielding_borrow` and `yielding_mutate` respectively.
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -16,7 +19,7 @@ struct Int {
 }
 
 open class B {
-  open var i: Int { yielding borrow set }
+  open var i: Int { read set }
 }
 
 sil @B_i_read : $@yield_once @convention(method) (@guaranteed B) -> @yields Int

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -263,7 +263,7 @@ protocol GettableTitle {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
-// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!read2
+// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!yielding_borrow
 // CHECK:         ([[TITLE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         [[RETVAL:%[^,]+]] = copy_value [[TITLE]]
 // CHECK:         end_apply [[TOKEN]] as $()
@@ -286,7 +286,7 @@ class OverridableReader : GettableTitle {
 
 // CHECK-LABEL: sil_default_witness_table ReadableField {
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #ReadableField.field!read2 
+// CHECK-NEXT:    method #ReadableField.field!yielding_borrow
 // CHECK-SAME:        : @$s19coroutine_accessors13ReadableFieldP5fieldSivy
 // CHECK-NEXT:  }
 public protocol ReadableField {

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -383,8 +383,8 @@ public class DerivedOldFromBaseClassOld : BaseClassOld {
 // CHECK-LABEL: sil_vtable [serialized] DerivedOldFromBaseClassOld {
 // CHECK-NEXT:    #BaseClassOld.init!allocator
 // CHECK-NEXT:    #BaseClassOld.i!read
-// CHECK-NEXT:    #BaseClassOld.i!read2
+// CHECK-NEXT:    #BaseClassOld.i!yielding_borrow
 // CHECK-NEXT:    #BaseClassOld.i!setter
 // CHECK-NEXT:    #BaseClassOld.i!modify
-// CHECK-NEXT:    #BaseClassOld.i!modify2
+// CHECK-NEXT:    #BaseClassOld.i!yielding_mutate
 // CHECK:       }

--- a/test/SILGen/coroutine_accessors_skip.swift
+++ b/test/SILGen/coroutine_accessors_skip.swift
@@ -21,11 +21,11 @@
 // CHECK-LABEL: sil_default_witness_table MutatableAssociatedField {
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #MutatableAssociatedField.field!read2
+// CHECK-NEXT:    method #MutatableAssociatedField.field!yielding_borrow
 // CHECK-SAME:        : @$s24coroutine_accessors_skip24MutatableAssociatedFieldP5field5AssocQzvy
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #MutatableAssociatedField.field!modify2
+// CHECK-NEXT:    method #MutatableAssociatedField.field!yielding_mutate
 // CHECK-SAME:        : @$s24coroutine_accessors_skip24MutatableAssociatedFieldP5field5AssocQzvx
 // CHECK-NEXT:  }
 public protocol MutatableAssociatedField {

--- a/test/SILGen/default_override.swift
+++ b/test/SILGen/default_override.swift
@@ -298,26 +298,26 @@ class InternalBase<T> {
 }
 
 // CHECK-LABEL: sil_default_override_table OpenBase {
-// CHECK-NEXT:    #OpenBase.openField!read2
+// CHECK-NEXT:    #OpenBase.openField!yielding_borrow
 // CHECK-SAME:        #OpenBase.openField!read
 // CHECK-SAME:        <T> (OpenBase<T>) -> () -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseC9openFieldxvyTwd
-// CHECK-NEXT:    #OpenBase.openField!modify2
+// CHECK-NEXT:    #OpenBase.openField!yielding_mutate
 // CHECK-SAME:        #OpenBase.openField!modify
 // CHECK-SAME:        <T> (OpenBase<T>) -> () -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseC9openFieldxvxTwd
-// CHECK-NEXT:    #OpenBase.subscript!read2
+// CHECK-NEXT:    #OpenBase.subscript!yielding_borrow
 // CHECK-SAME:        #OpenBase.subscript!read
 // CHECK-SAME:        <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluiyTwd
-// CHECK-NEXT:    #OpenBase.subscript!modify2
+// CHECK-NEXT:    #OpenBase.subscript!yielding_mutate
 // CHECK-SAME:        #OpenBase.subscript!modify
 // CHECK-SAME:        <T><U> (OpenBase<T>) -> (U, Open.Type) -> ()
 // CHECK-SAME:        @$s16default_override8OpenBaseCyxqd___AA0C0OmtcluixTwd
-// CHECK-NOT:     #OpenBase.publicField!read2
-// CHECK-NOT:     #OpenBase.publicField!modify2
-// CHECK-NOT:     #OpenBase.subscript!read2: #OpenBase.subscript!read: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
-// CHECK-NOT:     #OpenBase.subscript!modify2: #OpenBase.subscript!modify: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
+// CHECK-NOT:     #OpenBase.publicField!yielding_borrow
+// CHECK-NOT:     #OpenBase.publicField!yielding_mutate
+// CHECK-NOT:     #OpenBase.subscript!yielding_borrow: #OpenBase.subscript!read: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
+// CHECK-NOT:     #OpenBase.subscript!yielding_mutate: #OpenBase.subscript!modify: <T><U> (OpenBase<T>) -> (U, Public.Type) -> ()
 // CHECK-NEXT:  }
 
 // CHECK-NOT: sil_default_override_table PublicBase {

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1455,178 +1455,178 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAStored: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-NEXT:    method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-NEXT:    method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
-// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
-// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCStored: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW
-// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-NEXT:    method #P3.ur!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnderscoredCoroutineAccessors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-NEXT:    method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-NEXT:    method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
-// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
-// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnderscoredCoroutineAccessors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-NEXT:    method #P3.ur!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplACoroutineAccessors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-NEXT:    method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-NEXT:    method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
-// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
-// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCCoroutineAccessors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-NEXT:    method #P3.ur!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAGetSet: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK-NEXT:  method #P1.ubgs!read2
+// CHECK-NEXT:  method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK-NEXT:  method #P1.ubgs!modify2
+// CHECK-NEXT:  method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
-// CHECK-NEXT:  method #P2.urs!read2
+// CHECK-NEXT:  method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
-// CHECK-NEXT:  method #P2.urs!modify2
+// CHECK-NEXT:  method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCGetSet: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW
-// CHECK-NEXT:  method #P3.ur!read2
+// CHECK-NEXT:  method #P3.ur!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnsafeAddressors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-NEXT:    method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-NEXT:    method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
 // CHECK-unstable:    method #P2.urs!read
-// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-NEXT:    method #P2.urs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-unstable:    method #P2.urs!modify
-// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-NEXT:    method #P2.urs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnsafeAddressors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-NEXT:    method #P3.ur!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_default_witness_table P1 {
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-NEXT:    method #P1.ubgs!yielding_borrow
 // CHECK-SAME:      : @$s17read_requirements2P1P4ubgsAA1UVvy
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-NEXT:    method #P1.ubgs!yielding_mutate
 // CHECK-SAME:      : @$s17read_requirements2P1P4ubgsAA1UVvx
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_default_witness_table P2 {
 // CHECK-NEXT:    no_default
-// CHECK-unstable-NEXT:  method #P2.urs!read2
+// CHECK-unstable-NEXT:  method #P2.urs!yielding_borrow
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-unstable-NEXT:  method #P2.urs!modify2
+// CHECK-unstable-NEXT:  method #P2.urs!yielding_mutate
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_default_witness_table P3 {
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #P3.ur!read2:
+// CHECK-NEXT:    method #P3.ur!yielding_borrow:
 // CHECK-SAME:      : @$s17read_requirements2P3P2urAA1UVvy
 // CHECK-NEXT:  }


### PR DESCRIPTION
To help reduce cognitive burden for future Swift compiler engineers, let's use the same terminology for coroutine accessors in SIL dumps as we use in the surface language and inside the compiler.

This really just changes two lines in SILPrinter.cpp and updates a lot of tests.  I've also copied one test to preserve the old syntax to make sure that SIL parsing still accepts it.  That should hopefully prevent unfortunate round-tripping issues while these changes settle.

This is a follow-on to #86277 