### PR TITLE
Sema: Don't just ignore protocol type aliases in LookupResultBuilder::add()

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -204,12 +204,15 @@ namespace {
       }
 
       // Dig out the witness.
-      ValueDecl *witness = nullptr;
       auto concrete = conformance.getConcrete();
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(found)) {
-        witness = concrete->getTypeWitnessAndDecl(assocType).getWitnessDecl();
+        auto *witness = concrete->getTypeWitnessAndDecl(assocType)
+            .getWitnessDecl();
+        ASSERT(witness != assocType);
+        if (witness)
+          addResult(witness);
       } else if (found->isProtocolRequirement()) {
-        witness = concrete->getWitnessDecl(found);
+        auto *witness = concrete->getWitnessDecl(found);
 
         // It is possible that a requirement is visible to us, but
         // not the witness. In this case, just return the requirement;
@@ -220,22 +223,18 @@ namespace {
           addResult(found);
           return;
         }
+
+        // If we have an imported conformance or the witness could
+        // not be deserialized, getWitnessDecl() will just return
+        // the requirement, so just drop the lookup result here.
+        if (witness && witness != found)
+          addResult(witness);
       } else if (isa<NominalTypeDecl>(found)) {
         // Declaring nested types inside other types is currently
         // not supported by lookup would still return such members
         // so we have to account for that here as well.
         addResult(found);
-        return;
       }
-
-      // FIXME: the "isa<ProtocolDecl>()" check will be wrong for
-      // default implementations in protocols.
-      //
-      // If we have an imported conformance or the witness could
-      // not be deserialized, getWitnessDecl() will just return
-      // the requirement, so just drop the lookup result here.
-      if (witness && !isa<ProtocolDecl>(witness->getDeclContext()))
-        addResult(witness);
     }
   };
 } // end anonymous namespace

--- a/test/decl/typealias/protocol_type_witness.swift
+++ b/test/decl/typealias/protocol_type_witness.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+// Let's make sure that a protocol type alias can serve as a
+// type witness, and lookup can find it when that is the case.
+
+// rdar://problem/167851622.
+
+protocol P1 {
+  typealias ID = Int
+}
+
+protocol P2 {
+  associatedtype ID
+  var id: ID { get }
+}
+
+struct S: P1, P2 {
+  let id: ID
+  let id2: S.ID
+  let id3: Self.ID
+  let id4: P1.ID
+
+  init() {
+    id = ID()
+    id2 = S.ID()
+    id3 = Self.ID()
+    id4 = P1.ID()
+
+    // But they're all the same type.
+    same(id, id2, id3, id4)
+  }
+}
+
+func same<T>(_: T, _: T, _: T, _: T) {}


### PR DESCRIPTION
Fix regression from 62e4979691570df8e66452eed5be71ce69c7aa54, although the erroneous logic has actually been here since 2015.

An associated type can be witnessed by a type alias that is directly declared in a protocol. Don't drop it in this case.

It seems that this didn't matter too much in the past, but now that name lookup prefers an associated type declaration over a type alias (which may or may not be the type witness), we really must correctly resolve the associated type to a type witness instead of just dropping it sometimes.

Fixes rdar://167851622.