### PR TITLE
[CSRanking] Restore tuple label stripping in function parameter/resul…

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -892,11 +892,12 @@ static Type getStrippedType(Type type, ASTContext &ctx) {
   return type.transformRec([&](TypeBase *type) -> std::optional<Type> {
     if (auto *tupleType = dyn_cast<TupleType>(type)) {
       if (tupleType->getNumElements() == 1)
-        return tupleType->getElementType(0);
+        return getStrippedType(tupleType->getElementType(0), ctx);
 
       SmallVector<TupleTypeElt, 8> elts;
       for (auto elt : tupleType->getElements()) {
-        elts.push_back(elt.getWithoutName());
+        auto eltTy = getStrippedType(elt.getType(), ctx);
+        elts.push_back(TupleTypeElt(eltTy));
       }
 
       return TupleType::get(elts, ctx);
@@ -906,7 +907,8 @@ static Type getStrippedType(Type type, ASTContext &ctx) {
       auto params = funcType->getParams();
       SmallVector<AnyFunctionType::Param, 4> newParams;
       for (auto param : params) {
-        auto newParam = param;
+        auto newParam =
+            param.withType(getStrippedType(param.getPlainType(), ctx));
         switch (param.getParameterFlags().getOwnershipSpecifier()) {
         case ParamSpecifier::Borrowing:
         case ParamSpecifier::Consuming: {
@@ -922,9 +924,8 @@ static Type getStrippedType(Type type, ASTContext &ctx) {
       }
       auto newExtInfo = funcType->getExtInfo().withRepresentation(
           AnyFunctionType::Representation::Swift);
-      return FunctionType::get(newParams,
-                               funcType->getResult(),
-                               newExtInfo);
+      return FunctionType::get(
+          newParams, getStrippedType(funcType->getResult(), ctx), newExtInfo);
     }
 
     return std::nullopt;

--- a/test/Constraints/tuple_subtype_label_mismatch.swift
+++ b/test/Constraints/tuple_subtype_label_mismatch.swift
@@ -31,3 +31,29 @@ func testTupleLabelMismatchFuncConversion(fn1: @escaping ((x: Int, y: Int)) -> V
   let _: () -> (x: Int, y: Int) = fn2
   let _: () -> (Int, y: Int) = fn2
 }
+
+func testErasure() {
+  func checkCall<T, Arg0>(
+    _ lhs: T, calling functionCall: (T, Arg0) throws -> Bool, _ argument0: Arg0
+  ) {}
+
+  func test(data: [(key: String, data: String)]) {
+    checkCall(
+      data.self,
+      calling: { $0.contains(where: $1) },
+      { $0 == (key: "Name", data: "kernel") } // Ok
+    )
+
+    checkCall(
+      data.self,
+      calling: { $0.contains(where: $1) },
+      { $0 == ("Name", "kernel") } // Ok
+    )
+
+    checkCall(
+      data.self,
+      calling: { $0.contains(where: $1) },
+      { $0 == (key: "Name", value: "kernel") } // Ok
+    )
+  }
+}


### PR DESCRIPTION
…t positions

This is follow-up to https://github.com/swiftlang/swift/pull/85933 which erases ownership specifiers and should also strip the labels in any tuples that appears in parameter/result positions.

Resolves: rdar://167849055

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
