### PR TITLE
🍒 [windows] improve SKIP_TESTS substitution

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -62,9 +62,15 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,lldb,lldb-swift,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,
-for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
-if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
+set TestsList=lld,lldb,lldb-swift,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp
+set "TestArg="
+set "Skip=,%SKIP_TESTS%,"
+for %%I in (%TestsList%) do (
+  if "!Skip:,%%I,=!" == "!Skip!" (
+      set "TestArg=!TestArg!%%I,"
+  )
+)
+set "TestArg=-Test !TestArg!"
 
 :: Build the packaging arguments (skipped for normal PRs and an added stage for toolchain PRs)
 set "PackagingArg=-SkipPackaging"


### PR DESCRIPTION
**Explanation**:
This patch improves the `SKIP_TESTS` substitution pattern matching in build-windows-toolchain.bat.
Currently, if a skipped test (swift) is a substring of another test (lldb-swift), then that other test will also be skipped. i.e both swift and lldb-swift are skipped.
This will allow to fix the https://ci-external.swift.org/job/oss-lldb-windows-x86_64-swift-6.3/ bot, which does not run the lldb tests due to the bug above.
- **Scope**:
This change impacts the Swift toolchain CI test invocation on Windows.
- **Issues**:

- **Original PRs**:
	- https://github.com/swiftlang/swift/pull/85614
- **Risk**:
Low
- **Testing**:
Built at desk on an x64 Windows PC.
- **Reviewers**:
  - @compnerd 

