### PR TITLE
FP Parsing: Fix over-eager underflow check

### DIFF
--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -593,7 +593,7 @@ fileprivate func hexFloat(
     return .infinity(sign: sign) // Overflow
   }
 
-  if binaryExponent < targetFormat.minBinaryExponent - targetFormat.significandBits + 1 {
+  if binaryExponent < targetFormat.minBinaryExponent - targetFormat.significandBits {
     return .zero(sign: sign) // Underflow
   }
 

--- a/test/stdlib/ParseFloat32.swift
+++ b/test/stdlib/ParseFloat32.swift
@@ -162,6 +162,15 @@ tests.test("HexFloats") {
 
   expectParse("0x.000001", 5.9604645e-08)
   expectParse("0x1p-150", 0.0)
+  expectParse("0x0.0000010000000000000000000000p-126", 0.0)
+  expectParse("0x0.00000100000000000000000000000000000000000000000000000000000000000000000000000000000000000001p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.00000100000000001p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.0000010000000000000001p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.0000010000000000000002p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.0000010000000000000004p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.0000010000000000000008p-126", Float32.leastNonzeroMagnitude)
+  expectParse("0x0.000001000000000000001p-126", Float32.leastNonzeroMagnitude)
+
   expectParse("0x1p-149", Float32.leastNonzeroMagnitude)
   expectParse("0x1p-149", Float32(bitPattern:1))
   expectParse("0x1p-148", Float32(bitPattern:2))

--- a/test/stdlib/ParseFloat64.swift
+++ b/test/stdlib/ParseFloat64.swift
@@ -183,8 +183,17 @@ tests.test("HexFloats") {
   expectParse("0x0.0p999999999", 0.0)
   expectParse("0x.0p-999999999", 0.0)
   expectParse("0x0p-999999999", 0.0)
-
   expectParse("0x.000001", 0x0.000001p0)
+
+  expectParse("0x0.80000000000p-1074", 0.0)
+  expectParse("0x0.8000000000000000000000000000000000000000001p-1074", Float64.leastNonzeroMagnitude)
+  expectParse("0x0.80000000000000008p-1074", Float64.leastNonzeroMagnitude)
+  expectParse("0x0.8000000000000001p-1074", Float64.leastNonzeroMagnitude)
+  expectParse("0x0.80000000001p-1074", Float64.leastNonzeroMagnitude)
+
+  expectParse("0x0.0000000000000fffffffffffp-1022", Float64.leastNonzeroMagnitude)
+  expectParse("0x0.fffffffffffp-1074", Float64.leastNonzeroMagnitude)
+
   expectParse("0x1p-1074", Float64.leastNonzeroMagnitude)
   expectParse("0x1p-1074", Float64(bitPattern:1))
   expectParse("0x1p-1073", Float64(bitPattern:2))


### PR DESCRIPTION
An early check for underflow was a bit too aggressive, resulting in values that would otherwise round up to the smallest subnormal failing to go through the regular rounding logic.

Resolves #86462
Resolves rdar://167942063
