### PR TITLE
Sema: Increase default solver arena limit from 512Mb to 564Mb [6.3]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -934,7 +934,7 @@ namespace swift {
 
     /// The upper bound, in bytes, of temporary data that can be
     /// allocated by the constraint solver.
-    unsigned SolverMemoryThreshold = 512 * 1024 * 1024;
+    unsigned SolverMemoryThreshold = 564 * 1024 * 1024;
 
     /// The maximum number of scopes we explore before giving up.
     unsigned SolverScopeThreshold = 1024 * 1024;


### PR DESCRIPTION
* **Description:** The prepared overloads optimization is meant to reduce solver arena memory usage by allocating fewer constraints and type variables, but in some pathological cases it doesn't help, and we use more memory because of the PreparedOverload structures themselves. This seems to happen with SwiftUI Views in some cases. Bump the limit so that some extreme instances we saw that were right up against the old memory limit continue to work without diagnosing.

* **Reviewed by:** @xedin 

* **Risk:** None.