### PR TITLE
[6.3] [IDE] Reference appendInterpolation calls in string interpolation

### DIFF
--- a/test/Index/index_string_interpolation.swift
+++ b/test/Index/index_string_interpolation.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -swift-version 5 -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+// Test that appendInterpolation methods are referenced from string interpolation
+// (https://github.com/swiftlang/swift/issues/56189)
+
+extension DefaultStringInterpolation {
+  // CHECK: [[@LINE+1]]:17 | instance-method(internal)/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR:.*]] | Def
+  mutating func appendInterpolation(value: Int) {}
+}
+
+func testStringInterpolation() {
+  // CHECK: [[@LINE+1]]:11 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call,Impl
+  print("\(value: 1)")
+
+  // CHECK: [[@LINE+1]]:18 | instance-method/Swift | appendInterpolation(value:) | [[appendInterpolation_value_USR]] | Ref,Call,Impl
+  print("value: \(value: 42)")
+}


### PR DESCRIPTION
- **Explanation**:
Fix missing references to `appendInterpolation` functions called implicitly in string interpolations.
- **Scope**:
Purely additive to the index store. Can help tools such as [Periphery](https://github.com/peripheryapp/periphery) be more accurate.
- **Issues**:
#56189
- **Original PRs**:
#86166
- **Risk**:
Very low, perhaps a slight increase in index store size.
- **Testing**:
Passed all tests across all platforms.
- **Reviewers**:
@hamishknight 
