### PR TITLE
MoveOnlyChecker: Fix iterative destructuring in computeAvailableValues

### DIFF
--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -4282,3 +4282,32 @@ func rdar_118059326_example2(_ path: String) {
   _ = consume decoded // expected-note {{consumed}}
   borrowVal(decoded) // expected-note {{used}}
 }
+
+struct rdar_167469090_NC: ~Copyable {
+    var s: String
+}
+
+struct rdar_167469090_S: ~Copyable {
+    let a: rdar_167469090_NC?
+    let b: rdar_167469090_NC?
+    let c: rdar_167469090_NC?
+
+    var computed: Bool {
+        a == nil && b == nil && c == nil
+    }
+
+    var string: String { // expected-error {{'self' is borrowed and cannot be consumed}}
+        let s = if computed { // expected-note {{consumed here}}
+            "computed"
+        } else if let a { // expected-note {{consumed here}}
+            "a: \(a.s)"
+        } else {
+            "unknown"
+        }
+        if let c {
+            return s + ": " + c.s
+        } else {
+            return s
+        }
+    }
+}


### PR DESCRIPTION
rdar://167469090

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
