### PR TITLE
[Test][SourceKit] Use lit DEFINE directive for compiler args in checkdeps tests

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -1,10 +1,11 @@
-// UNSUPPORTED: OS=windows-msvc
 import ClangFW
 import SwiftFW
 
 func foo() {
   /*HERE*/
 }
+
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -5,42 +5,29 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
-
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 // RUN: touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
 
 // RUN:   -shell -- echo '### Modify bridging header library file' == \
-// RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/LocalCFunc.h %t/MyProject/ == \
+// RUN:   -shell -- cp -R %S/Inputs/checkdeps/MyProject_mod/LocalCFunc.h %t/MyProject/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -10,6 +10,15 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
+
 // RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
 // RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
@@ -20,16 +29,16 @@ func foo() {
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Modify bridging header library file' == \
 // RUN:   -shell -- cp -R %S/Inputs/checkdeps/MyProject_mod/LocalCFunc.h %t/MyProject/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: OS=windows-msvc
 import ClangFW
 import SwiftFW
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -1,10 +1,11 @@
-// UNSUPPORTED: OS=windows-msvc
 import ClangFW
 import SwiftFW
 
 func foo() {
   /*HERE*/
 }
+
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -5,42 +5,29 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
-
-// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
 // RUN: touch -t 202001010101 %t/MyProject/Library.swift
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
 
 // RUN:   -shell -- echo "### Modify local library file" == \
-// RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/Library.swift %t/MyProject/ == \
+// RUN:   -shell -- cp -R %S/Inputs/checkdeps/MyProject_mod/Library.swift %t/MyProject/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/MyProject/Library.swift == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/MyProject/Library.swift == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -10,6 +10,15 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
+
 // RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
 // RUN: touch -t 202001010101 %t/MyProject/Library.swift
 // RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
@@ -20,16 +29,16 @@ func foo() {
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo "### Modify local library file" == \
 // RUN:   -shell -- cp -R %S/Inputs/checkdeps/MyProject_mod/Library.swift %t/MyProject/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/MyProject/Library.swift == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/MyProject/Library.swift == \
-// RUN:   -req=complete -pos=5:3 %s -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %s \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: OS=windows-msvc
 import ClangFW
 import SwiftFW
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: OS=windows-msvc
 // BEGIN State1.swift
 import ClangFW
 import SwiftFW

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -17,12 +17,22 @@ func foo(val: MyStruct) {
 // BEGIN DUMMY.swift
 
 // Checks that editing and saving the current file doesn't affect dependency checking.
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
 // RUN: %{python} %utils/split_file.py -o %t %s
+
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %t/test.swift
 
 // RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
 // RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
@@ -36,22 +46,22 @@ func foo(val: MyStruct) {
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:4 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- %{args} == \
 
 // RUN:   -shell -- echo "### Modify own file - 1" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010101 %t/test.swift == \
-// RUN:   -req=complete -pos=5:9 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- %{args} == \
 
 // RUN:   -shell -- echo "### Modify own file - 2" == \
 // RUN:   -shell -- cp %t/State1.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010102 %t/test.swift == \
-// RUN:   -req=complete -pos=5:4 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- %{args} == \
 
 // RUN:   -shell -- echo "### Modify own file - 3" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010103 %t/test.swift == \
-// RUN:   -req=complete -pos=5:9 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- %{args} \
 // RUN:   | %FileCheck %s
 
 // CHECK-LABEL: ### Initial

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -1,4 +1,3 @@
-// UNSUPPORTED: OS=windows-msvc
 // BEGIN State1.swift
 import ClangFW
 import SwiftFW

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -17,7 +17,6 @@ func foo(val: MyStruct) {
 // BEGIN DUMMY.swift
 
 // Checks that editing and saving the current file doesn't affect dependency checking.
-// REQUIRES: shell
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Frameworks)
@@ -25,21 +24,10 @@ func foo(val: MyStruct) {
 
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %t/test.swift \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
-
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 
 // RUN: cp %t/State1.swift %t/test.swift
 // RUN: touch -t 202001010101 %t/test.swift
@@ -48,22 +36,22 @@ func foo(val: MyStruct) {
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
 
 // RUN:   -shell -- echo "### Modify own file - 1" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010101 %t/test.swift == \
-// RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
 
 // RUN:   -shell -- echo "### Modify own file - 2" == \
 // RUN:   -shell -- cp %t/State1.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010102 %t/test.swift == \
-// RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift == \
 
 // RUN:   -shell -- echo "### Modify own file - 3" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
 // RUN:   -shell -- touch -t 210001010103 %t/test.swift == \
-// RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- -target %target-triple -module-name MyProject -F %t/Frameworks -I %t/MyProject -import-objc-header %t/MyProject/Bridging.h %t/MyProject/Library.swift %t/test.swift \
 // RUN:   | %FileCheck %s
 
 // CHECK-LABEL: ### Initial


### PR DESCRIPTION
Inlines bash array and variable expansion in checkdeps tests for internal shell compatibility

Partially address #84407 

```
#86494 fixed:
- test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
- test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
- test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
```