### PR TITLE
[6.3] mark `Span.mutableBytes` as unsafe

### DIFF
--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -189,7 +189,7 @@ internal func _Float16ToASCII(
   // We need a MutableRawSpan in order to use wide store/load operations
   // TODO: Tune this value down to the actual minimum for Float16
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle various input cases:
   let binaryExponent: Int
@@ -482,7 +482,7 @@ internal func _Float32ToASCII(
   // TODO: Tune this limit down to the actual minimum we need here
   // TODO: `assert` that the buffer is filled with 0x30 bytes (in debug builds)
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle the special cases, decompose the input
 
@@ -725,7 +725,7 @@ internal func _Float64ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   //
   // Step 1: Handle the special cases, decompose the input
@@ -1227,7 +1227,7 @@ internal func _Float80ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle special cases, decompose the input
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1396,7 +1396,7 @@ internal func _BinaryIntegerToASCII<T: BinaryInteger>(
   let radix = radix.magnitude
 
   // We need a `MutableRawSpan` to use wide store/load operations.
-  var buffer = utf8Buffer.mutableBytes
+  var buffer = unsafe utf8Buffer.mutableBytes
   var offset = buffer.byteCount
 
   if value == (0 as T.Magnitude) {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -267,8 +267,13 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   /// Construct a MutableRawSpan over the memory represented by this span
   ///
+  /// Mutating `self` through this property is unsafe because
+  /// it is possible to mutate a byte so as to produce an invalid
+  /// bit pattern in the corresponding instance of `Element`.
+  ///
   /// - Returns: a MutableRawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
+  @unsafe
   public var mutableBytes: MutableRawSpan {
     @lifetime(&self)
     mutating get {


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/86420

**Explanation**: Fix the mistake of not marking this accessor with `@unsafe`, as it had been proposed.
**Scope**: affects projects that compile with `-strict-memory-safety` and use `MutableSpan.mutableBytes`
**Risk**: low
**Testing**: existing tests are unaffected
**Issue**: rdar://167661807
**Reviewer**: @stephentyrone 