### PR TITLE
SIL verifier: accept "owned" ownership for borrowed-from's enclosing values

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Verifier.swift
@@ -150,11 +150,19 @@ private extension Value {
     switch ownership {
     case .owned:
       return true
+    case .none:
+      // "none" is like "owned" and can happen e.g. if a non-trivial enum is constructed with a trivial case:
+      // ```
+      //   %1 = enum $Optional<AnyObject>, #Optional.none!enumelt   // ownership: none
+      //   ...
+      //   %3 = borrowed %phi from (%1)
+      // ```
+      return true
     case .guaranteed:
       return BeginBorrowValue(self) != nil ||
              self is BorrowedFromInst ||
              forwardingInstruction != nil
-    case .none, .unowned:
+    case .unowned:
       return false
     }
   }

--- a/test/SIL/OwnershipVerifier/guaranteed_phis.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_phis.sil
@@ -402,6 +402,19 @@ bb3(%14 : @reborrow $Klass, %15 : @reborrow $Klass):
   return %20
 }
 
+sil [ossa] @borrowed_from_trivial_enum : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $Optional<Klass>, #Optional.none!enumelt
+  %1 = begin_borrow %0
+  br bb1(%1)
+
+bb1(%3 : @reborrow $Optional<Klass>):
+  %4 = borrowed %3 from (%0)
+  end_borrow %4
+  %r = tuple ()
+  return %r
+}
+
 sil [ossa] @dont_follow_trivial_field_to_phi : $@convention(thin) (@owned KlassAndInt, @guaranteed Klass) -> () {
 bb0(%0 : @owned $KlassAndInt, %1 : @guaranteed $Klass):
   %2 = begin_borrow %0


### PR DESCRIPTION
"none" is like "owned" and can happen e.g. if a non-trivial enum is constructed with a trivial case:
```
  %1 = enum $Optional<AnyObject>, #Optional.none!enumelt   // ownership: none
  ...
  %3 = borrowed %phi from (%1)
```

Fix a false verification error
https://github.com/swiftlang/swift/issues/86407
rdar://167833469
