### PR TITLE
[stdlib] simplify span-family `withUnsafe...` implementations

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -154,10 +154,7 @@ extension MutableRawSpan {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = unsafe _pointer, _count > 0 else {
-      return try unsafe body(.init(start: nil, count: 0))
-    }
-    return try unsafe body(.init(start: pointer, count: _count))
+    try unsafe body(.init(start: _pointer, count: _count))
   }
 
   @_alwaysEmitIntoClient
@@ -165,10 +162,7 @@ extension MutableRawSpan {
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = unsafe _pointer, _count > 0 else {
-      return try unsafe body(.init(start: nil, count: 0))
-    }
-    return try unsafe body(.init(start: pointer, count: _count))
+    try unsafe body(.init(start: _pointer, count: _count))
   }
 }
 

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -386,15 +386,13 @@ extension MutableSpan where Element: ~Copyable {
   >(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = unsafe _pointer, count > 0 else {
-      return try unsafe body(.init(start: nil, count: 0))
-    }
-    // bind memory by hand to sidestep alignment concerns
-    let binding = Builtin.bindMemory(
-      pointer._rawValue, count._builtinWordValue, Element.self
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count
     )
-    defer { Builtin.rebindMemory(pointer._rawValue, binding) }
-    return try unsafe body(.init(start: .init(pointer._rawValue), count: count))
+    return try unsafe bytes.withMemoryRebound(to: Element.self) {
+      buffer throws(E) -> Result in
+      try unsafe body(buffer)
+    }
   }
 }
 
@@ -417,8 +415,7 @@ extension MutableSpan where Element: BitwiseCopyable {
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
     let bytes = unsafe UnsafeMutableRawBufferPointer(
-      start: (_count == 0) ? nil : _pointer,
-      count: _count &* MemoryLayout<Element>.stride
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
     )
     return try unsafe body(bytes)
   }

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -293,23 +293,9 @@ extension OutputRawSpan {
       _ initializedCount: inout Int
     ) throws(E) -> R
   ) throws(E) -> R {
-    guard let start = unsafe _pointer, capacity > 0 else {
-      let buffer = UnsafeMutableRawBufferPointer(_empty: ())
-      var initializedCount = 0
-      defer {
-        _precondition(initializedCount == 0, "OutputRawSpan capacity overflow")
-      }
-      return unsafe try body(buffer, &initializedCount)
-    }
-#if SPAN_COMPATIBILITY_STUB
-    let buffer = unsafe UnsafeMutableRawBufferPointer(
-      start: start, count: capacity
+    let bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: capacity
     )
-#else
-    let buffer = unsafe UnsafeMutableRawBufferPointer(
-      _uncheckedStart: start, count: capacity
-    )
-#endif
     var initializedCount = _count
     defer {
       _precondition(
@@ -318,7 +304,7 @@ extension OutputRawSpan {
       )
       _count = initializedCount
     }
-    return unsafe try body(buffer, &initializedCount)
+    return unsafe try body(bytes, &initializedCount)
   }
 }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -534,10 +534,7 @@ extension RawSpan {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let _pointer = unsafe _pointer, byteCount > 0 else {
-      return try unsafe body(.init(start: nil, count: 0))
-    }
-    return try unsafe body(.init(start: _pointer, count: byteCount))
+    try unsafe body(.init(start: _pointer, count: byteCount))
   }
 }
 

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -128,7 +128,7 @@ suite.test("withUnsafeBytes()")
     view = MutableRawSpan(_unsafeBytes: empty)
     view.withUnsafeBytes {
       expectEqual($0.count, 0)
-      expectNil($0.baseAddress)
+      expectNotNil($0.baseAddress)
     }
   }
 }
@@ -157,7 +157,7 @@ suite.test("withUnsafeMutableBytes")
     view = MutableRawSpan(_unsafeBytes: empty)
     view.withUnsafeMutableBytes {
       expectEqual($0.count, 0)
-      expectNil($0.baseAddress)
+      expectNotNil($0.baseAddress)
     }
   }
   expectEqual(Int(a[i]), i+1)

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -255,7 +255,7 @@ suite.test("withUnsafeMutableBufferPointer")
     var emptySpan = MutableSpan(_unsafeElements: empty0)
     emptySpan.withUnsafeMutableBufferPointer {
       expectEqual($0.count, 0)
-      expectNil($0.baseAddress)
+      expectNotNil($0.baseAddress)
     }
   }
   expectEqual(Int(a[i]), i+1)
@@ -282,7 +282,7 @@ suite.test("withUnsafeMutableBytes")
     var emptySpan = MutableSpan(_unsafeElements: empty0)
     emptySpan.withUnsafeMutableBytes {
       expectEqual($0.count, 0)
-      expectNil($0.baseAddress)
+      expectNotNil($0.baseAddress)
     }
   }
   expectEqual(Int(a[i]), i+1)

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -290,7 +290,8 @@ suite.test("withUnsafeBytes()")
 
     let emptySpan = RawSpan(_unsafeElements: emptyBuffer)
     emptySpan.withUnsafeBytes {
-      expectNil($0.baseAddress)
+      expectTrue($0.isEmpty)
+      expectNotNil($0.baseAddress)
     }
   }
 }

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -462,7 +462,8 @@ suite.test("withUnsafeBufferPointer")
 
     let emptySpan = Span(_unsafeElements: emptyBuffer)
     emptySpan.withUnsafeBufferPointer {
-      expectNil($0.baseAddress)
+      expectTrue($0.isEmpty)
+      expectNotNil($0.baseAddress)
     }
   }
 }
@@ -491,7 +492,8 @@ suite.test("withUnsafeBytes()")
 
     let emptySpan = Span(_unsafeElements: emptyBuffer)
     emptySpan.withUnsafeBytes {
-      expectNil($0.baseAddress)
+      expectTrue($0.isEmpty)
+      expectNotNil($0.baseAddress)
     }
   }
 }


### PR DESCRIPTION
In their original implementation, we avoided passing non-nil base pointers of empty spans. In practice, this occasionally makes porting existing code to `Span` unwieldy, so we drop this unnecessary flourish. In so doing, the implementations are simplified. We also no longer avoid using `UnsafeRawPointer`'s `withMemoryRebound` function, since typed `Span` instances are always well aligned for `Element`. The `debugPrecondition` calls in the `UnsafeRawPointer` functions are not a concern for performance, because all of these functions are `@_alwaysEmitIntoClient`, ensuring that debug preconditions will be excluded in release mode.

Addresses rdar://165001871