### PR TITLE
Sema: Fix crash in diagnoseAttemptedRegexBuilder with callAsFunction

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7849,7 +7849,8 @@ bool ArgumentMismatchFailure::diagnoseAttemptedRegexBuilder() const {
   auto &ctx = getASTContext();
 
   // Should be a lone trailing closure argument.
-  if (!Info.isTrailingClosure() || !Info.getArgList()->isUnary())
+  auto *argList = Info.getArgList();
+  if (!Info.isTrailingClosure() || !argList || !argList->isUnary())
     return false;
 
   // Check if this an application of a Regex initializer, and the user has not

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -122,3 +122,13 @@ func test_default_arguments_do_not_interfere() {
   _ = S(a: 42) { _ = 42 }
   _ = S(b: "") { _ = 42 }
 }
+
+// https://github.com/swiftlang/swift/issues/86461
+// Closure return type mismatch with callAsFunction should emit error, not crash.
+func test_callAsFunction_closure_return_type_mismatch() {
+  struct C {
+    func callAsFunction(_ update: () -> Int) {}
+  }
+
+  _ = C { } // expected-error {{cannot convert value of type '()' to closure result type 'Int'}}
+}


### PR DESCRIPTION
When diagnosing an argument mismatch for a trailing closure passed to `callAsFunction`, the argument list may be null. Add a null check before dereferencing to prevent the segfault.

Fixes https://github.com/swiftlang/swift/issues/86461