### PR TITLE
Enable dynamic exclusivity checking in the standard library + friends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,10 +732,6 @@ option(SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS
   "Enable runtime function counters and expose the API."
   FALSE)
 
-option(SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING
-  "Build stdlibCore with exclusivity checking enabled"
-  FALSE)
-
 option(SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE
   "Enable _debugPrecondition checks in the stdlib in Release configurations"
   FALSE)

--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -190,7 +190,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:-no-link-objc-runtime>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -empty-abi-descriptor>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<AND:$<NOT:$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -disable-objc-interop>"

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -71,7 +71,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -75,7 +75,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   $<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>)
 

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -81,7 +81,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
   "$<$<COMPILE_LANGUAGE:Swift>:-warn-implicit-overrides>"

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -68,7 +68,6 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -77,7 +77,6 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 5>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -68,7 +68,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -92,7 +92,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-autolinking-runtime-compatibility-concurrency>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-lexical-lifetimes=false>"
   "$<$<COMPILE_LANGUAGE:Swift>:-warn-implicit-overrides>"

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -123,11 +123,29 @@ private func isEmptyCOWSingleton(_ value: Value) -> Bool {
         v = (v as! UnaryInstruction).operand.value
       case let globalAddr as GlobalAddrInst:
         let name = globalAddr.global.name
-        return name == "_swiftEmptyArrayStorage" ||
-               name == "_swiftEmptyDictionarySingleton" ||
-               name == "_swiftEmptySetSingleton"
+        return name.isEmptyCollectionSingleton
       default:
         return false
+    }
+  }
+}
+
+extension StringRef {
+  /// Whether this is the name of one of the empty collection singletons.
+  ///
+  /// For historic reasons, we check both the C name and the mangled Swift
+  /// name (for an @extern(c) declaration).
+  var isEmptyCollectionSingleton: Bool {
+    switch self {
+    case "_swiftEmptyArrayStorage",
+         "_swiftEmptyDictionarySingleton",
+         "_swiftEmptySetSingleton",
+         "$ss23_swiftEmptyArrayStorageSo06_SwiftbcD0Vvp",
+         "$ss30_swiftEmptyDictionarySingletonSo06_SwiftbcD0Vvp",
+         "$ss23_swiftEmptySetSingletonSo06_SwiftbcD0Vvp":
+      return true
+    default:
+      return false
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -150,14 +150,7 @@ extension LoadInst : OnoneSimplifiable, SILCombineSimplifiable {
     while true {
       switch addr {
       case let ga as GlobalAddrInst:
-        switch ga.global.name {
-        case "_swiftEmptyArrayStorage",
-             "_swiftEmptyDictionarySingleton",
-             "_swiftEmptySetSingleton":
-          return true
-        default:
-          return false
-        }
+        return ga.global.name.isEmptyCollectionSingleton
       case let sea as StructElementAddrInst:
         let structType = sea.struct.type
         if structType.nominal!.name == "_SwiftArrayBodyStorage" {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3693,6 +3693,10 @@ bool AbstractStorageDecl::isResilient() const {
   if (getAttrs().hasAttribute<FixedLayoutAttr>())
     return false;
 
+  // Check for an explicit @_extern attribute.
+  if (getAttrs().hasAttribute<ExternAttr>())
+    return false;
+
   // If we're an instance property of a nominal type, query the type.
   if (!isStatic())
     if (auto *nominalDecl = getDeclContext()->getSelfNominalTypeDecl())

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -561,10 +561,6 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-assume-single-threaded")
   endif()
 
-  if(NOT SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING AND SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-enforce-exclusivity=unchecked")
-  endif()
-
   if(SWIFT_EMIT_SORTED_SIL_OUTPUT)
     list(APPEND swift_flags "-Xfrontend" "-emit-sorted-sil")
   endif()

--- a/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
@@ -40,9 +40,6 @@ struct _SwiftEmptyArrayStorage {
   struct _SwiftArrayBodyStorage body;
 };
 
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
-
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
@@ -77,12 +74,6 @@ struct _SwiftEmptySetSingleton {
   struct _SwiftSetBodyStorage body;
   __swift_uintptr_t metadata;
 };
-
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
-
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
 
 struct _SwiftHashingParameters {
   __swift_uint64_t seed0;

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -146,7 +146,7 @@ internal final class _ContiguousArrayStorage<
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R {
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self))
-    let count = countAndCapacity.count
+    let count = unsafe countAndCapacity.count
     let elements = unsafe UnsafeRawPointer(_elementPointer)
       .assumingMemoryBound(to: AnyObject.self)
     defer { _fixLifetime(self) }
@@ -251,7 +251,7 @@ internal final class _ContiguousArrayStorage<
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> Void
   ) rethrows {
     if _isBridgedVerbatimToObjectiveC(Element.self) {
-      let count = countAndCapacity.count
+      let count = unsafe countAndCapacity.count
       let elements = unsafe UnsafeRawPointer(_elementPointer)
         .assumingMemoryBound(to: AnyObject.self)
       defer { _fixLifetime(self) }
@@ -266,7 +266,7 @@ internal final class _ContiguousArrayStorage<
     _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
-    let count = countAndCapacity.count
+    let count = unsafe countAndCapacity.count
     let result = _BridgingBuffer(count)
     let resultPtr = unsafe result.baseAddress
     let p = unsafe _elementPointer
@@ -413,7 +413,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
     // We can initialize by assignment because _ArrayBody is a trivial type,
     // i.e. contains no references.
-    _storage.countAndCapacity = _ArrayBody(
+    unsafe _storage.countAndCapacity = _ArrayBody(
       count: count,
       capacity: capacity,
       elementTypeIsBridgedVerbatim: verbatim)
@@ -639,7 +639,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @inlinable
   internal var count: Int {
     get {
-      return _storage.countAndCapacity.count
+      return unsafe _storage.countAndCapacity.count
     }
     nonmutating set {
       _internalInvariant(newValue >= 0)
@@ -648,7 +648,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
         newValue <= mutableCapacity,
         "Can't grow an array buffer past its capacity")
 
-      mutableStorage.countAndCapacity.count = newValue
+      unsafe mutableStorage.countAndCapacity.count = newValue
     }
   }
   
@@ -658,7 +658,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var immutableCount: Int {
-    return immutableStorage.countAndCapacity.count
+    return unsafe immutableStorage.countAndCapacity.count
   }
 
   /// The number of elements of the buffer.
@@ -668,7 +668,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   internal var mutableCount: Int {
     @inline(__always)
     get {
-      return mutableOrEmptyStorage.countAndCapacity.count
+      return unsafe mutableOrEmptyStorage.countAndCapacity.count
     }
     @inline(__always)
     nonmutating set {
@@ -678,7 +678,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
         newValue <= mutableCapacity,
         "Can't grow an array buffer past its capacity")
 
-      mutableStorage.countAndCapacity.count = newValue
+      unsafe mutableStorage.countAndCapacity.count = newValue
     }
   }
 
@@ -715,7 +715,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// Use `immutableCapacity` or `mutableCapacity` instead.
   @inlinable
   internal var capacity: Int {
-    return _storage.countAndCapacity.capacity
+    return unsafe _storage.countAndCapacity.capacity
   }
 
   /// The number of elements the buffer can store without reallocation.
@@ -724,7 +724,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var immutableCapacity: Int {
-    return immutableStorage.countAndCapacity.capacity
+    return unsafe immutableStorage.countAndCapacity.capacity
   }
 
   /// The number of elements the buffer can store without reallocation.
@@ -733,7 +733,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var mutableCapacity: Int {
-    return mutableOrEmptyStorage.countAndCapacity.capacity
+    return unsafe mutableOrEmptyStorage.countAndCapacity.capacity
   }
 
   /// Copy the elements in `bounds` from this buffer into uninitialized

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -70,9 +70,13 @@ internal final class __EmptyArrayStorage
 //
 // TODO: We should figure out how to make this a constant so that it's placed in
 // non-writable memory (can't be a let, Builtin.addressof below requires a var).
-@unsafe
+@exclusivity(unchecked)
 public var _swiftEmptyArrayStorage: (Int, Int, Int, Int) =
     (/*isa*/0, /*refcount*/-1, /*count*/0, /*flags*/1)
+#else
+@exclusivity(unchecked)
+@_extern(c)
+public var _swiftEmptyArrayStorage: _SwiftEmptyArrayStorage
 #endif
 
 /// The storage for static read-only arrays.

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -195,7 +195,7 @@ extension __EmptyDictionarySingleton: @unsafe _NSDictionaryCore {
 //
 // TODO: We should figure out how to make this a constant so that it's placed in
 // non-writable memory (can't be a let, Builtin.addressof below requires a var).
-@unsafe
+@exclusivity(unchecked)
 public var _swiftEmptyDictionarySingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, UInt32, Int, Int, Int, Int) =
     (
       /*isa*/0, /*refcount*/-1, // HeapObject header
@@ -210,6 +210,10 @@ public var _swiftEmptyDictionarySingleton: (Int, Int, Int, Int, UInt8, UInt8, UI
       /*rawValues*/1,
       /*metadata*/~1
     )
+#else
+@exclusivity(unchecked)
+@_extern(c)
+public var _swiftEmptyDictionarySingleton: _SwiftEmptyDictionarySingleton
 #endif
 
 extension __RawDictionaryStorage {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -135,7 +135,7 @@ internal class __EmptySetSingleton: __RawSetStorage {
 //
 // TODO: We should figure out how to make this a constant so that it's placed in
 // non-writable memory (can't be a let, Builtin.addressof below requires a var).
-@unsafe
+@exclusivity(unchecked)
 public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, UInt32, Int, Int, Int) =
     (
       /*isa*/0, /*refcount*/-1, // HeapObject header
@@ -149,6 +149,10 @@ public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, U
       /*rawElements*/1, 
       /*metadata*/~1
     )
+#else
+@exclusivity(unchecked)
+@_extern(c)
+public var _swiftEmptySetSingleton: _SwiftEmptySetSingleton
 #endif
 
 extension __RawSetStorage {

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -427,7 +427,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   /// bridging of array elements.
   @objc
   internal override final var count: Int {
-    return _nativeStorage.countAndCapacity.count
+    return unsafe _nativeStorage.countAndCapacity.count
   }
 }
 
@@ -480,7 +480,7 @@ internal final class __SwiftDeferredStaticNSArray<Element>
     _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
-    let count = _nativeStorage.countAndCapacity.count
+    let count = unsafe _nativeStorage.countAndCapacity.count
     let result = _BridgingBuffer(count)
     let resultPtr = unsafe result.baseAddress
     let p = unsafe UnsafeMutablePointer<Element>(Builtin.projectTailElems(_nativeStorage, Element.self))
@@ -520,6 +520,7 @@ internal class __ContiguousArrayStorageBase
   : __SwiftNativeNSArrayWithContiguousStorage {
 
   @usableFromInline
+  @exclusivity(unchecked)
   final var countAndCapacity: _ArrayBody
 
   @inlinable

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -36,6 +36,20 @@ ClassMetadata CLASS_METADATA_SYM(s26__EmptyDictionarySingleton);
 // _direct type metadata for Swift.__EmptySetSingleton
 SWIFT_RUNTIME_STDLIB_API
 ClassMetadata CLASS_METADATA_SYM(s19__EmptySetSingleton);
+
+extern "C" {
+
+SWIFT_RUNTIME_STDLIB_API
+struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
+
+SWIFT_RUNTIME_STDLIB_API
+struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
+
+SWIFT_RUNTIME_STDLIB_API
+struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
+
+}
+
 } // namespace swift
 
 SWIFT_RUNTIME_STDLIB_API

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -28,7 +28,7 @@
 
 import Test
 
-// CHECK-SIL: sil_global public_external [serialized] @_swiftEmptySetSingleton : $_SwiftEmptySetSingleton
+// CHECK-SIL: sil_global public_external [serialized] [asmname "_swiftEmptySetSingleton"] @$ss23_swiftEmptySetSingletonSo06_SwiftbcD0Vvp : $_SwiftEmptySetSingleton
 
 func testNestedTypes() {
   let c = Container()

--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -6,7 +6,7 @@
 // Test optimal code generation for creating empty sets.
 
 // CHECK-LABEL: sil {{.*}}@$s4test30createEmptySetFromArrayLiteralShySiGyF
-// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK:         global_addr @$ss23_swiftEmptySetSingletonSo06_SwiftbcD0Vvp
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function '$s4test30createEmptySetFromArrayLiteralShySiGyF'
 public func createEmptySetFromArrayLiteral() -> Set<Int> {
@@ -14,7 +14,7 @@ public func createEmptySetFromArrayLiteral() -> Set<Int> {
 }
 
 // CHECK-LABEL: sil {{.*}}@$s4test29createEmptySetWithInitializerShySiGyF
-// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK:         global_addr @$ss23_swiftEmptySetSingletonSo06_SwiftbcD0Vvp
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function '$s4test29createEmptySetWithInitializerShySiGyF'
 public func createEmptySetWithInitializer() -> Set<Int> {

--- a/test/ScanDependencies/clang-target-clang-irgen.swift
+++ b/test/ScanDependencies/clang-target-clang-irgen.swift
@@ -19,7 +19,7 @@
 // RUN: %FileCheck %s < %t/explicit-clang-target-irgen.ll
 
 // Ensure that the platform version check is not optimized away, which it would, if we code-generate for '-clang-target' of macosx12.0
-// CHECK: {{%[0-9]+}} = tail call i32 @__isPlatformVersionAtLeast(i32 1, i32 11, i32 0, i32 0)
+// CHECK: {{%[0-9]+}} = {{.*}}call i32 @__isPlatformVersionAtLeast(i32 1, i32 11, i32 0, i32 0)
 
 //--- map.json.template
 [


### PR DESCRIPTION
Dynamic exclusivity checking was disabled in the standard library a
long time ago for performance reasons. It shouldn't be needed anywhere
in the standard library, but enable it now for memory-safety reasons
and for consistency with Swift defaults.