### PR TITLE
Utils: Remove unused Android Swift flag

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1876,11 +1876,6 @@ function Build-CMakeProject {
             "-Xclang-linker", "-resource-dir", "-Xclang-linker", "${AndroidPrebuiltRoot}\lib\clang\$($(Get-AndroidNDK).ClangVersion)"
           )
 
-          # FIXME(compnerd) remove this once we have the early swift-driver
-          if ($SwiftSDK) {
-            $SwiftFlags += @("-Xclang-linker", "-L", "-Xclang-linker", [IO.Path]::Combine($SwiftSDK, "usr", "lib", "swift", "android", $Platform.Architecture.LLVMName))
-          }
-
           $SwiftFlags += if ($DebugInfo) { @("-g") } else { @("-gnone") }
 
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags


### PR DESCRIPTION
Explicitly passing the arch-specific Android library directory from the SDK to the linker should no longer be necessary since we build the toolchain with the eaarly swift-driver.