### PR TITLE
Support internal bridging headers for non-LibraryEvolution/fragile

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -591,8 +591,9 @@ ERROR(no_swift_sources_with_embedded,none,
 ERROR(package_cmo_requires_library_evolution, none,
         "Library evolution must be enabled for Package CMO", ())
 
-WARNING(internal_bridging_header_without_library_evolution,none,
-        "using internal bridging headers without library evolution can cause instability", ())
+WARNING(internal_bridging_header_without_library_evolution, none,
+        "using internal bridging headers without library evolution and "
+        "'-enable-experimental-feature CheckImplementationOnly' can cause instability", ())
 
 ERROR(error_invalid_clang_header_access_level, none,
       "invalid minimum clang header access level '%0'; chose from "

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4020,6 +4020,8 @@ ImportDecl *swift::createImportDecl(ASTContext &Ctx,
   if (Ctx.ClangImporterOpts.BridgingHeaderIsInternal) {
     ID->addAttribute(new (Ctx) AccessControlAttr(
         SourceLoc(), SourceRange(), AccessLevel::Internal, /*implicit=*/true));
+    if (!Ctx.LangOpts.hasFeature(Feature::LibraryEvolution))
+      ID->addAttribute(new (Ctx) ImplementationOnlyAttr(/*IsImplicit=*/true));
   } else if (IsExported) {
     ID->addAttribute(new (Ctx) ExportedAttr(/*IsImplicit=*/false));
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2242,7 +2242,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
   // Until we have some checking in place, internal bridging headers are a
   // bit unsafe without library evolution.
   if (Opts.BridgingHeaderIsInternal &&
-      !LangOpts.hasFeature(Feature::LibraryEvolution)) {
+      !LangOpts.hasFeature(Feature::LibraryEvolution) &&
+      !LangOpts.hasFeature(Feature::CheckImplementationOnly)) {
     Diags.diagnose(SourceLoc(),
                    diag::internal_bridging_header_without_library_evolution);
   }

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -607,6 +607,8 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
         ImportedModule(headerModule), SourceLoc(), ImportFlags::Exported);
     if (ctx.ClangImporterOpts.BridgingHeaderIsInternal) {
       import.accessLevel = AccessLevel::Internal;
+      if (!ctx.LangOpts.hasFeature(Feature::LibraryEvolution))
+        import.options |= ImportFlags::ImplementationOnly;
     }
 
     imports.emplace_back(import);

--- a/test/ClangImporter/InternalBridgingHeader/interface.swift
+++ b/test/ClangImporter/InternalBridgingHeader/interface.swift
@@ -4,6 +4,12 @@
 
 // RUN: %FileCheck %s < %t/MyModule.swiftinterface
 
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/MyModule.swiftinterface) %s -module-name MyModule -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -enable-experimental-feature CheckImplementationOnly
+
+// RUN: %FileCheck %s < %t/MyModule.swiftinterface
+
 // CHECK-NOT: internal-import-bridging-header
 
 // CHECK: public func g()

--- a/test/ClangImporter/InternalBridgingHeader/library_evolution.swift
+++ b/test/ClangImporter/InternalBridgingHeader/library_evolution.swift
@@ -1,8 +1,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s 2>&1 | %FileCheck -check-prefix NONRESILIENT %s
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s -enable-experimental-feature CheckImplementationOnly 2>&1 | %FileCheck -check-prefix CHECKIMPLEMENTATIONONLY %s
+
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s -enable-library-evolution 2>&1 | %FileCheck -check-prefix EVOLUTION %s
 
 // NONRESILIENT: warning: using internal bridging headers without library evolution can cause instability
+
+// CHECKIMPLEMENTATIONONLY-NOT: internal bridging head
 
 // EVOLUTION-NOT: internal bridging head
 


### PR DESCRIPTION
Imply @_implementationOnly on -internal-import-bridging-header imports when LibraryEvolution is not enabled.

rdar://166322874