### PR TITLE
[Tests] NFC: Test type reference without `.self` on `DynamicSelf` base

### DIFF
--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -392,5 +392,9 @@ class Container {
   func someFunc() {
     let _ = [Container.NestedType]()  // ok
     let _ = [Self.NestedType]()  // ok
+
+    _ = Self.NestedType // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{24-24=.self}}
   }
 }


### PR DESCRIPTION
Make sure that such uses of nested types are diagnosed.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
