### PR TITLE
[stdlib] Mark the countAndCapacity field of arrays as @exclusivity(unchecked)

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -146,7 +146,7 @@ internal final class _ContiguousArrayStorage<
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R {
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self))
-    let count = countAndCapacity.count
+    let count = unsafe countAndCapacity.count
     let elements = unsafe UnsafeRawPointer(_elementPointer)
       .assumingMemoryBound(to: AnyObject.self)
     defer { _fixLifetime(self) }
@@ -251,7 +251,7 @@ internal final class _ContiguousArrayStorage<
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> Void
   ) rethrows {
     if _isBridgedVerbatimToObjectiveC(Element.self) {
-      let count = countAndCapacity.count
+      let count = unsafe countAndCapacity.count
       let elements = unsafe UnsafeRawPointer(_elementPointer)
         .assumingMemoryBound(to: AnyObject.self)
       defer { _fixLifetime(self) }
@@ -266,7 +266,7 @@ internal final class _ContiguousArrayStorage<
     _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
-    let count = countAndCapacity.count
+    let count = unsafe countAndCapacity.count
     let result = _BridgingBuffer(count)
     let resultPtr = unsafe result.baseAddress
     let p = unsafe _elementPointer
@@ -413,7 +413,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
     // We can initialize by assignment because _ArrayBody is a trivial type,
     // i.e. contains no references.
-    _storage.countAndCapacity = _ArrayBody(
+    unsafe _storage.countAndCapacity = _ArrayBody(
       count: count,
       capacity: capacity,
       elementTypeIsBridgedVerbatim: verbatim)
@@ -639,7 +639,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @inlinable
   internal var count: Int {
     get {
-      return _storage.countAndCapacity.count
+      return unsafe _storage.countAndCapacity.count
     }
     nonmutating set {
       _internalInvariant(newValue >= 0)
@@ -648,7 +648,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
         newValue <= mutableCapacity,
         "Can't grow an array buffer past its capacity")
 
-      mutableStorage.countAndCapacity.count = newValue
+      unsafe mutableStorage.countAndCapacity.count = newValue
     }
   }
   
@@ -658,7 +658,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var immutableCount: Int {
-    return immutableStorage.countAndCapacity.count
+    return unsafe immutableStorage.countAndCapacity.count
   }
 
   /// The number of elements of the buffer.
@@ -668,7 +668,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   internal var mutableCount: Int {
     @inline(__always)
     get {
-      return mutableOrEmptyStorage.countAndCapacity.count
+      return unsafe mutableOrEmptyStorage.countAndCapacity.count
     }
     @inline(__always)
     nonmutating set {
@@ -678,7 +678,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
         newValue <= mutableCapacity,
         "Can't grow an array buffer past its capacity")
 
-      mutableStorage.countAndCapacity.count = newValue
+      unsafe mutableStorage.countAndCapacity.count = newValue
     }
   }
 
@@ -715,7 +715,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// Use `immutableCapacity` or `mutableCapacity` instead.
   @inlinable
   internal var capacity: Int {
-    return _storage.countAndCapacity.capacity
+    return unsafe _storage.countAndCapacity.capacity
   }
 
   /// The number of elements the buffer can store without reallocation.
@@ -724,7 +724,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var immutableCapacity: Int {
-    return immutableStorage.countAndCapacity.capacity
+    return unsafe immutableStorage.countAndCapacity.capacity
   }
 
   /// The number of elements the buffer can store without reallocation.
@@ -733,7 +733,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal var mutableCapacity: Int {
-    return mutableOrEmptyStorage.countAndCapacity.capacity
+    return unsafe mutableOrEmptyStorage.countAndCapacity.capacity
   }
 
   /// Copy the elements in `bounds` from this buffer into uninitialized

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -427,7 +427,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   /// bridging of array elements.
   @objc
   internal override final var count: Int {
-    return _nativeStorage.countAndCapacity.count
+    return unsafe _nativeStorage.countAndCapacity.count
   }
 }
 
@@ -480,7 +480,7 @@ internal final class __SwiftDeferredStaticNSArray<Element>
     _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
-    let count = _nativeStorage.countAndCapacity.count
+    let count = unsafe _nativeStorage.countAndCapacity.count
     let result = _BridgingBuffer(count)
     let resultPtr = unsafe result.baseAddress
     let p = unsafe UnsafeMutablePointer<Element>(Builtin.projectTailElems(_nativeStorage, Element.self))
@@ -520,6 +520,7 @@ internal class __ContiguousArrayStorageBase
   : __SwiftNativeNSArrayWithContiguousStorage {
 
   @usableFromInline
+  @exclusivity(unchecked)
   final var countAndCapacity: _ArrayBody
 
   @inlinable


### PR DESCRIPTION
We carefully manage access to this field via copy-on-write and a number of our tests (+ array performance model) depend on not having exclusivity checking for it.