### PR TITLE
[Swiftify] fix tests and reland bridging header import fix

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1921,7 +1921,7 @@ bool ClangImporter::importBridgingHeader(StringRef header, ModuleDecl *adapter,
                                          bool trackParsedSymbols,
                                          bool implicitImport) {
   if (adapter->isNonSwiftModule()) {
-    // bridging header has already been imported by main module
+    // non-swift modules don't need to access anything from the bridging header
     return true;
   }
   if (isPCHFilenameExtension(header)) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1920,6 +1920,10 @@ bool ClangImporter::importBridgingHeader(StringRef header, ModuleDecl *adapter,
                                          SourceLoc diagLoc,
                                          bool trackParsedSymbols,
                                          bool implicitImport) {
+  if (adapter->isNonSwiftModule()) {
+    // bridging header has already been imported by main module
+    return true;
+  }
   if (isPCHFilenameExtension(header)) {
     return bindBridgingHeader(adapter, diagLoc);
   }

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -20,7 +20,6 @@ imports for TMP_DIR/test.swift:
 imports for A.foo:
 imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 	Swift
-	__ObjC
 	lifetimebound
 	ptrcheck
 	_StringProcessing

--- a/test/Interop/C/swiftify-import/bridging-header-import-once.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-import-once.swift
@@ -1,0 +1,37 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -import-bridging-header %t%{fs-sep}bridging_header.h -I %t -plugin-path %swift-plugin-dir -enable-experimental-feature SafeInteropWrappers %t/test.swift -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}header.h -disable-objc-interop
+
+//--- module.modulemap
+module Module {
+    header "header.h"
+}
+
+//--- bridging_header.h
+const int FOO = 42;
+
+//--- header.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+// expected-expansion@+10:52{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func func1(_ p: UnsafeBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe func1(p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:6{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'func1' here}}
+// }}
+void func1(const int * __counted_by(len) p, int len);
+
+//--- test.swift
+import Module
+
+func g(s: UnsafeBufferPointer<CInt>) {
+    func1(s)
+}

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -24,7 +24,6 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 imports for TestClang.bar:
 imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
 	Swift
-	__ObjC
 	lifetimebound
 	ptrcheck
 	_StringProcessing

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -1,0 +1,90 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -Xcc -I -Xcc %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -verify
+// RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
+// RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
+// RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
+// RUN: %diff %t/imports.out %t/imports.expected
+
+//--- imports.expected
+imports for TMP_DIR/test.swift:
+	Swift
+	__ObjC
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+	TestClang
+imports for __ObjC.foo:
+imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
+	__ObjC
+	Swift
+imports for TestClang.bar:
+imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
+	Swift
+	__ObjC
+	lifetimebound
+	ptrcheck
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+
+//--- macro-expansions.expected
+@__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeBufferPointer { _pPtr in
+      return unsafe foo(len, _pPtr.baseAddress!)
+    }
+}
+------------------------------
+@__swiftmacro_So3bar15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar(_ p: Span<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeBufferPointer { _pPtr in
+      return unsafe bar(len, _pPtr.baseAddress!)
+    }
+}
+------------------------------
+
+//--- test.swift
+import TestClang
+
+func test(s: Span<CInt>) {
+  foo(s)
+  bar(s)
+}
+
+//--- test2.swift
+import TestClang
+
+func test2(s: Span<CInt>) {
+  foo(s)
+  bar(s)
+}
+
+//--- bridging.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+
+void foo(int len, const int * __counted_by(len) p __noescape);
+
+static const int placeholder = 2;
+
+//--- test-clang.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+
+void bar(int len, const int * __counted_by(len) p __noescape);
+
+//--- module.modulemap
+module TestClang {
+  header "test-clang.h"
+}
+

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -1,0 +1,125 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/namespace.swift -emit-module \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}namespace.h -Rmacro-expansions -strict-memory-safety -o %t/out.swiftmodule -import-bridging-header %t/bridging.h
+
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/namespace.swift -typecheck \
+// RUN:   -dump-source-file-imports -import-bridging-header %t/bridging.h 2>&1 | %FileCheck --dry-run > %t/imports.txt
+// RUN: %diff %t/imports.txt %t/imports.txt.expected
+
+// This test checks that macro expansions can access symbols from namespaces
+// (which are dumped into the __ObjC module) despite not having an implicit
+// import of the bridging header module (aka __ObjC).
+
+//--- imports.txt.expected
+imports for TMP_DIR/namespace.swift:
+	Swift
+	__ObjC
+	CxxShim
+	Cxx
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+	Namespace
+imports for Namespace.bar:
+imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
+	Swift
+	CxxShim
+	Cxx
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+imports for Namespace.bar2:
+imports for @__swiftmacro_So4bar215_SwiftifyImportfMp_.swift:
+	Swift
+	CxxShim
+	Cxx
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+imports for __ObjC.baz.baz_func:
+imports for @__swiftmacro_So3bazO0A5_func15_SwiftifyImportfMp_.swift:
+	Namespace
+	Swift
+	CxxShim
+	Cxx
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+
+//--- bridging.h
+const int FOO = 42; // not used
+
+//--- module.modulemap
+module Namespace {
+    header "namespace.h"
+    requires cplusplus
+}
+
+//--- namespace.h
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+namespace foo {
+  typedef int foo_t;
+}
+
+// expected-expansion@+10:141{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bar(_ p: UnsafeMutableBufferPointer<Float>, _ extra: foo.foo_t) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(p.baseAddress!, len, extra)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+3:102{{
+//   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bar' here}}
+// }}
+__attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len, foo::foo_t extra);
+// expected-expansion@+12:94{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar2(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
+//   expected-remark@3{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe p.withUnsafeBufferPointer { _pPtr in|}}
+//   expected-remark@5{{macro content: |      return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+// expected-expansion@+3:6{{
+//   expected-note@1 7{{in expansion of macro '_SwiftifyImport' on global function 'bar2' here}}
+// }}
+void bar2(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
+namespace baz {
+  // expected-expansion@+13:100{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public static func baz_func(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
+  //   expected-remark@4{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe p.withUnsafeBufferPointer { _pPtr in|}}
+  //   expected-remark@6{{macro content: |      return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
+  //   expected-remark@7{{macro content: |    }|}}
+  //   expected-remark@8{{macro content: |}|}}
+  // }}
+  // expected-expansion@+3:8{{
+  //   expected-note@1 8{{in expansion of macro '_SwiftifyImport' on static method 'baz_func' here}}
+  // }}
+  void baz_func(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
+}
+
+//--- namespace.swift
+import Namespace
+
+func test(s: UnsafeMutableBufferPointer<Float>, extra: foo.foo_t) {
+  unsafe bar(s, extra)
+}
+
+func test2(s: Span<CInt>, extra: foo.foo_t) {
+  bar2(s, extra)
+}
+
+func test3(s: Span<CInt>, extra: foo.foo_t) {
+  baz.baz_func(s, extra)
+}
+


### PR DESCRIPTION
Somehow these tests passed CI despite being incorrect from the start.
The original intention with the bridging header import fix was to only
stop re-importing the AST nodes from the bridging header, but still have
the macro expansions implicitly import the bridging header module. I
accidentally returned true instead of false in importBridgingHeader,
which resulted in the macro expansions not importing the bridging header
module. This turned out to be fine however, because the macro expansion
won't refer to anything in the bridging header. So instead update the
tests to reflect this. This also adds a test to verify that the macro
expansion can still access symbols from a C++ namespace despite not
importing the __ObjC module.

The original PR is relanded in the first commit, new additions are in the second commit.

rdar://165851601