### PR TITLE
[Test][SourceKit] Remove REQUIRES shell directive

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -2,7 +2,6 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
-// REQUIRES: shell
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -2,7 +2,6 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
-// REQUIRES: shell
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -23,8 +23,8 @@ func foo(value: MyStruct) {
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 // RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t%{fs-sep}VFS%{fs-sep}Main.swift=@%s,%t%{fs-sep}VFS%{fs-sep}Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t%{fs-sep}VFS%{fs-sep}Main.swift -- -target %target-triple %t%{fs-sep}VFS%{fs-sep}Main.swift %t%{fs-sep}VFS%{fs-sep}LibraryExt.swift %t%{fs-sep}VFS%{fs-sep}Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t%{fs-sep}VFS%{fs-sep}Main.swift %s \
-
-// RUN:   | tee %t/trace | %FileCheck %s
+//
+// RUN:   | %FileCheck %s
 
 // CHECK-LABEL: ### Initial
 // CHECK: key.results: [

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -4,25 +4,25 @@ func foo(value: MyStruct) {
 
 
 // RUN: %empty-directory(%t)
-// RUN: %empty-directory(%t/VFS)
-// RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
+// RUN: %empty-directory(%t%{fs-sep}VFS)
+// RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t%{fs-sep}VFS%{fs-sep}
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
-// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t%{fs-sep}VFS%{fs-sep}Main.swift=@%s,%t%{fs-sep}VFS%{fs-sep}Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t%{fs-sep}VFS%{fs-sep}Main.swift -- -target %target-triple %t%{fs-sep}VFS%{fs-sep}Main.swift %t%{fs-sep}VFS%{fs-sep}LibraryExt.swift %t%{fs-sep}VFS%{fs-sep}Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t%{fs-sep}VFS%{fs-sep}Main.swift %s == \
 
 // RUN:   -shell -- echo "### Modify" == \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
-// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t%{fs-sep}VFS%{fs-sep}Main.swift=@%s,%t%{fs-sep}VFS%{fs-sep}Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t%{fs-sep}VFS%{fs-sep}Main.swift -- -target %target-triple %t%{fs-sep}VFS%{fs-sep}Main.swift %t%{fs-sep}VFS%{fs-sep}LibraryExt.swift %t%{fs-sep}VFS%{fs-sep}Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t%{fs-sep}VFS%{fs-sep}Main.swift %s == \
 
 // RUN:   -shell -- echo "### Keep" == \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
-// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t%{fs-sep}VFS%{fs-sep}Main.swift=@%s,%t%{fs-sep}VFS%{fs-sep}Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t%{fs-sep}VFS%{fs-sep}Main.swift -- -target %target-triple %t%{fs-sep}VFS%{fs-sep}Main.swift %t%{fs-sep}VFS%{fs-sep}LibraryExt.swift %t%{fs-sep}VFS%{fs-sep}Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t%{fs-sep}VFS%{fs-sep}Main.swift %s \
 
 // RUN:   | tee %t/trace | %FileCheck %s
 


### PR DESCRIPTION
Partially address #84407 

It looks like `-shell` is a built in option in `sourcekitd-test` and the tests are passing without `REQUIRES: shell`.

```
#86488 fixed:
- test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
- test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
```